### PR TITLE
fix: remove force-include that duplicated wheel entries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,9 +61,14 @@ Changelog = "https://github.com/logly/mureo/blob/main/CHANGELOG.md"
 [tool.hatch.build.targets.wheel]
 packages = ["mureo"]
 
-[tool.hatch.build.targets.wheel.force-include]
-".claude/commands" = "mureo/_data/commands"
-"skills" = "mureo/_data/skills"
+# NB: the previous ``[tool.hatch.build.targets.wheel.force-include]``
+# block that copied top-level ``.claude/commands/`` and ``skills/`` into
+# ``mureo/_data/`` was removed because it duplicated files already
+# included via ``packages = ["mureo"]``. The duplicate ZIP entries
+# produced a wheel that PyPI rejects with
+# ``400 Invalid distribution file. ZIP archive not accepted:
+# Mis-matched data size.`` The bundled runtime data lives under
+# ``mureo/_data/`` in the package tree and is sufficient on its own.
 
 [tool.black]
 line-length = 88


### PR DESCRIPTION
## Summary

TestPyPI rejected `mureo-0.6.0.dev1-py3-none-any.whl` with:

```
400 Invalid distribution file. ZIP archive not accepted:
Mis-matched data size.
```

## Root cause

`[tool.hatch.build.targets.wheel.force-include]` in `pyproject.toml` was injecting top-level `.claude/commands/` and `skills/` into `mureo/_data/` at build time. The same files were **already** being picked up by `packages = ["mureo"]` because they live under `mureo/_data/` in git, so hatchling wrote them to the wheel ZIP twice. The resulting CDR / local-header size mismatch is what PyPI's validator refuses.

During build, hatchling emitted warnings like:

```
UserWarning: Duplicate name: 'mureo/_data/skills/mureo-workflows/SKILL.md'
```

which were the same duplicates PyPI is now rejecting.

## Fix

Remove the redundant `force-include` block. `packages = ["mureo"]` already includes all non-Python data under `mureo/_data/`. The force-include was a legacy of an older layout where data lived at the repo root; it has been redundant since `mureo/_data/` became the canonical location.

## Verification

- `python -m build` — no duplicate warnings, produces clean wheel + sdist.
- `unzip -l dist/mureo-0.6.0.dev1-py3-none-any.whl` — 10 commands under `mureo/_data/commands/` and 6 skills under `mureo/_data/skills/`, no duplicates, 130 total entries.
- `twine check dist/*` — PASSED for both artifacts.
- `pytest tests/` — 1774 passed, package layout unchanged at runtime.

## Out of scope (noted for follow-up)

Top-level `.claude/commands/` and `skills/` directories still exist (maintainer's Claude Code dogfooding copy) and have **drifted** from `mureo/_data/`:

- `.claude/commands/learn.md` exists; no `learn.md` in `mureo/_data/commands/`
- `mureo/_data/commands/weekly-report.md` exists; no `weekly-report.md` in `.claude/commands/`
- 9 shared command filenames have diverged content
- `skills/mureo-pro-diagnosis/` exists; missing from `mureo/_data/skills/`

This drift is real but separate from the wheel-duplicate bug. A follow-up PR should reconcile the two trees.

## Test plan

- [x] `python -m build` clean
- [x] `unzip -l` shows no duplicate entries
- [x] `twine check` passes both artifacts
- [x] `pytest tests/` — 1774 passed
- [ ] CI pass
- [ ] After merge: rebuild on main + `twine upload --repository testpypi dist/*` succeeds (to be verified by the user)
