### PR TITLE
fix(docker): remove introspection-only ENV defaults to unblock Glama

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,13 +40,12 @@ RUN pip install --no-cache-dir --no-deps .
 RUN chown -R mureo:mureo /app
 USER mureo
 
-# Introspection-only defaults for server registries. Replace at runtime
-# via `-v ~/.mureo:/home/mureo/.mureo` or `--env-file`.
-ENV GOOGLE_ADS_DEVELOPER_TOKEN=introspection-only \
-    GOOGLE_ADS_CLIENT_ID=introspection-only \
-    GOOGLE_ADS_CLIENT_SECRET=introspection-only \
-    GOOGLE_ADS_REFRESH_TOKEN=introspection-only \
-    META_ADS_ACCESS_TOKEN=introspection-only
+# Credentials are loaded at runtime from ~/.mureo/credentials.json.
+# Mount the host directory when running:
+#   docker run --rm -v ~/.mureo:/home/mureo/.mureo mureo
+# Credential checks are lazy (per-tool), so the server starts without
+# credentials — MCP introspection on registries like Glama works
+# without dummy env vars.
 
 # MCP server over stdio (Claude Code / Cursor / Codex CLI / Gemini CLI)
 CMD ["python", "-m", "mureo.mcp"]


### PR DESCRIPTION
## Summary
- Remove the five `introspection-only` ENV declarations (`GOOGLE_ADS_*`, `META_ADS_ACCESS_TOKEN`) from the Dockerfile.
- Replace with a short comment pointing to `~/.mureo/credentials.json` as the canonical credentials path at runtime.
- Refresh the block comment to call out that MCP introspection on registries (Glama) now works without dummy env vars.

## Why
Glama's registry fails to spin up the introspection container for `logly/mureo` with `HTTP 414 Request-URI Too Large` from the Docker daemon. Root cause: Glama injects format-accurate synthesized dummy values for every declared env var. With 12 credential vars (Google Ads + Meta Ads) the URL exceeds Docker's limit and the container never starts, which leaves the Glama quality/security scores stuck at `?` — which in turn blocks the awesome-mcp-servers listing PR ([punkpeye/awesome-mcp-servers#5232](https://github.com/punkpeye/awesome-mcp-servers/pull/5232)).

Credentials are primarily loaded from `~/.mureo/credentials.json` (`mureo/auth.py::load_credentials`). The env var path is a fallback and per-tool credential checks are lazy, so the server boots cleanly with zero env vars.

## Test plan
- [x] `docker build -t mureo:test-no-env .` — succeeds.
- [x] `docker run -i --rm mureo:test-no-env` with MCP `initialize` + `tools/list` over stdio — server responds with full tool catalog, no errors.
- [ ] Trigger Glama rebuild after merge; confirm quality and security scores populate (any grade is acceptable per upstream guidance).
- [ ] Update the awesome-mcp-servers PR once scores are assigned.

## Notes
No user-facing behavior change. README.md / README.ja.md continue to document both credentials paths.