### PR TITLE
feat(mcp): rewrite remaining 49 C/B- tool descriptions for TDQS A tier (PR #3b)

### DIFF
--- a/mureo/mcp/_tools_google_ads_analysis.py
+++ b/mureo/mcp/_tools_google_ads_analysis.py
@@ -39,6 +39,52 @@ _PERIOD_PARAM = {
     ),
 }
 
+_CAMPAIGN_ID_PARAM = {
+    "type": "string",
+    "description": (
+        "Campaign ID as a numeric string without dashes "
+        "(e.g. '23743184133'). Obtain via google_ads.campaigns.list."
+    ),
+}
+
+_CAMPAIGN_ID_FILTER_PARAM = {
+    "type": "string",
+    "description": (
+        "Optional campaign ID as a numeric string (e.g. '23743184133') to "
+        "restrict the report to a single campaign. Omit to aggregate across "
+        "every campaign in the account."
+    ),
+}
+
+_AD_GROUP_ID_FILTER_PARAM = {
+    "type": "string",
+    "description": (
+        "Optional ad group ID as a numeric string (e.g. '145680123456') to "
+        "restrict results to a single ad group. Omit to include every ad "
+        "group matching the campaign filter."
+    ),
+}
+
+_SHORT_PERIOD_PARAM = {
+    "type": "string",
+    "enum": [
+        "TODAY",
+        "YESTERDAY",
+        "LAST_7_DAYS",
+        "LAST_14_DAYS",
+        "LAST_30_DAYS",
+        "LAST_90_DAYS",
+        "THIS_MONTH",
+        "LAST_MONTH",
+    ],
+    "description": (
+        "Reporting window for the metrics. Default 'LAST_7_DAYS' — this tool "
+        "is tuned for short-horizon comparison. Use LAST_14_DAYS or "
+        "LAST_30_DAYS for longer baselines."
+    ),
+}
+
+
 TOOLS: list[Tool] = [
     # === Analysis ===
     Tool(
@@ -119,68 +165,133 @@ TOOLS: list[Tool] = [
     ),
     Tool(
         name="google_ads.search_terms.review",
-        description="Review Google Ads search terms with multi-stage rules and suggest addition/exclusion candidates",
+        description=(
+            "Score every search term in a Google Ads campaign against six "
+            "hardcoded rules and split them into add / exclude / watch "
+            "buckets. Returns {campaign_id, ad_group_id, period, "
+            "target_cpa, target_cpa_source, add_candidates, "
+            "exclude_candidates, watch_candidates, summary:{"
+            "total_search_terms, add_count, exclude_count, watch_count}, "
+            "intent_analysis?}. Each candidate has {search_term, action, "
+            "match_type ('EXACT'|'PHRASE'), score (40-90), reason, "
+            "metrics:{conversions, clicks, cost, ctr}}. target_cpa is "
+            "resolved from the explicit argument first, then the "
+            "campaign's bidding strategy, then last-30-days actual CPA; "
+            "target_cpa_source reports which path ('explicit'|"
+            "'bidding_strategy'|'actual'|'none'). New terms absent from "
+            "the previous period are routed to watch_candidates. "
+            "Read-only — emits candidates but does not add or exclude "
+            "anything. Default period is LAST_7_DAYS. For keyword/N-gram "
+            "overlap stats use google_ads.search_terms.analyze; for the "
+            "raw query log use google_ads.search_terms.report."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
-                    "type": "string",
-                    "description": "Google Ads customer ID",
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "campaign_id": _CAMPAIGN_ID_PARAM,
+                "period": _SHORT_PERIOD_PARAM,
+                "target_cpa": {
+                    "type": "number",
+                    "minimum": 0,
+                    "description": (
+                        "Optional explicit target CPA in account currency "
+                        "(e.g. 3000 = ¥3,000). Exclusion rule 4 fires at "
+                        "cost >= target_cpa * 2. Falls back to the "
+                        "campaign's bidding strategy target, then "
+                        "last-30-days actual CPA; if none can be resolved, "
+                        "CPA-gated rules are skipped."
+                    ),
                 },
-                "campaign_id": {"type": "string", "description": "Campaign ID"},
-                "period": {
-                    "type": "string",
-                    "description": "Period (default: LAST_7_DAYS)",
-                },
-                "target_cpa": {"type": "number", "description": "Target CPA"},
             },
             "required": ["campaign_id"],
         },
     ),
     Tool(
         name="google_ads.auction_insights.analyze",
-        description="Analyze Google Ads auction insights",
+        description=(
+            "Interpret a campaign's impression-share metrics and surface "
+            "human-readable insights about competitive position. Returns "
+            "{campaign_id, campaign_name, period, impression_share_metrics:"
+            "{search_impression_share, search_rank_lost_is, "
+            "search_budget_lost_is, search_top_is, search_abs_top_is, "
+            "note}, insights:[strings], note}. Each impression-share "
+            "value is a percentage (0-100, rounded to 1 decimal) or None. "
+            "Insights fire when IS < 50/70%, rank-lost > 20%, "
+            "budget-lost > 20%, or abs-top-IS < 20%. Read-only. Note: "
+            "Google Ads API v23 removed competitor-level auction_insight "
+            "(domain overlap, outranking share); only impression-share "
+            "proxies are returned. For the raw metrics without insights "
+            "use google_ads.auction_insights.get; full competitor data is "
+            "only available in the Google Ads UI."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
-                    "type": "string",
-                    "description": "Google Ads customer ID",
-                },
-                "campaign_id": {"type": "string", "description": "Campaign ID"},
-                "period": {"type": "string", "description": "Period"},
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "campaign_id": _CAMPAIGN_ID_PARAM,
+                "period": _PERIOD_PARAM,
             },
             "required": ["campaign_id"],
         },
     ),
     Tool(
         name="google_ads.cpc.detect_trend",
-        description="Detect Google Ads CPC increase trends",
+        description=(
+            "Detect rising/falling CPC trends in a Google Ads campaign "
+            "over a reporting window using daily segmentation and linear "
+            "regression. Returns {campaign_id, campaign_name, period, "
+            "data_points, daily_data:[{date, average_cpc, clicks, "
+            "impressions, cost}], trend:{direction "
+            "('rising'|'falling'|'stable'|'insufficient_data'), "
+            "slope_per_day, change_rate_per_day_pct? (present only "
+            "when direction is not 'insufficient_data' — i.e. when "
+            "at least 2 daily data points are available), avg_cpc, "
+            "min_cpc, max_cpc}, insights:[strings]}. Direction is "
+            "'rising' when "
+            "daily change > +1%, 'falling' when < -1%. Days with zero "
+            "clicks are excluded from the GAQL. Insights call out "
+            "week-over-week surges >15% and days exceeding 2x average "
+            "CPC. Read-only. For device or auction-share investigation "
+            "use google_ads.device.analyze or "
+            "google_ads.auction_insights.analyze."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
-                    "type": "string",
-                    "description": "Google Ads customer ID",
-                },
-                "campaign_id": {"type": "string", "description": "Campaign ID"},
-                "period": {"type": "string", "description": "Period"},
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "campaign_id": _CAMPAIGN_ID_PARAM,
+                "period": _PERIOD_PARAM,
             },
             "required": ["campaign_id"],
         },
     ),
     Tool(
         name="google_ads.device.analyze",
-        description="Analyze Google Ads performance by device",
+        description=(
+            "Compare Google Ads campaign performance across device "
+            "segments (Desktop / Mobile / Tablet). Returns {campaign_id, "
+            "campaign_name, period, devices:[{device_type, impressions, "
+            "clicks, cost, conversions, ctr (percent), average_cpc, cpa, "
+            "cvr (percent)}], insights:[strings]}, sorted by cost "
+            "descending. cpa is None when conversions == 0. Insights "
+            "fire for devices with spend and zero conversions, "
+            "worst/best CPA ratios > 1.5x, and Mobile CTR less than half "
+            "of Desktop CTR. Read-only. Returns a 'message' field and "
+            "empty devices list when no device-segmented data exists. "
+            "For applying device bid modifiers use "
+            "google_ads.bid_adjustments.update or "
+            "google_ads.device_targeting.set; for the raw "
+            "ad-schedule criteria (hour-of-day targeting config, "
+            "NOT performance segmentation by hour) use "
+            "google_ads.schedule_targeting.list."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
-                    "type": "string",
-                    "description": "Google Ads customer ID",
-                },
-                "campaign_id": {"type": "string", "description": "Campaign ID"},
-                "period": {"type": "string", "description": "Period"},
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "campaign_id": _CAMPAIGN_ID_PARAM,
+                "period": _PERIOD_PARAM,
             },
             "required": ["campaign_id"],
         },
@@ -188,19 +299,26 @@ TOOLS: list[Tool] = [
     # === Network performance report ===
     Tool(
         name="google_ads.network_performance.report",
-        description="Get Google Ads network performance report (Google Search vs Search Partners)",
+        description=(
+            "Report Google Ads performance split by ad network — Google "
+            "Search vs. Search Partners. Returns one row per (campaign, "
+            "network) shaped as {campaign_id, campaign_name, "
+            "network_type ('SEARCH'|'SEARCH_PARTNERS'), network_label "
+            "('Google Search'|'Search Partners'), impressions, clicks, "
+            "cost, conversions, ctr (percent), average_cpc, "
+            "cost_per_conversion}. Display, YouTube, and Discover rows "
+            "are filtered out. ctr, average_cpc, and cost_per_conversion "
+            "are rounded to whole-unit currency. Read-only. Use this to "
+            "decide whether to toggle Search Partners. For overall "
+            "campaign totals use google_ads.performance.report; for "
+            "per-ad breakdowns use google_ads.ad_performance.report."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
-                    "type": "string",
-                    "description": "Google Ads customer ID",
-                },
-                "campaign_id": {
-                    "type": "string",
-                    "description": "Filter by campaign ID",
-                },
-                "period": {"type": "string", "description": "Period"},
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "campaign_id": _CAMPAIGN_ID_FILTER_PARAM,
+                "period": _PERIOD_PARAM,
             },
             "required": [],
         },
@@ -208,23 +326,28 @@ TOOLS: list[Tool] = [
     # === Per-ad report ===
     Tool(
         name="google_ads.ad_performance.report",
-        description="Get Google Ads per-ad performance report",
+        description=(
+            "Report per-ad performance across Google Ads ad_group_ad "
+            "rows. Returns one row per ad shaped as {ad_id, ad_type, "
+            "status ('ENABLED'|'PAUSED'|'REMOVED'), ad_group_id, "
+            "ad_group_name, campaign_id, campaign_name, metrics} where "
+            "metrics contains impressions, clicks, cost_micros, cost "
+            "(currency), conversions, ctr, average_cpc_micros, "
+            "average_cpc, cost_per_conversion_micros, "
+            "cost_per_conversion. Filterable by ad_group_id and/or "
+            "campaign_id (both optional, both numeric). Read-only; no "
+            "mutation. For ENABLED-only A/B comparison within a single "
+            "ad group with WINNER/LOSER verdicts use "
+            "google_ads.ad_performance.compare; for campaign-level "
+            "aggregates use google_ads.performance.report."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
-                    "type": "string",
-                    "description": "Google Ads customer ID",
-                },
-                "ad_group_id": {
-                    "type": "string",
-                    "description": "Filter by ad group ID",
-                },
-                "campaign_id": {
-                    "type": "string",
-                    "description": "Filter by campaign ID",
-                },
-                "period": {"type": "string", "description": "Period"},
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "ad_group_id": _AD_GROUP_ID_FILTER_PARAM,
+                "campaign_id": _CAMPAIGN_ID_FILTER_PARAM,
+                "period": _PERIOD_PARAM,
             },
             "required": [],
         },
@@ -232,16 +355,27 @@ TOOLS: list[Tool] = [
     # === Search Term Analysis ===
     Tool(
         name="google_ads.search_terms.analyze",
-        description="Analyze Google Ads search term and keyword overlap and N-gram distribution",
+        description=(
+            "Analyze keyword/search-term overlap and N-gram distribution "
+            "for a Google Ads campaign. Returns {campaign_id, period, "
+            "registered_keywords_count, search_terms_count, overlap_rate "
+            "(0.0-1.0), ngram_distribution:{unigrams, bigrams, trigrams} "
+            "(each top-10 of {text, count, cost, conversions}), "
+            "keyword_candidates:[{search_term, conversions, cost, "
+            "clicks}] (CV>0 and not yet registered), "
+            "negative_candidates:[{search_term, cost, clicks, "
+            "impressions}] (top 20 by cost with cost>0 and "
+            "conversions=0), insights:[strings]}. Read-only. For "
+            "rule-scored add/exclude/watch buckets use "
+            "google_ads.search_terms.review; for the raw unscored term "
+            "log use google_ads.search_terms.report."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
-                    "type": "string",
-                    "description": "Google Ads customer ID",
-                },
-                "campaign_id": {"type": "string", "description": "Campaign ID"},
-                "period": {"type": "string", "description": "Period"},
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "campaign_id": _CAMPAIGN_ID_PARAM,
+                "period": _PERIOD_PARAM,
             },
             "required": ["campaign_id"],
         },
@@ -249,61 +383,124 @@ TOOLS: list[Tool] = [
     # === Performance analysis ===
     Tool(
         name="google_ads.performance.analyze",
-        description="Comprehensively analyze Google Ads campaign performance",
+        description=(
+            "Diagnose a single Google Ads campaign by composing "
+            "current-vs-previous comparison, top search terms, Google "
+            "recommendations, and recent change history. Returns "
+            "{campaign_id, period, campaign (get_campaign shape), "
+            "performance_current, performance_previous, changes:{"
+            "impressions_change_pct, clicks_change_pct, cost_change_pct, "
+            "conversions_change_pct}, cpa_current? (only when "
+            "current-period conversions > 0), cpa_previous? (only when "
+            "previous-period conversions > 0), cpa_change_pct? (only "
+            "when both above are present), top_search_terms (top 20 by "
+            "cost), "
+            "recommendations_from_google (up to 10), recent_changes (up "
+            "to 10), issues:[strings], insights:[strings], "
+            "recommendations:[strings]}. Any subcomponent that fails is "
+            "replaced with the string 'Retrieval failed' rather than "
+            "aborting the call. Read-only. Default period is "
+            "LAST_7_DAYS. For cost-spike root-cause analysis use "
+            "google_ads.cost_increase.investigate; for account-wide "
+            "health use google_ads.health_check.all."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
-                    "type": "string",
-                    "description": "Google Ads customer ID",
-                },
-                "campaign_id": {"type": "string", "description": "Campaign ID"},
-                "period": {"type": "string", "description": "Period"},
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "campaign_id": _CAMPAIGN_ID_PARAM,
+                "period": _SHORT_PERIOD_PARAM,
             },
             "required": ["campaign_id"],
         },
     ),
     Tool(
         name="google_ads.cost_increase.investigate",
-        description="Investigate causes of Google Ads cost increase or CPA degradation",
+        description=(
+            "Investigate the root cause of a Google Ads cost spike or "
+            "CPA deterioration by comparing the last 7 days against the "
+            "prior 7 days. Returns {campaign_id, "
+            "performance_current_7d, performance_previous_7d, changes, "
+            "cost_breakdown:{cpc_current, cpc_previous, cpc_change_pct, "
+            "clicks_current, clicks_previous, clicks_change_pct}, "
+            "new_search_terms (top 20 by cost), wasteful_search_terms "
+            "(top 20 zero-CV terms with cost), bid_budget_changes (up "
+            "to 10 CAMPAIGN/CAMPAIGN_BUDGET/AD_GROUP/"
+            "CAMPAIGN_BID_MODIFIER events from change history), "
+            "existing_negative_keywords_count, "
+            "negative_keyword_candidates (up to 10), findings:[strings], "
+            "recommended_actions:[strings]}. The comparison window is "
+            "hardcoded to LAST_7_DAYS. Read-only. For a broader "
+            "diagnostic composite use google_ads.performance.analyze; "
+            "for CPA-vs-target monitoring use "
+            "google_ads.monitoring.cpa_goal."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
-                    "type": "string",
-                    "description": "Google Ads customer ID",
-                },
-                "campaign_id": {"type": "string", "description": "Campaign ID"},
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "campaign_id": _CAMPAIGN_ID_PARAM,
             },
             "required": ["campaign_id"],
         },
     ),
     Tool(
         name="google_ads.health_check.all",
-        description="Run a health check on all active Google Ads campaigns",
+        description=(
+            "Screen every campaign in the Google Ads account by "
+            "primary_status and run detailed delivery diagnostics on up "
+            "to 5 problem/warning campaigns. Returns {total_campaigns, "
+            "enabled_count, paused_count, removed_count, "
+            "healthy_campaigns (ELIGIBLE), warning_campaigns (other "
+            "primary_status among ENABLED), problem_campaigns "
+            "(NOT_ELIGIBLE/ENDED/REMOVED among ENABLED — each: "
+            "{campaign_id, name, primary_status}), detailed_diagnostics:"
+            "[{campaign_id, name, issues, warnings, recommendations}] "
+            "(up to 5; problem-first, then warning), summary:"
+            "{total_enabled, healthy, warning, problem, message}}. "
+            "Read-only. For single-campaign delivery diagnosis use "
+            "google_ads.campaigns.diagnose; for CPA-goal monitoring use "
+            "google_ads.monitoring.cpa_goal."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
-                    "type": "string",
-                    "description": "Google Ads customer ID",
-                },
+                "customer_id": _CUSTOMER_ID_PARAM,
             },
             "required": [],
         },
     ),
     Tool(
         name="google_ads.ad_performance.compare",
-        description="Compare ad performance within a Google Ads ad group",
+        description=(
+            "Rank ENABLED ads within a single Google Ads ad group and "
+            "assign WINNER / LOSER / INSUFFICIENT_DATA verdicts. Returns "
+            "{ad_group_id, period, ads:[{ad_id, impressions, clicks, "
+            "conversions, cost, ctr, cvr, cpa, score (ctr*cvr, or ctr "
+            "when conversions=0), rank, verdict, headlines?, "
+            "descriptions?}], winner, recommendation, "
+            "insights:[strings]}. Ads with impressions < 100 are flagged "
+            "INSUFFICIENT_DATA; all ads tied at the top score receive "
+            "WINNER, the rest LOSER. Read-only — does not pause or "
+            "rotate ads. For cross-ad-group per-ad reporting use "
+            "google_ads.ad_performance.report; for RSA asset-level "
+            "splits use google_ads.rsa_assets.analyze."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "ad_group_id": {
                     "type": "string",
-                    "description": "Google Ads customer ID",
+                    "description": (
+                        "Ad group ID as a numeric string "
+                        "(e.g. '145680123456'). Required — comparison "
+                        "is always scoped to one ad group so the ads "
+                        "share targeting. Obtain via "
+                        "google_ads.ad_groups.list."
+                    ),
                 },
-                "ad_group_id": {"type": "string", "description": "Ad group ID"},
-                "period": {"type": "string", "description": "Period"},
+                "period": _PERIOD_PARAM,
             },
             "required": ["ad_group_id"],
         },
@@ -311,30 +508,57 @@ TOOLS: list[Tool] = [
     # === Budget analysis ===
     Tool(
         name="google_ads.budget.efficiency",
-        description="Analyze budget allocation efficiency across all active Google Ads campaigns",
+        description=(
+            "Score budget allocation efficiency across every ENABLED "
+            "Google Ads campaign. Returns {period, total_cost, "
+            "total_conversions, campaigns:[{campaign_id, name, cost, "
+            "conversions, cost_share, cv_share, efficiency_ratio "
+            "(cv_share / cost_share), verdict ('EFFICIENT' when ratio "
+            "> 1.2, 'INEFFICIENT' when < 0.8, 'NORMAL' otherwise, "
+            "'NO_COST' when cost==0), cpa}], recommendations:[strings], "
+            "insights:[strings]}. Per-campaign cost/conversions come "
+            "from get_performance_report — individual failures are "
+            "silently treated as zero. Read-only. For a concrete "
+            "DECREASE/INCREASE reallocation plan use "
+            "google_ads.budget.reallocation; to change a single budget "
+            "use google_ads.budget.update."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
-                    "type": "string",
-                    "description": "Google Ads customer ID",
-                },
-                "period": {"type": "string", "description": "Period"},
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "period": _PERIOD_PARAM,
             },
             "required": [],
         },
     ),
     Tool(
         name="google_ads.budget.reallocation",
-        description="Generate budget reallocation suggestions for all Google Ads campaigns",
+        description=(
+            "Propose a budget reallocation plan by cutting up to 20% "
+            "from INEFFICIENT campaigns and distributing the freed "
+            "amount equally across EFFICIENT campaigns. Returns the "
+            "full google_ads.budget.efficiency payload plus "
+            "{reallocation_plan:[{campaign_id, campaign_name, action "
+            "('DECREASE'|'INCREASE'), current_daily_budget, "
+            "proposed_daily_budget, change_amount, reason}], "
+            "total_freed, summary}. When the account has no campaigns "
+            "with spend in the window, the response short-circuits to "
+            "just {...efficiency payload, reallocation_plan:[], "
+            "summary:'No campaigns with spend in period'} and the "
+            "total_freed key is omitted — parse defensively. Reductions "
+            "below 100 (currency units) are skipped. Current daily "
+            "budgets are fetched via get_budget — failures fall back "
+            "to 0. Read-only — emits a "
+            "plan only, does not apply any budget changes. To actually "
+            "apply a change use google_ads.budget.update; for the "
+            "efficiency scoring alone use google_ads.budget.efficiency."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
-                    "type": "string",
-                    "description": "Google Ads customer ID",
-                },
-                "period": {"type": "string", "description": "Period"},
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "period": _PERIOD_PARAM,
             },
             "required": [],
         },
@@ -342,16 +566,27 @@ TOOLS: list[Tool] = [
     # === Auction insights ===
     Tool(
         name="google_ads.auction_insights.get",
-        description="Get Google Ads campaign auction insights data",
+        description=(
+            "Fetch raw impression-share metrics for one Google Ads "
+            "campaign. Returns a list with a single entry: {campaign_id, "
+            "campaign_name, search_impression_share, "
+            "search_rank_lost_is, search_budget_lost_is, search_top_is, "
+            "search_abs_top_is, note} — every IS field is a percentage "
+            "(0-100, float, rounded to 1 decimal) or None. On failure "
+            "returns a single-element list with {error:"
+            "'auction_insights_unavailable'|'no_data', reason, hint}. "
+            "Read-only. Note: Google Ads API v23 removed "
+            "competitor-level auction_insight (domain, overlap, "
+            "outranking); only impression-share proxies are returned. "
+            "For a version with human-readable insights layered on top "
+            "use google_ads.auction_insights.analyze."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
-                    "type": "string",
-                    "description": "Google Ads customer ID",
-                },
-                "campaign_id": {"type": "string", "description": "Campaign ID"},
-                "period": {"type": "string", "description": "Period"},
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "campaign_id": _CAMPAIGN_ID_PARAM,
+                "period": _PERIOD_PARAM,
             },
             "required": ["campaign_id"],
         },
@@ -359,32 +594,56 @@ TOOLS: list[Tool] = [
     # === RSA analysis ===
     Tool(
         name="google_ads.rsa_assets.analyze",
-        description="Analyze Google Ads RSA per-asset performance",
+        description=(
+            "Split Responsive Search Ad asset performance within a "
+            "Google Ads campaign into headlines and descriptions. "
+            "Returns {campaign_id, period, headlines:[{text, "
+            "performance_label ('BEST'|'GOOD'|'LOW'|'POOR'|"
+            "'LEARNING'|'PENDING'|'UNKNOWN'), impressions, clicks, "
+            "conversions, cost, ctr (percent)}], descriptions (same "
+            "shape), best_headlines (performance_label == 'BEST'), "
+            "worst_headlines ('LOW'|'POOR'), best_descriptions, "
+            "worst_descriptions, insights:[strings]}. Rows sorted by "
+            "impressions descending. Read-only. For an audit version "
+            "with replacement recommendations use "
+            "google_ads.rsa_assets.audit; for ad-level A/B use "
+            "google_ads.ad_performance.compare."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
-                    "type": "string",
-                    "description": "Google Ads customer ID",
-                },
-                "campaign_id": {"type": "string", "description": "Campaign ID"},
-                "period": {"type": "string", "description": "Period"},
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "campaign_id": _CAMPAIGN_ID_PARAM,
+                "period": _PERIOD_PARAM,
             },
             "required": ["campaign_id"],
         },
     ),
     Tool(
         name="google_ads.rsa_assets.audit",
-        description="Audit Google Ads RSA assets and generate replacement/addition recommendations",
+        description=(
+            "Audit Responsive Search Ad assets against Google's "
+            "quantity and quality guidance and emit replacement "
+            "recommendations. Returns {campaign_id, period, "
+            "headline_count, description_count, label_distribution:{"
+            "<label>:count}, best_headlines, worst_headlines, "
+            "best_descriptions, worst_descriptions, recommendations:[{"
+            "type ('add_headlines'|'add_descriptions'|"
+            "'replace_headline'|'replace_description'|'wait_for_data'), "
+            "priority ('HIGH'|'MEDIUM'|'LOW'), message, asset_text?, "
+            "performance_label?}], recommendation_count}. HIGH "
+            "priorities fire when headlines < 8 or descriptions < 3. "
+            "LOW 'wait_for_data' fires when LEARNING+UNKNOWN > 50% of "
+            "assets. Read-only; does not modify any assets. For the "
+            "raw per-asset performance breakdown use "
+            "google_ads.rsa_assets.analyze."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
-                    "type": "string",
-                    "description": "Google Ads customer ID",
-                },
-                "campaign_id": {"type": "string", "description": "Campaign ID"},
-                "period": {"type": "string", "description": "Period"},
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "campaign_id": _CAMPAIGN_ID_PARAM,
+                "period": _PERIOD_PARAM,
             },
             "required": ["campaign_id"],
         },
@@ -392,16 +651,27 @@ TOOLS: list[Tool] = [
     # === BtoB ===
     Tool(
         name="google_ads.btob.optimizations",
-        description="Run B2B business optimization checks and generate improvement suggestions",
+        description=(
+            "Run three B2B-specific optimization checks (ad schedule, "
+            "device CPA disparity, informational-query ratio) against a "
+            "Google Ads campaign. Returns {campaign_id, campaign_name, "
+            "period, suggestion_count, suggestions:[{category "
+            "('schedule'|'device'|'search_terms'), priority ('HIGH'|"
+            "'MEDIUM'|'LOW'), message}]}. Schedule fires HIGH when no "
+            "ad schedule is set, MEDIUM for weekend delivery. Device "
+            "fires MEDIUM when Mobile CPA > Desktop CPA * 1.3, LOW when "
+            "Tablet has zero conversions with spend. Search-terms fires "
+            "MEDIUM when informational patterns exceed 20% of queries. "
+            "Read-only. Use this when the advertiser self-identifies as "
+            "B2B. For general campaign diagnosis use "
+            "google_ads.performance.analyze."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
-                    "type": "string",
-                    "description": "Google Ads customer ID",
-                },
-                "campaign_id": {"type": "string", "description": "Campaign ID"},
-                "period": {"type": "string", "description": "Period"},
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "campaign_id": _CAMPAIGN_ID_PARAM,
+                "period": _PERIOD_PARAM,
             },
             "required": ["campaign_id"],
         },
@@ -452,20 +722,43 @@ TOOLS: list[Tool] = [
     ),
     Tool(
         name="google_ads.creative.research",
-        description="Creative research: batch collection of LP analysis, existing ads, search terms, and keyword suggestions",
+        description=(
+            "Collect every input an LLM needs to draft or refresh "
+            "Google Ads creative for a single campaign. Returns "
+            "{campaign_id, url, lp_analysis (same shape as "
+            "google_ads.landing_page.analyze), existing_ads:[{ad_id, "
+            "headlines, descriptions, final_urls, impressions, clicks, "
+            "conversions, ctr}] (top 5 RSA ads by impressions, REMOVED "
+            "excluded), search_term_insights:{high_cv_terms (top 10 by "
+            "conversions), high_click_terms (top 10 by clicks), "
+            "total_terms}, keyword_suggestions (KeywordPlanIdeaService "
+            "output for up to 5 seeds derived from LP title + h1 + "
+            "meta_description), existing_keywords (list_keywords "
+            "output), context_summary (string)}. Any failing sub-step "
+            "is replaced with the literal string '取得失敗' so the "
+            "envelope never raises. Side effect: one outbound LP fetch "
+            "(same SSRF policy as google_ads.landing_page.analyze) plus "
+            "several GAQL queries. For just the LP use "
+            "google_ads.landing_page.analyze; for just RSA asset "
+            "diagnostics use google_ads.rsa_assets.analyze."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "campaign_id": _CAMPAIGN_ID_PARAM,
+                "url": {
                     "type": "string",
-                    "description": "Google Ads customer ID",
+                    "format": "uri",
+                    "description": (
+                        "Absolute landing page URL to analyze (http:// "
+                        "or https:// only, e.g. "
+                        "'https://example.com/lp/'). SSRF-protected — "
+                        "private-range, loopback, and cloud-metadata "
+                        "hosts are rejected."
+                    ),
                 },
-                "campaign_id": {"type": "string", "description": "Campaign ID"},
-                "url": {"type": "string", "description": "Landing page URL"},
-                "ad_group_id": {
-                    "type": "string",
-                    "description": "Filter by ad group ID",
-                },
+                "ad_group_id": _AD_GROUP_ID_FILTER_PARAM,
             },
             "required": ["campaign_id", "url"],
         },
@@ -473,49 +766,101 @@ TOOLS: list[Tool] = [
     # === Monitoring ===
     Tool(
         name="google_ads.monitoring.delivery_goal",
-        description="Evaluate Google Ads delivery goals and assess delivery status and performance",
+        description=(
+            "Check whether a Google Ads campaign is actively delivering "
+            "yesterday by composing campaign info, delivery diagnostics, "
+            "and yesterday's performance. Returns {campaign_id, "
+            "campaign, diagnosis:{issues, warnings, recommendations, "
+            "...}, performance (list of yesterday rows with metrics), "
+            "status ('critical'|'warning'|'healthy'), issues:[strings], "
+            "summary, suggested_workflow?}. 'critical' fires when "
+            "delivery diagnostics have issues, the campaign is not "
+            "ENABLED, or yesterday impressions == 0. 'warning' fires "
+            "for diagnostic warnings or impressions 1-9. "
+            "suggested_workflow is set to 'delivery_fix' when status != "
+            "'healthy'. Read-only. For the raw diagnostics without the "
+            "yesterday composite use google_ads.campaigns.diagnose; for "
+            "CPA-target evaluation use google_ads.monitoring.cpa_goal."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
-                    "type": "string",
-                    "description": "Google Ads customer ID",
-                },
-                "campaign_id": {"type": "string", "description": "Campaign ID"},
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "campaign_id": _CAMPAIGN_ID_PARAM,
             },
             "required": ["campaign_id"],
         },
     ),
     Tool(
         name="google_ads.monitoring.cpa_goal",
-        description="Evaluate current performance against Google Ads CPA goals",
+        description=(
+            "Evaluate a Google Ads campaign's last-7-days CPA against a "
+            "user-supplied target and integrate cost-increase analysis. "
+            "Returns {campaign_id, target_cpa, current_cpa (float or "
+            "None when conversions==0), cost_analysis (full "
+            "google_ads.cost_increase.investigate payload), "
+            "wasteful_terms (top 5 zero-CV cost terms from "
+            "cost_analysis), deviation_pct, status ('healthy' when "
+            "current<=target, 'warning' when <=target*1.2 or when "
+            "CV==0, 'critical' when >target*1.2), issues:[strings], "
+            "summary, suggested_workflow?}. The CPA window is hardcoded "
+            "to LAST_7_DAYS. Read-only; does not change bids. For "
+            "account-wide rollup use google_ads.health_check.all; for "
+            "daily CV-count vs target use google_ads.monitoring.cv_goal."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
-                    "type": "string",
-                    "description": "Google Ads customer ID",
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "campaign_id": _CAMPAIGN_ID_PARAM,
+                "target_cpa": {
+                    "type": "number",
+                    "minimum": 0,
+                    "description": (
+                        "Target cost per acquisition in account "
+                        "currency (e.g. 3000 = ¥3,000). Required — "
+                        "this tool does NOT fall back to bidding-"
+                        "strategy or actual CPA. 'warning' threshold is "
+                        "target_cpa * 1.2; above that is 'critical'."
+                    ),
                 },
-                "campaign_id": {"type": "string", "description": "Campaign ID"},
-                "target_cpa": {"type": "number", "description": "Target CPA"},
             },
             "required": ["campaign_id", "target_cpa"],
         },
     ),
     Tool(
         name="google_ads.monitoring.cv_goal",
-        description="Evaluate current performance against Google Ads daily conversion goals",
+        description=(
+            "Evaluate a Google Ads campaign's daily conversion rate "
+            "against a target and identify the dominant bottleneck. "
+            "Returns {campaign_id, target_cv_daily, current_cv_daily "
+            "(7-day conversions / 7), performance_analysis (full "
+            "google_ads.performance.analyze payload), deviation_pct, "
+            "status ('healthy' when >= target, 'warning' when >= "
+            "target*0.8, 'critical' otherwise), bottleneck "
+            "('impression'|'ctr'|'cvr'), issues:[strings], summary, "
+            "suggested_workflow?}. Bottleneck routing: 'impression' "
+            "when analyze insights mention impression drops or "
+            "impressions<clicks*10; 'ctr' when CTR<2%; 'cvr' otherwise. "
+            "The evaluation window is hardcoded to LAST_7_DAYS. "
+            "Read-only. For CPA-target evaluation use "
+            "google_ads.monitoring.cpa_goal; for the underlying "
+            "composite use google_ads.performance.analyze."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
-                    "type": "string",
-                    "description": "Google Ads customer ID",
-                },
-                "campaign_id": {"type": "string", "description": "Campaign ID"},
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "campaign_id": _CAMPAIGN_ID_PARAM,
                 "target_cv_daily": {
                     "type": "number",
-                    "description": "Daily conversion target",
+                    "minimum": 0,
+                    "description": (
+                        "Target daily conversion count (e.g. 5.0 means "
+                        "5 conversions per day). Required. status "
+                        "'warning' fires at 80-100% of target; "
+                        "'critical' below 80%."
+                    ),
                 },
             },
             "required": ["campaign_id", "target_cv_daily"],
@@ -523,15 +868,33 @@ TOOLS: list[Tool] = [
     ),
     Tool(
         name="google_ads.monitoring.zero_conversions",
-        description="Diagnose causes of zero conversions in Google Ads",
+        description=(
+            "Diagnose a Google Ads campaign that is not acquiring "
+            "conversions by composing tracking config, bidding "
+            "alignment, last-7-days funnel, delivery diagnostics, and "
+            "search-term quality. Returns {campaign_id, "
+            "conversion_tracking:{total_actions, enabled_actions, "
+            "has_issue, actions}, bidding_cv_alignment:{strategy, "
+            "is_smart_bidding, cv_tracking_configured, issue}, "
+            "funnel:{period:'LAST_7_DAYS', impressions, clicks, "
+            "conversions, cost, ctr, cvr, bottleneck ('no_delivery'|"
+            "'no_clicks'|'no_conversions'|None)}, delivery_diagnosis:{"
+            "issues, warnings, recommendations}, search_term_quality:{"
+            "total_terms, zero_cv_terms, zero_cv_cost, "
+            "top_wasteful_terms} (null when clicks==0), status "
+            "('critical'|'warning'|'healthy'), issues:[strings], "
+            "summary, suggested_workflow?, recommended_actions:[{"
+            "priority, action, description}]}. The evaluation window "
+            "is hardcoded to LAST_7_DAYS. Read-only; generates an "
+            "action plan but does not execute anything. For CPA "
+            "monitoring use google_ads.monitoring.cpa_goal; for "
+            "CV-count monitoring use google_ads.monitoring.cv_goal."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
-                    "type": "string",
-                    "description": "Google Ads customer ID",
-                },
-                "campaign_id": {"type": "string", "description": "Campaign ID"},
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "campaign_id": _CAMPAIGN_ID_PARAM,
             },
             "required": ["campaign_id"],
         },

--- a/mureo/mcp/_tools_google_ads_assets.py
+++ b/mureo/mcp/_tools_google_ads_assets.py
@@ -4,20 +4,57 @@ from __future__ import annotations
 
 from mcp.types import Tool
 
+_CUSTOMER_ID_PARAM = {
+    "type": "string",
+    "description": (
+        "Google Ads customer ID as a 10-digit string without dashes "
+        "(e.g. '1234567890'). Optional — falls back to "
+        "GOOGLE_ADS_CUSTOMER_ID / GOOGLE_ADS_LOGIN_CUSTOMER_ID from the "
+        "configured credentials when omitted."
+    ),
+}
+
 TOOLS: list[Tool] = [
     # === Image Assets ===
     Tool(
         name="google_ads.assets.upload_image",
-        description="Upload an image asset to Google Ads from a local file",
+        description=(
+            "Upload a local image file to Google Ads as an image Asset "
+            "for use in Responsive Display Ads or image extensions. "
+            "Returns {resource_name ('customers/<cid>/assets/<aid>'), "
+            "id (asset id as string), name (asset display name or "
+            "basename)}. Mutating — creates a new Asset row in the "
+            "customer account; removal must be done through the Google "
+            "Ads UI (there is no corresponding delete tool). The file "
+            "is validated before upload: max 5 MB, extensions must be "
+            "jpg/jpeg/png/gif. Side effect: reads file_path from the "
+            "local filesystem of the MCP server host and POSTs the raw "
+            "bytes to Google. For creating the ad that references this "
+            "asset afterwards use google_ads.ads.create_display."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "file_path": {
                     "type": "string",
-                    "description": "Google Ads customer ID",
+                    "description": (
+                        "Absolute or MCP-server-relative path to the "
+                        "image file on the host running mureo "
+                        "(e.g. '/Users/me/ads/hero.png'). Must have "
+                        "a .jpg/.jpeg/.png/.gif extension and be "
+                        "<= 5 MB."
+                    ),
                 },
-                "file_path": {"type": "string", "description": "Image file path"},
-                "name": {"type": "string", "description": "Asset name (optional)"},
+                "name": {
+                    "type": "string",
+                    "maxLength": 128,
+                    "description": (
+                        "Optional display name for the asset as shown "
+                        "in the Google Ads UI. Defaults to the file's "
+                        "basename when omitted."
+                    ),
+                },
             },
             "required": ["file_path"],
         },

--- a/mureo/mcp/_tools_google_ads_extensions.py
+++ b/mureo/mcp/_tools_google_ads_extensions.py
@@ -4,54 +4,161 @@ from __future__ import annotations
 
 from mcp.types import Tool
 
+_CUSTOMER_ID_PARAM = {
+    "type": "string",
+    "description": (
+        "Google Ads customer ID as a 10-digit string without dashes "
+        "(e.g. '1234567890'). Optional — falls back to "
+        "GOOGLE_ADS_CUSTOMER_ID / GOOGLE_ADS_LOGIN_CUSTOMER_ID from "
+        "the configured credentials when omitted."
+    ),
+}
+
+_CAMPAIGN_ID_PARAM = {
+    "type": "string",
+    "description": (
+        "Campaign ID as a numeric string without dashes "
+        "(e.g. '23743184133'). Obtain via google_ads.campaigns.list."
+    ),
+}
+
+_PERIOD_PARAM = {
+    "type": "string",
+    "enum": [
+        "TODAY",
+        "YESTERDAY",
+        "LAST_7_DAYS",
+        "LAST_14_DAYS",
+        "LAST_30_DAYS",
+        "LAST_90_DAYS",
+        "THIS_MONTH",
+        "LAST_MONTH",
+    ],
+    "description": (
+        "Reporting window. Default 'LAST_30_DAYS'. Use LAST_7_DAYS / "
+        "LAST_14_DAYS for recent diagnosis; LAST_90_DAYS for baseline."
+    ),
+}
+
+_CONVERSION_ACTION_ID_PARAM = {
+    "type": "string",
+    "description": (
+        "Conversion action ID as a numeric string (e.g. "
+        "'987654321'). Obtain via google_ads.conversions.list."
+    ),
+}
+
+
 TOOLS: list[Tool] = [
     # === Sitelinks ===
     Tool(
         name="google_ads.sitelinks.list",
-        description="List Google Ads campaign sitelinks",
+        description=(
+            "List sitelink assets attached to a Google Ads campaign, "
+            "merging campaign-level and account-level entries. Returns "
+            "[{id, resource_name, link_text, description1, "
+            "description2, final_urls:[string], level "
+            "('campaign'|'account')}]. Account-level sitelinks apply "
+            "to the whole customer and are deduplicated by id. "
+            "Read-only. Use this to audit extensions before calling "
+            "google_ads.sitelinks.create (20 per-campaign limit) or "
+            "google_ads.sitelinks.remove. For callouts use "
+            "google_ads.callouts.list."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
-                    "type": "string",
-                    "description": "Google Ads customer ID",
-                },
-                "campaign_id": {"type": "string", "description": "Campaign ID"},
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "campaign_id": _CAMPAIGN_ID_PARAM,
             },
             "required": ["campaign_id"],
         },
     ),
     Tool(
         name="google_ads.sitelinks.create",
-        description="Create a Google Ads sitelink and link it to a campaign",
+        description=(
+            "Create a sitelink Asset and link it to a Google Ads "
+            "campaign in a two-step mutate (AssetService then "
+            "CampaignAssetService). Returns {resource_name} of the "
+            "created asset on success, or {error:true, "
+            "error_type:'validation_error', message} when the "
+            "campaign already has 20 campaign-level sitelinks "
+            "(hardcoded _MAX_SITELINKS_PER_CAMPAIGN limit). Mutating "
+            "— reversible only by google_ads.sitelinks.remove using "
+            "the returned asset_id. The asset is newly minted per "
+            "call; identical text produces duplicate assets unless "
+            "deduplicated upstream."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "campaign_id": _CAMPAIGN_ID_PARAM,
+                "link_text": {
                     "type": "string",
-                    "description": "Google Ads customer ID",
+                    "maxLength": 25,
+                    "description": (
+                        "Link text shown to searchers (e.g. 'Pricing'). "
+                        "Google Ads limits this to 25 characters."
+                    ),
                 },
-                "campaign_id": {"type": "string", "description": "Campaign ID"},
-                "link_text": {"type": "string", "description": "Link text"},
-                "final_url": {"type": "string", "description": "Final URL"},
-                "description1": {"type": "string", "description": "Description line 1"},
-                "description2": {"type": "string", "description": "Description line 2"},
+                "final_url": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": (
+                        "Absolute landing URL (http:// or https://) "
+                        "for the sitelink. Must be a crawlable page on "
+                        "the advertiser's verified domain."
+                    ),
+                },
+                "description1": {
+                    "type": "string",
+                    "maxLength": 35,
+                    "description": (
+                        "Optional first description line (max 35 "
+                        "characters). Only displayed when "
+                        "description2 is also provided and Google "
+                        "chooses to render the expanded format."
+                    ),
+                },
+                "description2": {
+                    "type": "string",
+                    "maxLength": 35,
+                    "description": (
+                        "Optional second description line (max 35 "
+                        "characters). Requires description1."
+                    ),
+                },
             },
             "required": ["campaign_id", "link_text", "final_url"],
         },
     ),
     Tool(
         name="google_ads.sitelinks.remove",
-        description="Remove a Google Ads sitelink",
+        description=(
+            "Detach a sitelink asset from a Google Ads campaign by "
+            "removing the CampaignAsset link. Returns {resource_name} "
+            "of the removed campaign-asset association. Destructive — "
+            "unlinks the asset from the campaign so it stops serving, "
+            "but does not delete the underlying Asset row. Re-linking "
+            "requires google_ads.sitelinks.create with the same "
+            "text/URL. To list current sitelinks use "
+            "google_ads.sitelinks.list."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "campaign_id": _CAMPAIGN_ID_PARAM,
+                "asset_id": {
                     "type": "string",
-                    "description": "Google Ads customer ID",
+                    "description": (
+                        "Asset ID as a numeric string (e.g. "
+                        "'123456789'). Obtain from the 'id' field of "
+                        "google_ads.sitelinks.list rows where "
+                        "level=='campaign'."
+                    ),
                 },
-                "campaign_id": {"type": "string", "description": "Campaign ID"},
-                "asset_id": {"type": "string", "description": "Asset ID"},
             },
             "required": ["campaign_id", "asset_id"],
         },
@@ -59,33 +166,52 @@ TOOLS: list[Tool] = [
     # === Callouts ===
     Tool(
         name="google_ads.callouts.list",
-        description="List Google Ads campaign callouts",
+        description=(
+            "List callout extension assets linked to a Google Ads "
+            "campaign. Returns [{id, resource_name, callout_text}]. "
+            "Unlike google_ads.sitelinks.list, this only scans "
+            "campaign_asset rows (no account-level merge). Read-only. "
+            "Use this to audit coverage before calling "
+            "google_ads.callouts.create (hardcoded limit: 20 callouts "
+            "per campaign) or google_ads.callouts.remove."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
-                    "type": "string",
-                    "description": "Google Ads customer ID",
-                },
-                "campaign_id": {"type": "string", "description": "Campaign ID"},
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "campaign_id": _CAMPAIGN_ID_PARAM,
             },
             "required": ["campaign_id"],
         },
     ),
     Tool(
         name="google_ads.callouts.create",
-        description="Create a Google Ads callout and link it to a campaign",
+        description=(
+            "Create a callout Asset and link it to a Google Ads "
+            "campaign in a two-step mutate (AssetService then "
+            "CampaignAssetService). Returns {resource_name} of the "
+            "newly created asset, or {error:true, "
+            "error_type:'validation_error', message} when the "
+            "campaign already has 20 callouts "
+            "(_MAX_CALLOUTS_PER_CAMPAIGN limit). Mutating — "
+            "reversible only by google_ads.callouts.remove. The asset "
+            "is minted per call, so identical text creates duplicate "
+            "asset rows. For sitelink variants use "
+            "google_ads.sitelinks.create."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
-                    "type": "string",
-                    "description": "Google Ads customer ID",
-                },
-                "campaign_id": {"type": "string", "description": "Campaign ID"},
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "campaign_id": _CAMPAIGN_ID_PARAM,
                 "callout_text": {
                     "type": "string",
-                    "description": "Callout text",
+                    "maxLength": 25,
+                    "description": (
+                        "Callout text shown below the ad (e.g. "
+                        "'Free shipping', '24/7 support'). Google "
+                        "Ads limit: 25 characters."
+                    ),
                 },
             },
             "required": ["campaign_id", "callout_text"],
@@ -93,16 +219,28 @@ TOOLS: list[Tool] = [
     ),
     Tool(
         name="google_ads.callouts.remove",
-        description="Remove a Google Ads callout",
+        description=(
+            "Detach a callout asset from a Google Ads campaign by "
+            "removing the CampaignAsset link. Returns {resource_name} "
+            "of the removed campaign-asset association. Destructive — "
+            "the callout stops serving on the campaign but the Asset "
+            "row itself is not deleted. Re-enabling requires "
+            "google_ads.callouts.create with the same text. For the "
+            "sibling list operation use google_ads.callouts.list."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "campaign_id": _CAMPAIGN_ID_PARAM,
+                "asset_id": {
                     "type": "string",
-                    "description": "Google Ads customer ID",
+                    "description": (
+                        "Asset ID as a numeric string (e.g. "
+                        "'123456789'). Obtain from the 'id' field of "
+                        "google_ads.callouts.list."
+                    ),
                 },
-                "campaign_id": {"type": "string", "description": "Campaign ID"},
-                "asset_id": {"type": "string", "description": "Asset ID"},
             },
             "required": ["campaign_id", "asset_id"],
         },
@@ -110,92 +248,195 @@ TOOLS: list[Tool] = [
     # === Conversions ===
     Tool(
         name="google_ads.conversions.list",
-        description="List Google Ads conversion actions",
+        description=(
+            "List every conversion action configured on the Google "
+            "Ads customer, ordered by numeric id. Returns [{id "
+            "(string), name, type (ConversionActionType enum string, "
+            "e.g. 'WEBPAGE'), status ('ENABLED'|'HIDDEN'|'REMOVED'|"
+            "'UNSPECIFIED'|'UNKNOWN'), category (enum string, e.g. "
+            "'PURCHASE', 'SIGNUP')}]. Read-only. Use this to discover "
+            "conversion_action_id values before calling .get, .update, "
+            ".remove, or .tag. For CV performance metrics use "
+            "google_ads.conversions.performance."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
-                    "type": "string",
-                    "description": "Google Ads customer ID",
-                },
+                "customer_id": _CUSTOMER_ID_PARAM,
             },
             "required": [],
         },
     ),
     Tool(
         name="google_ads.conversions.get",
-        description="Get Google Ads conversion action details",
+        description=(
+            "Fetch one conversion action's configuration from Google "
+            "Ads by numeric ID. Returns {id, name, type "
+            "(ConversionActionType enum string, e.g. 'WEBPAGE'), "
+            "status ('ENABLED'|'HIDDEN'|'REMOVED'|'UNSPECIFIED'|"
+            "'UNKNOWN'), category (enum string, e.g. 'PURCHASE', "
+            "'SIGNUP')} or null when no row matches. Read-only; does "
+            "NOT return value settings or lookback-window values — use "
+            "the Google Ads UI for those. For the HTML/JS tag snippet "
+            "to embed on a site use google_ads.conversions.tag; for "
+            "full listings use google_ads.conversions.list."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
-                    "type": "string",
-                    "description": "Google Ads customer ID",
-                },
-                "conversion_action_id": {
-                    "type": "string",
-                    "description": "Conversion action ID",
-                },
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "conversion_action_id": _CONVERSION_ACTION_ID_PARAM,
             },
             "required": ["conversion_action_id"],
         },
     ),
     Tool(
         name="google_ads.conversions.performance",
-        description="Get Google Ads conversion performance by conversion action",
+        description=(
+            "Report Google Ads conversions broken down by "
+            "conversion_action and date, with optional campaign "
+            "filter. Returns {period, campaign_id, total_conversions, "
+            "actions:[{campaign_id, campaign_name, "
+            "conversion_action_name, conversions, conversions_value, "
+            "first_date, last_date, cost_per_conversion}] (sorted by "
+            "conversions desc), daily_details:[{date, campaign_id, "
+            "campaign_name, conversion_action_name, conversions, "
+            "conversions_value}], landing_pages:[{date, "
+            "landing_page_url, campaign_id, campaign_name, "
+            "conversions, conversions_value, clicks}]}. Only rows with "
+            "conversions > 0 are included. cost_per_conversion is "
+            "computed via a separate GAQL because GAQL cannot SELECT "
+            "cost_per_conversion alongside segments.conversion_action_name. "
+            "Read-only. For campaign-level metrics use "
+            "google_ads.performance.report."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
-                    "type": "string",
-                    "description": "Google Ads customer ID",
-                },
+                "customer_id": _CUSTOMER_ID_PARAM,
                 "campaign_id": {
                     "type": "string",
-                    "description": "Filter by campaign ID",
+                    "description": (
+                        "Optional campaign ID as a numeric string to "
+                        "restrict the report. Omit for account-wide "
+                        "aggregation."
+                    ),
                 },
-                "period": {"type": "string", "description": "Period"},
+                "period": _PERIOD_PARAM,
             },
             "required": [],
         },
     ),
     Tool(
         name="google_ads.conversions.create",
-        description="Create a Google Ads conversion action",
+        description=(
+            "Create a new Google Ads conversion action. Returns "
+            "{resource_name:'customers/<cid>/conversionActions/<caid>'} "
+            "of the newly created row. Mutating — the conversion "
+            "action is persisted with status ENABLED by default. "
+            "Reversible via google_ads.conversions.update with "
+            "status='REMOVED' or google_ads.conversions.remove. Name "
+            "must be <= 256 characters. Category defaults to "
+            "'DEFAULT'. For updating an existing action use "
+            "google_ads.conversions.update."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
-                    "type": "string",
-                    "description": "Google Ads customer ID",
-                },
+                "customer_id": _CUSTOMER_ID_PARAM,
                 "name": {
                     "type": "string",
-                    "description": "Conversion action name",
+                    "maxLength": 256,
+                    "description": (
+                        "Human-readable conversion action name shown "
+                        "in the Google Ads UI (e.g. 'Purchase - "
+                        "Checkout Complete'). Required. Max 256 "
+                        "characters."
+                    ),
                 },
                 "type": {
                     "type": "string",
-                    "description": "Type (WEBPAGE/UPLOAD_CLICKS etc.)",
+                    "enum": [
+                        "WEBPAGE",
+                        "UPLOAD_CLICKS",
+                        "UPLOAD_CALLS",
+                        "AD_CALL",
+                        "WEBSITE_CALL",
+                        "STORE_SALES_DIRECT_UPLOAD",
+                        "STORE_SALES",
+                    ],
+                    "description": (
+                        "ConversionActionType enum. Default 'WEBPAGE' "
+                        "(site tag fires). Use 'UPLOAD_CLICKS' for "
+                        "offline-conversion uploads or 'WEBSITE_CALL' "
+                        "for call conversions."
+                    ),
                 },
                 "category": {
                     "type": "string",
-                    "description": "Category (PURCHASE/SIGNUP etc.)",
+                    "enum": [
+                        "DEFAULT",
+                        "PAGE_VIEW",
+                        "PURCHASE",
+                        "SIGNUP",
+                        "DOWNLOAD",
+                        "ADD_TO_CART",
+                        "BEGIN_CHECKOUT",
+                        "SUBSCRIBE_PAID",
+                        "PHONE_CALL_LEAD",
+                        "IMPORTED_LEAD",
+                        "SUBMIT_LEAD_FORM",
+                        "BOOK_APPOINTMENT",
+                        "QUALIFIED_LEAD",
+                        "CONVERTED_LEAD",
+                        "REQUEST_QUOTE",
+                        "GET_DIRECTIONS",
+                        "OUTBOUND_CLICK",
+                        "CONTACT",
+                        "ENGAGEMENT",
+                        "STORE_VISIT",
+                        "STORE_SALE",
+                    ],
+                    "description": (
+                        "Conversion category. Default 'DEFAULT'. "
+                        "Smart bidding uses this to group similar "
+                        "goals."
+                    ),
                 },
                 "default_value": {
                     "type": "number",
-                    "description": "Default conversion value",
+                    "minimum": 0,
+                    "description": (
+                        "Default monetary conversion value in account "
+                        "currency (e.g. 5000 = ¥5,000). Used when the "
+                        "site tag does not send a value."
+                    ),
                 },
                 "always_use_default_value": {
                     "type": "boolean",
-                    "description": "Whether to always use the default value",
+                    "description": (
+                        "When true, always use default_value even if "
+                        "the site tag sends a dynamic value."
+                    ),
                 },
                 "click_through_lookback_window_days": {
                     "type": "integer",
-                    "description": "Click-through lookback window (1-90 days)",
+                    "minimum": 1,
+                    "maximum": 90,
+                    "description": (
+                        "Click-through attribution window in days "
+                        "(1-90). Server-side validated — invalid "
+                        "values raise ValueError."
+                    ),
                 },
                 "view_through_lookback_window_days": {
                     "type": "integer",
-                    "description": "View-through lookback window (1-30 days)",
+                    "minimum": 1,
+                    "maximum": 30,
+                    "description": (
+                        "View-through attribution window in days "
+                        "(1-30). Server-side validated."
+                    ),
                 },
             },
             "required": ["name"],
@@ -203,39 +444,98 @@ TOOLS: list[Tool] = [
     ),
     Tool(
         name="google_ads.conversions.update",
-        description="Update a Google Ads conversion action",
+        description=(
+            "Update fields on an existing Google Ads conversion "
+            "action via FieldMask mutate. Returns {resource_name} of "
+            "the updated row. Mutating — partial update: only the "
+            "fields you pass are modified, the rest are preserved. "
+            "At least one updatable field must be supplied (name, "
+            "category, status, default_value, "
+            "always_use_default_value, "
+            "click_through_lookback_window_days, "
+            "view_through_lookback_window_days) or the call raises "
+            "ValueError. To delete/archive an action use status "
+            "'REMOVED' here or call google_ads.conversions.remove."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "conversion_action_id": _CONVERSION_ACTION_ID_PARAM,
+                "name": {
                     "type": "string",
-                    "description": "Google Ads customer ID",
+                    "maxLength": 256,
+                    "description": (
+                        "New display name (max 256 characters). Omit "
+                        "to leave the name unchanged."
+                    ),
                 },
-                "conversion_action_id": {
+                "category": {
                     "type": "string",
-                    "description": "Conversion action ID",
+                    "enum": [
+                        "DEFAULT",
+                        "PAGE_VIEW",
+                        "PURCHASE",
+                        "SIGNUP",
+                        "DOWNLOAD",
+                        "ADD_TO_CART",
+                        "BEGIN_CHECKOUT",
+                        "SUBSCRIBE_PAID",
+                        "PHONE_CALL_LEAD",
+                        "IMPORTED_LEAD",
+                        "SUBMIT_LEAD_FORM",
+                        "BOOK_APPOINTMENT",
+                        "QUALIFIED_LEAD",
+                        "CONVERTED_LEAD",
+                        "REQUEST_QUOTE",
+                        "GET_DIRECTIONS",
+                        "OUTBOUND_CLICK",
+                        "CONTACT",
+                        "ENGAGEMENT",
+                        "STORE_VISIT",
+                        "STORE_SALE",
+                    ],
+                    "description": ("New category. Must match the allowed enum."),
                 },
-                "name": {"type": "string", "description": "New name"},
-                "category": {"type": "string", "description": "Category"},
                 "status": {
                     "type": "string",
-                    "description": "Status (ENABLED/HIDDEN/REMOVED)",
+                    "enum": ["ENABLED", "HIDDEN", "REMOVED"],
+                    "description": (
+                        "New status. 'ENABLED' counts toward "
+                        "'Conversions' column; 'HIDDEN' excludes it "
+                        "from the column but keeps the action; "
+                        "'REMOVED' archives it."
+                    ),
                 },
                 "default_value": {
                     "type": "number",
-                    "description": "Default conversion value",
+                    "minimum": 0,
+                    "description": (
+                        "New default conversion value in account " "currency."
+                    ),
                 },
                 "always_use_default_value": {
                     "type": "boolean",
-                    "description": "Whether to always use the default value",
+                    "description": (
+                        "Toggle whether default_value always overrides "
+                        "tag-supplied values."
+                    ),
                 },
                 "click_through_lookback_window_days": {
                     "type": "integer",
-                    "description": "Click-through lookback window (1-90 days)",
+                    "minimum": 1,
+                    "maximum": 90,
+                    "description": (
+                        "New click-through attribution window in days " "(1-90)."
+                    ),
                 },
                 "view_through_lookback_window_days": {
                     "type": "integer",
-                    "description": "View-through lookback window (1-30 days)",
+                    "minimum": 1,
+                    "maximum": 30,
+                    "description": (
+                        "New view-through attribution window in days " "(1-30)."
+                    ),
                 },
             },
             "required": ["conversion_action_id"],
@@ -243,36 +543,42 @@ TOOLS: list[Tool] = [
     ),
     Tool(
         name="google_ads.conversions.remove",
-        description="Remove a Google Ads conversion action",
+        description=(
+            "Archive (status=REMOVED) a Google Ads conversion action. "
+            "Returns {resource_name} of the removed row. Destructive — "
+            "historical data remains but the action stops counting "
+            "toward 'Conversions'. Re-enabling requires "
+            "google_ads.conversions.update with status='ENABLED'. For "
+            "soft-hide that keeps the row visible use "
+            "google_ads.conversions.update with status='HIDDEN'."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
-                    "type": "string",
-                    "description": "Google Ads customer ID",
-                },
-                "conversion_action_id": {
-                    "type": "string",
-                    "description": "Conversion action ID",
-                },
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "conversion_action_id": _CONVERSION_ACTION_ID_PARAM,
             },
             "required": ["conversion_action_id"],
         },
     ),
     Tool(
         name="google_ads.conversions.tag",
-        description="Get Google Ads conversion action tag snippet",
+        description=(
+            "Fetch the HTML/JavaScript tag snippets for a Google Ads "
+            "conversion action so you can install them on the "
+            "advertiser's site. Returns [{type (TagSnippetType enum "
+            "string, e.g. 'WEBPAGE', 'WEBPAGE_ONCLICK'), page_header "
+            "(the <script> block that goes in <head>), event_snippet "
+            "(the goal event snippet)}]. Empty list when no snippets "
+            "are configured (e.g. UPLOAD_CLICKS actions have no web "
+            "tag). Read-only. For configuration metadata use "
+            "google_ads.conversions.get."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
-                    "type": "string",
-                    "description": "Google Ads customer ID",
-                },
-                "conversion_action_id": {
-                    "type": "string",
-                    "description": "Conversion action ID",
-                },
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "conversion_action_id": _CONVERSION_ACTION_ID_PARAM,
             },
             "required": ["conversion_action_id"],
         },
@@ -280,21 +586,38 @@ TOOLS: list[Tool] = [
     # === Recommendations ===
     Tool(
         name="google_ads.recommendations.list",
-        description="List Google Ads recommendations",
+        description=(
+            "List Google's current automated recommendations for the "
+            "account. Returns [{resource_name, type "
+            "(RecommendationType enum string, e.g. "
+            "'KEYWORD', 'TEXT_AD', 'TARGET_CPA_OPT_IN', "
+            "'MAXIMIZE_CONVERSIONS_OPT_IN'), impact:{base_metrics:{"
+            "impressions, clicks, cost_micros}}, campaign_id "
+            "(resource path when scoped to a campaign)}]. Read-only. "
+            "Filter by campaign_id to scope to one campaign, or by "
+            "recommendation_type to scope to one kind. To apply a "
+            "recommendation use google_ads.recommendations.apply with "
+            "resource_name from this list."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
-                    "type": "string",
-                    "description": "Google Ads customer ID",
-                },
+                "customer_id": _CUSTOMER_ID_PARAM,
                 "campaign_id": {
                     "type": "string",
-                    "description": "Filter by campaign ID",
+                    "description": (
+                        "Optional campaign ID as a numeric string. "
+                        "Omit to list account-wide recommendations."
+                    ),
                 },
                 "recommendation_type": {
                     "type": "string",
-                    "description": "Filter by recommendation type",
+                    "description": (
+                        "Optional RecommendationType enum string "
+                        "(e.g. 'KEYWORD', 'TEXT_AD', "
+                        "'TARGET_CPA_OPT_IN'). Validated against the "
+                        "client's allow-list before GAQL embedding."
+                    ),
                 },
             },
             "required": [],
@@ -302,17 +625,32 @@ TOOLS: list[Tool] = [
     ),
     Tool(
         name="google_ads.recommendations.apply",
-        description="Apply a Google Ads recommendation",
+        description=(
+            "Apply one Google Ads recommendation by resource name. "
+            "Returns {resource_name} of the applied recommendation. "
+            "Mutating — the underlying change (new keyword, ad copy, "
+            "bidding strategy switch, etc.) is committed to the "
+            "campaign immediately and is NOT reversible through this "
+            "tool. The resource_name format "
+            "'customers/<cid>/recommendations/<rid>' is re-validated "
+            "server-side to prevent injection. To list candidates "
+            "use google_ads.recommendations.list; some recommendation "
+            "types also change budget, device, or schedule settings."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
-                    "type": "string",
-                    "description": "Google Ads customer ID",
-                },
+                "customer_id": _CUSTOMER_ID_PARAM,
                 "resource_name": {
                     "type": "string",
-                    "description": "Recommendation resource name",
+                    "pattern": r"^customers/\d+/recommendations/\d+$",
+                    "description": (
+                        "Recommendation resource name exactly as "
+                        "returned by google_ads.recommendations.list "
+                        "(format: 'customers/<cid>/recommendations/"
+                        "<rid>'). Re-validated against a strict regex "
+                        "before submission."
+                    ),
                 },
             },
             "required": ["resource_name"],
@@ -321,34 +659,68 @@ TOOLS: list[Tool] = [
     # === Device Targeting ===
     Tool(
         name="google_ads.device_targeting.get",
-        description="Get Google Ads campaign device targeting settings",
+        description=(
+            "Get the device targeting state for a Google Ads "
+            "campaign. Always returns three entries (DESKTOP, MOBILE, "
+            "TABLET in that order), each shaped {criterion_id "
+            "(string or null when no explicit criterion exists), "
+            "device_type ('DESKTOP'|'MOBILE'|'TABLET'), bid_modifier "
+            "(float or null), enabled (bool — True when no criterion "
+            "exists OR bid_modifier != 0.0; False when "
+            "bid_modifier==0 meaning delivery is off)}. Read-only. "
+            "The 'enabled=False' semantics are mureo's convention: "
+            "Google represents 'don't serve' as bid_modifier=0.0 "
+            "(i.e. -100%). For modifying, use "
+            "google_ads.device_targeting.set or "
+            "google_ads.bid_adjustments.update."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
-                    "type": "string",
-                    "description": "Google Ads customer ID",
-                },
-                "campaign_id": {"type": "string", "description": "Campaign ID"},
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "campaign_id": _CAMPAIGN_ID_PARAM,
             },
             "required": ["campaign_id"],
         },
     ),
     Tool(
         name="google_ads.device_targeting.set",
-        description="Set Google Ads device targeting (serve only on specified devices)",
+        description=(
+            "Toggle device delivery on a Google Ads campaign by "
+            "setting bid_modifier=1.0 on enabled devices and 0.0 on "
+            "disabled ones. Iterates all three devices individually "
+            "so one failure does not abort the others. Returns "
+            "{message, enabled_devices (sorted list), "
+            "disabled_devices (sorted list), updated (list of "
+            "resource_names that succeeded), errors (list of "
+            "'<device>(<op>): <detail>' strings, or null)}. Mutating "
+            "— existing device criteria are UPDATE-ed, missing ones "
+            "are CREATE-ed. Reversible only by calling this tool "
+            "again with a different enabled_devices. enabled_devices "
+            "must be non-empty (passing an empty array raises "
+            "ValueError). For fine-grained non-zero bid modifiers "
+            "use google_ads.bid_adjustments.update."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
-                    "type": "string",
-                    "description": "Google Ads customer ID",
-                },
-                "campaign_id": {"type": "string", "description": "Campaign ID"},
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "campaign_id": _CAMPAIGN_ID_PARAM,
                 "enabled_devices": {
                     "type": "array",
-                    "items": {"type": "string"},
-                    "description": "List of devices to enable (MOBILE/DESKTOP/TABLET)",
+                    "items": {
+                        "type": "string",
+                        "enum": ["MOBILE", "DESKTOP", "TABLET"],
+                    },
+                    "minItems": 1,
+                    "maxItems": 3,
+                    "uniqueItems": True,
+                    "description": (
+                        "Devices that should continue serving "
+                        "(bid_modifier=1.0). Devices not in this "
+                        "list have bid_modifier set to 0.0 (delivery "
+                        "off). At least one device must be enabled."
+                    ),
                 },
             },
             "required": ["campaign_id", "enabled_devices"],
@@ -357,37 +729,65 @@ TOOLS: list[Tool] = [
     # === Bid adjustments ===
     Tool(
         name="google_ads.bid_adjustments.get",
-        description="Get Google Ads campaign bid adjustments",
+        description=(
+            "List every campaign_criterion row that has a non-null "
+            "bid_modifier on a Google Ads campaign. Returns [{"
+            "criterion_id, type (CriterionType enum string, e.g. "
+            "'DEVICE', 'LOCATION', 'AD_SCHEDULE'), bid_modifier "
+            "(float), device_type ('DESKTOP'|'MOBILE'|'TABLET' for "
+            "DEVICE criteria; 'UNKNOWN(<n>)' for non-DEVICE rows "
+            "such as LOCATION or AD_SCHEDULE, where n is the raw "
+            "device-type enum ordinal — never null)}]. Read-only. "
+            "For the device-summary view (all three devices, even "
+            "implicit ones) use google_ads.device_targeting.get. For "
+            "location-only use google_ads.location_targeting.list."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
-                    "type": "string",
-                    "description": "Google Ads customer ID",
-                },
-                "campaign_id": {"type": "string", "description": "Campaign ID"},
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "campaign_id": _CAMPAIGN_ID_PARAM,
             },
             "required": ["campaign_id"],
         },
     ),
     Tool(
         name="google_ads.bid_adjustments.update",
-        description="Update Google Ads bid adjustments",
+        description=(
+            "Update the bid_modifier of a single campaign_criterion. "
+            "Returns {resource_name} of the updated criterion. "
+            "Mutating — FieldMask-based partial update on "
+            "bid_modifier only; other criterion fields are "
+            "preserved. Reversible by another call to this tool. "
+            "bid_modifier must be 0.1-10.0 (0.1 = -90%, 1.0 = "
+            "neutral, 10.0 = +900%); values outside this range "
+            "raise ValueError. To toggle a device on/off with "
+            "bid_modifier 0.0 use google_ads.device_targeting.set "
+            "instead (this tool rejects 0.0)."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
-                    "type": "string",
-                    "description": "Google Ads customer ID",
-                },
-                "campaign_id": {"type": "string", "description": "Campaign ID"},
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "campaign_id": _CAMPAIGN_ID_PARAM,
                 "criterion_id": {
                     "type": "string",
-                    "description": "Criterion ID",
+                    "description": (
+                        "Criterion ID as a numeric string (e.g. "
+                        "'30001'). Obtain via "
+                        "google_ads.bid_adjustments.get or "
+                        "google_ads.device_targeting.get."
+                    ),
                 },
                 "bid_modifier": {
                     "type": "number",
-                    "description": "Bid modifier (0.1 to 10.0)",
+                    "minimum": 0.1,
+                    "maximum": 10.0,
+                    "description": (
+                        "New bid modifier (0.1 = -90%, 1.0 = no "
+                        "change, 2.0 = +100%, 10.0 = +900%). Outside "
+                        "0.1-10.0 raises ValueError server-side."
+                    ),
                 },
             },
             "required": ["campaign_id", "criterion_id", "bid_modifier"],
@@ -396,39 +796,65 @@ TOOLS: list[Tool] = [
     # === Geographic Targeting ===
     Tool(
         name="google_ads.location_targeting.list",
-        description="List Google Ads campaign location targeting",
+        description=(
+            "List every LOCATION campaign_criterion on a Google Ads "
+            "campaign. Returns [{criterion_id, geo_target_constant "
+            "(resource path, e.g. 'geoTargetConstants/2392' for "
+            "Japan), bid_modifier (float or null)}]. Read-only. Geo "
+            "target constant IDs map to countries/regions/cities — "
+            "look up via Google's GeoTargetConstantService. For "
+            "adding or removing locations use "
+            "google_ads.location_targeting.update; for "
+            "schedule-based targeting use "
+            "google_ads.schedule_targeting.list."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
-                    "type": "string",
-                    "description": "Google Ads customer ID",
-                },
-                "campaign_id": {"type": "string", "description": "Campaign ID"},
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "campaign_id": _CAMPAIGN_ID_PARAM,
             },
             "required": ["campaign_id"],
         },
     ),
     Tool(
         name="google_ads.location_targeting.update",
-        description="Update Google Ads location targeting (add/remove)",
+        description=(
+            "Add and/or remove location criteria on a Google Ads "
+            "campaign in a single mutate. Returns [{resource_name}] "
+            "— one entry per operation executed (adds first, then "
+            "removes). Mutating — adds create new criteria, removes "
+            "delete them by criterion_id. Reversible only by "
+            "calling this tool again with the inverse operations. "
+            "At least one of add_locations / remove_criterion_ids "
+            "must be provided. Locations can be passed as bare "
+            "numeric IDs or as full 'geoTargetConstants/<id>' paths; "
+            "bare IDs are auto-prefixed."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
-                    "type": "string",
-                    "description": "Google Ads customer ID",
-                },
-                "campaign_id": {"type": "string", "description": "Campaign ID"},
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "campaign_id": _CAMPAIGN_ID_PARAM,
                 "add_locations": {
                     "type": "array",
                     "items": {"type": "string"},
-                    "description": "Location IDs to add (geoTargetConstants/2392 format)",
+                    "description": (
+                        "Geo target constants to add, either as "
+                        "numeric IDs (e.g. '2392' for Japan, '2840' "
+                        "for US) or as full resource paths "
+                        "('geoTargetConstants/2392'). Bare IDs are "
+                        "auto-prefixed."
+                    ),
                 },
                 "remove_criterion_ids": {
                     "type": "array",
                     "items": {"type": "string"},
-                    "description": "List of criterion IDs to remove",
+                    "description": (
+                        "Existing criterion_ids to remove (numeric "
+                        "strings, e.g. '30002'). Obtain via "
+                        "google_ads.location_targeting.list."
+                    ),
                 },
             },
             "required": ["campaign_id"],
@@ -483,15 +909,22 @@ TOOLS: list[Tool] = [
     ),
     Tool(
         name="google_ads.schedule_targeting.update",
-        description="Update Google Ads ad schedules (add/remove)",
+        description=(
+            "Add and/or remove ad-schedule criteria on a Google Ads "
+            "campaign in a single mutate. Returns [{resource_name}] "
+            "— one entry per operation (adds first, then removes). "
+            "Mutating — new schedule criteria default to "
+            "start_minute/end_minute=ZERO (on the hour). Reversible "
+            "only by calling this tool again with inverse "
+            "operations. At least one of add_schedules / "
+            "remove_criterion_ids must be provided. For the "
+            "read-only listing use google_ads.schedule_targeting.list."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
-                    "type": "string",
-                    "description": "Google Ads customer ID",
-                },
-                "campaign_id": {"type": "string", "description": "Campaign ID"},
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "campaign_id": _CAMPAIGN_ID_PARAM,
                 "add_schedules": {
                     "type": "array",
                     "items": {
@@ -499,25 +932,56 @@ TOOLS: list[Tool] = [
                         "properties": {
                             "day": {
                                 "type": "string",
-                                "description": "Day of week (MONDAY to SUNDAY)",
+                                "enum": [
+                                    "MONDAY",
+                                    "TUESDAY",
+                                    "WEDNESDAY",
+                                    "THURSDAY",
+                                    "FRIDAY",
+                                    "SATURDAY",
+                                    "SUNDAY",
+                                ],
+                                "description": (
+                                    "Day of week. Case-insensitive; "
+                                    "uppercased before enum lookup."
+                                ),
                             },
                             "start_hour": {
                                 "type": "integer",
-                                "description": "Start hour (0-23)",
+                                "minimum": 0,
+                                "maximum": 23,
+                                "description": (
+                                    "Hour of day when delivery starts "
+                                    "(0-23). Defaults to 0 when "
+                                    "omitted."
+                                ),
                             },
                             "end_hour": {
                                 "type": "integer",
-                                "description": "End hour (1-24)",
+                                "minimum": 1,
+                                "maximum": 24,
+                                "description": (
+                                    "Hour of day when delivery ends "
+                                    "(1-24; 24 means end-of-day). "
+                                    "Defaults to 24 when omitted."
+                                ),
                             },
                         },
                         "required": ["day"],
                     },
-                    "description": "List of schedules to add",
+                    "description": (
+                        "List of schedules to create. Each entry "
+                        "maps to one AdSchedule criterion."
+                    ),
                 },
                 "remove_criterion_ids": {
                     "type": "array",
                     "items": {"type": "string"},
-                    "description": "List of criterion IDs to remove",
+                    "description": (
+                        "Existing criterion_ids to remove (numeric "
+                        "strings). Obtain via "
+                        "google_ads.schedule_targeting.list."
+                    ),
                 },
             },
             "required": ["campaign_id"],
@@ -526,21 +990,44 @@ TOOLS: list[Tool] = [
     # === Change History ===
     Tool(
         name="google_ads.change_history.list",
-        description="List Google Ads change history (default: last 14 days)",
+        description=(
+            "List the most recent change_event rows on a Google Ads "
+            "account, sorted newest-first and capped at 100. Returns "
+            "[{change_date_time (Google-formatted timestamp string "
+            "returned verbatim from the API — typically "
+            "'YYYY-MM-DD HH:MM:SS.ffffff+00:00' but no format "
+            "coercion is applied, so callers should parse "
+            "defensively), change_resource_type (enum string e.g. "
+            "'CAMPAIGN', 'CAMPAIGN_BUDGET', 'AD_GROUP', 'AD', "
+            "'CAMPAIGN_BID_MODIFIER'), resource_change_operation "
+            "('CREATE'|'UPDATE'|'REMOVE' as enum string), "
+            "changed_fields (list of dotted field paths), "
+            "user_email}]. Read-only. Defaults to the last 14 days "
+            "when dates are omitted; the API rejects an open-ended "
+            "range so mureo always fills one. Use this for audit-"
+            "trail diagnosis. For narrower bid/budget-only filtering "
+            "use google_ads.cost_increase.investigate."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "customer_id": {
-                    "type": "string",
-                    "description": "Google Ads customer ID",
-                },
+                "customer_id": _CUSTOMER_ID_PARAM,
                 "start_date": {
                     "type": "string",
-                    "description": "Start date (YYYY-MM-DD)",
+                    "format": "date",
+                    "pattern": r"^\d{4}-\d{2}-\d{2}$",
+                    "description": (
+                        "Inclusive start date ('YYYY-MM-DD'). "
+                        "Default: today - 14 days."
+                    ),
                 },
                 "end_date": {
                     "type": "string",
-                    "description": "End date (YYYY-MM-DD)",
+                    "format": "date",
+                    "pattern": r"^\d{4}-\d{2}-\d{2}$",
+                    "description": (
+                        "Inclusive end date ('YYYY-MM-DD'). Default: " "today."
+                    ),
                 },
             },
             "required": [],

--- a/mureo/mcp/_tools_search_console.py
+++ b/mureo/mcp/_tools_search_console.py
@@ -4,11 +4,67 @@ from __future__ import annotations
 
 from mcp.types import Tool
 
+_SITE_URL_PARAM = {
+    "type": "string",
+    "description": (
+        "Property identifier as registered in Search Console. For "
+        "URL-prefix properties use the full URL including trailing "
+        "slash (e.g. 'https://example.com/'). For Domain properties "
+        "use the 'sc-domain:' prefix (e.g. 'sc-domain:example.com'). "
+        "The property must be verified and accessible to the "
+        "authenticated Google account."
+    ),
+}
+
+_DATE_PARAM_START = {
+    "type": "string",
+    "format": "date",
+    "pattern": r"^\d{4}-\d{2}-\d{2}$",
+    "description": (
+        "Inclusive start date in 'YYYY-MM-DD' format (e.g. "
+        "'2026-03-01'). Search Console data typically lags 2-3 days, "
+        "so 'today' returns no rows. Maximum lookback is 16 months."
+    ),
+}
+
+_DATE_PARAM_END = {
+    "type": "string",
+    "format": "date",
+    "pattern": r"^\d{4}-\d{2}-\d{2}$",
+    "description": (
+        "Inclusive end date in 'YYYY-MM-DD' format (e.g. "
+        "'2026-03-31'). Must be >= start_date. Search Console data "
+        "lags 2-3 days; requesting the last two days typically "
+        "returns no rows."
+    ),
+}
+
+_ROW_LIMIT_PARAM = {
+    "type": "integer",
+    "minimum": 1,
+    "maximum": 25000,
+    "description": (
+        "Maximum rows to return. Default 100. Search Console API "
+        "caps at 25000 per request; agents that need more should "
+        "split the call by date range."
+    ),
+}
+
 TOOLS: list[Tool] = [
     # === Sites ===
     Tool(
         name="search_console.sites.list",
-        description="List all verified Google Search Console sites",
+        description=(
+            "List every Search Console property the authenticated "
+            "Google account can access, regardless of permission "
+            "level. Returns the raw 'siteEntry' array from the "
+            "Webmasters API: [{siteUrl (URL-prefix form or "
+            "'sc-domain:' form), permissionLevel ('siteOwner'|"
+            "'siteFullUser'|'siteRestrictedUser'|"
+            "'siteUnverifiedUser')}]. Read-only; takes no input. For "
+            "permission and metadata on a single property use "
+            "search_console.sites.get."
+        ),
         inputSchema={
             "type": "object",
             "properties": {},
@@ -16,17 +72,23 @@ TOOLS: list[Tool] = [
     ),
     Tool(
         name="search_console.sites.get",
-        description="Get details for a specific Search Console site",
+        description=(
+            "Fetch metadata and the current user's permission level for "
+            "a single Search Console property. Returns the raw "
+            "Webmasters API response shape: {siteUrl, permissionLevel "
+            "('siteOwner'|'siteFullUser'|'siteRestrictedUser'|"
+            "'siteUnverifiedUser')}. Read-only; no mutation. Use this "
+            "to verify whether the authenticated account has write "
+            "access before calling mutating tools like "
+            "search_console.sitemaps.submit. For a full list of "
+            "accessible properties use search_console.sites.list; for "
+            "per-URL indexing data use "
+            "search_console.url_inspection.inspect."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "site_url": {
-                    "type": "string",
-                    "description": (
-                        "Site URL (e.g., 'https://example.com/' or "
-                        "'sc-domain:example.com')"
-                    ),
-                },
+                "site_url": _SITE_URL_PARAM,
             },
             "required": ["site_url"],
         },
@@ -35,37 +97,61 @@ TOOLS: list[Tool] = [
     Tool(
         name="search_console.analytics.query",
         description=(
-            "Query Google Search Console search analytics data. "
-            "Returns clicks, impressions, CTR, and position."
+            "Query the Search Console Search Analytics API for organic "
+            "Google Search performance data. Returns the raw 'rows' "
+            "array from the searchAnalytics.query response: [{keys: "
+            "[<one value per requested dimension>], clicks (int), "
+            "impressions (int), ctr (float 0.0-1.0), position (float, "
+            "1-indexed average ranking)}]. Empty array when no data. "
+            "Read-only. Use dimensions=['query'] for keywords, ['page'] "
+            "for URLs, ['device'] for device split, ['date'] for a "
+            "daily trend. For convenience shortcuts use "
+            "search_console.analytics.top_queries / top_pages / "
+            "device_breakdown; for before/after comparisons use "
+            "search_console.analytics.compare_periods."
         ),
         inputSchema={
             "type": "object",
             "properties": {
-                "site_url": {
-                    "type": "string",
-                    "description": "Site URL",
-                },
-                "start_date": {
-                    "type": "string",
-                    "description": "Start date (YYYY-MM-DD)",
-                },
-                "end_date": {
-                    "type": "string",
-                    "description": "End date (YYYY-MM-DD)",
-                },
+                "site_url": _SITE_URL_PARAM,
+                "start_date": _DATE_PARAM_START,
+                "end_date": _DATE_PARAM_END,
                 "dimensions": {
                     "type": "array",
-                    "items": {"type": "string"},
-                    "description": ("Dimensions: query, page, country, device, date"),
+                    "items": {
+                        "type": "string",
+                        "enum": [
+                            "query",
+                            "page",
+                            "country",
+                            "device",
+                            "date",
+                            "searchAppearance",
+                        ],
+                    },
+                    "minItems": 1,
+                    "maxItems": 4,
+                    "description": (
+                        "Dimensions to group rows by. Allowed: query, "
+                        "page, country, device, date, searchAppearance. "
+                        "Omit for an ungrouped total (clicks/"
+                        "impressions/ctr/position across the window). "
+                        "Each additional dimension multiplies row "
+                        "cardinality — agents should usually pick 1-2."
+                    ),
                 },
-                "row_limit": {
-                    "type": "integer",
-                    "description": "Max rows (default: 100)",
-                },
+                "row_limit": _ROW_LIMIT_PARAM,
                 "dimension_filter_groups": {
                     "type": "array",
                     "items": {"type": "object"},
-                    "description": "Optional dimension filter groups",
+                    "description": (
+                        "Optional Search Console dimensionFilterGroups "
+                        "payload (list of {groupType: 'and', filters: "
+                        "[{dimension, operator ('equals'|'contains'|"
+                        "'notContains'|'notEquals'|'includingRegex'|"
+                        "'excludingRegex'), expression}]}). Passed "
+                        "through verbatim to the REST API."
+                    ),
                 },
             },
             "required": ["site_url", "start_date", "end_date"],
@@ -161,40 +247,80 @@ TOOLS: list[Tool] = [
     Tool(
         name="search_console.analytics.compare_periods",
         description=(
-            "Compare search analytics between two date periods. "
-            "Returns data for both periods side by side."
+            "Query Search Console search analytics twice and return "
+            "both periods side-by-side. Returns {period_1: [rows], "
+            "period_2: [rows]} where each rows list has the same shape "
+            "as search_console.analytics.query (keys, clicks, "
+            "impressions, ctr, position). The tool does NOT diff or "
+            "merge the periods — the agent must align by the first key "
+            "in each row. Read-only. Two REST calls are issued per "
+            "invocation. Defaults: dimensions=['query'], row_limit=100 "
+            "per period. For a single-period query use "
+            "search_console.analytics.query."
         ),
         inputSchema={
             "type": "object",
             "properties": {
-                "site_url": {
-                    "type": "string",
-                    "description": "Site URL",
-                },
+                "site_url": _SITE_URL_PARAM,
                 "start_date_1": {
-                    "type": "string",
-                    "description": "Period 1 start date (YYYY-MM-DD)",
+                    **_DATE_PARAM_START,
+                    "description": (
+                        "Period 1 inclusive start date "
+                        "('YYYY-MM-DD'). Convention: period 1 is the "
+                        "older / baseline window."
+                    ),
                 },
                 "end_date_1": {
-                    "type": "string",
-                    "description": "Period 1 end date (YYYY-MM-DD)",
+                    **_DATE_PARAM_END,
+                    "description": (
+                        "Period 1 inclusive end date ('YYYY-MM-DD'). "
+                        "Must be >= start_date_1."
+                    ),
                 },
                 "start_date_2": {
-                    "type": "string",
-                    "description": "Period 2 start date (YYYY-MM-DD)",
+                    **_DATE_PARAM_START,
+                    "description": (
+                        "Period 2 inclusive start date "
+                        "('YYYY-MM-DD'). Convention: period 2 is the "
+                        "newer / comparison window."
+                    ),
                 },
                 "end_date_2": {
-                    "type": "string",
-                    "description": "Period 2 end date (YYYY-MM-DD)",
+                    **_DATE_PARAM_END,
+                    "description": (
+                        "Period 2 inclusive end date ('YYYY-MM-DD'). "
+                        "Must be >= start_date_2."
+                    ),
                 },
                 "dimensions": {
                     "type": "array",
-                    "items": {"type": "string"},
-                    "description": "Dimensions (default: ['query'])",
+                    "items": {
+                        "type": "string",
+                        "enum": [
+                            "query",
+                            "page",
+                            "country",
+                            "device",
+                            "date",
+                            "searchAppearance",
+                        ],
+                    },
+                    "minItems": 1,
+                    "maxItems": 4,
+                    "description": (
+                        "Dimensions shared across both periods. "
+                        "Default ['query']. Use ['page'] to compare "
+                        "URL-level changes, ['device'] for device "
+                        "shifts."
+                    ),
                 },
                 "row_limit": {
-                    "type": "integer",
-                    "description": "Max rows per period (default: 100)",
+                    **_ROW_LIMIT_PARAM,
+                    "description": (
+                        "Maximum rows per period (default 100, cap "
+                        "25000). Applied independently to period 1 "
+                        "and period 2."
+                    ),
                 },
             },
             "required": [
@@ -209,14 +335,22 @@ TOOLS: list[Tool] = [
     # === Sitemaps ===
     Tool(
         name="search_console.sitemaps.list",
-        description="List all sitemaps for a Search Console site",
+        description=(
+            "List every sitemap registered against a Search Console "
+            "property, with their most recent crawl status. Returns "
+            "the raw Webmasters 'sitemap' array: [{path (absolute "
+            "sitemap URL), lastSubmitted (ISO 8601), isPending, "
+            "isSitemapsIndex, type ('sitemap'|'sitemapIndex'|"
+            "'rssFeed'|'atomFeed'|'urlList'|'patternSitemap'), "
+            "lastDownloaded (ISO 8601), warnings (int), errors (int), "
+            "contents: [{type, submitted (int), indexed (int)}]}]. "
+            "Read-only. For submitting or resubmitting a sitemap use "
+            "search_console.sitemaps.submit."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "site_url": {
-                    "type": "string",
-                    "description": "Site URL",
-                },
+                "site_url": _SITE_URL_PARAM,
             },
             "required": ["site_url"],
         },
@@ -272,19 +406,38 @@ TOOLS: list[Tool] = [
     Tool(
         name="search_console.url_inspection.inspect",
         description=(
-            "Inspect a URL's indexing status in Google Search Console. "
-            "Returns coverage state, verdict, and crawl details."
+            "Inspect a single URL's indexing state via the Search "
+            "Console URL Inspection API. Returns the raw "
+            "inspectionResult envelope: {inspectionResult:{"
+            "inspectionResultLink (live UI URL), indexStatusResult:{"
+            "verdict ('PASS'|'PARTIAL'|'FAIL'|'NEUTRAL'), "
+            "coverageState (string, e.g. 'Submitted and indexed' / "
+            "'Crawled - currently not indexed' / 'Discovered - "
+            "currently not indexed'), robotsTxtState, indexingState, "
+            "lastCrawlTime (ISO 8601), pageFetchState, "
+            "googleCanonical, userCanonical, referringUrls, "
+            "sitemap}, mobileUsabilityResult, "
+            "richResultsResult?, ampResult?}}. Read-only; no "
+            "re-indexing is triggered. Rate limit: Search Console "
+            "caps inspection at ~2000 URLs per property per day. Use "
+            "this to debug why a specific page isn't ranking. For "
+            "site-wide coverage numbers use "
+            "search_console.sitemaps.list; for organic-performance "
+            "metrics use search_console.analytics.query."
         ),
         inputSchema={
             "type": "object",
             "properties": {
-                "site_url": {
-                    "type": "string",
-                    "description": "Site URL",
-                },
+                "site_url": _SITE_URL_PARAM,
                 "inspection_url": {
                     "type": "string",
-                    "description": "URL to inspect",
+                    "format": "uri",
+                    "description": (
+                        "Absolute URL to inspect (e.g. "
+                        "'https://example.com/about'). Must be under "
+                        "site_url's property; cross-property "
+                        "inspection is rejected by the API."
+                    ),
                 },
             },
             "required": ["site_url", "inspection_url"],


### PR DESCRIPTION
## Summary

Completes the Glama TDQS sweep started in PR #45. Rewrites the remaining
**49 tool descriptions** (every tool still scoring below 3.5/5 after the
pilot) so the server-level TDQS score can clear the A-tier threshold.

## Motivation

After PR #45 merged and Glama re-scored mureo at v1.0.3, the five pilot
tools all jumped from C (2.4–2.6) into A (4.5–4.9) — the style-guide
template works. But server-level TDQS stayed at **3.34 (B)** because the
formula `0.6 × mean + 0.4 × min` is dominated by the minimum, which
simply migrated to the next-worst tool at 2.3.

The composite Glama grade is currently **AAB** (`security=A`,
`license=A`, `quality=B`). Merging `punkpeye/awesome-mcp-servers` PR
#5232 requires **AAA**, so `quality_grade` must flip B → A, which
requires both server TDQS and ideally Coherence to clear 3.5.

## Approach

Every rewritten description follows
[`docs/tdqs-style-guide.md`](docs/tdqs-style-guide.md):
specific verb + resource + verified returned fields + side effects +
sibling differentiation. Every `inputSchema.properties` entry gains
real format/default/fallback info (no more restating the key name) and,
where the code constrains it, `enum` / `format` / `minimum` / `maximum`
/ `minItems` / `maxItems` / `pattern` / `maxLength`.

Reusable `_CUSTOMER_ID_PARAM`, `_CAMPAIGN_ID_PARAM`, `_PERIOD_PARAM`,
`_CONVERSION_ACTION_ID_PARAM`, `_SITE_URL_PARAM`, `_DATE_PARAM_*`, and
`_ROW_LIMIT_PARAM` fragments keep parameter descriptions consistent
across tools (pattern already adopted by
`_tools_google_ads_campaigns.py` / `_tools_meta_ads_campaigns.py` in
PRs #43 / #44).

### Verification protocol

Per the feedback memory added after PR #45's first commit shipped three
CRITICAL factual errors (descriptions claiming fields the mappers never
produced), **every claimed returned-field name in this PR was
cross-checked against the actual mapper function, GAQL SELECT clause,
or REST response handler before being written**. An independent code
review then audited the full diff and flagged two HIGH + five MEDIUM
factual mismatches; all seven were fixed before the commit:

- `conversions.get` — status enum widened 3 → 5 values (match
  `map_entity_status`)
- `bid_adjustments.get` — `device_type` fallback corrected from
  "null" to `"UNKNOWN(<n>)"` (per `_normalize_device_type`)
- `performance.analyze` — `cpa_current/previous/change_pct` marked
  optional (only emitted when conversions > 0)
- `change_history.list` — softened timestamp format claim (mapper
  passes API value through without coercion)
- `budget.reallocation` — documented empty-data short-circuit that
  omits `total_freed` key
- `cpc.detect_trend` — `change_rate_per_day_pct` marked optional
  (absent when direction is `'insufficient_data'`)
- `device.analyze` — replaced misleading sibling pointer

## What stays the same

- Tool `name` values — unchanged (handler dispatch is by name)
- `required` field lists — unchanged
- `inputSchema.properties` keys — unchanged (only enriched metadata
  added; no keys removed or renamed)
- Handlers — not touched
- Tool count — 173

## Expected effect

Projected post-Glama-rescore of this release:

| Metric | Pre-PR #3b | Post-PR #3b (projected) |
|---|---|---|
| mean TDQS | 4.03 | ~4.30 |
| min TDQS | 2.3 | ~4.0 |
| server TDQS | 3.34 (B) | ~3.95 (**A**) |
| `quality_grade` | B | **A** |
| composite Glama | AAB | **AAA** |

Unblocks `punkpeye/awesome-mcp-servers` PR #5232 merge.

## Test plan

- [x] `ast.parse` on all 4 modified files — OK
- [x] `ruff check` — All checks passed
- [x] `black --line-length 88 --check` — 4 files unchanged
- [x] `pytest tests/ -x -q` — 1774 passed, 0 failures
- [x] Aggregator smoke test: 173 tools, no duplicates, no malformed
- [x] Independent code review (mapper/handler fact-check) — 2 HIGH +
      5 MEDIUM fixed; no CRITICAL
- [ ] Request Glama re-index after merge; confirm `quality_grade`
      flips to A and the composite grade reaches AAA
- [ ] Re-ping punkpeye on awesome-mcp-servers PR #5232 once AAA
      confirmed

## Known follow-ups (out of scope)

- File sizes now exceed `AGENTS.md`'s 800-line soft limit
  (`_tools_google_ads_analysis.py` = 900, `_extensions.py` = 1030).
  A dedicated refactor PR should split both by feature group.
- `capture.screenshot` and `analytics.top_queries/top_pages/device_breakdown`
  remain in legacy terse style; rewrite in a follow-up if Glama's
  re-scoring reveals they drag the mean.
- `map_conversion_action`, `map_tag_snippet`, `map_recommendation`,
  `map_change_event` use bare `str(x.type_)` instead of `_map_enum`.
  Code review flagged this as a theoretical proto-plus stringification
  risk — deserves an integration test against a real proto fixture.
