### PR TITLE
chore: bump to 0.6.0 for first production PyPI release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.6.0.dev1] - 2026-04-20
+## [0.6.0] - 2026-04-20
 
-Pre-release uploaded to TestPyPI for colleague beta testing. No functional differences from the entries below as of this tag; when the final 0.6.0 is cut, the `[0.6.0.dev1]` section below is promoted to `## [0.6.0] - <release date>` and the `.dev1` tag is dropped.
+First production PyPI release (`pip install mureo`). Supersedes the internal `0.6.0.dev1` preview that was published to TestPyPI during colleague beta testing.
 
 ### Security
 - `mureo setup codex` command-skill generation now escapes all control characters and unicode line separators (U+2028 / U+2029) in the skill `description:` frontmatter field, so a future bundled command whose first line contains a tab, CR, LF, NEL, or other byte that YAML treats as a line break cannot silently truncate the description or corrupt the frontmatter block. Today's bundled commands don't trigger the old behavior — this is a defense-in-depth guard against a future maintainer adding a command with an unusual first line.

--- a/mureo/__init__.py
+++ b/mureo/__init__.py
@@ -1,3 +1,3 @@
 """mureo — Marketing orchestration framework for AI agents."""
 
-__version__ = "0.6.0.dev1"
+__version__ = "0.6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mureo"
-version = "0.6.0.dev1"
+version = "0.6.0"
 description = "Marketing orchestration framework for AI agents"
 requires-python = ">=3.10"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Promotes the internal `0.6.0.dev1` preview (uploaded to TestPyPI for colleague beta testing) to **`0.6.0` stable** for publication to production PyPI (https://pypi.org/).

### Changes

- `pyproject.toml`: `version = "0.6.0.dev1"` → `"0.6.0"`
- `mureo/__init__.py`: `__version__` kept in sync
- `CHANGELOG.md`: `[0.6.0.dev1] - 2026-04-20` → `[0.6.0] - 2026-04-20` with a release note explaining this is the first production PyPI release

No functional changes. Same content set as `0.6.0.dev1` — the `.dev1` tag is dropped because PEP 440 developmental releases are only for pre-publication testing.

## Production-PyPI readiness

- [x] Name `mureo` is available on production PyPI (https://pypi.org/pypi/mureo/json returns 404)
- [x] License metadata: Apache-2.0
- [x] README renders (verified with `twine check` earlier)
- [x] No accidentally-bundled secrets (dist/ produced from clean source tree)

## Test plan

- [x] `pytest tests/` → 1774 passed (no functional changes)
- [x] `mureo/__init__.py` `__version__` matches `pyproject.toml version`
- [x] CHANGELOG date format matches existing entries
- [ ] CI pass
- [ ] After merge: `python -m build` + `twine upload dist/*` produce `mureo-0.6.0.tar.gz` and `mureo-0.6.0-py3-none-any.whl` on production PyPI
