### PR TITLE
feat: add Dockerfile for containerized MCP server and registry health checks

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,43 @@
+# Python artifacts
+**/__pycache__
+**/*.pyc
+**/*.pyo
+**/*.pyd
+*.egg-info
+.pytest_cache
+.mypy_cache
+.ruff_cache
+.coverage
+htmlcov
+
+# Build outputs
+dist/
+build/
+
+# Git
+.git
+.github
+.gitignore
+.gitattributes
+
+# Tests (not shipped in image)
+tests/
+
+# Docs (not needed inside the image)
+docs/
+
+# Editors / OS
+.vscode
+.idea
+.DS_Store
+*.swp
+
+# Environment
+.env
+.env.*
+.venv
+venv
+
+# Docker itself
+.dockerignore
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# Dockerfile for mureo — AI agent framework for ad operations.
+#
+# Primary purpose: enable MCP introspection checks on server registries
+# such as Glama (https://glama.ai/mcp/servers/logly/mureo).
+#
+# Secondary purpose: let users try mureo without touching their host
+# Python environment. Real usage requires credentials; see README.
+#
+# Usage:
+#   docker build -t mureo .
+#   docker run --rm -v ~/.mureo:/root/.mureo mureo
+
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Copy package metadata and sources
+COPY pyproject.toml README.md LICENSE ./
+COPY mureo/ ./mureo/
+
+# Install mureo from source
+RUN pip install --no-cache-dir .
+
+# Introspection-only defaults. Replace with real credentials at runtime
+# via `-v ~/.mureo:/root/.mureo` or `--env-file`.
+ENV GOOGLE_ADS_DEVELOPER_TOKEN=introspection-only \
+    GOOGLE_ADS_CLIENT_ID=introspection-only \
+    GOOGLE_ADS_CLIENT_SECRET=introspection-only \
+    GOOGLE_ADS_REFRESH_TOKEN=introspection-only \
+    META_ADS_ACCESS_TOKEN=introspection-only
+
+# MCP server over stdio (Claude Code / Cursor / Codex CLI / Gemini CLI)
+CMD ["python", "-m", "mureo.mcp"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,21 +8,40 @@
 #
 # Usage:
 #   docker build -t mureo .
-#   docker run --rm -v ~/.mureo:/root/.mureo mureo
+#   docker run --rm -v ~/.mureo:/home/mureo/.mureo mureo
 
 FROM python:3.11-slim
 
+LABEL org.opencontainers.image.source="https://github.com/logly/mureo" \
+      org.opencontainers.image.description="AI agent framework for autonomous ad operations across Google Ads, Meta Ads, and Search Console" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.vendor="Logly, Inc." \
+      org.opencontainers.image.documentation="https://mureo.io" \
+      org.opencontainers.image.url="https://github.com/logly/mureo"
+
+# Non-root user for runtime
+RUN groupadd --system mureo && useradd --system --gid mureo --create-home mureo
+
 WORKDIR /app
 
-# Copy package metadata and sources
+# Install dependencies first in a cacheable layer.
+# We create an empty package stub so `pip install .` resolves deps
+# without needing the full source tree; sources are copied next.
 COPY pyproject.toml README.md LICENSE ./
+RUN mkdir -p mureo && touch mureo/__init__.py \
+ && pip install --no-cache-dir . \
+ && rm -rf mureo
+
+# Copy real sources. Edits here do not invalidate the deps layer above.
 COPY mureo/ ./mureo/
+RUN pip install --no-cache-dir --no-deps .
 
-# Install mureo from source
-RUN pip install --no-cache-dir .
+# Drop privileges
+RUN chown -R mureo:mureo /app
+USER mureo
 
-# Introspection-only defaults. Replace with real credentials at runtime
-# via `-v ~/.mureo:/root/.mureo` or `--env-file`.
+# Introspection-only defaults for server registries. Replace at runtime
+# via `-v ~/.mureo:/home/mureo/.mureo` or `--env-file`.
 ENV GOOGLE_ADS_DEVELOPER_TOKEN=introspection-only \
     GOOGLE_ADS_CLIENT_ID=introspection-only \
     GOOGLE_ADS_CLIENT_SECRET=introspection-only \

--- a/README.ja.md
+++ b/README.ja.md
@@ -217,14 +217,74 @@ mureo auth status
 
 ### Docker
 
-MCPサーバーを隔離されたコンテナで動かしたい場合や、外部のMCPレジストリ（Glama など）の健全性チェックのために `Dockerfile` を同梱しています。
+mureoのMCPサーバーを隔離されたコンテナで動かせます。想定ユースケース:
+
+- **Claude Code以外のMCPクライアント**: Cursor, Codex CLI, Gemini CLI, Continue, Cline, Zed など
+- **CI/CDパイプライン**: 異常検知、ロールバック dry-run、週次レポートの自動実行
+- **マルチテナント / 代理店運用**: クライアントごとにコンテナ・認証情報を分離
+- **MCPレジストリの健全性チェック**（Glama 等）
+
+> スラッシュコマンド（`/daily-check`, `/rescue` など）と credential-guard フックは Claude Code 固有のUXです。これらを使う場合は `pip install mureo` + `mureo setup claude-code` を使ってください。
+
+#### ビルドと起動
 
 ```bash
 docker build -t mureo .
 docker run --rm -v ~/.mureo:/home/mureo/.mureo mureo
 ```
 
-イメージはソースからmureoをインストールし、stdio上でMCPサーバー（`python -m mureo.mcp`）を起動します。認証情報はコンテナ内の `/home/mureo/.mureo/credentials.json` に置かれることを想定しています。ホストの `~/.mureo` をマウントするか、`--env-file` で環境変数として渡してください。
+MCPクライアント側の設定で上記 `docker run` をコマンドとして指定してください。
+
+#### 認証
+
+認証情報は `/home/mureo/.mureo/credentials.json`（コンテナ内、bind mount 経由）または環境変数から読み込まれます。3つの方式から選べます:
+
+**1. マウントした認証ファイル** — ホストに `~/.mureo/credentials.json` が既にある場合（`mureo auth setup` 実行済、チーム共有、手書き等）、上記の bind mount だけで十分です。
+
+手書き用スキーマ:
+
+```json
+{
+  "google_ads": {
+    "developer_token": "...",
+    "client_id": "...apps.googleusercontent.com",
+    "client_secret": "...",
+    "refresh_token": "...",
+    "login_customer_id": "1234567890"
+  },
+  "meta_ads": { "access_token": "..." }
+}
+```
+
+必須フィールド: Google は `developer_token` / `client_id` / `client_secret` / `refresh_token`、Meta は `access_token`。Search Console は Google の OAuth 認証情報を共用（OAuth アプリに `https://www.googleapis.com/auth/webmasters` スコープが必要）。
+
+**2. 環境変数** — CI/CDで secret manager から渡す場合に便利:
+
+```bash
+docker run --rm \
+  -e GOOGLE_ADS_DEVELOPER_TOKEN=... \
+  -e GOOGLE_ADS_CLIENT_ID=... \
+  -e GOOGLE_ADS_CLIENT_SECRET=... \
+  -e GOOGLE_ADS_REFRESH_TOKEN=... \
+  -e GOOGLE_ADS_LOGIN_CUSTOMER_ID=... \
+  -e META_ADS_ACCESS_TOKEN=... \
+  mureo
+```
+
+対応環境変数: `GOOGLE_ADS_{DEVELOPER_TOKEN, CLIENT_ID, CLIENT_SECRET, REFRESH_TOKEN, LOGIN_CUSTOMER_ID, CUSTOMER_ID}`, `META_ADS_{ACCESS_TOKEN, APP_ID, APP_SECRET, TOKEN_OBTAINED_AT, ACCOUNT_ID}`。
+
+**3. Docker内で対話型ウィザード実行** — OAuthトークンをまだ持っておらず、ホストにmureoをインストールしたくない場合:
+
+```bash
+docker run -it --rm -v ~/.mureo:/home/mureo/.mureo mureo mureo auth setup
+```
+
+ターミナル上でOAuthフローを案内します。`credentials.json` はマウントボリュームに書き出されるので、次回以降は方式1で起動できます。
+
+mureo以外でOAuthトークンを取得する方法:
+
+- Google Ads OAuth 2.0: https://developers.google.com/google-ads/api/docs/oauth/overview
+- Meta 長期アクセストークン: https://developers.facebook.com/docs/facebook-login/guides/access-tokens/get-long-lived
 
 ### インストール内容
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -215,6 +215,17 @@ mureo auth setup
 mureo auth status
 ```
 
+### Docker
+
+MCPサーバーを隔離されたコンテナで動かしたい場合や、外部のMCPレジストリ（Glama など）の健全性チェックのために `Dockerfile` を同梱しています。
+
+```bash
+docker build -t mureo .
+docker run --rm -v ~/.mureo:/home/mureo/.mureo mureo
+```
+
+イメージはソースからmureoをインストールし、stdio上でMCPサーバー（`python -m mureo.mcp`）を起動します。認証情報はコンテナ内の `/home/mureo/.mureo/credentials.json` に置かれることを想定しています。ホストの `~/.mureo` をマウントするか、`--env-file` で環境変数として渡してください。
+
 ### インストール内容
 
 | 構成要素 | `mureo setup claude-code` | `mureo setup cursor` | `mureo setup codex` | `mureo setup gemini` | `mureo auth setup` |

--- a/README.md
+++ b/README.md
@@ -269,14 +269,74 @@ mureo auth status
 
 ### Docker
 
-A `Dockerfile` is provided for users who want to run the MCP server in an isolated container, and for registry health checks (e.g. Glama).
+Run the mureo MCP server in an isolated container. Useful for:
+
+- **Non–Claude Code MCP clients**: Cursor, Codex CLI, Gemini CLI, Continue, Cline, Zed, or any custom MCP client.
+- **CI/CD pipelines**: scheduled anomaly checks, rollback dry-runs, weekly reports.
+- **Multi-tenant / agency ops**: isolated credentials per client via separate containers.
+- **MCP registry health checks** (Glama, etc.).
+
+> Slash commands (`/daily-check`, `/rescue`) and the credential-guard hook are Claude Code–specific UX. For those, use `pip install mureo` with `mureo setup claude-code` instead.
+
+#### Build and run
 
 ```bash
 docker build -t mureo .
-docker run --rm -v ~/.mureo:/root/.mureo mureo
+docker run --rm -v ~/.mureo:/home/mureo/.mureo mureo
 ```
 
-The image installs mureo from source and starts the MCP server over stdio (`python -m mureo.mcp`). Credentials are expected at `/root/.mureo/credentials.json` inside the container — mount your host `~/.mureo` directory, or supply env vars via `--env-file`.
+Connect your MCP client by pointing its config at this `docker run` command.
+
+#### Authentication
+
+Credentials are loaded from `/home/mureo/.mureo/credentials.json` inside the container (via bind mount) or from environment variables. Three common patterns:
+
+**1. Mounted credentials file** — if `~/.mureo/credentials.json` already exists on the host (from a prior `mureo auth setup`, a team-shared vault, or hand-crafted), the bind mount above is enough.
+
+Schema for hand-crafting:
+
+```json
+{
+  "google_ads": {
+    "developer_token": "...",
+    "client_id": "...apps.googleusercontent.com",
+    "client_secret": "...",
+    "refresh_token": "...",
+    "login_customer_id": "1234567890"
+  },
+  "meta_ads": { "access_token": "..." }
+}
+```
+
+Required: Google needs `developer_token` / `client_id` / `client_secret` / `refresh_token`. Meta needs `access_token`. Search Console reuses the Google OAuth credentials (OAuth app must include the `https://www.googleapis.com/auth/webmasters` scope).
+
+**2. Environment variables** — useful for CI/CD where secrets come from a secret manager:
+
+```bash
+docker run --rm \
+  -e GOOGLE_ADS_DEVELOPER_TOKEN=... \
+  -e GOOGLE_ADS_CLIENT_ID=... \
+  -e GOOGLE_ADS_CLIENT_SECRET=... \
+  -e GOOGLE_ADS_REFRESH_TOKEN=... \
+  -e GOOGLE_ADS_LOGIN_CUSTOMER_ID=... \
+  -e META_ADS_ACCESS_TOKEN=... \
+  mureo
+```
+
+Supported: `GOOGLE_ADS_{DEVELOPER_TOKEN, CLIENT_ID, CLIENT_SECRET, REFRESH_TOKEN, LOGIN_CUSTOMER_ID, CUSTOMER_ID}`, `META_ADS_{ACCESS_TOKEN, APP_ID, APP_SECRET, TOKEN_OBTAINED_AT, ACCOUNT_ID}`.
+
+**3. Interactive wizard inside Docker** — if you don't have OAuth tokens yet and don't want to install mureo on the host:
+
+```bash
+docker run -it --rm -v ~/.mureo:/home/mureo/.mureo mureo mureo auth setup
+```
+
+Walks you through the OAuth flow in the terminal and writes `credentials.json` to the mounted volume. Subsequent runs pick it up automatically (pattern 1).
+
+To obtain OAuth tokens outside mureo:
+
+- Google Ads OAuth 2.0 refresh token: https://developers.google.com/google-ads/api/docs/oauth/overview
+- Meta long-lived access token: https://developers.facebook.com/docs/facebook-login/guides/access-tokens/get-long-lived
 
 ### What gets installed
 

--- a/README.md
+++ b/README.md
@@ -267,6 +267,17 @@ mureo auth setup
 mureo auth status
 ```
 
+### Docker
+
+A `Dockerfile` is provided for users who want to run the MCP server in an isolated container, and for registry health checks (e.g. Glama).
+
+```bash
+docker build -t mureo .
+docker run --rm -v ~/.mureo:/root/.mureo mureo
+```
+
+The image installs mureo from source and starts the MCP server over stdio (`python -m mureo.mcp`). Credentials are expected at `/root/.mureo/credentials.json` inside the container — mount your host `~/.mureo` directory, or supply env vars via `--env-file`.
+
 ### What gets installed
 
 | Component | `mureo setup claude-code` | `mureo setup cursor` | `mureo setup codex` | `mureo setup gemini` | `mureo auth setup` |


### PR DESCRIPTION
## Summary

Add a `Dockerfile` so users can run the MCP server in an isolated container, and so external MCP registries (Glama, in particular) can run introspection health checks against a canonical image.

## Changes

- New `Dockerfile` — Python 3.11-slim base, installs mureo from source, runs `python -m mureo.mcp` on stdio.
- README gets a new **Docker** subsection under Quick Start showing the build/run pattern with credentials mounted from `~/.mureo`.

## Notes

- The `ENV` block sets `introspection-only` defaults so the MCP server starts cleanly in environments without real credentials (used by registry health checks). Real usage replaces these via `-v ~/.mureo:/root/.mureo` or `--env-file`.
- No behavior change for existing `pip install mureo` users.