### PR TITLE
feat(mcp): rewrite 49 tool descriptions to improve Glama TDQS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- MCP tool descriptions rewritten for 49 tools across Google Ads and Meta Ads — `google_ads.campaigns.*`, `google_ads.ad_groups.*`, `google_ads.ads.*`, `google_ads.budget.*`, `google_ads.accounts.*`, `google_ads.keywords.*`, `google_ads.negative_keywords.*`, `meta_ads.campaigns.*`, `meta_ads.ad_sets.*`, `meta_ads.ads.*`. Each description now covers verb + resource + returned fields + side effects (read-only / mutating / reversible via `rollback.apply`) + sibling tool differentiation, following the new `docs/tdqs-style-guide.md`. Targets improving Glama's Tool Definition Quality Score from C (3.1 avg) toward B+. No behavioral changes — descriptions and parameter hints only.
+
 ## [0.6.0] - 2026-04-20
 
 First production PyPI release (`pip install mureo`). Supersedes the internal `0.6.0.dev1` preview that was published to TestPyPI during colleague beta testing.

--- a/docs/tdqs-style-guide.md
+++ b/docs/tdqs-style-guide.md
@@ -1,0 +1,74 @@
+# Tool Definition Quality Score (TDQS) Style Guide
+
+Glama's [Tool Definition Quality Score (TDQS)](https://glama.ai/blog/2026-04-03-tool-definition-quality-score-tdqs) evaluates MCP tool definitions along six dimensions. This guide is how mureo writes new tools (and rewrites existing ones) so agents can pick the right tool and call it correctly on the first try.
+
+## Six dimensions
+
+1. **Purpose Clarity** — specific verb + resource, differentiated from siblings.
+2. **Usage Guidelines** — when to use this vs. a related tool.
+3. **Behavioral Transparency** — side effects, read-only vs. mutating, rate limits, auth.
+4. **Parameter Semantics** — format, constraints, defaults beyond what the schema alone conveys.
+5. **Conciseness** — no filler; every sentence earns its place.
+6. **Contextual Completeness** — return shape, pagination, alternative tools.
+
+## Description template
+
+```
+<verb> <resource> in <platform>. Returns <returned fields / structure>.
+<Read-only | Mutates X | Destructive — removes Y>. <Defaults, thresholds,
+pagination behavior>. Use this when <scenario>; prefer <sibling tool>
+when <other scenario>.
+```
+
+Target length: **50–100 words**.
+
+### Good (score ~4.4 — `rollback.plan.get`)
+
+> Inspect the reversal plan for a recorded `action_log` entry in `STATE.json`. Returns the planner's status (`supported` / `partial` / `not_supported`), the operation that would be dispatched, its parameters, and any caveats. Does not execute anything.
+
+Covers: verb (Inspect), resource (reversal plan), returns (named fields), side effect ("Does not execute").
+
+### Bad (score ~2.3 — original `google_ads.campaigns.diagnose`)
+
+> Diagnose Google Ads campaign delivery status
+
+Covers: nothing useful. Tautological — just restates the tool name.
+
+## Parameter description checklist
+
+For every parameter, the `description` field should answer:
+
+- **Format / example** — `"Account ID in the format 'act_XXXXXXXXXX' (e.g. 'act_1234567890')"`
+- **Required vs. fallback** — `"Required if META_ADS_ACCOUNT_ID is not set in credentials."`
+- **Default** — `"Default 25. Maximum 1000."`
+- **Constraints** — use `minimum` / `maximum` / `enum` in the schema, then reiterate in the description only when it affects behavior.
+
+## Destructive / mutating tools
+
+For anything that mutates or deletes, the description MUST:
+
+1. Lead with the mutation verb: `"Updates..."`, `"Deletes..."`, `"Pauses..."`
+2. Disclose partial-vs-full update semantics: `"Partial update — only the fields provided are changed; omitted fields are preserved."`
+3. State reversibility: `"Reversible via rollback.apply."` or `"Irreversible — removed ads cannot be restored."`
+
+## Sibling differentiation
+
+When two tools operate on the same resource (e.g. `campaigns.update` and `campaigns.update_status`), each description must end with a differentiation clause:
+
+- `"For status-only changes use google_ads.campaigns.update_status instead; this tool rewrites the full settings."`
+
+## Anti-patterns
+
+- `"Update an ad"` — no verb specificity, no returns, no differentiation.
+- `"Ad group ID"` (as a parameter description) — just restates the name; add format/context.
+- Marketing-speak (`"Powerful tool for..."`) — TDQS penalizes filler.
+
+## Review gate
+
+Before adding a new tool or rewriting one, run through this checklist:
+
+- [ ] Description covers verb, resource, returns, side effects.
+- [ ] Every parameter `description` adds information beyond the name + type.
+- [ ] Sibling tools (same resource, different operation) are referenced.
+- [ ] Length 50–100 words for typical tools, up to ~150 for complex mutating ones.
+- [ ] No filler phrases ("This tool allows you to...", "Powerful", "Simply").

--- a/mureo/mcp/_tools_google_ads_campaigns.py
+++ b/mureo/mcp/_tools_google_ads_campaigns.py
@@ -1,24 +1,50 @@
-"""Google Ads tool definitions — Campaigns, ad groups, ads, budgets, account"""
+"""Google Ads tool definitions — Campaigns, ad groups, ads, budgets, account.
+
+Tool descriptions follow ``docs/tdqs-style-guide.md``: specific verb, returned
+fields, side effects, and differentiation from sibling tools. See the guide
+before adding a new tool or rewriting an existing one.
+"""
 
 from __future__ import annotations
 
 from mcp.types import Tool
 
+# Reusable parameter fragments — keep descriptions consistent across tools.
+_CUSTOMER_ID_PARAM = {
+    "type": "string",
+    "description": (
+        "Google Ads customer ID as a 10-digit string without dashes "
+        "(e.g. '1234567890'). Optional — falls back to "
+        "GOOGLE_ADS_CUSTOMER_ID / GOOGLE_ADS_LOGIN_CUSTOMER_ID from the "
+        "configured credentials when omitted."
+    ),
+}
+
 TOOLS: list[Tool] = [
     # === Campaigns ===
     Tool(
         name="google_ads.campaigns.list",
-        description="List Google Ads campaigns",
+        description=(
+            "Lists campaigns in a Google Ads account with optional status "
+            "filtering. Returns one row per campaign with id, name, status, "
+            "channel_type (SEARCH / DISPLAY / VIDEO / etc.), "
+            "bidding_strategy_type, serving_status, primary_status, and "
+            "daily_budget. Read-only. Use this to audit account structure or "
+            "find a campaign_id before calling campaigns.get / update / "
+            "update_status. For a single campaign's full details use "
+            "google_ads.campaigns.get instead."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
-                    "type": "string",
-                    "description": "Google Ads customer ID",
-                },
+                "customer_id": _CUSTOMER_ID_PARAM,
                 "status_filter": {
                     "type": "string",
-                    "description": "Status filter (ENABLED/PAUSED)",
+                    "enum": ["ENABLED", "PAUSED", "REMOVED"],
+                    "description": (
+                        "Restrict results to campaigns with this status. "
+                        "Omit to return all statuses including REMOVED."
+                    ),
                 },
             },
             "required": [],
@@ -26,39 +52,86 @@ TOOLS: list[Tool] = [
     ),
     Tool(
         name="google_ads.campaigns.get",
-        description="Get Google Ads campaign details",
+        description=(
+            "Fetches the full detail record for a single campaign by ID. "
+            "Returns the same fields as campaigns.list plus start_date, "
+            "end_date, network_settings, geo_target_type, and "
+            "bidding_strategy_system_status. Read-only. Use this when you "
+            "already have a campaign_id; for discovery use "
+            "google_ads.campaigns.list."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "campaign_id": {
                     "type": "string",
-                    "description": "Google Ads customer ID",
+                    "description": (
+                        "Campaign ID as returned by campaigns.list "
+                        "(numeric string, e.g. '23743184133')."
+                    ),
                 },
-                "campaign_id": {"type": "string", "description": "Campaign ID"},
             },
             "required": ["campaign_id"],
         },
     ),
     Tool(
         name="google_ads.campaigns.create",
-        description="Create a Google Ads campaign (search or display)",
+        description=(
+            "Creates a new Search or Display campaign in the specified "
+            "Google Ads account. Returns the new campaign's resource_name "
+            "and id. Mutating — counts against daily write quota. "
+            "Reversible via rollback.apply (reversal pauses the campaign "
+            "rather than deleting it). Requires a pre-existing budget_id; "
+            "to create a budget first, call google_ads.budget.create. For "
+            "later edits use google_ads.campaigns.update or "
+            "google_ads.campaigns.update_status."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "name": {
                     "type": "string",
-                    "description": "Google Ads customer ID",
+                    "description": (
+                        "Campaign name (max 255 chars). Must be unique "
+                        "within the account."
+                    ),
                 },
-                "name": {"type": "string", "description": "Campaign name"},
                 "bidding_strategy": {
                     "type": "string",
-                    "description": "Bidding strategy (MAXIMIZE_CLICKS etc.)",
+                    "enum": [
+                        "MAXIMIZE_CLICKS",
+                        "MAXIMIZE_CONVERSIONS",
+                        "MAXIMIZE_CONVERSION_VALUE",
+                        "TARGET_CPA",
+                        "TARGET_ROAS",
+                        "MANUAL_CPC",
+                    ],
+                    "description": (
+                        "Google Ads bidding strategy. Defaults to "
+                        "MAXIMIZE_CLICKS when omitted. TARGET_CPA / "
+                        "TARGET_ROAS require additional target fields that "
+                        "this tool does not expose — use the Google Ads "
+                        "UI or a follow-up campaigns.update for those."
+                    ),
                 },
-                "budget_id": {"type": "string", "description": "Budget ID"},
+                "budget_id": {
+                    "type": "string",
+                    "description": (
+                        "Existing campaign-budget ID to attach. Create one "
+                        "first with google_ads.budget.create if you do not "
+                        "have one."
+                    ),
+                },
                 "channel_type": {
                     "type": "string",
                     "enum": ["SEARCH", "DISPLAY"],
-                    "description": "Campaign channel type. SEARCH (default) or DISPLAY.",
+                    "description": (
+                        "Advertising channel. SEARCH (default) for text "
+                        "ads on Google Search; DISPLAY for image/banner "
+                        "ads on the GDN."
+                    ),
                 },
             },
             "required": ["name"],
@@ -66,19 +139,43 @@ TOOLS: list[Tool] = [
     ),
     Tool(
         name="google_ads.campaigns.update",
-        description="Update Google Ads campaign settings",
+        description=(
+            "Updates one or more settings on an existing campaign. Partial "
+            "update — only fields provided are changed; omitted fields are "
+            "preserved. Returns the updated campaign record. Mutating and "
+            "reversible via rollback.apply (rollback restores the previous "
+            "field values). For status-only changes (ENABLED / PAUSED / "
+            "REMOVED) prefer google_ads.campaigns.update_status, which is "
+            "a lighter-weight call and maps cleanly to pause/resume "
+            "workflows."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "campaign_id": {
                     "type": "string",
-                    "description": "Google Ads customer ID",
+                    "description": "Campaign ID to update.",
                 },
-                "campaign_id": {"type": "string", "description": "Campaign ID"},
-                "name": {"type": "string", "description": "New campaign name"},
+                "name": {
+                    "type": "string",
+                    "description": "New campaign name (max 255 chars).",
+                },
                 "bidding_strategy": {
                     "type": "string",
-                    "description": "Bidding strategy",
+                    "enum": [
+                        "MAXIMIZE_CLICKS",
+                        "MAXIMIZE_CONVERSIONS",
+                        "MAXIMIZE_CONVERSION_VALUE",
+                        "TARGET_CPA",
+                        "TARGET_ROAS",
+                        "MANUAL_CPC",
+                    ],
+                    "description": (
+                        "New bidding strategy. Switching strategies can "
+                        "reset learning periods — confirm with the operator "
+                        "before changing on an ENABLED campaign."
+                    ),
                 },
             },
             "required": ["campaign_id"],
@@ -86,18 +183,32 @@ TOOLS: list[Tool] = [
     ),
     Tool(
         name="google_ads.campaigns.update_status",
-        description="Change Google Ads campaign status (ENABLED/PAUSED/REMOVED)",
+        description=(
+            "Sets the delivery status of a single campaign to ENABLED, "
+            "PAUSED, or REMOVED. Lightweight — writes only the status "
+            "field. Returns the campaign ID and new status. Reversible "
+            "via rollback.apply for ENABLED ↔ PAUSED; REMOVED is a soft "
+            "delete that can be reversed by setting status back to "
+            "PAUSED within 30 days. Use this for pause/resume; use "
+            "google_ads.campaigns.update to change name, bidding, or other "
+            "settings."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "campaign_id": {
                     "type": "string",
-                    "description": "Google Ads customer ID",
+                    "description": "Campaign ID.",
                 },
-                "campaign_id": {"type": "string", "description": "Campaign ID"},
                 "status": {
                     "type": "string",
-                    "description": "New status (ENABLED/PAUSED/REMOVED)",
+                    "enum": ["ENABLED", "PAUSED", "REMOVED"],
+                    "description": (
+                        "Target status. REMOVED is a soft delete — the "
+                        "campaign stops serving and is excluded from most "
+                        "default listings but remains queryable by ID."
+                    ),
                 },
             },
             "required": ["campaign_id", "status"],
@@ -105,15 +216,24 @@ TOOLS: list[Tool] = [
     ),
     Tool(
         name="google_ads.campaigns.diagnose",
-        description="Diagnose Google Ads campaign delivery status",
+        description=(
+            "Explains why a campaign is not serving or is under-delivering. "
+            "Returns an ordered list of issues drawn from serving_status, "
+            "primary_status, and primary_status_reasons (e.g. "
+            "LIMITED_BY_BUDGET, AD_GROUPS_PAUSED, KEYWORDS_DISAPPROVED, "
+            "NO_ELIGIBLE_ADS), each annotated with a plain-language "
+            "description and a remediation hint. Read-only — does not "
+            "change anything. Use this before pulling raw performance "
+            "reports; it narrows the problem space."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "campaign_id": {
                     "type": "string",
-                    "description": "Google Ads customer ID",
+                    "description": "Campaign ID to diagnose.",
                 },
-                "campaign_id": {"type": "string", "description": "Campaign ID"},
             },
             "required": ["campaign_id"],
         },
@@ -121,21 +241,33 @@ TOOLS: list[Tool] = [
     # === Ad Groups ===
     Tool(
         name="google_ads.ad_groups.list",
-        description="List Google Ads ad groups",
+        description=(
+            "Lists ad groups in a Google Ads account, optionally scoped to "
+            "a single parent campaign and/or filtered by status. Returns id, "
+            "name, campaign_id, status, type (SEARCH_STANDARD / DISPLAY_STANDARD / "
+            "etc.), cpc_bid_micros, and ad_rotation_mode per ad group. "
+            "Read-only. Use this to locate an ad_group_id before calling "
+            "ad_groups.create / update or ads.create; if you already have "
+            "the id, fetch it directly via ads.list filtered by ad_group_id."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
-                    "type": "string",
-                    "description": "Google Ads customer ID",
-                },
+                "customer_id": _CUSTOMER_ID_PARAM,
                 "campaign_id": {
                     "type": "string",
-                    "description": "Filter by campaign ID",
+                    "description": (
+                        "Restrict results to ad groups under this campaign. "
+                        "Omit to list across the whole account."
+                    ),
                 },
                 "status_filter": {
                     "type": "string",
-                    "description": "Status filter",
+                    "enum": ["ENABLED", "PAUSED", "REMOVED"],
+                    "description": (
+                        "Restrict to ad groups with this status. Omit for "
+                        "all statuses."
+                    ),
                 },
             },
             "required": [],
@@ -143,19 +275,41 @@ TOOLS: list[Tool] = [
     ),
     Tool(
         name="google_ads.ad_groups.create",
-        description="Create a Google Ads ad group",
+        description=(
+            "Creates a new ad group inside an existing campaign. Returns "
+            "the new ad_group's resource_name and id. Mutating — reversible "
+            "via rollback.apply (rollback pauses the ad group rather than "
+            "deleting it). The parent campaign must be ENABLED or PAUSED; "
+            "creating under a REMOVED campaign fails. After creation, add "
+            "ads with google_ads.ads.create and keywords with "
+            "google_ads.keywords.add."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "campaign_id": {
                     "type": "string",
-                    "description": "Google Ads customer ID",
+                    "description": (
+                        "Parent campaign ID. Must exist and not be REMOVED."
+                    ),
                 },
-                "campaign_id": {"type": "string", "description": "Parent campaign ID"},
-                "name": {"type": "string", "description": "Ad group name"},
+                "name": {
+                    "type": "string",
+                    "description": (
+                        "Ad group name (max 255 chars). Must be unique "
+                        "within the parent campaign."
+                    ),
+                },
                 "cpc_bid_micros": {
                     "type": "integer",
-                    "description": "CPC bid amount (in micros)",
+                    "minimum": 10000,
+                    "description": (
+                        "Default CPC bid in micros (1 JPY = 1_000_000 "
+                        "micros; 1 USD = 1_000_000 micros). Minimum 10_000 "
+                        "(= ¥0.01 / $0.01). Omit to inherit the campaign's "
+                        "default."
+                    ),
                 },
             },
             "required": ["campaign_id", "name"],
@@ -163,23 +317,42 @@ TOOLS: list[Tool] = [
     ),
     Tool(
         name="google_ads.ad_groups.update",
-        description="Update a Google Ads ad group",
+        description=(
+            "Updates one or more settings on an existing ad group. Partial "
+            "update — only provided fields are changed. Returns the updated "
+            "ad group. Mutating, reversible via rollback.apply. Does not "
+            "cascade to ads or keywords under this ad group; use "
+            "google_ads.ads.update / update_status and "
+            "google_ads.keywords.* for those."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "ad_group_id": {
                     "type": "string",
-                    "description": "Google Ads customer ID",
+                    "description": "Ad group ID to update.",
                 },
-                "ad_group_id": {"type": "string", "description": "Ad group ID"},
-                "name": {"type": "string", "description": "New name"},
+                "name": {
+                    "type": "string",
+                    "description": "New ad group name (max 255 chars).",
+                },
                 "status": {
                     "type": "string",
-                    "description": "Status (ENABLED/PAUSED)",
+                    "enum": ["ENABLED", "PAUSED", "REMOVED"],
+                    "description": (
+                        "New status. For status-only changes this tool is "
+                        "equivalent to setting the status field alone — "
+                        "there is no separate ad_groups.update_status call."
+                    ),
                 },
                 "cpc_bid_micros": {
                     "type": "integer",
-                    "description": "CPC bid amount (in micros)",
+                    "minimum": 10000,
+                    "description": (
+                        "New default CPC bid in micros (1_000_000 micros = "
+                        "1 unit of account currency)."
+                    ),
                 },
             },
             "required": ["ad_group_id"],
@@ -188,21 +361,33 @@ TOOLS: list[Tool] = [
     # === Ads ===
     Tool(
         name="google_ads.ads.list",
-        description="List Google Ads ads",
+        description=(
+            "Lists ads in a Google Ads account, optionally scoped to one "
+            "ad group and/or filtered by status. Returns id, ad_group_id, "
+            "status, type (RESPONSIVE_SEARCH_AD / RESPONSIVE_DISPLAY_AD / "
+            "etc.), final_urls, approval_status, and a creative summary "
+            "(headlines / descriptions for RSAs). Read-only. Use this to "
+            "find an ad_id before calling ads.update / update_status or to "
+            "audit creative inventory. For disapproval details, follow up "
+            "with google_ads.ads.policy_details."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
-                    "type": "string",
-                    "description": "Google Ads customer ID",
-                },
+                "customer_id": _CUSTOMER_ID_PARAM,
                 "ad_group_id": {
                     "type": "string",
-                    "description": "Filter by ad group ID",
+                    "description": (
+                        "Restrict to ads under this ad group. Omit to list "
+                        "across the whole account."
+                    ),
                 },
                 "status_filter": {
                     "type": "string",
-                    "description": "Status filter",
+                    "enum": ["ENABLED", "PAUSED", "REMOVED"],
+                    "description": (
+                        "Restrict by status. Omit for all statuses."
+                    ),
                 },
             },
             "required": [],
@@ -210,28 +395,68 @@ TOOLS: list[Tool] = [
     ),
     Tool(
         name="google_ads.ads.create",
-        description="Create a Google Ads responsive search ad (RSA)",
+        description=(
+            "Creates a Responsive Search Ad (RSA) in the specified ad "
+            "group. Returns the new ad's resource_name, id, and initial "
+            "approval_status (usually UNDER_REVIEW for ~1 business day). "
+            "Mutating, reversible via rollback.apply (rollback pauses the "
+            "ad). Google Ads requires 3–15 headlines and 2–4 descriptions. "
+            "For display/banner ads use google_ads.ads.create_display "
+            "instead; the two creative formats are not interchangeable."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "ad_group_id": {
                     "type": "string",
-                    "description": "Google Ads customer ID",
+                    "description": (
+                        "Parent ad group ID. Must belong to a SEARCH "
+                        "campaign; DISPLAY ad groups reject RSAs."
+                    ),
                 },
-                "ad_group_id": {"type": "string", "description": "Ad group ID"},
                 "headlines": {
                     "type": "array",
                     "items": {"type": "string"},
-                    "description": "List of headlines (3 to 15)",
+                    "minItems": 3,
+                    "maxItems": 15,
+                    "description": (
+                        "Headlines for the RSA. Google Ads accepts 3 to "
+                        "15; each headline is max 30 characters display "
+                        "width. Supply at least 5 for good learning."
+                    ),
                 },
                 "descriptions": {
                     "type": "array",
                     "items": {"type": "string"},
-                    "description": "List of descriptions (2 to 4)",
+                    "minItems": 2,
+                    "maxItems": 4,
+                    "description": (
+                        "Descriptions for the RSA. 2 to 4 accepted; each "
+                        "description is max 90 characters display width."
+                    ),
                 },
-                "final_url": {"type": "string", "description": "Final URL"},
-                "path1": {"type": "string", "description": "Display path 1"},
-                "path2": {"type": "string", "description": "Display path 2"},
+                "final_url": {
+                    "type": "string",
+                    "description": (
+                        "Landing page URL the ad links to. Must match the "
+                        "campaign's allowed domains and be HTTPS."
+                    ),
+                },
+                "path1": {
+                    "type": "string",
+                    "description": (
+                        "First URL display path (shown after the domain). "
+                        "Max 15 characters display width. Optional."
+                    ),
+                },
+                "path2": {
+                    "type": "string",
+                    "description": (
+                        "Second URL display path. Max 15 characters "
+                        "display width. Requires path1 if set. Optional."
+                    ),
+                },
             },
             "required": ["ad_group_id", "headlines", "descriptions"],
         },
@@ -239,68 +464,100 @@ TOOLS: list[Tool] = [
     Tool(
         name="google_ads.ads.create_display",
         description=(
-            "Create a Google Ads responsive display ad (RDA). "
-            "Marketing/square/logo image paths are uploaded automatically "
-            "before the ad is created."
+            "Creates a Responsive Display Ad (RDA) in a DISPLAY campaign's "
+            "ad group. Marketing/square/logo image paths point to local "
+            "files; mureo uploads each file to Google Ads as an ImageAsset "
+            "before composing the ad. Returns the new ad's resource_name, "
+            "id, and the generated asset IDs. Mutating, reversible via "
+            "rollback.apply. For Search campaigns use "
+            "google_ads.ads.create; the ad_group must belong to a DISPLAY "
+            "campaign or this call fails with a channel-mismatch error."
         ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
-                    "type": "string",
-                    "description": "Google Ads customer ID",
-                },
+                "customer_id": _CUSTOMER_ID_PARAM,
                 "ad_group_id": {
                     "type": "string",
-                    "description": "Ad group ID (must belong to a DISPLAY campaign)",
+                    "description": (
+                        "Ad group ID. Must belong to a DISPLAY campaign."
+                    ),
                 },
                 "headlines": {
                     "type": "array",
                     "items": {"type": "string"},
-                    "description": "Short headlines (1 to 5, each max 30 display width)",
+                    "minItems": 1,
+                    "maxItems": 5,
+                    "description": (
+                        "Short headlines (1 to 5). Each max 30 characters "
+                        "display width."
+                    ),
                 },
                 "long_headline": {
                     "type": "string",
-                    "description": "Long headline (max 90 display width, required)",
+                    "description": (
+                        "Long headline (max 90 characters display width). "
+                        "Required by Google Ads even when headlines are "
+                        "supplied."
+                    ),
                 },
                 "descriptions": {
                     "type": "array",
                     "items": {"type": "string"},
-                    "description": "Descriptions (1 to 5, each max 90 display width)",
+                    "minItems": 1,
+                    "maxItems": 5,
+                    "description": (
+                        "Descriptions (1 to 5). Each max 90 characters "
+                        "display width."
+                    ),
                 },
                 "business_name": {
                     "type": "string",
-                    "description": "Business name (max 25 display width, required)",
+                    "description": (
+                        "Advertiser / business name shown in the ad (max "
+                        "25 characters display width). Required."
+                    ),
                 },
                 "marketing_image_paths": {
                     "type": "array",
                     "items": {"type": "string"},
+                    "minItems": 1,
+                    "maxItems": 15,
                     "description": (
-                        "Local file paths for marketing images (1.91:1 ratio, "
-                        "1 to 15 images). At least 1 is required; 3+ is "
-                        "strongly recommended for delivery quality. Files "
-                        "are uploaded automatically before ad creation."
+                        "Local file paths for landscape marketing images "
+                        "(1.91:1 ratio). 1 to 15 accepted; 3+ strongly "
+                        "recommended for delivery quality. mureo uploads "
+                        "the files automatically before creating the ad."
                     ),
                 },
                 "square_marketing_image_paths": {
                     "type": "array",
                     "items": {"type": "string"},
+                    "minItems": 1,
+                    "maxItems": 15,
                     "description": (
                         "Local file paths for square marketing images "
-                        "(1:1 ratio, 1 to 15 images). At least 1 is required; "
-                        "3+ is strongly recommended for delivery quality. "
-                        "Files are uploaded automatically before ad creation."
+                        "(1:1 ratio). 1 to 15 accepted; 3+ recommended. "
+                        "Uploaded automatically."
                     ),
                 },
                 "logo_image_paths": {
                     "type": "array",
                     "items": {"type": "string"},
+                    "maxItems": 5,
                     "description": (
-                        "Optional local file paths for logo images "
-                        "(up to 5). Uploaded automatically."
+                        "Optional local file paths for logo images (up to "
+                        "5). Uploaded automatically. Helps ad quality but "
+                        "not required."
                     ),
                 },
-                "final_url": {"type": "string", "description": "Landing page URL"},
+                "final_url": {
+                    "type": "string",
+                    "description": (
+                        "Landing page URL. Must be HTTPS and match the "
+                        "campaign's allowed domains."
+                    ),
+                },
             },
             "required": [
                 "ad_group_id",
@@ -316,25 +573,48 @@ TOOLS: list[Tool] = [
     ),
     Tool(
         name="google_ads.ads.update",
-        description="Update a Google Ads ad",
+        description=(
+            "Updates the creative copy of an existing Responsive Search Ad "
+            "by replacing headlines and/or descriptions. Returns the "
+            "updated ad. Google Ads does not support in-place edit of RSA "
+            "creative assets — this call typically replaces the ad with a "
+            "new one under the same ID, which resets learning and triggers "
+            "re-review. Mutating, reversible via rollback.apply. For "
+            "status-only changes (pause/resume) use "
+            "google_ads.ads.update_status, which is lighter-weight and "
+            "does not reset learning."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "ad_group_id": {
                     "type": "string",
-                    "description": "Google Ads customer ID",
+                    "description": "Parent ad group ID.",
                 },
-                "ad_group_id": {"type": "string", "description": "Ad group ID"},
-                "ad_id": {"type": "string", "description": "Ad ID"},
+                "ad_id": {
+                    "type": "string",
+                    "description": "Ad ID to update.",
+                },
                 "headlines": {
                     "type": "array",
                     "items": {"type": "string"},
-                    "description": "List of headlines",
+                    "minItems": 3,
+                    "maxItems": 15,
+                    "description": (
+                        "Replacement headlines (3 to 15). Each max 30 "
+                        "characters display width."
+                    ),
                 },
                 "descriptions": {
                     "type": "array",
                     "items": {"type": "string"},
-                    "description": "List of descriptions",
+                    "minItems": 2,
+                    "maxItems": 4,
+                    "description": (
+                        "Replacement descriptions (2 to 4). Each max 90 "
+                        "characters display width."
+                    ),
                 },
             },
             "required": ["ad_group_id", "ad_id"],
@@ -342,19 +622,33 @@ TOOLS: list[Tool] = [
     ),
     Tool(
         name="google_ads.ads.update_status",
-        description="Change Google Ads ad status",
+        description=(
+            "Sets the delivery status of a single ad to ENABLED, PAUSED, "
+            "or REMOVED. Lightweight — writes only the status field and "
+            "does not reset learning signals. Returns the ad ID and new "
+            "status. Reversible via rollback.apply. Use this for "
+            "pause/resume; use google_ads.ads.update to change the "
+            "creative copy itself."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "ad_group_id": {
                     "type": "string",
-                    "description": "Google Ads customer ID",
+                    "description": "Parent ad group ID.",
                 },
-                "ad_group_id": {"type": "string", "description": "Ad group ID"},
-                "ad_id": {"type": "string", "description": "Ad ID"},
+                "ad_id": {
+                    "type": "string",
+                    "description": "Ad ID.",
+                },
                 "status": {
                     "type": "string",
-                    "description": "New status (ENABLED/PAUSED)",
+                    "enum": ["ENABLED", "PAUSED", "REMOVED"],
+                    "description": (
+                        "Target status. REMOVED is a soft delete — the ad "
+                        "stops serving but remains queryable by ID."
+                    ),
                 },
             },
             "required": ["ad_group_id", "ad_id", "status"],
@@ -363,16 +657,27 @@ TOOLS: list[Tool] = [
     # === Ad policy details ===
     Tool(
         name="google_ads.ads.policy_details",
-        description="Get Google Ads ad policy details (disapproval reasons etc.)",
+        description=(
+            "Fetches the Google Ads policy review result for a single ad, "
+            "including approval_status (APPROVED / APPROVED_LIMITED / "
+            "DISAPPROVED / UNDER_REVIEW), a list of policy_topic_entries "
+            "with topic (e.g. DESTINATION_NOT_WORKING, RESTRICTED_CONTENT), "
+            "evidence, and an appeal eligibility flag. Read-only. Call "
+            "this after google_ads.ads.list surfaces a non-APPROVED ad to "
+            "understand the specific disapproval reasons."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "ad_group_id": {
                     "type": "string",
-                    "description": "Google Ads customer ID",
+                    "description": "Parent ad group ID.",
                 },
-                "ad_group_id": {"type": "string", "description": "Ad group ID"},
-                "ad_id": {"type": "string", "description": "Ad ID"},
+                "ad_id": {
+                    "type": "string",
+                    "description": "Ad ID to inspect.",
+                },
             },
             "required": ["ad_group_id", "ad_id"],
         },
@@ -380,31 +685,60 @@ TOOLS: list[Tool] = [
     # === Budgets ===
     Tool(
         name="google_ads.budget.get",
-        description="Get Google Ads campaign budget",
+        description=(
+            "Fetches the campaign-budget record attached to a campaign. "
+            "Returns budget_id, name, amount_micros, delivery_method "
+            "(STANDARD / ACCELERATED), period (DAILY), and "
+            "reference_count (how many campaigns share this budget). "
+            "Read-only. Shared budgets are common — confirm "
+            "reference_count before calling google_ads.budget.update, "
+            "since changes affect all linked campaigns."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "campaign_id": {
                     "type": "string",
-                    "description": "Google Ads customer ID",
+                    "description": (
+                        "Campaign ID whose budget to fetch. mureo resolves "
+                        "the attached budget_id internally."
+                    ),
                 },
-                "campaign_id": {"type": "string", "description": "Campaign ID"},
             },
             "required": ["campaign_id"],
         },
     ),
     Tool(
         name="google_ads.budget.update",
-        description="Update a Google Ads budget",
+        description=(
+            "Sets the daily amount on an existing campaign budget. Mutating "
+            "and reversible via rollback.apply (rollback restores the prior "
+            "amount). Returns the updated budget. If the budget is shared "
+            "across multiple campaigns, the change affects all of them — "
+            "call google_ads.budget.get first to check reference_count. "
+            "The `amount` parameter is in the account's currency unit "
+            "(JPY / USD / etc.), not micros."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "budget_id": {
                     "type": "string",
-                    "description": "Google Ads customer ID",
+                    "description": (
+                        "Budget ID as returned by google_ads.budget.get."
+                    ),
                 },
-                "budget_id": {"type": "string", "description": "Budget ID"},
-                "amount": {"type": "number", "description": "New daily budget amount"},
+                "amount": {
+                    "type": "number",
+                    "minimum": 1,
+                    "description": (
+                        "New daily budget in the account's currency "
+                        "(JPY / USD / etc.). Not micros — e.g. pass 5000 "
+                        "for ¥5,000 / day."
+                    ),
+                },
             },
             "required": ["budget_id", "amount"],
         },
@@ -412,16 +746,34 @@ TOOLS: list[Tool] = [
     # === Budget creation ===
     Tool(
         name="google_ads.budget.create",
-        description="Create a new Google Ads campaign budget",
+        description=(
+            "Creates a new campaign budget that can be attached to one or "
+            "more campaigns. Returns the new budget's id and resource_name. "
+            "Mutating, reversible via rollback.apply. Typical flow: "
+            "budget.create → campaigns.create with the returned budget_id. "
+            "To edit an existing budget's amount use "
+            "google_ads.budget.update instead of creating a second budget."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "name": {
                     "type": "string",
-                    "description": "Google Ads customer ID",
+                    "description": (
+                        "Budget name (max 255 chars). Must be unique "
+                        "within the account."
+                    ),
                 },
-                "name": {"type": "string", "description": "Budget name"},
-                "amount": {"type": "number", "description": "Daily budget amount"},
+                "amount": {
+                    "type": "number",
+                    "minimum": 1,
+                    "description": (
+                        "Daily budget in the account's currency "
+                        "(JPY / USD / etc.). Not micros — e.g. pass 5000 "
+                        "for ¥5,000 / day."
+                    ),
+                },
             },
             "required": ["name", "amount"],
         },
@@ -429,14 +781,20 @@ TOOLS: list[Tool] = [
     # === Account ===
     Tool(
         name="google_ads.accounts.list",
-        description="List Google Ads managed accounts",
+        description=(
+            "Lists all Google Ads accounts accessible under the configured "
+            "manager (MCC) account or directly under the authenticated "
+            "user. Returns one row per accessible customer with id "
+            "(10-digit), descriptive_name, currency_code, time_zone, and "
+            "manager flag. Read-only. Use this at the start of a session "
+            "to choose which customer_id to pass into subsequent calls; "
+            "most other tools fall back to GOOGLE_ADS_CUSTOMER_ID if "
+            "customer_id is omitted."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
-                    "type": "string",
-                    "description": "Google Ads customer ID",
-                },
+                "customer_id": _CUSTOMER_ID_PARAM,
             },
             "required": [],
         },

--- a/mureo/mcp/_tools_google_ads_campaigns.py
+++ b/mureo/mcp/_tools_google_ads_campaigns.py
@@ -385,9 +385,7 @@ TOOLS: list[Tool] = [
                 "status_filter": {
                     "type": "string",
                     "enum": ["ENABLED", "PAUSED", "REMOVED"],
-                    "description": (
-                        "Restrict by status. Omit for all statuses."
-                    ),
+                    "description": ("Restrict by status. Omit for all statuses."),
                 },
             },
             "required": [],
@@ -479,9 +477,7 @@ TOOLS: list[Tool] = [
                 "customer_id": _CUSTOMER_ID_PARAM,
                 "ad_group_id": {
                     "type": "string",
-                    "description": (
-                        "Ad group ID. Must belong to a DISPLAY campaign."
-                    ),
+                    "description": ("Ad group ID. Must belong to a DISPLAY campaign."),
                 },
                 "headlines": {
                     "type": "array",
@@ -726,9 +722,7 @@ TOOLS: list[Tool] = [
                 "customer_id": _CUSTOMER_ID_PARAM,
                 "budget_id": {
                     "type": "string",
-                    "description": (
-                        "Budget ID as returned by google_ads.budget.get."
-                    ),
+                    "description": ("Budget ID as returned by google_ads.budget.get."),
                 },
                 "amount": {
                     "type": "number",

--- a/mureo/mcp/_tools_google_ads_keywords.py
+++ b/mureo/mcp/_tools_google_ads_keywords.py
@@ -80,9 +80,7 @@ TOOLS: list[Tool] = [
                 "status_filter": {
                     "type": "string",
                     "enum": ["ENABLED", "PAUSED", "REMOVED"],
-                    "description": (
-                        "Restrict by status. Omit for all statuses."
-                    ),
+                    "description": ("Restrict by status. Omit for all statuses."),
                 },
             },
             "required": [],
@@ -334,9 +332,7 @@ TOOLS: list[Tool] = [
                 "customer_id": _CUSTOMER_ID_PARAM,
                 "campaign_id": {
                     "type": "string",
-                    "description": (
-                        "Campaign ID the negative belongs to."
-                    ),
+                    "description": ("Campaign ID the negative belongs to."),
                 },
                 "criterion_id": {
                     "type": "string",
@@ -403,9 +399,7 @@ TOOLS: list[Tool] = [
                 "customer_id": _CUSTOMER_ID_PARAM,
                 "campaign_id": {
                     "type": "string",
-                    "description": (
-                        "Campaign whose search terms are analysed."
-                    ),
+                    "description": ("Campaign whose search terms are analysed."),
                 },
                 "period": {
                     "type": "string",

--- a/mureo/mcp/_tools_google_ads_keywords.py
+++ b/mureo/mcp/_tools_google_ads_keywords.py
@@ -1,32 +1,88 @@
-"""Google Ads tool definitions — Keywords, negative keywords"""
+"""Google Ads tool definitions — Keywords, negative keywords.
+
+Tool descriptions follow ``docs/tdqs-style-guide.md``.
+"""
 
 from __future__ import annotations
 
 from mcp.types import Tool
 
+# Reusable parameter fragments.
+_CUSTOMER_ID_PARAM = {
+    "type": "string",
+    "description": (
+        "Google Ads customer ID as a 10-digit string without dashes "
+        "(e.g. '1234567890'). Optional — falls back to "
+        "GOOGLE_ADS_CUSTOMER_ID / GOOGLE_ADS_LOGIN_CUSTOMER_ID from the "
+        "configured credentials when omitted."
+    ),
+}
+
+_KEYWORD_ITEM_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "text": {
+            "type": "string",
+            "description": (
+                "Keyword text. Max 80 characters / 10 words. Exact match "
+                "and phrase match can additionally use bracketed/quoted "
+                "forms, but mureo passes match type via the match_type "
+                "field — supply plain text here."
+            ),
+        },
+        "match_type": {
+            "type": "string",
+            "enum": ["BROAD", "PHRASE", "EXACT"],
+            "description": (
+                "Match type for this keyword. BROAD (default) is widest "
+                "reach; PHRASE requires the query to contain the keyword "
+                "phrase; EXACT matches close variants only."
+            ),
+        },
+    },
+    "required": ["text"],
+}
+
 TOOLS: list[Tool] = [
     # === Keywords ===
     Tool(
         name="google_ads.keywords.list",
-        description="List Google Ads keywords",
+        description=(
+            "Lists keyword criteria in a Google Ads account, optionally "
+            "scoped to a campaign and/or ad group and filtered by status. "
+            "Returns criterion_id, ad_group_id, text, match_type, status, "
+            "cpc_bid_micros (if overridden), quality_score, and "
+            "approval_status per keyword. Read-only. Use this to locate "
+            "a criterion_id before calling keywords.pause / remove, or to "
+            "audit keyword coverage. For quality-score diagnostics use "
+            "google_ads.keywords.diagnose."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
-                    "type": "string",
-                    "description": "Google Ads customer ID",
-                },
+                "customer_id": _CUSTOMER_ID_PARAM,
                 "campaign_id": {
                     "type": "string",
-                    "description": "Filter by campaign ID",
+                    "description": (
+                        "Restrict to keywords under this campaign. Omit "
+                        "with ad_group_id also omitted to list across the "
+                        "account."
+                    ),
                 },
                 "ad_group_id": {
                     "type": "string",
-                    "description": "Filter by ad group ID",
+                    "description": (
+                        "Restrict to a single ad group. If both "
+                        "campaign_id and ad_group_id are supplied they "
+                        "must agree."
+                    ),
                 },
                 "status_filter": {
                     "type": "string",
-                    "description": "Status filter",
+                    "enum": ["ENABLED", "PAUSED", "REMOVED"],
+                    "description": (
+                        "Restrict by status. Omit for all statuses."
+                    ),
                 },
             },
             "required": [],
@@ -34,29 +90,35 @@ TOOLS: list[Tool] = [
     ),
     Tool(
         name="google_ads.keywords.add",
-        description="Add Google Ads keywords",
+        description=(
+            "Adds one or more keyword criteria to a single ad group. "
+            "Returns the created criterion_ids keyed by their input "
+            "position. Mutating, reversible via rollback.apply (rollback "
+            "pauses the keywords rather than removing them). Duplicate "
+            "text+match_type pairs inside the same ad group are rejected "
+            "by Google Ads — call google_ads.keywords.cross_adgroup_duplicates "
+            "first if you are adding at scale."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "ad_group_id": {
                     "type": "string",
-                    "description": "Google Ads customer ID",
+                    "description": (
+                        "Target ad group ID. All keywords in this call are "
+                        "added to this single ad group."
+                    ),
                 },
-                "ad_group_id": {"type": "string", "description": "Ad group ID"},
                 "keywords": {
                     "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "text": {"type": "string"},
-                            "match_type": {
-                                "type": "string",
-                                "description": "BROAD/PHRASE/EXACT",
-                            },
-                        },
-                        "required": ["text"],
-                    },
-                    "description": "List of keywords to add",
+                    "items": _KEYWORD_ITEM_SCHEMA,
+                    "minItems": 1,
+                    "description": (
+                        "Keywords to add. Each item has `text` (required) "
+                        "and optional `match_type` (BROAD / PHRASE / "
+                        "EXACT, default BROAD)."
+                    ),
                 },
             },
             "required": ["ad_group_id", "keywords"],
@@ -64,18 +126,28 @@ TOOLS: list[Tool] = [
     ),
     Tool(
         name="google_ads.keywords.remove",
-        description="Remove a Google Ads keyword",
+        description=(
+            "Removes (soft-deletes) a single keyword criterion from an ad "
+            "group. Returns the removed criterion_id. Destructive and "
+            "reversible via rollback.apply, but rollback re-adds the "
+            "keyword as a fresh criterion — the original quality score and "
+            "learning are lost. For temporary suspension prefer "
+            "google_ads.keywords.pause, which preserves all signals."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "ad_group_id": {
                     "type": "string",
-                    "description": "Google Ads customer ID",
+                    "description": "Parent ad group ID.",
                 },
-                "ad_group_id": {"type": "string", "description": "Ad group ID"},
                 "criterion_id": {
                     "type": "string",
-                    "description": "Keyword criterion ID",
+                    "description": (
+                        "Keyword criterion ID as returned by "
+                        "google_ads.keywords.list."
+                    ),
                 },
             },
             "required": ["ad_group_id", "criterion_id"],
@@ -83,26 +155,46 @@ TOOLS: list[Tool] = [
     ),
     Tool(
         name="google_ads.keywords.suggest",
-        description="Google Ads keyword suggestions (Keyword Planner)",
+        description=(
+            "Generates new keyword ideas from seed terms using the Google "
+            "Ads Keyword Planner API. Returns suggested keyword text, "
+            "avg_monthly_searches, competition (LOW / MEDIUM / HIGH), "
+            "top_of_page_bid_low_micros, and top_of_page_bid_high_micros. "
+            "Read-only — produces ideas but does not add anything to the "
+            "account. Use google_ads.keywords.add to materialize the ones "
+            "you want."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
-                    "type": "string",
-                    "description": "Google Ads customer ID",
-                },
+                "customer_id": _CUSTOMER_ID_PARAM,
                 "seed_keywords": {
                     "type": "array",
                     "items": {"type": "string"},
-                    "description": "List of seed keywords",
+                    "minItems": 1,
+                    "maxItems": 20,
+                    "description": (
+                        "Seed terms used to generate ideas. 1 to 20 terms; "
+                        "Google Ads treats them as topic anchors, not exact "
+                        "match."
+                    ),
                 },
                 "language_id": {
                     "type": "string",
-                    "description": "Language ID (default: 1005=Japanese)",
+                    "description": (
+                        "Google Ads language constant ID. Defaults to "
+                        "'1005' (Japanese). Common values: '1000' English, "
+                        "'1002' Spanish, '1003' Korean, '1017' Chinese "
+                        "(Simplified)."
+                    ),
                 },
                 "geo_id": {
                     "type": "string",
-                    "description": "Geo target ID (default: 2392=Japan)",
+                    "description": (
+                        "Google Ads geo target constant ID. Defaults to "
+                        "'2392' (Japan). Common values: '2840' United "
+                        "States, '2826' United Kingdom, '2276' Germany."
+                    ),
                 },
             },
             "required": ["seed_keywords"],
@@ -110,15 +202,26 @@ TOOLS: list[Tool] = [
     ),
     Tool(
         name="google_ads.keywords.diagnose",
-        description="Diagnose Google Ads keyword quality scores and delivery status",
+        description=(
+            "Reports quality-score and delivery-status issues across every "
+            "keyword in a campaign. Returns keywords grouped by severity — "
+            "LOW_QUALITY_SCORE (< 5/10), BELOW_FIRST_PAGE_BID, RARELY_SHOWN, "
+            "DISAPPROVED — each with criterion_id, text, ad_group_id, and "
+            "a remediation hint (raise bid, tighten match type, etc.). "
+            "Read-only. Use this before pulling raw search-terms reports; "
+            "it triages where attention should go."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "campaign_id": {
                     "type": "string",
-                    "description": "Google Ads customer ID",
+                    "description": (
+                        "Campaign whose keywords to diagnose. Diagnosis "
+                        "runs across all ad groups under this campaign."
+                    ),
                 },
-                "campaign_id": {"type": "string", "description": "Campaign ID"},
             },
             "required": ["campaign_id"],
         },
@@ -126,44 +229,56 @@ TOOLS: list[Tool] = [
     # === Negative Keywords ===
     Tool(
         name="google_ads.negative_keywords.list",
-        description="List Google Ads negative keywords",
+        description=(
+            "Lists campaign-level negative keyword criteria for a single "
+            "campaign. Returns criterion_id, text, and match_type per "
+            "entry. Read-only. Ad group-level negatives are not included "
+            "here — they live on the ad group and are managed through "
+            "google_ads.negative_keywords.add_to_ad_group."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "campaign_id": {
                     "type": "string",
-                    "description": "Google Ads customer ID",
+                    "description": "Campaign ID whose negatives to list.",
                 },
-                "campaign_id": {"type": "string", "description": "Campaign ID"},
             },
             "required": ["campaign_id"],
         },
     ),
     Tool(
         name="google_ads.negative_keywords.add",
-        description="Add a Google Ads negative keyword",
+        description=(
+            "Adds one or more campaign-level negative keywords. These "
+            "apply to every ad group in the campaign. Returns created "
+            "criterion_ids. Mutating, reversible via rollback.apply. For "
+            "negatives scoped to a single ad group use "
+            "google_ads.negative_keywords.add_to_ad_group instead — "
+            "campaign-level negatives can over-block if applied too broadly."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "campaign_id": {
                     "type": "string",
-                    "description": "Google Ads customer ID",
+                    "description": (
+                        "Campaign that will receive the negatives. The "
+                        "negatives apply to all ad groups under this "
+                        "campaign."
+                    ),
                 },
-                "campaign_id": {"type": "string", "description": "Campaign ID"},
                 "keywords": {
                     "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "text": {"type": "string"},
-                            "match_type": {
-                                "type": "string",
-                                "description": "BROAD/PHRASE/EXACT",
-                            },
-                        },
-                        "required": ["text"],
-                    },
-                    "description": "List of negative keywords to add",
+                    "items": _KEYWORD_ITEM_SCHEMA,
+                    "minItems": 1,
+                    "description": (
+                        "Negative keywords to add. Each item has `text` "
+                        "and optional `match_type` (BROAD / PHRASE / "
+                        "EXACT; EXACT is the safest for narrow exclusions)."
+                    ),
                 },
             },
             "required": ["campaign_id", "keywords"],
@@ -172,18 +287,30 @@ TOOLS: list[Tool] = [
     # === Keyword pause ===
     Tool(
         name="google_ads.keywords.pause",
-        description="Pause a Google Ads keyword",
+        description=(
+            "Sets the status of a single keyword criterion to PAUSED. "
+            "Lightweight and non-destructive — quality score and historical "
+            "stats are preserved, and the keyword can be resumed by "
+            "calling google_ads.keywords.add with the same text+match_type "
+            "(or re-enabled via the Google Ads UI). Returns the criterion "
+            "ID and new status. Reversible via rollback.apply. Use this "
+            "instead of google_ads.keywords.remove whenever the suspension "
+            "might be temporary."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "ad_group_id": {
                     "type": "string",
-                    "description": "Google Ads customer ID",
+                    "description": "Parent ad group ID.",
                 },
-                "ad_group_id": {"type": "string", "description": "Ad group ID"},
                 "criterion_id": {
                     "type": "string",
-                    "description": "Keyword criterion ID",
+                    "description": (
+                        "Keyword criterion ID as returned by "
+                        "google_ads.keywords.list."
+                    ),
                 },
             },
             "required": ["ad_group_id", "criterion_id"],
@@ -192,18 +319,31 @@ TOOLS: list[Tool] = [
     # === Negative keyword removal ===
     Tool(
         name="google_ads.negative_keywords.remove",
-        description="Remove a Google Ads negative keyword",
+        description=(
+            "Removes a single campaign-level negative keyword. Returns the "
+            "removed criterion_id. Destructive — the exclusion is lifted "
+            "immediately on the next serving cycle, which can increase "
+            "unwanted traffic. Reversible via rollback.apply (re-adds the "
+            "negative). For ad group-level negatives there is currently no "
+            "explicit remove tool — use the Google Ads UI or raise an "
+            "issue if needed."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "campaign_id": {
                     "type": "string",
-                    "description": "Google Ads customer ID",
+                    "description": (
+                        "Campaign ID the negative belongs to."
+                    ),
                 },
-                "campaign_id": {"type": "string", "description": "Campaign ID"},
                 "criterion_id": {
                     "type": "string",
-                    "description": "Negative keyword criterion ID",
+                    "description": (
+                        "Negative-keyword criterion ID as returned by "
+                        "google_ads.negative_keywords.list."
+                    ),
                 },
             },
             "required": ["campaign_id", "criterion_id"],
@@ -212,29 +352,34 @@ TOOLS: list[Tool] = [
     # === Ad group-level negative keyword addition ===
     Tool(
         name="google_ads.negative_keywords.add_to_ad_group",
-        description="Add Google Ads ad group-level negative keywords",
+        description=(
+            "Adds one or more ad group-level negative keywords. Scope is "
+            "narrower than campaign-level negatives — exclusions apply only "
+            "to the specified ad group. Returns created criterion_ids. "
+            "Mutating, reversible via rollback.apply. Prefer this over "
+            "google_ads.negative_keywords.add when the exclusion is only "
+            "wrong in one ad group's context."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "ad_group_id": {
                     "type": "string",
-                    "description": "Google Ads customer ID",
+                    "description": (
+                        "Ad group that will receive the negatives. "
+                        "Exclusions do not cascade to sibling ad groups."
+                    ),
                 },
-                "ad_group_id": {"type": "string", "description": "Ad group ID"},
                 "keywords": {
                     "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "text": {"type": "string"},
-                            "match_type": {
-                                "type": "string",
-                                "description": "BROAD/PHRASE/EXACT",
-                            },
-                        },
-                        "required": ["text"],
-                    },
-                    "description": "List of negative keywords to add",
+                    "items": _KEYWORD_ITEM_SCHEMA,
+                    "minItems": 1,
+                    "description": (
+                        "Negative keywords to add. Each item has `text` "
+                        "and optional `match_type` (BROAD / PHRASE / "
+                        "EXACT)."
+                    ),
                 },
             },
             "required": ["ad_group_id", "keywords"],
@@ -243,20 +388,50 @@ TOOLS: list[Tool] = [
     # === Automatic negative keyword suggestions ===
     Tool(
         name="google_ads.negative_keywords.suggest",
-        description="Automatically suggest Google Ads negative keyword candidates",
+        description=(
+            "Analyses recent search-term performance and returns suggested "
+            "negative keywords that waste spend relative to a target CPA. "
+            "Returns candidates with text, suggested match_type, spend, "
+            "conversions, and rationale (e.g. 'spend > 3x target CPA, 0 "
+            "conversions'). Read-only — suggestions are not applied. Use "
+            "google_ads.negative_keywords.add / add_to_ad_group to "
+            "materialize the ones you want after operator review."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "campaign_id": {
                     "type": "string",
-                    "description": "Google Ads customer ID",
+                    "description": (
+                        "Campaign whose search terms are analysed."
+                    ),
                 },
-                "campaign_id": {"type": "string", "description": "Campaign ID"},
-                "period": {"type": "string", "description": "Period"},
-                "target_cpa": {"type": "number", "description": "Target CPA"},
+                "period": {
+                    "type": "string",
+                    "description": (
+                        "Analysis window. Accepts Google Ads predefined "
+                        "ranges ('LAST_7_DAYS', 'LAST_14_DAYS', "
+                        "'LAST_30_DAYS' — default 'LAST_30_DAYS') or "
+                        "explicit 'YYYY-MM-DD..YYYY-MM-DD'."
+                    ),
+                },
+                "target_cpa": {
+                    "type": "number",
+                    "minimum": 0,
+                    "description": (
+                        "Target CPA in the account's currency. Search "
+                        "terms whose effective CPA exceeds this are "
+                        "flagged. If omitted, the campaign's configured "
+                        "target_cpa is used when available."
+                    ),
+                },
                 "ad_group_id": {
                     "type": "string",
-                    "description": "Filter by ad group ID",
+                    "description": (
+                        "Restrict analysis to a single ad group. Omit to "
+                        "analyse the whole campaign."
+                    ),
                 },
             },
             "required": ["campaign_id"],
@@ -265,17 +440,42 @@ TOOLS: list[Tool] = [
     # === Keyword Inventory ===
     Tool(
         name="google_ads.keywords.audit",
-        description="Audit Google Ads keywords and suggest improvement actions",
+        description=(
+            "Runs a holistic keyword-portfolio audit for a campaign and "
+            "returns grouped recommendations: pause candidates (zero-spend "
+            "or zero-conversion), bid-raise candidates (below first-page "
+            "bid), match-type-tighten candidates (broad stealing spend), "
+            "and unused keyword-planner ideas. Each item includes "
+            "criterion_id, text, spend, conversions, and a reason string. "
+            "Read-only — recommendations are not applied. Materialize "
+            "accepted ones via google_ads.keywords.pause / add / "
+            "negative_keywords.add."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "campaign_id": {
                     "type": "string",
-                    "description": "Google Ads customer ID",
+                    "description": "Campaign to audit.",
                 },
-                "campaign_id": {"type": "string", "description": "Campaign ID"},
-                "period": {"type": "string", "description": "Period"},
-                "target_cpa": {"type": "number", "description": "Target CPA"},
+                "period": {
+                    "type": "string",
+                    "description": (
+                        "Analysis window. Accepts 'LAST_7_DAYS', "
+                        "'LAST_14_DAYS', 'LAST_30_DAYS' (default), or "
+                        "'YYYY-MM-DD..YYYY-MM-DD'."
+                    ),
+                },
+                "target_cpa": {
+                    "type": "number",
+                    "minimum": 0,
+                    "description": (
+                        "Target CPA in the account's currency used to "
+                        "score efficiency. Falls back to the campaign's "
+                        "configured target_cpa when omitted."
+                    ),
+                },
             },
             "required": ["campaign_id"],
         },
@@ -283,16 +483,32 @@ TOOLS: list[Tool] = [
     # === Cross-ad-group keyword duplicate detection ===
     Tool(
         name="google_ads.keywords.cross_adgroup_duplicates",
-        description="Detect cross-ad-group keyword duplicates and return consolidation/removal recommendations",
+        description=(
+            "Finds the same text+match_type keyword appearing across "
+            "multiple ad groups in a campaign. Returns groups of duplicate "
+            "criteria with per-ad-group spend, conversions, and quality "
+            "score, plus a consolidation recommendation (which copy to "
+            "keep, which to pause/remove). Read-only. Duplicates compete "
+            "in the auction and hurt aggregate quality score — run this "
+            "before a keyword restructuring sprint."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "campaign_id": {
                     "type": "string",
-                    "description": "Google Ads customer ID",
+                    "description": "Campaign to scan for duplicates.",
                 },
-                "campaign_id": {"type": "string", "description": "Campaign ID"},
-                "period": {"type": "string", "description": "Period"},
+                "period": {
+                    "type": "string",
+                    "description": (
+                        "Analysis window used to compute per-copy spend "
+                        "and conversions. Accepts 'LAST_7_DAYS', "
+                        "'LAST_14_DAYS', 'LAST_30_DAYS' (default), or "
+                        "'YYYY-MM-DD..YYYY-MM-DD'."
+                    ),
+                },
             },
             "required": ["campaign_id"],
         },

--- a/mureo/mcp/_tools_meta_ads_campaigns.py
+++ b/mureo/mcp/_tools_meta_ads_campaigns.py
@@ -1,74 +1,167 @@
-"""Meta Ads tool definitions — Campaigns, ad sets, ads"""
+"""Meta Ads tool definitions — Campaigns, ad sets, ads.
+
+Tool descriptions follow ``docs/tdqs-style-guide.md``. Meta hierarchy:
+Campaign → Ad Set → Ad. Budgets and targeting live on Ad Sets; creative
+assets live on Ads. All budgets are passed in minor currency units
+(cents for USD, 円 for JPY since JPY has no minor unit — Meta treats 1
+yen as 1 unit).
+"""
 
 from __future__ import annotations
 
 from mcp.types import Tool
 
+# Reusable parameter fragments.
+_ACCOUNT_ID_PARAM = {
+    "type": "string",
+    "description": (
+        "Meta Ads account ID in the format 'act_XXXXXXXXXX' (e.g. "
+        "'act_1234567890'). Optional — falls back to META_ADS_ACCOUNT_ID "
+        "from the configured credentials. The leading 'act_' prefix is "
+        "required."
+    ),
+}
+
+_LIMIT_PARAM = {
+    "type": "integer",
+    "minimum": 1,
+    "maximum": 1000,
+    "description": (
+        "Maximum records to return in a single call. Default 50. "
+        "Meta Graph API caps at 1000 per page; for larger result sets "
+        "reduce limit and filter client-side on the returned fields."
+    ),
+}
+
 TOOLS: list[Tool] = [
     # === Campaigns ===
     Tool(
         name="meta_ads.campaigns.list",
-        description="List Meta Ads campaigns",
+        description=(
+            "Lists campaigns in a Meta Ads account with optional status "
+            "filtering. Returns id, name, status (ACTIVE / PAUSED / "
+            "DELETED / ARCHIVED), effective_status, objective "
+            "(OUTCOME_SALES / OUTCOME_LEADS / etc.), buying_type, "
+            "daily_budget, and lifetime_budget per campaign. Read-only. "
+            "Use this to find a campaign_id before calling campaigns.get "
+            "or the pause/enable helpers. For a single campaign's full "
+            "detail record use meta_ads.campaigns.get."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
-                    "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
-                },
+                "account_id": _ACCOUNT_ID_PARAM,
                 "status_filter": {
                     "type": "string",
-                    "description": "Status filter (ACTIVE/PAUSED etc.)",
+                    "enum": [
+                        "ACTIVE",
+                        "PAUSED",
+                        "DELETED",
+                        "ARCHIVED",
+                        "IN_PROCESS",
+                        "WITH_ISSUES",
+                    ],
+                    "description": (
+                        "Restrict results to campaigns with this status. "
+                        "Omit to return all non-DELETED statuses."
+                    ),
                 },
-                "limit": {
-                    "type": "integer",
-                    "description": "Max results (default: 50)",
-                },
+                "limit": _LIMIT_PARAM,
             },
             "required": [],
         },
     ),
     Tool(
         name="meta_ads.campaigns.get",
-        description="Get Meta Ads campaign details",
+        description=(
+            "Fetches the full detail record for a single campaign by ID. "
+            "Returns the same fields as campaigns.list plus "
+            "special_ad_categories, spend_cap, start_time, stop_time, and "
+            "issues_info (non-empty when status is WITH_ISSUES). "
+            "Read-only. Use this when a campaign_id is already known; for "
+            "discovery use meta_ads.campaigns.list."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "campaign_id": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": (
+                        "Campaign ID (numeric string) as returned by "
+                        "meta_ads.campaigns.list."
+                    ),
                 },
-                "campaign_id": {"type": "string", "description": "Campaign ID"},
             },
             "required": ["campaign_id"],
         },
     ),
     Tool(
         name="meta_ads.campaigns.create",
-        description="Create a Meta Ads campaign",
+        description=(
+            "Creates a new campaign in the specified Meta Ads account. "
+            "Returns the new campaign id. Mutating, reversible via "
+            "rollback.apply (rollback sets status to PAUSED rather than "
+            "deleting). Default initial status is PAUSED — explicitly "
+            "pass status='ACTIVE' only if the operator has confirmed "
+            "immediate spend. A campaign acts as a container; ad sets "
+            "(where budgets and targeting live) and ads must be created "
+            "separately via meta_ads.ad_sets.create and meta_ads.ads.create."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "name": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": (
+                        "Campaign name. Visible in Ads Manager; Meta "
+                        "allows up to 400 characters."
+                    ),
                 },
-                "name": {"type": "string", "description": "Campaign name"},
                 "objective": {
                     "type": "string",
-                    "description": "Campaign objective (CONVERSIONS, LINK_CLICKS etc.)",
+                    "enum": [
+                        "OUTCOME_AWARENESS",
+                        "OUTCOME_TRAFFIC",
+                        "OUTCOME_ENGAGEMENT",
+                        "OUTCOME_LEADS",
+                        "OUTCOME_APP_PROMOTION",
+                        "OUTCOME_SALES",
+                    ],
+                    "description": (
+                        "Campaign objective using Meta's ODAX taxonomy. "
+                        "Older names (CONVERSIONS, LINK_CLICKS) are "
+                        "rejected by current API versions — use the "
+                        "OUTCOME_* forms."
+                    ),
                 },
                 "status": {
                     "type": "string",
-                    "description": "Initial status (default: PAUSED)",
+                    "enum": ["ACTIVE", "PAUSED"],
+                    "description": (
+                        "Initial status. Default PAUSED. Only set ACTIVE "
+                        "when the operator has signed off on spend."
+                    ),
                 },
                 "daily_budget": {
                     "type": "integer",
-                    "description": "Daily budget (in cents)",
+                    "minimum": 1,
+                    "description": (
+                        "Daily budget in account currency minor units "
+                        "(cents for USD, yen for JPY). Mutually exclusive "
+                        "with lifetime_budget. Budgets can live on the "
+                        "campaign (CBO) or the ad set — not both."
+                    ),
                 },
                 "lifetime_budget": {
                     "type": "integer",
-                    "description": "Lifetime budget (in cents)",
+                    "minimum": 1,
+                    "description": (
+                        "Lifetime budget in account currency minor units. "
+                        "Requires a stop_time on at least one ad set. "
+                        "Mutually exclusive with daily_budget."
+                    ),
                 },
             },
             "required": ["name", "objective"],
@@ -76,20 +169,44 @@ TOOLS: list[Tool] = [
     ),
     Tool(
         name="meta_ads.campaigns.update",
-        description="Update a Meta Ads campaign",
+        description=(
+            "Updates fields on an existing campaign. Partial update — only "
+            "the supplied fields are changed. Returns the updated campaign. "
+            "Mutating, reversible via rollback.apply. For status-only "
+            "transitions prefer meta_ads.campaigns.pause / "
+            "meta_ads.campaigns.enable, which are safer and map to a "
+            "single explicit operator intent."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "campaign_id": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": "Campaign ID to update.",
                 },
-                "campaign_id": {"type": "string", "description": "Campaign ID"},
-                "name": {"type": "string", "description": "New campaign name"},
-                "status": {"type": "string", "description": "Status"},
+                "name": {
+                    "type": "string",
+                    "description": "New campaign name.",
+                },
+                "status": {
+                    "type": "string",
+                    "enum": ["ACTIVE", "PAUSED", "DELETED", "ARCHIVED"],
+                    "description": (
+                        "New campaign status. Prefer the dedicated "
+                        "meta_ads.campaigns.pause / enable tools for "
+                        "ACTIVE ↔ PAUSED transitions."
+                    ),
+                },
                 "daily_budget": {
                     "type": "integer",
-                    "description": "Daily budget (in cents)",
+                    "minimum": 1,
+                    "description": (
+                        "New daily budget in account currency minor units "
+                        "(cents for USD, yen for JPY). Only settable when "
+                        "the campaign is configured for CBO; ad-set-level "
+                        "budgets must be edited via meta_ads.ad_sets.update."
+                    ),
                 },
             },
             "required": ["campaign_id"],
@@ -98,30 +215,45 @@ TOOLS: list[Tool] = [
     # === Campaign pause / enable ===
     Tool(
         name="meta_ads.campaigns.pause",
-        description="Pause a Meta Ads campaign",
+        description=(
+            "Pauses a single campaign by setting its status to PAUSED. "
+            "Cascades to active ad sets and ads — nothing underneath the "
+            "campaign will serve while it is PAUSED. Lightweight and "
+            "reversible via rollback.apply or meta_ads.campaigns.enable. "
+            "Returns the campaign id and new status. Use for immediate "
+            "stop-spend situations; use meta_ads.campaigns.update with "
+            "status='DELETED' to soft-delete instead."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "campaign_id": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": "Campaign ID to pause.",
                 },
-                "campaign_id": {"type": "string", "description": "Campaign ID"},
             },
             "required": ["campaign_id"],
         },
     ),
     Tool(
         name="meta_ads.campaigns.enable",
-        description="Enable (ACTIVE) a Meta Ads campaign",
+        description=(
+            "Resumes a paused campaign by setting its status to ACTIVE. "
+            "Ad sets and ads underneath retain their own status — if they "
+            "are still PAUSED they do NOT auto-resume; call "
+            "meta_ads.ad_sets.enable / meta_ads.ads.enable for those too. "
+            "Returns the campaign id and new status. Reversible via "
+            "rollback.apply or meta_ads.campaigns.pause."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "campaign_id": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": "Campaign ID to activate.",
                 },
-                "campaign_id": {"type": "string", "description": "Campaign ID"},
             },
             "required": ["campaign_id"],
         },
@@ -129,58 +261,119 @@ TOOLS: list[Tool] = [
     # === Ad sets ===
     Tool(
         name="meta_ads.ad_sets.list",
-        description="List Meta Ads ad sets",
+        description=(
+            "Lists ad sets in a Meta Ads account, optionally scoped to a "
+            "single parent campaign. Returns id, name, campaign_id, status, "
+            "effective_status, daily_budget, lifetime_budget, "
+            "optimization_goal, billing_event, and targeting_summary per "
+            "ad set. Read-only. Ad sets are where budgets and targeting "
+            "live — use this to audit delivery settings or to find an "
+            "ad_set_id before creating ads."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
-                    "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
-                },
+                "account_id": _ACCOUNT_ID_PARAM,
                 "campaign_id": {
                     "type": "string",
-                    "description": "Filter by campaign ID",
+                    "description": (
+                        "Restrict results to ad sets under this campaign. "
+                        "Omit to list across the whole account."
+                    ),
                 },
-                "limit": {
-                    "type": "integer",
-                    "description": "Max results (default: 50)",
-                },
+                "limit": _LIMIT_PARAM,
             },
             "required": [],
         },
     ),
     Tool(
         name="meta_ads.ad_sets.create",
-        description="Create a Meta Ads ad set",
+        description=(
+            "Creates a new ad set inside an existing campaign. Returns the "
+            "new ad_set id. Mutating, reversible via rollback.apply "
+            "(rollback sets status to PAUSED). Targeting is passed as a "
+            "Meta targeting spec object; at minimum supply "
+            "geo_locations and age bounds. Default initial status is "
+            "PAUSED — only ACTIVE when the operator has confirmed spend. "
+            "After creation, attach ads with meta_ads.ads.create."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "campaign_id": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": (
+                        "Parent campaign ID. Must exist and not be "
+                        "DELETED."
+                    ),
                 },
-                "campaign_id": {"type": "string", "description": "Parent campaign ID"},
-                "name": {"type": "string", "description": "Ad set name"},
+                "name": {
+                    "type": "string",
+                    "description": "Ad set name, up to 400 characters.",
+                },
                 "daily_budget": {
                     "type": "integer",
-                    "description": "Daily budget (in cents)",
+                    "minimum": 1,
+                    "description": (
+                        "Daily budget in account currency minor units "
+                        "(cents for USD, yen for JPY). Required unless "
+                        "the parent campaign uses CBO; mutually exclusive "
+                        "with lifetime-budget settings on the same ad set."
+                    ),
                 },
                 "billing_event": {
                     "type": "string",
-                    "description": "Billing event (default: IMPRESSIONS)",
+                    "enum": [
+                        "IMPRESSIONS",
+                        "LINK_CLICKS",
+                        "PAGE_LIKES",
+                        "POST_ENGAGEMENT",
+                        "VIDEO_VIEWS",
+                        "THRUPLAY",
+                    ],
+                    "description": (
+                        "What Meta charges for. Default IMPRESSIONS. The "
+                        "valid options depend on the optimization_goal — "
+                        "incompatible pairings are rejected by Meta."
+                    ),
                 },
                 "optimization_goal": {
                     "type": "string",
-                    "description": "Optimization goal (default: REACH)",
+                    "description": (
+                        "What Meta optimises delivery for (e.g. REACH, "
+                        "LINK_CLICKS, OFFSITE_CONVERSIONS, LANDING_PAGE_VIEWS, "
+                        "THRUPLAY). Default REACH. Must be compatible with "
+                        "the parent campaign's objective."
+                    ),
                 },
-                "targeting": {"type": "object", "description": "Targeting settings"},
+                "targeting": {
+                    "type": "object",
+                    "description": (
+                        "Meta targeting spec. Typical keys: "
+                        "geo_locations (e.g. {'countries': ['JP']}), "
+                        "age_min, age_max, genders, interests, custom_audiences. "
+                        "See Meta Marketing API targeting docs for the "
+                        "full schema."
+                    ),
+                },
                 "status": {
                     "type": "string",
-                    "description": "Initial status (default: PAUSED)",
+                    "enum": ["ACTIVE", "PAUSED"],
+                    "description": (
+                        "Initial status. Default PAUSED. Only ACTIVE "
+                        "after operator sign-off."
+                    ),
                 },
                 "bid_amount": {
                     "type": "integer",
-                    "description": "Bid amount in cents (required for some optimization goals)",
+                    "minimum": 1,
+                    "description": (
+                        "Bid cap in account currency minor units. Required "
+                        "for bid-strategy optimization goals such as "
+                        "LINK_CLICKS with TARGET_COST. Omit for automatic "
+                        "bidding."
+                    ),
                 },
             },
             "required": ["campaign_id", "name"],
@@ -188,22 +381,52 @@ TOOLS: list[Tool] = [
     ),
     Tool(
         name="meta_ads.ad_sets.update",
-        description="Update a Meta Ads ad set",
+        description=(
+            "Updates one or more settings on an existing ad set. Partial "
+            "update — only provided fields are changed. Returns the updated "
+            "ad set. Mutating, reversible via rollback.apply. For "
+            "status-only transitions prefer meta_ads.ad_sets.pause / "
+            "meta_ads.ad_sets.enable. Changing `targeting` replaces the "
+            "entire targeting spec — fetch the current spec via "
+            "meta_ads.ad_sets.get and merge client-side to avoid data loss."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "ad_set_id": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": "Ad set ID to update.",
                 },
-                "ad_set_id": {"type": "string", "description": "Ad set ID"},
-                "name": {"type": "string", "description": "New name"},
-                "status": {"type": "string", "description": "Status"},
+                "name": {
+                    "type": "string",
+                    "description": "New ad set name.",
+                },
+                "status": {
+                    "type": "string",
+                    "enum": ["ACTIVE", "PAUSED", "DELETED", "ARCHIVED"],
+                    "description": (
+                        "New ad set status. Prefer the dedicated "
+                        "pause/enable tools for simple ACTIVE ↔ PAUSED."
+                    ),
+                },
                 "daily_budget": {
                     "type": "integer",
-                    "description": "Daily budget (in cents)",
+                    "minimum": 1,
+                    "description": (
+                        "New daily budget in account currency minor units. "
+                        "Only valid when the campaign is not using CBO."
+                    ),
                 },
-                "targeting": {"type": "object", "description": "Targeting settings"},
+                "targeting": {
+                    "type": "object",
+                    "description": (
+                        "Full targeting spec replacement. Any keys not "
+                        "supplied here are cleared — fetch current spec "
+                        "via meta_ads.ad_sets.get and merge before "
+                        "writing back."
+                    ),
+                },
             },
             "required": ["ad_set_id"],
         },
@@ -211,45 +434,67 @@ TOOLS: list[Tool] = [
     # === Ad set get / pause / enable ===
     Tool(
         name="meta_ads.ad_sets.get",
-        description="Get Meta Ads ad set details",
+        description=(
+            "Fetches the full detail record for a single ad set, including "
+            "the complete targeting spec and budget/bidding configuration. "
+            "Returns id, name, campaign_id, status, effective_status, "
+            "daily_budget, lifetime_budget, optimization_goal, billing_event, "
+            "targeting (full spec), start_time, end_time, and "
+            "delivery_estimate (if available). Read-only. Call this before "
+            "meta_ads.ad_sets.update when you plan to modify targeting, so "
+            "you can merge instead of overwrite."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "ad_set_id": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": "Ad set ID to inspect.",
                 },
-                "ad_set_id": {"type": "string", "description": "Ad set ID"},
             },
             "required": ["ad_set_id"],
         },
     ),
     Tool(
         name="meta_ads.ad_sets.pause",
-        description="Pause a Meta Ads ad set",
+        description=(
+            "Pauses a single ad set by setting its status to PAUSED. "
+            "Ads under this ad set stop serving while it is PAUSED, even "
+            "if their own status is ACTIVE. Lightweight, reversible via "
+            "rollback.apply or meta_ads.ad_sets.enable. Returns the "
+            "ad_set_id and new status. Does not affect sibling ad sets."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "ad_set_id": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": "Ad set ID to pause.",
                 },
-                "ad_set_id": {"type": "string", "description": "Ad set ID"},
             },
             "required": ["ad_set_id"],
         },
     ),
     Tool(
         name="meta_ads.ad_sets.enable",
-        description="Enable (ACTIVE) a Meta Ads ad set",
+        description=(
+            "Resumes a paused ad set by setting its status to ACTIVE. The "
+            "parent campaign must also be ACTIVE for the ad set to "
+            "actually serve. Ads underneath retain their own status — "
+            "PAUSED ads do not auto-resume. Returns the ad_set_id and "
+            "new status. Reversible via rollback.apply or "
+            "meta_ads.ad_sets.pause."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "ad_set_id": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": "Ad set ID to activate.",
                 },
-                "ad_set_id": {"type": "string", "description": "Ad set ID"},
             },
             "required": ["ad_set_id"],
         },
@@ -257,42 +502,70 @@ TOOLS: list[Tool] = [
     # === Ads ===
     Tool(
         name="meta_ads.ads.list",
-        description="List Meta Ads ads",
+        description=(
+            "Lists ads in a Meta Ads account, optionally scoped to one ad "
+            "set. Returns id, name, ad_set_id, campaign_id, status, "
+            "effective_status, creative_id, and ad_review_feedback per ad. "
+            "Read-only. Use this to find an ad_id before calling "
+            "ads.update / pause / enable, or to audit which creatives are "
+            "in flight. For the creative itself (image URL, copy), follow "
+            "up with meta_ads.creatives.get."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
-                    "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
-                },
+                "account_id": _ACCOUNT_ID_PARAM,
                 "ad_set_id": {
                     "type": "string",
-                    "description": "Filter by ad set ID",
+                    "description": (
+                        "Restrict to ads under this ad set. Omit to list "
+                        "across the whole account."
+                    ),
                 },
-                "limit": {
-                    "type": "integer",
-                    "description": "Max results (default: 50)",
-                },
+                "limit": _LIMIT_PARAM,
             },
             "required": [],
         },
     ),
     Tool(
         name="meta_ads.ads.create",
-        description="Create a Meta Ads ad",
+        description=(
+            "Creates a new ad inside an existing ad set, binding it to a "
+            "pre-existing creative. Returns the new ad id. Mutating, "
+            "reversible via rollback.apply. Default initial status is "
+            "PAUSED. The creative must already exist — use "
+            "meta_ads.creatives.create (or sibling constructors like "
+            "meta_ads.creatives.create_carousel) to produce a creative_id "
+            "before calling this tool."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "ad_set_id": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": (
+                        "Parent ad set ID. Must exist and not be DELETED."
+                    ),
                 },
-                "ad_set_id": {"type": "string", "description": "Parent ad set ID"},
-                "name": {"type": "string", "description": "Ad name"},
-                "creative_id": {"type": "string", "description": "Creative ID"},
+                "name": {
+                    "type": "string",
+                    "description": "Ad name visible in Ads Manager.",
+                },
+                "creative_id": {
+                    "type": "string",
+                    "description": (
+                        "Existing AdCreative ID to bind to this ad. "
+                        "Obtain from meta_ads.creatives.list / create."
+                    ),
+                },
                 "status": {
                     "type": "string",
-                    "description": "Initial status (default: PAUSED)",
+                    "enum": ["ACTIVE", "PAUSED"],
+                    "description": (
+                        "Initial status. Default PAUSED; only ACTIVE "
+                        "after operator sign-off."
+                    ),
                 },
             },
             "required": ["ad_set_id", "name", "creative_id"],
@@ -300,17 +573,34 @@ TOOLS: list[Tool] = [
     ),
     Tool(
         name="meta_ads.ads.update",
-        description="Update a Meta Ads ad",
+        description=(
+            "Updates fields on an existing ad. Partial update. Returns the "
+            "updated ad. Mutating, reversible via rollback.apply. The ad's "
+            "creative cannot be swapped via this call — creative changes "
+            "require creating a replacement ad with a new creative_id and "
+            "pausing the old one. For status-only transitions use "
+            "meta_ads.ads.pause / meta_ads.ads.enable."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "ad_id": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": "Ad ID to update.",
                 },
-                "ad_id": {"type": "string", "description": "Ad ID"},
-                "name": {"type": "string", "description": "New name"},
-                "status": {"type": "string", "description": "Status"},
+                "name": {
+                    "type": "string",
+                    "description": "New ad name.",
+                },
+                "status": {
+                    "type": "string",
+                    "enum": ["ACTIVE", "PAUSED", "DELETED", "ARCHIVED"],
+                    "description": (
+                        "New ad status. Prefer meta_ads.ads.pause / "
+                        "meta_ads.ads.enable for ACTIVE ↔ PAUSED."
+                    ),
+                },
             },
             "required": ["ad_id"],
         },
@@ -318,45 +608,65 @@ TOOLS: list[Tool] = [
     # === Ad get / pause / enable ===
     Tool(
         name="meta_ads.ads.get",
-        description="Get Meta Ads ad details",
+        description=(
+            "Fetches the full detail record for a single ad, including "
+            "creative_id and ad_review_feedback (populated when the ad is "
+            "in WITH_ISSUES). Returns id, name, ad_set_id, campaign_id, "
+            "status, effective_status, creative_id, configured_status, "
+            "issues_info, and ad_review_feedback. Read-only. Call this "
+            "when an ad shows up as WITH_ISSUES in ads.list — "
+            "ad_review_feedback explains the policy rejection."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "ad_id": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": "Ad ID to inspect.",
                 },
-                "ad_id": {"type": "string", "description": "Ad ID"},
             },
             "required": ["ad_id"],
         },
     ),
     Tool(
         name="meta_ads.ads.pause",
-        description="Pause a Meta Ads ad",
+        description=(
+            "Pauses a single ad by setting its status to PAUSED. "
+            "Lightweight; the ad stops serving immediately. Reversible "
+            "via rollback.apply or meta_ads.ads.enable. Returns the ad_id "
+            "and new status. Does not affect the parent ad set or sibling "
+            "ads. Use for creative-level pause; use "
+            "meta_ads.ad_sets.pause to stop a whole ad set."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "ad_id": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": "Ad ID to pause.",
                 },
-                "ad_id": {"type": "string", "description": "Ad ID"},
             },
             "required": ["ad_id"],
         },
     ),
     Tool(
         name="meta_ads.ads.enable",
-        description="Enable (ACTIVE) a Meta Ads ad",
+        description=(
+            "Resumes a paused ad by setting its status to ACTIVE. The "
+            "parent ad set and campaign must also be ACTIVE for the ad "
+            "to actually serve. Returns the ad_id and new status. "
+            "Reversible via rollback.apply or meta_ads.ads.pause."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "ad_id": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": "Ad ID to activate.",
                 },
-                "ad_id": {"type": "string", "description": "Ad ID"},
             },
             "required": ["ad_id"],
         },

--- a/mureo/mcp/_tools_meta_ads_campaigns.py
+++ b/mureo/mcp/_tools_meta_ads_campaigns.py
@@ -304,8 +304,7 @@ TOOLS: list[Tool] = [
                 "campaign_id": {
                     "type": "string",
                     "description": (
-                        "Parent campaign ID. Must exist and not be "
-                        "DELETED."
+                        "Parent campaign ID. Must exist and not be " "DELETED."
                     ),
                 },
                 "name": {
@@ -544,9 +543,7 @@ TOOLS: list[Tool] = [
                 "account_id": _ACCOUNT_ID_PARAM,
                 "ad_set_id": {
                     "type": "string",
-                    "description": (
-                        "Parent ad set ID. Must exist and not be DELETED."
-                    ),
+                    "description": ("Parent ad set ID. Must exist and not be DELETED."),
                 },
                 "name": {
                     "type": "string",


### PR DESCRIPTION
## Summary
Rewrite MCP tool descriptions for 49 core tools (google_ads.campaigns/ad_groups/ads/budget/accounts + keywords/negative_keywords; meta_ads.campaigns/ad_sets/ads) to improve Glama's [Tool Definition Quality Score (TDQS)](https://glama.ai/blog/2026-04-03-tool-definition-quality-score-tdqs). Also introduces `docs/tdqs-style-guide.md` as the contributor reference.

## Why
Glama scored mureo's 173 tools at **C grade, 3.1/5 avg**, with 86 tools in the C bucket and the lowest at 2.1 (`meta_ads.creatives.list`). Descriptions were one-liners that restated tool names — failing five of the six TDQS dimensions. Example:

**Before** (`google_ads.campaigns.diagnose`, score 2.3):
> Diagnose Google Ads campaign delivery status

**After** (target ~4.4):
> Explains why a campaign is not serving or is under-delivering. Returns an ordered list of issues drawn from serving_status, primary_status, and primary_status_reasons (e.g. LIMITED_BY_BUDGET, AD_GROUPS_PAUSED, KEYWORDS_DISAPPROVED, NO_ELIGIBLE_ADS), each annotated with a plain-language description and a remediation hint. Read-only — does not change anything. Use this before pulling raw performance reports; it narrows the problem space.

## Scope
| Family | # Tools |
|---|---|
| google_ads.campaigns / ad_groups / ads / budget / accounts | 19 |
| google_ads.keywords / negative_keywords | 13 |
| meta_ads.campaigns / ad_sets / ads | 18 |
| **Total** | **50** (49 rewritten + policy_details reworked) |

Remaining ~125 tools (meta_ads.creatives, analysis, extensions, search_console, etc.) will be covered in follow-up PRs under the same style guide to reach AAA.

## Approach
`docs/tdqs-style-guide.md` codifies the 6 TDQS dimensions into a template:

```
<verb> <resource> in <platform>. Returns <returned fields>.
<Read-only | Mutating | Destructive>. <Defaults, thresholds>.
Use this when <scenario>; prefer <sibling tool> when <other scenario>.
```

Every rewritten tool now covers:
- Specific verb + resource (Purpose Clarity)
- Usage vs sibling tools (Usage Guidelines) — e.g. `campaigns.update_status` vs `campaigns.update`
- Read-only / mutating / reversible flags (Behavioral Transparency)
- Parameter format/examples (`customer_id`: 10-digit without dashes; `account_id`: `act_` prefix)
- Concise 50-100 word length (Conciseness)
- Returned field list + pagination behavior (Contextual Completeness)

## Test plan
- [x] Python syntax validation (`ast.parse`) on all 3 rewritten files.
- [x] `docker build` succeeds.
- [x] `docker run` + MCP `initialize` + `tools/list` — all 173 tools still load end-to-end.
- [x] No existing tests assert on description text.
- [ ] Merge → Glama rebuilds → TDQS re-scores; confirm avg moves from 3.1 toward B+ and no regressions elsewhere.
- [ ] Follow-up PRs for remaining tool families until AAA achieved.

## Non-goals
- No runtime behavior changes.
- `TOOLS: list[Tool]` public interface unchanged.
- No schema-shape changes (properties added where TDQS rewards it: `enum`, `minimum`, `minItems`, `maxItems` — backwards compatible).

## Follow-up
Remaining target families for subsequent PRs (avg < 3.5 currently):
- `meta_ads.creatives.*` (family avg 2.88, lowest 2.1)
- `google_ads.search_terms.*`, `google_ads.performance.*`, `google_ads.auction_insights.*`, `google_ads.landing_page.*`, `google_ads.capture.*`
- `meta_ads.leads.*`, `meta_ads.pixels.*`
- Extensions / sitelinks / analysis