### PR TITLE
docs(readme): soften BYOD-first callout for users new to GCP / Meta for Developers

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -29,9 +29,7 @@ mureoには学習の仕組みもあります。エージェントの分析を修
 
 ## mureoの始め方は2通り — BYOD（5分・OAuth不要）か Real-API（完全自動化）
 
-> Google Ads の Developer Token は審査に1〜3週間かかり、初回申請が却下されることもよくあります（特に Apps Script による個人 GCP プロジェクトの自動作成がブロックされる Google Workspace **組織アカウント** の場合）。Meta も Business app の登録が必要です。**BYOD なら、これらのセットアップに時間を割く前に mureo の価値を体験できます。**
-
-**プラットフォームごとにモードを使い分ける**こともできます（Google Ads は BYOD で Meta Ads は real API、あるいはその逆）。エージェントはツール呼び出しごとにプラットフォーム別のモードを自動判別します — 設定フラグもグローバルなスイッチもありません。
+> **Google Cloud Console や Meta for Developers に慣れていない方へ。** OAuth フロー / Developer Token の発行 / Business app 登録は、これらのコンソールを使ったことがない方には難しく感じるかもしれません。**まずは BYOD から始めてください** — 数分で mureo がどう動くかが分かります。それから real-API のセットアップに踏み込むかどうか判断すれば OK です。
 
 ### モード A: BYOD — 5分で最初の診断、OAuth 不要
 

--- a/README.md
+++ b/README.md
@@ -29,9 +29,7 @@ mureo also learns. When you correct the agent's analysis or share an operational
 
 ## Two paths in: BYOD (5 min, no auth) or Real-API (full automation)
 
-> Google Ads requires a Developer Token approval that can take 1–3 weeks and is often rejected on the first attempt — especially on Google Workspace **organization** accounts where Apps Script is blocked from auto-creating a personal GCP project. Meta needs a Business app registered. **BYOD lets you get value from mureo before you invest in any of that auth setup.**
-
-You can also **mix modes per platform** (Google Ads on BYOD while Meta Ads is on real API, or vice versa). The agent auto-discovers each platform's mode at every tool call — no flags, no global toggle.
+> **Not familiar with Google Cloud Console or Meta for Developers?** OAuth flows, developer-token registration, and Business-app sign-ups can feel intimidating if you have never used those consoles before. **Start with BYOD** — you will see what mureo can do for your account in a few minutes, then decide whether the real-API path is worth setting up.
 
 ### Mode A: BYOD — 5 minutes to first diagnosis, no OAuth
 


### PR DESCRIPTION
## Summary

Replaces the "Two paths" callout that explained Developer Token approval timelines and per-platform mode mixing with a friendlier BYOD-first nudge for users who have never used Google Cloud Console / Meta for Developers.

**Before:** A detailed callout about Developer Token approval (1–3 weeks), Workspace organization GCP block, Business-app registration, and per-platform mode mixing.

**After:** A short callout that simply tells newcomers to start with BYOD if those consoles feel unfamiliar, and decide later whether to graduate to real-API.

Per-platform mode-mixing is still documented further down the README in the comparison table footer ("The presence of `~/.mureo/byod/manifest.json` is the switch — no config flags, no global toggle"), so removing the dedicated paragraph at the top doesn't lose that information.

Both `README.md` and `README.ja.md` are updated.

## Test plan

- [x] No code changes — pure documentation
- [x] Wording aligned across English (`Google Cloud Console` / `Meta for Developers`) and Japanese
- [x] No internal links broken (no links removed from this section)
