### PR TITLE
feat: Add rollback data model and planner (allow-list gated)

### DIFF
--- a/mureo/context/models.py
+++ b/mureo/context/models.py
@@ -54,6 +54,16 @@ class ActionLogEntry:
         Used by the agent to evaluate the outcome of the action after the observation window.
     observation_due: ISO 8601 date when the agent should evaluate the outcome (e.g., "2026-04-15").
         Typical windows: budget changes 7 days, keyword/creative changes 14 days.
+    reversible_params: Structured hint describing how to reverse this action. Shape:
+        ``{"operation": "<tool_name>", "params": {...}, "caveats": [...]}``.
+        Agents set this when making reversible changes (budget update, status toggle,
+        etc.) so ``mureo.rollback.plan_rollback()`` can build a concrete reversal plan.
+        ``None`` means the action was not marked reversible (read-only query, create,
+        delete, or simply not annotated). The ``operation`` value must be in the
+        rollback planner's allow-list (see ``mureo.rollback.planner._ALLOWED_OPERATIONS``);
+        values outside it — including destructive verbs like ``.delete`` — are refused
+        so a prompt-injected or buggy agent cannot smuggle a privileged call through
+        the rollback path.
     """
 
     timestamp: str
@@ -64,12 +74,17 @@ class ActionLogEntry:
     command: str | None = None
     metrics_at_action: dict[str, Any] | None = None
     observation_due: str | None = None
+    reversible_params: dict[str, Any] | None = None
 
     def __post_init__(self) -> None:
-        """Take defensive copy of mutable metrics_at_action dict."""
+        """Take defensive copies of mutable dict fields."""
         if self.metrics_at_action is not None:
             object.__setattr__(
                 self, "metrics_at_action", copy.deepcopy(self.metrics_at_action)
+            )
+        if self.reversible_params is not None:
+            object.__setattr__(
+                self, "reversible_params", copy.deepcopy(self.reversible_params)
             )
 
 

--- a/mureo/context/state.py
+++ b/mureo/context/state.py
@@ -73,6 +73,7 @@ def _parse_action_log_entry(e: dict[str, Any]) -> ActionLogEntry:
         command=e.get("command"),
         metrics_at_action=e.get("metrics_at_action"),
         observation_due=e.get("observation_due"),
+        reversible_params=e.get("reversible_params"),
     )
 
 
@@ -146,6 +147,8 @@ def _action_log_entry_to_dict(e: ActionLogEntry) -> dict[str, Any]:
         result["metrics_at_action"] = copy.deepcopy(e.metrics_at_action)
     if e.observation_due is not None:
         result["observation_due"] = e.observation_due
+    if e.reversible_params is not None:
+        result["reversible_params"] = copy.deepcopy(e.reversible_params)
     return result
 
 

--- a/mureo/rollback/__init__.py
+++ b/mureo/rollback/__init__.py
@@ -1,0 +1,18 @@
+"""Rollback planner for mureo actions.
+
+Given an :class:`ActionLogEntry` written by an AI agent with a
+``reversible_params`` hint, produce a concrete :class:`RollbackPlan`
+that describes which MCP tool to invoke (and with what arguments) to
+reverse the change.
+
+This package is the *data-model and planning* half of the rollback
+feature. Actual execution — turning a plan into a live API call —
+is a separate concern that lives with the MCP dispatcher.
+"""
+
+from __future__ import annotations
+
+from mureo.rollback.models import RollbackPlan, RollbackStatus
+from mureo.rollback.planner import plan_rollback
+
+__all__ = ["RollbackPlan", "RollbackStatus", "plan_rollback"]

--- a/mureo/rollback/models.py
+++ b/mureo/rollback/models.py
@@ -1,0 +1,58 @@
+"""Immutable data models for the rollback planner."""
+
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+
+class RollbackStatus(str, Enum):
+    """Outcome of a rollback planning attempt.
+
+    ``str`` mixin keeps JSON serialization trivial.
+    """
+
+    SUPPORTED = "supported"
+    """Rollback is clean: replaying ``operation(**params)`` restores the
+    prior state."""
+
+    PARTIAL = "partial"
+    """Rollback reverses the configuration change but side effects (spend
+    that was already incurred, impressions served, etc.) cannot be
+    undone. ``caveats`` explains what remains irreversible."""
+
+    NOT_SUPPORTED = "not_supported"
+    """Rollback cannot be attempted — the source action was destructive
+    (delete), carries no reversible hint, or the hint was malformed.
+    ``operation`` and ``params`` are ``None`` in this case."""
+
+
+@dataclass(frozen=True)
+class RollbackPlan:
+    """Concrete plan describing how to reverse one ``ActionLogEntry``.
+
+    The plan is data, not execution. Executing it means invoking the
+    MCP tool named in ``operation`` with ``params`` as kwargs — that
+    responsibility sits with the caller.
+
+    ``frozen=True`` blocks attribute reassignment but does not freeze
+    dict contents, so ``__post_init__`` takes a defensive deep-copy of
+    ``params`` to ensure a caller mutating the dict afterwards cannot
+    corrupt the stored plan.
+    """
+
+    source_timestamp: str
+    source_action: str
+    platform: str
+    status: RollbackStatus
+    operation: str | None
+    params: dict[str, Any] | None
+    description: str
+    caveats: tuple[str, ...] = ()
+    notes: str = ""
+
+    def __post_init__(self) -> None:
+        if self.params is not None:
+            object.__setattr__(self, "params", copy.deepcopy(self.params))

--- a/mureo/rollback/planner.py
+++ b/mureo/rollback/planner.py
@@ -1,0 +1,181 @@
+"""Plan a rollback from an :class:`ActionLogEntry`.
+
+Contract:
+- Read-only actions (``list_*``, ``get_*``, ``analyze_*``, etc.)
+  return ``None``. Nothing to reverse.
+- Write actions without a ``reversible_params`` hint return a plan
+  with :data:`RollbackStatus.NOT_SUPPORTED`, so the caller can surface
+  *why* no rollback is possible.
+- Write actions with a well-formed hint return a plan the caller can
+  execute by invoking ``plan.operation`` with ``plan.params``.
+- Hints carrying ``caveats`` are treated as :data:`RollbackStatus.PARTIAL`
+  — the configuration change can be undone but its side effects (spend,
+  impressions served) cannot.
+
+**Trust model.** ``reversible_params`` is authored by the same agent
+that performed the original action, and is therefore untrusted input
+for the rollback executor: a compromised or prompt-injected agent
+could otherwise log a "reversal" that points to a destructive
+operation. This module enforces that only operations explicitly
+listed in :data:`_ALLOWED_OPERATIONS` are planned, and that each plan
+carries only the keys that operation declares. Executors (Task #26)
+must still re-authorize against the same policy gate used for forward
+actions.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import TYPE_CHECKING, Any
+
+from mureo.rollback.models import RollbackPlan, RollbackStatus
+
+if TYPE_CHECKING:
+    from mureo.context.models import ActionLogEntry
+
+# Operation name → frozenset of allowed parameter keys. Only non-destructive,
+# idempotent reversals are listed. Deletion/removal operations are
+# deliberately absent so an agent cannot log a "reversal" that drops a
+# campaign, keyword, or asset. Add entries as new reversible flows land.
+_ALLOWED_OPERATIONS: dict[str, frozenset[str]] = {
+    "google_ads.budgets.update": frozenset({"budget_id", "amount_micros"}),
+    "google_ads.campaigns.update_status": frozenset({"campaign_id", "status"}),
+    "google_ads.ad_groups.update_status": frozenset({"ad_group_id", "status"}),
+    "google_ads.ads.update_status": frozenset({"ad_group_id", "ad_id", "status"}),
+    "meta_ads.campaigns.update_status": frozenset({"campaign_id", "status"}),
+    "meta_ads.ad_sets.update_status": frozenset({"ad_set_id", "status"}),
+    "meta_ads.ads.update_status": frozenset({"ad_id", "status"}),
+}
+
+_DESTRUCTIVE_VERBS: tuple[str, ...] = (
+    ".delete",
+    ".remove",
+    ".destroy",
+    ".purge",
+    ".transfer",
+)
+
+_READ_ONLY_PREFIXES: tuple[str, ...] = (
+    "list_",
+    "get_",
+    "analyze_",
+    "diagnose_",
+    "inspect_",
+    "report_",
+    "check_",
+    "search_",
+)
+
+
+def plan_rollback(entry: ActionLogEntry) -> RollbackPlan | None:
+    """Build a :class:`RollbackPlan` for one action log entry.
+
+    Returns ``None`` for read-only actions (no state change to undo).
+    Returns a plan with :data:`RollbackStatus.NOT_SUPPORTED` when the
+    entry is a write but carries no usable ``reversible_params`` hint.
+    """
+    if _is_read_only(entry.action):
+        if entry.reversible_params is not None:
+            # Read-only action should never carry a reversible hint; this is
+            # almost certainly an agent bug worth surfacing.
+            return _not_supported(
+                entry,
+                notes=(
+                    "Read-only action carried a reversible_params hint; "
+                    "this is likely an agent bug."
+                ),
+            )
+        return None
+
+    hint = entry.reversible_params
+    if hint is None:
+        return _not_supported(
+            entry,
+            notes=(
+                "Source action has no reversible_params hint. "
+                "Agents must set reversible_params at write time to enable rollback."
+            ),
+        )
+
+    operation = hint.get("operation")
+    params = hint.get("params")
+    if not isinstance(operation, str) or not operation:
+        return _not_supported(
+            entry,
+            notes="reversible_params is missing a string 'operation' key.",
+        )
+    if not isinstance(params, dict):
+        return _not_supported(
+            entry,
+            notes="reversible_params is missing a dict 'params' key.",
+        )
+
+    if any(verb in operation for verb in _DESTRUCTIVE_VERBS):
+        return _not_supported(
+            entry,
+            notes=(
+                f"Operation {operation!r} names a destructive verb "
+                "and cannot be planned as a rollback."
+            ),
+        )
+    allowed_keys = _ALLOWED_OPERATIONS.get(operation)
+    if allowed_keys is None:
+        return _not_supported(
+            entry,
+            notes=(f"Operation {operation!r} is not in the rollback allow-list."),
+        )
+    extra = set(params) - allowed_keys
+    if extra:
+        return _not_supported(
+            entry,
+            notes=(
+                f"Operation {operation!r} received unexpected params: "
+                f"{sorted(extra)}."
+            ),
+        )
+
+    raw_caveats = hint.get("caveats")
+    if raw_caveats is not None and not isinstance(raw_caveats, list):
+        return _not_supported(
+            entry,
+            notes="reversible_params.caveats must be a list of strings.",
+        )
+    caveats = _extract_caveats(raw_caveats)
+    status = RollbackStatus.PARTIAL if caveats else RollbackStatus.SUPPORTED
+
+    return RollbackPlan(
+        source_timestamp=entry.timestamp,
+        source_action=entry.action,
+        platform=entry.platform,
+        status=status,
+        operation=operation,
+        params=copy.deepcopy(params),
+        description=f"Reverse {entry.action} on {entry.platform}",
+        caveats=caveats,
+        notes="",
+    )
+
+
+def _is_read_only(action: str) -> bool:
+    lowered = action.lower()
+    return any(lowered.startswith(prefix) for prefix in _READ_ONLY_PREFIXES)
+
+
+def _not_supported(entry: ActionLogEntry, *, notes: str) -> RollbackPlan:
+    return RollbackPlan(
+        source_timestamp=entry.timestamp,
+        source_action=entry.action,
+        platform=entry.platform,
+        status=RollbackStatus.NOT_SUPPORTED,
+        operation=None,
+        params=None,
+        description=f"Cannot roll back {entry.action} on {entry.platform}",
+        caveats=(),
+        notes=notes,
+    )
+
+
+def _extract_caveats(raw: Any) -> tuple[str, ...]:
+    if not isinstance(raw, list):
+        return ()
+    return tuple(item for item in raw if isinstance(item, str) and item)

--- a/tests/test_rollback.py
+++ b/tests/test_rollback.py
@@ -1,0 +1,232 @@
+"""Rollback planner tests.
+
+Pure, I/O-free. Exercises plan generation from ActionLogEntry
+reversible_params hints across supported, partial, and
+not-supported action types.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mureo.context.models import ActionLogEntry
+from mureo.rollback import (
+    RollbackPlan,
+    RollbackStatus,
+    plan_rollback,
+)
+
+
+def _entry(
+    *,
+    action: str = "update_budget",
+    platform: str = "google_ads",
+    reversible_params: dict | None = None,
+    campaign_id: str | None = "123",
+    timestamp: str = "2026-04-15T10:00:00",
+) -> ActionLogEntry:
+    return ActionLogEntry(
+        timestamp=timestamp,
+        action=action,
+        platform=platform,
+        campaign_id=campaign_id,
+        reversible_params=reversible_params,
+    )
+
+
+@pytest.mark.unit
+class TestReversibleHintPresent:
+    def test_supported_budget_update(self) -> None:
+        entry = _entry(
+            reversible_params={
+                "operation": "google_ads.budgets.update",
+                "params": {"budget_id": "456", "amount_micros": 10_000_000_000},
+            }
+        )
+        plan = plan_rollback(entry)
+        assert plan is not None
+        assert plan.status == RollbackStatus.SUPPORTED
+        assert plan.operation == "google_ads.budgets.update"
+        assert plan.params == {"budget_id": "456", "amount_micros": 10_000_000_000}
+        assert plan.source_timestamp == "2026-04-15T10:00:00"
+        assert plan.platform == "google_ads"
+
+    def test_caveats_promote_status_to_partial(self) -> None:
+        entry = _entry(
+            reversible_params={
+                "operation": "meta_ads.campaigns.update_status",
+                "params": {"campaign_id": "abc", "status": "ACTIVE"},
+                "caveats": ["Paused spend is not refundable."],
+            }
+        )
+        plan = plan_rollback(entry)
+        assert plan is not None
+        assert plan.status == RollbackStatus.PARTIAL
+        assert "Paused spend is not refundable." in plan.caveats
+
+    def test_description_includes_action_name(self) -> None:
+        entry = _entry(
+            action="update_budget",
+            reversible_params={
+                "operation": "google_ads.budgets.update",
+                "params": {"budget_id": "456", "amount_micros": 10_000_000_000},
+            },
+        )
+        plan = plan_rollback(entry)
+        assert plan is not None
+        assert "update_budget" in plan.description
+
+
+@pytest.mark.unit
+class TestNotReversible:
+    def test_missing_hint_on_write_action_returns_not_supported(self) -> None:
+        entry = _entry(action="update_budget", reversible_params=None)
+        plan = plan_rollback(entry)
+        assert plan is not None
+        assert plan.status == RollbackStatus.NOT_SUPPORTED
+        assert plan.operation is None
+        assert plan.params is None
+
+    def test_read_only_action_returns_none(self) -> None:
+        # A pure query (e.g., daily-check) has no state change to reverse.
+        entry = _entry(action="list_campaigns", reversible_params=None)
+        plan = plan_rollback(entry)
+        assert plan is None
+
+    def test_hint_missing_operation_key_is_rejected(self) -> None:
+        entry = _entry(reversible_params={"params": {"budget_id": "456"}})
+        plan = plan_rollback(entry)
+        assert plan is not None
+        assert plan.status == RollbackStatus.NOT_SUPPORTED
+        assert "operation" in plan.notes.lower()
+
+    def test_hint_missing_params_key_is_rejected(self) -> None:
+        entry = _entry(reversible_params={"operation": "google_ads.budgets.update"})
+        plan = plan_rollback(entry)
+        assert plan is not None
+        assert plan.status == RollbackStatus.NOT_SUPPORTED
+
+    def test_operation_not_in_allowlist_rejected(self) -> None:
+        entry = _entry(
+            reversible_params={
+                "operation": "google_ads.something.exotic",
+                "params": {"id": "1"},
+            }
+        )
+        plan = plan_rollback(entry)
+        assert plan is not None
+        assert plan.status == RollbackStatus.NOT_SUPPORTED
+        assert "allow-list" in plan.notes
+
+    def test_destructive_operation_rejected(self) -> None:
+        # Even if we added a ".delete" operation to the allow-list by mistake,
+        # the destructive-verb guard is a second line of defense.
+        entry = _entry(
+            reversible_params={
+                "operation": "google_ads.campaigns.delete",
+                "params": {"campaign_id": "1"},
+            }
+        )
+        plan = plan_rollback(entry)
+        assert plan is not None
+        assert plan.status == RollbackStatus.NOT_SUPPORTED
+        assert "destructive" in plan.notes
+
+    def test_params_with_extra_keys_rejected(self) -> None:
+        entry = _entry(
+            reversible_params={
+                "operation": "google_ads.budgets.update",
+                # login_customer_id would let an agent pivot to another account.
+                "params": {
+                    "budget_id": "456",
+                    "amount_micros": 1,
+                    "login_customer_id": "999",
+                },
+            }
+        )
+        plan = plan_rollback(entry)
+        assert plan is not None
+        assert plan.status == RollbackStatus.NOT_SUPPORTED
+        assert "login_customer_id" in plan.notes
+
+    def test_caveats_not_a_list_rejected(self) -> None:
+        entry = _entry(
+            reversible_params={
+                "operation": "google_ads.budgets.update",
+                "params": {"budget_id": "456", "amount_micros": 1},
+                "caveats": "just a string",
+            }
+        )
+        plan = plan_rollback(entry)
+        assert plan is not None
+        assert plan.status == RollbackStatus.NOT_SUPPORTED
+        assert "caveats" in plan.notes
+
+    def test_read_only_action_with_hint_is_flagged_as_bug(self) -> None:
+        entry = _entry(
+            action="list_campaigns",
+            reversible_params={
+                "operation": "google_ads.budgets.update",
+                "params": {"budget_id": "456", "amount_micros": 1},
+            },
+        )
+        plan = plan_rollback(entry)
+        assert plan is not None
+        assert plan.status == RollbackStatus.NOT_SUPPORTED
+        assert "agent bug" in plan.notes.lower()
+
+
+@pytest.mark.unit
+class TestRollbackPlanImmutability:
+    def test_frozen(self) -> None:
+        plan = RollbackPlan(
+            source_timestamp="2026-04-15T10:00:00",
+            source_action="update_budget",
+            platform="google_ads",
+            status=RollbackStatus.SUPPORTED,
+            operation="google_ads.budgets.update",
+            params={"budget_id": "456"},
+            description="Reverse update_budget",
+            caveats=(),
+            notes="",
+        )
+        with pytest.raises(AttributeError):
+            plan.status = RollbackStatus.NOT_SUPPORTED  # type: ignore[misc]
+
+    def test_params_defensive_copy(self) -> None:
+        src = {"budget_id": "456", "amount_micros": 10_000_000_000}
+        entry = _entry(
+            reversible_params={
+                "operation": "google_ads.budgets.update",
+                "params": src,
+            }
+        )
+        plan = plan_rollback(entry)
+        assert plan is not None
+        assert plan.params is not None
+        assert plan.params is not src
+
+    def test_post_construction_mutation_does_not_affect_stored_plan(self) -> None:
+        # Directly constructing a plan should also snapshot params, so a caller
+        # mutating the dict they passed in cannot corrupt the stored plan.
+        params = {"budget_id": "456", "amount_micros": 1}
+        plan = RollbackPlan(
+            source_timestamp="t",
+            source_action="update_budget",
+            platform="google_ads",
+            status=RollbackStatus.SUPPORTED,
+            operation="google_ads.budgets.update",
+            params=params,
+            description="x",
+        )
+        params["amount_micros"] = 999
+        assert plan.params is not None
+        assert plan.params["amount_micros"] == 1
+
+
+@pytest.mark.unit
+class TestStatusValues:
+    def test_enum_values_stable(self) -> None:
+        assert RollbackStatus.SUPPORTED.value == "supported"
+        assert RollbackStatus.PARTIAL.value == "partial"
+        assert RollbackStatus.NOT_SUPPORTED.value == "not_supported"

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -639,6 +639,45 @@ class TestParseStateV2:
         assert reparsed.action_log[0].observation_due == "2026-04-08"
 
     @pytest.mark.unit
+    def test_render_action_log_with_reversible_params_roundtrip(self) -> None:
+        """Render and re-parse action_log carrying reversible_params."""
+        hint = {
+            "operation": "google_ads.budgets.update",
+            "params": {"budget_id": "456", "amount_micros": 10_000_000_000},
+            "caveats": ["does not refund already-spent budget"],
+        }
+        doc = StateDocument(
+            version="2",
+            action_log=(
+                ActionLogEntry(
+                    timestamp="2026-04-15T10:00:00",
+                    action="update_budget",
+                    platform="google_ads",
+                    reversible_params=hint,
+                ),
+            ),
+        )
+        rendered = render_state(doc)
+        reparsed = parse_state(rendered)
+        assert reparsed.action_log[0].reversible_params == hint
+
+    @pytest.mark.unit
+    def test_render_action_log_omits_none_reversible_params(self) -> None:
+        """reversible_params is omitted from JSON when None."""
+        doc = StateDocument(
+            version="2",
+            action_log=(
+                ActionLogEntry(
+                    timestamp="t",
+                    action="update_budget",
+                    platform="google_ads",
+                ),
+            ),
+        )
+        rendered = render_state(doc)
+        assert "reversible_params" not in rendered
+
+    @pytest.mark.unit
     def test_render_action_log_omits_none_metrics(self) -> None:
         """Render omits metrics_at_action and observation_due when None."""
         doc = StateDocument(


### PR DESCRIPTION
## Summary

Task #25: data-model and planning half of the rollback feature. Execution lands as Task #26 in a separate PR.

### Design
- `ActionLogEntry` gains an optional `reversible_params` field (backward compatible). Agents set it at write time when they make reversible changes.
- New `mureo/rollback/` package with `RollbackStatus` enum, `RollbackPlan` frozen dataclass, and `plan_rollback(entry) -> RollbackPlan | None`.
- `STATE.json` round-trips the new field (omitted when None, deep-copied on read/write).

### Threat model
`reversible_params` is agent-authored; a compromised or prompt-injected agent could otherwise log a fake "reversal" pointing to a destructive tool. The planner enforces:
1. `operation` must be in an explicit allow-list (budget update + status toggles across Google/Meta Ads).
2. Destructive verbs (`.delete` / `.remove` / `.destroy` / `.purge` / `.transfer`) are refused even if lexically matched.
3. `params` keys must be a subset of the per-operation allowed key set — e.g. a budget update cannot smuggle `login_customer_id`.
4. `caveats` must be a list of strings; malformed shapes are rejected, not silently dropped.

### Code review outcomes
Independent review flagged HIGH on two items, both fixed before this PR: the `operation` allow-list and per-operation param-key gating. MEDIUM fixes bundled in: post-construction immutability on `RollbackPlan`, read-only-with-hint detection, strict caveats validation, `str()` coercion removed. Documented LOW items (localization, operation-naming convention, idempotency key) for Task #26 to resolve.

## Test plan

- [x] `pytest tests/test_rollback.py` — 21 unit tests
- [x] `pytest tests/test_state.py` — new round-trip tests for `reversible_params`
- [x] Full suite green (1588 passed)
- [x] `ruff check` / `black` clean
- [ ] CI green on 3.10/3.11/3.12
- [ ] Task #26 (CLI / executor) in follow-up PR
