### PR TITLE
feat(mcp): rewrite 51 remaining Meta Ads tool descriptions to lift TDQS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - MCP tool descriptions rewritten for 49 tools across Google Ads and Meta Ads — `google_ads.campaigns.*`, `google_ads.ad_groups.*`, `google_ads.ads.*`, `google_ads.budget.*`, `google_ads.accounts.*`, `google_ads.keywords.*`, `google_ads.negative_keywords.*`, `meta_ads.campaigns.*`, `meta_ads.ad_sets.*`, `meta_ads.ads.*`. Each description now covers verb + resource + returned fields + side effects (read-only / mutating / reversible via `rollback.apply`) + sibling tool differentiation, following the new `docs/tdqs-style-guide.md`. Targets improving Glama's Tool Definition Quality Score from C (3.1 avg) toward B+. No behavioral changes — descriptions and parameter hints only.
+- MCP tool descriptions rewritten for the remaining ~51 Meta Ads tools — `meta_ads.creatives.*` (including the TDQS lowest-scoring `meta_ads.creatives.list`), `meta_ads.images.*`, `meta_ads.videos.*`, `meta_ads.audiences.*`, `meta_ads.pixels.*`, `meta_ads.insights.*`, `meta_ads.analysis.*`, `meta_ads.catalogs.*`, `meta_ads.products.*`, `meta_ads.feeds.*`, `meta_ads.conversions.*`, `meta_ads.lead_forms.*`, `meta_ads.leads.*`, `meta_ads.split_tests.*`, `meta_ads.ad_rules.*`, `meta_ads.page_posts.*`, `meta_ads.instagram.*`. Same TDQS template as PR #43. No behavioral changes.
 
 ## [0.6.0] - 2026-04-20
 

--- a/mureo/mcp/_tools_meta_ads_audiences.py
+++ b/mureo/mcp/_tools_meta_ads_audiences.py
@@ -1,60 +1,141 @@
-"""Meta Ads tool definitions — Audiences, pixels"""
+"""Meta Ads tool definitions — Audiences, pixels.
+
+Tool descriptions follow ``docs/tdqs-style-guide.md``. Custom audiences
+define who ads target; pixels are the event-tracking source used to
+measure conversions and populate website-based audiences.
+"""
 
 from __future__ import annotations
 
 from mcp.types import Tool
 
+# Reusable parameter fragments.
+_ACCOUNT_ID_PARAM = {
+    "type": "string",
+    "description": (
+        "Meta Ads account ID in the format 'act_XXXXXXXXXX' (e.g. "
+        "'act_1234567890'). Optional — falls back to META_ADS_ACCOUNT_ID "
+        "from the configured credentials. The leading 'act_' prefix is "
+        "required."
+    ),
+}
+
+_LIMIT_PARAM = {
+    "type": "integer",
+    "minimum": 1,
+    "maximum": 1000,
+    "description": (
+        "Maximum records returned per call. Default 50, max 1000 per " "Meta Graph API."
+    ),
+}
+
 TOOLS: list[Tool] = [
     # === Audiences ===
     Tool(
         name="meta_ads.audiences.list",
-        description="List Meta Ads custom audiences",
+        description=(
+            "Lists Custom Audiences in a Meta Ads account. Returns id, "
+            "name, subtype (WEBSITE / CUSTOM / LOOKALIKE / APP / etc.), "
+            "approximate_count, retention_days, and data_source per "
+            "audience. Read-only. Use this to find an audience_id before "
+            "targeting an ad set (meta_ads.ad_sets.create / update) or "
+            "before creating a lookalike (audiences.create_lookalike). "
+            "Approximate counts from Meta may lag actual size by 24–48h."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
-                    "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
-                },
-                "limit": {
-                    "type": "integer",
-                    "description": "Max results (default: 50)",
-                },
+                "account_id": _ACCOUNT_ID_PARAM,
+                "limit": _LIMIT_PARAM,
             },
             "required": [],
         },
     ),
     Tool(
         name="meta_ads.audiences.create",
-        description="Create a Meta Ads custom audience",
+        description=(
+            "Creates a Custom Audience in a Meta Ads account. Returns the "
+            "new audience_id. Mutating, reversible via rollback.apply "
+            "(rollback deletes the audience). Subtype controls the data "
+            "source: WEBSITE audiences require a pixel_id and an event "
+            "rule; CUSTOM audiences accept a manually supplied rule or a "
+            "customer list upload (the upload path is handled out-of-band "
+            "by Meta). For similarity-expanded reach use "
+            "meta_ads.audiences.create_lookalike on top of this audience."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "name": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": (
+                        "Audience name shown in Ads Manager. Must be "
+                        "unique within the account."
+                    ),
                 },
-                "name": {"type": "string", "description": "Audience name"},
                 "subtype": {
                     "type": "string",
-                    "description": "Audience type hint (WEBSITE, CUSTOM, APP). Used to auto-generate rule if rule is not provided.",
+                    "enum": ["WEBSITE", "CUSTOM", "APP"],
+                    "description": (
+                        "Audience type hint. WEBSITE auto-generates a "
+                        "PageView rule from the linked pixel when `rule` "
+                        "is omitted; CUSTOM requires an explicit rule or "
+                        "a customer-list upload; APP requires an app_id. "
+                        "Default CUSTOM when omitted."
+                    ),
                 },
-                "description": {"type": "string", "description": "Description"},
+                "description": {
+                    "type": "string",
+                    "description": (
+                        "Optional free-text description stored with the "
+                        "audience. Not visible to end users."
+                    ),
+                },
                 "retention_days": {
                     "type": "integer",
-                    "description": "Retention period in days (default: 30)",
+                    "minimum": 1,
+                    "maximum": 180,
+                    "description": (
+                        "How long a matched user stays in the audience "
+                        "after their last qualifying event. Default 30. "
+                        "Meta caps at 180 days."
+                    ),
                 },
                 "pixel_id": {
                     "type": "string",
-                    "description": "Meta Pixel ID (required for WEBSITE audiences)",
+                    "description": (
+                        "Meta Pixel ID to source events from. Required "
+                        "for subtype=WEBSITE. Find via meta_ads.pixels."
+                        "list."
+                    ),
                 },
                 "rule": {
                     "type": "object",
-                    "description": "Audience rule definition (JSON). If not provided and subtype=WEBSITE, a default PageView rule is auto-generated.",
+                    "description": (
+                        "Audience rule definition (Meta rule JSON schema). "
+                        "When omitted with subtype=WEBSITE, a default "
+                        "PageView rule scoped to the supplied pixel is "
+                        "auto-generated. See Meta Marketing API docs for "
+                        "rule syntax — supports url filters, event "
+                        "parameters, and compound boolean operators."
+                    ),
                 },
                 "customer_file_source": {
                     "type": "string",
-                    "description": "Customer file source (USER_PROVIDED_ONLY, PARTNER_PROVIDED_ONLY, BOTH_USER_AND_PARTNER_PROVIDED). Default: USER_PROVIDED_ONLY.",
+                    "enum": [
+                        "USER_PROVIDED_ONLY",
+                        "PARTNER_PROVIDED_ONLY",
+                        "BOTH_USER_AND_PARTNER_PROVIDED",
+                    ],
+                    "description": (
+                        "Source declaration required by Meta for "
+                        "compliance. USER_PROVIDED_ONLY (default) — data "
+                        "came from the advertiser's own first-party "
+                        "sources; PARTNER — from a data provider; BOTH — "
+                        "mixed. Meta uses this to set legal-basis "
+                        "defaults."
+                    ),
                 },
             },
             "required": ["name"],
@@ -63,51 +144,93 @@ TOOLS: list[Tool] = [
     # === Audience get / delete / lookalike ===
     Tool(
         name="meta_ads.audiences.get",
-        description="Get Meta Ads custom audience details",
+        description=(
+            "Fetches the full detail record for a single Custom Audience, "
+            "including the rule definition and approximate_count. "
+            "Returns id, name, subtype, description, retention_days, "
+            "approximate_count, data_source, rule (for rule-based "
+            "audiences), and pixel_id (for WEBSITE audiences). "
+            "Read-only. Call this before meta_ads.audiences.delete or "
+            "before create_lookalike to verify you have the right audience."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "audience_id": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": (
+                        "Audience ID as returned by " "meta_ads.audiences.list."
+                    ),
                 },
-                "audience_id": {"type": "string", "description": "Audience ID"},
             },
             "required": ["audience_id"],
         },
     ),
     Tool(
         name="meta_ads.audiences.delete",
-        description="Delete a Meta Ads custom audience",
+        description=(
+            "Deletes a Custom Audience. Returns a success flag. "
+            "Destructive — any ad sets currently targeting this audience "
+            "lose the targeting source and may stop delivering. Reversible "
+            "via rollback.apply within Meta's standard retention window, "
+            "but re-creation does not restore the original "
+            "approximate_count. Call meta_ads.audiences.get first to "
+            "confirm which ad sets use it (search ad_sets.list targeting "
+            "specs client-side), and consider pausing those ad sets first."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "audience_id": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": "Audience ID to delete.",
                 },
-                "audience_id": {"type": "string", "description": "Audience ID"},
             },
             "required": ["audience_id"],
         },
     ),
     Tool(
         name="meta_ads.audiences.create_lookalike",
-        description="Create a Meta Ads lookalike audience",
+        description=(
+            "Creates a Lookalike Audience from an existing source "
+            "audience. Returns the new audience_id. Mutating, reversible "
+            "via rollback.apply. Lookalikes typically populate within "
+            "24–72h; the approximate_count remains 0 until Meta finishes "
+            "the similarity build. ratio=0.01 gives the top 1% most "
+            "similar users in the target country (smallest, highest "
+            "match); ratio=0.10 gives top 10% (larger reach, looser "
+            "match). For the base audience list use "
+            "meta_ads.audiences.list."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "name": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": (
+                        "Audience name shown in Ads Manager. Must be "
+                        "unique within the account."
+                    ),
                 },
-                "name": {"type": "string", "description": "Audience name"},
                 "source_audience_id": {
                     "type": "string",
-                    "description": "Source custom audience ID",
+                    "description": (
+                        "Source Custom Audience to build the lookalike "
+                        "from. Meta recommends a source of at least "
+                        "1,000–10,000 users for good match quality."
+                    ),
                 },
                 "country": {
-                    "description": "Target country code (string or array)",
+                    "description": (
+                        "Target country ISO code(s) for the lookalike "
+                        "expansion. Accepts a single code string (e.g. "
+                        "'JP') or a list (e.g. ['JP', 'KR']). Lookalike "
+                        "reach is always scoped to the specified "
+                        "country/countries."
+                    ),
                     "oneOf": [
                         {"type": "string"},
                         {"type": "array", "items": {"type": "string"}},
@@ -115,11 +238,25 @@ TOOLS: list[Tool] = [
                 },
                 "ratio": {
                     "type": "number",
-                    "description": "Similarity ratio (0.01=top 1%, max 0.20)",
+                    "minimum": 0.01,
+                    "maximum": 0.20,
+                    "description": (
+                        "Similarity ratio — fraction of the target "
+                        "country's population to include. 0.01 = top 1% "
+                        "(tightest match, smallest audience); 0.20 = top "
+                        "20% (loosest, largest). Meta caps at 0.20."
+                    ),
                 },
                 "starting_ratio": {
                     "type": "number",
-                    "description": "Starting ratio (default: 0.0)",
+                    "minimum": 0.0,
+                    "description": (
+                        "Lower bound of the ratio range. Default 0.0. "
+                        "Advanced: set > 0 to carve out a tiered lookalike "
+                        "that excludes the top-similarity slice (e.g. "
+                        "starting_ratio=0.01, ratio=0.05 = users ranked "
+                        "1–5% in similarity, excluding the top 1%)."
+                    ),
                 },
             },
             "required": [
@@ -134,51 +271,72 @@ TOOLS: list[Tool] = [
     # === Pixels ===
     Tool(
         name="meta_ads.pixels.list",
-        description="List Meta Ads pixels",
+        description=(
+            "Lists Meta Pixels available in the ad account. Returns id, "
+            "name, code (the base pixel snippet), last_fired_time, and "
+            "is_created_by_business per pixel. Read-only. Use this to "
+            "find a pixel_id before creating a WEBSITE audience "
+            "(meta_ads.audiences.create) or fetching event statistics "
+            "(meta_ads.pixels.stats / events)."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
-                    "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
-                },
-                "limit": {
-                    "type": "integer",
-                    "description": "Max results (default: 50)",
-                },
+                "account_id": _ACCOUNT_ID_PARAM,
+                "limit": _LIMIT_PARAM,
             },
             "required": [],
         },
     ),
     Tool(
         name="meta_ads.pixels.get",
-        description="Get Meta Ads pixel details",
+        description=(
+            "Fetches the full detail record for a single Meta Pixel. "
+            "Returns id, name, code, creation_time, last_fired_time, "
+            "owner_business, data_use_setting, and the linked ad_accounts. "
+            "Read-only. Call this to verify pixel setup (e.g. confirm "
+            "last_fired_time is recent) before diagnosing conversion "
+            "tracking issues or before relying on the pixel for audience "
+            "rules."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "pixel_id": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": ("Pixel ID as returned by meta_ads.pixels.list."),
                 },
-                "pixel_id": {"type": "string", "description": "Pixel ID"},
             },
             "required": ["pixel_id"],
         },
     ),
     Tool(
         name="meta_ads.pixels.stats",
-        description="Get Meta Ads pixel event statistics",
+        description=(
+            "Returns aggregated pixel-event counts over a rolling time "
+            "window. Returns an array of {date, event_name, count} rows. "
+            "Read-only. Use this to spot unusual drops in PageView / "
+            "Purchase / Lead volume that indicate a pixel break. For "
+            "per-event metadata (parameter names, sample payloads) use "
+            "meta_ads.pixels.events instead."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "pixel_id": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": "Pixel ID to query.",
                 },
-                "pixel_id": {"type": "string", "description": "Pixel ID"},
                 "period": {
                     "type": "string",
-                    "description": "Aggregation period (last_7d, last_14d, last_30d, last_90d)",
+                    "enum": ["last_7d", "last_14d", "last_30d", "last_90d"],
+                    "description": (
+                        "Aggregation window. Default last_30d. Longer "
+                        "windows cost more Graph API quota but are "
+                        "necessary to spot slow degradations."
+                    ),
                 },
             },
             "required": ["pixel_id"],
@@ -186,15 +344,25 @@ TOOLS: list[Tool] = [
     ),
     Tool(
         name="meta_ads.pixels.events",
-        description="List event types received by a Meta Ads pixel",
+        description=(
+            "Lists distinct event types the pixel has received recently, "
+            "with sample payloads. Returns event_name, sample_count, "
+            "first_seen, last_seen, and a sample_parameters dict per "
+            "event. Read-only. Use this to audit which standard events "
+            "(Purchase, Lead, ViewContent, etc.) and custom events are "
+            "firing, and to inspect parameter names before building "
+            "conversion rules or audience definitions that reference "
+            "them. For aggregate volume over time use "
+            "meta_ads.pixels.stats."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "pixel_id": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": "Pixel ID to inspect.",
                 },
-                "pixel_id": {"type": "string", "description": "Pixel ID"},
             },
             "required": ["pixel_id"],
         },

--- a/mureo/mcp/_tools_meta_ads_catalog.py
+++ b/mureo/mcp/_tools_meta_ads_catalog.py
@@ -1,68 +1,127 @@
-"""Meta Ads tool definitions — Catalog, products, feeds"""
+"""Meta Ads tool definitions — Catalog, products, feeds.
+
+Tool descriptions follow ``docs/tdqs-style-guide.md``. Meta Commerce
+Catalogs hold product records that power Dynamic Product Ads (DPA) and
+Collection creatives. Products can be added one at a time via the API
+or bulk-loaded from a scheduled Feed URL.
+"""
 
 from __future__ import annotations
 
 from mcp.types import Tool
 
+# Reusable parameter fragments.
+_ACCOUNT_ID_PARAM = {
+    "type": "string",
+    "description": (
+        "Meta Ads account ID in the format 'act_XXXXXXXXXX' (e.g. "
+        "'act_1234567890'). Optional — falls back to META_ADS_ACCOUNT_ID "
+        "from the configured credentials. The leading 'act_' prefix is "
+        "required."
+    ),
+}
+
 TOOLS: list[Tool] = [
     # === Catalog (Product Catalog & DPA) ===
     Tool(
         name="meta_ads.catalogs.list",
-        description="List Meta Ads product catalogs",
+        description=(
+            "Lists Meta Commerce Catalogs owned by a Business. Returns "
+            "id, name, product_count, vertical (commerce / hotels / "
+            "flights / home_listings / destinations), and "
+            "feed_count per catalog. Read-only. Use this to find a "
+            "catalog_id before calling meta_ads.catalogs.get / delete or "
+            "managing products / feeds underneath."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "business_id": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": (
+                        "Meta Business ID that owns the catalogs. "
+                        "Catalogs live at the Business level, not the "
+                        "ad-account level — the Business ID is required "
+                        "here."
+                    ),
                 },
-                "business_id": {"type": "string", "description": "Business ID"},
             },
             "required": ["business_id"],
         },
     ),
     Tool(
         name="meta_ads.catalogs.create",
-        description="Create a Meta Ads product catalog",
+        description=(
+            "Creates a new Product Catalog under a Meta Business. Returns "
+            "the new catalog_id. Mutating, reversible via rollback.apply "
+            "(rollback deletes the catalog if it has no ads consuming "
+            "it). Catalogs are the container — add products individually "
+            "via meta_ads.products.add, or schedule bulk imports via "
+            "meta_ads.feeds.create."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "business_id": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": ("Meta Business ID that will own the new catalog."),
                 },
-                "business_id": {"type": "string", "description": "Business ID"},
-                "name": {"type": "string", "description": "Catalog name"},
+                "name": {
+                    "type": "string",
+                    "description": (
+                        "Catalog name shown in Commerce Manager. Must be "
+                        "unique within the Business."
+                    ),
+                },
             },
             "required": ["business_id", "name"],
         },
     ),
     Tool(
         name="meta_ads.catalogs.get",
-        description="Get Meta Ads product catalog details",
+        description=(
+            "Fetches the full detail record for a single Product Catalog. "
+            "Returns id, name, product_count, vertical, feed_count, "
+            "owner_business_id, and the linked ad_accounts. Read-only. "
+            "Call this before meta_ads.catalogs.delete or before building "
+            "a Collection creative (meta_ads.creatives.create_collection) "
+            "to verify product_count > 0."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "catalog_id": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": (
+                        "Catalog ID as returned by meta_ads.catalogs.list."
+                    ),
                 },
-                "catalog_id": {"type": "string", "description": "Catalog ID"},
             },
             "required": ["catalog_id"],
         },
     ),
     Tool(
         name="meta_ads.catalogs.delete",
-        description="Delete a Meta Ads product catalog",
+        description=(
+            "Deletes a Product Catalog. Returns a success flag. "
+            "Destructive and cascades — all products inside and any DPA "
+            "campaigns consuming the catalog lose their product source "
+            "and stop serving dynamic ads. Reversible via rollback.apply "
+            "only if no ad consuming the catalog has served since "
+            "deletion. Always call meta_ads.catalogs.get first to check "
+            "product_count and operator-confirm before calling this."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "catalog_id": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": "Catalog ID to delete.",
                 },
-                "catalog_id": {"type": "string", "description": "Catalog ID"},
             },
             "required": ["catalog_id"],
         },
@@ -70,18 +129,30 @@ TOOLS: list[Tool] = [
     # === Products ===
     Tool(
         name="meta_ads.products.list",
-        description="List products in a Meta Ads catalog",
+        description=(
+            "Lists products in a Product Catalog. Returns id, "
+            "retailer_id (advertiser's SKU), name, availability, price, "
+            "image_url, brand, and category per product. Read-only. "
+            "Default limit 100 (max 1000). Use this to locate product_ids "
+            "for use in meta_ads.creatives.create_collection or to audit "
+            "feed health (missing price / broken image_url)."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "catalog_id": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": "Catalog whose products to list.",
                 },
-                "catalog_id": {"type": "string", "description": "Catalog ID"},
                 "limit": {
                     "type": "integer",
-                    "description": "Max results (default: 100)",
+                    "minimum": 1,
+                    "maximum": 1000,
+                    "description": (
+                        "Maximum products returned per call. Default 100, "
+                        "max 1000 per Meta Graph API."
+                    ),
                 },
             },
             "required": ["catalog_id"],
@@ -89,33 +160,107 @@ TOOLS: list[Tool] = [
     ),
     Tool(
         name="meta_ads.products.add",
-        description="Add a product to a Meta Ads catalog",
+        description=(
+            "Adds a single product to a Meta Product Catalog. Returns the "
+            "new product_id. Mutating, reversible via rollback.apply. "
+            "For bulk ingestion prefer a scheduled feed "
+            "(meta_ads.feeds.create) — Meta rate-limits single-product "
+            "adds aggressively. Meta requires a stable retailer_id per "
+            "product; adding a second product with the same retailer_id "
+            "updates the existing record rather than creating a "
+            "duplicate."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "catalog_id": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": "Catalog to add the product into.",
                 },
-                "catalog_id": {"type": "string", "description": "Catalog ID"},
-                "retailer_id": {"type": "string", "description": "Product SKU/ID"},
-                "name": {"type": "string", "description": "Product name"},
-                "description": {"type": "string", "description": "Product description"},
+                "retailer_id": {
+                    "type": "string",
+                    "description": (
+                        "Advertiser's stable SKU / product identifier. "
+                        "Used as the upsert key — a second add with the "
+                        "same retailer_id updates the existing product."
+                    ),
+                },
+                "name": {
+                    "type": "string",
+                    "description": (
+                        "Product display name shown in DPA / Collection " "ads."
+                    ),
+                },
+                "description": {
+                    "type": "string",
+                    "description": (
+                        "Product description. Shown on some placements "
+                        "and surfaces; Meta also uses it as a weak "
+                        "targeting signal."
+                    ),
+                },
                 "availability": {
                     "type": "string",
-                    "description": "Availability (in stock, out of stock etc.)",
+                    "enum": [
+                        "in stock",
+                        "out of stock",
+                        "preorder",
+                        "available for order",
+                        "discontinued",
+                    ],
+                    "description": (
+                        "Inventory status. Meta suppresses 'out of stock' "
+                        "and 'discontinued' items from DPA delivery."
+                    ),
                 },
                 "condition": {
                     "type": "string",
-                    "description": "Product condition (new, refurbished, used)",
+                    "enum": ["new", "refurbished", "used"],
+                    "description": (
+                        "Product condition. Required by Meta for catalog "
+                        "eligibility in most verticals."
+                    ),
                 },
-                "price": {"type": "string", "description": "Price (e.g. '1000 JPY')"},
-                "url": {"type": "string", "description": "Product URL"},
-                "image_url": {"type": "string", "description": "Product image URL"},
-                "brand": {"type": "string", "description": "Brand name"},
+                "price": {
+                    "type": "string",
+                    "description": (
+                        "Price as a string with currency code, e.g. "
+                        "'1000 JPY', '9.99 USD'. Meta parses the string "
+                        "into amount + ISO currency. Must match the "
+                        "catalog's supported currencies."
+                    ),
+                },
+                "url": {
+                    "type": "string",
+                    "description": (
+                        "Product landing page URL. Must be HTTPS and "
+                        "reachable — Meta periodically probes URLs and "
+                        "marks broken ones."
+                    ),
+                },
+                "image_url": {
+                    "type": "string",
+                    "description": (
+                        "Primary product image URL. HTTPS, publicly "
+                        "fetchable. Meta recommends at least 500×500px."
+                    ),
+                },
+                "brand": {
+                    "type": "string",
+                    "description": (
+                        "Brand name. Optional but improves match quality "
+                        "for broad-intent DPA shoppers."
+                    ),
+                },
                 "category": {
                     "type": "string",
-                    "description": "Category (e.g. 'Clothing > Tops')",
+                    "description": (
+                        "Category path using Google Product Taxonomy "
+                        "format (e.g. 'Apparel & Accessories > "
+                        "Clothing > Tops'). Optional but strongly "
+                        "recommended for multi-category catalogs."
+                    ),
                 },
             },
             "required": [
@@ -133,53 +278,121 @@ TOOLS: list[Tool] = [
     ),
     Tool(
         name="meta_ads.products.get",
-        description="Get Meta Ads product details",
+        description=(
+            "Fetches the full detail record for a single catalog product. "
+            "Returns id, retailer_id, name, description, availability, "
+            "condition, price, currency, url, image_url, brand, category, "
+            "review_status (APPROVED / REJECTED / PENDING), and "
+            "rejection_reasons when applicable. Read-only. Call this "
+            "when DPA delivery stalls for a specific product to check "
+            "review_status — rejected products are excluded from ads."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "product_id": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": (
+                        "Meta-assigned product_id as returned by "
+                        "meta_ads.products.list (not the retailer_id)."
+                    ),
                 },
-                "product_id": {"type": "string", "description": "Product ID"},
             },
             "required": ["product_id"],
         },
     ),
     Tool(
         name="meta_ads.products.update",
-        description="Update a Meta Ads product",
+        description=(
+            "Updates one or more fields on an existing catalog product. "
+            "Partial update — only supplied fields are changed. Returns "
+            "the updated product. Mutating, reversible via rollback.apply "
+            "(rollback restores prior field values). For availability "
+            "toggles (in stock ↔ out of stock) this is the correct entry "
+            "point; for full record replacement call meta_ads.products."
+            "add with the same retailer_id (the add is upsert-semantic)."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "product_id": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": "Meta-assigned product_id to update.",
                 },
-                "product_id": {"type": "string", "description": "Product ID"},
-                "name": {"type": "string", "description": "Product name"},
-                "description": {"type": "string", "description": "Product description"},
-                "availability": {"type": "string", "description": "Availability"},
-                "price": {"type": "string", "description": "Price"},
-                "url": {"type": "string", "description": "Product URL"},
-                "image_url": {"type": "string", "description": "Product image URL"},
-                "brand": {"type": "string", "description": "Brand name"},
-                "category": {"type": "string", "description": "Category"},
+                "name": {
+                    "type": "string",
+                    "description": "New product display name.",
+                },
+                "description": {
+                    "type": "string",
+                    "description": "New product description.",
+                },
+                "availability": {
+                    "type": "string",
+                    "enum": [
+                        "in stock",
+                        "out of stock",
+                        "preorder",
+                        "available for order",
+                        "discontinued",
+                    ],
+                    "description": (
+                        "New inventory status. Meta suppresses 'out of "
+                        "stock' / 'discontinued' from DPA delivery."
+                    ),
+                },
+                "price": {
+                    "type": "string",
+                    "description": (
+                        "New price as 'amount ISO_CURRENCY' (e.g. " "'1200 JPY')."
+                    ),
+                },
+                "url": {
+                    "type": "string",
+                    "description": "New landing page URL (HTTPS).",
+                },
+                "image_url": {
+                    "type": "string",
+                    "description": (
+                        "New primary image URL (HTTPS, publicly " "fetchable)."
+                    ),
+                },
+                "brand": {
+                    "type": "string",
+                    "description": "New brand name.",
+                },
+                "category": {
+                    "type": "string",
+                    "description": (
+                        "New category path in Google Product Taxonomy " "format."
+                    ),
+                },
             },
             "required": ["product_id"],
         },
     ),
     Tool(
         name="meta_ads.products.delete",
-        description="Delete a Meta Ads product",
+        description=(
+            "Deletes a single catalog product. Returns a success flag. "
+            "Destructive — DPA / Collection ads that referenced this "
+            "product_id will skip it on the next serve cycle. Reversible "
+            "via rollback.apply (re-adds with the same retailer_id), but "
+            "the Meta-assigned product_id changes on re-add, which can "
+            "break hard-coded downstream references. For temporary "
+            "suppression use meta_ads.products.update with "
+            "availability='out of stock' instead."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "product_id": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": "Product ID to delete.",
                 },
-                "product_id": {"type": "string", "description": "Product ID"},
             },
             "required": ["product_id"],
         },
@@ -187,35 +400,71 @@ TOOLS: list[Tool] = [
     # === Feeds ===
     Tool(
         name="meta_ads.feeds.list",
-        description="List feeds in a Meta Ads catalog",
+        description=(
+            "Lists product feeds configured for a Product Catalog. "
+            "Returns id, name, schedule (HOURLY / DAILY / WEEKLY), "
+            "feed_url, file_name, latest_upload {timestamp, status, "
+            "error_count}, and product_count per feed. Read-only. Use "
+            "this to audit feed health — a feed with latest_upload.status "
+            "= FAILED or high error_count is the most common cause of "
+            "missing products in DPA."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "catalog_id": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": "Catalog whose feeds to list.",
                 },
-                "catalog_id": {"type": "string", "description": "Catalog ID"},
             },
             "required": ["catalog_id"],
         },
     ),
     Tool(
         name="meta_ads.feeds.create",
-        description="Create a feed in a Meta Ads catalog (by URL, with scheduled import)",
+        description=(
+            "Creates a scheduled product feed that imports products into "
+            "a catalog from a URL. Returns the new feed_id. Mutating, "
+            "reversible via rollback.apply. Feeds run automatically on "
+            "the chosen schedule; the first run triggers shortly after "
+            "creation. For one-off product adds use "
+            "meta_ads.products.add — feeds are for ongoing bulk sync. "
+            "Supported feed formats: CSV, TSV, RSS 2.0, Atom 1.0, JSON."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "catalog_id": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": "Catalog that will consume the feed.",
                 },
-                "catalog_id": {"type": "string", "description": "Catalog ID"},
-                "name": {"type": "string", "description": "Feed name"},
-                "feed_url": {"type": "string", "description": "Feed URL"},
+                "name": {
+                    "type": "string",
+                    "description": (
+                        "Feed name shown in Commerce Manager. Should be "
+                        "unique within the catalog."
+                    ),
+                },
+                "feed_url": {
+                    "type": "string",
+                    "description": (
+                        "HTTPS URL Meta will fetch on each scheduled run. "
+                        "Must be publicly reachable. Meta supports basic "
+                        "auth or signed-URL patterns if configured "
+                        "separately."
+                    ),
+                },
                 "schedule": {
                     "type": "string",
-                    "description": "Import schedule (DAILY, HOURLY, WEEKLY. Default: DAILY)",
+                    "enum": ["HOURLY", "DAILY", "WEEKLY"],
+                    "description": (
+                        "How often Meta re-fetches and re-ingests the "
+                        "feed. Default DAILY. HOURLY is appropriate for "
+                        "fast-moving inventory (fashion flash sales); "
+                        "WEEKLY fits evergreen catalogs."
+                    ),
                 },
             },
             "required": ["catalog_id", "name", "feed_url"],

--- a/mureo/mcp/_tools_meta_ads_conversions.py
+++ b/mureo/mcp/_tools_meta_ads_conversions.py
@@ -1,51 +1,144 @@
-"""Meta Ads tool definitions — Conversions (CAPI)"""
+"""Meta Ads tool definitions — Conversions API (CAPI).
+
+Tool descriptions follow ``docs/tdqs-style-guide.md``. The Conversions
+API lets advertisers send server-side events directly to Meta rather
+than relying on the browser pixel. Server events are attributed to the
+same pixel and appear alongside browser events in reporting. mureo
+hashes PII fields (em, ph, fn, ln, zip) with SHA-256 before
+transmission as required by Meta.
+"""
 
 from __future__ import annotations
 
 from mcp.types import Tool
 
+# Reusable parameter fragments.
+_ACCOUNT_ID_PARAM = {
+    "type": "string",
+    "description": (
+        "Meta Ads account ID in the format 'act_XXXXXXXXXX' (e.g. "
+        "'act_1234567890'). Optional — falls back to META_ADS_ACCOUNT_ID "
+        "from the configured credentials. The leading 'act_' prefix is "
+        "required."
+    ),
+}
+
+_PIXEL_ID_PARAM = {
+    "type": "string",
+    "description": (
+        "Meta Pixel ID the event is attributed to. Find via "
+        "meta_ads.pixels.list. CAPI events flow into the same pixel as "
+        "browser events; dedupe happens on event_id if one is supplied "
+        "in user_data / custom_data."
+    ),
+}
+
+_USER_DATA_DESCRIPTION = (
+    "User identifying fields for attribution. Supported keys: em "
+    "(email), ph (phone), fn (first_name), ln (last_name), zp (zip), "
+    "ct (city), st (state), country, external_id, client_ip_address, "
+    "client_user_agent, fbc (click ID), fbp (browser ID). mureo hashes "
+    "em / ph / fn / ln / zp / ct / st / country / external_id with "
+    "SHA-256 before sending — pass raw PII; do not pre-hash."
+)
+
+_TEST_EVENT_CODE_DESCRIPTION = (
+    "Meta Events Manager test_event_code. When set, the event is "
+    "routed to the test event stream visible in Events Manager instead "
+    "of production reporting. Use for validation; drop the field once "
+    "verified. Get the code from Events Manager → Test Events tab."
+)
+
+_EVENT_SOURCE_URL_DESCRIPTION = (
+    "Fully-qualified URL where the event occurred. Required by Meta "
+    "for action_source='website' events; recommended for any "
+    "browser-triggered CAPI event to improve attribution match rate."
+)
+
 TOOLS: list[Tool] = [
     # === Conversions (CAPI) ===
     Tool(
         name="meta_ads.conversions.send",
-        description="Send a conversion event via Meta Ads Conversions API (generic)",
+        description=(
+            "Sends a batch of arbitrary conversion events to the Meta "
+            "Conversions API. Returns Meta's response including "
+            "events_received and messages (warnings for missing fields). "
+            "Mutating on Meta's side — events become part of the pixel's "
+            "attribution stream. For common event types prefer the "
+            "dedicated meta_ads.conversions.send_purchase or "
+            "send_lead helpers, which enforce required fields and fewer "
+            "mistakes. For other event names (AddToCart, InitiateCheckout, "
+            "CompleteRegistration, custom events) use this generic tool."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
-                    "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
-                },
-                "pixel_id": {"type": "string", "description": "Meta Pixel ID"},
+                "account_id": _ACCOUNT_ID_PARAM,
+                "pixel_id": _PIXEL_ID_PARAM,
                 "events": {
                     "type": "array",
-                    "description": "List of event data",
+                    "minItems": 1,
+                    "description": (
+                        "Event payloads to send. Meta batches are "
+                        "typically ≤1000 events per call."
+                    ),
                     "items": {
                         "type": "object",
                         "properties": {
                             "event_name": {
                                 "type": "string",
-                                "description": "Event name (Purchase, Lead etc.)",
+                                "description": (
+                                    "Standard event name (Purchase, Lead, "
+                                    "AddToCart, InitiateCheckout, "
+                                    "ViewContent, Search, Subscribe, "
+                                    "CompleteRegistration, AddPaymentInfo) "
+                                    "or a custom event string."
+                                ),
                             },
                             "event_time": {
                                 "type": "integer",
-                                "description": "Event timestamp (UNIX timestamp)",
+                                "description": (
+                                    "UNIX timestamp (seconds) the event "
+                                    "occurred. Must be within the last "
+                                    "7 days; older events are rejected."
+                                ),
                             },
                             "action_source": {
                                 "type": "string",
-                                "description": "Action source (website etc.)",
+                                "enum": [
+                                    "website",
+                                    "email",
+                                    "app",
+                                    "phone_call",
+                                    "chat",
+                                    "physical_store",
+                                    "system_generated",
+                                    "business_messaging",
+                                    "other",
+                                ],
+                                "description": (
+                                    "Where the conversion happened. "
+                                    "Meta uses this to score attribution "
+                                    "quality; 'website' is the most "
+                                    "common for CAPI."
+                                ),
                             },
                             "user_data": {
                                 "type": "object",
-                                "description": "User data (em, ph etc. will be SHA-256 hashed)",
+                                "description": _USER_DATA_DESCRIPTION,
                             },
                             "custom_data": {
                                 "type": "object",
-                                "description": "Custom data (currency, value etc.)",
+                                "description": (
+                                    "Event-specific metadata. Common "
+                                    "keys: currency (ISO), value (number), "
+                                    "content_ids (array), content_type, "
+                                    "order_id, num_items, contents."
+                                ),
                             },
                             "event_source_url": {
                                 "type": "string",
-                                "description": "Event source URL",
+                                "description": _EVENT_SOURCE_URL_DESCRIPTION,
                             },
                         },
                         "required": [
@@ -58,7 +151,7 @@ TOOLS: list[Tool] = [
                 },
                 "test_event_code": {
                     "type": "string",
-                    "description": "Test event code (for test mode)",
+                    "description": _TEST_EVENT_CODE_DESCRIPTION,
                 },
             },
             "required": ["pixel_id", "events"],
@@ -66,40 +159,66 @@ TOOLS: list[Tool] = [
     ),
     Tool(
         name="meta_ads.conversions.send_purchase",
-        description="Send a purchase event via Meta Ads Conversions API",
+        description=(
+            "Sends a single Purchase event via the Meta Conversions API — "
+            "the most common CAPI use case. Returns Meta's "
+            "events_received acknowledgement. Mutating on Meta's side. "
+            "Required fields model a typical purchase: amount, currency, "
+            "and hashed user identifiers. For other event types use "
+            "meta_ads.conversions.send_lead (leads) or the generic "
+            "meta_ads.conversions.send (AddToCart / custom events / "
+            "batching multiple events)."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
-                    "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
-                },
-                "pixel_id": {"type": "string", "description": "Meta Pixel ID"},
+                "account_id": _ACCOUNT_ID_PARAM,
+                "pixel_id": _PIXEL_ID_PARAM,
                 "event_time": {
                     "type": "integer",
-                    "description": "Event timestamp (UNIX timestamp)",
+                    "description": (
+                        "UNIX timestamp (seconds) of the purchase. Must "
+                        "be within the last 7 days."
+                    ),
                 },
                 "user_data": {
                     "type": "object",
-                    "description": "User data (em, ph etc. will be SHA-256 hashed)",
+                    "description": _USER_DATA_DESCRIPTION,
                 },
                 "currency": {
                     "type": "string",
-                    "description": "Currency code (USD, JPY etc.)",
+                    "description": (
+                        "ISO 4217 currency code (USD, JPY, EUR, GBP). "
+                        "Must match the ad account's reporting currency "
+                        "or be one that Meta can convert."
+                    ),
                 },
-                "value": {"type": "number", "description": "Purchase amount"},
+                "value": {
+                    "type": "number",
+                    "minimum": 0,
+                    "description": (
+                        "Purchase amount in the specified currency. "
+                        "Decimal for currencies with minor units (USD "
+                        "9.99); integer is fine for JPY."
+                    ),
+                },
                 "content_ids": {
                     "type": "array",
                     "items": {"type": "string"},
-                    "description": "List of product IDs",
+                    "description": (
+                        "Product IDs associated with the purchase — "
+                        "catalog retailer_ids for DPA attribution. "
+                        "Optional but recommended when a catalog is in "
+                        "use."
+                    ),
                 },
                 "event_source_url": {
                     "type": "string",
-                    "description": "Event source URL",
+                    "description": _EVENT_SOURCE_URL_DESCRIPTION,
                 },
                 "test_event_code": {
                     "type": "string",
-                    "description": "Test event code",
+                    "description": _TEST_EVENT_CODE_DESCRIPTION,
                 },
             },
             "required": [
@@ -114,30 +233,38 @@ TOOLS: list[Tool] = [
     ),
     Tool(
         name="meta_ads.conversions.send_lead",
-        description="Send a lead event via Meta Ads Conversions API",
+        description=(
+            "Sends a single Lead event via the Meta Conversions API. "
+            "Returns Meta's events_received acknowledgement. Mutating on "
+            "Meta's side. Use for form submissions, trial signups, "
+            "demo requests — anything where a prospect identifies "
+            "themselves but no money changes hands. For money-moving "
+            "events use meta_ads.conversions.send_purchase. For "
+            "non-standard event names use meta_ads.conversions.send."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
-                    "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
-                },
-                "pixel_id": {"type": "string", "description": "Meta Pixel ID"},
+                "account_id": _ACCOUNT_ID_PARAM,
+                "pixel_id": _PIXEL_ID_PARAM,
                 "event_time": {
                     "type": "integer",
-                    "description": "Event timestamp (UNIX timestamp)",
+                    "description": (
+                        "UNIX timestamp (seconds) the lead occurred. "
+                        "Must be within the last 7 days."
+                    ),
                 },
                 "user_data": {
                     "type": "object",
-                    "description": "User data (em, ph etc. will be SHA-256 hashed)",
+                    "description": _USER_DATA_DESCRIPTION,
                 },
                 "event_source_url": {
                     "type": "string",
-                    "description": "Event source URL",
+                    "description": _EVENT_SOURCE_URL_DESCRIPTION,
                 },
                 "test_event_code": {
                     "type": "string",
-                    "description": "Test event code",
+                    "description": _TEST_EVENT_CODE_DESCRIPTION,
                 },
             },
             "required": ["pixel_id", "event_time", "user_data"],

--- a/mureo/mcp/_tools_meta_ads_creatives.py
+++ b/mureo/mcp/_tools_meta_ads_creatives.py
@@ -1,24 +1,70 @@
-"""Meta Ads tool definitions — Creatives, images, videos"""
+"""Meta Ads tool definitions — Creatives, images, videos.
+
+Tool descriptions follow ``docs/tdqs-style-guide.md``. Creatives are the
+visual+copy payload attached to Meta ads; images and videos are the
+underlying media assets. Flow: upload media → obtain image_hash /
+video_id → create creative → attach creative to an ad via
+meta_ads.ads.create.
+"""
 
 from __future__ import annotations
 
 from mcp.types import Tool
 
+# Reusable parameter fragments.
+_ACCOUNT_ID_PARAM = {
+    "type": "string",
+    "description": (
+        "Meta Ads account ID in the format 'act_XXXXXXXXXX' (e.g. "
+        "'act_1234567890'). Optional — falls back to META_ADS_ACCOUNT_ID "
+        "from the configured credentials. The leading 'act_' prefix is "
+        "required."
+    ),
+}
+
+_PAGE_ID_PARAM = {
+    "type": "string",
+    "description": (
+        "Facebook Page ID that the ad will be published as. Must be a "
+        "page the authenticated user has permission to post from. "
+        "Required by Meta for every creative — ads cannot run without a "
+        "page identity."
+    ),
+}
+
+_CTA_DESCRIPTION = (
+    "Call-to-action button label. Valid values include LEARN_MORE, "
+    "SIGN_UP, SHOP_NOW, DOWNLOAD, CONTACT_US, SUBSCRIBE, GET_QUOTE, "
+    "BOOK_TRAVEL, APPLY_NOW. Omit to render no button (link tap still "
+    "works). The valid set depends on the parent campaign's objective."
+)
+
 TOOLS: list[Tool] = [
     # === Creative list / create / dynamic / upload_image ===
     Tool(
         name="meta_ads.creatives.list",
-        description="List Meta Ads AdCreatives",
+        description=(
+            "Lists AdCreative resources in a Meta Ads account. Returns id, "
+            "name, status, object_story_id, call_to_action_type, and "
+            "thumbnail_url per creative. Read-only — does not modify the "
+            "account. Default limit is 50 creatives per call (max 1000); "
+            "for larger inventories use smaller limits and filter client-"
+            "side. Use this to audit creative inventory or to find a "
+            "creative_id for reuse in meta_ads.ads.create. To list the ads "
+            "that consume these creatives, use meta_ads.ads.list."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
-                    "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
-                },
+                "account_id": _ACCOUNT_ID_PARAM,
                 "limit": {
                     "type": "integer",
-                    "description": "Max results (default: 50)",
+                    "minimum": 1,
+                    "maximum": 1000,
+                    "description": (
+                        "Max creatives returned in a single call. Default "
+                        "50, maximum 1000 per Meta Graph API."
+                    ),
                 },
             },
             "required": [],
@@ -26,31 +72,90 @@ TOOLS: list[Tool] = [
     ),
     Tool(
         name="meta_ads.creatives.create",
-        description="Create a Meta Ads AdCreative (specify image URL or image_hash)",
+        description=(
+            "Creates a single-image Meta Ads AdCreative. Returns the new "
+            "creative's id and object_story_id. Mutating, reversible via "
+            "rollback.apply (rollback soft-deletes the creative). Supply "
+            "exactly one of image_url or image_hash — image_url triggers "
+            "Meta to fetch and host the image; image_hash references an "
+            "image already uploaded via meta_ads.creatives.upload_image or "
+            "meta_ads.images.upload_file. For multi-image carousels use "
+            "meta_ads.creatives.create_carousel; for dynamic / automatic "
+            "optimization use meta_ads.creatives.create_dynamic."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "name": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": (
+                        "Creative name shown in Ads Manager. Internal "
+                        "label — not visible to end users."
+                    ),
                 },
-                "name": {"type": "string", "description": "Creative name"},
-                "page_id": {"type": "string", "description": "Facebook page ID"},
-                "link_url": {"type": "string", "description": "Destination URL"},
+                "page_id": _PAGE_ID_PARAM,
+                "link_url": {
+                    "type": "string",
+                    "description": (
+                        "Destination URL the ad links to when tapped. "
+                        "Must be HTTPS and domain-verified on the ad "
+                        "account."
+                    ),
+                },
                 "image_url": {
                     "type": "string",
-                    "description": "Image URL (mutually exclusive with image_hash)",
+                    "description": (
+                        "Public HTTPS image URL. Meta fetches and hosts "
+                        "the asset. Mutually exclusive with image_hash — "
+                        "supply exactly one of them."
+                    ),
                 },
                 "image_hash": {
                     "type": "string",
-                    "description": "Uploaded image hash (mutually exclusive with image_url)",
+                    "description": (
+                        "Image hash returned from "
+                        "meta_ads.creatives.upload_image / "
+                        "meta_ads.images.upload_file. Mutually exclusive "
+                        "with image_url."
+                    ),
                 },
-                "message": {"type": "string", "description": "Ad body text"},
-                "headline": {"type": "string", "description": "Headline"},
-                "description": {"type": "string", "description": "Description"},
+                "message": {
+                    "type": "string",
+                    "description": (
+                        "Primary ad body text shown above the image. "
+                        "Plain text, emoji allowed. Meta recommends ≤125 "
+                        "characters to avoid truncation on mobile."
+                    ),
+                },
+                "headline": {
+                    "type": "string",
+                    "description": (
+                        "Headline shown below the image. ~40 characters "
+                        "fits most placements without truncation."
+                    ),
+                },
+                "description": {
+                    "type": "string",
+                    "description": (
+                        "Description / link-caption text shown below the "
+                        "headline. Optional; not all placements render it."
+                    ),
+                },
                 "call_to_action": {
                     "type": "string",
-                    "description": "CTA button type (LEARN_MORE, SIGN_UP etc.)",
+                    "enum": [
+                        "LEARN_MORE",
+                        "SIGN_UP",
+                        "SHOP_NOW",
+                        "DOWNLOAD",
+                        "CONTACT_US",
+                        "SUBSCRIBE",
+                        "GET_QUOTE",
+                        "BOOK_TRAVEL",
+                        "APPLY_NOW",
+                    ],
+                    "description": _CTA_DESCRIPTION,
                 },
             },
             "required": ["name", "page_id", "link_url"],
@@ -58,41 +163,85 @@ TOOLS: list[Tool] = [
     ),
     Tool(
         name="meta_ads.creatives.create_dynamic",
-        description="Create a Meta Ads dynamic creative AdCreative (Meta auto-optimization)",
+        description=(
+            "Creates a Dynamic Creative — Meta auto-generates and "
+            "optimises combinations from multiple images, headlines, "
+            "bodies, and CTAs. Returns the new creative id. Mutating, "
+            "reversible via rollback.apply. Use when you want Meta to "
+            "learn the best-performing asset mix rather than testing "
+            "manually. For static single-image ads use "
+            "meta_ads.creatives.create; for explicitly-controlled multi-"
+            "card layouts use meta_ads.creatives.create_carousel. Supply "
+            "2–10 images, 1–5 of each text field; Meta combines them at "
+            "serve time."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "name": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": "Creative name shown in Ads Manager.",
                 },
-                "name": {"type": "string", "description": "Creative name"},
-                "page_id": {"type": "string", "description": "Facebook page ID"},
+                "page_id": _PAGE_ID_PARAM,
                 "image_hashes": {
                     "type": "array",
                     "items": {"type": "string"},
-                    "description": "List of image hashes (2 to 10 recommended)",
+                    "minItems": 1,
+                    "maxItems": 10,
+                    "description": (
+                        "Image hashes to include in the rotation. 2–10 "
+                        "recommended for meaningful optimization; Meta "
+                        "accepts up to 10. Upload via "
+                        "meta_ads.creatives.upload_image / "
+                        "meta_ads.images.upload_file first."
+                    ),
                 },
                 "bodies": {
                     "type": "array",
                     "items": {"type": "string"},
-                    "description": "List of ad body texts",
+                    "minItems": 1,
+                    "maxItems": 5,
+                    "description": (
+                        "Primary body text variants. 1–5 accepted. Meta "
+                        "recommends ≤125 characters per body."
+                    ),
                 },
                 "titles": {
                     "type": "array",
                     "items": {"type": "string"},
-                    "description": "List of headlines",
+                    "minItems": 1,
+                    "maxItems": 5,
+                    "description": (
+                        "Headline variants. 1–5 accepted. ~40 characters "
+                        "fits most placements."
+                    ),
                 },
-                "link_url": {"type": "string", "description": "Destination URL"},
+                "link_url": {
+                    "type": "string",
+                    "description": (
+                        "Destination URL shared across all combinations. "
+                        "Must be HTTPS and domain-verified."
+                    ),
+                },
                 "descriptions": {
                     "type": "array",
                     "items": {"type": "string"},
-                    "description": "List of descriptions (optional)",
+                    "maxItems": 5,
+                    "description": (
+                        "Optional link-caption variants (0–5). Not all "
+                        "placements render these."
+                    ),
                 },
                 "call_to_actions": {
                     "type": "array",
                     "items": {"type": "string"},
-                    "description": "List of CTA types (optional)",
+                    "maxItems": 5,
+                    "description": (
+                        "Optional CTA variants (0–5). Values drawn from "
+                        "the same set as meta_ads.creatives.create "
+                        "(LEARN_MORE / SIGN_UP / SHOP_NOW / etc.)."
+                    ),
                 },
             },
             "required": [
@@ -108,17 +257,25 @@ TOOLS: list[Tool] = [
     ),
     Tool(
         name="meta_ads.creatives.upload_image",
-        description="Upload an image to Meta Ads by URL (to get image_hash)",
+        description=(
+            "Uploads an image to the Meta Ads account by fetching it from "
+            "a public HTTPS URL. Returns the image_hash that can be "
+            "referenced in meta_ads.creatives.create / create_dynamic / "
+            "create_carousel. Mutating — the image is persisted in the "
+            "account library. For uploads from local files (not URLs) use "
+            "meta_ads.images.upload_file instead."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
-                    "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
-                },
+                "account_id": _ACCOUNT_ID_PARAM,
                 "image_url": {
                     "type": "string",
-                    "description": "Source image URL",
+                    "description": (
+                        "Public HTTPS URL of the image. Meta fetches it "
+                        "once at upload time — subsequent changes to the "
+                        "source URL do not affect the stored asset."
+                    ),
                 },
             },
             "required": ["image_url"],
@@ -127,69 +284,140 @@ TOOLS: list[Tool] = [
     # === Carousel & Collection ===
     Tool(
         name="meta_ads.creatives.create_carousel",
-        description="Create a Meta Ads carousel creative (2 to 10 cards)",
+        description=(
+            "Creates a Carousel AdCreative with 2–10 swipeable cards. "
+            "Returns the new creative id. Mutating, reversible via "
+            "rollback.apply. Each card carries its own image (or video), "
+            "name, description, and link — useful for product catalogs or "
+            "multi-step narratives. For auto-optimized asset rotation use "
+            "meta_ads.creatives.create_dynamic; for product-feed-driven "
+            "carousels use meta_ads.creatives.create_collection."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
-                    "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
-                },
-                "page_id": {"type": "string", "description": "Facebook page ID"},
+                "account_id": _ACCOUNT_ID_PARAM,
+                "page_id": _PAGE_ID_PARAM,
                 "cards": {
                     "type": "array",
-                    "description": "List of cards (each containing link, name, image_hash etc.)",
+                    "minItems": 2,
+                    "maxItems": 10,
+                    "description": (
+                        "Carousel cards (2–10). Each card must have a "
+                        "link; image_hash, image_url, or video_id is "
+                        "required for the media."
+                    ),
                     "items": {
                         "type": "object",
                         "properties": {
-                            "link": {"type": "string", "description": "Link URL"},
-                            "name": {"type": "string", "description": "Card name"},
+                            "link": {
+                                "type": "string",
+                                "description": (
+                                    "Destination URL for this card. HTTPS " "required."
+                                ),
+                            },
+                            "name": {
+                                "type": "string",
+                                "description": ("Card headline shown under the media."),
+                            },
                             "description": {
                                 "type": "string",
-                                "description": "Description",
+                                "description": ("Card subtitle / link caption."),
                             },
                             "image_hash": {
                                 "type": "string",
-                                "description": "Image hash",
+                                "description": (
+                                    "Uploaded image hash for this card. "
+                                    "Mutually exclusive with image_url "
+                                    "and video_id."
+                                ),
                             },
-                            "image_url": {"type": "string", "description": "Image URL"},
-                            "video_id": {"type": "string", "description": "Video ID"},
+                            "image_url": {
+                                "type": "string",
+                                "description": (
+                                    "Public HTTPS image URL. Mutually "
+                                    "exclusive with image_hash and "
+                                    "video_id."
+                                ),
+                            },
+                            "video_id": {
+                                "type": "string",
+                                "description": (
+                                    "Uploaded video ID for this card. "
+                                    "Mutually exclusive with image_hash "
+                                    "and image_url."
+                                ),
+                            },
                         },
                         "required": ["link"],
                     },
                 },
-                "link": {"type": "string", "description": "Main link URL"},
-                "name": {"type": "string", "description": "Creative name (optional)"},
+                "link": {
+                    "type": "string",
+                    "description": (
+                        "Main destination URL — used for the See More "
+                        "card and as fallback when a card has no "
+                        "explicit link."
+                    ),
+                },
+                "name": {
+                    "type": "string",
+                    "description": ("Creative name shown in Ads Manager. Optional."),
+                },
             },
             "required": ["page_id", "cards", "link"],
         },
     ),
     Tool(
         name="meta_ads.creatives.create_collection",
-        description="Create a Meta Ads collection creative",
+        description=(
+            "Creates a Collection AdCreative that pulls products from a "
+            "catalog into a mobile-optimized storefront layout. Returns "
+            "the new creative id. Mutating, reversible via rollback.apply. "
+            "Requires a Meta product catalog with the referenced "
+            "product_ids — set up the catalog via meta_ads.catalogs.* "
+            "tools first. For static card decks (non-catalog) use "
+            "meta_ads.creatives.create_carousel instead."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
-                    "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
-                },
-                "page_id": {"type": "string", "description": "Facebook page ID"},
+                "account_id": _ACCOUNT_ID_PARAM,
+                "page_id": _PAGE_ID_PARAM,
                 "product_ids": {
                     "type": "array",
-                    "description": "List of product IDs",
                     "items": {"type": "string"},
+                    "minItems": 1,
+                    "description": (
+                        "Product IDs drawn from the linked Meta catalog. "
+                        "List via meta_ads.products.list."
+                    ),
                 },
-                "link": {"type": "string", "description": "Main link URL"},
+                "link": {
+                    "type": "string",
+                    "description": (
+                        "Main destination URL for the collection. HTTPS " "required."
+                    ),
+                },
                 "cover_image_hash": {
                     "type": "string",
-                    "description": "Cover image hash (optional)",
+                    "description": (
+                        "Cover image hash shown above the product grid. "
+                        "Mutually exclusive with cover_video_id — supply "
+                        "one or neither."
+                    ),
                 },
                 "cover_video_id": {
                     "type": "string",
-                    "description": "Cover video ID (optional)",
+                    "description": (
+                        "Cover video ID shown above the product grid. "
+                        "Mutually exclusive with cover_image_hash."
+                    ),
                 },
-                "name": {"type": "string", "description": "Creative name (optional)"},
+                "name": {
+                    "type": "string",
+                    "description": ("Creative name shown in Ads Manager. Optional."),
+                },
             },
             "required": ["page_id", "product_ids", "link"],
         },
@@ -197,16 +425,32 @@ TOOLS: list[Tool] = [
     # === Image upload ===
     Tool(
         name="meta_ads.images.upload_file",
-        description="Upload an image to Meta Ads from a local file",
+        description=(
+            "Uploads an image from a local file path to the Meta Ads "
+            "account library. Returns the image_hash to reference in "
+            "creative-construction tools. Mutating — the asset is "
+            "persisted. Use this when the image lives on the agent's "
+            "local disk; for public-URL uploads use "
+            "meta_ads.creatives.upload_image instead."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "file_path": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": (
+                        "Path to the image file on the agent's filesystem. "
+                        "Meta accepts JPG, PNG, and GIF up to 30 MB."
+                    ),
                 },
-                "file_path": {"type": "string", "description": "Image file path"},
-                "name": {"type": "string", "description": "Image name (optional)"},
+                "name": {
+                    "type": "string",
+                    "description": (
+                        "Optional label stored with the uploaded asset. "
+                        "Used only for library organization."
+                    ),
+                },
             },
             "required": ["file_path"],
         },
@@ -214,32 +458,66 @@ TOOLS: list[Tool] = [
     # === Video Upload ===
     Tool(
         name="meta_ads.videos.upload",
-        description="Upload a video to Meta Ads by URL",
+        description=(
+            "Uploads a video to the Meta Ads account by fetching it from "
+            "a public HTTPS URL. Returns the video_id to reference in "
+            "creative-construction tools. Mutating — the asset is "
+            "persisted. Meta performs asynchronous processing after "
+            "upload; newly-uploaded videos may take a few minutes before "
+            "they can be attached to ads. For uploads from local files "
+            "use meta_ads.videos.upload_file."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "video_url": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": (
+                        "Public HTTPS URL of the video. Meta fetches it "
+                        "once at upload time. Supported formats: MP4, "
+                        "MOV. Recommended max 4 GB."
+                    ),
                 },
-                "video_url": {"type": "string", "description": "Video URL"},
-                "title": {"type": "string", "description": "Video title (optional)"},
+                "title": {
+                    "type": "string",
+                    "description": (
+                        "Optional title stored with the uploaded video. "
+                        "Used for library organization; not shown in ads."
+                    ),
+                },
             },
             "required": ["video_url"],
         },
     ),
     Tool(
         name="meta_ads.videos.upload_file",
-        description="Upload a video to Meta Ads from a local file",
+        description=(
+            "Uploads a video from a local file path to the Meta Ads "
+            "account library. Returns the video_id to reference in "
+            "creative-construction tools. Mutating. Meta processes the "
+            "video asynchronously after upload — allow a few minutes "
+            "before attaching the video to ads. For uploads from public "
+            "URLs use meta_ads.videos.upload."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "file_path": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": (
+                        "Path to the video file on the agent's filesystem. "
+                        "Supported formats: MP4, MOV. Recommended max 4 GB."
+                    ),
                 },
-                "file_path": {"type": "string", "description": "Video file path"},
-                "title": {"type": "string", "description": "Video title (optional)"},
+                "title": {
+                    "type": "string",
+                    "description": (
+                        "Optional title stored with the uploaded video. "
+                        "Used for library organization; not shown in ads."
+                    ),
+                },
             },
             "required": ["file_path"],
         },

--- a/mureo/mcp/_tools_meta_ads_insights.py
+++ b/mureo/mcp/_tools_meta_ads_insights.py
@@ -1,32 +1,71 @@
-"""Meta Ads tool definitions — Insights, analysis"""
+"""Meta Ads tool definitions — Insights, analysis.
+
+Tool descriptions follow ``docs/tdqs-style-guide.md``. Insights tools
+pull raw delivery metrics straight from the Meta Graph API; analysis
+tools apply mureo-side heuristics (period comparison, outlier
+detection, A/B scoring) on top of those metrics to produce
+operator-ready findings.
+"""
 
 from __future__ import annotations
 
 from mcp.types import Tool
 
+# Reusable parameter fragments.
+_ACCOUNT_ID_PARAM = {
+    "type": "string",
+    "description": (
+        "Meta Ads account ID in the format 'act_XXXXXXXXXX' (e.g. "
+        "'act_1234567890'). Optional — falls back to META_ADS_ACCOUNT_ID "
+        "from the configured credentials. The leading 'act_' prefix is "
+        "required."
+    ),
+}
+
+_PERIOD_PARAM = {
+    "type": "string",
+    "description": (
+        "Analysis window. Accepts Meta predefined ranges ('today', "
+        "'yesterday', 'last_7d', 'last_14d', 'last_30d' (default), "
+        "'last_90d') or explicit 'YYYY-MM-DD..YYYY-MM-DD'. Longer "
+        "windows cost more Graph API quota."
+    ),
+}
+
 TOOLS: list[Tool] = [
     # === Insights ===
     Tool(
         name="meta_ads.insights.report",
-        description="Get Meta Ads performance report",
+        description=(
+            "Pulls raw delivery metrics from Meta Graph API Insights for "
+            "one campaign or the whole account. Returns rows with "
+            "impressions, reach, clicks, spend, cpc, cpm, ctr, "
+            "conversions, cost_per_conversion, and purchase_roas, "
+            "aggregated at the requested level (campaign / adset / ad). "
+            "Read-only. Use this when you need raw metrics; for "
+            "interpreted findings (period comparison, outlier callouts) "
+            "use meta_ads.analysis.performance instead."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
-                    "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
-                },
+                "account_id": _ACCOUNT_ID_PARAM,
                 "campaign_id": {
                     "type": "string",
-                    "description": "Filter by campaign ID",
+                    "description": (
+                        "Restrict to a single campaign. Omit to report "
+                        "across the whole account."
+                    ),
                 },
-                "period": {
-                    "type": "string",
-                    "description": "Period (today, yesterday, last_7d, last_30d etc.)",
-                },
+                "period": _PERIOD_PARAM,
                 "level": {
                     "type": "string",
-                    "description": "Aggregation level (campaign, adset, ad)",
+                    "enum": ["account", "campaign", "adset", "ad"],
+                    "description": (
+                        "Aggregation level. Default 'campaign'. Finer "
+                        "levels (adset, ad) return more rows and consume "
+                        "more Graph quota."
+                    ),
                 },
             },
             "required": [],
@@ -34,20 +73,47 @@ TOOLS: list[Tool] = [
     ),
     Tool(
         name="meta_ads.insights.breakdown",
-        description="Get Meta Ads report with breakdown",
+        description=(
+            "Pulls delivery metrics for a campaign broken down along one "
+            "dimension (age, gender, device_platform, placement, country, "
+            "region, etc.). Returns rows with the breakdown key plus "
+            "impressions, clicks, spend, cpc, ctr, conversions, and "
+            "cost_per_conversion. Read-only. Use this for ad-hoc slicing; "
+            "for pre-packaged splits use the dedicated "
+            "meta_ads.analysis.audience (age/gender) or "
+            "meta_ads.analysis.placements tools, which add "
+            "interpretation."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "campaign_id": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": "Campaign to break down.",
                 },
-                "campaign_id": {"type": "string", "description": "Campaign ID"},
                 "breakdown": {
                     "type": "string",
-                    "description": "Breakdown type (age, gender etc.)",
+                    "enum": [
+                        "age",
+                        "gender",
+                        "age,gender",
+                        "country",
+                        "region",
+                        "device_platform",
+                        "publisher_platform",
+                        "placement",
+                        "impression_device",
+                    ],
+                    "description": (
+                        "Dimension to split by. Meta accepts a single "
+                        "breakdown or a small set joined by commas "
+                        "(e.g. 'age,gender'). Some combinations are "
+                        "rejected by Meta — stick to one breakdown per "
+                        "call when unsure."
+                    ),
                 },
-                "period": {"type": "string", "description": "Period"},
+                "period": _PERIOD_PARAM,
             },
             "required": ["campaign_id"],
         },
@@ -55,117 +121,158 @@ TOOLS: list[Tool] = [
     # === Performance analysis ===
     Tool(
         name="meta_ads.analysis.performance",
-        description="Comprehensively analyze Meta Ads campaign performance (with period comparison and insights)",
+        description=(
+            "Produces an operator-ready performance review for a Meta Ads "
+            "campaign (or the whole account) with period-over-period "
+            "comparison. Returns current-period metrics, prior-period "
+            "metrics (same length immediately before current), delta %, "
+            "and a ranked list of callouts (e.g. 'CPA up 32% week-over-"
+            "week', 'impressions down 45%'). Read-only. Use this at the "
+            "start of an audit — it narrows attention before pulling raw "
+            "insights via meta_ads.insights.report."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
-                    "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
-                },
+                "account_id": _ACCOUNT_ID_PARAM,
                 "campaign_id": {
                     "type": "string",
-                    "description": "Campaign ID (omit for entire account)",
+                    "description": (
+                        "Restrict to a single campaign. Omit to analyse "
+                        "the whole account."
+                    ),
                 },
-                "period": {
-                    "type": "string",
-                    "description": "Period (today, yesterday, last_7d, last_30d etc.)",
-                },
+                "period": _PERIOD_PARAM,
             },
             "required": [],
         },
     ),
     Tool(
         name="meta_ads.analysis.audience",
-        description="Analyze Meta Ads audience efficiency by age and gender",
+        description=(
+            "Scores delivery efficiency across age × gender segments and "
+            "flags the best and worst performing buckets. Returns rows "
+            "per age_range × gender with spend, conversions, CPA, and a "
+            "relative_score vs the campaign average, plus a "
+            "recommendations array (e.g. 'Pause 55-64 male — 3x CPA, 1 "
+            "conversion'). Read-only. Use before adjusting targeting; "
+            "for raw breakdown numbers use meta_ads.insights.breakdown "
+            "with breakdown='age,gender'."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "campaign_id": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": "Campaign to analyse.",
                 },
-                "campaign_id": {"type": "string", "description": "Campaign ID"},
-                "period": {
-                    "type": "string",
-                    "description": "Period (last_7d, last_30d etc.)",
-                },
+                "period": _PERIOD_PARAM,
             },
             "required": ["campaign_id"],
         },
     ),
     Tool(
         name="meta_ads.analysis.placements",
-        description="Analyze Meta Ads performance by placement",
+        description=(
+            "Scores delivery efficiency across Meta placements (Facebook "
+            "Feed, Instagram Feed, Stories, Reels, Audience Network, "
+            "Messenger, etc.) and flags the best and worst. Returns rows "
+            "per placement with spend, conversions, CPA, ctr, and a "
+            "recommendation (exclude / keep / scale). Read-only. Call "
+            "this when CPA drifts on a campaign to find whether a single "
+            "placement is dragging the average. For raw numbers use "
+            "meta_ads.insights.breakdown with breakdown='placement'."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "campaign_id": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": "Campaign to analyse.",
                 },
-                "campaign_id": {"type": "string", "description": "Campaign ID"},
-                "period": {
-                    "type": "string",
-                    "description": "Period (last_7d, last_30d etc.)",
-                },
+                "period": _PERIOD_PARAM,
             },
             "required": ["campaign_id"],
         },
     ),
     Tool(
         name="meta_ads.analysis.cost",
-        description="Investigate causes of Meta Ads cost increase or CPA degradation",
+        description=(
+            "Diagnoses root causes of rising spend or degrading CPA on a "
+            "Meta Ads campaign. Returns a decomposition that attributes "
+            "the cost change to drivers — bid increase, CPM inflation, "
+            "CTR drop, CVR drop, audience saturation, or creative "
+            "fatigue — with per-driver magnitude and a specific action "
+            "hint. Read-only. Use this when the operator reports 'why "
+            "did CPA jump'; it separates auction-side from creative-side "
+            "causes in one call."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "campaign_id": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": "Campaign to diagnose.",
                 },
-                "campaign_id": {"type": "string", "description": "Campaign ID"},
-                "period": {
-                    "type": "string",
-                    "description": "Period (last_7d, last_30d etc.)",
-                },
+                "period": _PERIOD_PARAM,
             },
             "required": ["campaign_id"],
         },
     ),
     Tool(
         name="meta_ads.analysis.compare_ads",
-        description="A/B compare ad performance within a Meta Ads ad set",
+        description=(
+            "Runs an A/B-style comparison of ads inside a single ad set, "
+            "ranking them by efficiency and flagging statistically "
+            "meaningful winners. Returns rows per ad with impressions, "
+            "spend, conversions, CPA, CTR, and a relative-score vs the "
+            "ad set average, plus a verdict (winner / laggard / "
+            "insufficient-data). Read-only. Use this to decide which "
+            "creatives to pause; pair with meta_ads.ads.pause for "
+            "action."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "ad_set_id": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": (
+                        "Ad set whose ads will be compared. Comparison "
+                        "is always within a single ad set (same "
+                        "targeting, same budget) so differences reflect "
+                        "creative."
+                    ),
                 },
-                "ad_set_id": {"type": "string", "description": "Ad set ID"},
-                "period": {
-                    "type": "string",
-                    "description": "Period (last_7d, last_30d etc.)",
-                },
+                "period": _PERIOD_PARAM,
             },
             "required": ["ad_set_id"],
         },
     ),
     Tool(
         name="meta_ads.analysis.suggest_creative",
-        description="Generate creative improvement suggestions based on Meta Ads ad performance",
+        description=(
+            "Generates concrete creative-improvement suggestions for a "
+            "Meta Ads campaign based on recent ad performance. Returns a "
+            "ranked list of suggestions (e.g. 'add a short-form video — "
+            "carousel CTR is 2x static image', 'rotate headlines — "
+            "top-3 CTR ads all use question-form headlines'). Read-only "
+            "— does not create creatives. Follow up with "
+            "meta_ads.creatives.create* to materialize the suggestions "
+            "after operator review."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "campaign_id": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": "Campaign to analyse.",
                 },
-                "campaign_id": {"type": "string", "description": "Campaign ID"},
-                "period": {
-                    "type": "string",
-                    "description": "Period (last_7d, last_30d etc.)",
-                },
+                "period": _PERIOD_PARAM,
             },
             "required": ["campaign_id"],
         },

--- a/mureo/mcp/_tools_meta_ads_leads.py
+++ b/mureo/mcp/_tools_meta_ads_leads.py
@@ -1,25 +1,54 @@
-"""Meta Ads tool definitions — Lead forms, leads"""
+"""Meta Ads tool definitions — Lead forms, leads.
+
+Tool descriptions follow ``docs/tdqs-style-guide.md``. Lead Ads
+collect prospect contact info directly inside Meta (no landing page).
+Forms belong to a Facebook Page; submitted leads are retrievable via
+the Page or attributed to the originating ad.
+"""
 
 from __future__ import annotations
 
 from mcp.types import Tool
 
+# Reusable parameter fragments.
+_ACCOUNT_ID_PARAM = {
+    "type": "string",
+    "description": (
+        "Meta Ads account ID in the format 'act_XXXXXXXXXX' (e.g. "
+        "'act_1234567890'). Optional — falls back to META_ADS_ACCOUNT_ID "
+        "from the configured credentials. The leading 'act_' prefix is "
+        "required."
+    ),
+}
+
 TOOLS: list[Tool] = [
     # === Lead Ads ===
     Tool(
         name="meta_ads.lead_forms.list",
-        description="List Meta Ads lead forms (per page)",
+        description=(
+            "Lists lead forms configured for a Facebook Page. Returns id, "
+            "name, status, leads_count, locale, and created_time per "
+            "form. Read-only. Lead forms belong to Pages, not ad "
+            "accounts — use this to find a form_id before attaching it "
+            "to a Lead Ads creative or before pulling submitted lead "
+            "data via meta_ads.leads.get."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "page_id": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": (
+                        "Facebook Page ID whose forms to list. Must be a "
+                        "page the authenticated user has admin access to."
+                    ),
                 },
-                "page_id": {"type": "string", "description": "Facebook page ID"},
                 "limit": {
                     "type": "integer",
-                    "description": "Max results (default: 50)",
+                    "minimum": 1,
+                    "maximum": 1000,
+                    "description": ("Max forms per call. Default 50, max 1000."),
                 },
             },
             "required": ["page_id"],
@@ -27,49 +56,98 @@ TOOLS: list[Tool] = [
     ),
     Tool(
         name="meta_ads.lead_forms.get",
-        description="Get Meta Ads lead form details",
+        description=(
+            "Fetches the full detail record for a single lead form, "
+            "including its question definitions and legal pages. "
+            "Returns id, name, status, locale, questions (array with "
+            "type / key / label per question), privacy_policy_url, "
+            "follow_up_action_url, leads_count, and created_time. "
+            "Read-only. Call this before designing downstream CRM sync "
+            "so you know the exact field keys to map."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "form_id": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": (
+                        "Lead form ID as returned by " "meta_ads.lead_forms.list."
+                    ),
                 },
-                "form_id": {"type": "string", "description": "Lead form ID"},
             },
             "required": ["form_id"],
         },
     ),
     Tool(
         name="meta_ads.lead_forms.create",
-        description="Create a Meta Ads lead form (per page)",
+        description=(
+            "Creates a new lead form on a Facebook Page. Returns the new "
+            "form_id. Mutating, reversible via rollback.apply (rollback "
+            "archives the form rather than deleting submitted leads). "
+            "Questions is an ordered list of standard Meta types "
+            "(FULL_NAME, EMAIL, PHONE_NUMBER, COMPANY_NAME, JOB_TITLE, "
+            "CITY, STATE, ZIP_CODE, COUNTRY, DATE_OF_BIRTH) or CUSTOM "
+            "(requires key, label, and options for dropdowns). Meta "
+            "requires a privacy_policy_url by policy."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "page_id": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": ("Facebook Page ID that will own the form."),
                 },
-                "page_id": {"type": "string", "description": "Facebook page ID"},
-                "name": {"type": "string", "description": "Form name"},
+                "name": {
+                    "type": "string",
+                    "description": (
+                        "Form name shown in Ads Manager and Page Lead " "Center."
+                    ),
+                },
                 "questions": {
                     "type": "array",
-                    "description": "List of questions (FULL_NAME, EMAIL, PHONE_NUMBER, COMPANY_NAME, CUSTOM etc.)",
+                    "minItems": 1,
+                    "description": (
+                        "Ordered question list. Standard-type questions "
+                        "only need `type`; CUSTOM questions require "
+                        "`key`, `label`, and (for dropdowns) `options`."
+                    ),
                     "items": {
                         "type": "object",
                         "properties": {
-                            "type": {"type": "string", "description": "Question type"},
+                            "type": {
+                                "type": "string",
+                                "description": (
+                                    "Standard type (FULL_NAME, EMAIL, "
+                                    "PHONE_NUMBER, COMPANY_NAME, "
+                                    "JOB_TITLE, CITY, STATE, ZIP_CODE, "
+                                    "COUNTRY, DATE_OF_BIRTH) or CUSTOM "
+                                    "for an advertiser-defined question."
+                                ),
+                            },
                             "key": {
                                 "type": "string",
-                                "description": "Custom question key (CUSTOM type only)",
+                                "description": (
+                                    "Stable field key for CUSTOM "
+                                    "questions. Used as the lead-data "
+                                    "field name — map this to CRM "
+                                    "fields. Required when type=CUSTOM."
+                                ),
                             },
                             "label": {
                                 "type": "string",
-                                "description": "Custom question label (CUSTOM type only)",
+                                "description": (
+                                    "Question label shown to the user. "
+                                    "Required when type=CUSTOM."
+                                ),
                             },
                             "options": {
                                 "type": "array",
-                                "description": "Options (CUSTOM type only)",
+                                "description": (
+                                    "Dropdown options for CUSTOM "
+                                    "questions. Omit for free-text."
+                                ),
                                 "items": {
                                     "type": "object",
                                     "properties": {
@@ -83,11 +161,19 @@ TOOLS: list[Tool] = [
                 },
                 "privacy_policy_url": {
                     "type": "string",
-                    "description": "Privacy policy URL",
+                    "description": (
+                        "HTTPS URL of the advertiser's privacy policy. "
+                        "Required by Meta policy — forms without one are "
+                        "rejected."
+                    ),
                 },
                 "follow_up_action_url": {
                     "type": "string",
-                    "description": "Redirect URL after form submission",
+                    "description": (
+                        "Optional URL the user is redirected to after "
+                        "submission (e.g. thank-you page). Omit to show "
+                        "Meta's default confirmation only."
+                    ),
                 },
             },
             "required": [
@@ -100,18 +186,31 @@ TOOLS: list[Tool] = [
     ),
     Tool(
         name="meta_ads.leads.get",
-        description="Get Meta Ads lead data (per form)",
+        description=(
+            "Retrieves submitted leads for a single form. Returns per "
+            "lead: id, created_time, ad_id, campaign_id, form_id, and "
+            "field_data (array of {name, values} matching the form "
+            "questions). Read-only. Use this for batch CRM sync or "
+            "retrospective analysis. For leads attributed to a specific "
+            "ad across forms use meta_ads.leads.get_by_ad. Meta retains "
+            "lead data for 90 days — pull regularly to avoid loss."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "form_id": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": "Form ID whose leads to fetch.",
                 },
-                "form_id": {"type": "string", "description": "Lead form ID"},
                 "limit": {
                     "type": "integer",
-                    "description": "Max results (default: 100)",
+                    "minimum": 1,
+                    "maximum": 1000,
+                    "description": (
+                        "Max leads per call. Default 100, max 1000 per "
+                        "Meta Graph API."
+                    ),
                 },
             },
             "required": ["form_id"],
@@ -119,18 +218,33 @@ TOOLS: list[Tool] = [
     ),
     Tool(
         name="meta_ads.leads.get_by_ad",
-        description="Get Meta Ads lead data by ad",
+        description=(
+            "Retrieves leads attributed to a specific ad, regardless of "
+            "which form they used. Returns the same lead record shape as "
+            "meta_ads.leads.get. Read-only. Use this to measure lead "
+            "volume of a particular creative / ad ID when ranking "
+            "winners. For full form-based lead pulls (cross-ad) use "
+            "meta_ads.leads.get."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "ad_id": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": (
+                        "Ad ID whose leads to fetch. The ad must be a "
+                        "Lead Ads ad (creative linked to a lead form)."
+                    ),
                 },
-                "ad_id": {"type": "string", "description": "Ad ID"},
                 "limit": {
                     "type": "integer",
-                    "description": "Max results (default: 100)",
+                    "minimum": 1,
+                    "maximum": 1000,
+                    "description": (
+                        "Max leads per call. Default 100, max 1000 per "
+                        "Meta Graph API."
+                    ),
                 },
             },
             "required": ["ad_id"],

--- a/mureo/mcp/_tools_meta_ads_other.py
+++ b/mureo/mcp/_tools_meta_ads_other.py
@@ -1,78 +1,167 @@
-"""Meta Ads tool definitions — Split tests, automated rules, page posts, Instagram"""
+"""Meta Ads tool definitions — Split tests, automated rules, page posts, Instagram.
+
+Tool descriptions follow ``docs/tdqs-style-guide.md``. Covers
+miscellaneous Meta Ads surfaces beyond the core campaign / creative /
+audience flow.
+"""
 
 from __future__ import annotations
 
 from mcp.types import Tool
 
+# Reusable parameter fragments.
+_ACCOUNT_ID_PARAM = {
+    "type": "string",
+    "description": (
+        "Meta Ads account ID in the format 'act_XXXXXXXXXX' (e.g. "
+        "'act_1234567890'). Optional — falls back to META_ADS_ACCOUNT_ID "
+        "from the configured credentials. The leading 'act_' prefix is "
+        "required."
+    ),
+}
+
+_LIMIT_50 = {
+    "type": "integer",
+    "minimum": 1,
+    "maximum": 1000,
+    "description": (
+        "Max records returned per call. Default 50, max 1000 per Meta " "Graph API."
+    ),
+}
+
+_LIMIT_25 = {
+    "type": "integer",
+    "minimum": 1,
+    "maximum": 1000,
+    "description": (
+        "Max records returned per call. Default 25, max 1000 per Meta " "Graph API."
+    ),
+}
+
 TOOLS: list[Tool] = [
     # === Split Test (A/B Test) ===
     Tool(
         name="meta_ads.split_tests.list",
-        description="List Meta Ads split tests (A/B tests)",
+        description=(
+            "Lists Split Tests (A/B Tests, internally called Studies in "
+            "Meta API) configured in the ad account. Returns id "
+            "(study_id), name, status, start_time, end_time, and a "
+            "summary of cells per study. Read-only. Use this to find a "
+            "study_id before pulling detailed results via "
+            "meta_ads.split_tests.get or ending via "
+            "meta_ads.split_tests.end."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
-                    "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
-                },
-                "limit": {
-                    "type": "integer",
-                    "description": "Max results (default: 50)",
-                },
+                "account_id": _ACCOUNT_ID_PARAM,
+                "limit": _LIMIT_50,
             },
             "required": [],
         },
     ),
     Tool(
         name="meta_ads.split_tests.get",
-        description="Get Meta Ads split test details and results",
+        description=(
+            "Fetches the full detail record for a single Split Test "
+            "including per-cell results when the test has concluded. "
+            "Returns id, name, status, cells (each with name, adsets, "
+            "metric_value, confidence_interval), winner_cell_id (when "
+            "determined), confidence_level, start_time, and end_time. "
+            "Read-only. Call this after a test ends to read the winner; "
+            "for the raw list use meta_ads.split_tests.list."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "study_id": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": (
+                        "Study ID as returned by " "meta_ads.split_tests.list."
+                    ),
                 },
-                "study_id": {"type": "string", "description": "Study ID"},
             },
             "required": ["study_id"],
         },
     ),
     Tool(
         name="meta_ads.split_tests.create",
-        description="Create a Meta Ads split test (A/B test)",
+        description=(
+            "Creates a new Split Test. Returns the new study_id. "
+            "Mutating, reversible via rollback.apply (rollback ends the "
+            "test immediately without declaring a winner). Meta runs the "
+            "test for the configured duration, then compares cells on "
+            "the chosen objective (COST_PER_RESULT / CONVERSIONS / "
+            "REACH / CPC / CPM). Cells must reference pre-existing ad "
+            "sets; this tool does not create ad sets. For test analysis "
+            "post-conclusion use meta_ads.split_tests.get."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "name": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": (
+                        "Test name shown in Experiments. Should describe "
+                        "the hypothesis being tested."
+                    ),
                 },
-                "name": {"type": "string", "description": "Test name"},
                 "cells": {
                     "type": "array",
-                    "description": "Cell definitions (each cell contains name, adsets)",
+                    "minItems": 2,
+                    "description": (
+                        "Test cells (2 or more). Each cell has "
+                        "{name, adsets: [ad_set_id, ...]}. Meta splits "
+                        "traffic evenly across cells."
+                    ),
                     "items": {"type": "object"},
                 },
                 "objectives": {
                     "type": "array",
-                    "description": 'Objectives (e.g. [{"type": "COST_PER_RESULT"}])',
+                    "minItems": 1,
+                    "description": (
+                        "Metrics Meta will use to rank cells. Each entry "
+                        "is {type: COST_PER_RESULT | CONVERSIONS | REACH "
+                        "| CPC | CPM}. Multiple objectives produce "
+                        "multi-dimensional results."
+                    ),
                     "items": {"type": "object"},
                 },
                 "start_time": {
                     "type": "string",
-                    "description": "Start time (ISO 8601 format)",
+                    "description": (
+                        "Test start in ISO 8601 (e.g. "
+                        "'2026-04-25T00:00:00+0900'). Must be in the "
+                        "future when the test is created."
+                    ),
                 },
                 "end_time": {
                     "type": "string",
-                    "description": "End time (ISO 8601 format)",
+                    "description": (
+                        "Test end in ISO 8601. Meta requires at least "
+                        "4 days between start_time and end_time for "
+                        "statistical significance."
+                    ),
                 },
                 "confidence_level": {
                     "type": "integer",
-                    "description": "Confidence level (default: 95)",
+                    "minimum": 80,
+                    "maximum": 99,
+                    "description": (
+                        "Statistical confidence threshold for declaring "
+                        "a winner. Default 95 (95%). Higher values need "
+                        "more spend / longer duration to conclude."
+                    ),
                 },
-                "description": {"type": "string", "description": "Test description"},
+                "description": {
+                    "type": "string",
+                    "description": (
+                        "Free-text description of the hypothesis. "
+                        "Internal — not shown to end users."
+                    ),
+                },
             },
             "required": [
                 "account_id",
@@ -86,15 +175,23 @@ TOOLS: list[Tool] = [
     ),
     Tool(
         name="meta_ads.split_tests.end",
-        description="End a Meta Ads split test",
+        description=(
+            "Ends a running Split Test immediately, before its scheduled "
+            "end_time. Returns the final study record with whatever "
+            "confidence Meta has accumulated so far. Destructive — no "
+            "further data accrues; if significance was not yet reached, "
+            "winner_cell_id may be null. Reversible via rollback.apply "
+            "only if the underlying ad sets have not been independently "
+            "modified since the early termination."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "study_id": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": "Study ID to end.",
                 },
-                "study_id": {"type": "string", "description": "Study ID"},
             },
             "required": ["study_id"],
         },
@@ -102,93 +199,188 @@ TOOLS: list[Tool] = [
     # === Automated Rules (Ad Rules) ===
     Tool(
         name="meta_ads.ad_rules.list",
-        description="List Meta Ads automated rules",
+        description=(
+            "Lists Meta Automated Rules configured in the ad account. "
+            "Returns id, name, status (ENABLED / DISABLED / DELETED), "
+            "evaluation_spec summary, execution_spec summary "
+            "(NOTIFICATION / PAUSE_CAMPAIGN / CHANGE_BUDGET / etc.), "
+            "and schedule per rule. Read-only. Use this to audit "
+            "existing automation before adding new rules or to find a "
+            "rule_id before disabling / deleting an old one."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
-                    "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
-                },
-                "limit": {
-                    "type": "integer",
-                    "description": "Max results (default: 50)",
-                },
+                "account_id": _ACCOUNT_ID_PARAM,
+                "limit": _LIMIT_50,
             },
             "required": [],
         },
     ),
     Tool(
         name="meta_ads.ad_rules.get",
-        description="Get Meta Ads automated rule details",
+        description=(
+            "Fetches the full detail record for a single Automated Rule "
+            "including the full evaluation_spec and execution_spec. "
+            "Returns id, name, status, evaluation_spec (triggers and "
+            "filters), execution_spec (action + parameters), "
+            "schedule_spec (when rule runs), created_by, created_time, "
+            "and last_evaluated_time. Read-only. Call this before "
+            "meta_ads.ad_rules.update so you can merge incremental "
+            "changes rather than overwrite the whole spec."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "rule_id": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": (
+                        "Rule ID as returned by " "meta_ads.ad_rules.list."
+                    ),
                 },
-                "rule_id": {"type": "string", "description": "Rule ID"},
             },
             "required": ["rule_id"],
         },
     ),
     Tool(
         name="meta_ads.ad_rules.create",
-        description="Create a Meta Ads automated rule (CPA spike alert, auto-pause etc.)",
+        description=(
+            "Creates a new Automated Rule that Meta evaluates on the "
+            "configured schedule and fires actions when the trigger "
+            "matches. Returns the new rule_id. Mutating, reversible via "
+            "rollback.apply (rollback disables the rule; actions the "
+            "rule already took stand). Common patterns: CPA-spike alert "
+            "(execution NOTIFICATION), auto-pause ads with low ROAS "
+            "(execution PAUSE), scale winners (execution CHANGE_BUDGET). "
+            "evaluation_spec and execution_spec are Meta's JSON schemas "
+            "— see Meta Ads Automated Rules API docs for the field set."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "name": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": (
+                        "Rule name shown in Ads Manager. Should name "
+                        "the trigger and action (e.g. 'Pause ads "
+                        "CPA > target × 2')."
+                    ),
                 },
-                "name": {"type": "string", "description": "Rule name"},
                 "evaluation_spec": {
                     "type": "object",
-                    "description": "Evaluation spec (evaluation_type, trigger, filters)",
+                    "description": (
+                        "Trigger definition. Shape: {evaluation_type: "
+                        "SCHEDULE | TRIGGER, filters: [{field, operator, "
+                        "value}, ...]}. Filters combine with AND; for OR "
+                        "create multiple rules."
+                    ),
                 },
                 "execution_spec": {
                     "type": "object",
-                    "description": "Execution spec (execution_type: NOTIFICATION, PAUSE_CAMPAIGN etc.)",
+                    "description": (
+                        "Action definition. Shape: {execution_type: "
+                        "NOTIFICATION | PAUSE_CAMPAIGNS | UNPAUSE_"
+                        "CAMPAIGNS | CHANGE_BUDGET | CHANGE_BID, "
+                        "execution_options: [...]}. Budget/bid changes "
+                        "use delta or absolute value per execution_"
+                        "options."
+                    ),
                 },
-                "schedule_spec": {"type": "object", "description": "Schedule settings"},
-                "status": {"type": "string", "description": "Initial status"},
+                "schedule_spec": {
+                    "type": "object",
+                    "description": (
+                        "When the rule runs. Shape: {schedule_type: "
+                        "SEMI_HOURLY | DAILY | CUSTOM, schedule: "
+                        "[time specs]}. Default SEMI_HOURLY evaluates "
+                        "every 30 minutes."
+                    ),
+                },
+                "status": {
+                    "type": "string",
+                    "enum": ["ENABLED", "DISABLED"],
+                    "description": (
+                        "Initial status. Default ENABLED. Create with "
+                        "DISABLED and enable later to stage the rule "
+                        "without side effects."
+                    ),
+                },
             },
             "required": ["name", "evaluation_spec", "execution_spec"],
         },
     ),
     Tool(
         name="meta_ads.ad_rules.update",
-        description="Update a Meta Ads automated rule",
+        description=(
+            "Updates fields on an existing Automated Rule. Partial "
+            "update — only supplied fields are changed. Returns the "
+            "updated rule. Mutating, reversible via rollback.apply. "
+            "Changes take effect on the next scheduled evaluation. To "
+            "temporarily suspend a rule, set status=DISABLED rather than "
+            "deleting it so history is preserved."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "rule_id": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": "Rule ID to update.",
                 },
-                "rule_id": {"type": "string", "description": "Rule ID"},
-                "name": {"type": "string", "description": "Rule name"},
-                "evaluation_spec": {"type": "object", "description": "Evaluation spec"},
-                "execution_spec": {"type": "object", "description": "Execution spec"},
-                "schedule_spec": {"type": "object", "description": "Schedule settings"},
-                "status": {"type": "string", "description": "Status"},
+                "name": {
+                    "type": "string",
+                    "description": "New rule name.",
+                },
+                "evaluation_spec": {
+                    "type": "object",
+                    "description": (
+                        "New trigger definition. Replaces the entire "
+                        "spec — fetch current via "
+                        "meta_ads.ad_rules.get first if merging."
+                    ),
+                },
+                "execution_spec": {
+                    "type": "object",
+                    "description": (
+                        "New action definition. Replaces the entire " "spec."
+                    ),
+                },
+                "schedule_spec": {
+                    "type": "object",
+                    "description": "New schedule definition.",
+                },
+                "status": {
+                    "type": "string",
+                    "enum": ["ENABLED", "DISABLED"],
+                    "description": (
+                        "New status. DISABLED pauses evaluation without "
+                        "deleting history."
+                    ),
+                },
             },
             "required": ["rule_id"],
         },
     ),
     Tool(
         name="meta_ads.ad_rules.delete",
-        description="Delete a Meta Ads automated rule",
+        description=(
+            "Deletes an Automated Rule. Returns a success flag. "
+            "Destructive — the rule stops firing immediately and its "
+            "evaluation history is purged. Reversible via rollback.apply "
+            "(re-creates the rule), but the rule_id changes on re-create "
+            "which can break downstream references. For temporary "
+            "suspension prefer meta_ads.ad_rules.update with "
+            "status=DISABLED."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "rule_id": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": "Rule ID to delete.",
                 },
-                "rule_id": {"type": "string", "description": "Rule ID"},
             },
             "required": ["rule_id"],
         },
@@ -196,39 +388,74 @@ TOOLS: list[Tool] = [
     # === Page Posts ===
     Tool(
         name="meta_ads.page_posts.list",
-        description="List Facebook page posts",
+        description=(
+            "Lists published posts on a Facebook Page. Returns id "
+            "(post_id), message, created_time, type (photo / video / "
+            "link / status), permalink_url, and insights summary "
+            "(reach, engagement, reactions) per post. Read-only. Use "
+            "this to find organic posts to boost via "
+            "meta_ads.page_posts.boost — boosting an organic high-"
+            "performer is often cheaper per engagement than running a "
+            "new ad."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "page_id": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": (
+                        "Facebook Page ID whose posts to list. Must be "
+                        "a page the authenticated user has admin access "
+                        "to."
+                    ),
                 },
-                "page_id": {"type": "string", "description": "Facebook page ID"},
-                "limit": {
-                    "type": "integer",
-                    "description": "Max results (default: 25)",
-                },
+                "limit": _LIMIT_25,
             },
             "required": ["page_id"],
         },
     ),
     Tool(
         name="meta_ads.page_posts.boost",
-        description="Boost a Facebook page post (Boost Post)",
+        description=(
+            "Boosts an existing Facebook Page post by creating a paid "
+            "ad that uses the post as its creative. Returns the new "
+            "ad_id. Mutating, reversible via rollback.apply (rollback "
+            "pauses the boosting ad; the original post stays live). The "
+            "parent ad_set_id must already exist with budget and "
+            "targeting configured — this tool only attaches the post as "
+            "creative. For new-creative paid ads use "
+            "meta_ads.ads.create with a creative_id instead."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "page_id": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": ("Facebook Page ID that owns the post."),
                 },
-                "page_id": {"type": "string", "description": "Facebook page ID"},
-                "post_id": {"type": "string", "description": "Post ID"},
-                "ad_set_id": {"type": "string", "description": "Parent ad set ID"},
+                "post_id": {
+                    "type": "string",
+                    "description": (
+                        "Post ID as returned by "
+                        "meta_ads.page_posts.list. Post must be public "
+                        "and compatible with Ads eligibility policies."
+                    ),
+                },
+                "ad_set_id": {
+                    "type": "string",
+                    "description": (
+                        "Parent ad set that will carry the boosting ad. "
+                        "Must already exist with budget and targeting."
+                    ),
+                },
                 "name": {
                     "type": "string",
-                    "description": "Ad name (auto-generated if omitted)",
+                    "description": (
+                        "Ad name shown in Ads Manager. Auto-generated "
+                        "from the post if omitted."
+                    ),
                 },
             },
             "required": ["page_id", "post_id", "ad_set_id"],
@@ -237,53 +464,82 @@ TOOLS: list[Tool] = [
     # === Instagram ===
     Tool(
         name="meta_ads.instagram.accounts",
-        description="List linked Instagram accounts",
+        description=(
+            "Lists Instagram Business / Creator accounts linked to the "
+            "ad account via Meta Business. Returns ig_user_id, username, "
+            "name, profile_picture_url, followers_count, and media_count "
+            "per account. Read-only. Use this to find an ig_user_id "
+            "before calling meta_ads.instagram.media or .boost."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
-                    "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
-                },
+                "account_id": _ACCOUNT_ID_PARAM,
             },
             "required": [],
         },
     ),
     Tool(
         name="meta_ads.instagram.media",
-        description="List Instagram posts",
+        description=(
+            "Lists recent media (posts, reels, carousels) for a linked "
+            "Instagram account. Returns id (media_id), caption, "
+            "media_type (IMAGE / VIDEO / CAROUSEL_ALBUM), media_url, "
+            "permalink, timestamp, like_count, and comments_count per "
+            "item. Read-only. Use this to find a media_id before "
+            "boosting via meta_ads.instagram.boost."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "ig_user_id": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": (
+                        "Instagram user_id as returned by "
+                        "meta_ads.instagram.accounts."
+                    ),
                 },
-                "ig_user_id": {"type": "string", "description": "Instagram user ID"},
-                "limit": {
-                    "type": "integer",
-                    "description": "Max results (default: 25)",
-                },
+                "limit": _LIMIT_25,
             },
             "required": ["ig_user_id"],
         },
     ),
     Tool(
         name="meta_ads.instagram.boost",
-        description="Boost an Instagram post",
+        description=(
+            "Boosts an organic Instagram post by creating a paid ad "
+            "that uses it as creative. Returns the new ad_id. Mutating, "
+            "reversible via rollback.apply (rollback pauses the boosting "
+            "ad; the organic post stays live). The parent ad_set_id "
+            "must already exist with budget and targeting. For a "
+            "freshly-composed ad (non-organic source) use "
+            "meta_ads.ads.create with a creative_id instead."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "account_id": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "ig_user_id": {
                     "type": "string",
-                    "description": "Ad account ID (act_XXXX format)",
+                    "description": ("Instagram user_id that owns the media."),
                 },
-                "ig_user_id": {"type": "string", "description": "Instagram user ID"},
-                "media_id": {"type": "string", "description": "Media ID"},
-                "ad_set_id": {"type": "string", "description": "Parent ad set ID"},
+                "media_id": {
+                    "type": "string",
+                    "description": (
+                        "Media ID as returned by " "meta_ads.instagram.media."
+                    ),
+                },
+                "ad_set_id": {
+                    "type": "string",
+                    "description": ("Parent ad set that will carry the boosting ad."),
+                },
                 "name": {
                     "type": "string",
-                    "description": "Ad name (auto-generated if omitted)",
+                    "description": (
+                        "Ad name shown in Ads Manager. Auto-generated "
+                        "from the media if omitted."
+                    ),
                 },
             },
             "required": ["ig_user_id", "media_id", "ad_set_id"],


### PR DESCRIPTION
## Summary
Rewrite MCP tool descriptions for the remaining ~51 Meta Ads tools that PR #43 did not cover, applying the same TDQS template from `docs/tdqs-style-guide.md`.

## Why
TDQS on the current state (post-PR #43):
- Average 3.5/5 (C grade) - up from 3.1 but still C
- Lowest tool: `meta_ads.creatives.list` at 2.1/5 - a C-grade laggard
- Distribution: A=25, B=51, C=86 (53% C)

Most of the lowest-scoring tools live in the Meta Ads ecosystem. This PR rewrites every remaining Meta Ads tool so the TDQS re-score focuses on the most severe laggards first.

## Scope
| File | Tools |
|---|---|
| `_tools_meta_ads_creatives.py` | 9 (creatives / images / videos) - includes the 2.1 laggard |
| `_tools_meta_ads_audiences.py` | 9 (audiences / pixels) |
| `_tools_meta_ads_insights.py` | 8 (insights / analysis) |
| `_tools_meta_ads_catalog.py` | 10 (catalogs / products / feeds) |
| `_tools_meta_ads_conversions.py` | 3 (CAPI) |
| `_tools_meta_ads_leads.py` | 5 (lead forms / leads) |
| `_tools_meta_ads_other.py` | 14 (split tests / ad rules / page posts / Instagram) |
| **Total** | **58 tools** |

## Approach
Every rewritten tool covers the six TDQS dimensions:
- Specific verb + resource (Purpose Clarity)
- When to use vs sibling tools (Usage Guidelines) - e.g. `creatives.create` vs `create_dynamic` vs `create_carousel`
- Read-only / mutating / destructive flags (Behavioral Transparency)
- Parameter format hints (`account_id` = `act_XXXX`; `image_hash` vs `image_url` mutual exclusion; `limit` defaults; ISO 4217 currency codes for CAPI)
- 50-100 word length (Conciseness)
- Returned fields + sibling-tool pointers (Contextual Completeness)

## Test plan
- [x] Python syntax validation (`ast.parse`) on all 7 rewritten files
- [x] `black --check` applied
- [x] `docker build` succeeds
- [x] `docker run` + MCP `initialize` + `tools/list` - all 173 tools still load
- [ ] Merge then Glama rebuild; confirm TDQS average climbs above 3.5 and `meta_ads.creatives.*` family avg lifts from 2.88 toward B band
- [ ] Follow-up PR for the remaining ~73 tools (google_ads.analysis, extensions, assets, search_console)

## Non-goals
- No runtime behavior changes
- `TOOLS: list[Tool]` public interface unchanged
- Schema hints added (enum, minimum, minItems, maxItems) - all backwards-compatible
