### PR TITLE
docs: update positioning hero — local-first, safety-gated

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,12 +4,11 @@ Guidelines for AI agents contributing to the mureo codebase.
 
 ## Project Overview
 
-mureo is a marketing orchestration framework for AI agents. It combines strategy
-context, workflow commands, and domain knowledge to help agents achieve marketing
-goals across platforms. Currently supports Google Ads, Meta Ads, and Google Search Console, with more
-platforms planned. Provides MCP tools for direct platform operations and
-workflow commands for strategy-driven ad operations via Claude Code slash commands.
-Designed for AI agents — no database, no LLM SDK, no web framework.
+**mureo** — Local-first, safety-gated AI ad-ops framework for Claude Code, Codex, Cursor & Gemini.
+
+Strategy-aware agents that autonomously analyze and operate Google Ads, Meta Ads, Search Console & GA4 — credentials never leave your machine.
+
+mureo combines strategy context, workflow commands, and domain knowledge to help AI agents achieve marketing goals across platforms. Provides MCP tools for direct platform operations and workflow commands for strategy-driven ad operations via Claude Code slash commands. Designed for AI agents — no database, no LLM SDK, no web framework.
 
 ## Build & Test
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -17,6 +17,10 @@
   <a href="https://github.com/logly/mureo/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/logly/mureo/actions/workflows/ci.yml/badge.svg"></a>
 </p>
 
+**mureo** — ローカル完結・安全設計のAI広告運用フレームワーク。Claude Code、Codex、Cursor、Gemini に対応。
+
+戦略を理解するエージェントが Google Ads、Meta Ads、Search Console、GA4 を自律的に分析・運用します。**認証情報は端末の外に出ません。**
+
 ## mureoとは
 
 mureoは、AIエージェントが広告アカウントを自動運用するためのフレームワークです。インストールすると、AIエージェント（Claude Code、Cursor、Codex、Geminiなど）がGoogle広告・Meta広告・Search Console・GA4を横断して、配信診断・検索語分析・予算評価・入稿チェックなどを実行できるようになります。すべての操作はあなたのビジネス戦略（`STRATEGY.md`）に基づいて行われます。

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@
   <a href="https://github.com/logly/mureo/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/logly/mureo/actions/workflows/ci.yml/badge.svg"></a>
 </p>
 
+**mureo** — Local-first, safety-gated AI ad-ops framework for Claude Code, Codex, Cursor & Gemini.
+
+Strategy-aware agents that autonomously analyze and operate Google Ads, Meta Ads, Search Console & GA4 — **credentials never leave your machine**.
+
 ## What is mureo?
 
 mureo is a framework for AI agents to autonomously operate ad accounts. Once installed, AI agents (Claude Code, Cursor, Codex, Gemini, etc.) can work across Google Ads, Meta Ads, Search Console, and GA4 -- running campaign diagnostics, search term analysis, budget evaluation, ad validation, and more. Every operation is grounded in your business strategy (`STRATEGY.md`), so the agent makes decisions based on your persona, USP, goals, and brand voice -- not just raw metrics.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "mureo",
   "version": "0.2.0",
-  "description": "Marketing orchestration framework for AI agents",
+  "description": "Local-first, safety-gated AI ad-ops framework for Claude Code, Codex, Cursor & Gemini",
   "contextFileName": "CONTEXT.md"
 }

--- a/mureo/__init__.py
+++ b/mureo/__init__.py
@@ -1,3 +1,3 @@
-"""mureo — Marketing orchestration framework for AI agents."""
+"""mureo — Local-first, safety-gated AI ad-ops framework for Claude Code, Codex, Cursor & Gemini."""
 
 __version__ = "0.6.0"

--- a/mureo/cli/main.py
+++ b/mureo/cli/main.py
@@ -14,7 +14,7 @@ from mureo.cli.setup_cmd import setup_app
 
 app = typer.Typer(
     name="mureo",
-    help="Marketing orchestration framework for AI agents",
+    help="Local-first, safety-gated AI ad-ops framework for Claude Code, Codex, Cursor & Gemini",
     no_args_is_help=True,
 )
 

--- a/mureo/cli/setup_gemini.py
+++ b/mureo/cli/setup_gemini.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 
 _EXTENSION_NAME = "mureo"
-_DESCRIPTION = "Marketing orchestration framework for AI agents"
+_DESCRIPTION = "Local-first, safety-gated AI ad-ops framework for Claude Code, Codex, Cursor & Gemini"
 
 
 def _mureo_version() -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "mureo"
 version = "0.6.0"
-description = "Marketing orchestration framework for AI agents"
+description = "Local-first, safety-gated AI ad-ops framework for Claude Code, Codex, Cursor & Gemini"
 requires-python = ">=3.10"
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
## Summary
Rewrite the hero / positioning copy across README, package metadata, and the Gemini extension manifest. Same message everywhere:

> **mureo** — Local-first, safety-gated AI ad-ops framework for Claude Code, Codex, Cursor & Gemini.
>
> Strategy-aware agents that autonomously analyze and operate Google Ads, Meta Ads, Search Console & GA4 — **credentials never leave your machine**.

## Why
Existing positioning ("Marketing orchestration framework for AI agents") was vague and missed the two things the marketer / ad-ops audience cares about most:
- **Where their credentials live** (local vs. SaaS)
- **What stops AI from breaking their account** (rollback / safety gates)

The new hero leads with those two pillars before getting to platform breadth and the strategy-aware mental model. Order is deliberate (marketing-funnel order):

1. Local-first → dispels SaaS / data-sovereignty fear
2. Safety-gated → dispels accidental-spend fear
3. AI client coverage → removes adoption barrier (Claude Code, Codex, Cursor, Gemini)
4. Cross-platform breadth → Google Ads, Meta Ads, Search Console, GA4 in one workflow
5. Strategy-aware autonomy → mureo's unique mental model, last because it carries the highest explanation cost

## Files touched

| File | Change |
|---|---|
| `README.md` | English hero block above the existing "What is mureo?" section |
| `README.ja.md` | Japanese hero block above "mureoとは" — pre-translated, parallel structure |
| `pyproject.toml` | `[project].description` (powers `pip show mureo` / PyPI) |
| `mureo/__init__.py` | Package docstring |
| `mureo/cli/main.py` | `mureo --help` one-liner (typer `help=`) |
| `mureo/cli/setup_gemini.py` | `_DESCRIPTION` constant used when writing the user's gemini-extension manifest |
| `gemini-extension.json` | Repo-level reference manifest, kept in sync with the generator |
| `AGENTS.md` | Project Overview block — first thing AI contributors read |

## Test plan
- [x] `python3 -m black --check` clean on touched `.py` files
- [x] `python3 -m ast` parse clean
- [x] No tests assert on the previous description string (`grep -rn "Marketing orchestration" tests/` is empty)
- [ ] Wait for CI: lint + Analyze + CodeQL + test (3.10/3.11/3.12)
- [ ] After merge, also update the GitHub repo "About" description and `mureo.io` LP hero (out of scope for this PR — manual)

## Non-goals
- No code or behavior changes
- No PyPI version bump (description-only is metadata; will surface on next normal release)
- mureo-site repo update is a separate PR
