### PR TITLE
docs(readme): promote /search-term-cleanup sample to hero (above the fold)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -21,6 +21,12 @@
 
 戦略を理解するエージェントが Google Ads、Meta Ads、Search Console、GA4 を自律的に分析・運用します。**認証情報は端末の外に出ません。**
 
+<p align="center">
+  <img src="docs/img/sample-search-term-cleanup.ja.svg" alt="mureo /search-term-cleanup の出力: ブランド自己カニバリゼーションを自動検出 — 同じブランド検索語が片方で CPA ¥172、もう片方で ¥1,226 が無駄、約 ¥12,000/30日 を再配分可能">
+</p>
+
+<p align="center"><em>実出力: 30日分の BYOD バンドルでブランドカニバリゼーションを自動検出 (B2B SaaS アカウント、匿名化済)。<a href="#実際のアウトプット例b2b-saas-アカウント匿名化済">他のサンプルを見る ↓</a></em></p>
+
 ## mureoとは
 
 mureoは、AIエージェントが広告アカウントを自動運用するためのフレームワークです。インストールすると、AIエージェント（Claude Code、Cursor、Codex、Geminiなど）がGoogle広告・Meta広告・Search Console・GA4を横断して、配信診断・検索語分析・予算評価・入稿チェックなどを実行できるようになります。すべての操作はあなたのビジネス戦略（`STRATEGY.md`）に基づいて行われます。

--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@
 
 Strategy-aware agents that autonomously analyze and operate Google Ads, Meta Ads, Search Console & GA4 — **credentials never leave your machine**.
 
+<p align="center">
+  <img src="docs/img/sample-search-term-cleanup.svg" alt="mureo /search-term-cleanup output: brand self-cannibalization detected — same brand term converts at ¥172 CPA in one campaign vs ¥1,226 wasted in another, ~¥12,000/30d redirectable">
+</p>
+
+<p align="center"><em>Real output: brand cannibalization auto-detected on a 30-day BYOD bundle (anonymized B2B SaaS account). <a href="#what-the-output-actually-looks-like-anonymized-b2b-saas-account">More samples ↓</a></em></p>
+
 ## What is mureo?
 
 mureo is a framework for AI agents to autonomously operate ad accounts. Once installed, AI agents (Claude Code, Cursor, Codex, Gemini, etc.) can work across Google Ads, Meta Ads, Search Console, and GA4 -- running campaign diagnostics, search term analysis, budget evaluation, ad validation, and more. Every operation is grounded in your business strategy (`STRATEGY.md`), so the agent makes decisions based on your persona, USP, goals, and brand voice -- not just raw metrics.


### PR DESCRIPTION
## Summary

OSS README ROI is highest when the first scroll shows what the tool actually does. Currently the strongest visual proof we have — the `/search-term-cleanup` brand-cannibalization sample (¥172 vs ¥1,226 CPA gap, ~¥12,000/30d redirectable) — sits at line ~210 of the README, three to four scrolls down.

This PR centers a single `<img>` of that SVG directly under the tagline so the first viewport carries the visual. The deeper "What the output actually looks like" section is unchanged — both SVGs (search-term-cleanup + Meta CV mismatch) remain there for readers who scroll, with the hero linking down via "More samples ↓".

## Changes

- README.md: 6 lines added directly after the tagline
- README.ja.md: 6 lines added in matching position with locale-matched alt text and caption

No code changes. No new assets.

## Why /search-term-cleanup as the hero (not /daily-check Meta CV mismatch)

- Concrete numbers (CPA ¥172 vs ¥1,226, ¥12,000 saving) read at a glance
- "Same brand term, two campaigns, mureo catches it" is one-sentence comprehensible
- "45 results vs 3 leads" requires a second of mental work — better suited to deeper context

## Test plan

- [x] Image renders centered on github.com README preview
- [x] Caption + anchor link works (first-scroll → deeper samples section)
- [x] CI lint passes