### PR TITLE
docs: update SECURITY.md supported versions to 0.6.x

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,9 +4,8 @@
 
 | Version | Supported          |
 |---------|--------------------|
-| 0.3.x   | :white_check_mark: |
-| 0.2.x   | :white_check_mark: |
-| < 0.2   | :x:                |
+| 0.6.x   | :white_check_mark: |
+| < 0.6   | :x:                |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
## Summary
- Supported Versions テーブルが 0.3.x / 0.2.x のままで古くなっていたため、現行の 0.6.x に更新

## Test plan
- [x] Markdown レンダリング確認（GitHub preview）
- [x] 他ファイルからの SECURITY.md 参照リンク破損なし（ファイル名不変）