### PR TITLE
docs: drop Claude Desktop install flow, keep Terminal-based setup

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -145,55 +145,9 @@ STATE.jsonから接続媒体を検出:
 
 いずれも `mureo auth setup` の対話型ウィザードが手順を案内します。
 
-### Claude Code Desktop から導入する
+### ブラウザベースの認証ウィザード (`mureo auth setup --web`)
 
-Claude Desktop の **Code タブ** に以下を貼り付けてください。Python が無ければ Claude に任せて入れさせる構成になっています。途中で macOS が「Claude が Terminal を操作する」許可ダイアログを出すので **OK** を押してください。
-
-> まず最初に、Python 3.10 以上を私の Mac に用意してください。`pip3 install mureo` がそのまま通る状態にしてほしいので、Homebrew 経由でも python.org 公式インストーラー経由でも、適切な方法を選んでください (PEP 668 の `externally-managed-environment` エラーを回避する必要があれば、それも含めて対処してください)。サンドボックス外での実行が必要なら `osascript` で Terminal.app に頼んでください。
->
-> Python が揃ったら、以下の mureo セットアップスクリプトをそのまま実行してください:
->
-> ```python
-> import subprocess, shutil
-> from pathlib import Path
->
-> # 1. mureo をインストール (既に入っていればスキップ)
-> if not shutil.which("mureo"):
->     subprocess.run([
->         "pip3", "install", "--break-system-packages", "mureo"
->     ], check=True)
->
-> # 2. ブラウザで Google広告 / Meta広告 の OAuth を完了
-> subprocess.run(["mureo", "auth", "setup", "--web"], check=True)
->
-> # 3. 認証情報が保存されたか確認
-> assert (Path.home() / ".mureo" / "credentials.json").exists(), \
->     "認証情報が保存されませんでした — ステップ2をやり直してください"
->
-> # 4. Claude Code 用の設定ファイルを配置 (権限の都合でTerminalに委譲)
-> subprocess.run([
->     "osascript", "-e",
->     'tell application "Terminal" to do script '
->     '"mureo setup claude-code --skip-auth; echo DONE; sleep 5"'
-> ])
-> ```
->
-> 途中で「Terminal を操作する許可」や Mac のパスワード入力を求められたら、その都度私に知らせてください。ブラウザで Google 広告 / Meta 広告の OAuth 画面が開いたら、私が承認します。完了したら Claude Desktop を再起動するよう伝えてください。
-
-### 何が起きるか
-
-| 起こること | 対応 |
-|---|---|
-| 「Claude が Terminal を操作する」許可ポップアップ | **OK** を押す |
-| Mac のログインパスワードを要求される (Homebrewやpython.orgインストール時) | 入力 |
-| ブラウザで Google広告 / Meta広告 の OAuth 画面 | 承認 |
-| Terminal が一瞬開いて閉じる (最終ステップ) | 自動、放置でOK |
-
-完了後は Claude Desktop を **完全終了 (⌘Q) → 再起動** してください。Code タブで `/daily-check` や `/onboard` などのスラッシュコマンドが利用可能になります。
-
-**なぜこの構成か**: Python の用意は環境ごとに最適解が違うので Claude に判断を任せ、mureo 固有の処理 (インストール・認証・Claude Code設定) は再現性が必要なので固定スクリプトに。最後のステップは `~/.claude/` への書き込みが TCC で拒否されるため Terminal に完全委譲しています。
-
-`mureo auth setup --web` は **ブラウザベースのセットアップウィザード** を `http://127.0.0.1:<ランダムポート>/` で起動します。Developer Token・App ID・App Secret はローカル画面のフォームに貼り付け（各欄のリンクから Google Cloud Console / Google Ads API Center / Meta for Developers の該当ページに飛べます）、そのままブラウザ上で OAuth を完了すると `~/.mureo/credentials.json` に書き込まれます。完了後に Claude Desktop を再起動すれば、Code タブで mureo のツールが使えるようになります。**ターミナルを一度も開く必要がありません。**
+ターミナルに長い秘密情報を貼り付けるのはミスしやすいので、インストール後は `mureo auth setup --web` を実行してください。短命のローカルウィザードが `http://127.0.0.1:<ランダムポート>/` で起動し、ブラウザが自動で開いて Developer Token・App ID・App Secret を貼り付けるフォームが表示されます（各欄のリンクから Google Cloud Console / Google Ads API Center / Meta for Developers の該当ページに飛べます）。同じブラウザウィンドウで OAuth を完了すると `~/.mureo/credentials.json` に書き込まれます。
 
 <details>
 <summary>ウィザードをローカル実行しても安全な理由</summary>

--- a/README.md
+++ b/README.md
@@ -197,56 +197,9 @@ You approve → Agent updates each platform.
 
 The `mureo auth setup` wizard walks you through both.
 
-### From inside Claude Code Desktop
+### Browser-based auth wizard (`mureo auth setup --web`)
 
-Paste the following into Claude Desktop's **Code tab**. Python is handled by Claude itself if missing — the fixed script only covers mureo-specific steps. Along the way, macOS may show a "Claude wants to control Terminal" permission popup — click **OK**.
-
-> First, please make sure Python 3.10 or newer is available on my Mac, set up so that `pip3 install mureo` runs without issues. Use whichever method is appropriate — Homebrew, the python.org installer, or something else — and handle PEP 668 `externally-managed-environment` workarounds if they come up. If any step needs to run outside the sandbox, delegate it to Terminal.app via `osascript`.
->
-> Once Python is ready, run the following mureo setup script as-is:
->
-> ```python
-> import subprocess, shutil
-> from pathlib import Path
->
-> # 1. Install mureo (skip if already present)
-> if not shutil.which("mureo"):
->     subprocess.run([
->         "pip3", "install", "--break-system-packages", "mureo"
->     ], check=True)
->
-> # 2. Browser-based OAuth wizard for Google Ads / Meta Ads
-> subprocess.run(["mureo", "auth", "setup", "--web"], check=True)
->
-> # 3. Verify credentials were saved
-> assert (Path.home() / ".mureo" / "credentials.json").exists(), \
->     "Credentials not saved — retry step 2."
->
-> # 4. Install Claude Code config files by handing off to Terminal
-> #    (required because ~/.claude/ is outside Claude Desktop's sandbox)
-> subprocess.run([
->     "osascript", "-e",
->     'tell application "Terminal" to do script '
->     '"mureo setup claude-code --skip-auth; echo DONE; sleep 5"'
-> ])
-> ```
->
-> Let me know if macOS asks for my Mac password or shows a "Claude wants to control Terminal" popup along the way. When a browser opens for Google Ads / Meta Ads OAuth, I'll complete it. Once done, remind me to restart Claude Desktop.
-
-### What happens while it runs
-
-| Event | Action |
-|---|---|
-| "Claude wants to control Terminal" popup | Click **OK** |
-| macOS login password prompt (Homebrew or python.org install) | Enter your password |
-| Browser opens for Google Ads / Meta Ads OAuth | Authorize |
-| Terminal briefly flashes open at the end | Automatic; nothing to do |
-
-Restart Claude Desktop (⌘Q, then launch again) to pick up the MCP config. Slash commands (`/daily-check`, `/onboard`, etc.) will appear in the Code tab.
-
-**Why this structure**: Python setup is environment-dependent so we let Claude figure out the best path (Homebrew, python.org installer, etc.), while mureo's specific operations stay in a fixed, reproducible script. The final step delegates fully to Terminal because macOS TCC denies the sandboxed process write access to `~/.claude/`.
-
-`mureo auth setup --web` launches a **browser-based wizard** on `http://127.0.0.1:<random-port>/`. You paste the Developer Token / App ID / App Secret into a local form (deep links next to each field point at Google Cloud Console / Google Ads API Center / Meta for Developers), complete OAuth in the same browser window, and the wizard writes `~/.mureo/credentials.json` for you. Restart Claude Desktop afterwards and mureo tools appear in the Code tab — no terminal required at any step.
+Pasting long secrets into a terminal prompt is error-prone. After installation, `mureo auth setup --web` starts a short-lived local wizard on `http://127.0.0.1:<random-port>/` and opens your browser to a local form where you paste the Developer Token / App ID / App Secret (each field has a deep link to Google Cloud Console / Google Ads API Center / Meta for Developers). The OAuth flow completes in the same browser window and the wizard writes `~/.mureo/credentials.json` for you.
 
 <details>
 <summary>Why the wizard is safe to run locally</summary>


### PR DESCRIPTION
## Summary

Real-user testing with a colleague exposed that the "From inside Claude Code Desktop" / 「Claude Code Desktop から導入する」 sections do not work reliably:

1. **Sandbox constraint**: Claude Desktop's Code tool runs in a macOS sandbox. `~/.claude/commands/` writes are denied by TCC. Our `osascript` handoff to Terminal.app was a correct technical workaround, but
2. **Safety-gate collision**: Claude Desktop (correctly) flags the combination of TestPyPI + `--break-system-packages` + OAuth credential save + osascript sandbox escape as textbook malware / supply-chain-attack shape. Even a well-primed natural-language prompt does not consistently clear the gate.

Rather than escalate escape hatches, **drop the sections entirely**. The existing terminal-based setup instructions (`Claude Code (recommended)`, `Cursor`, `Codex CLI`, `Gemini CLI`, `CLI only`) remain as the documented install path.

## Changes

- `README.md` / `README.ja.md`: removed the "From inside Claude Code Desktop" / 「Claude Code Desktop から導入する」subsection including the 4-step Python script, the "What happens while it runs" / 「何が起きるか」 table, and the "Why this structure" / 「なぜこの構成か」 paragraph
- The browser-based auth wizard description is retained in a trimmed standalone subsection — `mureo auth setup --web` remains a useful feature once mureo is installed
- Net: +6 / -99 across both READMEs

## Future work (out of scope)

- Signed `.pkg` installer for non-technical users (Apple Developer enrollment required)
- Homebrew tap for one-liner `brew install logly/tap/mureo`
- MCP config generator writing `sys.executable` instead of hardcoded `"python"` — enables pipx / venv installs to work cleanly with Claude Desktop's MCP launcher

## Test plan

- [x] Both READMEs still have working Terminal-based install paths
- [x] `mureo auth setup --web` is still documented as a feature
- [x] No dangling references to the removed Claude Desktop install flow
- [ ] CI pass
