### PR TITLE
feat(demo): add `mureo demo init` for zero-friction trial

### DIFF
--- a/mureo/cli/demo_cmd.py
+++ b/mureo/cli/demo_cmd.py
@@ -1,0 +1,61 @@
+"""``mureo demo`` CLI subcommands: init.
+
+Materializes a self-contained demo directory so users can try mureo
+against a realistic synthetic dataset without exporting their own ad
+data first. The bundle round-trips through the same ``mureo byod
+import`` pipeline that real BYOD users go through, so the demo and
+real flows share a single code path downstream.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path  # noqa: TCH003 (used at runtime by typer)
+
+import typer
+
+from mureo.demo.installer import DemoInitError, materialize
+
+demo_app = typer.Typer(
+    name="demo",
+    help=(
+        "Bootstrap a self-contained demo directory (synthetic XLSX "
+        "bundle + STRATEGY.md + .mcp.json) so you can try mureo "
+        "without exporting your real ad data first."
+    ),
+    no_args_is_help=True,
+)
+
+
+@demo_app.command("init")  # type: ignore[untyped-decorator, unused-ignore]
+def init(
+    target: Path = typer.Argument(  # noqa: B008
+        Path("./mureo-demo"),
+        help="Directory to create (default: ./mureo-demo).",
+    ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Overwrite the target even if it already contains unrelated files.",
+    ),
+) -> None:
+    """Materialize a demo directory at TARGET (default ``./mureo-demo``).
+
+    After this completes, follow the printed next steps to import the
+    bundle and open the directory in Claude Code.
+    """
+    try:
+        results = materialize(target, force=force)
+    except DemoInitError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(code=1) from None
+
+    typer.echo("=== mureo demo init ===\n")
+    typer.echo(f"  Wrote demo to: {results['bundle'].parent}")
+    for label in ("bundle", "strategy", "mcp", "readme"):
+        typer.echo(f"    - {results[label].name}")
+    typer.echo("")
+    typer.echo("Next steps:")
+    typer.echo(f"  1. cd {results['bundle'].parent}")
+    typer.echo("  2. mureo byod import bundle.xlsx")
+    typer.echo("  3. Open this directory in Claude Code")
+    typer.echo("  4. Ask: /daily-check  (or /search-term-cleanup)")

--- a/mureo/cli/main.py
+++ b/mureo/cli/main.py
@@ -10,6 +10,7 @@ import typer
 
 from mureo.cli.auth_cmd import auth_app
 from mureo.cli.byod_cmd import byod_app
+from mureo.cli.demo_cmd import demo_app
 from mureo.cli.rollback_cmd import rollback_app
 from mureo.cli.setup_cmd import setup_app
 
@@ -23,6 +24,7 @@ app.add_typer(auth_app)
 app.add_typer(setup_app)
 app.add_typer(rollback_app)
 app.add_typer(byod_app)
+app.add_typer(demo_app)
 
 if __name__ == "__main__":
     app()

--- a/mureo/demo/__init__.py
+++ b/mureo/demo/__init__.py
@@ -1,0 +1,12 @@
+"""Demo bootstrap for ``mureo demo init``.
+
+Materializes a self-contained directory containing a synthetic XLSX
+bundle, a STRATEGY.md seed, a ``.mcp.json`` for Claude Code, and a
+README. The bundle round-trips through the existing BYOD pipeline so
+the demo experience is identical to a real BYOD import minus the data
+download step.
+"""
+
+from mureo.demo.installer import DemoInitError, materialize
+
+__all__ = ["DemoInitError", "materialize"]

--- a/mureo/demo/builder.py
+++ b/mureo/demo/builder.py
@@ -1,0 +1,62 @@
+"""Build the demo XLSX bundle from the scenario row tables.
+
+The output file is a single XLSX workbook with five sheets:
+
+  campaigns / ad_groups / search_terms / keywords  (Google Ads)
+  meta_ads                                         (Meta Ads export)
+
+The Google Ads tabs match the schema produced by
+``scripts/sheet-template/google-ads-script.js`` (the same shape
+``mureo/byod/adapters/google_ads.py`` consumes). The Meta sheet
+matches the verified English-locale Ads Manager export header
+``mureo/byod/adapters/meta_ads.py`` recognizes.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from mureo.demo import scenario
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def build_bundle(out_path: Path) -> None:
+    """Write the demo XLSX bundle to ``out_path``.
+
+    Overwrites any existing file at the target. Caller is responsible
+    for ensuring the parent directory exists.
+
+    Raises:
+        ImportError: if ``openpyxl`` is not installed. mureo declares
+            it as a required dependency, so this should never trigger
+            in a normal install — surfaced explicitly for editable
+            checkouts where the user forgot to ``pip install -e .``.
+    """
+    try:
+        from openpyxl import Workbook
+    except ImportError as exc:
+        raise ImportError(
+            "openpyxl is required to build the demo bundle. "
+            "Install with: pip install 'openpyxl>=3.1,<4'"
+        ) from exc
+
+    wb = Workbook()
+    default = wb.active
+    if default is not None:
+        wb.remove(default)
+
+    sheets: list[tuple[str, list[list[object]]]] = [
+        ("campaigns", scenario.google_campaigns_rows()),
+        ("ad_groups", scenario.google_ad_groups_rows()),
+        ("search_terms", scenario.google_search_terms_rows()),
+        ("keywords", scenario.google_keywords_rows()),
+        ("meta_ads", scenario.meta_ads_rows()),
+    ]
+    for name, rows in sheets:
+        sheet = wb.create_sheet(name)
+        for row in rows:
+            sheet.append(row)
+
+    wb.save(out_path)

--- a/mureo/demo/installer.py
+++ b/mureo/demo/installer.py
@@ -1,0 +1,208 @@
+"""Materialize the ``mureo demo init`` artifacts on disk.
+
+The installer is intentionally narrow: it writes four files into a
+target directory and otherwise stays out of the user's way. It does
+**not** import the bundle into ``~/.mureo/byod/`` — that step remains
+the user's explicit ``mureo byod import`` invocation, so the demo
+flow cannot silently overwrite real BYOD data the user already has.
+
+Artifacts written:
+
+  bundle.xlsx     — synthetic Google Ads + Meta Ads bundle
+                    (see :mod:`mureo.demo.scenario` /
+                    :mod:`mureo.demo.builder`)
+  STRATEGY.md     — minimal seed strategy for the FlowDesk B2B SaaS
+                    scenario, suitable for ``mureo-strategy`` skills
+  .mcp.json       — Claude Code MCP server registration for the
+                    ``mureo`` stdio server
+  README.md       — quickstart instructions
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from mureo.demo.builder import build_bundle
+
+
+class DemoInitError(RuntimeError):
+    """Raised when ``materialize`` cannot safely write the demo artifacts."""
+
+
+# Files the installer writes. Used by the empty-dir guard so re-running
+# on a partial install (e.g. when the previous run was interrupted)
+# does not wedge the user behind a "directory not empty" error.
+_DEMO_FILES: tuple[str, ...] = (
+    "bundle.xlsx",
+    "STRATEGY.md",
+    ".mcp.json",
+    "README.md",
+)
+
+
+def materialize(target_dir: Path | str, *, force: bool = False) -> dict[str, Path]:
+    """Write the demo artifacts into ``target_dir``.
+
+    Args:
+        target_dir: Destination directory. Created (with parents) if
+            absent. Existing **empty** directories are reused without
+            complaint.
+        force: When True, overwrite any existing demo artifacts in the
+            target without checking for unrelated files. When False
+            (default) the call refuses if the target already contains
+            files other than the four artifacts this installer
+            manages, so the user is never surprised by losing
+            unrelated data.
+
+    Returns:
+        Mapping of artifact name → absolute path of the written file.
+
+    Raises:
+        DemoInitError: if ``target_dir`` exists as a non-directory, or
+            if the target is non-empty and ``force`` is False (with
+            existing-but-unrelated files present).
+    """
+    target = Path(target_dir).expanduser().resolve()
+
+    if target.exists() and not target.is_dir():
+        raise DemoInitError(
+            f"{target}: exists and is not a directory. "
+            "Pick a different path or remove the file first."
+        )
+
+    if target.exists() and not force:
+        existing = [p for p in target.iterdir() if p.name not in _DEMO_FILES]
+        if existing:
+            sample = ", ".join(sorted(p.name for p in existing[:5]))
+            raise DemoInitError(
+                f"{target}: directory is not empty (contains {sample}). "
+                "Re-run with --force to overwrite, or pick a different "
+                "target path."
+            )
+
+    try:
+        target.mkdir(parents=True, exist_ok=True)
+
+        bundle_path = target / "bundle.xlsx"
+        build_bundle(bundle_path)
+
+        strategy_path = target / "STRATEGY.md"
+        strategy_path.write_text(_strategy_md(), encoding="utf-8")
+
+        mcp_path = target / ".mcp.json"
+        mcp_path.write_text(_mcp_json(), encoding="utf-8")
+
+        readme_path = target / "README.md"
+        readme_path.write_text(_readme_md(), encoding="utf-8")
+    except OSError as exc:
+        # Surface filesystem failures (broken symlinks, permission errors,
+        # ENOSPC, symlink loops resolving to non-existent paths) as a
+        # clean DemoInitError so the CLI prints a one-line message
+        # instead of a stack trace. The pre-checks above only cover the
+        # "target exists and isn't usable" case; this catches the
+        # mid-write surprises.
+        raise DemoInitError(f"{target}: {exc}") from exc
+
+    return {
+        "bundle": bundle_path,
+        "strategy": strategy_path,
+        "mcp": mcp_path,
+        "readme": readme_path,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Static artifact bodies
+# ---------------------------------------------------------------------------
+
+
+def _mcp_json() -> str:
+    """Claude Code MCP registration pointing at the local mureo server.
+
+    ``python -m mureo.mcp`` matches the entry point used by
+    ``mureo/cli/setup_codex.py`` so the demo and the real install path
+    stay in sync if one changes.
+    """
+    config = {
+        "mcpServers": {
+            "mureo": {
+                "type": "stdio",
+                "command": "python",
+                "args": ["-m", "mureo.mcp"],
+            }
+        }
+    }
+    return json.dumps(config, indent=2) + "\n"
+
+
+def _strategy_md() -> str:
+    return """# STRATEGY — FlowDesk (demo)
+
+> Synthetic mid-market B2B SaaS scenario shipped with `mureo demo init`.
+> Replace with your real strategy when you switch to a live account.
+
+## Business
+- **Brand:** FlowDesk
+- **Product:** Project management & team collaboration SaaS
+- **ICP:** 50–500 person companies, ops / PM leaders
+- **Plan range:** ~JPY 1,200 / seat / month
+
+## Marketing goals (this quarter)
+- Hit 320 paid signups / month at <= JPY 12,000 CPA
+- Keep brand-search CTR >= 15%
+- Hold blended Google + Meta ROAS >= 2.5x
+
+## Channel mix
+- **Google Ads:** Brand (Exact + Phrase), Generic (High intent + Low intent)
+- **Meta Ads:** Awareness video at the top of funnel, Lead-form conversion at the bottom
+
+## Constraints
+- No competitor-name bidding
+- Brand terms should not appear in Phrase or Broad campaigns
+- Demo bundle covers the 30 days ending 2026-04-29
+"""
+
+
+def _readme_md() -> str:
+    return """# mureo demo
+
+This directory was generated by `mureo demo init`. It contains a
+self-contained, synthetic-data demo of mureo so you can try the
+skills against a realistic dataset without exporting your own data
+first.
+
+## Quickstart (Claude Code)
+
+1. Import the demo bundle into mureo's BYOD store:
+
+       mureo byod import bundle.xlsx
+
+2. Open this directory in Claude Code. The bundled `.mcp.json`
+   registers the `mureo` MCP server automatically.
+
+3. In Claude Code, try one of:
+
+       /daily-check
+       /search-term-cleanup
+       /budget-rebalance
+       /weekly-report
+
+The bundle deliberately contains a few realistic problems
+(brand-cannibalization in the Phrase campaign, an over-funded
+low-intent generic campaign, a fatiguing Meta video creative) so the
+skills surface actionable findings instead of "everything is fine."
+
+## Files
+
+- `bundle.xlsx`  — Google Ads + Meta Ads synthetic data, 30 days
+- `STRATEGY.md`  — seed strategy used by `mureo-strategy` skills
+- `.mcp.json`    — Claude Code MCP server registration
+- `README.md`    — this file
+
+## Cleaning up
+
+To remove the imported demo data afterwards:
+
+    mureo byod clear
+"""

--- a/mureo/demo/scenario.py
+++ b/mureo/demo/scenario.py
@@ -1,0 +1,447 @@
+"""Synthetic data scenario for the ``mureo demo init`` bundle.
+
+The scenario portrays a fictional mid-market B2B SaaS account
+(brand: ``FlowDesk``) running Google Ads + Meta Ads over the 30 days
+ending :data:`DEMO_END_DATE`. Numbers are picked so that the standard
+mureo skills (``/daily-check``, ``/search-term-cleanup``,
+``/budget-rebalance``, ``/creative-refresh``, ``/weekly-report``) each
+surface at least one actionable finding when run against the demo
+bundle:
+
+  - ``Brand - Phrase`` matches on pure-brand search terms that should
+    be moved into the Exact match campaign (cannibalization).
+  - ``Generic - Low Intent`` consumes a disproportionate share of
+    spend with poor CVR (budget skew).
+  - Meta ``Awareness - Video A`` shows a CTR slope that drops late in
+    the period (creative fatigue).
+
+All values are deterministic — no randomness — so re-running
+``mureo demo init`` produces an identical bundle byte-for-byte.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, timedelta
+
+# ---------------------------------------------------------------------------
+# Scenario constants
+# ---------------------------------------------------------------------------
+
+DEMO_END_DATE: date = date(2026, 4, 29)
+DEMO_DAYS: int = 30
+DEMO_BRAND: str = "FlowDesk"
+
+
+def _days() -> list[date]:
+    return [DEMO_END_DATE - timedelta(days=DEMO_DAYS - 1 - i) for i in range(DEMO_DAYS)]
+
+
+# ---------------------------------------------------------------------------
+# Google Ads scenario
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _GAdsCampaign:
+    name: str
+    base_impr: int
+    ctr: float
+    cpc_jpy: float
+    cvr: float
+    impr_slope: float
+    ctr_slope: float
+
+
+_GADS_CAMPAIGNS: tuple[_GAdsCampaign, ...] = (
+    _GAdsCampaign("Brand - Exact", 1200, 0.18, 80.0, 0.12, 0.002, 0.0),
+    _GAdsCampaign("Brand - Phrase", 800, 0.10, 110.0, 0.06, -0.003, -0.001),
+    _GAdsCampaign("Generic - High Intent", 3500, 0.06, 220.0, 0.05, 0.001, 0.0),
+    _GAdsCampaign("Generic - Low Intent", 6000, 0.02, 350.0, 0.008, 0.0, 0.0),
+)
+
+
+@dataclass(frozen=True)
+class _GAdsAdGroup:
+    campaign: str
+    name: str
+    share: float
+
+
+_GADS_AD_GROUPS: tuple[_GAdsAdGroup, ...] = (
+    _GAdsAdGroup("Brand - Exact", "Exact - Core", 1.0),
+    _GAdsAdGroup("Brand - Phrase", "Phrase - Variants", 1.0),
+    _GAdsAdGroup("Generic - High Intent", "Project Management Software", 0.55),
+    _GAdsAdGroup("Generic - High Intent", "Team Collaboration Tool", 0.45),
+    _GAdsAdGroup("Generic - Low Intent", "Productivity Tips", 0.60),
+    _GAdsAdGroup("Generic - Low Intent", "Remote Work", 0.40),
+)
+
+
+@dataclass(frozen=True)
+class _GAdsSearchTerm:
+    term: str
+    campaign: str
+    ad_group: str
+    impressions: int
+    clicks: int
+    cost_jpy: float
+    conversions: float
+
+
+_GADS_SEARCH_TERMS: tuple[_GAdsSearchTerm, ...] = (
+    _GAdsSearchTerm(
+        "flowdesk", "Brand - Exact", "Exact - Core", 8200, 1480, 118400, 178
+    ),
+    _GAdsSearchTerm(
+        "flowdesk login", "Brand - Exact", "Exact - Core", 1100, 198, 15840, 22
+    ),
+    _GAdsSearchTerm(
+        "flowdesk app", "Brand - Phrase", "Phrase - Variants", 950, 95, 10450, 5
+    ),
+    _GAdsSearchTerm(
+        "flowdesk pricing", "Brand - Phrase", "Phrase - Variants", 720, 72, 7920, 4
+    ),
+    _GAdsSearchTerm(
+        "flowdesk vs notion", "Brand - Phrase", "Phrase - Variants", 540, 38, 4180, 2
+    ),
+    _GAdsSearchTerm(
+        "project management software",
+        "Generic - High Intent",
+        "Project Management Software",
+        15400,
+        924,
+        203280,
+        46,
+    ),
+    _GAdsSearchTerm(
+        "best project management tool",
+        "Generic - High Intent",
+        "Project Management Software",
+        8800,
+        528,
+        116160,
+        26,
+    ),
+    _GAdsSearchTerm(
+        "team collaboration software",
+        "Generic - High Intent",
+        "Team Collaboration Tool",
+        6300,
+        315,
+        69300,
+        15,
+    ),
+    _GAdsSearchTerm(
+        "productivity tips",
+        "Generic - Low Intent",
+        "Productivity Tips",
+        42000,
+        840,
+        294000,
+        7,
+    ),
+    _GAdsSearchTerm(
+        "how to be productive",
+        "Generic - Low Intent",
+        "Productivity Tips",
+        18000,
+        360,
+        126000,
+        2,
+    ),
+    _GAdsSearchTerm(
+        "work from home tips",
+        "Generic - Low Intent",
+        "Remote Work",
+        24000,
+        480,
+        168000,
+        3,
+    ),
+    _GAdsSearchTerm(
+        "remote work guide",
+        "Generic - Low Intent",
+        "Remote Work",
+        12000,
+        240,
+        84000,
+        2,
+    ),
+)
+
+
+@dataclass(frozen=True)
+class _GAdsKeyword:
+    keyword: str
+    match_type: str
+    quality_score: int
+    campaign: str
+    ad_group: str
+    impressions: int
+    clicks: int
+    cost_jpy: float
+    conversions: float
+
+
+_GADS_KEYWORDS: tuple[_GAdsKeyword, ...] = (
+    _GAdsKeyword(
+        "flowdesk",
+        "EXACT",
+        10,
+        "Brand - Exact",
+        "Exact - Core",
+        9300,
+        1678,
+        134240,
+        200,
+    ),
+    _GAdsKeyword(
+        '"flowdesk"',
+        "PHRASE",
+        6,
+        "Brand - Phrase",
+        "Phrase - Variants",
+        2210,
+        205,
+        22550,
+        11,
+    ),
+    _GAdsKeyword(
+        "project management software",
+        "PHRASE",
+        8,
+        "Generic - High Intent",
+        "Project Management Software",
+        15400,
+        924,
+        203280,
+        46,
+    ),
+    _GAdsKeyword(
+        "team collaboration software",
+        "PHRASE",
+        7,
+        "Generic - High Intent",
+        "Team Collaboration Tool",
+        6300,
+        315,
+        69300,
+        15,
+    ),
+    _GAdsKeyword(
+        "productivity tips",
+        "PHRASE",
+        4,
+        "Generic - Low Intent",
+        "Productivity Tips",
+        42000,
+        840,
+        294000,
+        7,
+    ),
+    _GAdsKeyword(
+        "remote work",
+        "PHRASE",
+        4,
+        "Generic - Low Intent",
+        "Remote Work",
+        36000,
+        720,
+        252000,
+        5,
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# Meta Ads scenario
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _MetaAd:
+    campaign: str
+    ad_set: str
+    ad: str
+    base_impr: int
+    base_ctr: float
+    cpc_jpy: float
+    base_results: float
+    ctr_slope: float
+
+
+_META_ADS: tuple[_MetaAd, ...] = (
+    _MetaAd(
+        "Awareness - Video", "Tokyo 25-34", "Video A", 4800, 0.014, 95.0, 0.05, -0.0004
+    ),
+    _MetaAd(
+        "Conversion - Lead Form",
+        "Decision-makers JP",
+        "Lead Form B",
+        1700,
+        0.022,
+        240.0,
+        0.18,
+        0.0,
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# Row builders — flat sequences that the workbook builder writes verbatim
+# ---------------------------------------------------------------------------
+
+
+def google_campaigns_rows() -> list[list[object]]:
+    """``campaigns`` tab rows including header.
+
+    Schema: day, campaign, impressions, clicks, cost, conversions
+    """
+    rows: list[list[object]] = [
+        ["day", "campaign", "impressions", "clicks", "cost", "conversions"]
+    ]
+    days = _days()
+    for c in _GADS_CAMPAIGNS:
+        for i, d in enumerate(days):
+            impr = max(0, int(round(c.base_impr * (1.0 + c.impr_slope * i))))
+            ctr = max(0.0001, c.ctr + c.ctr_slope * i)
+            clicks = int(round(impr * ctr))
+            cost = round(clicks * c.cpc_jpy, 2)
+            conversions = round(clicks * c.cvr, 2)
+            rows.append([d.isoformat(), c.name, impr, clicks, cost, conversions])
+    return rows
+
+
+def google_ad_groups_rows() -> list[list[object]]:
+    """``ad_groups`` tab rows including header.
+
+    Schema: day, campaign, ad_group, impressions, clicks, cost, conversions
+    """
+    rows: list[list[object]] = [
+        [
+            "day",
+            "campaign",
+            "ad_group",
+            "impressions",
+            "clicks",
+            "cost",
+            "conversions",
+        ]
+    ]
+    days = _days()
+    by_campaign = {c.name: c for c in _GADS_CAMPAIGNS}
+    for ag in _GADS_AD_GROUPS:
+        c = by_campaign[ag.campaign]
+        for i, d in enumerate(days):
+            impr = max(0, int(round(c.base_impr * ag.share * (1.0 + c.impr_slope * i))))
+            ctr = max(0.0001, c.ctr + c.ctr_slope * i)
+            clicks = int(round(impr * ctr))
+            cost = round(clicks * c.cpc_jpy, 2)
+            conversions = round(clicks * c.cvr, 2)
+            rows.append(
+                [d.isoformat(), ag.campaign, ag.name, impr, clicks, cost, conversions]
+            )
+    return rows
+
+
+def google_search_terms_rows() -> list[list[object]]:
+    """``search_terms`` tab rows including header (aggregated, no day column)."""
+    rows: list[list[object]] = [
+        [
+            "search_term",
+            "campaign",
+            "ad_group",
+            "impressions",
+            "clicks",
+            "cost",
+            "conversions",
+        ]
+    ]
+    for st in _GADS_SEARCH_TERMS:
+        rows.append(
+            [
+                st.term,
+                st.campaign,
+                st.ad_group,
+                st.impressions,
+                st.clicks,
+                st.cost_jpy,
+                st.conversions,
+            ]
+        )
+    return rows
+
+
+def google_keywords_rows() -> list[list[object]]:
+    """``keywords`` tab rows including header."""
+    rows: list[list[object]] = [
+        [
+            "keyword",
+            "match_type",
+            "quality_score",
+            "campaign",
+            "ad_group",
+            "impressions",
+            "clicks",
+            "cost",
+            "conversions",
+        ]
+    ]
+    for kw in _GADS_KEYWORDS:
+        rows.append(
+            [
+                kw.keyword,
+                kw.match_type,
+                kw.quality_score,
+                kw.campaign,
+                kw.ad_group,
+                kw.impressions,
+                kw.clicks,
+                kw.cost_jpy,
+                kw.conversions,
+            ]
+        )
+    return rows
+
+
+def meta_ads_rows() -> list[list[object]]:
+    """Meta Ads Manager export — single sheet with daily breakdown.
+
+    Header matches the verified English locale of the actual Ads
+    Manager export: Day / Campaign name / Ad set name / Ad name /
+    Impressions / Clicks (all) / Amount spent (JPY) / Results.
+    """
+    rows: list[list[object]] = [
+        [
+            "Day",
+            "Campaign name",
+            "Ad set name",
+            "Ad name",
+            "Impressions",
+            "Clicks (all)",
+            "Amount spent (JPY)",
+            "Results",
+        ]
+    ]
+    days = _days()
+    for ad in _META_ADS:
+        for i, d in enumerate(days):
+            impr = ad.base_impr
+            ctr = max(0.0001, ad.base_ctr + ad.ctr_slope * i)
+            clicks = int(round(impr * ctr))
+            spent = round(clicks * ad.cpc_jpy, 0)
+            results = round(clicks * ad.base_results, 1)
+            rows.append(
+                [
+                    d.isoformat(),
+                    ad.campaign,
+                    ad.ad_set,
+                    ad.ad,
+                    impr,
+                    clicks,
+                    spent,
+                    results,
+                ]
+            )
+    return rows

--- a/tests/test_demo_init.py
+++ b/tests/test_demo_init.py
@@ -1,0 +1,224 @@
+"""Tests for ``mureo demo init`` — the zero-friction demo bootstrap.
+
+The demo flow materializes a self-contained directory with a synthetic
+XLSX bundle, a STRATEGY.md seed, a Claude Code ``.mcp.json`` snippet
+and a README. The goal is parity-of-experience with BYOD without the
+user having to download their real ad data first.
+
+Coverage:
+  - ``materialize`` writes the four expected artifacts
+  - refuses an existing non-empty target unless ``force=True``
+  - empty target dir is OK
+  - the generated bundle parses cleanly through the existing BYOD
+    pipeline (both google_ads and meta_ads land)
+  - .mcp.json registers a stdio mureo MCP server
+  - STRATEGY.md is non-empty and looks like markdown
+  - CLI ``mureo demo init`` works end-to-end via the typer runner
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+from typer.testing import CliRunner
+
+from mureo.cli.main import app
+from mureo.demo.installer import DemoInitError, materialize
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+pytestmark = pytest.mark.unit
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def byod_root(tmp_path, monkeypatch):
+    """Redirect ``Path.home()`` so BYOD writes land in a sandbox.
+
+    Mirrors the pattern used by ``tests/test_byod_bundle.py`` so the
+    demo-bundle round-trip test does not touch the real ``~/.mureo``.
+    """
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setattr("pathlib.Path.home", lambda: fake_home)
+    return fake_home
+
+
+# ---------------------------------------------------------------------------
+# materialize() — direct unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_materialize_creates_expected_files(tmp_path: Path) -> None:
+    target = tmp_path / "mureo-demo"
+    materialize(target)
+
+    assert (target / "bundle.xlsx").is_file()
+    assert (target / "STRATEGY.md").is_file()
+    assert (target / ".mcp.json").is_file()
+    assert (target / "README.md").is_file()
+
+
+def test_materialize_creates_target_dir_if_missing(tmp_path: Path) -> None:
+    target = tmp_path / "deep" / "nested" / "mureo-demo"
+    materialize(target)
+    assert target.is_dir()
+    assert (target / "bundle.xlsx").is_file()
+
+
+def test_materialize_refuses_existing_non_empty_dir(tmp_path: Path) -> None:
+    target = tmp_path / "mureo-demo"
+    target.mkdir()
+    (target / "junk").write_text("hi")
+    with pytest.raises(DemoInitError):
+        materialize(target)
+
+
+def test_materialize_force_overwrites(tmp_path: Path) -> None:
+    target = tmp_path / "mureo-demo"
+    target.mkdir()
+    (target / "bundle.xlsx").write_text("stale")
+    materialize(target, force=True)
+    # The new file should be a real xlsx (zip magic), not the stub text.
+    assert (target / "bundle.xlsx").read_bytes()[:2] == b"PK"
+
+
+def test_materialize_empty_existing_dir_ok(tmp_path: Path) -> None:
+    target = tmp_path / "mureo-demo"
+    target.mkdir()
+    materialize(target)
+    assert (target / "bundle.xlsx").is_file()
+
+
+def test_materialize_refuses_target_that_is_a_file(tmp_path: Path) -> None:
+    target = tmp_path / "demo"
+    target.write_text("not a directory")
+    with pytest.raises(DemoInitError):
+        materialize(target)
+
+
+def test_materialize_force_preserves_unrelated_files(tmp_path: Path) -> None:
+    """``--force`` must not delete anything outside ``_DEMO_FILES``.
+
+    Pins the contract so a future refactor cannot introduce a
+    ``shutil.rmtree`` cleanup that wipes user data sitting next to
+    where they pointed ``mureo demo init``.
+    """
+    target = tmp_path / "demo"
+    target.mkdir()
+    (target / ".env").write_text("SECRET=keep-me", encoding="utf-8")
+    sub = target / "src"
+    sub.mkdir()
+    (sub / "app.py").write_text("print('hi')\n", encoding="utf-8")
+
+    materialize(target, force=True)
+
+    assert (target / ".env").read_text(encoding="utf-8") == "SECRET=keep-me"
+    assert (sub / "app.py").read_text(encoding="utf-8") == "print('hi')\n"
+    assert (target / "bundle.xlsx").is_file()
+
+
+def test_materialize_wraps_filesystem_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An OSError mid-write is surfaced as DemoInitError.
+
+    Simulates the symlink-loop / permission-denied / ENOSPC case so
+    the CLI prints a clean one-liner instead of a stack trace.
+    """
+    target = tmp_path / "demo"
+
+    def _boom(path):  # pragma: no cover - injected failure
+        raise OSError("simulated disk failure")
+
+    monkeypatch.setattr("mureo.demo.installer.build_bundle", _boom)
+
+    with pytest.raises(DemoInitError) as excinfo:
+        materialize(target)
+    assert "simulated disk failure" in str(excinfo.value)
+
+
+def test_mcp_json_registers_mureo_server(tmp_path: Path) -> None:
+    target = tmp_path / "mureo-demo"
+    materialize(target)
+    config = json.loads((target / ".mcp.json").read_text(encoding="utf-8"))
+    assert "mcpServers" in config
+    assert "mureo" in config["mcpServers"]
+    server = config["mcpServers"]["mureo"]
+    assert server["type"] == "stdio"
+    assert isinstance(server["command"], str) and server["command"]
+
+
+def test_strategy_md_is_seeded_markdown(tmp_path: Path) -> None:
+    target = tmp_path / "mureo-demo"
+    materialize(target)
+    text = (target / "STRATEGY.md").read_text(encoding="utf-8")
+    assert text.strip()
+    # Looks like markdown with at least one heading.
+    assert "#" in text
+
+
+def test_readme_contains_quickstart_steps(tmp_path: Path) -> None:
+    target = tmp_path / "mureo-demo"
+    materialize(target)
+    text = (target / "README.md").read_text(encoding="utf-8")
+    assert "mureo byod import" in text
+    assert "bundle.xlsx" in text
+
+
+def test_bundle_imports_via_byod_pipeline(tmp_path: Path, byod_root) -> None:
+    """End-to-end: the demo bundle is consumable by ``import_bundle``.
+
+    Contract: the bundle must round-trip through the same pipeline real
+    BYOD users go through, so any divergence between the demo data
+    shape and production schemas is caught here.
+    """
+    from mureo.byod.bundle import import_bundle
+
+    target = tmp_path / "mureo-demo"
+    materialize(target)
+
+    results = import_bundle(target / "bundle.xlsx")
+    assert "google_ads" in results
+    assert "meta_ads" in results
+    assert results["google_ads"]["rows"] > 0
+    assert results["meta_ads"]["rows"] > 0
+
+
+# ---------------------------------------------------------------------------
+# CLI integration via Typer's CliRunner
+# ---------------------------------------------------------------------------
+
+
+def test_cli_demo_init_creates_artifacts(tmp_path: Path) -> None:
+    target = tmp_path / "demo"
+    result = runner.invoke(app, ["demo", "init", str(target)])
+    assert result.exit_code == 0, result.stdout
+    assert (target / "bundle.xlsx").is_file()
+    assert (target / ".mcp.json").is_file()
+
+
+def test_cli_demo_init_refuses_non_empty_without_force(tmp_path: Path) -> None:
+    target = tmp_path / "demo"
+    target.mkdir()
+    (target / "junk").write_text("x")
+    result = runner.invoke(app, ["demo", "init", str(target)])
+    assert result.exit_code != 0
+
+
+def test_cli_demo_init_force_overrides(tmp_path: Path) -> None:
+    target = tmp_path / "demo"
+    target.mkdir()
+    (target / "junk").write_text("x")
+    result = runner.invoke(app, ["demo", "init", str(target), "--force"])
+    assert result.exit_code == 0, result.stdout
+    assert (target / "bundle.xlsx").is_file()


### PR DESCRIPTION
## Summary

- New CLI subcommand: `mureo demo init [TARGET] [--force]` materializes a self-contained directory with a synthetic XLSX bundle (Google Ads + Meta Ads), `STRATEGY.md` seed, `.mcp.json` for Claude Code, and a `README.md`.
- The bundle is consumed by the existing `mureo byod import` pipeline — demo and real BYOD flows share one code path downstream.
- The bundle deliberately contains realistic problems (brand cannibalization in the Phrase campaign, an over-funded low-intent generic campaign, a fatiguing Meta video creative) so `/daily-check`, `/search-term-cleanup`, `/budget-rebalance`, `/weekly-report`, `/creative-refresh` each surface findings.

## Why

BYOD reduced setup friction (no OAuth / no GCP / no Meta dev account) but still requires the user to download their real account data first. `demo init` removes that last step so a new user can experience mureo end-to-end in seconds.

Scope of this PR is intentionally narrow — only the local artifact generator. Claude Desktop `.mcpb` packaging, hosted endpoints, and a `web claude.ai` path are explicitly out of scope here and may follow later.

## Design choices

- **No auto-import**: `demo init` does **not** write to `~/.mureo/byod/`. The user runs `mureo byod import bundle.xlsx` explicitly so demo cannot silently overwrite real BYOD data.
- **Deterministic synthetic data**: scenario uses no randomness, so re-runs produce byte-for-byte identical bundles.
- **`--force` is non-destructive**: only writes the four whitelisted demo files; unrelated files (`.env`, `.git/`, `src/`, …) survive untouched. Pinned by `test_materialize_force_preserves_unrelated_files`.
- **Filesystem errors → friendly message**: mid-write `OSError` (broken symlinks, ENOSPC, perms) is wrapped as `DemoInitError` so the CLI prints a one-liner instead of a stack trace. Pinned by `test_materialize_wraps_filesystem_errors`.

## Files

- `mureo/demo/scenario.py` — synthetic FlowDesk B2B SaaS data tables (deterministic)
- `mureo/demo/builder.py` — XLSX workbook builder
- `mureo/demo/installer.py` — `materialize(target_dir, force)` entry point
- `mureo/cli/demo_cmd.py` — Typer subcommand
- `mureo/cli/main.py` — register `demo_app`
- `tests/test_demo_init.py` — 15 unit + integration tests (incl. round-trip through `import_bundle`)

## Test plan

- [x] `pytest tests/test_demo_init.py` — 15/15 green
- [x] `pytest tests/test_cli.py tests/test_byod.py tests/test_byod_bundle.py tests/test_cli_rollback.py tests/test_setup_cmd.py` — 101/101 green (no regressions in adjacent surfaces)
- [x] `ruff check` clean on new files
- [x] `black --check` clean on new files
- [x] CLI smoke: `mureo demo init /tmp/_smoke --force` produces all four artifacts and prints next-steps banner
- [x] End-to-end: generated `bundle.xlsx` round-trips through `mureo.byod.bundle.import_bundle()` yielding both `google_ads` and `meta_ads` entries (covered by `test_bundle_imports_via_byod_pipeline`)

## Out of scope (follow-ups)

- Claude Desktop `.mcpb` packaging (UI-install path)
- Optional `--auto-import` flag (would need a confirmation guard)
- Multi-locale demo (all data in EN/JP today)