### PR TITLE
feat(demo): ship STATE.json and auto-import bundle in 'mureo demo init'

### DIFF
--- a/mureo/cli/demo_cmd.py
+++ b/mureo/cli/demo_cmd.py
@@ -62,8 +62,15 @@ def init(
         typer.echo(f"Error: {exc}", err=True)
         raise typer.Exit(code=1) from None
 
+    # ``bundle`` is always written by materialize(); only ``state`` can
+    # be None (under --skip-import). Pull bundle out so the rest of the
+    # block doesn't have to relitigate the union.
+    bundle = results["bundle"]
+    assert bundle is not None
+    target_dir = bundle.parent
+
     typer.echo("=== mureo demo init ===\n")
-    typer.echo(f"  Wrote demo to: {results['bundle'].parent}")
+    typer.echo(f"  Wrote demo to: {target_dir}")
     for label in ("bundle", "strategy", "state", "mcp", "readme"):
         path = results[label]
         if path is None:
@@ -72,12 +79,12 @@ def init(
     typer.echo("")
     typer.echo("Next steps:")
     if skip_import:
-        typer.echo(f"  1. cd {results['bundle'].parent}")
+        typer.echo(f"  1. cd {target_dir}")
         typer.echo("  2. mureo byod import bundle.xlsx")
         typer.echo("  3. Open this directory in Claude Code")
         typer.echo("  4. Ask: /daily-check  (or /search-term-cleanup)")
     else:
         typer.echo("  Bundle imported into ~/.mureo/byod/.")
-        typer.echo(f"  1. cd {results['bundle'].parent}")
+        typer.echo(f"  1. cd {target_dir}")
         typer.echo("  2. Open this directory in Claude Code")
         typer.echo("  3. Ask: /daily-check  (or /search-term-cleanup)")

--- a/mureo/cli/demo_cmd.py
+++ b/mureo/cli/demo_cmd.py
@@ -35,27 +35,49 @@ def init(
     force: bool = typer.Option(
         False,
         "--force",
-        help="Overwrite the target even if it already contains unrelated files.",
+        help=(
+            "Overwrite the target even if it contains unrelated files, "
+            "and replace any conflicting BYOD data in ~/.mureo/byod/."
+        ),
+    ),
+    skip_import: bool = typer.Option(
+        False,
+        "--skip-import",
+        help=(
+            "Write the demo files but do NOT import the bundle into "
+            "~/.mureo/byod/. Useful if you want to inspect the bundle "
+            "first or already have BYOD data you do not want to disturb."
+        ),
     ),
 ) -> None:
     """Materialize a demo directory at TARGET (default ``./mureo-demo``).
 
-    After this completes, follow the printed next steps to import the
-    bundle and open the directory in Claude Code.
+    By default this also imports the demo bundle into ``~/.mureo/byod/``
+    so the workflow skills (``/daily-check`` etc.) are immediately
+    runnable in Claude Code with no extra steps.
     """
     try:
-        results = materialize(target, force=force)
+        results = materialize(target, force=force, skip_import=skip_import)
     except DemoInitError as exc:
         typer.echo(f"Error: {exc}", err=True)
         raise typer.Exit(code=1) from None
 
     typer.echo("=== mureo demo init ===\n")
     typer.echo(f"  Wrote demo to: {results['bundle'].parent}")
-    for label in ("bundle", "strategy", "mcp", "readme"):
-        typer.echo(f"    - {results[label].name}")
+    for label in ("bundle", "strategy", "state", "mcp", "readme"):
+        path = results[label]
+        if path is None:
+            continue  # ``state`` is None when --skip-import is set
+        typer.echo(f"    - {path.name}")
     typer.echo("")
     typer.echo("Next steps:")
-    typer.echo(f"  1. cd {results['bundle'].parent}")
-    typer.echo("  2. mureo byod import bundle.xlsx")
-    typer.echo("  3. Open this directory in Claude Code")
-    typer.echo("  4. Ask: /daily-check  (or /search-term-cleanup)")
+    if skip_import:
+        typer.echo(f"  1. cd {results['bundle'].parent}")
+        typer.echo("  2. mureo byod import bundle.xlsx")
+        typer.echo("  3. Open this directory in Claude Code")
+        typer.echo("  4. Ask: /daily-check  (or /search-term-cleanup)")
+    else:
+        typer.echo("  Bundle imported into ~/.mureo/byod/.")
+        typer.echo(f"  1. cd {results['bundle'].parent}")
+        typer.echo("  2. Open this directory in Claude Code")
+        typer.echo("  3. Ask: /daily-check  (or /search-term-cleanup)")

--- a/mureo/demo/installer.py
+++ b/mureo/demo/installer.py
@@ -21,9 +21,21 @@ Artifacts written:
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 
+from mureo.byod.bundle import BundleImportError, import_bundle
+from mureo.byod.runtime import byod_platform_info
+from mureo.demo import scenario
 from mureo.demo.builder import build_bundle
+
+# Marker used to recognize a prior ``mureo demo init`` run. The
+# ``import_bundle`` flow records ``source_filename`` in the manifest
+# entry; we set it to the same name (``bundle.xlsx``) the demo writes,
+# so a re-run can distinguish "user has real BYOD data" from "user has
+# the demo's BYOD data and is just running demo init again".
+_DEMO_BUNDLE_FILENAME: str = "bundle.xlsx"
+_DEMO_PLATFORMS: tuple[str, ...] = ("google_ads", "meta_ads")
 
 
 class DemoInitError(RuntimeError):
@@ -36,32 +48,49 @@ class DemoInitError(RuntimeError):
 _DEMO_FILES: tuple[str, ...] = (
     "bundle.xlsx",
     "STRATEGY.md",
+    "STATE.json",
     ".mcp.json",
     "README.md",
 )
 
 
-def materialize(target_dir: Path | str, *, force: bool = False) -> dict[str, Path]:
+def materialize(
+    target_dir: Path | str,
+    *,
+    force: bool = False,
+    skip_import: bool = False,
+) -> dict[str, Path]:
     """Write the demo artifacts into ``target_dir``.
+
+    Default behavior is the full one-step demo: write the five demo
+    files into ``target_dir`` *and* import the bundle into
+    ``~/.mureo/byod/`` so ``/daily-check`` works immediately when the
+    user opens the directory in Claude Code.
 
     Args:
         target_dir: Destination directory. Created (with parents) if
             absent. Existing **empty** directories are reused without
             complaint.
-        force: When True, overwrite any existing demo artifacts in the
-            target without checking for unrelated files. When False
-            (default) the call refuses if the target already contains
-            files other than the four artifacts this installer
-            manages, so the user is never surprised by losing
-            unrelated data.
+        force: When True, overwrite the target even if it contains
+            unrelated files, AND replace any existing BYOD platform
+            data conflicting with the demo bundle. When False
+            (default) the call refuses on either conflict so the user
+            never silently loses real data.
+        skip_import: When True, write the demo files but do NOT touch
+            ``~/.mureo/byod/``. The user can run ``mureo byod import
+            bundle.xlsx`` themselves later. Useful when the user wants
+            to inspect the bundle first or already has BYOD data they
+            don't want to disturb.
 
     Returns:
         Mapping of artifact name → absolute path of the written file.
 
     Raises:
-        DemoInitError: if ``target_dir`` exists as a non-directory, or
-            if the target is non-empty and ``force`` is False (with
-            existing-but-unrelated files present).
+        DemoInitError: if ``target_dir`` exists as a non-directory; or
+            the target is non-empty (with unrelated files) and
+            ``force`` is False; or BYOD already has demo-conflicting
+            platforms and ``force`` is False; or any filesystem /
+            adapter error surfaces during the write.
     """
     target = Path(target_dir).expanduser().resolve()
 
@@ -81,6 +110,27 @@ def materialize(target_dir: Path | str, *, force: bool = False) -> dict[str, Pat
                 "target path."
             )
 
+    if not skip_import and not force:
+        # Refuse to clobber the user's real BYOD data, but treat a prior
+        # ``mureo demo init`` run as a benign idempotent re-run rather
+        # than a conflict — the user shouldn't need ``--force`` just to
+        # repeat the demo bootstrap.
+        conflicts: list[str] = []
+        for p in _DEMO_PLATFORMS:
+            info = byod_platform_info(p)
+            if info is None:
+                continue
+            if info.get("source_filename") == _DEMO_BUNDLE_FILENAME:
+                continue  # prior demo run, safe to re-import
+            conflicts.append(p)
+        if conflicts:
+            raise DemoInitError(
+                f"BYOD already has data for {', '.join(conflicts)}. "
+                "Re-run with --force to replace it, or with "
+                "--skip-import to leave BYOD untouched."
+            )
+
+    state_path: Path | None = None
     try:
         target.mkdir(parents=True, exist_ok=True)
 
@@ -90,23 +140,44 @@ def materialize(target_dir: Path | str, *, force: bool = False) -> dict[str, Pat
         strategy_path = target / "STRATEGY.md"
         strategy_path.write_text(_strategy_md(), encoding="utf-8")
 
+        # STATE.json is paired with imported BYOD data. When the user
+        # opts out of the import, shipping STATE.json would lie — its
+        # campaign_ids would point at CSV rows that don't exist yet.
+        # The skip_import README documents the manual flow instead.
+        if not skip_import:
+            state_path = target / "STATE.json"
+            state_path.write_text(_state_json(), encoding="utf-8")
+
         mcp_path = target / ".mcp.json"
         mcp_path.write_text(_mcp_json(), encoding="utf-8")
 
         readme_path = target / "README.md"
-        readme_path.write_text(_readme_md(), encoding="utf-8")
+        readme_path.write_text(_readme_md(skip_import=skip_import), encoding="utf-8")
     except OSError as exc:
         # Surface filesystem failures (broken symlinks, permission errors,
         # ENOSPC, symlink loops resolving to non-existent paths) as a
         # clean DemoInitError so the CLI prints a one-line message
-        # instead of a stack trace. The pre-checks above only cover the
-        # "target exists and isn't usable" case; this catches the
-        # mid-write surprises.
+        # instead of a stack trace.
         raise DemoInitError(f"{target}: {exc}") from exc
+
+    if not skip_import:
+        # Pass replace=True whenever any prior platform data exists
+        # (real or demo). The demo-platform conflict was already
+        # filtered above; --force is required for real-data conflicts.
+        # In both cases, replace=True satisfies import_bundle's own
+        # per-platform conflict guard.
+        needs_replace = force or any(
+            byod_platform_info(p) is not None for p in _DEMO_PLATFORMS
+        )
+        try:
+            import_bundle(bundle_path, replace=needs_replace)
+        except BundleImportError as exc:
+            raise DemoInitError(f"BYOD import failed: {exc}") from exc
 
     return {
         "bundle": bundle_path,
         "strategy": strategy_path,
+        "state": state_path,
         "mcp": mcp_path,
         "readme": readme_path,
     }
@@ -115,6 +186,35 @@ def materialize(target_dir: Path | str, *, force: bool = False) -> dict[str, Pat
 # ---------------------------------------------------------------------------
 # Static artifact bodies
 # ---------------------------------------------------------------------------
+
+
+def _state_json() -> str:
+    """Initial v2 STATE.json for the demo scenario.
+
+    Schema follows ``docs/strategy-context.md`` — version "2",
+    per-platform campaigns, empty action_log. ``last_synced_at`` uses
+    a fixed ISO 8601 timestamp tied to the demo period so re-runs of
+    ``mureo demo init`` produce identical STATE.json bytes.
+    """
+    last_synced = datetime.combine(
+        scenario.DEMO_END_DATE, datetime.min.time(), tzinfo=timezone.utc
+    ).isoformat(timespec="seconds")
+    doc = {
+        "version": "2",
+        "last_synced_at": last_synced,
+        "platforms": {
+            "google_ads": {
+                "account_id": "demo-flowdesk-google-ads",
+                "campaigns": scenario.google_ads_state_campaigns(),
+            },
+            "meta_ads": {
+                "account_id": "demo-flowdesk-meta-ads",
+                "campaigns": scenario.meta_ads_state_campaigns(),
+            },
+        },
+        "action_log": [],
+    }
+    return json.dumps(doc, indent=2, ensure_ascii=False) + "\n"
 
 
 def _mcp_json() -> str:
@@ -164,13 +264,12 @@ def _strategy_md() -> str:
 """
 
 
-def _readme_md() -> str:
-    return """# mureo demo
+def _readme_md(*, skip_import: bool) -> str:
+    if skip_import:
+        return """# mureo demo
 
-This directory was generated by `mureo demo init`. It contains a
-self-contained, synthetic-data demo of mureo so you can try the
-skills against a realistic dataset without exporting your own data
-first.
+This directory was generated by `mureo demo init --skip-import`. The
+synthetic data has NOT been imported into mureo's BYOD store yet.
 
 ## Quickstart (Claude Code)
 
@@ -188,21 +287,60 @@ first.
        /budget-rebalance
        /weekly-report
 
-The bundle deliberately contains a few realistic problems
-(brand-cannibalization in the Phrase campaign, an over-funded
-low-intent generic campaign, a fatiguing Meta video creative) so the
-skills surface actionable findings instead of "everything is fine."
+The bundle deliberately contains realistic problems (brand
+cannibalization in the Phrase campaign, an over-funded low-intent
+generic campaign, a fatiguing Meta video creative) so the skills
+surface actionable findings instead of "everything is fine."
 
 ## Files
 
 - `bundle.xlsx`  — Google Ads + Meta Ads synthetic data, 30 days
 - `STRATEGY.md`  — seed strategy used by `mureo-strategy` skills
+- `STATE.json`   — campaign snapshots used by `/daily-check` etc.
 - `.mcp.json`    — Claude Code MCP server registration
 - `README.md`    — this file
 
 ## Cleaning up
 
 To remove the imported demo data afterwards:
+
+    mureo byod clear
+"""
+    return """# mureo demo
+
+This directory was generated by `mureo demo init`. The synthetic
+bundle has already been imported into mureo's BYOD store and a
+matching `STATE.json` has been written, so the workflow skills are
+ready to run with no extra setup.
+
+## Quickstart (Claude Code)
+
+1. Open this directory in Claude Code. The bundled `.mcp.json`
+   registers the `mureo` MCP server automatically.
+
+2. In Claude Code, try one of:
+
+       /daily-check
+       /search-term-cleanup
+       /budget-rebalance
+       /weekly-report
+
+The bundle deliberately contains realistic problems (brand
+cannibalization in the Phrase campaign, an over-funded low-intent
+generic campaign, a fatiguing Meta video creative) so the skills
+surface actionable findings instead of "everything is fine."
+
+## Files
+
+- `bundle.xlsx`  — Google Ads + Meta Ads synthetic data, 30 days
+- `STRATEGY.md`  — seed strategy used by `mureo-strategy` skills
+- `STATE.json`   — campaign snapshots used by `/daily-check` etc.
+- `.mcp.json`    — Claude Code MCP server registration
+- `README.md`    — this file
+
+## Cleaning up
+
+To remove the imported demo data and restore an empty BYOD store:
 
     mureo byod clear
 """

--- a/mureo/demo/installer.py
+++ b/mureo/demo/installer.py
@@ -59,7 +59,7 @@ def materialize(
     *,
     force: bool = False,
     skip_import: bool = False,
-) -> dict[str, Path]:
+) -> dict[str, Path | None]:
     """Write the demo artifacts into ``target_dir``.
 
     Default behavior is the full one-step demo: write the five demo

--- a/mureo/demo/scenario.py
+++ b/mureo/demo/scenario.py
@@ -24,6 +24,15 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import date, timedelta
 
+# Imported for ID parity with what ``mureo byod import`` will write to
+# ``~/.mureo/byod/<platform>/campaigns.csv``. Reaching into the
+# adapter's underscore-prefixed helper is a deliberate coupling — if
+# the formula ever changes the demo's STATE.json must move in lockstep
+# (otherwise STATE.json campaign_ids and BYOD CSV campaign_ids diverge
+# and skills can't join them). Importing rather than duplicating means
+# any rename surfaces as an ImportError instead of silent ID drift.
+from mureo.byod.adapters.google_ads import _synthetic_id as _byod_synthetic_id
+
 # ---------------------------------------------------------------------------
 # Scenario constants
 # ---------------------------------------------------------------------------
@@ -403,6 +412,91 @@ def google_keywords_rows() -> list[list[object]]:
             ]
         )
     return rows
+
+
+# ---------------------------------------------------------------------------
+# STATE.json campaign snapshots
+# ---------------------------------------------------------------------------
+#
+# These are consumed by ``mureo.demo.installer`` to produce a v2
+# STATE.json so that ``/daily-check`` and friends can resolve campaign
+# metadata (budget, goal, status) from STATE while joining BYOD
+# performance data on ``campaign_id``.
+
+
+def _campaign_id(name: str) -> str:
+    """Synthesize the campaign_id the BYOD pipeline will assign to ``name``.
+
+    Delegates to ``mureo.byod.adapters.google_ads._synthetic_id`` so the
+    demo's STATE.json IDs always match the BYOD-imported CSV IDs. Both
+    Google and Meta adapters use the same formula today; if they ever
+    diverge we'd need per-platform branches here.
+    """
+    return _byod_synthetic_id("camp", name)
+
+
+_GADS_DAILY_BUDGETS_JPY: dict[str, int] = {
+    "Brand - Exact": 30000,
+    "Brand - Phrase": 15000,
+    "Generic - High Intent": 80000,
+    "Generic - Low Intent": 60000,
+}
+
+_GADS_GOALS: dict[str, str] = {
+    "Brand - Exact": "Capture branded demand at high efficiency (target CPA <= JPY 1,500).",
+    "Brand - Phrase": "Catch brand long-tail; tighten match types if cannibalization detected.",
+    "Generic - High Intent": "Acquire net-new trial signups at <= JPY 12,000 CPA.",
+    "Generic - Low Intent": "Top-of-funnel awareness; demote if CVR stays below 0.5%.",
+}
+
+_META_DAILY_BUDGETS_JPY: dict[str, int] = {
+    "Awareness - Video": 15000,
+    "Conversion - Lead Form": 50000,
+}
+
+_META_GOALS: dict[str, str] = {
+    "Awareness - Video": "Build top-of-funnel awareness in JP-25-44 ICP segment.",
+    "Conversion - Lead Form": "Generate sales-qualified leads at <= JPY 8,000 cost-per-lead.",
+}
+
+
+def google_ads_state_campaigns() -> list[dict[str, object]]:
+    """Campaign records for STATE.json ``platforms.google_ads.campaigns``.
+
+    The synthesized ``campaign_id`` matches what
+    :mod:`mureo.byod.adapters.google_ads` writes to ``campaigns.csv``,
+    so STATE.json and BYOD data join cleanly on the same key.
+    """
+    return [
+        {
+            "campaign_id": _campaign_id(c.name),
+            "campaign_name": c.name,
+            "status": "ENABLED",
+            "daily_budget": _GADS_DAILY_BUDGETS_JPY[c.name],
+            "campaign_goal": _GADS_GOALS[c.name],
+        }
+        for c in _GADS_CAMPAIGNS
+    ]
+
+
+def meta_ads_state_campaigns() -> list[dict[str, object]]:
+    """Campaign records for STATE.json ``platforms.meta_ads.campaigns``."""
+    seen: set[str] = set()
+    out: list[dict[str, object]] = []
+    for ad in _META_ADS:
+        if ad.campaign in seen:
+            continue
+        seen.add(ad.campaign)
+        out.append(
+            {
+                "campaign_id": _campaign_id(ad.campaign),
+                "campaign_name": ad.campaign,
+                "status": "ENABLED",
+                "daily_budget": _META_DAILY_BUDGETS_JPY[ad.campaign],
+                "campaign_goal": _META_GOALS[ad.campaign],
+            }
+        )
+    return out
 
 
 def meta_ads_rows() -> list[list[object]]:

--- a/tests/test_demo_init.py
+++ b/tests/test_demo_init.py
@@ -40,12 +40,14 @@ runner = CliRunner()
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def byod_root(tmp_path, monkeypatch):
     """Redirect ``Path.home()`` so BYOD writes land in a sandbox.
 
-    Mirrors the pattern used by ``tests/test_byod_bundle.py`` so the
-    demo-bundle round-trip test does not touch the real ``~/.mureo``.
+    Autouse because ``materialize()`` now auto-imports the bundle into
+    ``~/.mureo/byod/`` by default — every test in this module needs a
+    sandboxed home or it would clobber the developer's real BYOD data.
+    Mirrors the pattern in ``tests/test_byod_bundle.py``.
     """
     fake_home = tmp_path / "home"
     fake_home.mkdir()
@@ -168,30 +170,210 @@ def test_strategy_md_is_seeded_markdown(tmp_path: Path) -> None:
 
 
 def test_readme_contains_quickstart_steps(tmp_path: Path) -> None:
+    """Default README describes the 1-step quickstart (no manual import)."""
     target = tmp_path / "mureo-demo"
     materialize(target)
+    text = (target / "README.md").read_text(encoding="utf-8")
+    assert "/daily-check" in text
+    assert "Claude Code" in text
+    # The default flow auto-imports, so the manual import command must
+    # NOT appear in the default README — that copy is reserved for the
+    # --skip-import variant only.
+    assert "mureo byod import" not in text
+
+
+def test_readme_skip_import_variant_documents_manual_import(tmp_path: Path) -> None:
+    """``--skip-import`` README still documents the manual import step."""
+    target = tmp_path / "mureo-demo"
+    materialize(target, skip_import=True)
     text = (target / "README.md").read_text(encoding="utf-8")
     assert "mureo byod import" in text
     assert "bundle.xlsx" in text
 
 
-def test_bundle_imports_via_byod_pipeline(tmp_path: Path, byod_root) -> None:
-    """End-to-end: the demo bundle is consumable by ``import_bundle``.
+def test_materialize_writes_state_json(tmp_path: Path) -> None:
+    """STATE.json (v2 platforms shape) is written alongside the bundle.
 
-    Contract: the bundle must round-trip through the same pipeline real
-    BYOD users go through, so any divergence between the demo data
-    shape and production schemas is caught here.
+    /daily-check and the other workflow skills require STATE.json — if
+    the demo only shipped bundle.xlsx the user would have to run
+    /onboard manually before any skill could read campaign metadata.
     """
-    from mureo.byod.bundle import import_bundle
-
-    target = tmp_path / "mureo-demo"
+    target = tmp_path / "demo"
     materialize(target)
 
-    results = import_bundle(target / "bundle.xlsx")
-    assert "google_ads" in results
-    assert "meta_ads" in results
-    assert results["google_ads"]["rows"] > 0
-    assert results["meta_ads"]["rows"] > 0
+    state_path = target / "STATE.json"
+    assert state_path.is_file()
+
+    doc = json.loads(state_path.read_text(encoding="utf-8"))
+    assert doc["version"] == "2"
+    assert "platforms" in doc
+    assert "google_ads" in doc["platforms"]
+    assert "meta_ads" in doc["platforms"]
+
+    gads = doc["platforms"]["google_ads"]["campaigns"]
+    meta = doc["platforms"]["meta_ads"]["campaigns"]
+    assert gads, "google_ads campaigns must not be empty"
+    assert meta, "meta_ads campaigns must not be empty"
+    for camp in list(gads) + list(meta):
+        assert camp["campaign_id"].startswith("camp_")
+        assert camp["campaign_name"]
+        assert camp["status"]
+
+
+def test_materialize_auto_imports_bundle(tmp_path: Path) -> None:
+    """``materialize`` populates ``~/.mureo/byod/`` so /daily-check works.
+
+    Replaces the v1 round-trip test — the round-trip is now exercised
+    by materialize itself rather than by a separate import_bundle call.
+    """
+    from mureo.byod.runtime import byod_active_platforms
+
+    target = tmp_path / "demo"
+    materialize(target)
+
+    active = byod_active_platforms()
+    assert "google_ads" in active
+    assert "meta_ads" in active
+
+
+def test_materialize_skip_import_leaves_byod_untouched(tmp_path: Path) -> None:
+    """``--skip-import`` writes the demo files but does NOT touch BYOD.
+
+    STATE.json is intentionally NOT written because its campaign_ids
+    would refer to BYOD CSV rows that don't exist yet — shipping it
+    would mislead any skill the user runs before doing the manual
+    ``mureo byod import``.
+    """
+    from mureo.byod.runtime import byod_active_platforms
+
+    target = tmp_path / "demo"
+    materialize(target, skip_import=True)
+
+    assert (target / "bundle.xlsx").is_file()
+    assert not (
+        target / "STATE.json"
+    ).exists(), "skip_import must not ship STATE.json — see installer.py docstring"
+    assert byod_active_platforms() == []
+
+
+def test_materialize_idempotent_re_run(tmp_path: Path) -> None:
+    """Re-running ``mureo demo init`` against an existing demo is a no-op-ish.
+
+    Pins the contract that prior-demo BYOD data is not treated as a
+    conflict — the user shouldn't need ``--force`` just to refresh
+    the demo. Real (non-demo) BYOD data still requires --force; that
+    is covered by ``test_materialize_refuses_existing_byod_without_force``.
+    """
+    from mureo.byod.runtime import byod_active_platforms
+
+    target = tmp_path / "demo"
+    materialize(target)
+    materialize(target)  # must succeed without --force
+
+    active = byod_active_platforms()
+    assert "google_ads" in active
+    assert "meta_ads" in active
+
+
+def test_materialize_refuses_existing_byod_without_force(tmp_path: Path) -> None:
+    """Real (non-demo) BYOD data conflicts → refuse without ``--force``.
+
+    Pins the safety contract: when the user already has BYOD data
+    from a real ``mureo byod import <their-bundle>.xlsx``, a demo
+    init without ``--force`` must refuse rather than silently
+    replace their data. (Prior-demo conflicts are intentionally
+    benign — covered by ``test_materialize_idempotent_re_run``.)
+    """
+    from mureo.byod.runtime import write_manifest
+
+    # Fake a manifest entry that looks like a real (non-demo) import
+    # — ``source_filename`` is the discriminator that distinguishes
+    # demo bundles from user-supplied ones.
+    write_manifest(
+        {
+            "schema_version": 1,
+            "imported_on": "2026-04-29T00:00:00+09:00",
+            "platforms": {
+                "google_ads": {
+                    "files": ["campaigns.csv"],
+                    "date_range": {"start": "", "end": ""},
+                    "rows": 0,
+                    "campaigns": 0,
+                    "ad_groups": 0,
+                    "source_format": "real_user_bundle_v1",
+                    "imported_at": "2026-04-29T00:00:00+09:00",
+                    "source_file_sha256": "deadbeef",
+                    "source_filename": "real-account-export.xlsx",
+                }
+            },
+        }
+    )
+
+    with pytest.raises(DemoInitError) as excinfo:
+        materialize(tmp_path / "demo")
+    msg = str(excinfo.value).lower()
+    assert "byod" in msg or "already" in msg
+
+
+def test_materialize_force_replaces_existing_byod(tmp_path: Path) -> None:
+    """``--force`` clears the BYOD conflict and re-imports cleanly."""
+    from mureo.byod.runtime import byod_active_platforms
+
+    materialize(tmp_path / "first")
+    materialize(tmp_path / "second", force=True)
+
+    active = byod_active_platforms()
+    assert "google_ads" in active
+    assert "meta_ads" in active
+
+
+def test_state_campaign_ids_match_byod_csv(tmp_path: Path) -> None:
+    """STATE.json campaign_ids must equal the BYOD adapter's synthesized ids.
+
+    /daily-check, /search-term-cleanup, /budget-rebalance all join
+    STATE.json campaign metadata with BYOD performance data on
+    ``campaign_id``. If the IDs diverge by even one character the
+    skills can't correlate the two — which is exactly the bug the
+    demo flow needs to avoid.
+    """
+    import csv as _csv
+    from pathlib import Path as _Path
+
+    target = tmp_path / "demo"
+    materialize(target)
+
+    state = json.loads((target / "STATE.json").read_text(encoding="utf-8"))
+    byod_root = _Path.home() / ".mureo" / "byod"
+
+    # The Google Ads adapter writes the CSV column as ``name`` (not
+    # ``campaign_name``); see ``mureo/byod/adapters/google_ads.py:221``.
+    # The Meta Ads adapter mirrors that convention.
+    for platform in ("google_ads", "meta_ads"):
+        state_ids = {
+            c["campaign_name"]: c["campaign_id"]
+            for c in state["platforms"][platform]["campaigns"]
+        }
+        csv_path = byod_root / platform / "campaigns.csv"
+        with csv_path.open(encoding="utf-8") as f:
+            rows = list(_csv.DictReader(f))
+        csv_ids = {row["name"]: row["campaign_id"] for row in rows}
+
+        for name, sid in state_ids.items():
+            assert csv_ids.get(name) == sid, (
+                f"{platform}: campaign_id mismatch for {name!r}: "
+                f"STATE.json={sid!r} vs BYOD csv={csv_ids.get(name)!r}"
+            )
+
+
+def test_cli_demo_init_skip_import_flag(tmp_path: Path) -> None:
+    """``mureo demo init --skip-import`` works end-to-end via Typer."""
+    from mureo.byod.runtime import byod_active_platforms
+
+    target = tmp_path / "demo"
+    result = runner.invoke(app, ["demo", "init", str(target), "--skip-import"])
+    assert result.exit_code == 0, result.stdout
+    assert (target / "bundle.xlsx").is_file()
+    assert byod_active_platforms() == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes the friction gap noticed during PR #69 dogfooding: previously `mureo demo init` produced `bundle.xlsx` but the user still had to run `mureo byod import bundle.xlsx` AND `/onboard` before `/daily-check` could run. After this PR the demo flow is one command:

```bash
mureo demo init && cd mureo-demo && claude
# then in Claude Code: /daily-check
```

## What changes

- **STATE.json shipped** — v2 platforms shape (`google_ads` + `meta_ads`), populated with campaigns whose `campaign_id` values exactly match the IDs the BYOD adapter writes to `~/.mureo/byod/<platform>/campaigns.csv`. Workflow skills can now join STATE metadata against BYOD performance data without `/onboard`.
- **Auto-import** — `materialize()` calls `import_bundle()` after writing the demo files. Default behavior, opt out with `--skip-import`.
- **Real BYOD protection** — refuses on existing real BYOD data without `--force`. Recognized via `manifest.source_filename != "bundle.xlsx"` so prior-demo BYOD entries are not treated as conflicts (idempotent re-runs).
- **`--skip-import` flag** — for users who want to inspect first or have BYOD data they do not want to touch. STATE.json is suppressed in this mode (its IDs would point at non-existent CSVs).
- **Campaign-id drift guard** — scenario.py now imports `_synthetic_id` from the BYOD adapter rather than duplicating the SHA-256 formula inline. A future adapter rename surfaces as `ImportError` instead of silent ID divergence.

## Why these defaults

The user explicitly asked for the 1-step flow (auto-import inside demo init) so auto-import is the default. The two safety nets are:
- Never silently replace real (non-demo) BYOD data — refuse and ask for `--force`
- Never ship STATE.json that would mislead skills — suppress under `--skip-import`

## Test coverage

23 tests, including:
- `test_state_campaign_ids_match_byod_csv` — round-trip ID equality across Google + Meta CSVs
- `test_materialize_idempotent_re_run` — second `mureo demo init` succeeds without `--force`
- `test_materialize_refuses_existing_byod_without_force` — real (non-demo) data is protected
- `test_materialize_force_replaces_existing_byod` — `--force` cleans the conflict
- `test_materialize_skip_import_leaves_byod_untouched` — `--skip-import` writes no BYOD AND no STATE.json
- 101/101 adjacent CLI/BYOD/setup tests still pass

## Code review

`python-reviewer` flagged 3 HIGH issues — all addressed in this PR:
1. Re-run idempotency (HIGH #1) → prior-demo recognition via `source_filename`
2. STATE.json under `--skip-import` (HIGH #2) → suppressed
3. ID-formula drift (HIGH #3) → import from adapter

## Test plan

- [x] `pytest tests/test_demo_init.py` — 23/23 green
- [x] `pytest tests/test_cli.py tests/test_byod.py tests/test_byod_bundle.py tests/test_cli_rollback.py tests/test_setup_cmd.py` — 101/101 green
- [x] `ruff check` clean
- [x] `black --check` clean
- [ ] Manual smoke (user is doing this in their environment)

## Out of scope

- Claude Desktop `.mcpb` packaging (unchanged from PR #69 — still a follow-up)
- README.md (the project root one) update advertising the new 1-step flow — separate cleanup PR
