### PR TITLE
chore(codex): harden _yaml_escape and symlink-guard legacy cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- `mureo setup codex` command-skill generation now escapes all control characters and unicode line separators (U+2028 / U+2029) in the skill `description:` frontmatter field, so a future bundled command whose first line contains a tab, CR, LF, NEL, or other byte that YAML treats as a line break cannot silently truncate the description or corrupt the frontmatter block. Today's bundled commands don't trigger the old behavior — this is a defense-in-depth guard against a future maintainer adding a command with an unusual first line.
+- The legacy `~/.codex/prompts/<bundled>.md` cleanup in `install_codex_command_skills` now skips symlinks. Previously a user who had symlinked a bundled filename at their own file (e.g. via a dotfiles repo) would see the symlink silently removed on every `mureo setup codex` re-run, even though the target stayed intact. The symlink now survives so the operator's intentional link-over-bundled-name is preserved.
+
 ### Fixed
 - `mureo setup codex` now installs bundled workflow commands as Codex **skills** at `~/.codex/skills/<command>/SKILL.md` (with YAML frontmatter — `name:` / `description:`) instead of as custom prompts at `~/.codex/prompts/*.md`. Codex CLI 0.117.0 (2026-03) [stopped rendering the custom-prompts directory](https://github.com/openai/codex/issues/15941) in its slash-command menu, so `mureo setup codex` was silently installing ten files that Codex no longer picked up. Users invoke the workflows with `$daily-check` (explicit) or the `/skills` picker. Re-running `mureo setup codex` also removes the stale `~/.codex/prompts/<bundled>.md` files left behind by prior installs; user-authored prompts with names outside mureo's bundled set are preserved.
 

--- a/mureo/cli/setup_codex.py
+++ b/mureo/cli/setup_codex.py
@@ -221,8 +221,30 @@ def _first_nonblank_line(text: str) -> str:
 
 
 def _yaml_escape(value: str) -> str:
-    """Escape a string for a YAML double-quoted scalar."""
-    return value.replace("\\", "\\\\").replace('"', '\\"')
+    """Escape a string for a YAML double-quoted scalar.
+
+    YAML's double-quoted scalar interprets backslash escapes, so in
+    addition to escaping ``\\`` and ``"`` we also need to guard against
+    characters that would either (a) terminate the scalar prematurely —
+    LF / CR / NEL / U+2028 / U+2029 are all treated as line breaks by
+    YAML parsers — or (b) survive into the rendered description as raw
+    control bytes. Any character outside printable ASCII/Unicode is
+    emitted as ``\\xNN`` (for bytes < 0x100) or ``\\uNNNN`` so the
+    frontmatter round-trips through any conformant YAML parser.
+    """
+    value = value.replace("\\", "\\\\").replace('"', '\\"')
+    out: list[str] = []
+    for ch in value:
+        code = ord(ch)
+        # Safe: printable ASCII OR non-ASCII printable Unicode (minus the
+        # line-separator set that YAML treats as a newline).
+        if (0x20 <= code < 0x7F) or (code >= 0xA0 and code not in (0x2028, 0x2029)):
+            out.append(ch)
+        elif code <= 0xFF:
+            out.append(f"\\x{code:02x}")
+        else:
+            out.append(f"\\u{code:04x}")
+    return "".join(out)
 
 
 def _build_command_skill(name: str, body: str) -> str:
@@ -275,11 +297,18 @@ def install_codex_command_skills(
         count += 1
 
     # Legacy cleanup: remove stale ~/.codex/prompts/<bundled>.md from prior
-    # installs so the user sees a clean Codex state.
+    # installs so the user sees a clean Codex state. Skip symlinks — they
+    # imply the operator intentionally pointed a bundled name at their own
+    # file (e.g. a dotfiles repo), and silently unlinking loses the link
+    # even though the target stays intact.
     legacy_prompts = Path.home() / ".codex" / "prompts"
     if legacy_prompts.is_dir():
         for legacy_file in legacy_prompts.iterdir():
-            if legacy_file.is_file() and legacy_file.name in bundled_names:
+            if (
+                legacy_file.is_file()
+                and not legacy_file.is_symlink()
+                and legacy_file.name in bundled_names
+            ):
                 try:
                     legacy_file.unlink()
                 except OSError:

--- a/tests/test_setup_codex.py
+++ b/tests/test_setup_codex.py
@@ -15,6 +15,7 @@ import pytest
 
 from mureo.cli.setup_codex import (  # noqa: I001
     CodexMcpConflictError,
+    _yaml_escape,
     install_codex_command_skills,
     install_codex_credential_guard,
     install_codex_mcp_config,
@@ -222,6 +223,82 @@ class TestInstallCodexCommandSkills:
         # User's own prompt untouched.
         assert (legacy / "my-custom.md").exists()
         assert (legacy / "my-custom.md").read_text(encoding="utf-8") == "mine"
+
+    def test_skips_symlinked_legacy_prompts(self, home: Path, tmp_path: Path) -> None:
+        """A symlink at ~/.codex/prompts/<bundled>.md must NOT be removed.
+
+        A user may have symlinked a bundled-name file to their own copy
+        kept outside `~/.codex/` (e.g. a dotfiles repo). Silently
+        unlinking the symlink surprises the operator and loses the link
+        even though the target remains intact. The cleanup should skip
+        symlinks and leave the operator's link alone.
+        """
+        legacy = home / ".codex" / "prompts"
+        legacy.mkdir(parents=True)
+        # Real target lives outside the legacy dir.
+        external = tmp_path / "external_onboard.md"
+        external.write_text("user's own onboard", encoding="utf-8")
+        symlink_path = legacy / "onboard.md"
+        symlink_path.symlink_to(external)
+
+        install_codex_command_skills()
+
+        # Symlink survived — we did not silently unlink it.
+        assert symlink_path.is_symlink()
+        # External target untouched.
+        assert external.exists()
+        assert external.read_text(encoding="utf-8") == "user's own onboard"
+
+    def test_skips_broken_symlink_legacy_prompt(
+        self, home: Path, tmp_path: Path
+    ) -> None:
+        """A broken symlink (target missing) at a bundled path must also
+        survive. ``Path.is_file()`` returns False for a dangling symlink,
+        so it's already skipped by the primary guard — but a regression
+        test pins that behavior in case the guard is ever restructured."""
+        legacy = home / ".codex" / "prompts"
+        legacy.mkdir(parents=True)
+        broken_link = legacy / "onboard.md"
+        broken_link.symlink_to(tmp_path / "does-not-exist.md")
+
+        install_codex_command_skills()
+
+        # Broken symlink untouched: the operator can still see and repair it.
+        assert broken_link.is_symlink()
+
+
+class TestYamlEscape:
+    """``_yaml_escape`` must produce a string safe for a YAML double-quoted
+    scalar so the skill description survives Codex's frontmatter parser.
+
+    A double-quoted YAML scalar interprets backslash escapes, so a raw
+    tab, CR, or unicode line separator in the description would either
+    mangle the value or break the frontmatter block entirely.
+    """
+
+    def test_escapes_backslash_and_quote(self) -> None:
+        assert _yaml_escape(r"a\b") == r"a\\b"
+        assert _yaml_escape('say "hi"') == r"say \"hi\""
+
+    def test_escapes_control_characters(self) -> None:
+        """Tabs, CR, LF, and other C0 control chars must be escaped so
+        they can't silently inject a newline into the frontmatter and
+        truncate the description at an unexpected boundary."""
+        assert "\\x09" in _yaml_escape("line\tafter-tab")
+        assert "\\x0d" in _yaml_escape("carriage\rreturn")
+        assert "\\x0a" in _yaml_escape("with\nnewline")
+
+    def test_escapes_unicode_line_separators(self) -> None:
+        """U+2028 (LINE SEPARATOR) and U+2029 (PARAGRAPH SEPARATOR) are
+        treated as line terminators by some YAML parsers and would break
+        a single-line description, so they must be escaped too."""
+        assert "\u2028" not in _yaml_escape("a\u2028b")
+        assert "\u2029" not in _yaml_escape("a\u2029b")
+
+    def test_leaves_normal_text_unchanged(self) -> None:
+        """Regression guard: escaping should be a no-op on ASCII text
+        without quotes or backslashes."""
+        assert _yaml_escape("run a daily health check") == "run a daily health check"
 
 
 class TestInstallCodexSkills:


### PR DESCRIPTION
## Summary

Addresses the two MEDIUM findings from the code review of PR #24 (Codex prompts → skills migration).

### 1. `_yaml_escape` — escape control chars and unicode line separators

Old code escaped only `\` and `"`. A future bundled command whose first line contained a tab, CR, LF, NEL, U+2028, or U+2029 would leak into the skill `description:` frontmatter, where YAML treats several as line terminators — silently truncating the description or breaking the frontmatter block. Today's bundled commands don't trigger it; this is defense-in-depth for future content.

New behavior: after escaping `\` and `"`, iterate the string and emit any char outside printable ASCII (0x20–0x7E) and printable non-ASCII (≥ 0xA0, minus U+2028 / U+2029) as `\xNN` (≤ 0xFF) or `\uNNNN`.

### 2. Legacy `~/.codex/prompts/` cleanup — skip symlinks

`Path.is_file()` follows symlinks, so a user who had symlinked `~/.codex/prompts/onboard.md` at their own file (e.g. from a dotfiles repo) would have seen mureo silently unlink the symlink on every `mureo setup codex` re-run. Added `not is_symlink()` leaves it alone.

## Test plan

- [x] 5 new unit tests: backslash/quote, control chars, unicode line seps, ASCII no-op, symlinked bundled path, broken symlink bundled path
- [x] Full suite: `pytest tests/` → 1736 passed
- [x] `ruff check` + `black --check` + `mypy mureo/cli/setup_codex.py` clean
- [x] code-reviewer: no CRITICAL / HIGH findings; LOW suggestion (broken-symlink regression test) incorporated
- [ ] CI pass
