### PR TITLE
feat(P2-2): Browser-based OAuth wizard (mureo auth setup --web)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `mureo auth setup --web` — browser-based OAuth wizard for non-technical users. Starts a short-lived localhost HTTP server on a random port, opens the browser to a simple HTML form for Developer Token / OAuth Client ID / Client Secret, redirects to Google's own sign-in, receives the callback on the same wizard server, and writes `~/.mureo/credentials.json` — all without the operator opening a terminal. Inline deep links point at Google Cloud Console / Google Ads API Center so users know where to fetch each secret.
+- Security hardening for the wizard: CSRF token rotates after every successful submit (replay guard); OAuth `state` parameter is stored at submit time and re-validated with `secrets.compare_digest` on callback; `Host` header must match `127.0.0.1:<port>` or `localhost:<port>` (DNS-rebinding guard); redirect URL is verified to start with `https://accounts.google.com/` before emitting 302 (open-redirect guard); session secret fields are zeroed after `save_credentials` succeeds; CSP includes `default-src 'none'`, `base-uri 'none'`, `frame-ancestors 'none'`, `object-src 'none'`, and `form-action 'self' https://accounts.google.com`; responses also set `X-Frame-Options: DENY` and `Referrer-Policy: no-referrer`; POST bodies over 16 KiB are refused with 413; exception messages from OAuth failures are logged server-side only — the browser sees a generic retry hint.
+
 ### Changed
 - `mureo setup claude-code` / `cursor` / `codex` / `gemini` are now TTY-safe. When run from an AI agent's subprocess (Claude Code's Bash tool, Codex, etc.) without a controlling TTY, they auto-imply `--skip-auth` and print a banner instructing the operator to finish authentication in Terminal.app. Previously they hung forever on the first `typer.confirm` prompt.
 - Each setup subcommand gained explicit `--google-ads/--no-google-ads` and `--meta-ads/--no-meta-ads` flags so choices can be specified without any prompt. Passing them together with `--skip-auth` (or under a non-TTY) emits a warning explaining they were ignored.
@@ -15,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - README + README.ja: "From inside Claude Code Desktop" section with a natural-language install phrase that non-technical users can paste into the Code tab. Notes that OAuth (Developer Token, App ID/Secret input) still requires a one-time Terminal.app session for safety.
 
-## [0.5.0] - 2026-04-18
+## [0.5.0] - 2026-04-19
 
 ### Added
 - `mureo setup codex` — new subcommand that installs the full mureo kit for OpenAI Codex CLI: tagged `[mcp_servers.mureo]` block in `~/.codex/config.toml` (append-only, idempotent, refuses to proceed if an untagged `[mcp_servers.mureo]` already exists), Read + Bash PreToolUse credential guard in `~/.codex/hooks.json`, workflow prompts in `~/.codex/prompts/*.md`, and skills in `~/.codex/skills/mureo-*/`. Config and hooks are written atomically via temp-file + rename so a mid-install crash cannot defeat the tag-based idempotency check. Corrupt `hooks.json` and non-list `PreToolUse` values are refused rather than silently clobbered.

--- a/mureo/cli/auth_cmd.py
+++ b/mureo/cli/auth_cmd.py
@@ -85,9 +85,27 @@ def check_meta() -> None:
 
 
 @auth_app.command("setup")  # type: ignore[untyped-decorator, unused-ignore]
-def auth_setup() -> None:
-    """Interactive setup wizard."""
+def auth_setup(
+    web: bool = typer.Option(
+        False,
+        "--web",
+        help=(
+            "Run the browser-based wizard instead of the terminal "
+            "prompts. Recommended for non-technical users."
+        ),
+    ),
+) -> None:
+    """Interactive setup wizard (terminal or browser)."""
     import asyncio
+
+    if web:
+        from mureo.cli.web_auth import run_web_wizard
+
+        typer.echo("=== mureo Web Setup Wizard ===")
+        typer.echo("A browser tab will open for secret entry and OAuth.")
+        typer.echo("")
+        run_web_wizard()
+        return
 
     typer.echo("=== mureo Setup Wizard ===")
     typer.echo("")

--- a/mureo/cli/web_auth.py
+++ b/mureo/cli/web_auth.py
@@ -1,0 +1,529 @@
+"""Browser-based OAuth wizard for non-technical users.
+
+``mureo auth setup --web`` starts a short-lived localhost HTTP server
+and opens the operator's browser to a simple form. The user pastes
+the Google Ads Developer Token / OAuth Client ID / Secret, clicks
+"Continue", completes Google OAuth in the same browser window, and
+the wizard saves ``~/.mureo/credentials.json`` without requiring any
+terminal interaction.
+
+Design choices and safety properties:
+
+- **Stdlib only.** ``http.server.HTTPServer`` +
+  ``BaseHTTPRequestHandler``. No external Web framework dependency.
+- **Random local port.** Bind to ``127.0.0.1:0`` so the OS picks a
+  free port; the URL is printed once at startup.
+- **Localhost only.** Bind address is always ``127.0.0.1``; the
+  shared ``build_google_flow`` helper validates ``redirect_uri`` is
+  localhost-only as a second layer.
+- **CSRF.** Every form POST carries a hidden ``csrf_token`` input
+  that must match the per-session token. Compared with
+  ``secrets.compare_digest``.
+- **No external resources.** Inline CSS only; no CDN fetches, no JS
+  frameworks. Prevents a supply-chain compromise from injecting into
+  the wizard page.
+- **Server dies on completion.** The ``/done`` page marks the
+  wizard complete; callers can check ``wizard.completed`` and shut
+  down once they're satisfied.
+- **Session is in-memory only.** No persistence beyond the save of
+  final credentials. If the process dies before ``/done`` the half-
+  entered secrets are lost — desired, not regrettable.
+
+Meta Ads support ships in a follow-up PR (P2-3).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import html
+import http.server
+import logging
+import secrets as _secrets
+import socketserver
+import threading
+import time
+import urllib.parse
+import webbrowser
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from mureo.auth import GoogleAdsCredentials
+
+if TYPE_CHECKING:
+    from pathlib import Path
+from mureo.auth_setup import (
+    build_google_flow,
+    exchange_google_code,
+    google_auth_url,
+    save_credentials,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Session state
+# ---------------------------------------------------------------------------
+
+
+def _fresh_csrf_token() -> str:
+    return _secrets.token_urlsafe(32)
+
+
+@dataclass
+class WizardSession:
+    """In-memory state for a single setup run.
+
+    Not thread-safe — the wizard is single-user by design; only one
+    browser tab drives it at a time. Fields start as ``None`` and are
+    populated as the user walks through the flow.
+    """
+
+    csrf_token: str = field(default_factory=_fresh_csrf_token)
+    google_flow: Any = None
+    google_developer_token: str | None = None
+    google_client_id: str | None = None
+    google_client_secret: str | None = None
+    google_oauth_state: str | None = None
+
+    def rotate_csrf(self) -> None:
+        """Regenerate the CSRF token after a successful mutating POST.
+
+        Prevents replay — once the submit handler accepts a token, that
+        same token cannot be reused by another tab or a Back-button
+        resubmission.
+        """
+        self.csrf_token = _fresh_csrf_token()
+
+    def clear_secrets(self) -> None:
+        """Zero secret fields after credentials have been persisted.
+
+        The Flow object still holds a copy internally; we can't reach
+        into google-auth, but mureo's own session copies are cleared.
+        """
+        self.google_developer_token = None
+        self.google_client_id = None
+        self.google_client_secret = None
+        self.google_flow = None
+        self.google_oauth_state = None
+
+
+# ---------------------------------------------------------------------------
+# HTML templates (inline, escaped)
+# ---------------------------------------------------------------------------
+
+
+_BASE_STYLE = """<style>
+body { font-family: -apple-system, sans-serif; max-width: 640px; margin: 40px auto; padding: 0 16px; color: #222; }
+h1 { border-bottom: 1px solid #eee; padding-bottom: 8px; }
+form { margin: 24px 0; }
+label { display: block; margin: 12px 0 4px; font-weight: 600; }
+input[type=text], input[type=password] { width: 100%; padding: 8px; border: 1px solid #ccc; border-radius: 4px; font-size: 14px; box-sizing: border-box; }
+.hint { color: #666; font-size: 13px; margin-top: 2px; }
+.hint a { color: #06c; }
+button { margin-top: 16px; padding: 10px 20px; background: #06c; color: white; border: 0; border-radius: 4px; cursor: pointer; font-size: 14px; }
+button:hover { background: #05a; }
+.notice { background: #f5f9ff; border-left: 4px solid #06c; padding: 12px 16px; margin: 16px 0; font-size: 13px; }
+</style>"""
+
+
+def render_home(session: WizardSession) -> str:  # noqa: ARG001
+    """Platform chooser — first page the user sees."""
+    return f"""<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><title>mureo setup</title>{_BASE_STYLE}</head>
+<body>
+<h1>mureo setup</h1>
+<p>Pick the ad platform you want to configure.</p>
+<form method="get" action="/google-ads">
+  <button type="submit">Configure Google Ads</button>
+</form>
+<p class="notice">Meta Ads support is coming soon — it will appear here as a second button once the related release ships.</p>
+</body></html>
+"""
+
+
+def render_google_secrets_form(session: WizardSession) -> str:
+    """Form for Developer Token / Client ID / Secret."""
+    csrf = html.escape(session.csrf_token, quote=True)
+    return f"""<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><title>Google Ads — mureo setup</title>{_BASE_STYLE}</head>
+<body>
+<h1>Google Ads credentials</h1>
+<p>Paste the three values below. Links next to each field take you to the page in Google's console where each value is displayed.</p>
+<form method="post" action="/google-ads/submit">
+  <input type="hidden" name="csrf_token" value="{csrf}">
+
+  <label for="developer_token">Developer Token</label>
+  <input id="developer_token" name="developer_token" type="text" required autocomplete="off">
+  <div class="hint">Available in the Google Ads API Center — <a href="https://ads.google.com/aw/apicenter" target="_blank" rel="noopener">ads.google.com/aw/apicenter</a>. Requires an approved Google Ads manager account.</div>
+
+  <label for="client_id">OAuth Client ID</label>
+  <input id="client_id" name="client_id" type="text" required autocomplete="off">
+  <div class="hint">Create an OAuth 2.0 client (Application type: Desktop) in <a href="https://console.cloud.google.com/apis/credentials" target="_blank" rel="noopener">Google Cloud Console → APIs &amp; Services → Credentials</a>.</div>
+
+  <label for="client_secret">OAuth Client Secret</label>
+  <input id="client_secret" name="client_secret" type="password" required autocomplete="off">
+  <div class="hint">Shown once when the OAuth client is created. Re-open the client in Cloud Console to copy it again.</div>
+
+  <button type="submit">Continue to Google sign-in</button>
+</form>
+<p class="notice">Nothing leaves your machine. The next page is Google's own sign-in, and the refresh token it returns is written to <code>~/.mureo/credentials.json</code> locally.</p>
+</body></html>
+"""
+
+
+def render_done() -> str:
+    """Shown after Google OAuth + credentials save complete."""
+    return f"""<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><title>mureo setup — done</title>{_BASE_STYLE}</head>
+<body>
+<h1>Setup complete</h1>
+<p>Credentials saved to <code>~/.mureo/credentials.json</code>. You can close this tab.</p>
+<p class="notice">Restart Claude Desktop (or your MCP client) to pick up the new configuration.</p>
+</body></html>
+"""
+
+
+def render_error(message: str) -> str:
+    safe = html.escape(message)
+    return f"""<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><title>mureo setup — error</title>{_BASE_STYLE}</head>
+<body>
+<h1>Something went wrong</h1>
+<p>{safe}</p>
+<p><a href="/">Back to start</a></p>
+</body></html>
+"""
+
+
+# ---------------------------------------------------------------------------
+# HTTP server
+# ---------------------------------------------------------------------------
+
+
+class _WizardServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
+    """ThreadingHTTPServer with a ``wizard`` attribute for handlers."""
+
+    daemon_threads = True
+    allow_reuse_address = True
+    wizard: WebAuthWizard
+
+
+class _WizardHandler(http.server.BaseHTTPRequestHandler):
+    """Route dispatcher for the wizard HTTP server."""
+
+    server: _WizardServer
+
+    # --- routing ---------------------------------------------------------
+
+    def do_GET(self) -> None:  # noqa: N802
+        parsed = urllib.parse.urlparse(self.path)
+        path = parsed.path
+        if path == "/":
+            self._send_html(render_home(self.server.wizard.session))
+        elif path == "/google-ads":
+            self._send_html(render_google_secrets_form(self.server.wizard.session))
+        elif path == "/google-ads/callback":
+            self._handle_google_callback(parsed.query)
+        elif path == "/done":
+            self._send_html(render_done())
+            self.server.wizard.mark_completed()
+        else:
+            self.send_error(404, "Not found")
+
+    def do_POST(self) -> None:  # noqa: N802
+        parsed = urllib.parse.urlparse(self.path)
+        if parsed.path == "/google-ads/submit":
+            self._handle_google_submit()
+        else:
+            self.send_error(404, "Not found")
+
+    # --- route implementations ------------------------------------------
+
+    _MAX_FORM_BYTES = 16 * 1024  # 16 KiB cap; secrets are short.
+    _GOOGLE_AUTH_ORIGIN = "https://accounts.google.com/"
+
+    def _handle_google_submit(self) -> None:
+        if not self._host_header_ok():
+            self.send_error(403, "Host header not allowed (DNS rebinding guard)")
+            return
+
+        form = self._read_form()
+        if form is None:
+            self.send_error(413, "Payload too large")
+            return
+        if not self._csrf_ok(form.get("csrf_token", "")):
+            self.send_error(403, "CSRF token invalid")
+            return
+
+        dev_token = form.get("developer_token", "").strip()
+        client_id = form.get("client_id", "").strip()
+        client_secret = form.get("client_secret", "").strip()
+        if not (dev_token and client_id and client_secret):
+            self._send_html(render_error("All three fields are required."), status=400)
+            return
+
+        redirect_uri = (
+            f"http://127.0.0.1:{self.server.server_address[1]}/google-ads/callback"
+        )
+        try:
+            flow = build_google_flow(
+                client_id=client_id,
+                client_secret=client_secret,
+                redirect_uri=redirect_uri,
+            )
+            auth_url, state = google_auth_url(flow)
+        except Exception:
+            logger.exception("Failed to build Google OAuth URL")
+            self._send_html(
+                render_error(
+                    "Could not start Google OAuth. "
+                    "Verify the Client ID / Secret and retry."
+                ),
+                status=500,
+            )
+            return
+
+        if not auth_url.startswith(self._GOOGLE_AUTH_ORIGIN):
+            # Defensive: build_google_flow should always yield a
+            # Google-owned URL, but enforce explicitly so the wizard
+            # cannot become an open redirect.
+            logger.error("Refusing 302 to non-Google URL: %s", auth_url)
+            self._send_html(
+                render_error("Unexpected OAuth destination; aborting."),
+                status=500,
+            )
+            return
+
+        sess = self.server.wizard.session
+        sess.google_flow = flow
+        sess.google_developer_token = dev_token
+        sess.google_client_id = client_id
+        sess.google_client_secret = client_secret
+        sess.google_oauth_state = state
+        sess.rotate_csrf()  # Invalidate the token we just consumed.
+
+        self.send_response(302)
+        self.send_header("Location", auth_url)
+        self.end_headers()
+
+    def _handle_google_callback(self, query: str) -> None:
+        if not self._host_header_ok():
+            self.send_error(403, "Host header not allowed (DNS rebinding guard)")
+            return
+
+        params = urllib.parse.parse_qs(query)
+        code = params.get("code", [""])[0]
+        returned_state = params.get("state", [""])[0]
+        oauth_error = params.get("error", [""])[0]
+        sess = self.server.wizard.session
+
+        # Google redirects here with ``error=access_denied`` etc. when
+        # the user declines or Google refuses the authorization. Show a
+        # friendly message instead of a bare 400.
+        if oauth_error:
+            self._send_html(
+                render_error(
+                    f"Google sign-in was cancelled or refused "
+                    f"(error: {oauth_error}). Return to / and retry."
+                ),
+                status=400,
+            )
+            return
+
+        if not code or sess.google_flow is None:
+            self.send_error(
+                400,
+                "Missing authorization code or no in-progress OAuth flow",
+            )
+            return
+
+        expected_state = sess.google_oauth_state or ""
+        if not expected_state or not _secrets.compare_digest(
+            returned_state, expected_state
+        ):
+            logger.warning("OAuth state mismatch on callback")
+            self.send_error(
+                403,
+                "OAuth state mismatch -- possible CSRF or link reuse",
+            )
+            return
+
+        try:
+            result = exchange_google_code(sess.google_flow, code)
+        except Exception:
+            logger.exception("Google token exchange failed")
+            self._send_html(
+                render_error(
+                    "Google rejected the authorization. "
+                    "Re-open the wizard at / and retry."
+                ),
+                status=400,
+            )
+            return
+
+        creds = GoogleAdsCredentials(
+            developer_token=sess.google_developer_token or "",
+            client_id=sess.google_client_id or "",
+            client_secret=sess.google_client_secret or "",
+            refresh_token=result.refresh_token,
+        )
+        save_credentials(path=self.server.wizard.credentials_path, google=creds)
+        sess.clear_secrets()  # Zero session state now that it's persisted.
+
+        self.send_response(302)
+        self.send_header("Location", "/done")
+        self.end_headers()
+
+    # --- helpers ---------------------------------------------------------
+
+    def _host_header_ok(self) -> bool:
+        """Defend against DNS-rebinding: the browser's Host must match
+        127.0.0.1:<port> or localhost:<port>. A malicious page resolving
+        attacker.com to 127.0.0.1 would otherwise POST to the wizard
+        with the attacker origin intact."""
+        host = self.headers.get("Host", "")
+        port = self.server.server_address[1]
+        return host in {f"127.0.0.1:{port}", f"localhost:{port}"}
+
+    def _csrf_ok(self, supplied: str) -> bool:
+        expected = self.server.wizard.session.csrf_token
+        return bool(supplied) and _secrets.compare_digest(supplied, expected)
+
+    def _read_form(self) -> dict[str, str] | None:
+        length = int(self.headers.get("Content-Length", "0") or 0)
+        if length > self._MAX_FORM_BYTES:
+            return None
+        body = self.rfile.read(length) if length else b""
+        return {k: v[0] for k, v in urllib.parse.parse_qs(body.decode("utf-8")).items()}
+
+    def _send_html(self, body: str, status: int = 200) -> None:
+        encoded = body.encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.send_header(
+            "Content-Security-Policy",
+            (
+                "default-src 'none'; "
+                "style-src 'unsafe-inline'; "
+                "base-uri 'none'; "
+                "frame-ancestors 'none'; "
+                "object-src 'none'; "
+                "form-action 'self' https://accounts.google.com"
+            ),
+        )
+        self.send_header("X-Content-Type-Options", "nosniff")
+        self.send_header("X-Frame-Options", "DENY")
+        self.send_header("Referrer-Policy", "no-referrer")
+        self.end_headers()
+        # Client may have closed the tab between headers and body —
+        # swallow the resulting broken-pipe so it doesn't spam logs.
+        with contextlib.suppress(BrokenPipeError, ConnectionResetError):
+            self.wfile.write(encoded)
+
+    def log_message(self, fmt: str, *args: Any) -> None:  # noqa: A003
+        """Route HTTP access logs through the logger (quieter by default)."""
+        logger.debug(fmt, *args)
+
+
+# ---------------------------------------------------------------------------
+# WebAuthWizard — public API
+# ---------------------------------------------------------------------------
+
+
+class WebAuthWizard:
+    """Browser-driven OAuth wizard."""
+
+    def __init__(
+        self,
+        *,
+        bind_host: str = "127.0.0.1",
+        credentials_path: Path | None = None,
+    ) -> None:
+        self._bind_host = bind_host
+        self.credentials_path = credentials_path
+        self.session = WizardSession()
+        self.completed = False
+
+        self._server: _WizardServer | None = None
+        self._ready = threading.Event()
+        self._lock = threading.Lock()
+
+    @property
+    def port(self) -> int:
+        if self._server is None:
+            raise RuntimeError("serve() has not been called yet")
+        return int(self._server.server_address[1])
+
+    def home_url(self) -> str:
+        return f"http://{self._bind_host}:{self.port}/"
+
+    def serve(self) -> None:
+        """Block and serve requests until :meth:`shutdown` is called."""
+        with _WizardServer((self._bind_host, 0), _WizardHandler) as server:
+            server.wizard = self
+            self._server = server
+            self._ready.set()
+            try:
+                server.serve_forever(poll_interval=0.1)
+            finally:
+                with self._lock:
+                    self._server = None
+
+    def wait_until_ready(self, timeout: float = 5.0) -> None:
+        """Block until the server has bound its socket."""
+        if not self._ready.wait(timeout=timeout):
+            raise TimeoutError("wizard failed to bind within timeout")
+
+    def shutdown(self) -> None:
+        with self._lock:
+            server = self._server
+        if server is not None:
+            server.shutdown()
+
+    def mark_completed(self) -> None:
+        self.completed = True
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def run_web_wizard(
+    *,
+    credentials_path: Path | None = None,
+    open_browser: bool = True,
+    timeout_seconds: float = 600.0,
+) -> None:
+    """Start the wizard, open the browser, wait for completion."""
+    wizard = WebAuthWizard(credentials_path=credentials_path)
+    thread = threading.Thread(target=wizard.serve, daemon=True)
+    thread.start()
+    wizard.wait_until_ready()
+
+    url = wizard.home_url()
+    print(f"mureo setup wizard running at {url}")
+    print("(the browser should open automatically; if not, copy the URL)")
+    if open_browser:
+        try:
+            webbrowser.open(url)
+        except Exception:  # noqa: BLE001
+            logger.exception("Could not open browser automatically")
+
+    deadline = time.monotonic() + timeout_seconds
+    try:
+        while not wizard.completed:
+            if time.monotonic() > deadline:
+                print("Timed out waiting for setup completion.")
+                return
+            time.sleep(0.5)
+        print("Setup complete.")
+    finally:
+        wizard.shutdown()
+        thread.join(timeout=2.0)

--- a/tests/test_web_auth.py
+++ b/tests/test_web_auth.py
@@ -1,0 +1,422 @@
+"""Tests for mureo.cli.web_auth — the browser-based OAuth wizard.
+
+The wizard lets a non-technical user run ``mureo auth setup --web``
+and walk through secret-entry + OAuth entirely in their browser, so
+they never see a terminal.
+
+These tests start the real wizard HTTP server on 127.0.0.1:0 (random
+port) in a background thread, make requests via ``urllib.request``,
+and assert the route behavior. Google OAuth is mocked so nothing hits
+the network.
+"""
+
+from __future__ import annotations
+
+import threading
+import urllib.error
+import urllib.parse
+import urllib.request
+from http.client import HTTPResponse
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Module under test — does not exist yet (RED).
+from mureo.cli.web_auth import (  # noqa: I001
+    WebAuthWizard,
+    WizardSession,
+    render_google_secrets_form,
+    render_home,
+)
+
+
+# ---------------------------------------------------------------------------
+# Pure-view tests (no HTTP server)
+# ---------------------------------------------------------------------------
+
+
+class TestRenderHome:
+    def test_shows_google_ads_button(self) -> None:
+        session = WizardSession()
+        html = render_home(session)
+        assert "<!doctype html>" in html.lower()
+        assert "Google" in html and "Ads" in html
+        assert "/google-ads" in html
+
+
+class TestRenderGoogleSecretsForm:
+    def test_contains_csrf_hidden_input(self) -> None:
+        session = WizardSession(csrf_token="TOKEN_123")
+        html = render_google_secrets_form(session)
+        assert 'name="csrf_token"' in html
+        assert "TOKEN_123" in html
+
+    def test_has_three_required_secret_fields(self) -> None:
+        session = WizardSession()
+        html = render_google_secrets_form(session)
+        for field in ("developer_token", "client_id", "client_secret"):
+            assert f'name="{field}"' in html
+        # client_secret should be type=password to avoid over-the-shoulder leak.
+        assert 'type="password"' in html
+
+    def test_posts_to_submit_endpoint(self) -> None:
+        html = render_google_secrets_form(WizardSession())
+        assert 'action="/google-ads/submit"' in html
+        assert 'method="post"' in html.lower()
+
+    def test_has_external_links_to_secret_origins(self) -> None:
+        """Inline help tells the user WHERE to get each secret, so
+        they don't have to search Google docs from scratch."""
+        html = render_google_secrets_form(WizardSession())
+        assert "console.cloud.google.com" in html
+        assert "ads.google.com" in html
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — run a real wizard server on 127.0.0.1:0
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def wizard(tmp_path: Path) -> Any:
+    """Launch a real WebAuthWizard server on a random port for each test."""
+    creds_path = tmp_path / ".mureo" / "credentials.json"
+    wiz = WebAuthWizard(credentials_path=creds_path)
+    thread = threading.Thread(target=wiz.serve, daemon=True)
+    thread.start()
+    wiz.wait_until_ready(timeout=2.0)
+    try:
+        yield wiz
+    finally:
+        wiz.shutdown()
+        thread.join(timeout=2.0)
+
+
+def _url(wiz: Any, path: str) -> str:
+    return f"http://127.0.0.1:{wiz.port}{path}"
+
+
+def _fetch(wiz: Any, path: str) -> HTTPResponse:
+    return urllib.request.urlopen(_url(wiz, path), timeout=2.0)
+
+
+class TestHomeRoute:
+    def test_serves_home_page(self, wizard: Any) -> None:
+        resp = _fetch(wizard, "/")
+        assert resp.status == 200
+        body = resp.read().decode("utf-8")
+        assert "mureo" in body.lower()
+        assert "/google-ads" in body
+
+
+class TestGoogleAdsFormRoute:
+    def test_serves_form_with_csrf_token(self, wizard: Any) -> None:
+        resp = _fetch(wizard, "/google-ads")
+        assert resp.status == 200
+        body = resp.read().decode("utf-8")
+        assert wizard.session.csrf_token in body
+
+
+class TestGoogleAdsSubmitRoute:
+    def test_rejects_missing_csrf(self, wizard: Any) -> None:
+        data = urllib.parse.urlencode(
+            {
+                "developer_token": "DT",
+                "client_id": "CID",
+                "client_secret": "SECRET",
+            }
+        ).encode()
+        req = urllib.request.Request(
+            _url(wizard, "/google-ads/submit"), data=data, method="POST"
+        )
+        with pytest.raises(urllib.error.HTTPError) as exc_info:
+            urllib.request.urlopen(req, timeout=2.0)
+        assert exc_info.value.code == 403
+
+    def test_rejects_wrong_csrf(self, wizard: Any) -> None:
+        data = urllib.parse.urlencode(
+            {
+                "csrf_token": "not-the-real-token",
+                "developer_token": "DT",
+                "client_id": "CID",
+                "client_secret": "SECRET",
+            }
+        ).encode()
+        req = urllib.request.Request(
+            _url(wizard, "/google-ads/submit"), data=data, method="POST"
+        )
+        with pytest.raises(urllib.error.HTTPError) as exc_info:
+            urllib.request.urlopen(req, timeout=2.0)
+        assert exc_info.value.code == 403
+
+    def test_valid_submit_redirects_to_google_oauth(self, wizard: Any) -> None:
+        """With the correct CSRF, the handler builds a Flow, stashes it
+        in the session, and returns a 302 to Google's authorization URL."""
+        fake_flow = MagicMock()
+
+        with (
+            patch(
+                "mureo.cli.web_auth.build_google_flow", return_value=fake_flow
+            ) as mock_build,
+            patch(
+                "mureo.cli.web_auth.google_auth_url",
+                return_value=(
+                    "https://accounts.google.com/o/oauth2/auth?fake=1",
+                    "state-xyz",
+                ),
+            ),
+        ):
+            data = urllib.parse.urlencode(
+                {
+                    "csrf_token": wizard.session.csrf_token,
+                    "developer_token": "DT-123",
+                    "client_id": "CID-abc",
+                    "client_secret": "SECRET-xyz",
+                }
+            ).encode()
+            req = urllib.request.Request(
+                _url(wizard, "/google-ads/submit"), data=data, method="POST"
+            )
+            opener = urllib.request.build_opener(_NoRedirect())
+            with pytest.raises(urllib.error.HTTPError) as exc_info:
+                opener.open(req, timeout=2.0)
+
+            assert exc_info.value.code == 302
+            loc = exc_info.value.headers.get("Location", "")
+            assert loc.startswith("https://accounts.google.com/o/oauth2/auth")
+
+        assert wizard.session.google_flow is fake_flow
+        assert wizard.session.google_developer_token == "DT-123"
+        assert wizard.session.google_client_id == "CID-abc"
+        assert wizard.session.google_client_secret == "SECRET-xyz"
+        mock_build.assert_called_once()
+        kwargs = mock_build.call_args.kwargs
+        assert kwargs["client_id"] == "CID-abc"
+        assert kwargs["client_secret"] == "SECRET-xyz"
+        assert kwargs["redirect_uri"] == (
+            f"http://127.0.0.1:{wizard.port}/google-ads/callback"
+        )
+
+
+class TestGoogleAdsCallbackRoute:
+    def test_missing_code_returns_400(self, wizard: Any) -> None:
+        wizard.session.google_flow = MagicMock()
+        wizard.session.google_developer_token = "DT"
+        wizard.session.google_client_id = "CID"
+        wizard.session.google_client_secret = "SEC"
+
+        with pytest.raises(urllib.error.HTTPError) as exc_info:
+            _fetch(wizard, "/google-ads/callback")
+        assert exc_info.value.code == 400
+
+    def test_missing_session_flow_returns_400(self, wizard: Any) -> None:
+        """Hitting the callback URL without a prior /submit is invalid
+        (probably a stale link or direct URL guess)."""
+        with pytest.raises(urllib.error.HTTPError) as exc_info:
+            _fetch(wizard, "/google-ads/callback?code=abc")
+        assert exc_info.value.code == 400
+
+    def test_valid_code_exchanges_and_saves_credentials(
+        self, wizard: Any, tmp_path: Path
+    ) -> None:
+        fake_flow = MagicMock()
+        wizard.session.google_flow = fake_flow
+        wizard.session.google_developer_token = "DT-123"
+        wizard.session.google_client_id = "CID-abc"
+        wizard.session.google_client_secret = "SECRET-xyz"
+        wizard.session.google_oauth_state = "state-xyz"
+
+        from mureo.auth_setup import OAuthResult
+
+        with patch(
+            "mureo.cli.web_auth.exchange_google_code",
+            return_value=OAuthResult(
+                refresh_token="REFRESH_TOKEN",
+                access_token="ACCESS_TOKEN",
+            ),
+        ) as mock_exchange:
+            opener = urllib.request.build_opener(_NoRedirect())
+            with pytest.raises(urllib.error.HTTPError) as exc_info:
+                opener.open(
+                    _url(
+                        wizard,
+                        "/google-ads/callback?code=AUTH_CODE&state=state-xyz",
+                    ),
+                    timeout=2.0,
+                )
+            assert exc_info.value.code == 302
+            loc = exc_info.value.headers.get("Location", "")
+            assert loc == "/done"
+
+        mock_exchange.assert_called_once_with(fake_flow, "AUTH_CODE")
+
+        import json
+
+        creds_file = tmp_path / ".mureo" / "credentials.json"
+        assert creds_file.exists()
+        data = json.loads(creds_file.read_text(encoding="utf-8"))
+        g = data["google_ads"]
+        assert g["developer_token"] == "DT-123"
+        assert g["client_id"] == "CID-abc"
+        assert g["client_secret"] == "SECRET-xyz"
+        assert g["refresh_token"] == "REFRESH_TOKEN"
+
+        # Session secrets must be zeroed after successful save so they
+        # don't linger in process memory for the wizard's 10-minute
+        # lifetime.
+        assert wizard.session.google_developer_token is None
+        assert wizard.session.google_client_id is None
+        assert wizard.session.google_client_secret is None
+        assert wizard.session.google_flow is None
+
+    def test_user_declines_shows_friendly_error(self, wizard: Any) -> None:
+        """Google redirects back with ``error=access_denied`` when the
+        user clicks "Deny". The wizard shows a friendly message, not a
+        bare 400 with no guidance."""
+        wizard.session.google_flow = MagicMock()
+        wizard.session.google_oauth_state = "state-xyz"
+
+        opener = urllib.request.build_opener(_NoRedirect())
+        with pytest.raises(urllib.error.HTTPError) as exc_info:
+            opener.open(
+                _url(
+                    wizard,
+                    "/google-ads/callback?error=access_denied&state=state-xyz",
+                ),
+                timeout=2.0,
+            )
+        assert exc_info.value.code == 400
+        body = exc_info.value.read().decode("utf-8")
+        assert "cancelled" in body.lower() or "refused" in body.lower()
+        assert "access_denied" in body
+
+    def test_state_mismatch_returns_403(self, wizard: Any) -> None:
+        """OAuth state that doesn't match the stashed value is refused
+        — catches a stale-link or CSRF-on-callback attack."""
+        wizard.session.google_flow = MagicMock()
+        wizard.session.google_developer_token = "DT"
+        wizard.session.google_client_id = "CID"
+        wizard.session.google_client_secret = "SEC"
+        wizard.session.google_oauth_state = "legit-state"
+
+        with pytest.raises(urllib.error.HTTPError) as exc_info:
+            _fetch(wizard, "/google-ads/callback?code=abc&state=attacker-state")
+        assert exc_info.value.code == 403
+
+
+class TestSecurityHardening:
+    """Regression tests for the P2-2 security review findings."""
+
+    def test_response_has_full_security_headers(self, wizard: Any) -> None:
+        resp = _fetch(wizard, "/")
+        csp = resp.headers["Content-Security-Policy"]
+        for directive in (
+            "default-src 'none'",
+            "base-uri 'none'",
+            "frame-ancestors 'none'",
+            "object-src 'none'",
+            "form-action 'self' https://accounts.google.com",
+        ):
+            assert directive in csp
+        assert resp.headers["X-Frame-Options"] == "DENY"
+        assert resp.headers["Referrer-Policy"] == "no-referrer"
+        assert resp.headers["X-Content-Type-Options"] == "nosniff"
+
+    def test_dns_rebinding_host_refused(self, wizard: Any) -> None:
+        """A submit with a spoofed Host header (DNS rebind scenario)
+        is rejected, not processed."""
+        data = urllib.parse.urlencode(
+            {
+                "csrf_token": wizard.session.csrf_token,
+                "developer_token": "DT",
+                "client_id": "CID",
+                "client_secret": "SEC",
+            }
+        ).encode()
+        req = urllib.request.Request(
+            _url(wizard, "/google-ads/submit"),
+            data=data,
+            method="POST",
+            headers={"Host": "attacker.example.com"},
+        )
+        with pytest.raises(urllib.error.HTTPError) as exc_info:
+            urllib.request.urlopen(req, timeout=2.0)
+        assert exc_info.value.code == 403
+
+    def test_csrf_token_rotates_after_successful_submit(
+        self, wizard: Any
+    ) -> None:
+        """Replay protection: after a successful submit, the token that
+        authorized it cannot be reused."""
+        original_token = wizard.session.csrf_token
+
+        with (
+            patch("mureo.cli.web_auth.build_google_flow", return_value=MagicMock()),
+            patch(
+                "mureo.cli.web_auth.google_auth_url",
+                return_value=(
+                    "https://accounts.google.com/o/oauth2/auth?fake=1",
+                    "state-xyz",
+                ),
+            ),
+        ):
+            data = urllib.parse.urlencode(
+                {
+                    "csrf_token": original_token,
+                    "developer_token": "DT",
+                    "client_id": "CID",
+                    "client_secret": "SEC",
+                }
+            ).encode()
+            req = urllib.request.Request(
+                _url(wizard, "/google-ads/submit"), data=data, method="POST"
+            )
+            opener = urllib.request.build_opener(_NoRedirect())
+            with pytest.raises(urllib.error.HTTPError):
+                opener.open(req, timeout=2.0)
+
+        assert wizard.session.csrf_token != original_token
+
+    def test_oversize_post_body_rejected(self, wizard: Any) -> None:
+        """Cap on POST Content-Length prevents local DoS / OOM."""
+        huge = b"a" * (20 * 1024)  # 20 KB > 16 KB cap
+        req = urllib.request.Request(
+            _url(wizard, "/google-ads/submit"),
+            data=huge,
+            method="POST",
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        with pytest.raises(urllib.error.HTTPError) as exc_info:
+            urllib.request.urlopen(req, timeout=2.0)
+        assert exc_info.value.code == 413
+
+
+class TestDoneRoute:
+    def test_done_page_marks_completion(self, wizard: Any) -> None:
+        resp = _fetch(wizard, "/done")
+        assert resp.status == 200
+        body = resp.read().decode("utf-8")
+        assert "close" in body.lower() or "done" in body.lower()
+        assert wizard.completed is True
+
+
+class TestUnknownRoute:
+    def test_returns_404(self, wizard: Any) -> None:
+        with pytest.raises(urllib.error.HTTPError) as exc_info:
+            _fetch(wizard, "/unknown-path")
+        assert exc_info.value.code == 404
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """Opener that surfaces 302 redirects as HTTPError so tests can
+    assert on Location header directly."""
+
+    def redirect_request(self, *args: Any, **kwargs: Any) -> None:
+        return None


### PR DESCRIPTION
## Summary

Second of 4 PRs for Phase 2 of the web-auth wizard. Adds `mureo auth setup --web` — a short-lived local HTTP server that lets non-technical users complete Google Ads setup (secret entry + OAuth) entirely in their browser.

Builds on P2-1 (#20) pure helpers: the wizard calls `build_google_flow(redirect_uri=http://127.0.0.1:<port>/google-ads/callback)`, `google_auth_url`, and `exchange_google_code` so the CLI and web paths share the same OAuth scaffolding.

Also fixes the 0.5.0 CHANGELOG date (2026-04-18 → 2026-04-19) while we are here, per the retrospective review.

## Surface added

- New module `mureo/cli/web_auth.py` — `WebAuthWizard`, `_WizardServer` (ThreadingHTTPServer + `BaseHTTPRequestHandler`), HTML templates, `run_web_wizard()` entry point.
- CLI: `mureo auth setup --web` delegates to the wizard; interactive prompt flow unchanged when `--web` is not passed.
- Meta Ads support deferred to P2-3. Home page has a placeholder note.

## Security hardening (3 CRITICAL + 4 HIGH from review addressed)

- **CSRF rotation** after every successful mutating submit (replay guard).
- **OAuth `state` validation** — stored at submit, compared with `secrets.compare_digest` on callback.
- **Open-redirect guard** — refuses to emit 302 unless `auth_url` starts with `https://accounts.google.com/`.
- **DNS-rebinding guard** — `Host:` must match `127.0.0.1:<port>` or `localhost:<port>`.
- **Generic error messages** — exception text logged server-side only (no SDK leakage to browser).
- **CSP expanded** — `default-src 'none'`, `base-uri`, `frame-ancestors`, `object-src`, `form-action`; plus `X-Frame-Options: DENY` and `Referrer-Policy: no-referrer`.
- **Secret zero-out** after `save_credentials` succeeds.
- **POST size cap** 16 KiB (local DoS guard).
- **Graceful decline** — `?error=access_denied` from Google shows a friendly message, not a bare 400.

## Test plan

- [x] 20 new tests in `tests/test_web_auth.py` covering pure views, every route (home / form / submit / callback / done), all security regressions (CSRF rotation, state mismatch, host header, size cap, CSP shape, secret zero-out, user-declined OAuth).
- [x] Tests run a real HTTP server on 127.0.0.1:0 in a background thread; Google OAuth is mocked.
- [x] Full suite: 1705 passed; mypy / ruff / black all clean.
- [x] Code-review + security-review agents invoked; HIGH/CRITICAL findings all addressed.
- [ ] CI green after push.

## Follow-ups (tracked for later PRs)

- **P2-3**: Meta Ads support in the same wizard.
- **P2-4**: README polish + deep link text refinements.
- Make `save_credentials` atomic (write-to-tmp + `os.replace`) to close the MEDIUM finding about partial writes on crash.