### PR TITLE
feat: Add mureo rollback list/show inspection commands

### DIFF
--- a/mureo/cli/main.py
+++ b/mureo/cli/main.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import typer
 
 from mureo.cli.auth_cmd import auth_app
+from mureo.cli.rollback_cmd import rollback_app
 from mureo.cli.setup_cmd import setup_app
 
 app = typer.Typer(
@@ -19,6 +20,7 @@ app = typer.Typer(
 
 app.add_typer(auth_app)
 app.add_typer(setup_app)
+app.add_typer(rollback_app)
 
 if __name__ == "__main__":
     app()

--- a/mureo/cli/rollback_cmd.py
+++ b/mureo/cli/rollback_cmd.py
@@ -1,0 +1,154 @@
+"""Rollback inspection commands.
+
+``mureo rollback list`` — list every action_log entry that describes a
+state-changing action and the planner's verdict on reversing it.
+``mureo rollback show <index>`` — print the full :class:`RollbackPlan`
+for one entry.
+
+This module is inspection-only. It does **not** call any ad platform
+API — executing a plan lives with the MCP dispatcher so rollback goes
+through the same policy gate as forward actions. The CLI's job is to
+let an operator see, before executing anything, what mureo would do.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import typer
+
+from mureo.context.errors import ContextFileError
+from mureo.context.state import read_state_file
+from mureo.rollback import RollbackPlan, plan_rollback
+
+rollback_app = typer.Typer(name="rollback", help="Inspect reversible actions")
+
+# STATE.json is agent-writable, so any string field it contributes to terminal
+# output is attacker-influenceable. Strip C0/C1 control bytes (including ANSI
+# escape, BEL, CR, and newline) before echo to prevent an agent from clearing
+# the screen, spoofing prompts, or corrupting the column layout of the list
+# view.
+_CONTROL_CHARS = re.compile(r"[\x00-\x08\x0a-\x1f\x7f-\x9f]")
+
+
+def _safe(value: str) -> str:
+    """Return ``value`` with control characters replaced by ``?``."""
+    return _CONTROL_CHARS.sub("?", value)
+
+
+_STATE_FILE_OPTION = typer.Option(
+    Path("STATE.json"),
+    "--state-file",
+    help="Path to the STATE.json file to inspect.",
+)
+
+
+def _load_plans(
+    state_file: Path,
+    *,
+    platform: str | None = None,
+) -> list[tuple[int, RollbackPlan]]:
+    """Load STATE.json and return (index, plan) pairs for write actions.
+
+    Read-only actions (``plan_rollback`` returns ``None``) are filtered
+    out. The index is the position in ``doc.action_log`` so callers can
+    reference entries by number.
+    """
+    if not state_file.exists():
+        typer.echo(f"Error: STATE.json not found at {state_file}", err=True)
+        raise typer.Exit(1)
+
+    try:
+        doc = read_state_file(state_file)
+    except ContextFileError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(1) from exc
+
+    plans: list[tuple[int, RollbackPlan]] = []
+    for index, entry in enumerate(doc.action_log):
+        if platform is not None and entry.platform != platform:
+            continue
+        plan = plan_rollback(entry)
+        if plan is None:
+            continue
+        plans.append((index, plan))
+    return plans
+
+
+@rollback_app.command("list")  # type: ignore[untyped-decorator, unused-ignore]
+def rollback_list(
+    state_file: Path = _STATE_FILE_OPTION,
+    platform: str | None = typer.Option(
+        None,
+        "--platform",
+        help="Filter to one platform (e.g. google_ads, meta_ads).",
+    ),
+) -> None:
+    """List action_log entries and whether they can be rolled back."""
+    plans = _load_plans(state_file, platform=platform)
+    if not plans:
+        typer.echo("No reversible actions recorded in the action log.")
+        return
+
+    typer.echo(f"{'#':>3}  {'timestamp':19}  {'platform':10}  {'status':14}  action")
+    typer.echo("-" * 72)
+    for index, plan in plans:
+        caveat_marker = "*" if plan.caveats else " "
+        typer.echo(
+            f"{index:>3}  {_safe(plan.source_timestamp):19}  "
+            f"{_safe(plan.platform):10}  {plan.status.value:14}{caveat_marker} "
+            f"{_safe(plan.source_action)}"
+        )
+    if any(p.caveats for _, p in plans):
+        typer.echo("")
+        typer.echo("(*) Has caveats — run `mureo rollback show <#>` for detail.")
+
+
+@rollback_app.command("show")  # type: ignore[untyped-decorator, unused-ignore]
+def rollback_show(
+    index: int = typer.Argument(..., help="Index into STATE.json action_log.", min=0),
+    state_file: Path = _STATE_FILE_OPTION,
+) -> None:
+    """Show the full rollback plan for one action_log entry."""
+    if not state_file.exists():
+        typer.echo(f"Error: STATE.json not found at {state_file}", err=True)
+        raise typer.Exit(1)
+
+    try:
+        doc = read_state_file(state_file)
+    except ContextFileError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(1) from exc
+
+    if index < 0 or index >= len(doc.action_log):
+        typer.echo(
+            f"Error: index {index} is out of range "
+            f"(action_log has {len(doc.action_log)} entries).",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    entry = doc.action_log[index]
+    plan = plan_rollback(entry)
+    if plan is None:
+        typer.echo(
+            f"Entry #{index} ({_safe(entry.action)}) is read-only — "
+            "nothing to roll back."
+        )
+        return
+
+    payload = {
+        "index": index,
+        "source_timestamp": plan.source_timestamp,
+        "source_action": plan.source_action,
+        "platform": plan.platform,
+        "status": plan.status.value,
+        "description": plan.description,
+        "operation": plan.operation,
+        "params": plan.params,
+        "caveats": list(plan.caveats),
+        "notes": plan.notes,
+    }
+    typer.echo(json.dumps(payload, ensure_ascii=False, indent=2))

--- a/tests/test_cli_rollback.py
+++ b/tests/test_cli_rollback.py
@@ -1,0 +1,196 @@
+"""Rollback CLI tests.
+
+Exercises ``mureo rollback list`` and ``mureo rollback show`` against
+a temp STATE.json written with real action_log entries.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from typer.testing import CliRunner
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+runner = CliRunner()
+
+
+def _make_state(path: Path, action_log: list[dict[str, Any]]) -> None:
+    path.write_text(
+        json.dumps({"version": "2", "campaigns": [], "action_log": action_log}),
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture()
+def state_file(tmp_path: Path) -> Path:
+    state = tmp_path / "STATE.json"
+    _make_state(
+        state,
+        [
+            {
+                "timestamp": "2026-04-15T10:00:00",
+                "action": "update_budget",
+                "platform": "google_ads",
+                "campaign_id": "111",
+                "summary": "Reduced daily budget",
+                "reversible_params": {
+                    "operation": "google_ads.budgets.update",
+                    "params": {"budget_id": "222", "amount_micros": 10_000_000_000},
+                },
+            },
+            {
+                "timestamp": "2026-04-14T09:00:00",
+                "action": "list_campaigns",
+                "platform": "google_ads",
+            },
+            {
+                "timestamp": "2026-04-13T12:00:00",
+                "action": "update_status",
+                "platform": "meta_ads",
+                "campaign_id": "abc",
+                "reversible_params": {
+                    "operation": "meta_ads.campaigns.update_status",
+                    "params": {"campaign_id": "abc", "status": "ACTIVE"},
+                    "caveats": ["Spend during pause is not refundable."],
+                },
+            },
+            {
+                "timestamp": "2026-04-12T08:00:00",
+                "action": "update_budget",
+                "platform": "google_ads",
+                "campaign_id": "222",
+            },
+        ],
+    )
+    return state
+
+
+@pytest.mark.unit
+class TestRollbackList:
+    def test_lists_action_log_entries_with_status(self, state_file: Path) -> None:
+        from mureo.cli.main import app
+
+        result = runner.invoke(
+            app, ["rollback", "list", "--state-file", str(state_file)]
+        )
+        assert result.exit_code == 0, result.output
+        assert "update_budget" in result.output
+        assert "supported" in result.output.lower()
+        assert "partial" in result.output.lower()
+        assert "not_supported" in result.output.lower()
+        assert "list_campaigns" not in result.output
+
+    def test_filter_by_platform(self, state_file: Path) -> None:
+        from mureo.cli.main import app
+
+        result = runner.invoke(
+            app,
+            [
+                "rollback",
+                "list",
+                "--state-file",
+                str(state_file),
+                "--platform",
+                "meta_ads",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "meta_ads" in result.output
+        assert "google_ads" not in result.output
+
+    def test_missing_state_file_exits_with_helpful_message(
+        self, tmp_path: Path
+    ) -> None:
+        from mureo.cli.main import app
+
+        missing = tmp_path / "nowhere" / "STATE.json"
+        result = runner.invoke(app, ["rollback", "list", "--state-file", str(missing)])
+        assert result.exit_code != 0
+        assert "STATE.json" in result.output or "not found" in result.output.lower()
+
+    def test_empty_action_log_exits_zero_with_notice(self, tmp_path: Path) -> None:
+        from mureo.cli.main import app
+
+        state = tmp_path / "STATE.json"
+        _make_state(state, [])
+        result = runner.invoke(app, ["rollback", "list", "--state-file", str(state)])
+        assert result.exit_code == 0
+        assert "no" in result.output.lower() or "empty" in result.output.lower()
+
+
+@pytest.mark.unit
+class TestRollbackShow:
+    def test_show_index_prints_plan_details(self, state_file: Path) -> None:
+        from mureo.cli.main import app
+
+        result = runner.invoke(
+            app,
+            ["rollback", "show", "--state-file", str(state_file), "0"],
+        )
+        assert result.exit_code == 0
+        assert "google_ads.budgets.update" in result.output
+        assert "supported" in result.output.lower()
+
+    def test_show_out_of_range_exits_nonzero(self, state_file: Path) -> None:
+        from mureo.cli.main import app
+
+        result = runner.invoke(
+            app,
+            ["rollback", "show", "--state-file", str(state_file), "99"],
+        )
+        assert result.exit_code != 0
+
+    def test_show_partial_status_includes_caveats(self, state_file: Path) -> None:
+        from mureo.cli.main import app
+
+        result = runner.invoke(
+            app,
+            ["rollback", "show", "--state-file", str(state_file), "2"],
+        )
+        assert result.exit_code == 0
+        assert "partial" in result.output.lower()
+        assert "Spend during pause is not refundable." in result.output
+
+
+@pytest.mark.unit
+class TestSafeOutput:
+    def test_ansi_escape_in_action_is_stripped(self, tmp_path: Path) -> None:
+        from mureo.cli.main import app
+
+        state = tmp_path / "STATE.json"
+        # A malicious agent embeds an ANSI clear-screen sequence in the action
+        # name. The CLI must not emit the raw escape to the terminal.
+        _make_state(
+            state,
+            [
+                {
+                    "timestamp": "2026-04-15T10:00:00",
+                    "action": "update_budget\x1b[2Jspoof",
+                    "platform": "google_ads",
+                    "reversible_params": {
+                        "operation": "google_ads.budgets.update",
+                        "params": {"budget_id": "1", "amount_micros": 1},
+                    },
+                },
+            ],
+        )
+        result = runner.invoke(app, ["rollback", "list", "--state-file", str(state)])
+        assert result.exit_code == 0
+        assert "\x1b" not in result.output
+
+
+@pytest.mark.unit
+class TestRollbackGroupRegistered:
+    def test_rollback_subcommand_registered(self) -> None:
+        from mureo.cli.main import app
+
+        group_names = [
+            g.typer_instance.info.name
+            for g in app.registered_groups
+            if g.typer_instance
+        ]
+        assert "rollback" in group_names


### PR DESCRIPTION
## Summary

Task #26: operator-facing CLI for the rollback feature shipped in Task #25. Intentionally inspection-only — execution continues to route through MCP so it re-enters the same policy gate as forward actions.

### Commands
- `mureo rollback list [--state-file PATH] [--platform X]` — list every state-changing entry in the action log with the planner's verdict (supported / partial / not_supported). Read-only actions are omitted; entries with caveats are marked `*`.
- `mureo rollback show <index> [--state-file PATH]` — emit the full `RollbackPlan` as JSON for scripting.

### Security
- STATE.json is agent-writable. All string fields reaching the terminal (timestamp, platform, action) pass through a `_safe(value)` helper that strips C0/C1 control characters; this defends against ANSI clear-screen / cursor-spoofing attacks where a compromised agent embeds escape sequences in `action` or `summary`.
- `show` uses `min=0` on the index arg so negative indices fail at parse time, not in unhandled code paths.

### Code review outcomes
Review flagged HIGH: ANSI injection via agent-writable STATE.json fields — fixed with `_safe()` sanitation. MEDIUM: negative-index handling — fixed. Remaining LOW items (machine-parseable `--format json` for scripting, permission-error coverage, idempotency key for future executor) are noted for the executor PR.

## Test plan
- [x] `pytest tests/test_cli_rollback.py` — 9 unit tests
- [x] Full suite green (1597 passed)
- [x] `ruff check` / `black` clean
- [ ] CI green on 3.10/3.11/3.12
- [ ] Future PR: MCP executor (`rollback.apply`) with re-authorization through the forward-action policy gate
