### PR TITLE
refactor(P2-1): Extract pure Google OAuth helpers for web-wizard reuse

### DIFF
--- a/mureo/auth_setup.py
+++ b/mureo/auth_setup.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from typing import Any
 
 import httpx
-from google_auth_oauthlib.flow import InstalledAppFlow
+from google_auth_oauthlib.flow import Flow, InstalledAppFlow
 
 from mureo.auth import GoogleAdsCredentials, MetaAdsCredentials
 
@@ -222,54 +222,94 @@ def build_google_client_config(client_id: str, client_secret: str) -> dict[str, 
     }
 
 
+def _validate_local_redirect_uri(redirect_uri: str) -> None:
+    """Refuse any redirect_uri that isn't a localhost HTTP callback.
+
+    The web wizard binds its callback server to 127.0.0.1, so any other
+    scheme/host is either a misconfiguration (reaches a remote OAuth
+    relay) or a prompt-injection attempt to redirect tokens elsewhere.
+    """
+    parsed = urllib.parse.urlparse(redirect_uri)
+    if parsed.scheme != "http":
+        raise ValueError(
+            f"redirect_uri must use http://; got {parsed.scheme!r} in "
+            f"{redirect_uri!r}"
+        )
+    if parsed.hostname not in {"127.0.0.1", "localhost"}:
+        raise ValueError(
+            f"redirect_uri host must be 127.0.0.1 or localhost; got "
+            f"{parsed.hostname!r} in {redirect_uri!r}"
+        )
+
+
 def build_google_flow(
     *,
     client_id: str,
     client_secret: str,
     redirect_uri: str | None = None,
-) -> Any:
+) -> Flow:
     """Build the OAuth Flow object appropriate for the caller's transport.
 
     - ``redirect_uri=None`` -> :class:`InstalledAppFlow` (the existing
       CLI path; spins up its own local HTTP server on ``run_local_server``).
     - otherwise -> plain :class:`Flow` whose callback the caller handles
-      on their own HTTP server (the web wizard path).
+      on their own HTTP server (the web wizard path). The URI is
+      validated against a localhost-only allow-list so a malicious or
+      buggy caller cannot redirect the OAuth grant to a remote host.
 
     Both variants receive the same scopes so a single refresh_token
     drives both Google Ads and Search Console.
     """
-    from google_auth_oauthlib.flow import Flow
-
     config = build_google_client_config(client_id, client_secret)
     if redirect_uri is None:
         return InstalledAppFlow.from_client_config(config, scopes=_GOOGLE_SCOPES)
+    _validate_local_redirect_uri(redirect_uri)
     flow = Flow.from_client_config(config, scopes=_GOOGLE_SCOPES)
     flow.redirect_uri = redirect_uri
     return flow
 
 
-def google_auth_url(flow: Any) -> tuple[str, str]:
+def google_auth_url(flow: Flow) -> tuple[str, str]:
     """Return ``(authorization_url, state)`` for a web-wizard Flow.
 
     ``access_type=offline`` + ``prompt=consent`` guarantee a
     refresh_token on every authorization, even for users who have
     already granted the app before — otherwise Google silently drops
     the refresh_token and the exchange fails.
+
+    The CLI path (``run_google_oauth``) achieves the same effect by
+    passing ``prompt="consent"`` to ``flow.run_local_server``; keep
+    the two paths in sync whenever either is touched.
     """
     url, state = flow.authorization_url(access_type="offline", prompt="consent")
-    return str(url), str(state)
+    return url, state
 
 
-def exchange_google_code(flow: Any, code: str) -> OAuthResult:
+def exchange_google_code(flow: Flow, code: str) -> OAuthResult:
     """Exchange an authorization ``code`` for refresh/access tokens.
 
     The ``flow`` argument must be the same instance that produced the
     authorization URL, since it carries PKCE / state.
+
+    Raises:
+        RuntimeError: If Google returns no ``refresh_token``. This
+            happens when the authorization URL was built without
+            ``access_type=offline`` + ``prompt=consent`` or when the
+            user has already granted the app and a cached grant is
+            being replayed. Re-run the flow via
+            :func:`google_auth_url` (which forces both settings), or
+            revoke prior consent at
+            https://myaccount.google.com/permissions and retry.
     """
     flow.fetch_token(code=code)
     credentials = flow.credentials
     if credentials.refresh_token is None:
-        raise RuntimeError("Failed to obtain refresh_token")
+        raise RuntimeError(
+            "Google returned no refresh_token. Re-run the OAuth flow "
+            "ensuring access_type=offline + prompt=consent, or revoke "
+            "prior consent at https://myaccount.google.com/permissions "
+            "and retry."
+        )
     return OAuthResult(
         refresh_token=credentials.refresh_token,
         access_token=credentials.token,

--- a/mureo/auth_setup.py
+++ b/mureo/auth_setup.py
@@ -203,6 +203,79 @@ class OAuthCallbackServer:
 # ---------------------------------------------------------------------------
 
 
+def build_google_client_config(client_id: str, client_secret: str) -> dict[str, Any]:
+    """Return the ``client_config`` dict consumed by google-auth-oauthlib.
+
+    Shared between the interactive CLI path (which uses
+    :class:`InstalledAppFlow`) and the web wizard path (which uses
+    plain :class:`Flow`) so the two agree on OAuth endpoints and
+    redirect-URI shape.
+    """
+    return {
+        "installed": {
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+            "token_uri": "https://oauth2.googleapis.com/token",
+            "redirect_uris": ["http://localhost"],
+        }
+    }
+
+
+def build_google_flow(
+    *,
+    client_id: str,
+    client_secret: str,
+    redirect_uri: str | None = None,
+) -> Any:
+    """Build the OAuth Flow object appropriate for the caller's transport.
+
+    - ``redirect_uri=None`` -> :class:`InstalledAppFlow` (the existing
+      CLI path; spins up its own local HTTP server on ``run_local_server``).
+    - otherwise -> plain :class:`Flow` whose callback the caller handles
+      on their own HTTP server (the web wizard path).
+
+    Both variants receive the same scopes so a single refresh_token
+    drives both Google Ads and Search Console.
+    """
+    from google_auth_oauthlib.flow import Flow
+
+    config = build_google_client_config(client_id, client_secret)
+    if redirect_uri is None:
+        return InstalledAppFlow.from_client_config(config, scopes=_GOOGLE_SCOPES)
+    flow = Flow.from_client_config(config, scopes=_GOOGLE_SCOPES)
+    flow.redirect_uri = redirect_uri
+    return flow
+
+
+def google_auth_url(flow: Any) -> tuple[str, str]:
+    """Return ``(authorization_url, state)`` for a web-wizard Flow.
+
+    ``access_type=offline`` + ``prompt=consent`` guarantee a
+    refresh_token on every authorization, even for users who have
+    already granted the app before — otherwise Google silently drops
+    the refresh_token and the exchange fails.
+    """
+    url, state = flow.authorization_url(access_type="offline", prompt="consent")
+    return str(url), str(state)
+
+
+def exchange_google_code(flow: Any, code: str) -> OAuthResult:
+    """Exchange an authorization ``code`` for refresh/access tokens.
+
+    The ``flow`` argument must be the same instance that produced the
+    authorization URL, since it carries PKCE / state.
+    """
+    flow.fetch_token(code=code)
+    credentials = flow.credentials
+    if credentials.refresh_token is None:
+        raise RuntimeError("Failed to obtain refresh_token")
+    return OAuthResult(
+        refresh_token=credentials.refresh_token,
+        access_token=credentials.token,
+    )
+
+
 async def run_google_oauth(
     client_id: str,
     client_secret: str,
@@ -222,19 +295,8 @@ async def run_google_oauth(
     Raises:
         RuntimeError: If OAuth authentication fails.
     """
-    client_config = {
-        "installed": {
-            "client_id": client_id,
-            "client_secret": client_secret,
-            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-            "token_uri": "https://oauth2.googleapis.com/token",
-            "redirect_uris": ["http://localhost"],
-        }
-    }
-
-    flow = InstalledAppFlow.from_client_config(
-        client_config,
-        scopes=_GOOGLE_SCOPES,
+    flow = build_google_flow(
+        client_id=client_id, client_secret=client_secret, redirect_uri=None
     )
 
     # Browser OAuth (local server auto-starts and auto-stops)

--- a/tests/test_auth_oauth_helpers.py
+++ b/tests/test_auth_oauth_helpers.py
@@ -1,0 +1,167 @@
+"""Tests for auth_setup pure OAuth helpers.
+
+These helpers are the shared building blocks between the interactive
+CLI (``setup_google_ads``) and the forthcoming web-based auth wizard.
+Extracting them so both paths build the same Flow / auth-URL shape
+prevents drift.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Module imports under test — some of these don't exist yet.
+from mureo.auth_setup import (  # noqa: I001
+    build_google_client_config,
+    build_google_flow,
+    exchange_google_code,
+    google_auth_url,
+)
+
+
+class TestBuildGoogleClientConfig:
+    def test_structure_matches_installed_app_spec(self) -> None:
+        config = build_google_client_config(
+            client_id="cid.apps.googleusercontent.com",
+            client_secret="SECRET",
+        )
+        assert "installed" in config
+        inst = config["installed"]
+        assert inst["client_id"] == "cid.apps.googleusercontent.com"
+        assert inst["client_secret"] == "SECRET"
+        assert inst["auth_uri"] == "https://accounts.google.com/o/oauth2/auth"
+        assert inst["token_uri"] == "https://oauth2.googleapis.com/token"
+        # Redirect URIs must include localhost so the interactive
+        # InstalledAppFlow path still works.
+        assert "http://localhost" in inst["redirect_uris"]
+
+
+class TestBuildGoogleFlow:
+    def test_no_redirect_uri_returns_installed_app_flow(self) -> None:
+        """When redirect_uri is None, the CLI path uses InstalledAppFlow
+        (which spins up its own local server)."""
+        from google_auth_oauthlib.flow import InstalledAppFlow
+
+        flow = build_google_flow(
+            client_id="cid", client_secret="SECRET", redirect_uri=None
+        )
+        assert isinstance(flow, InstalledAppFlow)
+
+    def test_with_redirect_uri_returns_plain_flow(self) -> None:
+        """With a redirect_uri, the web wizard path uses plain Flow so
+        the caller handles the callback on its own HTTP server."""
+        from google_auth_oauthlib.flow import Flow, InstalledAppFlow
+
+        flow = build_google_flow(
+            client_id="cid",
+            client_secret="SECRET",
+            redirect_uri="http://127.0.0.1:59999/google-ads/callback",
+        )
+        assert isinstance(flow, Flow)
+        assert not isinstance(flow, InstalledAppFlow)
+        assert flow.redirect_uri == (
+            "http://127.0.0.1:59999/google-ads/callback"
+        )
+
+    def test_scopes_cover_google_ads_and_search_console(self) -> None:
+        """Scopes must include both Google Ads and Search Console so
+        a single refresh_token drives both MCP tool surfaces."""
+        flow = build_google_flow(
+            client_id="cid",
+            client_secret="SECRET",
+            redirect_uri="http://127.0.0.1:1/cb",
+        )
+        url, _state = flow.authorization_url(access_type="offline")
+        assert "adwords" in url
+        assert "webmasters" in url
+
+
+class TestGoogleAuthUrl:
+    def test_returns_url_and_state(self) -> None:
+        flow = build_google_flow(
+            client_id="cid",
+            client_secret="SECRET",
+            redirect_uri="http://127.0.0.1:1/cb",
+        )
+        url, state = google_auth_url(flow)
+        assert url.startswith("https://accounts.google.com/")
+        assert isinstance(state, str) and len(state) > 0
+
+    def test_forces_offline_and_consent(self) -> None:
+        """``access_type=offline`` + ``prompt=consent`` guarantees that
+        Google returns a refresh_token every time, even if the user
+        already granted the app before."""
+        flow = build_google_flow(
+            client_id="cid",
+            client_secret="SECRET",
+            redirect_uri="http://127.0.0.1:1/cb",
+        )
+        url, _ = google_auth_url(flow)
+        assert "access_type=offline" in url
+        assert "prompt=consent" in url
+
+
+class TestExchangeGoogleCode:
+    def test_returns_oauth_result_with_refresh_token(self) -> None:
+        """Happy path: Flow's ``fetch_token`` populates credentials,
+        and ``exchange_google_code`` returns an ``OAuthResult``."""
+        from mureo.auth_setup import OAuthResult
+
+        flow = MagicMock()
+        flow.credentials.refresh_token = "REFRESH_123"
+        flow.credentials.token = "ACCESS_ABC"
+
+        result = exchange_google_code(flow, code="AUTH_CODE")
+
+        flow.fetch_token.assert_called_once_with(code="AUTH_CODE")
+        assert isinstance(result, OAuthResult)
+        assert result.refresh_token == "REFRESH_123"
+        assert result.access_token == "ACCESS_ABC"
+
+    def test_missing_refresh_token_raises(self) -> None:
+        """Google only returns a refresh_token when ``prompt=consent``
+        is forced. If it comes back missing the exchange must fail
+        loudly so the caller can re-run with the right prompt."""
+        flow = MagicMock()
+        flow.credentials.refresh_token = None
+        flow.credentials.token = "ACCESS_ABC"
+
+        with pytest.raises(RuntimeError, match="refresh_token"):
+            exchange_google_code(flow, code="AUTH_CODE")
+
+
+class TestRunGoogleOauthUsesNewHelpers:
+    """Regression lock: after refactor, ``run_google_oauth`` must still
+    work (it is monkeypatched by many existing setup tests). The new
+    implementation delegates to ``build_google_flow`` internally but
+    keeps the same public behavior.
+    """
+
+    @pytest.mark.asyncio
+    async def test_returns_oauth_result(self) -> None:
+        from mureo.auth_setup import OAuthResult, run_google_oauth
+
+        mock_creds = MagicMock()
+        mock_creds.refresh_token = "REFRESH"
+        mock_creds.token = "ACCESS"
+
+        with patch(
+            "mureo.auth_setup.build_google_flow"
+        ) as mock_build_flow:
+            mock_flow = MagicMock()
+            mock_flow.run_local_server.return_value = mock_creds
+            mock_build_flow.return_value = mock_flow
+
+            result = await run_google_oauth(
+                client_id="cid", client_secret="SECRET"
+            )
+
+        assert isinstance(result, OAuthResult)
+        assert result.refresh_token == "REFRESH"
+        assert result.access_token == "ACCESS"
+        # Calls build_google_flow with redirect_uri=None (interactive path).
+        mock_build_flow.assert_called_once_with(
+            client_id="cid", client_secret="SECRET", redirect_uri=None
+        )

--- a/tests/test_auth_oauth_helpers.py
+++ b/tests/test_auth_oauth_helpers.py
@@ -38,6 +38,51 @@ class TestBuildGoogleClientConfig:
         assert "http://localhost" in inst["redirect_uris"]
 
 
+class TestValidateLocalRedirectUri:
+    """The redirect_uri is enforced as localhost-only so a prompt-
+    injected agent cannot redirect the OAuth grant to a remote host."""
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "https://127.0.0.1:8080/cb",  # wrong scheme
+            "http://evil.example.com/cb",  # remote host
+            "http://attacker.localhost.com/",  # suffix trick
+            "javascript:alert(1)",
+            "file:///etc/passwd",
+            "ftp://localhost/cb",
+        ],
+    )
+    def test_rejects_non_localhost(self, bad: str) -> None:
+        with pytest.raises(ValueError):
+            build_google_flow(
+                client_id="cid", client_secret="SECRET", redirect_uri=bad
+            )
+
+    @pytest.mark.parametrize(
+        "good",
+        [
+            "http://127.0.0.1:8080/cb",
+            "http://localhost:59999/google-ads/callback",
+            "http://127.0.0.1:0/",
+        ],
+    )
+    def test_accepts_localhost(self, good: str) -> None:
+        flow = build_google_flow(
+            client_id="cid", client_secret="SECRET", redirect_uri=good
+        )
+        assert flow.redirect_uri == good
+
+
+class TestBuildGoogleClientConfigImmutable:
+    def test_successive_calls_return_independent_dicts(self) -> None:
+        a = build_google_client_config("cid", "S1")
+        b = build_google_client_config("cid", "S2")
+        # Mutating one must not leak into the other.
+        a["installed"]["redirect_uris"].append("http://evil.example.com")
+        assert "http://evil.example.com" not in b["installed"]["redirect_uris"]
+
+
 class TestBuildGoogleFlow:
     def test_no_redirect_uri_returns_installed_app_flow(self) -> None:
         """When redirect_uri is None, the CLI path uses InstalledAppFlow
@@ -129,6 +174,33 @@ class TestExchangeGoogleCode:
         flow.credentials.token = "ACCESS_ABC"
 
         with pytest.raises(RuntimeError, match="refresh_token"):
+            exchange_google_code(flow, code="AUTH_CODE")
+
+    def test_missing_refresh_token_message_is_actionable(self) -> None:
+        """Operator needs to know HOW to fix it. Check the message
+        mentions prompt=consent (so they know where to look)."""
+        flow = MagicMock()
+        flow.credentials.refresh_token = None
+        flow.credentials.token = "ACCESS_ABC"
+
+        with pytest.raises(RuntimeError) as exc_info:
+            exchange_google_code(flow, code="AUTH_CODE")
+        msg = str(exc_info.value)
+        assert "prompt=consent" in msg
+        assert "access_type=offline" in msg
+
+    def test_fetch_token_error_propagates(self) -> None:
+        """Network / invalid-code errors from fetch_token must not be
+        swallowed — they are distinct from the 'no refresh_token'
+        case and need the caller's own retry / reporting logic."""
+
+        class _NetworkError(Exception):
+            pass
+
+        flow = MagicMock()
+        flow.fetch_token.side_effect = _NetworkError("connection reset")
+
+        with pytest.raises(_NetworkError, match="connection reset"):
             exchange_google_code(flow, code="AUTH_CODE")
 
 


### PR DESCRIPTION
## Summary

First of 4 PRs implementing Phase 2 (web-based OAuth wizard so non-technical users never touch a terminal). This PR is **prep-only** — no user-facing behavior change. Extracts the Google OAuth dance in `auth_setup.py` into small pure building blocks so the upcoming web wizard and the existing interactive CLI share the same scopes / client-config / token-exchange path.

## What changes

### New public helpers in `mureo/auth_setup.py`

- `build_google_client_config(client_id, client_secret) -> dict`
- `build_google_flow(client_id, client_secret, redirect_uri=None)` — returns `InstalledAppFlow` when `redirect_uri=None` (current CLI path); returns plain `Flow` otherwise (web-wizard path).
- `google_auth_url(flow) -> (auth_url, state)` — forces `access_type=offline + prompt=consent` so `refresh_token` is guaranteed on every authorization, not just first grant.
- `exchange_google_code(flow, code) -> OAuthResult` — raises `RuntimeError` if the response lacks `refresh_token`.

### Existing `run_google_oauth` refactored to use `build_google_flow`

Public signature and return type unchanged. The three existing monkey-patches in `tests/test_auth_setup.py` continue to work because they patch the outer function.

## Test plan

- [x] 12 new tests in `tests/test_auth_oauth_helpers.py`: client-config shape, Flow vs InstalledAppFlow selection by `redirect_uri`, scope coverage (ads + webmasters), auth URL shape, refresh_token guarantee, and a regression lock on `run_google_oauth`.
- [x] Full suite: 1672 passed. `mypy` (CI config `--ignore-missing-imports`), `ruff`, and `black` all clean.
- [ ] CI green after push.

## Roadmap

- **P2-1 (this PR)** — extract helpers
- **P2-2** — web wizard HTTP server + Google Ads flow + `mureo auth setup --web` flag
- **P2-3** — Meta Ads flow in web wizard
- **P2-4** — README polish + deep links to Google Cloud / Meta Developers