### PR TITLE
chore: add README badges for public release

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -9,6 +9,13 @@
   <a href="README.md">English</a>
 </p>
 
+<p align="center">
+  <a href="https://pypi.org/project/mureo/"><img alt="PyPI" src="https://img.shields.io/pypi/v/mureo.svg"></a>
+  <a href="https://pypi.org/project/mureo/"><img alt="Python versions" src="https://img.shields.io/pypi/pyversions/mureo.svg"></a>
+  <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache%202.0-blue.svg"></a>
+  <a href="https://github.com/logly/mureo/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/logly/mureo/actions/workflows/ci.yml/badge.svg"></a>
+</p>
+
 ## mureoとは
 
 mureoは、AIエージェントが広告アカウントを自動運用するためのフレームワークです。インストールすると、AIエージェント（Claude Code、Cursor、Codex、Geminiなど）がGoogle広告・Meta広告・Search Console・GA4を横断して、配信診断・検索語分析・予算評価・入稿チェックなどを実行できるようになります。すべての操作はあなたのビジネス戦略（`STRATEGY.md`）に基づいて行われます。

--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@
   <a href="README.ja.md">日本語</a>
 </p>
 
+<p align="center">
+  <a href="https://pypi.org/project/mureo/"><img alt="PyPI" src="https://img.shields.io/pypi/v/mureo.svg"></a>
+  <a href="https://pypi.org/project/mureo/"><img alt="Python versions" src="https://img.shields.io/pypi/pyversions/mureo.svg"></a>
+  <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache%202.0-blue.svg"></a>
+  <a href="https://github.com/logly/mureo/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/logly/mureo/actions/workflows/ci.yml/badge.svg"></a>
+</p>
+
 ## What is mureo?
 
 mureo is a framework for AI agents to autonomously operate ad accounts. Once installed, AI agents (Claude Code, Cursor, Codex, Gemini, etc.) can work across Google Ads, Meta Ads, Search Console, and GA4 -- running campaign diagnostics, search term analysis, budget evaluation, ad validation, and more. Every operation is grounded in your business strategy (`STRATEGY.md`), so the agent makes decisions based on your persona, USP, goals, and brand voice -- not just raw metrics.


### PR DESCRIPTION
## Summary

Public-release prep for 2026-04-22. Adds a centered badge row to both READMEs so the landing visually signals PyPI availability, Python support, license, and CI health at a glance.

### Badges

- **PyPI version** — live, updates whenever a new release is published
- **Python versions** — auto-reads `Programming Language :: Python :: 3.x` classifiers from `pyproject.toml`
- **License** — Apache-2.0 (pinned badge)
- **CI** — `github.com/logly/mureo/actions/workflows/ci.yml` badge, green while lint + test (3.10/3.11/3.12) pass

Badges sit right below the existing language switcher, keeping the logo-first hero intact.

## Public-release checklist status

Out of the 4 prep tasks discussed:

- [x] 1. Issue templates — already present (`.github/ISSUE_TEMPLATE/`)
- [x] 2. Code of Conduct — will be added via GitHub's Community Standards UI ("Add Contributor Covenant" flow) in a separate PR by the maintainer
- [x] 3. README badges — **this PR**
- [x] 4. LICENSE — already present (Apache-2.0, 10 KB full text)

## Test plan

- [x] Both `README.md` and `README.ja.md` rendered locally (preview shows badges)
- [x] Badge URLs resolve (`img.shields.io` + `github.com/actions`)
- [ ] CI pass
