### PR TITLE
feat(byod): make Meta Ads spend column currency-agnostic

### DIFF
--- a/docs/byod.md
+++ b/docs/byod.md
@@ -71,9 +71,12 @@ day × ad-set × ad):
 - **Breakdowns:** *By Time → Day*
 - **Level:** *Ad* (gives the full Campaign / Ad set / Ad hierarchy)
 - **Metrics:** Day, Campaign name, Ad set name, Ad name,
-  Impressions, Clicks (all), Amount spent (JPY), Results
-- **Account language:** English (other locales aren't recognized in
-  v1 — switch under *Reports → Account language*)
+  Impressions, Clicks (all), Amount spent, Results
+- **Account language:** any of the 9 supported locales (see the
+  multilingual section below) — Ads Manager always emits the spend
+  header as `Amount spent (XXX)` where `XXX` is the account's ISO
+  currency code (`JPY` / `USD` / `EUR` / …); mureo strips the
+  currency suffix automatically
 
 Click **Export → Excel (.xlsx)**. Save the file alongside the Google
 Ads Sheet's XLSX export.
@@ -270,6 +273,16 @@ The Meta export adapter recognizes column headers in English /
 日本語 / Español / Português / 한국어 / 繁體中文 / 简体中文 /
 Français / Deutsch — exporting from Ads Manager in any of these
 languages works without changing Account language.
+
+The spend column is **currency-agnostic**: Meta exports the header
+as `Amount spent (XXX)` where `XXX` is the account's ISO currency
+code (`JPY` / `USD` / `EUR` / `GBP` / `KRW` / `INR` / etc.) and
+mureo strips the suffix before alias matching. Cell values may also
+carry a leading currency symbol (`¥` / `$` / `€` / `£` / `₩` / `₹`
+/ etc.) which is stripped automatically. Cost values are stored
+raw in the account's own currency — mureo does not convert
+between currencies, so all per-account analysis (CTR / CPC / CPA)
+treats the cost column as a single coherent unit.
 
 For the full live-account experience, run `mureo auth setup` (or
 `mureo auth setup --web`) and `mureo byod clear` to switch back to

--- a/mureo/byod/adapters/meta_ads.py
+++ b/mureo/byod/adapters/meta_ads.py
@@ -29,10 +29,16 @@ column, so a workbook exported with Ads Manager in Japanese
 (キャンペーン名, インプレッション, …) imports the same way as an English
 export.
 
-Currency: only JPY is accepted. A non-JPY symbol prefix in the spend
-column (``$``, ``€``, ``£``, ``₩``, ``₹``, ``¢``) raises
-``UnsupportedFormatError`` so the user fixes Account currency before
-the BYOD pipeline silently mis-reports cost.
+Currency: any account currency is accepted. The spend column's
+header may carry an ISO currency suffix (``Amount spent (JPY)`` /
+``(USD)`` / ``(EUR)`` / etc.) — the suffix is stripped before alias
+matching so a USD account imports the same way a JPY one does.
+Cell values may also carry a leading currency symbol (``¥`` / ``$``
+/ ``€`` / ``£`` / ``₩`` / ``₹`` / ``¢`` / etc.); the symbol is
+stripped by ``_to_float``. Values are stored raw in the account's
+own currency — cross-account currency conversion is out of scope,
+so all of mureo's analysis (CTR, CPC, CPA per-campaign) treats the
+cost column as a single coherent unit.
 
 Pivot tables: Reports section pivot exports include subtotal rows
 where the date column reads ``All`` (or is blank) — these are
@@ -217,7 +223,12 @@ _CLICKS_ALIASES = (
 )
 
 _SPEND_ALIASES = (
-    # English (verified) + non-JPY suffix variants for safety
+    # The ISO currency suffix on each header (`(JPY)` / `(USD)` /
+    # `(EUR)` / etc.) is stripped before lookup by `_resolve_spend_idx`,
+    # so the no-suffix forms below match any account currency. The
+    # `(jpy)` variants remain as a fast-path for JPY accounts where
+    # the literal header is what mureo's tests pin.
+    # English (verified)
     "amount spent (jpy)",
     "amount spent",
     "spend",
@@ -557,7 +568,7 @@ class MetaAdsAdapter:
         camp_idx = _resolve_alias(header, _CAMPAIGN_ALIASES)
         impr_idx = _resolve_alias(header, _IMPRESSIONS_ALIASES)
         clicks_idx = _resolve_alias(header, _CLICKS_ALIASES)
-        spend_idx = _resolve_alias(header, _SPEND_ALIASES)
+        spend_idx = _resolve_spend_idx(header)
         conv_idx = _resolve_alias(header, _CONVERSIONS_ALIASES)
         ad_set_idx = _resolve_alias(header, _AD_SET_ALIASES)
         ad_idx = _resolve_alias(header, _AD_ALIASES)
@@ -735,13 +746,11 @@ class MetaAdsAdapter:
                     ad_records.append((camp_name, ad_set_name, ad_name, aid))
 
             spend_raw = _cell_at(raw, spend_idx)
-            if spend_raw and spend_raw[0] in _NON_JPY_CURRENCY_PREFIXES:
-                raise UnsupportedFormatError(
-                    f"{sheet_name}: spend column contains non-JPY value "
-                    f"{spend_raw!r}. The BYOD pipeline assumes JPY; "
-                    f"switch Ads Manager → Account currency to JPY "
-                    f"before export."
-                )
+            # mureo is currency-agnostic: any leading currency symbol
+            # (¥ / $ / € / £ / ₩ / ₹ / ¢ / etc.) is stripped by
+            # `_to_float`. Cost values are stored raw in the account's
+            # own currency; cross-account currency conversion is out
+            # of scope.
 
             impressions = _to_float(_cell_at(raw, impr_idx))
             clicks = _to_float(_cell_at(raw, clicks_idx))
@@ -1219,20 +1228,34 @@ class MetaAdsAdapter:
         )
 
 
+_CURRENCY_SYMBOLS = "¥$€£₩₹¢₽₺₪₫฿元"
+
+
 def _to_float(value: str) -> float:
     """Parse a numeric cell that may include a currency symbol or
-    thousands separators (Ads Manager export sometimes wraps ``Amount
-    spent`` as ``¥1,234.56`` or ``"1,234"``). Returns 0.0 on failure.
+    thousands separators (Ads Manager export sometimes wraps spend
+    as ``¥1,234.56`` / ``$1,234.56`` / ``€1,234.56`` / ``"1,234"``).
+    Strips a leading currency symbol from a known set
+    (:data:`_CURRENCY_SYMBOLS`) and any embedded comma. Returns 0.0
+    on failure — including when the cell starts with non-currency
+    junk like ``"abc123"`` (deliberately preserved so corrupted
+    cells do not silently coerce to a partial value).
 
-    Only ¥ (JPY) and bare numerics are tolerated. Non-JPY currency
-    symbols (``$``, ``€``, ``£``) leak through as 0.0 and are caught
-    upstream by :func:`_scan_non_jpy_currency` before this function
-    is reached on a real spend cell.
+    mureo is currency-agnostic at the data layer — values are stored
+    raw in the account's own currency (e.g. JPY for a JPY account,
+    USD for a USD account). Cross-account currency conversion is
+    out of scope; the user is expected to interpret cost numbers in
+    the account's own currency.
     """
     s = (value or "").strip()
     if not s:
         return 0.0
-    s = s.replace(",", "").replace("¥", "")
+    s = s.replace(",", "")
+    # Strip a leading currency symbol from the known set. We do not
+    # strip arbitrary non-numeric leads because that would silently
+    # accept corrupted cells like "abc123" as 123.
+    if s and s[0] in _CURRENCY_SYMBOLS:
+        s = s[1:]
     try:
         return float(s)
     except ValueError:
@@ -1243,7 +1266,34 @@ def _round2(value: float) -> str:
     return f"{value:.2f}"
 
 
-_NON_JPY_CURRENCY_PREFIXES = ("$", "€", "£", "₩", "₹", "¢")
+# Regex stripping a trailing ISO currency code wrapped in parentheses
+# from a column header — e.g. "Amount spent (USD)" → "Amount spent",
+# "消化金額 (JPY)" → "消化金額", "지출 금액 (KRW)" → "지출 금액".
+# Both ASCII (...) and full-width （...） parens are accepted because
+# Japanese exports occasionally use the latter.
+_CURRENCY_SUFFIX_RE = re.compile(r"\s*[\(（][a-z]{3}[\)）]\s*$")
+
+
+def _strip_currency_suffix(text: str) -> str:
+    """Return ``text`` with any trailing ``(XXX)`` currency code removed."""
+    return _CURRENCY_SUFFIX_RE.sub("", text)
+
+
+def _resolve_spend_idx(header: list[str]) -> int | None:
+    """Resolve the spend column index in a currency-agnostic way.
+
+    First tries an exact match against the alias tuple (handles
+    accounts whose header literally matches a known suffix such as
+    ``"amount spent (jpy)"``). On miss, retries against headers with
+    the ``(XXX)`` ISO currency suffix stripped, so a USD account's
+    ``"Amount spent (USD)"`` matches the no-suffix alias
+    ``"amount spent"``, and the same for EUR / GBP / KRW / INR / etc.
+    """
+    idx = _resolve_alias(header, _SPEND_ALIASES)
+    if idx is not None:
+        return idx
+    stripped = [_strip_currency_suffix(h) for h in header]
+    return _resolve_alias(stripped, _SPEND_ALIASES)
 
 
 # Cells starting with one of these characters are treated as formulas

--- a/tests/test_byod_bundle.py
+++ b/tests/test_byod_bundle.py
@@ -263,10 +263,14 @@ def test_meta_adapter_recognizes_date_aliases_and_locales(
     assert expected in metrics
 
 
-def test_meta_adapter_rejects_non_jpy_spend(tmp_path, byod_root):
-    """A non-JPY currency in the Spend column must abort the import
-    rather than silently coerce dollars/euros into the JPY column."""
-    from mureo.byod.bundle import BundleImportError, import_bundle
+def test_meta_adapter_currency_agnostic_spend(tmp_path, byod_root):
+    """A USD account's ``Amount spent (USD)`` header — and ``$``
+    leading currency symbol on the cell value — must import the
+    same way as a JPY account's ``Amount spent (JPY)`` / ``¥``
+    cells. mureo stores cost values raw in the account's own
+    currency (cross-account currency conversion is out of scope).
+    """
+    from mureo.byod.bundle import import_bundle
 
     src = _make_workbook(
         tmp_path,
@@ -276,14 +280,55 @@ def test_meta_adapter_rejects_non_jpy_spend(tmp_path, byod_root):
                     "Day",
                     "Campaign name",
                     "Impressions",
-                    "Amount spent",
+                    "Amount spent (USD)",
                 ],
                 ["2026-04-01", "Solo", 100, "$12.34"],
             ],
         },
     )
-    with pytest.raises(BundleImportError, match="non-JPY|JPY"):
-        import_bundle(src)
+    import_bundle(src)
+    metrics = (byod_root / "meta_ads" / "metrics_daily.csv").read_text(encoding="utf-8")
+    # The leading ``$`` is stripped by ``_to_float`` and the row is
+    # written with the bare numeric value.
+    assert "12.34" in metrics
+
+
+@pytest.mark.parametrize(
+    ("header_suffix", "cell_prefix"),
+    [
+        ("EUR", "€"),
+        ("GBP", "£"),
+        ("KRW", "₩"),
+        ("INR", "₹"),
+    ],
+)
+def test_meta_adapter_currency_suffix_locales(
+    tmp_path, byod_root, header_suffix, cell_prefix
+):
+    """Meta Ads Manager emits the spend header as
+    ``Amount spent (XXX)`` where XXX is the account's ISO currency
+    code. mureo strips the ``(XXX)`` suffix before alias matching
+    and strips any leading currency symbol on the cell value, so
+    every supported currency imports identically."""
+    from mureo.byod.bundle import import_bundle
+
+    src = _make_workbook(
+        tmp_path,
+        tabs={
+            "Sheet1": [
+                [
+                    "Day",
+                    "Campaign name",
+                    "Impressions",
+                    f"Amount spent ({header_suffix})",
+                ],
+                ["2026-04-01", "Solo", 100, f"{cell_prefix}45.67"],
+            ],
+        },
+    )
+    import_bundle(src)
+    metrics = (byod_root / "meta_ads" / "metrics_daily.csv").read_text(encoding="utf-8")
+    assert "45.67" in metrics
 
 
 def test_meta_adapter_csv_injection_sanitized(tmp_path, byod_root):


### PR DESCRIPTION
## Summary

Meta Ads Manager exports the spend header as `Amount spent (XXX)` where `XXX` is the account's ISO currency code (`JPY` / `USD` / `EUR` / `GBP` / `KRW` / `INR` / …).

Until now mureo accepted only JPY accounts:
- header alias matched only literal `Amount spent (JPY)` / `Amount spent`
- a non-`¥` leading symbol on a spend cell raised `UnsupportedFormatError`

This blocked every non-JP user from running BYOD even though the rest of the pipeline is locale-aware (9 languages already verified in v0.7.0).

## Changes

**`mureo/byod/adapters/meta_ads.py`**
- `_resolve_spend_idx(header)` — strips the trailing `(XXX)` ISO currency code (3 ASCII letters, in `()` or full-width `（）`) from each header before alias matching, with the literal-suffix fast path preserved for JPY accounts whose tests already pin the verbatim header.
- `_to_float()` — strips a leading currency symbol from a known explicit set (`¥ $ € £ ₩ ₹ ¢ ₽ ₺ ₪ ₫ ฿ 元`). Kept the set explicit (not "any non-numeric prefix") so corrupted cells like `"abc123"` still return `0.0` instead of silently coercing to `123.0`.
- Removed the JPY-only rejection block in the row loop — cost values are stored raw in the account's own currency. Cross-account currency conversion is out of scope; mureo is single-account by design.

**`docs/byod.md`** — Step 2b drops `(JPY)` from the columns list and explains the suffix-stripping. Multilingual section gains a "currency-agnostic" note.

**`tests/test_byod_bundle.py`** — replaced `test_meta_adapter_rejects_non_jpy_spend` (which expected rejection) with:
- `test_meta_adapter_currency_agnostic_spend` — USD account (`Amount spent (USD)` + `$12.34`)
- `test_meta_adapter_currency_suffix_locales` — parametrized over EUR / GBP / KRW / INR

## Why is `cost_jpy` still the CSV column name?

The output CSV's spend column is still `cost_jpy` even though the value is no longer guaranteed to be JPY. This is intentionally out of scope for this PR — renaming would be a breaking schema change for the MCP server and a fleet of pinned-column tests. Tracking as a follow-up; the column is still correct on JPY accounts, and on non-JPY accounts the value carries the account's own currency as documented in the new `byod.md` note.

## Test plan

- [x] `pytest tests/test_byod.py tests/test_byod_bundle.py -q` → 57 passed
- [x] `ruff check`, `black --check`, `mypy --ignore-missing-imports` — all clean
- [x] New tests cover USD / EUR / GBP / KRW / INR header + cell-prefix combinations
- [x] Existing JPY paths preserved (fast-path alias match unchanged for `Amount spent (JPY)`)