### PR TITLE
feat: Add anomaly detector for marketing campaign metrics

### DIFF
--- a/mureo/analysis/anomaly_detector.py
+++ b/mureo/analysis/anomaly_detector.py
@@ -1,0 +1,283 @@
+"""Anomaly detection for marketing campaign metrics.
+
+Pure, I/O-free detection logic. Given a point-in-time
+:class:`CampaignMetrics` snapshot and (optionally) a baseline built
+from historical ``action_log`` entries, return a prioritized list of
+:class:`Anomaly` objects describing what broke and what to do about
+it.
+
+Scope (2026-04 X research):
+- Zero spend on a previously-spending campaign → CRITICAL
+- CPA spike ≥ 1.5× baseline, gated by 30+ conversions
+- CTR drop ≤ 0.5× baseline, gated by 1000+ impressions
+
+Gates come from the mureo-learning skill's sample-size rules: below
+these thresholds, a single bad day is noise and must not trigger an
+alert.
+
+This module deliberately does *not* touch the network, the filesystem,
+or ``STATE.json``. Callers fetch metrics, build baselines, and act on
+the returned anomalies.
+"""
+
+from __future__ import annotations
+
+import statistics
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from mureo.context.models import ActionLogEntry
+
+CPA_SPIKE_RATIO = 1.5
+CPA_SPIKE_CRITICAL_RATIO = 2.0
+CPA_MIN_CONVERSIONS = 30
+
+CTR_DROP_RATIO = 0.5
+CTR_DROP_CRITICAL_RATIO = 0.3
+CTR_MIN_IMPRESSIONS = 1000
+
+
+class Severity(str, Enum):
+    """Ordered severity levels. ``str`` mixin makes JSON serialization trivial."""
+
+    CRITICAL = "critical"
+    HIGH = "high"
+    MEDIUM = "medium"
+
+
+_SEVERITY_ORDER: dict[Severity, int] = {
+    Severity.CRITICAL: 0,
+    Severity.HIGH: 1,
+    Severity.MEDIUM: 2,
+}
+
+
+@dataclass(frozen=True)
+class CampaignMetrics:
+    """Point-in-time metrics for one campaign.
+
+    CPA and CTR can be passed explicitly (preferred — the API may
+    round differently than a naive division) or derived from the raw
+    counters.
+    """
+
+    campaign_id: str
+    cost: float = 0.0
+    impressions: int = 0
+    clicks: int = 0
+    conversions: float = 0.0
+    cpa: float | None = None
+    ctr: float | None = None
+
+    def derived_cpa(self) -> float | None:
+        if self.cpa is not None:
+            return self.cpa
+        if self.conversions <= 0:
+            return None
+        return self.cost / self.conversions
+
+    def derived_ctr(self) -> float | None:
+        if self.ctr is not None:
+            return self.ctr
+        if self.impressions <= 0:
+            return None
+        return self.clicks / self.impressions
+
+
+@dataclass(frozen=True)
+class Anomaly:
+    """A single detected anomaly with recommended follow-up."""
+
+    campaign_id: str
+    metric: str
+    severity: Severity
+    current_value: float
+    baseline_value: float | None
+    deviation_pct: float | None
+    sample_size: int
+    message: str
+    recommended_action: str
+
+
+def detect_anomalies(
+    current: CampaignMetrics,
+    baseline: CampaignMetrics | None,
+    *,
+    had_prior_spend: bool = True,
+) -> list[Anomaly]:
+    """Compare ``current`` against ``baseline`` and return prioritized anomalies.
+
+    ``had_prior_spend`` tells us whether zero spend is suspicious; a
+    fresh campaign that never spent before should not trigger that
+    alert. Pass ``False`` for brand-new campaigns. When ``baseline``
+    is provided and its own ``cost`` is zero (paused campaign, weekend
+    dayparting), zero-spend is suppressed regardless of the flag.
+    """
+    anomalies: list[Anomaly] = []
+
+    zero_spend = _check_zero_spend(current, baseline, had_prior_spend)
+    if zero_spend is not None:
+        anomalies.append(zero_spend)
+
+    if baseline is not None:
+        cpa = _check_cpa_spike(current, baseline)
+        if cpa is not None:
+            anomalies.append(cpa)
+
+        ctr = _check_ctr_drop(current, baseline)
+        if ctr is not None:
+            anomalies.append(ctr)
+
+    anomalies.sort(key=lambda a: _SEVERITY_ORDER[a.severity])
+    return anomalies
+
+
+def _check_zero_spend(
+    current: CampaignMetrics,
+    baseline: CampaignMetrics | None,
+    had_prior_spend: bool,
+) -> Anomaly | None:
+    if current.cost > 0 or not had_prior_spend:
+        return None
+    # If baseline itself had zero spend, the campaign was already paused/inactive;
+    # alerting would be noise.
+    if baseline is not None and baseline.cost <= 0:
+        return None
+    return Anomaly(
+        campaign_id=current.campaign_id,
+        metric="cost",
+        severity=Severity.CRITICAL,
+        current_value=0.0,
+        baseline_value=None,
+        deviation_pct=None,
+        sample_size=0,
+        message="支出がゼロです。配信が停止している可能性があります。",
+        recommended_action=(
+            "キャンペーンの配信ステータス、予算残高、入札・ポリシー制限を確認してください。"
+        ),
+    )
+
+
+def _check_cpa_spike(
+    current: CampaignMetrics, baseline: CampaignMetrics
+) -> Anomaly | None:
+    current_cpa = current.derived_cpa()
+    baseline_cpa = baseline.derived_cpa()
+    if current_cpa is None or baseline_cpa is None or baseline_cpa <= 0:
+        return None
+    # Gate on whichever side has enough conversions: if current collapsed to
+    # 20/day from a 200/day baseline, the baseline's sample is what gives us
+    # confidence the spike isn't noise.
+    if max(current.conversions, baseline.conversions) < CPA_MIN_CONVERSIONS:
+        return None
+
+    ratio = current_cpa / baseline_cpa
+    if ratio < CPA_SPIKE_RATIO:
+        return None
+
+    severity = Severity.CRITICAL if ratio >= CPA_SPIKE_CRITICAL_RATIO else Severity.HIGH
+    deviation_pct = ratio - 1.0
+    return Anomaly(
+        campaign_id=current.campaign_id,
+        metric="cpa",
+        severity=severity,
+        current_value=current_cpa,
+        baseline_value=baseline_cpa,
+        deviation_pct=deviation_pct,
+        sample_size=round(current.conversions),
+        message=(
+            f"CPAがベースラインの{ratio:.2f}倍に上昇しました "
+            f"(current={current_cpa:.0f}, baseline={baseline_cpa:.0f})。"
+        ),
+        recommended_action=(
+            "高CPAキーワード・検索語句の特定と停止、または入札調整を検討してください。"
+        ),
+    )
+
+
+def _check_ctr_drop(
+    current: CampaignMetrics, baseline: CampaignMetrics
+) -> Anomaly | None:
+    current_ctr = current.derived_ctr()
+    baseline_ctr = baseline.derived_ctr()
+    if current_ctr is None or baseline_ctr is None or baseline_ctr <= 0:
+        return None
+    if max(current.impressions, baseline.impressions) < CTR_MIN_IMPRESSIONS:
+        return None
+
+    ratio = current_ctr / baseline_ctr
+    if ratio > CTR_DROP_RATIO:
+        return None
+
+    severity = Severity.CRITICAL if ratio <= CTR_DROP_CRITICAL_RATIO else Severity.HIGH
+    deviation_pct = ratio - 1.0
+    return Anomaly(
+        campaign_id=current.campaign_id,
+        metric="ctr",
+        severity=severity,
+        current_value=current_ctr,
+        baseline_value=baseline_ctr,
+        deviation_pct=deviation_pct,
+        sample_size=current.impressions,
+        message=(
+            f"CTRがベースラインの{ratio:.2f}倍まで低下しました "
+            f"(current={current_ctr:.3%}, baseline={baseline_ctr:.3%})。"
+        ),
+        recommended_action=(
+            "広告文の刷新、検索語句レビュー、マッチタイプ・ネガティブキーワードの見直しを検討してください。"
+        ),
+    )
+
+
+def baseline_from_history(
+    campaign_id: str,
+    action_log: Iterable[ActionLogEntry],
+    *,
+    min_entries: int = 3,
+) -> CampaignMetrics | None:
+    """Build a baseline by taking the median of historical ``metrics_at_action``.
+
+    Median — not mean — because a single outlier entry (e.g. a rescue
+    action during a CPA spike) would otherwise pull the baseline
+    toward the bad state and suppress future alerts.
+
+    Returns ``None`` if fewer than ``min_entries`` usable entries
+    exist for the given campaign.
+    """
+    relevant = [
+        entry.metrics_at_action
+        for entry in action_log
+        if entry.campaign_id == campaign_id and entry.metrics_at_action is not None
+    ]
+    if len(relevant) < min_entries:
+        return None
+
+    def _median(key: str) -> float | None:
+        # Tolerate malformed entries (string-typed values, "N/A", empty strings)
+        # that can appear when action_log is loaded from JSON written by a
+        # platform with inconsistent typing. One bad row must not take out the
+        # whole baseline.
+        values: list[float] = []
+        for m in relevant:
+            raw = m.get(key)
+            if raw is None:
+                continue
+            try:
+                values.append(float(raw))
+            except (TypeError, ValueError):
+                continue
+        return statistics.median(values) if values else None
+
+    return CampaignMetrics(
+        campaign_id=campaign_id,
+        cost=_median("cost") or 0.0,
+        impressions=int(_median("impressions") or 0),
+        clicks=int(_median("clicks") or 0),
+        conversions=_median("conversions") or 0.0,
+        cpa=_median("cpa"),
+        ctr=_median("ctr"),
+    )

--- a/mureo/analysis/anomaly_detector.py
+++ b/mureo/analysis/anomaly_detector.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 import statistics
 from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -42,17 +42,21 @@ CTR_MIN_IMPRESSIONS = 1000
 
 
 class Severity(str, Enum):
-    """Ordered severity levels. ``str`` mixin makes JSON serialization trivial."""
+    """Ordered severity levels. ``str`` mixin makes JSON serialization trivial.
+
+    Only CRITICAL and HIGH are emitted today. A lower tier (e.g. MEDIUM
+    for mild deviations) can be added if a real use case appears —
+    adding it prematurely invites the sample-size noise this module is
+    designed to suppress.
+    """
 
     CRITICAL = "critical"
     HIGH = "high"
-    MEDIUM = "medium"
 
 
 _SEVERITY_ORDER: dict[Severity, int] = {
     Severity.CRITICAL: 0,
     Severity.HIGH: 1,
-    Severity.MEDIUM: 2,
 }
 
 
@@ -237,7 +241,7 @@ def baseline_from_history(
     campaign_id: str,
     action_log: Iterable[ActionLogEntry],
     *,
-    min_entries: int = 3,
+    min_entries: int = 7,
 ) -> CampaignMetrics | None:
     """Build a baseline by taking the median of historical ``metrics_at_action``.
 
@@ -245,8 +249,15 @@ def baseline_from_history(
     action during a CPA spike) would otherwise pull the baseline
     toward the bad state and suppress future alerts.
 
+    Ratio metrics (CPA, CTR) are computed **per entry first** and then
+    medianed, so the returned baseline CPA is a real median daily CPA
+    rather than ``median(cost) / median(conversions)`` — those two can
+    diverge on noisy days and mismatch the real historical reality.
+
     Returns ``None`` if fewer than ``min_entries`` usable entries
-    exist for the given campaign.
+    exist. Default is 7 (one week) — enough that median resists one
+    or two outlier days. Callers that deliberately want a tighter
+    window can pass a smaller ``min_entries``.
     """
     relevant = [
         entry.metrics_at_action
@@ -256,28 +267,54 @@ def baseline_from_history(
     if len(relevant) < min_entries:
         return None
 
-    def _median(key: str) -> float | None:
+    def _numeric(m: dict[str, Any], key: str) -> float | None:
         # Tolerate malformed entries (string-typed values, "N/A", empty strings)
         # that can appear when action_log is loaded from JSON written by a
         # platform with inconsistent typing. One bad row must not take out the
         # whole baseline.
-        values: list[float] = []
-        for m in relevant:
-            raw = m.get(key)
-            if raw is None:
-                continue
-            try:
-                values.append(float(raw))
-            except (TypeError, ValueError):
-                continue
+        raw = m.get(key)
+        if raw is None:
+            return None
+        try:
+            return float(raw)
+        except (TypeError, ValueError):
+            return None
+
+    def _median_of(values: list[float]) -> float | None:
         return statistics.median(values) if values else None
+
+    per_entry_cpas: list[float] = []
+    per_entry_ctrs: list[float] = []
+    for m in relevant:
+        cpa = _numeric(m, "cpa")
+        if cpa is None:
+            cost = _numeric(m, "cost")
+            conv = _numeric(m, "conversions")
+            if cost is not None and conv is not None and conv > 0:
+                cpa = cost / conv
+        if cpa is not None:
+            per_entry_cpas.append(cpa)
+
+        ctr = _numeric(m, "ctr")
+        if ctr is None:
+            clicks = _numeric(m, "clicks")
+            impressions = _numeric(m, "impressions")
+            if clicks is not None and impressions is not None and impressions > 0:
+                ctr = clicks / impressions
+        if ctr is not None:
+            per_entry_ctrs.append(ctr)
+
+    costs = [v for v in (_numeric(m, "cost") for m in relevant) if v is not None]
+    imps = [v for v in (_numeric(m, "impressions") for m in relevant) if v is not None]
+    clks = [v for v in (_numeric(m, "clicks") for m in relevant) if v is not None]
+    convs = [v for v in (_numeric(m, "conversions") for m in relevant) if v is not None]
 
     return CampaignMetrics(
         campaign_id=campaign_id,
-        cost=_median("cost") or 0.0,
-        impressions=int(_median("impressions") or 0),
-        clicks=int(_median("clicks") or 0),
-        conversions=_median("conversions") or 0.0,
-        cpa=_median("cpa"),
-        ctr=_median("ctr"),
+        cost=_median_of(costs) or 0.0,
+        impressions=int(_median_of(imps) or 0),
+        clicks=int(_median_of(clks) or 0),
+        conversions=_median_of(convs) or 0.0,
+        cpa=_median_of(per_entry_cpas),
+        ctr=_median_of(per_entry_ctrs),
     )

--- a/tests/test_anomaly_detector.py
+++ b/tests/test_anomaly_detector.py
@@ -1,0 +1,314 @@
+"""Anomaly detector tests.
+
+Pure detection functions: no I/O, no mocks. Exercises the three
+signals prioritized by the 2026-04 X research — zero spend, CPA
+spike, CTR drop — plus sample-size and severity rules.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mureo.analysis.anomaly_detector import (
+    CPA_MIN_CONVERSIONS,
+    CTR_MIN_IMPRESSIONS,
+    Anomaly,
+    CampaignMetrics,
+    Severity,
+    baseline_from_history,
+    detect_anomalies,
+)
+from mureo.context.models import ActionLogEntry
+
+
+def _metrics(
+    campaign_id: str = "123",
+    *,
+    cost: float = 10000,
+    impressions: int = 5000,
+    clicks: int = 200,
+    conversions: float = 50,
+    cpa: float | None = None,
+    ctr: float | None = None,
+) -> CampaignMetrics:
+    return CampaignMetrics(
+        campaign_id=campaign_id,
+        cost=cost,
+        impressions=impressions,
+        clicks=clicks,
+        conversions=conversions,
+        cpa=cpa,
+        ctr=ctr,
+    )
+
+
+@pytest.mark.unit
+class TestCampaignMetrics:
+    def test_derived_cpa(self) -> None:
+        m = _metrics(cost=1000, conversions=10)
+        assert m.derived_cpa() == 100
+
+    def test_derived_cpa_zero_conversions(self) -> None:
+        m = _metrics(cost=1000, conversions=0)
+        assert m.derived_cpa() is None
+
+    def test_derived_ctr(self) -> None:
+        m = _metrics(clicks=50, impressions=1000)
+        assert m.derived_ctr() == 0.05
+
+    def test_derived_ctr_zero_impressions(self) -> None:
+        m = _metrics(clicks=0, impressions=0)
+        assert m.derived_ctr() is None
+
+    def test_explicit_cpa_wins(self) -> None:
+        m = _metrics(cost=1000, conversions=10, cpa=200)
+        assert m.derived_cpa() == 200
+
+
+@pytest.mark.unit
+class TestZeroSpendDetection:
+    def test_zero_spend_with_prior_spend_flagged(self) -> None:
+        current = _metrics(cost=0, impressions=0, clicks=0, conversions=0)
+        baseline = _metrics(cost=10000, conversions=50)
+        anomalies = detect_anomalies(current, baseline, had_prior_spend=True)
+        zero_spend = [a for a in anomalies if a.metric == "cost"]
+        assert len(zero_spend) == 1
+        assert zero_spend[0].severity == Severity.CRITICAL
+
+    def test_zero_spend_without_prior_not_flagged(self) -> None:
+        current = _metrics(cost=0)
+        anomalies = detect_anomalies(current, None, had_prior_spend=False)
+        assert not any(a.metric == "cost" for a in anomalies)
+
+    def test_zero_spend_no_baseline_but_prior_flag_still_fires(self) -> None:
+        current = _metrics(cost=0)
+        anomalies = detect_anomalies(current, None, had_prior_spend=True)
+        assert any(a.metric == "cost" for a in anomalies)
+
+    def test_zero_spend_suppressed_when_baseline_also_zero(self) -> None:
+        # Paused campaign or weekend dayparting — the "zero now" state was
+        # already the historical norm, so alerting is noise.
+        current = _metrics(cost=0)
+        baseline = _metrics(cost=0, conversions=0)
+        anomalies = detect_anomalies(current, baseline, had_prior_spend=True)
+        assert not any(a.metric == "cost" for a in anomalies)
+
+
+@pytest.mark.unit
+class TestCPASpikeDetection:
+    def test_spike_above_threshold_flagged(self) -> None:
+        baseline = _metrics(cpa=1000)
+        current = _metrics(cost=80_000, conversions=40, cpa=2000)
+        anomalies = detect_anomalies(current, baseline)
+        cpa = [a for a in anomalies if a.metric == "cpa"]
+        assert len(cpa) == 1
+        assert cpa[0].current_value == 2000
+        assert cpa[0].baseline_value == 1000
+
+    def test_spike_under_sample_size_suppressed(self) -> None:
+        # Both current and baseline below threshold — no confidence either way.
+        baseline = _metrics(conversions=10, cpa=1000)
+        current = _metrics(cost=20_000, conversions=10, cpa=2000)
+        anomalies = detect_anomalies(current, baseline)
+        assert not any(a.metric == "cpa" for a in anomalies)
+        assert CPA_MIN_CONVERSIONS == 30
+
+    def test_spike_severity_scales(self) -> None:
+        baseline = _metrics(cpa=1000)
+        critical = detect_anomalies(_metrics(conversions=40, cpa=2500), baseline)
+        assert any(
+            a.metric == "cpa" and a.severity == Severity.CRITICAL for a in critical
+        )
+        high = detect_anomalies(_metrics(conversions=40, cpa=1600), baseline)
+        assert any(a.metric == "cpa" and a.severity == Severity.HIGH for a in high)
+
+    def test_spike_within_tolerance_not_flagged(self) -> None:
+        baseline = _metrics(cpa=1000)
+        current = _metrics(conversions=40, cpa=1100)
+        anomalies = detect_anomalies(current, baseline)
+        assert not any(a.metric == "cpa" for a in anomalies)
+
+    def test_baseline_conversions_count_toward_sample_size(self) -> None:
+        # Current conversions collapsed to 20, but baseline averaged 200/day.
+        # The spike is real — the sample-size gate should rely on baseline.
+        baseline = _metrics(conversions=200, cpa=1000)
+        current = _metrics(conversions=20, cpa=2500)
+        anomalies = detect_anomalies(current, baseline)
+        assert any(a.metric == "cpa" for a in anomalies)
+
+
+@pytest.mark.unit
+class TestCTRDropDetection:
+    def test_drop_below_threshold_flagged(self) -> None:
+        baseline = _metrics(ctr=0.04)
+        current = _metrics(impressions=10_000, clicks=100, ctr=0.01)
+        anomalies = detect_anomalies(current, baseline)
+        ctr = [a for a in anomalies if a.metric == "ctr"]
+        assert len(ctr) == 1
+        assert ctr[0].severity in (Severity.HIGH, Severity.CRITICAL)
+
+    def test_drop_under_sample_size_suppressed(self) -> None:
+        baseline = _metrics(impressions=500, ctr=0.04)
+        current = _metrics(impressions=500, clicks=5, ctr=0.01)
+        anomalies = detect_anomalies(current, baseline)
+        assert not any(a.metric == "ctr" for a in anomalies)
+        assert CTR_MIN_IMPRESSIONS == 1000
+
+    def test_drop_severity_scales(self) -> None:
+        baseline = _metrics(ctr=0.04)
+        critical = detect_anomalies(_metrics(impressions=10_000, ctr=0.01), baseline)
+        assert any(
+            a.metric == "ctr" and a.severity == Severity.CRITICAL for a in critical
+        )
+        high = detect_anomalies(_metrics(impressions=10_000, ctr=0.018), baseline)
+        assert any(a.metric == "ctr" and a.severity == Severity.HIGH for a in high)
+
+    def test_drop_within_tolerance_not_flagged(self) -> None:
+        baseline = _metrics(ctr=0.04)
+        current = _metrics(impressions=10_000, ctr=0.035)
+        anomalies = detect_anomalies(current, baseline)
+        assert not any(a.metric == "ctr" for a in anomalies)
+
+
+@pytest.mark.unit
+class TestAnomalyPrioritization:
+    def test_sorted_by_severity_critical_first(self) -> None:
+        baseline = _metrics(cpa=1000, ctr=0.04)
+        current = _metrics(impressions=10_000, conversions=40, cpa=2500, ctr=0.018)
+        anomalies = detect_anomalies(current, baseline)
+        assert len(anomalies) >= 2
+        assert anomalies[0].severity == Severity.CRITICAL
+
+    def test_no_anomalies_returns_empty_list(self) -> None:
+        baseline = _metrics(cpa=1000, ctr=0.04)
+        current = _metrics(conversions=40, cpa=1000, ctr=0.04)
+        assert detect_anomalies(current, baseline) == []
+
+
+@pytest.mark.unit
+class TestBaselineFromHistory:
+    def _log(self, ts: str, cpa: float, ctr: float = 0.03) -> ActionLogEntry:
+        return ActionLogEntry(
+            timestamp=ts,
+            action="update",
+            platform="google_ads",
+            campaign_id="123",
+            metrics_at_action={
+                "cpa": cpa,
+                "ctr": ctr,
+                "cost": 10_000,
+                "conversions": 50,
+                "impressions": 10_000,
+                "clicks": 300,
+            },
+        )
+
+    def test_median_of_history(self) -> None:
+        log = (
+            self._log("2026-04-01", 800),
+            self._log("2026-04-05", 1000),
+            self._log("2026-04-10", 1200),
+        )
+        baseline = baseline_from_history("123", log, min_entries=3)
+        assert baseline is not None
+        assert baseline.cpa == 1000
+
+    def test_filters_by_campaign_id(self) -> None:
+        other = ActionLogEntry(
+            timestamp="2026-04-01",
+            action="update",
+            platform="google_ads",
+            campaign_id="999",
+            metrics_at_action={"cpa": 99_999},
+        )
+        log = (
+            other,
+            self._log("2026-04-02", 1000),
+            self._log("2026-04-03", 1000),
+            self._log("2026-04-04", 1000),
+        )
+        baseline = baseline_from_history("123", log, min_entries=3)
+        assert baseline is not None
+        assert baseline.cpa == 1000
+
+    def test_insufficient_entries_returns_none(self) -> None:
+        log = (self._log("2026-04-01", 1000),)
+        assert baseline_from_history("123", log, min_entries=3) is None
+
+    def test_tolerates_string_values_from_json(self) -> None:
+        # action_log round-tripped through JSON may arrive with string numerics
+        # ("1000") or sentinels ("N/A"). One bad row must not take out the
+        # baseline.
+        bad = ActionLogEntry(
+            timestamp="2026-04-01",
+            action="update",
+            platform="google_ads",
+            campaign_id="123",
+            metrics_at_action={"cpa": "N/A", "ctr": 0.03},
+        )
+        log = (
+            bad,
+            self._log("2026-04-02", 1000),
+            self._log("2026-04-03", 1000),
+            self._log("2026-04-04", 1000),
+        )
+        baseline = baseline_from_history("123", log, min_entries=3)
+        assert baseline is not None
+        assert baseline.cpa == 1000
+
+    def test_accepts_string_numerics(self) -> None:
+        stringy = ActionLogEntry(
+            timestamp="2026-04-01",
+            action="update",
+            platform="google_ads",
+            campaign_id="123",
+            metrics_at_action={"cpa": "1500", "cost": "20000"},
+        )
+        log = (
+            stringy,
+            self._log("2026-04-02", 1000),
+            self._log("2026-04-03", 1000),
+        )
+        baseline = baseline_from_history("123", log, min_entries=3)
+        assert baseline is not None
+        assert baseline.cpa == 1000  # median of [1000, 1000, 1500]
+
+    def test_ignores_entries_without_metrics(self) -> None:
+        no_metrics = ActionLogEntry(
+            timestamp="2026-04-01",
+            action="update",
+            platform="google_ads",
+            campaign_id="123",
+        )
+        log = (
+            no_metrics,
+            self._log("2026-04-02", 1000),
+            self._log("2026-04-03", 1100),
+            self._log("2026-04-04", 900),
+        )
+        baseline = baseline_from_history("123", log, min_entries=3)
+        assert baseline is not None
+        assert baseline.cpa == 1000
+
+
+@pytest.mark.unit
+class TestAnomalyFields:
+    def test_anomaly_is_frozen_dataclass(self) -> None:
+        a = Anomaly(
+            campaign_id="123",
+            metric="cpa",
+            severity=Severity.HIGH,
+            current_value=2000.0,
+            baseline_value=1000.0,
+            deviation_pct=1.0,
+            sample_size=40,
+            message="CPA has spiked 100% above baseline.",
+            recommended_action="Pause high-CPA keywords or review bids.",
+        )
+        with pytest.raises(AttributeError):
+            a.severity = Severity.CRITICAL  # type: ignore[misc]
+
+    def test_severity_values_stable(self) -> None:
+        assert Severity.CRITICAL.value == "critical"
+        assert Severity.HIGH.value == "high"
+        assert Severity.MEDIUM.value == "medium"

--- a/tests/test_anomaly_detector.py
+++ b/tests/test_anomaly_detector.py
@@ -235,6 +235,33 @@ class TestBaselineFromHistory:
         log = (self._log("2026-04-01", 1000),)
         assert baseline_from_history("123", log, min_entries=3) is None
 
+    def test_default_min_entries_is_week(self) -> None:
+        # Six days of history is not enough for the default; caller must opt
+        # into a tighter window explicitly.
+        log = tuple(self._log(f"2026-04-0{i}", 1000) for i in range(1, 7))
+        assert baseline_from_history("123", log) is None
+        log_week = tuple(self._log(f"2026-04-0{i}", 1000) for i in range(1, 8))
+        assert baseline_from_history("123", log_week) is not None
+
+    def test_cpa_medianed_per_entry_not_from_mixed_medians(self) -> None:
+        # Entries are constructed so that median(cost)/median(conv) differs
+        # from median of per-entry CPAs. Per-entry is the honest answer.
+        def _e(cost: float, conv: float) -> ActionLogEntry:
+            return ActionLogEntry(
+                timestamp="2026-04-01",
+                action="update",
+                platform="google_ads",
+                campaign_id="123",
+                metrics_at_action={"cost": cost, "conversions": conv},
+            )
+
+        # per-entry CPAs: 10, 50, 1 → median = 10
+        # independently: median(cost)=100, median(conv)=20 → 100/20 = 5
+        log = (_e(100, 10), _e(1000, 20), _e(20, 20))
+        baseline = baseline_from_history("123", log, min_entries=3)
+        assert baseline is not None
+        assert baseline.cpa == 10
+
     def test_tolerates_string_values_from_json(self) -> None:
         # action_log round-tripped through JSON may arrive with string numerics
         # ("1000") or sentinels ("N/A"). One bad row must not take out the
@@ -309,6 +336,8 @@ class TestAnomalyFields:
             a.severity = Severity.CRITICAL  # type: ignore[misc]
 
     def test_severity_values_stable(self) -> None:
+        # Only CRITICAL and HIGH are emitted today. MEDIUM was removed from
+        # the enum to avoid dead API surface.
         assert Severity.CRITICAL.value == "critical"
         assert Severity.HIGH.value == "high"
-        assert Severity.MEDIUM.value == "medium"
+        assert not hasattr(Severity, "MEDIUM")


### PR DESCRIPTION
## Summary

Task #24: Core anomaly detection module (`mureo/analysis/anomaly_detector.py`). Pure, I/O-free — given a `CampaignMetrics` snapshot and a baseline, returns a prioritized list of `Anomaly` objects with recommended actions.

### Signals (from 2026-04 X research demand)
- **Zero spend** on a previously-spending campaign → CRITICAL (suppressed when baseline is also zero to avoid crying wolf on paused campaigns)
- **CPA spike** ≥ 1.5× baseline (critical at 2×), gated by 30+ conversions
- **CTR drop** ≤ 0.5× baseline (critical at 0.3×), gated by 1000+ impressions

### Design notes
- Sample-size gate uses `max(current, baseline)` so a real spike from a high-volume campaign is caught even when today's activity collapses.
- Baseline uses median (not mean) to resist single-day outliers pulling the reference toward a bad state.
- `baseline_from_history` tolerates string-typed / malformed `metrics_at_action` values (a single bad row no longer kills the baseline).
- No CLI or MCP integration in this PR — follow-ups wire into `/daily-check`, `/rescue`, etc.

### Code review outcomes
Independent review flagged HIGH issues (string JSON crash, false-positive zero-spend on paused campaigns) and MEDIUM issues (sample-size gate, fractional-conversion truncation). All addressed before this PR.

## Test plan
- [x] `pytest tests/test_anomaly_detector.py` — 28 unit tests passing
- [x] Full suite green (`pytest tests/` — 1568 passed)
- [x] `ruff check` / `black` clean
- [ ] CI (GitHub Actions) green on 3.10/3.11/3.12
- [ ] Follow-up PR wires detector into commands + MCP handlers
