### PR TITLE
docs: Sync codex/gemini mentions across READMEs and skills

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -11,7 +11,7 @@
 
 ## mureoとは
 
-mureoは、AIエージェントが広告アカウントを自動運用するためのフレームワークです。インストールすると、AIエージェント（Claude Code、Cursorなど）がGoogle広告・Meta広告・Search Console・GA4を横断して、配信診断・検索語分析・予算評価・入稿チェックなどを実行できるようになります。すべての操作はあなたのビジネス戦略（`STRATEGY.md`）に基づいて行われます。
+mureoは、AIエージェントが広告アカウントを自動運用するためのフレームワークです。インストールすると、AIエージェント（Claude Code、Cursor、Codex、Geminiなど）がGoogle広告・Meta広告・Search Console・GA4を横断して、配信診断・検索語分析・予算評価・入稿チェックなどを実行できるようになります。すべての操作はあなたのビジネス戦略（`STRATEGY.md`）に基づいて行われます。
 
 mureoには学習の仕組みもあります。エージェントの分析を修正したり運用上の気づきを共有すると、`/learn` でナレッジベースに保存できます。保存した知識は次回以降のセッションで自動的に読み込まれるため、使い続けるほどエージェントがあなたのアカウントの特性を理解し、より的確な判断ができるようになります。
 
@@ -170,6 +170,24 @@ mureo setup cursor
 
 CursorはMCPツールを利用できますが、ワークフローコマンドとスキルには対応していません。
 
+### Codex CLI
+
+```bash
+pip install mureo
+mureo setup codex
+```
+
+Claude Codeと同じく4層すべて（MCPサーバー、認証情報ガード（PreToolUseフック）、ワークフロープロンプト、スキル）を `~/.codex/` 配下にインストールします。
+
+### Gemini CLI
+
+```bash
+pip install mureo
+mureo setup gemini
+```
+
+mureoをGemini CLIのextensionとして `~/.gemini/extensions/mureo/` に登録し、MCPサーバー設定と `CONTEXT.md` をコンテキストファイルとして指定します。Gemini CLIはPreToolUseフックと`.md`形式のコマンドに対応していないため、これらのレイヤーはインストールされません。
+
 ### CLIのみ（認証管理）
 
 ```bash
@@ -180,13 +198,14 @@ mureo auth status
 
 ### インストール内容
 
-| 構成要素 | `mureo setup claude-code` | `mureo setup cursor` | `mureo auth setup` |
-|---------|:---:|:---:|:---:|
-| 認証（~/.mureo/credentials.json） | Yes | Yes | Yes |
-| MCP設定 | Yes | Yes | Yes |
-| 認証情報ガード | Yes | N/A | Yes |
-| ワークフローコマンド | Yes | N/A | No |
-| スキル | Yes | N/A | No |
+| 構成要素 | `mureo setup claude-code` | `mureo setup cursor` | `mureo setup codex` | `mureo setup gemini` | `mureo auth setup` |
+|---------|:---:|:---:|:---:|:---:|:---:|
+| 認証（~/.mureo/credentials.json） | Yes | Yes | Yes | Yes | Yes |
+| MCP設定 | Yes | Yes | Yes | Yes | Yes |
+| 認証情報ガード（PreToolUseフック） | Yes | N/A | Yes | N/A | Yes |
+| ワークフローコマンド/プロンプト | Yes（~/.claude/commands/） | N/A | Yes（~/.codex/prompts/） | N/A | No |
+| スキル | Yes（~/.claude/skills/） | N/A | Yes（~/.codex/skills/） | N/A | No |
+| Extensionマニフェスト（contextFileName） | N/A | N/A | N/A | Yes（~/.gemini/extensions/mureo/） | No |
 
 ### スキル一覧
 
@@ -256,7 +275,7 @@ mureo auth setup
 
 1. **Google広告** — Developer Token + Client ID/Secret を入力 → ブラウザでOAuth → アカウント選択
 2. **Meta広告** — App ID/Secret を入力 → ブラウザでOAuth → 広告アカウント選択。Metaアプリは**開発モードのまま**で問題ありません（App Reviewは不要です）。OAuthの際に `business_management` の権限警告が表示されますが、ビジネスポートフォリオ経由のページ管理に必要なため、そのまま承認してください。
-3. **MCP設定** — Claude Code / Cursor用の設定ファイルを自動生成
+3. **MCP設定** — Claude Code / Cursor / Codex / Gemini用の設定ファイルを自動生成
 
 認証情報は `~/.mureo/credentials.json` に保存されます。Search ConsoleはGoogle広告と同じOAuth認証を使うため、追加の設定は不要です。
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## What is mureo?
 
-mureo is a framework for AI agents to autonomously operate ad accounts. Once installed, AI agents (Claude Code, Cursor, etc.) can work across Google Ads, Meta Ads, Search Console, and GA4 -- running campaign diagnostics, search term analysis, budget evaluation, ad validation, and more. Every operation is grounded in your business strategy (`STRATEGY.md`), so the agent makes decisions based on your persona, USP, goals, and brand voice -- not just raw metrics.
+mureo is a framework for AI agents to autonomously operate ad accounts. Once installed, AI agents (Claude Code, Cursor, Codex, Gemini, etc.) can work across Google Ads, Meta Ads, Search Console, and GA4 -- running campaign diagnostics, search term analysis, budget evaluation, ad validation, and more. Every operation is grounded in your business strategy (`STRATEGY.md`), so the agent makes decisions based on your persona, USP, goals, and brand voice -- not just raw metrics.
 
 mureo also learns. When you correct the agent's analysis or share an operational insight, `/learn` saves it to a persistent knowledge base. That knowledge is automatically loaded in every future session, so the agent gets increasingly attuned to your account's specific patterns and makes better decisions over time.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -16,7 +16,7 @@ mureo <subcommand-group> <command> [options]
 
 | Group | Description |
 |-------|-------------|
-| `setup` | Environment setup (Claude Code, Cursor) |
+| `setup` | Environment setup (Claude Code, Cursor, Codex, Gemini) |
 | `auth` | Authentication management |
 | `rollback` | Inspect reversible actions recorded in STATE.json |
 
@@ -157,6 +157,6 @@ Secrets are masked, showing only the last 4 characters.
 
 ## Ad Platform Operations
 
-Ad platform operations (listing campaigns, creating ads, analyzing performance, etc.) are available through **MCP tools**, not the CLI. AI agents (Claude Code, Cursor) call these tools directly.
+Ad platform operations (listing campaigns, creating ads, analyzing performance, etc.) are available through **MCP tools**, not the CLI. AI agents (Claude Code, Cursor, Codex, Gemini) call these tools directly.
 
 See [mcp-server.md](mcp-server.md) for the full tool reference.

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -4,7 +4,7 @@ mureo's core value is orchestration — knowing *what* to do, *when*, and *why* 
 
 ## How It Works
 
-MCP clients (Claude Code, Cursor, Claude Desktop) can connect to multiple MCP servers simultaneously. Each server exposes its own set of tools. When mureo's workflow commands run, the AI agent **discovers all configured platforms at runtime** and adapts its behavior accordingly — calling tools from any connected MCP server in the same session.
+MCP clients (Claude Code, Cursor, Codex, Gemini, Claude Desktop) can connect to multiple MCP servers simultaneously. Each server exposes its own set of tools. When mureo's workflow commands run, the AI agent **discovers all configured platforms at runtime** and adapts its behavior accordingly — calling tools from any connected MCP server in the same session.
 
 ### Platform Discovery
 

--- a/mureo/_data/skills/mureo-shared/SKILL.md
+++ b/mureo/_data/skills/mureo-shared/SKILL.md
@@ -20,7 +20,7 @@ metadata:
 
 **mureo** is a marketing orchestration framework for AI agents. It provides:
 - **CLI** (`mureo`) for direct command-line usage
-- **MCP Server** for integration with AI agent hosts (Claude Code, Cursor, etc.)
+- **MCP Server** for integration with AI agent hosts (Claude Code, Cursor, Codex, Gemini, etc.)
 - **Python library** for programmatic access
 
 All three interfaces share the same authentication, security rules, and output format.

--- a/skills/mureo-shared/SKILL.md
+++ b/skills/mureo-shared/SKILL.md
@@ -20,7 +20,7 @@ metadata:
 
 **mureo** is a marketing orchestration framework for AI agents. It provides:
 - **CLI** (`mureo`) for direct command-line usage
-- **MCP Server** for integration with AI agent hosts (Claude Code, Cursor, etc.)
+- **MCP Server** for integration with AI agent hosts (Claude Code, Cursor, Codex, Gemini, etc.)
 - **Python library** for programmatic access
 
 All three interfaces share the same authentication, security rules, and output format.


### PR DESCRIPTION
## Summary

Extends the existing AI-agent example lists across user-facing docs to include Codex and Gemini, now that `mureo setup codex` and `mureo setup gemini` shipped in #16. Also syncs the Japanese README with the English one (`### Codex CLI` / `### Gemini CLI` sections + 6-column installation matrix).

## Files touched

- `README.md` — lead paragraph agent list
- `README.ja.md` — lead paragraph, two new setup subsections, installation matrix expanded 4→6 columns, MCP-config note
- `docs/cli.md` — subcommand-group description + MCP-tool caller list
- `docs/integrations.md` — example MCP-clients list
- `skills/mureo-shared/SKILL.md` and bundled mirror `mureo/_data/skills/mureo-shared/SKILL.md` — agent hosts bullet

## Test plan

- [x] No code changes; full suite still 1651 passed.
- [ ] CI green after push.