### PR TITLE
docs: delegate Python prep to Claude; keep mureo setup in fixed script

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -145,24 +145,28 @@ STATE.jsonから接続媒体を検出:
 
 いずれも `mureo auth setup` の対話型ウィザードが手順を案内します。
 
-### Claude Code Desktop から導入する（ターミナル不要）
+### Claude Code Desktop から導入する
 
-Claude Desktop の **Code タブ** に以下を貼り付けてください。途中でブラウザでOAuth画面が開き、最後にターミナルが一瞬だけ開いて閉じます。初回のみ macOS が「Claudeがターミナルを操作する」許可ダイアログを出すので **OK** を押してください。
+Claude Desktop の **Code タブ** に以下を貼り付けてください。Python が無ければ Claude に任せて入れさせる構成になっています。途中で macOS が「Claude が Terminal を操作する」許可ダイアログを出すので **OK** を押してください。
 
-> 以下の4ステップを順番に実行してください:
+> まず最初に、Python 3.10 以上を私の Mac に用意してください。`pip3 install mureo` がそのまま通る状態にしてほしいので、Homebrew 経由でも python.org 公式インストーラー経由でも、適切な方法を選んでください (PEP 668 の `externally-managed-environment` エラーを回避する必要があれば、それも含めて対処してください)。サンドボックス外での実行が必要なら `osascript` で Terminal.app に頼んでください。
+>
+> Python が揃ったら、以下の mureo セットアップスクリプトをそのまま実行してください:
 >
 > ```python
 > import subprocess, shutil
+> from pathlib import Path
 >
 > # 1. mureo をインストール (既に入っていればスキップ)
 > if not shutil.which("mureo"):
->     subprocess.run(["pip3", "install", "mureo"], check=True)
+>     subprocess.run([
+>         "pip3", "install", "--break-system-packages", "mureo"
+>     ], check=True)
 >
 > # 2. ブラウザで Google広告 / Meta広告 の OAuth を完了
 > subprocess.run(["mureo", "auth", "setup", "--web"], check=True)
 >
 > # 3. 認証情報が保存されたか確認
-> from pathlib import Path
 > assert (Path.home() / ".mureo" / "credentials.json").exists(), \
 >     "認証情報が保存されませんでした — ステップ2をやり直してください"
 >
@@ -173,10 +177,21 @@ Claude Desktop の **Code タブ** に以下を貼り付けてください。途
 >     '"mureo setup claude-code --skip-auth; echo DONE; sleep 5"'
 > ])
 > ```
+>
+> 途中で「Terminal を操作する許可」や Mac のパスワード入力を求められたら、その都度私に知らせてください。ブラウザで Google 広告 / Meta 広告の OAuth 画面が開いたら、私が承認します。完了したら Claude Desktop を再起動するよう伝えてください。
 
-**なぜ4ステップに分かれているか**: Claude Desktop は macOS のサンドボックス内で動作するため、`~/.claude/commands/` への書き込みが TCC ポリシーで拒否されます。ステップ1〜3 はサンドボックス内で完結し（`~/.mureo/credentials.json` への書き込みは許可されている）、ステップ4のみ AppleScript 経由で通常のユーザー権限で動く Terminal に処理を委譲することで `~/.claude/` 配下にファイルを書き込めるようにしています。
+### 何が起きるか
 
-完了後は Claude Desktop を再起動すると MCP 設定が読み込まれ、Code タブで `/daily-check` や `/onboard` などのスラッシュコマンドが利用可能になります。
+| 起こること | 対応 |
+|---|---|
+| 「Claude が Terminal を操作する」許可ポップアップ | **OK** を押す |
+| Mac のログインパスワードを要求される (Homebrewやpython.orgインストール時) | 入力 |
+| ブラウザで Google広告 / Meta広告 の OAuth 画面 | 承認 |
+| Terminal が一瞬開いて閉じる (最終ステップ) | 自動、放置でOK |
+
+完了後は Claude Desktop を **完全終了 (⌘Q) → 再起動** してください。Code タブで `/daily-check` や `/onboard` などのスラッシュコマンドが利用可能になります。
+
+**なぜこの構成か**: Python の用意は環境ごとに最適解が違うので Claude に判断を任せ、mureo 固有の処理 (インストール・認証・Claude Code設定) は再現性が必要なので固定スクリプトに。最後のステップは `~/.claude/` への書き込みが TCC で拒否されるため Terminal に完全委譲しています。
 
 `mureo auth setup --web` は **ブラウザベースのセットアップウィザード** を `http://127.0.0.1:<ランダムポート>/` で起動します。Developer Token・App ID・App Secret はローカル画面のフォームに貼り付け（各欄のリンクから Google Cloud Console / Google Ads API Center / Meta for Developers の該当ページに飛べます）、そのままブラウザ上で OAuth を完了すると `~/.mureo/credentials.json` に書き込まれます。完了後に Claude Desktop を再起動すれば、Code タブで mureo のツールが使えるようになります。**ターミナルを一度も開く必要がありません。**
 

--- a/README.md
+++ b/README.md
@@ -197,24 +197,28 @@ You approve → Agent updates each platform.
 
 The `mureo auth setup` wizard walks you through both.
 
-### From inside Claude Code Desktop (no terminal needed)
+### From inside Claude Code Desktop
 
-Paste the following into Claude Desktop's **Code tab**. The browser will open for OAuth, and a Terminal window will briefly appear for the file-install step — on first run, macOS shows a one-time "Claude wants to control Terminal" permission popup. Click **OK**.
+Paste the following into Claude Desktop's **Code tab**. Python is handled by Claude itself if missing — the fixed script only covers mureo-specific steps. Along the way, macOS may show a "Claude wants to control Terminal" permission popup — click **OK**.
 
-> Run these four steps in order:
+> First, please make sure Python 3.10 or newer is available on my Mac, set up so that `pip3 install mureo` runs without issues. Use whichever method is appropriate — Homebrew, the python.org installer, or something else — and handle PEP 668 `externally-managed-environment` workarounds if they come up. If any step needs to run outside the sandbox, delegate it to Terminal.app via `osascript`.
+>
+> Once Python is ready, run the following mureo setup script as-is:
 >
 > ```python
 > import subprocess, shutil
+> from pathlib import Path
 >
 > # 1. Install mureo (skip if already present)
 > if not shutil.which("mureo"):
->     subprocess.run(["pip3", "install", "mureo"], check=True)
+>     subprocess.run([
+>         "pip3", "install", "--break-system-packages", "mureo"
+>     ], check=True)
 >
 > # 2. Browser-based OAuth wizard for Google Ads / Meta Ads
 > subprocess.run(["mureo", "auth", "setup", "--web"], check=True)
 >
 > # 3. Verify credentials were saved
-> from pathlib import Path
 > assert (Path.home() / ".mureo" / "credentials.json").exists(), \
 >     "Credentials not saved — retry step 2."
 >
@@ -226,10 +230,21 @@ Paste the following into Claude Desktop's **Code tab**. The browser will open fo
 >     '"mureo setup claude-code --skip-auth; echo DONE; sleep 5"'
 > ])
 > ```
+>
+> Let me know if macOS asks for my Mac password or shows a "Claude wants to control Terminal" popup along the way. When a browser opens for Google Ads / Meta Ads OAuth, I'll complete it. Once done, remind me to restart Claude Desktop.
 
-**Why split the flow?** Claude Desktop is sandboxed on macOS. Steps 1–3 run inside the sandbox (writing `~/.mureo/credentials.json` is allowed). Step 4 hands off to a real Terminal window via AppleScript because `~/.claude/commands/` writes require the normal user context — the sandbox's TCC policy denies them otherwise.
+### What happens while it runs
 
-Restart Claude Desktop afterwards to load the MCP config. Slash commands (`/daily-check`, `/onboard`, etc.) will appear in the Code tab.
+| Event | Action |
+|---|---|
+| "Claude wants to control Terminal" popup | Click **OK** |
+| macOS login password prompt (Homebrew or python.org install) | Enter your password |
+| Browser opens for Google Ads / Meta Ads OAuth | Authorize |
+| Terminal briefly flashes open at the end | Automatic; nothing to do |
+
+Restart Claude Desktop (⌘Q, then launch again) to pick up the MCP config. Slash commands (`/daily-check`, `/onboard`, etc.) will appear in the Code tab.
+
+**Why this structure**: Python setup is environment-dependent so we let Claude figure out the best path (Homebrew, python.org installer, etc.), while mureo's specific operations stay in a fixed, reproducible script. The final step delegates fully to Terminal because macOS TCC denies the sandboxed process write access to `~/.claude/`.
 
 `mureo auth setup --web` launches a **browser-based wizard** on `http://127.0.0.1:<random-port>/`. You paste the Developer Token / App ID / App Secret into a local form (deep links next to each field point at Google Cloud Console / Google Ads API Center / Meta for Developers), complete OAuth in the same browser window, and the wizard writes `~/.mureo/credentials.json` for you. Restart Claude Desktop afterwards and mureo tools appear in the Code tab — no terminal required at any step.
 


### PR DESCRIPTION
## Summary

The current Claude Desktop install prompt in both READMEs assumes Python is already installed. On a fresh Mac (a likely colleague scenario) the first line fails with no clear recovery path.

## Change

Split the prompt into two parts:

1. **Natural-language preamble**: asks Claude to ensure Python 3.10+ is available and `pip3 install` works (handling PEP 668 `externally-managed-environment` if needed). Python provisioning varies by environment — let Claude pick Homebrew, python.org installer, or whatever fits.
2. **Fixed Python script**: unchanged mureo-specific 4 steps — install (with `--break-system-packages` so a Homebrew-installed Python works without retry), OAuth wizard, credentials verify, `osascript` handoff to Terminal for `mureo setup claude-code --skip-auth`.

### Also

- Section heading dropped "（ターミナル不要） / (no terminal needed)" — a Terminal window does briefly open in step 4.
- Added a "What happens / 何が起きるか" table so the user knows what popups, password prompts, OAuth page, and Terminal flash to expect.

### Rationale

Python is a generic OS dependency Claude can reason about adaptively; mureo's install/auth/setup flow is specific and should stay reproducible.

## Test plan

- [x] Both README.md and README.ja.md updated consistently
- [x] `--break-system-packages` added to `pip3 install mureo` (harmless on non-externally-managed Python, required on Homebrew Python)
- [x] Heading wording fixed (dropped "no terminal needed" / "ターミナル不要")
- [ ] CI pass
- [ ] Post-merge: colleague test from a clean Mac with no Python
