### PR TITLE
chore: add glama.json for Glama ownership claim

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "hyoshi"
+  ]
+}


### PR DESCRIPTION
Adds a minimal `glama.json` to the repo root so the Glama server listing (https://glama.ai/mcp/servers/logly/mureo) can be claimed as maintainer-owned.

For organization-hosted repos like `logly/mureo`, Glama requires this file (plain GitHub OAuth alone does not suffice). The file lists `hyoshi` as the maintainer for claim verification.

No impact on builds, tests, code, or distributions. Spec: https://glama.ai/blog/2025-07-08-what-is-glamajson