### PR TITLE
chore: Add CODEOWNERS and Issue template config for OSS setup

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# Default owner for everything in the repository.
+# Override per-path below as contributors are added.
+*                                   @hyoshi
+
+# Critical areas — require explicit review even for small changes
+/mureo/auth.py                      @hyoshi
+/mureo/auth_setup.py                @hyoshi
+/pyproject.toml                     @hyoshi
+/.github/workflows/                 @hyoshi
+/SECURITY.md                        @hyoshi

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Questions & Ideas
+    url: https://github.com/logly/mureo/discussions
+    about: Ask questions, share ideas, or start a discussion. Please use Issues only for bug reports and feature requests.
+  - name: 🔒 Security Vulnerabilities
+    url: https://github.com/logly/mureo/security/advisories/new
+    about: Report security vulnerabilities privately. Do NOT open a public Issue.


### PR DESCRIPTION
## Summary
- Add `.github/CODEOWNERS` so PR reviews are auto-requested from the right maintainer
- Add `.github/ISSUE_TEMPLATE/config.yml` to disable blank issues and route:
  - Questions / ideas → Discussions
  - Security vulnerabilities → private Security Advisory

## Test plan
- [x] bug_report.md and feature_request.md remain as the only Issue templates
- [x] CI passes (lint / test 3.10-3.12 / bandit)