### PR TITLE
chore: Enable Dependabot for security updates and CI maintenance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  # Python dependencies declared in pyproject.toml.
+  # open-pull-requests-limit: 0 disables routine version-bump PRs while
+  # still allowing Dependabot to raise security advisories when a CVE
+  # affects one of our dependencies. Raise this number if we start to
+  # need regular version updates too.
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    labels:
+      - "area: mcp"
+      - "needs-triage"
+
+  # GitHub Actions used in .github/workflows. Keeping these up to date
+  # is low-risk and protects the CI supply chain, so we allow a small
+  # number of routine version-bump PRs in addition to security updates.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "needs-triage"


### PR DESCRIPTION
## Summary
- **pip**: security-only mode. `open-pull-requests-limit: 0` silences routine version bumps; CVE-driven advisories still come through.
- **github-actions**: weekly version bumps (limit 5) to keep the CI supply chain current.
- Both ecosystems tag PRs as `needs-triage`.

## Test plan
- [x] YAML syntax valid (Dependabot will validate on merge)
- [x] No CI changes required — config-only addition