### PR TITLE
chore: bump version to 0.6.0.dev1 for TestPyPI beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0.dev1] - 2026-04-20
+
+Pre-release uploaded to TestPyPI for colleague beta testing. No functional differences from the entries below as of this tag; when the final 0.6.0 is cut, the `[0.6.0.dev1]` section below is promoted to `## [0.6.0] - <release date>` and the `.dev1` tag is dropped.
+
 ### Security
 - `mureo setup codex` command-skill generation now escapes all control characters and unicode line separators (U+2028 / U+2029) in the skill `description:` frontmatter field, so a future bundled command whose first line contains a tab, CR, LF, NEL, or other byte that YAML treats as a line break cannot silently truncate the description or corrupt the frontmatter block. Today's bundled commands don't trigger the old behavior — this is a defense-in-depth guard against a future maintainer adding a command with an unusual first line.
 - The legacy `~/.codex/prompts/<bundled>.md` cleanup in `install_codex_command_skills` now skips symlinks. Previously a user who had symlinked a bundled filename at their own file (e.g. via a dotfiles repo) would see the symlink silently removed on every `mureo setup codex` re-run, even though the target stayed intact. The symlink now survives so the operator's intentional link-over-bundled-name is preserved.

--- a/mureo/__init__.py
+++ b/mureo/__init__.py
@@ -1,3 +1,3 @@
 """mureo — Marketing orchestration framework for AI agents."""
 
-__version__ = "0.5.0"
+__version__ = "0.6.0.dev1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mureo"
-version = "0.5.0"
+version = "0.6.0.dev1"
 description = "Marketing orchestration framework for AI agents"
 requires-python = ">=3.10"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Prepare a pre-release upload to TestPyPI so a colleague can install mureo with a straightforward `pip install --extra-index-url` invocation, without zip transfers or GitHub PAT.

### Changes

- `pyproject.toml`: `version = "0.5.0"` → `"0.6.0.dev1"`
- `mureo/__init__.py`: `__version__` kept in sync
- `CHANGELOG.md`: added `[0.6.0.dev1] - 2026-04-20` header above the existing `[Unreleased]` block. When the final 0.6.0 is cut, the entries get promoted to `[0.6.0]` and the `.dev1` tag is dropped.

### Why `0.6.0.dev1` and not `0.6.0`?

PEP 440 developmental release semantics: `pip install mureo` (no TestPyPI) still prefers stable 0.5.0. Colleagues pointing at TestPyPI explicitly (`--index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/`) pick up the preview. If the beta reveals an issue, we bump to `0.6.0.dev2` and re-upload; the real 0.6.0 stable is only published to production PyPI.

## Test plan

- [x] `pytest tests/` → 1774 passed (no functional changes)
- [x] `mureo/__init__.py` `__version__` matches `pyproject.toml version`
- [x] CHANGELOG date format matches existing entries (`- YYYY-MM-DD`)
- [ ] CI pass
- [ ] After merge: `python -m build` + `twine upload --repository testpypi dist/*` produce `mureo-0.6.0.dev1.tar.gz` and `mureo-0.6.0.dev1-py3-none-any.whl` on TestPyPI
