### PR TITLE
docs: rewrite Claude Desktop install flow to the four-step pattern

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -147,11 +147,36 @@ STATE.jsonから接続媒体を検出:
 
 ### Claude Code Desktop から導入する（ターミナル不要）
 
-ターミナル操作に慣れていない場合は、Claude Desktop の **Code タブ** で Claude に次のように頼んでください:
+Claude Desktop の **Code タブ** に以下を貼り付けてください。途中でブラウザでOAuth画面が開き、最後にターミナルが一瞬だけ開いて閉じます。初回のみ macOS が「Claudeがターミナルを操作する」許可ダイアログを出すので **OK** を押してください。
 
-> 「mureo を `https://github.com/logly/mureo` からインストールして。`pip install git+https://github.com/logly/mureo` を実行したあと、`mureo setup claude-code` を実行、続けて `mureo auth setup --web` を実行してください。」
+> 以下の4ステップを順番に実行してください:
+>
+> ```python
+> import subprocess, shutil
+>
+> # 1. mureo をインストール (既に入っていればスキップ)
+> if not shutil.which("mureo"):
+>     subprocess.run(["pip3", "install", "mureo"], check=True)
+>
+> # 2. ブラウザで Google広告 / Meta広告 の OAuth を完了
+> subprocess.run(["mureo", "auth", "setup", "--web"], check=True)
+>
+> # 3. 認証情報が保存されたか確認
+> from pathlib import Path
+> assert (Path.home() / ".mureo" / "credentials.json").exists(), \
+>     "認証情報が保存されませんでした — ステップ2をやり直してください"
+>
+> # 4. Claude Code 用の設定ファイルを配置 (権限の都合でTerminalに委譲)
+> subprocess.run([
+>     "osascript", "-e",
+>     'tell application "Terminal" to do script '
+>     '"mureo setup claude-code --skip-auth; echo DONE; sleep 5"'
+> ])
+> ```
 
-mureo の setup コマンドは AI エージェント経由（TTY 無し）で実行されたことを自動検出し、対話型の OAuth 手続きをスキップします（Claude がハングしません）。MCP設定・認証ガード・ワークフローコマンド・スキルは全部自動でインストールされます。
+**なぜ4ステップに分かれているか**: Claude Desktop は macOS のサンドボックス内で動作するため、`~/.claude/commands/` への書き込みが TCC ポリシーで拒否されます。ステップ1〜3 はサンドボックス内で完結し（`~/.mureo/credentials.json` への書き込みは許可されている）、ステップ4のみ AppleScript 経由で通常のユーザー権限で動く Terminal に処理を委譲することで `~/.claude/` 配下にファイルを書き込めるようにしています。
+
+完了後は Claude Desktop を再起動すると MCP 設定が読み込まれ、Code タブで `/daily-check` や `/onboard` などのスラッシュコマンドが利用可能になります。
 
 `mureo auth setup --web` は **ブラウザベースのセットアップウィザード** を `http://127.0.0.1:<ランダムポート>/` で起動します。Developer Token・App ID・App Secret はローカル画面のフォームに貼り付け（各欄のリンクから Google Cloud Console / Google Ads API Center / Meta for Developers の該当ページに飛べます）、そのままブラウザ上で OAuth を完了すると `~/.mureo/credentials.json` に書き込まれます。完了後に Claude Desktop を再起動すれば、Code タブで mureo のツールが使えるようになります。**ターミナルを一度も開く必要がありません。**
 

--- a/README.md
+++ b/README.md
@@ -199,11 +199,37 @@ The `mureo auth setup` wizard walks you through both.
 
 ### From inside Claude Code Desktop (no terminal needed)
 
-If you're not comfortable opening a terminal, ask Claude inside the Code tab:
+Paste the following into Claude Desktop's **Code tab**. The browser will open for OAuth, and a Terminal window will briefly appear for the file-install step — on first run, macOS shows a one-time "Claude wants to control Terminal" permission popup. Click **OK**.
 
-> "Install mureo from `https://github.com/logly/mureo`. Run `pip install git+https://github.com/logly/mureo`, then `mureo setup claude-code`, then `mureo auth setup --web`."
+> Run these four steps in order:
+>
+> ```python
+> import subprocess, shutil
+>
+> # 1. Install mureo (skip if already present)
+> if not shutil.which("mureo"):
+>     subprocess.run(["pip3", "install", "mureo"], check=True)
+>
+> # 2. Browser-based OAuth wizard for Google Ads / Meta Ads
+> subprocess.run(["mureo", "auth", "setup", "--web"], check=True)
+>
+> # 3. Verify credentials were saved
+> from pathlib import Path
+> assert (Path.home() / ".mureo" / "credentials.json").exists(), \
+>     "Credentials not saved — retry step 2."
+>
+> # 4. Install Claude Code config files by handing off to Terminal
+> #    (required because ~/.claude/ is outside Claude Desktop's sandbox)
+> subprocess.run([
+>     "osascript", "-e",
+>     'tell application "Terminal" to do script '
+>     '"mureo setup claude-code --skip-auth; echo DONE; sleep 5"'
+> ])
+> ```
 
-mureo's setup auto-detects when it's running under an AI agent (no TTY) and skips the interactive OAuth step so Claude doesn't hang. The MCP config, credential guard, workflow commands, and skills are all installed non-interactively.
+**Why split the flow?** Claude Desktop is sandboxed on macOS. Steps 1–3 run inside the sandbox (writing `~/.mureo/credentials.json` is allowed). Step 4 hands off to a real Terminal window via AppleScript because `~/.claude/commands/` writes require the normal user context — the sandbox's TCC policy denies them otherwise.
+
+Restart Claude Desktop afterwards to load the MCP config. Slash commands (`/daily-check`, `/onboard`, etc.) will appear in the Code tab.
 
 `mureo auth setup --web` launches a **browser-based wizard** on `http://127.0.0.1:<random-port>/`. You paste the Developer Token / App ID / App Secret into a local form (deep links next to each field point at Google Cloud Console / Google Ads API Center / Meta for Developers), complete OAuth in the same browser window, and the wizard writes `~/.mureo/credentials.json` for you. Restart Claude Desktop afterwards and mureo tools appear in the Code tab — no terminal required at any step.
 


### PR DESCRIPTION
## Summary

The "Claude Code Desktop" section in both `README.md` and `README.ja.md` told the reader to paste a natural-language install request with `git+https://github.com/logly/mureo` and run `mureo setup claude-code` *before* `mureo auth setup --web`.

That instruction was broken on two counts:

1. **Wrong ordering.** Running `mureo setup claude-code` inside Claude Desktop's macOS sandbox fails at the `~/.claude/commands/` write — macOS TCC denies the sandboxed process write access outside its container — so the slash commands never land.
2. **Wrong install target.** `git+https://` on a private repo.

## Change

Both READMEs' "Claude Code Desktop" section is replaced with the four-step Python flow validated end-to-end in real-user testing:

```python
import subprocess, shutil

# 1. Install mureo
if not shutil.which("mureo"):
    subprocess.run(["pip3", "install", "mureo"], check=True)

# 2. Browser-based OAuth wizard (sandbox-OK)
subprocess.run(["mureo", "auth", "setup", "--web"], check=True)

# 3. Verify credentials were saved
from pathlib import Path
assert (Path.home() / ".mureo" / "credentials.json").exists(), \
    "Credentials not saved — retry step 2."

# 4. Install Claude Code files by handing off to Terminal
subprocess.run([
    "osascript", "-e",
    'tell application "Terminal" to do script '
    '"mureo setup claude-code --skip-auth; echo DONE; sleep 5"'
])
```

Plus a "Why split the flow?" explanation covering the sandbox / TCC boundary, and a note about the one-time "Claude wants to control Terminal" permission popup on first run.

## Test plan

- [x] Copy the new snippet into Claude Desktop manually (done before this PR — the four-step flow is what the reporting user validated end-to-end)
- [x] Japanese translation matches English semantics
- [x] No stale `git+https://...` reference remains in either README in the section I touched
- [ ] CI pass
- [ ] Colleague test on a fresh Mac (will be done after merge using the wheel / PyPI install path this PR documents)
