### PR TITLE
feat: TTY-safe setup commands for AI-agent invocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `mureo setup claude-code` / `cursor` / `codex` / `gemini` are now TTY-safe. When run from an AI agent's subprocess (Claude Code's Bash tool, Codex, etc.) without a controlling TTY, they auto-imply `--skip-auth` and print a banner instructing the operator to finish authentication in Terminal.app. Previously they hung forever on the first `typer.confirm` prompt.
+- Each setup subcommand gained explicit `--google-ads/--no-google-ads` and `--meta-ads/--no-meta-ads` flags so choices can be specified without any prompt. Passing them together with `--skip-auth` (or under a non-TTY) emits a warning explaining they were ignored.
+- New helper `mureo/cli/_tty.py` (`is_tty`, `confirm_or_default`) centralizes the TTY + fallback logic. Both stdin and stdout must be terminals for `is_tty()` to return true. `confirm_or_default` catches `EOFError` / `click.Abort` if the TTY disappears mid-prompt and falls back to the caller-supplied default.
+
+### Added
+- README + README.ja: "From inside Claude Code Desktop" section with a natural-language install phrase that non-technical users can paste into the Code tab. Notes that OAuth (Developer Token, App ID/Secret input) still requires a one-time Terminal.app session for safety.
+
 ## [0.5.0] - 2026-04-18
 
 ### Added

--- a/README.ja.md
+++ b/README.ja.md
@@ -145,6 +145,16 @@ STATE.jsonから接続媒体を検出:
 
 いずれも `mureo auth setup` の対話型ウィザードが手順を案内します。
 
+### Claude Code Desktop から導入する（ターミナル操作ほぼ不要）
+
+ターミナル操作に慣れていない場合は、Claude Desktop の **Code タブ** で Claude に次のように頼んでください:
+
+> 「mureo を `https://github.com/logly/mureo` からインストールして。`pip install git+https://github.com/logly/mureo` を実行したあと、`mureo setup claude-code` を実行してください。その後、Terminal.app で `mureo auth setup` を一度だけ実行するよう私に指示してください。」
+
+mureo の setup コマンドは AI エージェント経由（TTY 無し）で実行されたことを自動検出し、対話型の OAuth 手続きをスキップします（Claude がハングしません）。MCP設定・認証ガード・ワークフローコマンド・スキルは全部自動でインストールされます。
+
+**初回だけ** macOS の **Terminal.app**（または Windows Terminal）を開いて `mureo auth setup` を実行してください — OAuth には Google Cloud の Developer Token や Meta の App ID / Secret の貼り付けが必要で、チャットよりローカルなターミナルに貼り付ける方が安全なためです。完了したら Claude Desktop を再起動すると、Code タブで mureo のツールが利用可能になります。
+
 ### Claude Code（推奨）
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -197,6 +197,16 @@ You approve → Agent updates each platform.
 
 The `mureo auth setup` wizard walks you through both.
 
+### From inside Claude Code Desktop (no terminal needed to install)
+
+If you're not comfortable opening a terminal, ask Claude inside the Code tab:
+
+> "Install mureo from `https://github.com/logly/mureo`. Run `pip install git+https://github.com/logly/mureo`, then `mureo setup claude-code`. After that tell me to run `mureo auth setup` in Terminal.app once to finish authentication."
+
+mureo's setup auto-detects when it's running under an AI agent (no TTY) and skips the interactive OAuth step so Claude doesn't hang. The MCP config, credential guard, workflow commands, and skills are all installed non-interactively.
+
+**One-time** you do need to open **macOS Terminal.app** (or Windows Terminal) and run `mureo auth setup` — OAuth requires pasting a Developer Token from Google Cloud and an App ID/Secret from Meta, which is safer to do in a local terminal than in chat. Restart Claude Desktop afterwards and mureo tools appear in the Code tab.
+
 ### Claude Code (recommended)
 
 ```bash

--- a/mureo/cli/_tty.py
+++ b/mureo/cli/_tty.py
@@ -1,0 +1,65 @@
+"""TTY-safe helpers for CLI prompts.
+
+When ``mureo setup claude-code`` is invoked by an AI agent (Claude
+Code's Bash tool, Codex, etc.) the subprocess does not have a
+controlling TTY. ``typer.confirm`` blocks forever in that case, which
+is the failure mode non-engineers hit when they tell an agent to
+install mureo.
+
+This module adds:
+
+- :func:`is_tty` — single source of truth for whether a TTY is
+  available on stdin.
+- :func:`confirm_or_default` — a drop-in replacement for
+  ``typer.confirm`` that takes ``default`` when no TTY is present and
+  honors an explicit ``override`` (for CLI flags) without prompting.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import click
+import typer
+
+
+def is_tty() -> bool:
+    """Return ``True`` only when *both* stdin and stdout are terminals.
+
+    ``typer.confirm`` reads from stdin and writes to stdout. Either
+    being redirected means we can't reliably prompt — e.g.
+    ``echo y | mureo setup``, ``mureo setup < /dev/null``, or Claude
+    Code's Bash tool (no TTY on either side). Requiring both ends is
+    what ``click``/``rich`` do for the same reason.
+    """
+    return sys.stdin.isatty() and sys.stdout.isatty()
+
+
+def confirm_or_default(
+    prompt: str,
+    *,
+    default: bool,
+    override: bool | None = None,
+) -> bool:
+    """Prompt for a yes/no answer with safe fallback paths.
+
+    Resolution order:
+
+    1. ``override`` wins if set (used when a CLI flag like
+       ``--google-ads`` / ``--no-google-ads`` makes the decision
+       explicit). Neither TTY state nor prompts are consulted.
+    2. If stdin/stdout have no TTY, return ``default`` silently so the
+       command does not hang under an AI agent or a CI runner.
+    3. Otherwise, delegate to :func:`typer.confirm`. If the TTY
+       disappears mid-prompt (``EOFError`` / ``click.Abort``), fall
+       back to ``default`` so the command still completes rather than
+       crashing with a stack trace.
+    """
+    if override is not None:
+        return override
+    if not is_tty():
+        return default
+    try:
+        return typer.confirm(prompt, default=default)
+    except (EOFError, click.exceptions.Abort):
+        return default

--- a/mureo/cli/setup_cmd.py
+++ b/mureo/cli/setup_cmd.py
@@ -12,7 +12,45 @@ from pathlib import Path
 
 import typer
 
+from mureo.cli._tty import confirm_or_default, is_tty
+
 setup_app = typer.Typer(name="setup", help="Set up mureo for AI agent environments")
+
+
+def _should_skip_auth(skip_auth_flag: bool) -> tuple[bool, str | None]:
+    """Decide whether to skip OAuth, accounting for missing TTYs.
+
+    When an AI agent (Claude Code Bash tool, Codex, etc.) runs this
+    command there is no TTY, so the interactive ``input()`` calls in
+    ``setup_google_ads`` / ``setup_meta_ads`` would hang. We auto-skip
+    in that case and return a banner message for the caller to echo so
+    the operator understands what happened.
+    """
+    if skip_auth_flag:
+        return True, "Skipping authentication (--skip-auth)."
+    if not is_tty():
+        return True, (
+            "No TTY detected (running under an AI agent or subprocess). "
+            "Skipping OAuth setup.\n"
+            "Run `mureo auth setup` in a real terminal to complete "
+            "authentication."
+        )
+    return False, None
+
+
+def _warn_unused_ads_flags(
+    should_skip: bool, google_ads: bool | None, meta_ads: bool | None
+) -> None:
+    """If the user passed --google-ads / --meta-ads but we're skipping
+    auth, they expected something to run. Be explicit rather than silent.
+    """
+    if should_skip and (google_ads is not None or meta_ads is not None):
+        typer.echo(
+            "Note: --google-ads / --meta-ads ignored because "
+            "authentication is skipped. Run `mureo auth setup` in a "
+            "terminal to apply them.",
+            err=True,
+        )
 
 
 def _get_data_path(subdir: str) -> Path:
@@ -95,11 +133,22 @@ def setup_claude_code(
         "--skip-auth",
         help="Skip authentication (install commands, skills, MCP config, and guard only)",
     ),
+    google_ads: bool | None = typer.Option(
+        None,
+        "--google-ads/--no-google-ads",
+        help="Configure Google Ads auth (default: prompt in TTY, yes in non-TTY).",
+    ),
+    meta_ads: bool | None = typer.Option(
+        None,
+        "--meta-ads/--no-meta-ads",
+        help="Configure Meta Ads auth (default: prompt in TTY, yes in non-TTY).",
+    ),
 ) -> None:
     """One-command setup for Claude Code users.
 
     Runs the full setup flow:
     1. Authentication (Google Ads / Meta Ads) — skipped with --skip-auth
+       or auto-skipped when no TTY is attached (e.g. run from an AI agent)
     2. MCP configuration
     3. Credential guard hook
     4. Workflow commands installation
@@ -110,9 +159,19 @@ def setup_claude_code(
     typer.echo("=== mureo Setup for Claude Code ===\n")
 
     # 1. Authentication
-    if not skip_auth:
-        google = typer.confirm("Configure Google Ads?", default=True)
-        meta = typer.confirm("Configure Meta Ads?", default=True)
+    should_skip, banner = _should_skip_auth(skip_auth)
+    _warn_unused_ads_flags(should_skip, google_ads, meta_ads)
+    if should_skip:
+        if banner is not None:
+            typer.echo(banner)
+        typer.echo("Run /onboard in Claude Code later to configure credentials.\n")
+    else:
+        google = confirm_or_default(
+            "Configure Google Ads?", default=True, override=google_ads
+        )
+        meta = confirm_or_default(
+            "Configure Meta Ads?", default=True, override=meta_ads
+        )
 
         if google:
             from mureo.auth_setup import setup_google_ads
@@ -123,9 +182,6 @@ def setup_claude_code(
             from mureo.auth_setup import setup_meta_ads
 
             asyncio.run(setup_meta_ads())
-    else:
-        typer.echo("Skipping authentication (--skip-auth).")
-        typer.echo("Run /onboard in Claude Code later to configure credentials.\n")
 
     # 2. MCP configuration
     from mureo.auth_setup import install_mcp_config
@@ -170,7 +226,21 @@ def setup_claude_code(
 
 
 @setup_app.command("cursor")  # type: ignore[untyped-decorator, unused-ignore]
-def setup_cursor() -> None:
+def setup_cursor(
+    skip_auth: bool = typer.Option(
+        False, "--skip-auth", help="Skip authentication (MCP config only)."
+    ),
+    google_ads: bool | None = typer.Option(
+        None,
+        "--google-ads/--no-google-ads",
+        help="Configure Google Ads auth (default: prompt in TTY, yes in non-TTY).",
+    ),
+    meta_ads: bool | None = typer.Option(
+        None,
+        "--meta-ads/--no-meta-ads",
+        help="Configure Meta Ads auth (default: prompt in TTY, yes in non-TTY).",
+    ),
+) -> None:
     """Setup for Cursor users (MCP configuration only).
 
     Cursor supports MCP but does not support slash commands,
@@ -180,20 +250,31 @@ def setup_cursor() -> None:
 
     typer.echo("=== mureo Setup for Cursor ===\n")
 
-    google = typer.confirm("Configure Google Ads?", default=True)
-    meta = typer.confirm("Configure Meta Ads?", default=True)
+    should_skip, banner = _should_skip_auth(skip_auth)
+    _warn_unused_ads_flags(should_skip, google_ads, meta_ads)
+    if should_skip:
+        if banner is not None:
+            typer.echo(banner)
+        google = meta = False
+    else:
+        google = confirm_or_default(
+            "Configure Google Ads?", default=True, override=google_ads
+        )
+        meta = confirm_or_default(
+            "Configure Meta Ads?", default=True, override=meta_ads
+        )
 
-    if google:
-        from mureo.auth_setup import setup_google_ads
+        if google:
+            from mureo.auth_setup import setup_google_ads
 
-        asyncio.run(setup_google_ads())
+            asyncio.run(setup_google_ads())
 
-    if meta:
-        from mureo.auth_setup import setup_meta_ads
+        if meta:
+            from mureo.auth_setup import setup_meta_ads
 
-        asyncio.run(setup_meta_ads())
+            asyncio.run(setup_meta_ads())
 
-    if not google and not meta:
+    if not google and not meta and not should_skip:
         typer.echo("Setup skipped.")
         return
 
@@ -220,6 +301,16 @@ def setup_codex(
         "--skip-auth",
         help="Skip authentication (install MCP config, guard, prompts, skills only)",
     ),
+    google_ads: bool | None = typer.Option(
+        None,
+        "--google-ads/--no-google-ads",
+        help="Configure Google Ads auth (default: prompt in TTY, yes in non-TTY).",
+    ),
+    meta_ads: bool | None = typer.Option(
+        None,
+        "--meta-ads/--no-meta-ads",
+        help="Configure Meta Ads auth (default: prompt in TTY, yes in non-TTY).",
+    ),
 ) -> None:
     """One-command setup for OpenAI Codex CLI users.
 
@@ -238,9 +329,19 @@ def setup_codex(
 
     typer.echo("=== mureo Setup for Codex CLI ===\n")
 
-    if not skip_auth:
-        google = typer.confirm("Configure Google Ads?", default=True)
-        meta = typer.confirm("Configure Meta Ads?", default=True)
+    should_skip, banner = _should_skip_auth(skip_auth)
+    _warn_unused_ads_flags(should_skip, google_ads, meta_ads)
+    if should_skip:
+        if banner is not None:
+            typer.echo(banner)
+        typer.echo("Run /onboard in Codex later to configure credentials.\n")
+    else:
+        google = confirm_or_default(
+            "Configure Google Ads?", default=True, override=google_ads
+        )
+        meta = confirm_or_default(
+            "Configure Meta Ads?", default=True, override=meta_ads
+        )
 
         if google:
             from mureo.auth_setup import setup_google_ads
@@ -251,9 +352,6 @@ def setup_codex(
             from mureo.auth_setup import setup_meta_ads
 
             asyncio.run(setup_meta_ads())
-    else:
-        typer.echo("Skipping authentication (--skip-auth).")
-        typer.echo("Run /onboard in Codex later to configure credentials.\n")
 
     mcp_result = install_codex_mcp_config()
     if mcp_result is not None:
@@ -289,7 +387,21 @@ def setup_codex(
 
 
 @setup_app.command("gemini")  # type: ignore[untyped-decorator, unused-ignore]
-def setup_gemini() -> None:
+def setup_gemini(
+    skip_auth: bool = typer.Option(
+        False, "--skip-auth", help="Skip authentication (extension manifest only)."
+    ),
+    google_ads: bool | None = typer.Option(
+        None,
+        "--google-ads/--no-google-ads",
+        help="Configure Google Ads auth (default: prompt in TTY, yes in non-TTY).",
+    ),
+    meta_ads: bool | None = typer.Option(
+        None,
+        "--meta-ads/--no-meta-ads",
+        help="Configure Meta Ads auth (default: prompt in TTY, yes in non-TTY).",
+    ),
+) -> None:
     """Setup for Gemini CLI users (extension manifest only).
 
     Registers mureo as a Gemini CLI extension at
@@ -304,18 +416,28 @@ def setup_gemini() -> None:
 
     typer.echo("=== mureo Setup for Gemini CLI ===\n")
 
-    google = typer.confirm("Configure Google Ads?", default=True)
-    meta = typer.confirm("Configure Meta Ads?", default=True)
+    should_skip, banner = _should_skip_auth(skip_auth)
+    _warn_unused_ads_flags(should_skip, google_ads, meta_ads)
+    if should_skip:
+        if banner is not None:
+            typer.echo(banner)
+    else:
+        google = confirm_or_default(
+            "Configure Google Ads?", default=True, override=google_ads
+        )
+        meta = confirm_or_default(
+            "Configure Meta Ads?", default=True, override=meta_ads
+        )
 
-    if google:
-        from mureo.auth_setup import setup_google_ads
+        if google:
+            from mureo.auth_setup import setup_google_ads
 
-        asyncio.run(setup_google_ads())
+            asyncio.run(setup_google_ads())
 
-    if meta:
-        from mureo.auth_setup import setup_meta_ads
+        if meta:
+            from mureo.auth_setup import setup_meta_ads
 
-        asyncio.run(setup_meta_ads())
+            asyncio.run(setup_meta_ads())
 
     manifest = install_gemini_extension()
     typer.echo(f"\nGemini extension manifest written to {manifest}")

--- a/tests/test_setup_cmd.py
+++ b/tests/test_setup_cmd.py
@@ -151,3 +151,102 @@ def test_install_skills_default_path(tmp_path: Path) -> None:
 
     assert dest == tmp_path / ".claude" / "skills"
     assert count == 6
+
+
+# ---------------------------------------------------------------------------
+# Non-interactive behavior — regression tests for TTY-safe setup commands
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_should_skip_auth_when_flag_true() -> None:
+    """--skip-auth always wins regardless of TTY state."""
+    from mureo.cli.setup_cmd import _should_skip_auth
+
+    skip, banner = _should_skip_auth(skip_auth_flag=True)
+    assert skip is True
+    assert banner is not None
+    assert "--skip-auth" in banner
+
+
+@pytest.mark.unit
+def test_should_skip_auth_when_no_tty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing TTY (AI-agent subprocess, CI) auto-implies skip-auth."""
+    from mureo.cli.setup_cmd import _should_skip_auth
+
+    monkeypatch.setattr("mureo.cli.setup_cmd.is_tty", lambda: False)
+    skip, banner = _should_skip_auth(skip_auth_flag=False)
+    assert skip is True
+    assert banner is not None
+    assert "No TTY" in banner
+    assert "mureo auth setup" in banner
+
+
+@pytest.mark.unit
+def test_should_not_skip_auth_when_tty_and_no_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Interactive TTY preserves the existing prompting flow."""
+    from mureo.cli.setup_cmd import _should_skip_auth
+
+    monkeypatch.setattr("mureo.cli.setup_cmd.is_tty", lambda: True)
+    skip, banner = _should_skip_auth(skip_auth_flag=False)
+    assert skip is False
+    assert banner is None
+
+
+@pytest.mark.unit
+def test_setup_claude_code_runs_without_tty(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """`mureo setup claude-code` must complete non-interactively under
+    an AI agent (no TTY) AND still perform every non-auth install step.
+
+    Regression lock: a future refactor that silently no-ops everything
+    in non-TTY mode would still print "Setup complete" — so we also
+    assert the MCP config file, the credential guard hook, the workflow
+    commands directory, and the skills directory were all actually
+    created on disk.
+    """
+    import json
+
+    import typer.testing
+
+    from mureo.cli.main import app
+
+    monkeypatch.setattr("mureo.cli.setup_cmd.is_tty", lambda: False)
+    monkeypatch.setattr("mureo.cli.setup_cmd.Path.home", lambda: tmp_path)
+    monkeypatch.setattr("mureo.auth_setup.Path.home", lambda: tmp_path)
+    monkeypatch.setattr("mureo.cli.setup_codex.Path.home", lambda: tmp_path)
+    # Guard: if any code path tries to reach OAuth, fail loudly.
+    from mureo import auth_setup
+
+    def _boom(*_: object, **__: object) -> None:
+        raise AssertionError("OAuth must not be invoked in non-TTY mode")
+
+    monkeypatch.setattr(auth_setup, "setup_google_ads", _boom)
+    monkeypatch.setattr(auth_setup, "setup_meta_ads", _boom)
+
+    runner = typer.testing.CliRunner()
+    result = runner.invoke(app, ["setup", "claude-code"])
+    assert result.exit_code == 0, result.output
+    assert "No TTY detected" in result.output
+    assert "Setup complete" in result.output
+
+    # MCP config must exist with mureo registered.
+    settings_path = tmp_path / ".claude" / "settings.json"
+    assert settings_path.exists()
+    settings = json.loads(settings_path.read_text(encoding="utf-8"))
+    assert "mureo" in settings.get("mcpServers", {})
+    # Credential guard hook installed (same settings.json).
+    hooks = settings.get("hooks", {}).get("PreToolUse", [])
+    assert any(
+        "[mureo-credential-guard]" in h.get("command", "")
+        for entry in hooks
+        for h in entry.get("hooks", [])
+    )
+    # Workflow commands + skills were copied.
+    assert (tmp_path / ".claude" / "commands" / "onboard.md").exists()
+    assert (tmp_path / ".claude" / "skills" / "mureo-workflows").exists()

--- a/tests/test_tty.py
+++ b/tests/test_tty.py
@@ -1,0 +1,141 @@
+"""Tests for mureo.cli._tty — TTY detection and safe confirm helper.
+
+Verifies that setup wizards don't hang when run as a subprocess (e.g.
+from Claude Code's Bash tool) by detecting a missing TTY and taking
+the caller-supplied default instead of calling ``typer.confirm``.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+# Module under test does not exist yet — this drives RED.
+from mureo.cli._tty import confirm_or_default, is_tty  # noqa: I001
+
+
+class _FakeStream:
+    """Minimal stream stand-in whose ``isatty()`` returns a fixed value.
+
+    Used to patch both ``sys.stdin`` and ``sys.stdout`` — ``is_tty``
+    now requires both ends to be terminals.
+    """
+
+    def __init__(self, tty: bool) -> None:
+        self._tty = tty
+
+    def isatty(self) -> bool:
+        return self._tty
+
+
+# Back-compat alias so existing test call sites still read naturally.
+_FakeStdin = _FakeStream
+
+
+def _set_tty(monkeypatch: pytest.MonkeyPatch, *, tty: bool) -> None:
+    """Patch both stdin and stdout to the same TTY state."""
+    monkeypatch.setattr(sys, "stdin", _FakeStream(tty=tty))
+    monkeypatch.setattr(sys, "stdout", _FakeStream(tty=tty))
+
+
+class TestIsTty:
+    def test_returns_true_when_stdin_is_tty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _set_tty(monkeypatch, tty=True)
+        assert is_tty() is True
+
+    def test_returns_false_when_stdin_is_not_tty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _set_tty(monkeypatch, tty=False)
+        assert is_tty() is False
+
+
+class TestConfirmOrDefault:
+    def test_no_tty_returns_default_true(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """In non-TTY (subprocess / Claude Bash tool), take the default
+        without any I/O — no typer.confirm, no input() call."""
+        _set_tty(monkeypatch, tty=False)
+        called = False
+
+        def _sentinel(*_args: object, **_kwargs: object) -> bool:
+            nonlocal called
+            called = True
+            return False
+
+        monkeypatch.setattr("typer.confirm", _sentinel)
+        assert confirm_or_default("Configure?", default=True) is True
+        assert called is False, "typer.confirm must not be called in non-TTY"
+
+    def test_no_tty_returns_default_false(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _set_tty(monkeypatch, tty=False)
+        assert confirm_or_default("Configure?", default=False) is False
+
+    def test_tty_delegates_to_typer_confirm(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With a TTY present, the helper must let typer.confirm drive the
+        actual prompt so existing CLI UX is unchanged."""
+        _set_tty(monkeypatch, tty=True)
+        captured: dict[str, object] = {}
+
+        def _fake_confirm(prompt: str, default: bool = False) -> bool:
+            captured["prompt"] = prompt
+            captured["default"] = default
+            return True
+
+        monkeypatch.setattr("typer.confirm", _fake_confirm)
+        result = confirm_or_default("Configure Google Ads?", default=True)
+
+        assert result is True
+        assert captured == {"prompt": "Configure Google Ads?", "default": True}
+
+    def test_explicit_override_bypasses_prompt(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If the caller already knows the value (e.g. from a CLI flag),
+        passing override=... skips both TTY detection and typer.confirm."""
+        _set_tty(monkeypatch, tty=True)
+        called = False
+
+        def _sentinel(*_args: object, **_kwargs: object) -> bool:
+            nonlocal called
+            called = True
+            return True
+
+        monkeypatch.setattr("typer.confirm", _sentinel)
+        assert (
+            confirm_or_default("Configure?", default=True, override=False) is False
+        )
+        assert called is False, "Explicit override must not call typer.confirm"
+
+    def test_asymmetric_tty_counts_as_non_tty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """stdin TTY but stdout piped (or vice versa) must be treated as
+        non-interactive — prompting would either have no visible output
+        or block on unreachable input."""
+        monkeypatch.setattr(sys, "stdin", _FakeStream(tty=True))
+        monkeypatch.setattr(sys, "stdout", _FakeStream(tty=False))
+        assert is_tty() is False
+        assert confirm_or_default("Configure?", default=True) is True
+
+    def test_eof_from_confirm_falls_back_to_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If stdin closes mid-prompt, fall back to default rather than
+        aborting with a stack trace."""
+        _set_tty(monkeypatch, tty=True)
+
+        def _raise_eof(*_: object, **__: object) -> bool:
+            raise EOFError
+
+        monkeypatch.setattr("typer.confirm", _raise_eof)
+        assert confirm_or_default("Configure?", default=True) is True
+        assert confirm_or_default("Configure?", default=False) is False


### PR DESCRIPTION
## Summary

Unblocks the path for non-technical users to install mureo **from inside Claude Code Desktop** without ever opening a terminal themselves for the setup step.

Previously, when an AI agent (Claude Code Bash tool, Codex, etc.) ran `mureo setup claude-code`, the first `typer.confirm` prompt would hang forever because the subprocess has no TTY. Users had to know to pass `--skip-auth` manually.

Now: setup auto-detects the absence of TTY, skips OAuth with a clear banner, and still installs MCP config / credential guard / workflow commands / skills. OAuth still requires a one-time Terminal.app session because pasting secrets into chat is unsafe — documented explicitly.

## Implementation

**Core**
- `mureo/cli/_tty.py` — new helper module. `is_tty()` requires **both** stdin and stdout to be terminals (stops pipe edge cases). `confirm_or_default(prompt, default, override=None)` with EOFError/Abort fallback so a TTY that disappears mid-prompt still completes the command.

**Setup commands (all 4)**
- Added `--google-ads/--no-google-ads`, `--meta-ads/--no-meta-ads` typer flags.
- Replaced `typer.confirm(...)` pairs with `confirm_or_default(..., override=...)`.
- New `_should_skip_auth()` and `_warn_unused_ads_flags()` helpers at module level.

**Docs**
- README + README.ja: new "From inside Claude Code Desktop" subsection with the natural-language install phrase.
- CHANGELOG: Unreleased entry.

## Test plan

- [x] TDD: 6 new `_tty` helper tests (TTY/non-TTY, asymmetric streams, override precedence, EOF fallback).
- [x] 4 new `setup_cmd` tests including an end-to-end CliRunner test that asserts `setup claude-code` under non-TTY exits 0, never invokes OAuth, and still writes MCP config + guard hook + commands + skills to disk (regression lock against silent no-op).
- [x] Full suite: 1663 passed. mypy / ruff / black clean.
- [ ] CI green after push.

## Known follow-ups (out of scope, tracked for later)

- Webform for Developer Token / App ID / Secret input so OAuth itself can run inside Claude Code without any terminal (Phase 2).
- Refactor the 4 near-duplicate auth blocks in `setup_cmd.py` into a shared `_run_auth_phase()` helper.