### PR TITLE
docs: Document rollback execution and anomaly-check MCP tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ mureo/
 │   └── _ad_rules.py     # AdRulesMixin (automated rules)
 ├── search_console/      # Google Search Console API client (reuses Google OAuth2 credentials)
 │   └── client.py        # SearchConsoleApiClient
-├── mcp/                 # MCP server (Google Ads + Meta Ads + Search Console)
+├── mcp/                 # MCP server (Google Ads + Meta Ads + Search Console + Rollback + Analysis)
 │   ├── server.py                          # MCP Server entry point (stdio-based)
 │   ├── _helpers.py                        # Shared handler utilities
 │   ├── tools_google_ads.py                # Google Ads tool definitions (aggregator)
@@ -75,18 +75,28 @@ mureo/
 │   ├── _handlers_meta_ads_extended.py     # Extended handlers
 │   ├── _handlers_meta_ads_other.py        # Other handlers
 │   ├── tools_search_console.py            # Search Console tool definitions
-│   └── _handlers_search_console.py        # Search Console handlers
-├── cli/                 # Typer CLI (setup + auth only; ad operations are via MCP)
+│   ├── _handlers_search_console.py        # Search Console handlers
+│   ├── tools_rollback.py                  # rollback.plan.get / rollback.apply
+│   ├── _handlers_rollback.py              # Rollback handlers (lazy-resolve dispatcher)
+│   ├── tools_analysis.py                  # analysis.anomalies.check
+│   └── _handlers_analysis.py              # Anomaly detector composition handler
+├── cli/                 # Typer CLI (setup + auth + rollback inspection; ad operations are via MCP)
 │   ├── main.py          # CLI entry point (`mureo` command)
 │   ├── setup_cmd.py     # `mureo setup claude-code` / `mureo setup cursor`
-│   └── auth_cmd.py      # `mureo auth setup` / `status` / `check-*`
+│   ├── auth_cmd.py      # `mureo auth setup` / `status` / `check-*`
+│   └── rollback_cmd.py  # `mureo rollback list` / `show` (inspection only; apply routes through MCP)
 ├── context/             # File-based strategy context (no DB)
 │   ├── strategy.py      # STRATEGY.md parser/writer
 │   ├── state.py         # STATE.json parser/writer
-│   ├── models.py        # StrategyEntry, StateDocument, CampaignSnapshot
+│   ├── models.py        # StrategyEntry, StateDocument, CampaignSnapshot, ActionLogEntry (rollback_of)
 │   └── errors.py        # Context-specific errors
 ├── analysis/            # Analysis utilities
-│   └── lp_analyzer.py   # Landing page analyzer
+│   ├── lp_analyzer.py   # Landing page analyzer
+│   └── anomaly_detector.py  # Zero-spend / CPA-spike / CTR-drop detection (pure, sample-size-gated)
+├── rollback/            # Rollback feature (allow-list gated, append-only audit trail)
+│   ├── models.py        # RollbackStatus enum + RollbackPlan dataclass
+│   ├── planner.py       # plan_rollback(ActionLogEntry) -> RollbackPlan | None
+│   └── executor.py      # execute_rollback(...) -> appends ActionLogEntry(rollback_of=index)
 .claude/commands/            # Workflow slash commands (11 orchestration commands)
 │   ├── onboard.md           # Platform discovery + strategy setup
 │   ├── daily-check.md       # Cross-platform health monitoring (ad platforms + SC + GA4)

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -202,12 +202,32 @@ A JSON file tracking campaign state snapshots across platforms:
       "summary": "Excluded informational queries",
       "metrics_at_action": {"cpa": 5200, "conversions": 45, "clicks": 1200},
       "observation_due": "2026-04-15"
+    },
+    {
+      "timestamp": "2026-04-02T09:00:00+09:00",
+      "action": "Raised daily budget",
+      "platform": "google_ads",
+      "campaign_id": "12345",
+      "reversible_params": {
+        "operation": "google_ads.budgets.update",
+        "params": {"budget_id": "B1", "amount_micros": 5000000000}
+      }
+    },
+    {
+      "timestamp": "2026-04-02T15:00:00+09:00",
+      "action": "google_ads.budgets.update",
+      "platform": "google_ads",
+      "campaign_id": "12345",
+      "summary": "Rolled back #1: Raised daily budget",
+      "rollback_of": 1
     }
   ]
 }
 ```
 
 The `metrics_at_action` and `observation_due` fields enable evidence-based outcome evaluation. See `skills/mureo-learning/SKILL.md` for the decision framework. The `skills/mureo-pro-diagnosis/SKILL.md` file contains learned diagnostic insights that grow with use — the agent saves marketing knowledge here when users provide corrections or new insights during operations.
+
+`reversible_params` is an optional, agent-authored hint describing how to reverse the action. Its `operation` must be in the rollback planner's allow-list (`mureo/rollback/planner.py`); destructive verbs (`.delete`, `.remove`, etc.) and unexpected parameter keys are refused. `rollback_of` is set by the rollback executor and points at the index of the entry that was reversed — a later entry with this field constitutes an append-only audit trail and causes a second apply against the same index to be refused. See `docs/mcp-server.md` for the `rollback.plan.get` / `rollback.apply` MCP tools.
 
 Use `mureo.context.state` to parse and write STATE.json programmatically.
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -56,8 +56,8 @@ AIエージェントに広告アカウントを任せる以上、認証情報の
 
 - **認証情報の保護** — `mureo setup claude-code` が `~/.claude/settings.json` に PreToolUse フックを追加し、`~/.mureo/credentials.json` や `.env` などの秘密ファイルをエージェントが読み取れないようにします。プロンプトインジェクションでトークンが盗まれる経路を塞ぎます。
 - **GAQL の入力チェック** — Google Ads クエリに渡される ID・日付・期間指定・文字列は、すべて `mureo/google_ads/_gaql_validator.py` のホワイトリスト検証を通ります。`BETWEEN` 句もそのまま流さず、日付部分を切り出して再検証します。
-- **異常の自動検知** — `mureo/analysis/anomaly_detector.py` が action_log の履歴から中央値で基準値を作り、いまのキャンペーン指標と比べて「支出がゼロ」「CPA が跳ねた」「CTR が落ちた」を優先度つきで通知します。サンプル数が少ない日は単日のノイズとして扱い、誤検知を抑えます。
-- **ロールバック（許可リスト制）** — `mureo/rollback/` が action_log に記録された `reversible_params` を解釈して、取り消しプランを組み立てます。対象にできる操作はあらかじめ許可リスト登録したものだけ。`.delete` / `.remove` / `.transfer` など破壊的なメソッドや、想定外のパラメータキーは拒否されるので、乗っ取られたエージェントが「取り消し」に見せかけて危険な操作を仕込むことはできません。`mureo rollback list` / `show` で実行前に内容を確認できます。
+- **異常の自動検知** — `mureo/analysis/anomaly_detector.py` が action_log の履歴から中央値で基準値を作り、いまのキャンペーン指標と比べて「支出がゼロ」「CPA が跳ねた」「CTR が落ちた」を優先度つきで通知します。サンプル数が少ない日は単日のノイズとして扱い、誤検知を抑えます。エージェントは MCP ツール `analysis.anomalies.check` から呼び出せます。`state_file` 引数は MCP サーバの作業ディレクトリ配下にサンドボックスされ、`..` による親ディレクトリ越えや、サンドボックス外を指すシンボリックリンクは拒否されます。これにより、プロンプトインジェクションされたエージェントが攻撃者が用意した別の `STATE.json` を読み込ませることはできません。
+- **ロールバック（許可リスト制）** — `mureo/rollback/` が action_log に記録された `reversible_params` を解釈して、取り消しプランを組み立てます。対象にできる操作はあらかじめ許可リスト登録したものだけ。`.delete` / `.remove` / `.transfer` など破壊的なメソッドや、想定外のパラメータキーは拒否されるので、乗っ取られたエージェントが「取り消し」に見せかけて危険な操作を仕込むことはできません。`mureo rollback list` / `show` で実行前に内容を確認でき、実行は MCP ツール `rollback.apply` として提供されます。apply は通常の操作と同じハンドラ経由でディスパッチされるため、認証・レート制限・入力検証ゲートをそのまま通ります。`confirm=true`（真偽値の `True`）を明示的に渡す必要があり、成功すると `rollback_of=<index>` タグ付きの追記専用ログが残ります。同じ index に対する二度目の apply は拒否され、`rollback.*` へのツール再帰も拒否されます。
 - **状態データの不変性** — `StateDocument` や `ActionLogEntry`、`RollbackPlan` など状態を表すクラスはすべて `frozen=True` の dataclass です。エージェントが自分で書いた記録を後から書き換えることはできません。
 - **認証情報はローカルのみ** — トークンは `~/.mureo/credentials.json` か環境変数から読むだけで、送信先は Google Ads / Meta / Search Console の公式 API に限定しています。mureo 側はテレメトリを一切送りません。
 

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ Marketing accounts are a high-value target. mureo is built with defense-in-depth
 
 - **Credential guard** — `mureo setup claude-code` installs a PreToolUse hook that blocks AI agents from reading `~/.mureo/credentials.json`, `.env`, and similar secrets, so a prompt-injection payload cannot exfiltrate tokens via the file-system tools.
 - **GAQL input validation** — every ID, date, date-range constant, and string literal that enters a Google Ads query flows through one whitelist-based surface (`mureo/google_ads/_gaql_validator.py`), and `BETWEEN` clauses pattern-match and revalidate their dates instead of passing raw caller input into GAQL.
-- **Anomaly detection** — `mureo/analysis/anomaly_detector.py` compares current campaign metrics against a median-based baseline from the action log and emits prioritized alerts for zero spend, CPA spikes, and CTR drops, with sample-size gates that suppress single-day noise.
-- **Rollback with allow-list gating** — `mureo/rollback/` turns agent-authored `reversible_params` hints into concrete `RollbackPlan` records. Only operations on an explicit allow-list are planned; destructive verbs (`.delete`, `.remove`, `.transfer`) and unexpected parameter keys are refused, so a compromised agent cannot smuggle a privileged call through the rollback path. `mureo rollback list` / `show` let operators preview plans before any execution.
+- **Anomaly detection** — `mureo/analysis/anomaly_detector.py` compares current campaign metrics against a median-based baseline from the action log and emits prioritized alerts for zero spend, CPA spikes, and CTR drops, with sample-size gates that suppress single-day noise. Exposed to agents via the `analysis.anomalies.check` MCP tool; `state_file` is sandboxed inside the MCP server's CWD so a prompt-injected agent cannot redirect it at an attacker-crafted `STATE.json`.
+- **Rollback with allow-list gating** — `mureo/rollback/` turns agent-authored `reversible_params` hints into concrete `RollbackPlan` records. Only operations on an explicit allow-list are planned; destructive verbs (`.delete`, `.remove`, `.transfer`) and unexpected parameter keys are refused, so a compromised agent cannot smuggle a privileged call through the rollback path. `mureo rollback list` / `show` let operators preview plans, and the `rollback.apply` MCP tool executes them by re-dispatching through the same handler used for forward actions so the reversal re-enters the full policy gate (auth, rate limit, validation). Apply requires `confirm=true` (literal boolean), refuses `rollback.*` self-recursion, records the reversal as an append-only `action_log` entry tagged with `rollback_of=<index>`, and refuses a second apply of the same index.
 - **Immutable data models** — every state object (`StateDocument`, `ActionLogEntry`, `CampaignSnapshot`, `Anomaly`, `RollbackPlan`) is a `frozen=True` dataclass; an agent cannot silently mutate its own record of what happened.
 - **Local-only credentials** — tokens are loaded from `~/.mureo/credentials.json` or environment variables and transmitted only to the official ad-platform APIs. mureo itself has no telemetry.
 
@@ -793,6 +793,33 @@ Add to `.cursor/mcp.json`:
 | Tool | Description |
 |------|-------------|
 | `search_console.url_inspection.inspect` | Inspect a URL for indexing status |
+
+</details>
+
+#### Rollback
+
+<details>
+<summary>Click to expand rollback tools</summary>
+
+Cross-platform tools that inspect and apply the reversal plan for a previously-recorded `action_log` entry. Apply re-dispatches through the same MCP handler used for forward actions, so the reversal re-enters the full policy gate (auth, rate limit, input validation, allow-list).
+
+| Tool | Description |
+|------|-------------|
+| `rollback.plan.get` | Inspect the reversal plan for an `action_log` entry (`supported` / `partial` / `not_supported`), its `operation` + `params`, and any caveats. Read-only; does not execute. |
+| `rollback.apply` | Execute the reversal plan for `action_log[index]`. Requires `confirm=true` as a literal boolean. Appends a new log entry tagged `rollback_of=<index>`; a second apply of the same index is refused. `state_file` is resolved strictly inside the MCP server's CWD — path traversal, symlink escape, and `rollback.*` self-recursion are all refused. |
+
+</details>
+
+#### Analysis
+
+<details>
+<summary>Click to expand analysis tools</summary>
+
+Cross-platform detection tools that operate on STATE.json's `action_log` history rather than on platform APIs directly.
+
+| Tool | Description |
+|------|-------------|
+| `analysis.anomalies.check` | Compare a campaign's current metrics against a median-based baseline built from `action_log` history. Returns severity-ordered anomalies — zero spend (CRITICAL), CPA spike (HIGH/CRITICAL, gated by 30+ conversions), CTR drop (HIGH/CRITICAL, gated by 1000+ impressions). Sample-size gates follow the `mureo-learning` skill's statistical-thinking rules. Returns `baseline=null` when history is shorter than `min_baseline_entries` (default 7); `baseline_warning` surfaces a parseable-but-corrupt `STATE.json` without silencing live zero-spend detection. |
 
 </details>
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -95,6 +95,26 @@ Sample-size gates (30+ conversions for CPA, 1000+ impressions for
 CTR) follow the `mureo-learning` skill's statistical-thinking rules
 to suppress single-day noise.
 
+Agents invoke the detector via the `analysis.anomalies.check` MCP
+tool, which composes `baseline_from_history` with `detect_anomalies`
+behind a single call. Safety properties of the MCP surface:
+
+- `current.campaign_id` and `current.cost` are required, so a
+  zero-spend alert is always an intentional zero rather than the
+  product of an omitted field.
+- Numeric fields accept int / float / numeric-string and reject
+  non-numeric strings (`"N/A"`) and booleans, so a malformed
+  current-snapshot fails loudly instead of silently disabling
+  detection.
+- `state_file` resolves strictly inside the MCP server's current
+  working directory. Absolute paths that escape, `..`-traversal, and
+  symlinks that cross CWD boundaries are all refused, so a
+  prompt-injected agent cannot redirect the tool at an
+  attacker-crafted history.
+- A parse-error on STATE.json does not silence live zero-spend
+  detection; the response carries a `baseline_warning` so the agent
+  can flag the unreliable baseline to the operator.
+
 ### Rollback with allow-list gating
 
 `mureo/rollback/` turns agent-authored `reversible_params` hints in
@@ -119,6 +139,42 @@ plan stays with the MCP dispatcher so it re-enters the same policy
 gate as forward actions. Control characters from STATE.json are
 stripped before terminal output to prevent ANSI-escape spoofing by
 a compromised agent.
+
+Execution is exposed to agents via two MCP tools:
+
+- `rollback.plan.get` returns the planner's verdict (`supported` /
+  `partial` / `not_supported`), the operation that would be
+  dispatched, its parameters, and any caveats. Read-only.
+- `rollback.apply` executes the plan by re-dispatching
+  `plan.operation` with `plan.params` through the same
+  `handle_call_tool` used for forward actions, so the reversal call
+  re-enters the full policy gate (auth, rate limit, GAQL validation,
+  planner allow-list).
+
+Additional hardening on the executor:
+
+- `confirm` must be the literal boolean `True`. Truthy non-booleans
+  (`1`, `"true"`, non-empty lists) are refused, so an agent that
+  bypasses the MCP schema validator still cannot smuggle an apply
+  call with a coerced affirmative.
+- The planner is re-invoked at execution time rather than cached, so
+  a stale allow-list decision can never be smuggled in via the log.
+- `plan.operation` starting with `rollback.` is refused as
+  defense-in-depth, preventing recursion into the rollback surface
+  even if a future allow-list entry accidentally names a rollback
+  tool.
+- A successful apply is recorded as an append-only `ActionLogEntry`
+  tagged with `rollback_of=<index>`. The appended entry carries
+  `reversible_params=None` so rollbacks of rollbacks do not chain by
+  default; a second apply of the same index is refused.
+- `state_file` resolves strictly inside the MCP server's current
+  working directory (same sandbox as `analysis.anomalies.check`) so
+  an attacker-controlled `STATE.json` outside the project cannot be
+  used as the reversal source.
+- Dispatch-time API failures never mutate `action_log`; the
+  downstream exception is logged server-side only, and the MCP
+  response returns a generic message (only `type(exc).__name__`) so
+  tokens and account identifiers cannot leak into model context.
 
 ### Immutable data models
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -102,11 +102,12 @@ mureo/
 ├── analysis/                # Cross-platform analysis utilities
 │   ├── lp_analyzer.py       # Landing page analysis
 │   └── anomaly_detector.py  # CPA spike / CTR drop / zero-spend detection with sample-size gates
-├── rollback/                # Rollback planner (allow-list gated)
+├── rollback/                # Rollback feature (allow-list gated, append-only)
 │   ├── models.py            # RollbackStatus enum + RollbackPlan dataclass
-│   └── planner.py           # plan_rollback(ActionLogEntry) -> RollbackPlan | None
+│   ├── planner.py           # plan_rollback(ActionLogEntry) -> RollbackPlan | None
+│   └── executor.py          # execute_rollback(...) -> appends ActionLogEntry(rollback_of=index)
 ├── context/                 # File-based context (STRATEGY.md, STATE.json)
-│   ├── models.py            # Immutable dataclasses
+│   ├── models.py            # Immutable dataclasses (ActionLogEntry.rollback_of for audit trail)
 │   ├── strategy.py          # STRATEGY.md parser / renderer
 │   ├── state.py             # STATE.json parser / renderer
 │   └── errors.py            # Context-specific exceptions
@@ -114,7 +115,7 @@ mureo/
 │   ├── main.py              # Entry point (mureo command)
 │   ├── setup_cmd.py         # mureo setup claude-code / cursor
 │   ├── auth_cmd.py          # mureo auth setup / status / check-*
-│   └── rollback_cmd.py      # mureo rollback list / show (inspection only)
+│   └── rollback_cmd.py      # mureo rollback list / show (inspection only; apply routes through MCP)
 └── mcp/                     # MCP server
     ├── __main__.py                        # python -m mureo.mcp entry point
     ├── server.py                          # MCP server setup (stdio transport)
@@ -130,7 +131,11 @@ mureo/
     ├── _handlers_meta_ads_extended.py     # Extended handlers
     ├── _handlers_meta_ads_other.py        # Other handlers
     ├── tools_search_console.py            # Search Console tool definitions
-    └── _handlers_search_console.py        # Search Console handlers
+    ├── _handlers_search_console.py        # Search Console handlers
+    ├── tools_rollback.py                  # rollback.plan.get / rollback.apply
+    ├── _handlers_rollback.py              # Rollback handlers (lazy-resolve dispatcher)
+    ├── tools_analysis.py                  # analysis.anomalies.check
+    └── _handlers_analysis.py              # Anomaly detector composition handler
 
 .claude/commands/                # Workflow slash commands for Claude Code
 ├── onboard.md                   # Account setup + STRATEGY.md generation

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -123,6 +123,18 @@ mureo rollback list --state-file /path/to/STATE.json
 
 A rollback entry only appears when the agent wrote a `reversible_params` hint at the time of the original action. Operations outside the planner's allow-list, or hints that smuggle unexpected parameter keys, are rejected at plan time — see [architecture.md](architecture.md#defense-in-depth-for-ai-agents) for the threat model.
 
+### Applying a rollback
+
+Execution is not a CLI command — it is the `rollback.apply` MCP tool. The CLI is intentionally read-only; applying a rollback from the CLI would bypass the authentication, rate-limiting, and input-validation gate that every forward action passes through. To apply a rollback, ask the agent to call `rollback.apply` with the index shown by `mureo rollback list`:
+
+```
+You: "Roll back action #0."
+Agent: rollback.plan.get → previews the reversal.
+Agent: rollback.apply({index: 0, confirm: true}) → dispatches.
+```
+
+`confirm` must be the literal boolean `true` (truthy non-booleans are refused). On success the executor appends a new log entry tagged `rollback_of=<index>`; a second apply of the same index is refused. `state_file` resolves strictly inside the MCP server's current working directory — `..`-traversal and symlink escape are refused so an attacker-crafted `STATE.json` elsewhere on disk cannot be used as the reversal source.
+
 ## Output Format
 
 Authentication check commands output JSON to stdout:

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -1,6 +1,6 @@
 # MCP Server Guide
 
-mureo exposes 169 advertising and SEO operation tools via the [Model Context Protocol](https://modelcontextprotocol.io/) (MCP). Any MCP-compatible client can connect and call these tools over stdio.
+mureo exposes 173 tools via the [Model Context Protocol](https://modelcontextprotocol.io/) (MCP): 170 advertising and SEO operation tools across Google Ads, Meta Ads, and Search Console, plus 2 rollback tools and 1 cross-platform anomaly-detection tool. Any MCP-compatible client can connect and call these tools over stdio.
 
 ## Starting the Server
 
@@ -455,6 +455,27 @@ Search Console tools reuse the same Google OAuth2 credentials as Google Ads -- n
 | Tool | Description | Required Parameters |
 |------|-------------|-------------------|
 | `search_console.url_inspection.inspect` | Inspect a URL for indexing status | `site_url`, `inspection_url` |
+
+### Rollback
+
+Cross-platform tools for inspecting and applying the reversal of a previously-recorded `action_log` entry. `rollback.apply` re-dispatches through the same MCP handler used for forward actions, so the reversal re-enters the full policy gate (auth, rate-limit, GAQL validation, planner allow-list).
+
+| Tool | Description | Required Parameters |
+|------|-------------|-------------------|
+| `rollback.plan.get` | Inspect the reversal plan for an `action_log` entry (`supported` / `partial` / `not_supported`), its `operation` + `params`, and any caveats. Read-only. | `index` |
+| `rollback.apply` | Execute the reversal plan for `action_log[index]`. Requires `confirm=true` as a literal boolean. Appends a new log entry tagged `rollback_of=<index>`. | `index`, `confirm` |
+
+Both tools accept an optional `state_file` argument (default `STATE.json`), which is resolved strictly inside the MCP server's current working directory. Path traversal, symlink escape, and `rollback.*` self-recursion are all refused. A second apply of the same index is refused (idempotency is enforced by scanning later log entries for a matching `rollback_of` marker). Downstream SDK exceptions are logged server-side only; the MCP response returns a generic message so tokens and account identifiers cannot leak into model context.
+
+### Analysis
+
+Cross-platform anomaly detection that operates on STATE.json's `action_log` history rather than a platform API directly.
+
+| Tool | Description | Required Parameters |
+|------|-------------|-------------------|
+| `analysis.anomalies.check` | Compare a campaign's current metrics against a median-based baseline built from `action_log` history. Returns severity-ordered anomalies — zero spend (CRITICAL), CPA spike (HIGH/CRITICAL, gated by 30+ conversions), CTR drop (HIGH/CRITICAL, gated by 1000+ impressions). | `current` (`current.campaign_id` and `current.cost` required) |
+
+`had_prior_spend` (default `true`) suppresses the zero-spend alert for fresh campaigns. `min_baseline_entries` (default `7`) controls how many history entries are required before a baseline is built; below this, `baseline` is `null` and only zero-spend is evaluated. Numeric fields accept int / float / numeric-string and reject `"N/A"` or booleans. `state_file` is sandboxed the same way as for the rollback tools. A parseable-but-corrupt `STATE.json` produces a `baseline_warning` in the response without silencing live zero-spend detection.
 
 ## Workflow Commands
 


### PR DESCRIPTION
## Summary

Documentation-only PR. Reflects the two features shipped in #13 (rollback execution, `rollback.apply` / `rollback.plan.get` MCP tools) and #14 (anomaly wiring, `analysis.anomalies.check` MCP tool) across every user-facing doc. No code changes.

## Files updated

- **README.md / README.ja.md** — Security section bullets updated to describe the new MCP surface (CWD sandbox, `confirm=true` literal gate, append-only `rollback_of` audit entry, `rollback.*` self-recursion refusal). Added Rollback + Analysis tool tables after Search Console.
- **SECURITY.md** — Expanded the Anomaly detection and Rollback sections with the full MCP-surface safety properties that emerged from code + security review.
- **docs/mcp-server.md** — Tool count 169 → 173, added Rollback and Analysis sections.
- **docs/cli.md** — Added an "Applying a rollback" subsection explaining apply is an MCP tool (not CLI) on purpose, so it re-enters the same policy gate as forward actions.
- **docs/architecture.md** — Tree diagram now shows `rollback/executor.py`, the four new MCP modules, and the `rollback_of` audit field on `ActionLogEntry`.
- **CONTEXT.md** — `STATE.json` `action_log[]` sample extended with a `reversible_params` entry and its `rollback_of` reversal, plus an explanatory paragraph.
- **AGENTS.md** — Tree diagram mirror of `docs/architecture.md`.

## Test plan

- [x] No code changes; `pytest tests/` still reports 1633 passed.
- [ ] CI green (verify after push).
