### PR TITLE
fix: install Codex workflow commands as skills (codex-cli 0.117.0+ prompts deprecation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `mureo setup codex` now installs bundled workflow commands as Codex **skills** at `~/.codex/skills/<command>/SKILL.md` (with YAML frontmatter — `name:` / `description:`) instead of as custom prompts at `~/.codex/prompts/*.md`. Codex CLI 0.117.0 (2026-03) [stopped rendering the custom-prompts directory](https://github.com/openai/codex/issues/15941) in its slash-command menu, so `mureo setup codex` was silently installing ten files that Codex no longer picked up. Users invoke the workflows with `$daily-check` (explicit) or the `/skills` picker. Re-running `mureo setup codex` also removes the stale `~/.codex/prompts/<bundled>.md` files left behind by prior installs; user-authored prompts with names outside mureo's bundled set are preserved.
+
 ### Changed
 - Docs refreshed for the browser-based wizard: `README.md` / `README.ja.md` "Claude Code Desktop" section now points at `mureo auth setup --web` and no longer instructs operators to open `Terminal.app`. `docs/cli.md` documents both terminal and `--web` modes of `mureo auth setup`. `SECURITY.md` gains a "Browser-based auth wizard" section enumerating every hardening layer (localhost bind, DNS-rebinding guard, CSRF rotation, OAuth `state` validation, redirect-origin pinning, generic error surface, session zero-out, POST size cap, CSP/X-Frame-Options/Referrer-Policy headers, stdlib-only implementation).
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -194,7 +194,7 @@ pip install mureo
 mureo setup codex
 ```
 
-Claude Codeと同じく4層すべて（MCPサーバー、認証情報ガード（PreToolUseフック）、ワークフロープロンプト、スキル）を `~/.codex/` 配下にインストールします。
+Claude Codeと同じく4層すべて（MCPサーバー、認証情報ガード（PreToolUseフック）、ワークフローコマンド、スキル）を `~/.codex/` 配下にインストールします。ワークフローコマンドは Codex スキル形式（`~/.codex/skills/<command>/SKILL.md`）としてインストールされ、`$daily-check` または `/skills` ピッカーから呼び出せます（Codex CLI 0.117.0 以降は `~/.codex/prompts/` を読み込まなくなりました。[openai/codex#15941](https://github.com/openai/codex/issues/15941)）。
 
 ### Gemini CLI
 
@@ -220,7 +220,7 @@ mureo auth status
 | 認証（~/.mureo/credentials.json） | Yes | Yes | Yes | Yes | Yes |
 | MCP設定 | Yes | Yes | Yes | Yes | Yes |
 | 認証情報ガード（PreToolUseフック） | Yes | N/A | Yes | N/A | Yes |
-| ワークフローコマンド/プロンプト | Yes（~/.claude/commands/） | N/A | Yes（~/.codex/prompts/） | N/A | No |
+| ワークフローコマンド | Yes（~/.claude/commands/） | N/A | Yes（~/.codex/skills/ — `$cmd`または`/skills`で起動） | N/A | No |
 | スキル | Yes（~/.claude/skills/） | N/A | Yes（~/.codex/skills/） | N/A | No |
 | Extensionマニフェスト（contextFileName） | N/A | N/A | N/A | Yes（~/.gemini/extensions/mureo/） | No |
 

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ pip install mureo
 mureo setup codex
 ```
 
-Full parity with Claude Code: MCP server, credential guard (PreToolUse hook), workflow prompts, and skills are all installed under `~/.codex/`.
+Full parity with Claude Code: MCP server, credential guard (PreToolUse hook), workflow commands, and skills are all installed under `~/.codex/`. Workflow commands are installed as Codex skills at `~/.codex/skills/<command>/SKILL.md` (Codex CLI 0.117.0+ no longer surfaces `~/.codex/prompts/`, see [openai/codex#15941](https://github.com/openai/codex/issues/15941)); invoke them with `$daily-check` or the `/skills` picker.
 
 ### Gemini CLI
 
@@ -272,7 +272,7 @@ mureo auth status
 | Authentication (~/.mureo/credentials.json) | Yes | Yes | Yes | Yes | Yes |
 | MCP configuration | Yes | Yes | Yes | Yes | Yes |
 | Credential guard (PreToolUse hook) | Yes | N/A | Yes | N/A | Yes |
-| Workflow commands / prompts | Yes (~/.claude/commands/) | N/A | Yes (~/.codex/prompts/) | N/A | No |
+| Workflow commands | Yes (~/.claude/commands/) | N/A | Yes (~/.codex/skills/ — invoke with `$cmd` or `/skills`) | N/A | No |
 | Skills | Yes (~/.claude/skills/) | N/A | Yes (~/.codex/skills/) | N/A | No |
 | Extension manifest (contextFileName) | N/A | N/A | N/A | Yes (~/.gemini/extensions/mureo/) | No |
 

--- a/mureo/cli/setup_cmd.py
+++ b/mureo/cli/setup_cmd.py
@@ -299,7 +299,7 @@ def setup_codex(
     skip_auth: bool = typer.Option(
         False,
         "--skip-auth",
-        help="Skip authentication (install MCP config, guard, prompts, skills only)",
+        help="Skip authentication (install MCP config, guard, command skills, and shared skills only)",
     ),
     google_ads: bool | None = typer.Option(
         None,
@@ -314,16 +314,18 @@ def setup_codex(
 ) -> None:
     """One-command setup for OpenAI Codex CLI users.
 
-    Runs the full setup flow (MCP + credential guard + prompts + skills)
-    in ``~/.codex/``. Mirrors the Claude Code setup layer-for-layer since
-    Codex CLI supports all four surfaces.
+    Runs the full setup flow (MCP + credential guard + workflow command
+    skills + shared skills) in ``~/.codex/``. Mirrors the Claude Code
+    setup layer-for-layer, except that workflow commands are installed
+    as Codex skills (invoked with ``$<command>`` or via ``/skills``)
+    because Codex CLI 0.117.0+ no longer surfaces ``~/.codex/prompts/``.
     """
     import asyncio
 
     from mureo.cli.setup_codex import (
+        install_codex_command_skills,
         install_codex_credential_guard,
         install_codex_mcp_config,
-        install_codex_prompts,
         install_codex_skills,
     )
 
@@ -334,7 +336,7 @@ def setup_codex(
     if should_skip:
         if banner is not None:
             typer.echo(banner)
-        typer.echo("Run /onboard in Codex later to configure credentials.\n")
+        typer.echo("Run `$onboard` in Codex later to configure credentials.\n")
     else:
         google = confirm_or_default(
             "Configure Google Ads?", default=True, override=google_ads
@@ -365,10 +367,13 @@ def setup_codex(
     else:
         typer.echo("Credential guard already installed.")
 
-    typer.echo("\n--- Installing prompts (slash commands) ---")
+    typer.echo("\n--- Installing workflow commands as Codex skills ---")
     try:
-        prompt_count, prompt_path = install_codex_prompts()
-        typer.echo(f"  {prompt_count} prompts installed to {prompt_path}")
+        cmd_count, cmd_path = install_codex_command_skills()
+        typer.echo(
+            f"  {cmd_count} workflow skills installed to {cmd_path}. "
+            "Invoke with $<command-name> or via Codex's /skills picker."
+        )
     except FileNotFoundError as e:
         typer.echo(f"  Warning: {e}", err=True)
 
@@ -381,9 +386,15 @@ def setup_codex(
 
     typer.echo("\n=== Setup complete ===")
     if skip_auth:
-        typer.echo("Next: Open Codex and run /onboard to configure credentials.")
+        typer.echo(
+            "Next: Open Codex and run `$onboard` (or pick it from /skills) "
+            "to configure credentials."
+        )
     else:
-        typer.echo("Next: Open Codex and run /onboard to get started.")
+        typer.echo(
+            "Next: Open Codex and run `$onboard` (or pick it from /skills) "
+            "to get started."
+        )
 
 
 @setup_app.command("gemini")  # type: ignore[untyped-decorator, unused-ignore]

--- a/mureo/cli/setup_codex.py
+++ b/mureo/cli/setup_codex.py
@@ -4,8 +4,11 @@ Layers installed, mirroring the Claude Code setup:
 
 1. MCP server config in ``~/.codex/config.toml`` (append-only tagged block)
 2. Credential guard PreToolUse hooks in ``~/.codex/hooks.json``
-3. Workflow commands as ``~/.codex/prompts/*.md``
-4. Skills as ``~/.codex/skills/mureo-*/``
+3. Workflow commands as Codex skills at ``~/.codex/skills/<command>/SKILL.md``
+   (previously written to ``~/.codex/prompts/*.md`` — deprecated in
+   codex-cli 0.117.0, see openai/codex#15941). Invoked via
+   ``$<command>`` or the ``/skills`` picker.
+4. Shared mureo skills as ``~/.codex/skills/mureo-*/``
 
 Idempotency is enforced via tag markers (``[mureo-mcp-config]`` /
 ``[mureo-credential-guard]``) so re-running ``mureo setup codex`` is
@@ -204,20 +207,86 @@ def install_codex_credential_guard() -> Path | None:
 
 
 # ---------------------------------------------------------------------------
-# 3. Prompts (slash commands)
+# 3. Workflow commands (as Codex skills)
 # ---------------------------------------------------------------------------
 
 
-def install_codex_prompts(target_dir: Path | None = None) -> tuple[int, Path]:
-    """Copy bundled command markdown files to ``~/.codex/prompts/``."""
-    dest = target_dir or (Path.home() / ".codex" / "prompts")
+def _first_nonblank_line(text: str) -> str:
+    """Return the first non-empty line of ``text``, stripped of whitespace."""
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped:
+            return stripped
+    return ""
+
+
+def _yaml_escape(value: str) -> str:
+    """Escape a string for a YAML double-quoted scalar."""
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _build_command_skill(name: str, body: str) -> str:
+    """Wrap a bundled command ``.md`` in Codex skill frontmatter.
+
+    ``description`` is the first non-empty line of the source file so
+    Codex's ``/skills`` picker can show a meaningful one-liner. The
+    body is copied verbatim after the frontmatter terminator.
+    """
+    description = _yaml_escape(_first_nonblank_line(body)) or name
+    return f'---\nname: {name}\ndescription: "{description}"\n---\n\n{body}'
+
+
+def install_codex_command_skills(
+    target_dir: Path | None = None,
+) -> tuple[int, Path]:
+    """Install bundled workflow commands as Codex skills.
+
+    Codex CLI 0.117.0 (2026-03) stopped surfacing files placed in
+    ``~/.codex/prompts/`` in the slash-command menu (Issue
+    `openai/codex#15941 <https://github.com/openai/codex/issues/15941>`_).
+    Custom prompts were deprecated in favor of skills, so mureo now
+    wraps each bundled command into
+    ``~/.codex/skills/<command>/SKILL.md`` with YAML frontmatter.
+    Users invoke them with ``$daily-check`` or via the ``/skills``
+    picker in Codex.
+
+    Re-running also removes the matching legacy files from
+    ``~/.codex/prompts/`` so stale copies don't show up as duplicates;
+    user-authored prompts with names outside mureo's bundled set are
+    left alone.
+    """
+    dest = target_dir or (Path.home() / ".codex" / "skills")
     dest.mkdir(parents=True, exist_ok=True)
 
     src = _get_data_path("commands")
+    bundled_names: set[str] = set()
     count = 0
     for md_file in sorted(src.glob("*.md")):
-        shutil.copy2(md_file, dest / md_file.name)
+        name = md_file.stem
+        bundled_names.add(md_file.name)
+        skill_dir = dest / name
+        if skill_dir.exists():
+            shutil.rmtree(skill_dir)
+        skill_dir.mkdir(parents=True)
+        body = md_file.read_text(encoding="utf-8")
+        (skill_dir / "SKILL.md").write_text(
+            _build_command_skill(name, body), encoding="utf-8"
+        )
         count += 1
+
+    # Legacy cleanup: remove stale ~/.codex/prompts/<bundled>.md from prior
+    # installs so the user sees a clean Codex state.
+    legacy_prompts = Path.home() / ".codex" / "prompts"
+    if legacy_prompts.is_dir():
+        for legacy_file in legacy_prompts.iterdir():
+            if legacy_file.is_file() and legacy_file.name in bundled_names:
+                try:
+                    legacy_file.unlink()
+                except OSError:
+                    logger.warning(
+                        "Could not remove stale legacy prompt: %s", legacy_file
+                    )
+
     return count, dest
 
 

--- a/tests/test_setup_codex.py
+++ b/tests/test_setup_codex.py
@@ -15,9 +15,9 @@ import pytest
 
 from mureo.cli.setup_codex import (  # noqa: I001
     CodexMcpConflictError,
+    install_codex_command_skills,
     install_codex_credential_guard,
     install_codex_mcp_config,
-    install_codex_prompts,
     install_codex_skills,
 )
 
@@ -109,9 +109,7 @@ class TestInstallCodexCredentialGuard:
             "PreToolUse": [
                 {
                     "matcher": "Bash",
-                    "hooks": [
-                        {"type": "command", "command": "echo 'existing guard'"}
-                    ],
+                    "hooks": [{"type": "command", "command": "echo 'existing guard'"}],
                 }
             ]
         }
@@ -128,16 +126,12 @@ class TestInstallCodexCredentialGuard:
         install_codex_credential_guard()
         result = install_codex_credential_guard()
         assert result is None
-        data = json.loads(
-            (home / ".codex" / "hooks.json").read_text(encoding="utf-8")
-        )
+        data = json.loads((home / ".codex" / "hooks.json").read_text(encoding="utf-8"))
         flat = json.dumps(data)
         # Two mureo entries (Read + Bash) persist; no duplicates are added.
         assert flat.count("[mureo-credential-guard]") == 2
 
-    def test_corrupt_hooks_json_returns_none_without_clobber(
-        self, home: Path
-    ) -> None:
+    def test_corrupt_hooks_json_returns_none_without_clobber(self, home: Path) -> None:
         """A corrupt hooks.json is not silently overwritten."""
         hooks_file = home / ".codex" / "hooks.json"
         hooks_file.parent.mkdir(parents=True)
@@ -161,28 +155,73 @@ class TestInstallCodexCredentialGuard:
         assert result is None
 
 
-class TestInstallCodexPrompts:
-    """Workflow commands are copied as .md files into ~/.codex/prompts/."""
+class TestInstallCodexCommandSkills:
+    """Workflow commands are installed as Codex skills at
+    ``~/.codex/skills/<command>/SKILL.md``. The older ``~/.codex/prompts/``
+    layout stopped being picked up in codex-cli 0.117.0+ (Issue #15941),
+    so every bundled command now ships as a skill invokable via ``$cmd``
+    or the ``/skills`` picker.
+    """
 
-    def test_copies_markdown_files(self, home: Path) -> None:
-        count, dest = install_codex_prompts()
-        assert dest == home / ".codex" / "prompts"
+    def test_installs_each_command_as_its_own_skill(self, home: Path) -> None:
+        count, dest = install_codex_command_skills()
+        assert dest == home / ".codex" / "skills"
         assert dest.exists()
         assert count >= 1
-        md_files = list(dest.glob("*.md"))
-        assert len(md_files) == count
-        # onboard.md is a known bundled command
-        assert (dest / "onboard.md").exists()
+        # Known bundled command landed as a skill directory with SKILL.md
+        onboard_skill = dest / "onboard" / "SKILL.md"
+        assert onboard_skill.exists()
+        daily_check_skill = dest / "daily-check" / "SKILL.md"
+        assert daily_check_skill.exists()
 
-    def test_overwrites_existing(self, home: Path) -> None:
-        dest = home / ".codex" / "prompts"
-        dest.mkdir(parents=True)
-        (dest / "onboard.md").write_text("stale content", encoding="utf-8")
+    def test_skill_has_yaml_frontmatter(self, home: Path) -> None:
+        """Each generated SKILL.md starts with ``---\\nname: ...\\ndescription:
+        ...\\n---`` so Codex's skill loader can index it and surface the
+        description in the ``/skills`` picker."""
+        install_codex_command_skills()
+        content = (home / ".codex" / "skills" / "daily-check" / "SKILL.md").read_text(
+            encoding="utf-8"
+        )
+        assert content.startswith("---\n")
+        # Frontmatter block terminates before the command body.
+        _, frontmatter, body = content.split("---\n", 2)
+        assert "name: daily-check" in frontmatter
+        assert "description:" in frontmatter
+        # Body preserves the source command's first line.
+        assert "daily health check" in body.lower()
 
-        install_codex_prompts()
+    def test_replaces_existing_command_skill(self, home: Path) -> None:
+        """Re-running setup clobbers a stale SKILL.md even if the
+        directory is already there."""
+        target = home / ".codex" / "skills" / "onboard"
+        target.mkdir(parents=True)
+        (target / "SKILL.md").write_text("stale content", encoding="utf-8")
 
-        updated = (dest / "onboard.md").read_text(encoding="utf-8")
+        install_codex_command_skills()
+
+        updated = (target / "SKILL.md").read_text(encoding="utf-8")
         assert "stale content" not in updated
+        assert updated.startswith("---\n")
+
+    def test_cleans_up_legacy_prompts_dir(self, home: Path) -> None:
+        """Prior installs placed the same commands in ``~/.codex/prompts/``.
+        Those files are dead on codex-cli 0.117.0+ and must be removed so
+        ``/skills`` doesn't show ghost duplicates when the user looks at
+        their Codex state."""
+        legacy = home / ".codex" / "prompts"
+        legacy.mkdir(parents=True)
+        (legacy / "onboard.md").write_text("legacy prompt", encoding="utf-8")
+        (legacy / "daily-check.md").write_text("legacy prompt", encoding="utf-8")
+        # A user-authored prompt that mureo shouldn't delete.
+        (legacy / "my-custom.md").write_text("mine", encoding="utf-8")
+
+        install_codex_command_skills()
+
+        assert not (legacy / "onboard.md").exists()
+        assert not (legacy / "daily-check.md").exists()
+        # User's own prompt untouched.
+        assert (legacy / "my-custom.md").exists()
+        assert (legacy / "my-custom.md").read_text(encoding="utf-8") == "mine"
 
 
 class TestInstallCodexSkills:


### PR DESCRIPTION
## Summary

**Bug**: After `mureo setup codex`, the mureo workflow commands (`/daily-check`, `/rescue`, `/onboard`, etc.) did not appear in the Codex CLI slash menu.

**Root cause**: Codex CLI 0.117.0 (2026-03) stopped rendering files placed in `~/.codex/prompts/` (openai/codex#15941). Custom prompts were deprecated in favor of skills, so `mureo setup codex` was silently installing ten files Codex no longer picks up.

**Fix**: Install the bundled workflow commands as Codex **skills** at `~/.codex/skills/<command>/SKILL.md` with YAML frontmatter (`name:` / `description:`). Users invoke them with `$daily-check` or via the `/skills` picker. Re-running `mureo setup codex` also removes stale `~/.codex/prompts/<bundled>.md` files from prior installs, preserving any user-authored prompts outside mureo bundled set.

- `install_codex_prompts` -> renamed to `install_codex_command_skills`
- New pure helpers: `_first_nonblank_line`, `_yaml_escape`, `_build_command_skill`
- `~/.codex/prompts/<bundled>.md` files are removed on every re-run (legacy cleanup)
- Docs refreshed: README / README.ja "What gets installed" table + Codex CLI section, CHANGELOG unreleased entry, `setup codex` CLI banner points at `$onboard` instead of `/onboard`

## Test plan

- [x] `pytest tests/test_setup_codex.py tests/test_setup_cmd.py -v` -> 29 passed
- [x] Full suite: `pytest tests/` -> 1731 passed
- [x] `ruff check` + `black --check` clean on changed files
- [x] `mypy mureo/cli/setup_codex.py` clean
- [x] code-reviewer agent: no CRITICAL / HIGH findings
- [x] New unit coverage: skill generation, YAML frontmatter shape, replace-existing, legacy cleanup preserving user prompts
- [ ] CI pass
- [ ] Manual verify on a real `~/.codex/` after merge: `mureo setup codex` lands SKILL.md files and removes legacy prompts, `$daily-check` is invocable in codex-cli 0.121.0
