### PR TITLE
feat(demo): 3 new scenarios (halo-effect, hidden-champion, strategy-drift)

### DIFF
--- a/mureo/demo/scenarios/__init__.py
+++ b/mureo/demo/scenarios/__init__.py
@@ -11,11 +11,19 @@ To add a new scenario:
 
 from __future__ import annotations
 
-from mureo.demo.scenarios import seasonality_trap
+from mureo.demo.scenarios import (
+    halo_effect,
+    hidden_champion,
+    seasonality_trap,
+    strategy_drift,
+)
 from mureo.demo.scenarios._base import Scenario, campaign_id
 
 SCENARIOS: dict[str, Scenario] = {
     seasonality_trap.SCENARIO.name: seasonality_trap.SCENARIO,
+    halo_effect.SCENARIO.name: halo_effect.SCENARIO,
+    hidden_champion.SCENARIO.name: hidden_champion.SCENARIO,
+    strategy_drift.SCENARIO.name: strategy_drift.SCENARIO,
 }
 
 DEFAULT_SCENARIO: str = seasonality_trap.SCENARIO.name

--- a/mureo/demo/scenarios/_base.py
+++ b/mureo/demo/scenarios/_base.py
@@ -50,6 +50,12 @@ class Scenario:
     sheet_rows: Mapping[str, Sequence[Sequence[object]]]
     state_doc: Mapping[str, object]
     strategy_md: str
+    # When False, the scenario's diagnostic story relies on a sparse
+    # or absent action_log (e.g. strategy-drift demos undocumented
+    # changes by a manager — empty action_log around active changes
+    # is itself the diagnostic signal). Contract tests skip the >=3
+    # entries floor only for these scenarios.
+    requires_action_log: bool = True
 
 
 def campaign_id(name: str) -> str:

--- a/mureo/demo/scenarios/halo_effect.py
+++ b/mureo/demo/scenarios/halo_effect.py
@@ -1,0 +1,751 @@
+"""The "Halo Effect" demo scenario — SkyRoof local roofing contractor.
+
+A small Japanese roofing contractor running ~JPY 5M / month split
+roughly 35% Google Search / 65% Meta. The owner believes Google
+Search "phone calls" are the workhorse — and reading any single-day
+report would agree. Last-click attribution credits Google Brand
+search for almost every conversion.
+
+The truth: Meta retargeting silently warms users into branded
+searches. The owner doesn't see this because the lift is delayed
+(~3 days) and shows up in a different channel.
+
+On Day 50 the owner ran a "controlled test" pausing Meta retargeting
+for 5 days to "prove it was wasted spend". The Meta retargeting
+spend dropped to zero Day 50-54. With a 3-day lag, Google Brand -
+Exact volume dropped 40% (Day 53-57). Day 55 Meta retargeting
+resumed; Day 58 onwards Brand - Exact recovered. The damage:
+~35 missed calls and a misleading "test" that, read literally,
+"proves" Meta retargeting is dispensable — the opposite of the truth.
+
+The "wow": mureo's analysis identifies the Day 53-57 Brand - Exact
+dip, cross-references the action_log entry on Day 50 (Meta pause),
+and reports the temporal correlation. Recommendation: do NOT cut
+Meta retargeting; it is upstream of the brand-search calls the owner
+is mentally crediting to Google.
+
+All numbers deterministic; re-running ``mureo demo init`` produces an
+identical bundle.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+from typing import TYPE_CHECKING
+
+from mureo.demo.scenarios._base import Scenario, campaign_id
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+# ---------------------------------------------------------------------------
+# Scenario constants
+# ---------------------------------------------------------------------------
+
+_NAME = "halo-effect"
+_TITLE = "The Halo Effect (SkyRoof / Local home services)"
+_BLURB = (
+    "Owner believed Google Search was the workhorse — Meta retargeting was "
+    "silently driving the brand-search calls. A 5-day Meta pause "
+    '"controlled test" cut Brand-Exact volume 40% three days later. mureo '
+    "spots the lagged dip and the action_log together to recommend keeping "
+    "Meta upstream investment, not cutting it."
+)
+_DAYS = 90
+_END_DATE = date(2026, 4, 29)
+_BRAND = "SkyRoof"
+
+# Day 50: owner pauses Meta retargeting for a "5-day test"
+_META_PAUSE_START_DAY = 50
+_META_PAUSE_END_DAY = 54  # inclusive — pause covers Day 50-54
+# Day 53-57: Google Brand-Exact volume drops 40% (3-day lag, 5-day window)
+_BRAND_DIP_START_DAY = 53
+_BRAND_DIP_END_DAY = 57  # inclusive
+_BRAND_DIP_FACTOR = 0.60  # 40% drop
+
+
+def _date_for_day(d: int) -> date:
+    return _END_DATE - timedelta(days=_DAYS - 1 - d)
+
+
+# ---------------------------------------------------------------------------
+# Google Ads — Brand-Exact dips Day 53-57; others stable
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _GAdsCampaignSpec:
+    name: str
+    daily_impr: int
+    ctr: float
+    cpc: float
+    cvr: float
+
+
+_GADS_CAMPAIGNS = (
+    _GAdsCampaignSpec("Brand - Exact", 200, 0.25, 80.0, 0.35),
+    _GAdsCampaignSpec("Generic - Roof Repair JP", 1500, 0.06, 350.0, 0.080),
+    _GAdsCampaignSpec("Generic - Local Roofer JP", 1200, 0.05, 320.0, 0.090),
+    _GAdsCampaignSpec("Retargeting - Branded Search", 400, 0.12, 180.0, 0.15),
+)
+
+
+_GADS_AD_GROUPS = (
+    ("Brand - Exact", "Brand - Exact - Core", 0.70),
+    ("Brand - Exact", "Brand - Exact - Service Areas", 0.30),
+    ("Generic - Roof Repair JP", "Roof Repair General", 0.55),
+    ("Generic - Roof Repair JP", "Storm Damage Repair", 0.45),
+    ("Generic - Local Roofer JP", "Local Roofer", 1.0),
+    ("Retargeting - Branded Search", "Site Visitors - Branded Search", 1.0),
+)
+
+
+def _brand_dip_factor(day: int) -> float:
+    """Return Brand-Exact's per-day demand multiplier."""
+    if _BRAND_DIP_START_DAY <= day <= _BRAND_DIP_END_DAY:
+        return _BRAND_DIP_FACTOR
+    return 1.0
+
+
+_GADS_SEARCH_TERMS = (
+    # Brand - Exact (core demand)
+    ("skyroof", "Brand - Exact", "Brand - Exact - Core", 8500, 2125, 170000, 744),
+    (
+        "skyroof 屋根工事",
+        "Brand - Exact",
+        "Brand - Exact - Core",
+        2400,
+        600,
+        48000,
+        210,
+    ),
+    (
+        "skyroof 見積もり",
+        "Brand - Exact",
+        "Brand - Exact - Core",
+        1800,
+        450,
+        36000,
+        158,
+    ),
+    (
+        "skyroof 評判",
+        "Brand - Exact",
+        "Brand - Exact - Core",
+        1200,
+        300,
+        24000,
+        105,
+    ),
+    (
+        "skyroof 横浜",
+        "Brand - Exact",
+        "Brand - Exact - Service Areas",
+        2200,
+        550,
+        44000,
+        193,
+    ),
+    (
+        "skyroof 川崎",
+        "Brand - Exact",
+        "Brand - Exact - Service Areas",
+        1600,
+        400,
+        32000,
+        140,
+    ),
+    # Generic - Roof Repair JP
+    (
+        "屋根 修理 業者",
+        "Generic - Roof Repair JP",
+        "Roof Repair General",
+        38000,
+        2280,
+        798000,
+        182,
+    ),
+    (
+        "雨漏り 修理",
+        "Generic - Roof Repair JP",
+        "Roof Repair General",
+        24000,
+        1440,
+        504000,
+        115,
+    ),
+    (
+        "屋根 修理 費用",
+        "Generic - Roof Repair JP",
+        "Roof Repair General",
+        18000,
+        1080,
+        378000,
+        86,
+    ),
+    (
+        "台風 屋根 修理",
+        "Generic - Roof Repair JP",
+        "Storm Damage Repair",
+        22000,
+        1320,
+        462000,
+        158,
+    ),
+    (
+        "強風 瓦 修理",
+        "Generic - Roof Repair JP",
+        "Storm Damage Repair",
+        12000,
+        720,
+        252000,
+        86,
+    ),
+    # Generic - Local Roofer JP
+    (
+        "屋根屋 横浜",
+        "Generic - Local Roofer JP",
+        "Local Roofer",
+        28000,
+        1400,
+        448000,
+        126,
+    ),
+    (
+        "屋根 業者 川崎",
+        "Generic - Local Roofer JP",
+        "Local Roofer",
+        18000,
+        900,
+        288000,
+        81,
+    ),
+    (
+        "屋根工事 神奈川",
+        "Generic - Local Roofer JP",
+        "Local Roofer",
+        14000,
+        700,
+        224000,
+        63,
+    ),
+    # Retargeting - Branded Search (high CVR — second-touch)
+    (
+        "skyroof 申し込み",
+        "Retargeting - Branded Search",
+        "Site Visitors - Branded Search",
+        4800,
+        576,
+        103680,
+        87,
+    ),
+    (
+        "skyroof 連絡",
+        "Retargeting - Branded Search",
+        "Site Visitors - Branded Search",
+        2200,
+        264,
+        47520,
+        40,
+    ),
+)
+
+
+_GADS_KEYWORDS = (
+    (
+        "[skyroof]",
+        "EXACT",
+        10,
+        "Brand - Exact",
+        "Brand - Exact - Core",
+        14000,
+        3500,
+        280000,
+        1225,
+    ),
+    (
+        "[skyroof 横浜]",
+        "EXACT",
+        9,
+        "Brand - Exact",
+        "Brand - Exact - Service Areas",
+        4200,
+        1050,
+        84000,
+        368,
+    ),
+    (
+        "屋根 修理",
+        "PHRASE",
+        7,
+        "Generic - Roof Repair JP",
+        "Roof Repair General",
+        82000,
+        4920,
+        1722000,
+        394,
+    ),
+    (
+        "雨漏り 修理",
+        "PHRASE",
+        8,
+        "Generic - Roof Repair JP",
+        "Roof Repair General",
+        24000,
+        1440,
+        504000,
+        115,
+    ),
+    (
+        "台風 屋根",
+        "PHRASE",
+        7,
+        "Generic - Roof Repair JP",
+        "Storm Damage Repair",
+        34000,
+        2040,
+        714000,
+        244,
+    ),
+    (
+        "屋根屋",
+        "PHRASE",
+        6,
+        "Generic - Local Roofer JP",
+        "Local Roofer",
+        46000,
+        2300,
+        736000,
+        207,
+    ),
+    (
+        "屋根工事",
+        "PHRASE",
+        7,
+        "Generic - Local Roofer JP",
+        "Local Roofer",
+        14000,
+        700,
+        224000,
+        63,
+    ),
+    (
+        '"skyroof"',
+        "PHRASE",
+        9,
+        "Retargeting - Branded Search",
+        "Site Visitors - Branded Search",
+        7000,
+        840,
+        151200,
+        126,
+    ),
+)
+
+
+def _build_google_campaigns_rows() -> list[list[object]]:
+    rows: list[list[object]] = [
+        ["day", "campaign", "impressions", "clicks", "cost", "conversions"]
+    ]
+    for c in _GADS_CAMPAIGNS:
+        for d in range(_DAYS):
+            day_iso = _date_for_day(d).isoformat()
+            # Only Brand - Exact reflects the halo dip; Meta upstream
+            # exposure is what carries demand into branded search.
+            factor = _brand_dip_factor(d) if c.name == "Brand - Exact" else 1.0
+            impr = int(round(c.daily_impr * factor))
+            clicks = int(round(impr * c.ctr))
+            cost = round(clicks * c.cpc, 2)
+            conv = round(clicks * c.cvr, 2)
+            rows.append([day_iso, c.name, impr, clicks, cost, conv])
+    return rows
+
+
+def _build_google_ad_groups_rows() -> list[list[object]]:
+    rows: list[list[object]] = [
+        [
+            "day",
+            "campaign",
+            "ad_group",
+            "impressions",
+            "clicks",
+            "cost",
+            "conversions",
+        ]
+    ]
+    by_camp = {c.name: c for c in _GADS_CAMPAIGNS}
+    for camp_name, ag_name, share in _GADS_AD_GROUPS:
+        c = by_camp[camp_name]
+        for d in range(_DAYS):
+            day_iso = _date_for_day(d).isoformat()
+            factor = _brand_dip_factor(d) if camp_name == "Brand - Exact" else 1.0
+            impr = int(round(c.daily_impr * share * factor))
+            clicks = int(round(impr * c.ctr))
+            cost = round(clicks * c.cpc, 2)
+            conv = round(clicks * c.cvr, 2)
+            rows.append([day_iso, camp_name, ag_name, impr, clicks, cost, conv])
+    return rows
+
+
+def _build_google_search_terms_rows() -> list[list[object]]:
+    rows: list[list[object]] = [
+        [
+            "search_term",
+            "campaign",
+            "ad_group",
+            "impressions",
+            "clicks",
+            "cost",
+            "conversions",
+        ]
+    ]
+    for term, camp, ag, impr, clicks, cost, conv in _GADS_SEARCH_TERMS:
+        rows.append([term, camp, ag, impr, clicks, cost, conv])
+    return rows
+
+
+def _build_google_keywords_rows() -> list[list[object]]:
+    rows: list[list[object]] = [
+        [
+            "keyword",
+            "match_type",
+            "quality_score",
+            "campaign",
+            "ad_group",
+            "impressions",
+            "clicks",
+            "cost",
+            "conversions",
+        ]
+    ]
+    for kw, mt, qs, camp, ag, impr, clicks, cost, conv in _GADS_KEYWORDS:
+        rows.append([kw, mt, qs, camp, ag, impr, clicks, cost, conv])
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Meta Ads — Retargeting paused Day 50-54
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _MetaAdSpec:
+    ad: str
+    campaign: str
+    adset: str
+    ctr: float
+    cpc: int
+    rpc: float
+    daily_spend: int
+    pause_start: int = -1  # -1 = never paused
+    pause_end: int = -1
+
+
+_META_ADS: tuple[_MetaAdSpec, ...] = (
+    _MetaAdSpec(
+        ad="Video - Storm Damage Stories",
+        campaign="Awareness - Storm Damage",
+        adset="Homeowners JP 35-65",
+        ctr=0.015,
+        cpc=90,
+        rpc=0.04,
+        daily_spend=30000,
+    ),
+    _MetaAdSpec(
+        ad="Carousel - Site Visitor Reminder",
+        campaign="Retargeting - Site Visitors",
+        adset="180-day site visitors",
+        ctr=0.025,
+        cpc=75,
+        rpc=0.10,
+        daily_spend=18000,
+        pause_start=_META_PAUSE_START_DAY,
+        pause_end=_META_PAUSE_END_DAY,
+    ),
+    _MetaAdSpec(
+        ad="Image - Free Inspection LAL",
+        campaign="Conversion - Free Inspection",
+        adset="LAL 1% Past Customers",
+        ctr=0.016,
+        cpc=110,
+        rpc=0.07,
+        daily_spend=24000,
+    ),
+    _MetaAdSpec(
+        ad="Image - Free Inspection Custom Audience",
+        campaign="Conversion - Free Inspection",
+        adset="Custom - Engaged 90d",
+        ctr=0.014,
+        cpc=130,
+        rpc=0.08,
+        daily_spend=18000,
+    ),
+)
+
+
+def _meta_is_paused(ad: _MetaAdSpec, day: int) -> bool:
+    if ad.pause_start < 0:
+        return False
+    return ad.pause_start <= day <= ad.pause_end
+
+
+def _build_meta_ads_rows() -> list[list[object]]:
+    rows: list[list[object]] = [
+        [
+            "Day",
+            "Campaign name",
+            "Ad set name",
+            "Ad name",
+            "Impressions",
+            "Clicks (all)",
+            "Amount spent (JPY)",
+            "Results",
+        ]
+    ]
+    for d in range(_DAYS):
+        date_iso = _date_for_day(d).isoformat()
+        for ad in _META_ADS:
+            if _meta_is_paused(ad, d):
+                continue  # paused day — omit row entirely
+            spend = ad.daily_spend
+            clicks = int(round(spend / ad.cpc))
+            impressions = int(round(clicks / ad.ctr))
+            results = round(clicks * ad.rpc, 1)
+            rows.append(
+                [
+                    date_iso,
+                    ad.campaign,
+                    ad.adset,
+                    ad.ad,
+                    impressions,
+                    clicks,
+                    spend,
+                    results,
+                ]
+            )
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# STATE.json
+# ---------------------------------------------------------------------------
+
+
+_GOOGLE_ADS_STATE_CAMPAIGNS = (
+    {
+        "campaign_id": campaign_id("Brand - Exact"),
+        "campaign_name": "Brand - Exact",
+        "status": "ENABLED",
+        "daily_budget": 5000,
+        "campaign_goal": (
+            "Capture branded demand for free-inspection calls "
+            "(target cost-per-call <= JPY 350)."
+        ),
+    },
+    {
+        "campaign_id": campaign_id("Generic - Roof Repair JP"),
+        "campaign_name": "Generic - Roof Repair JP",
+        "status": "ENABLED",
+        "daily_budget": 35000,
+        "campaign_goal": (
+            "Acquire net-new repair-intent leads at <= JPY 5,000 cost-per-call."
+        ),
+    },
+    {
+        "campaign_id": campaign_id("Generic - Local Roofer JP"),
+        "campaign_name": "Generic - Local Roofer JP",
+        "status": "ENABLED",
+        "daily_budget": 22000,
+        "campaign_goal": (
+            "Capture local-intent searches (Yokohama / Kawasaki); "
+            "target cost-per-call <= JPY 4,000."
+        ),
+    },
+    {
+        "campaign_id": campaign_id("Retargeting - Branded Search"),
+        "campaign_name": "Retargeting - Branded Search",
+        "status": "ENABLED",
+        "daily_budget": 10000,
+        "campaign_goal": (
+            "Recover site-visitor branded searches at <= JPY 1,500 cost-per-call."
+        ),
+    },
+)
+
+_META_ADS_STATE_CAMPAIGNS = (
+    {
+        "campaign_id": campaign_id("Awareness - Storm Damage"),
+        "campaign_name": "Awareness - Storm Damage",
+        "status": "ENABLED",
+        "daily_budget": 30000,
+        "campaign_goal": (
+            "Top-of-funnel awareness in JP homeowner segment; "
+            "stories about real storm-damage repairs."
+        ),
+    },
+    {
+        "campaign_id": campaign_id("Retargeting - Site Visitors"),
+        "campaign_name": "Retargeting - Site Visitors",
+        "status": "ENABLED",
+        "daily_budget": 18000,
+        "campaign_goal": (
+            "Re-engage 180-day site visitors. Note: paused Day 50-54 "
+            "for a 'controlled test' (see action_log)."
+        ),
+    },
+    {
+        "campaign_id": campaign_id("Conversion - Free Inspection"),
+        "campaign_name": "Conversion - Free Inspection",
+        "status": "ENABLED",
+        "daily_budget": 42000,
+        "campaign_goal": (
+            "Drive Free Inspection bookings at <= JPY 1,500 cost-per-result."
+        ),
+    },
+)
+
+
+def _action_iso(day: int, hour: int = 10, minute: int = 0) -> str:
+    d = _date_for_day(day)
+    dt = datetime(
+        d.year, d.month, d.day, hour, minute, tzinfo=timezone(timedelta(hours=9))
+    )
+    return dt.isoformat(timespec="seconds")
+
+
+_ACTION_LOG = (
+    {
+        "timestamp": _action_iso(10, 9, 0),
+        "action": "Increased Awareness - Storm Damage budget by +25%",
+        "platform": "meta_ads",
+        "campaign_id": campaign_id("Awareness - Storm Damage"),
+        "summary": (
+            "Routine seasonality bump for storm-season volume. (Manual "
+            "action — pre-mureo.)"
+        ),
+        "metrics_at_action": {
+            "meta_awareness_results_per_day": 22,
+            "google_brand_calls_per_day": 17.5,
+        },
+        "observation_due": _date_for_day(24).isoformat(),
+    },
+    {
+        "timestamp": _action_iso(35, 14, 0),
+        "action": "Paused 2 underperforming creative variants on Conversion - Free Inspection",
+        "platform": "meta_ads",
+        "campaign_id": campaign_id("Conversion - Free Inspection"),
+        "summary": (
+            "Routine creative cleanup; consolidated to LAL 1% + Custom "
+            "Audience 90d. No expected halo impact. (Manual action — pre-mureo.)"
+        ),
+        "metrics_at_action": {
+            "meta_conversion_results_per_day": 43,
+            "google_brand_calls_per_day": 17.5,
+        },
+        "observation_due": _date_for_day(49).isoformat(),
+    },
+    {
+        "timestamp": _action_iso(_META_PAUSE_START_DAY, 11, 0),
+        "action": "Paused Retargeting - Site Visitors for 5-day controlled test",
+        "platform": "meta_ads",
+        "campaign_id": campaign_id("Retargeting - Site Visitors"),
+        "summary": (
+            "Hypothesis: retargeting spend is largely cannibalized by "
+            "direct/brand-search; if we pause it for 5 days and brand-search "
+            "volume holds, we can cut the JPY 540K/month retargeting line. "
+            "(Manual action — pre-mureo. The pause produced a 40% Brand - "
+            "Exact dip 3 days later, the OPPOSITE of the hypothesis.)"
+        ),
+        "metrics_at_action": {
+            "meta_retargeting_results_per_day": 40,
+            "google_brand_calls_per_day": 17.5,
+        },
+        "observation_due": _date_for_day(_META_PAUSE_END_DAY + 9).isoformat(),
+    },
+)
+
+
+_LAST_SYNCED_AT = datetime.combine(
+    _END_DATE, datetime.min.time(), tzinfo=timezone.utc
+).isoformat(timespec="seconds")
+
+
+_STATE_DOC: Mapping[str, object] = {
+    "version": "2",
+    "last_synced_at": _LAST_SYNCED_AT,
+    "platforms": {
+        "google_ads": {
+            "account_id": "demo-skyroof-google-ads",
+            "campaigns": list(_GOOGLE_ADS_STATE_CAMPAIGNS),
+        },
+        "meta_ads": {
+            "account_id": "demo-skyroof-meta-ads",
+            "campaigns": list(_META_ADS_STATE_CAMPAIGNS),
+        },
+    },
+    "action_log": list(_ACTION_LOG),
+}
+
+
+# ---------------------------------------------------------------------------
+# STRATEGY.md
+# ---------------------------------------------------------------------------
+
+_STRATEGY_MD = """# STRATEGY — SkyRoof (demo: Halo Effect)
+
+> Synthetic local-roofing scenario shipped with `mureo demo init --scenario halo-effect`.
+> Replace with your real strategy when you switch to a live account.
+
+## Business
+- **Brand:** SkyRoof
+- **Vertical:** Local roofing contractor, JP (primary service area: Kanagawa)
+- **ICP:** Homeowners 35-65, owned home with roof age >= 10 years
+- **Average job value:** JPY 320,000 first-touch
+- **Total ad budget:** ~JPY 5M / month (Google + Meta)
+
+## Quarterly goals
+- **Cost-per-call <= JPY 4,500** blended across Google + Meta
+- **Brand-search volume >= 30 calls / day** (brand health + Meta-halo proxy)
+- **Free Inspection bookings >= 600 / month** (top-of-funnel pipeline)
+- **Blended ROAS >= 5.0x** (high AOV, long sales cycle)
+
+## Channel mix
+- **Google Ads:** Brand - Exact (high-intent calls), Generic - Roof Repair JP, Generic - Local Roofer JP, Retargeting - Branded Search
+- **Meta Ads:** Awareness - Storm Damage (top-of-funnel), Retargeting - Site Visitors (mid-funnel — drives branded search), Conversion - Free Inspection (LAL + Custom Audience)
+
+## Operation Mode
+**MAINTAIN** — Q2 is steady-state. No new service area expansion planned.
+
+## Constraints
+- **Cross-channel attribution awareness.** Last-click reports under-credit Meta retargeting because most users who see retargeting later complete via branded search on Google. Before cutting any Meta line, check whether brand-search volume changes in the same window with a 1-7 day lag.
+- **No competitor-name bidding** on either platform.
+- **Pause-then-diagnose** before pause-then-replace: paused campaigns should be re-enabled, not cut from inventory, until root cause is established. Specifically, "controlled test" pauses must verify halo channels (brand search, direct) before concluding incremental contribution.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Public scenario instance
+# ---------------------------------------------------------------------------
+
+
+_SHEET_ROWS: Mapping[str, Sequence[Sequence[object]]] = {
+    "campaigns": _build_google_campaigns_rows(),
+    "ad_groups": _build_google_ad_groups_rows(),
+    "search_terms": _build_google_search_terms_rows(),
+    "keywords": _build_google_keywords_rows(),
+    "meta_ads": _build_meta_ads_rows(),
+}
+
+
+SCENARIO = Scenario(
+    name=_NAME,
+    title=_TITLE,
+    blurb=_BLURB,
+    days=_DAYS,
+    end_date=_END_DATE,
+    brand=_BRAND,
+    sheet_rows=_SHEET_ROWS,
+    state_doc=_STATE_DOC,
+    strategy_md=_STRATEGY_MD,
+)

--- a/mureo/demo/scenarios/hidden_champion.py
+++ b/mureo/demo/scenarios/hidden_champion.py
@@ -197,7 +197,7 @@ _GADS_SEARCH_TERMS = (
         14000,
         630,
         598500,
-        25,
+        12,
     ),
     (
         "prometheus alternative",
@@ -206,7 +206,7 @@ _GADS_SEARCH_TERMS = (
         22000,
         990,
         940500,
-        40,
+        20,
     ),
     # Generic - Observability Discovery — Logs and Metrics ad group (healthy 4-5%)
     (
@@ -312,7 +312,7 @@ _GADS_KEYWORDS = (
         41400,
         2052,
         1948500,
-        143,
+        110,
     ),
     (
         "log management",

--- a/mureo/demo/scenarios/hidden_champion.py
+++ b/mureo/demo/scenarios/hidden_champion.py
@@ -1,0 +1,754 @@
+"""The "Hidden Champion" demo scenario — PulseGrid B2B SaaS observability.
+
+A B2B SaaS observability/monitoring vendor running ~JPY 6M / month.
+Headline metrics look fine (blended cost-per-trial ~JPY 18,500 vs
+target JPY 22,000). Three months of routine optimization actions in
+the action_log: budget shifts, creative refreshes, negative-keyword
+adds. None of them touched the search term hiding the real story.
+
+Buried in the low-priority "Generic - Observability Discovery" ad
+group, one specific long-tail term —
+"kubernetes monitoring open source" — has CVR ~18%, more than 4x
+the surrounding ad group's ~4% average. It has been there for 90
+days but is throttled by the ad group's daily budget, so it produces
+only ~5 clicks / day and ~0.9 trials / day. The volume looks small,
+which is exactly why nobody escalated it.
+
+The "wow": mureo's outlier detection isolates the term and models
+the impact of promoting it to its own campaign with 5x budget —
+projecting ~+104 trial signups / month at the strong existing CVR
+(roughly 26 / month today, ~130 / month uncapped). The framing is
+deliberately monthly because day-level volume is currently below
+1 trial / day; any user-facing copy that quotes a per-day count
+should phrase it as "~1 trial / day today" rather than "5 / day".
+
+All numbers deterministic; re-running ``mureo demo init`` produces an
+identical bundle.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+from typing import TYPE_CHECKING
+
+from mureo.demo.scenarios._base import Scenario, campaign_id
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+# ---------------------------------------------------------------------------
+# Scenario constants
+# ---------------------------------------------------------------------------
+
+_NAME = "hidden-champion"
+_TITLE = "The Hidden Champion (PulseGrid / B2B SaaS observability)"
+_BLURB = (
+    "A long-tail Google search term has been quietly converting at 18% CVR "
+    "(vs the ad group's 4% average) for 90 days, buried in a low-priority "
+    "Generic ad group nobody escalated. mureo finds the outlier, models the "
+    "uplift of promoting it to its own campaign with 5x budget."
+)
+_DAYS = 90
+_END_DATE = date(2026, 4, 29)
+_BRAND = "PulseGrid"
+
+
+def _date_for_day(d: int) -> date:
+    return _END_DATE - timedelta(days=_DAYS - 1 - d)
+
+
+# ---------------------------------------------------------------------------
+# Google Ads — steady state across 90 days
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _GAdsCampaignSpec:
+    name: str
+    daily_impr: int
+    ctr: float
+    cpc: float
+    cvr: float
+
+
+_GADS_CAMPAIGNS = (
+    _GAdsCampaignSpec("Brand - Exact", 800, 0.20, 350.0, 0.16),
+    _GAdsCampaignSpec("Generic - APM Tools", 4500, 0.05, 1100.0, 0.040),
+    _GAdsCampaignSpec("Generic - Observability Discovery", 6000, 0.045, 950.0, 0.045),
+    _GAdsCampaignSpec("Retargeting - Trial Users", 1200, 0.10, 400.0, 0.18),
+)
+
+
+_GADS_AD_GROUPS = (
+    ("Brand - Exact", "Brand - Exact - Core", 0.65),
+    ("Brand - Exact", "Brand - Exact - Comparison", 0.35),
+    ("Generic - APM Tools", "Application Monitoring", 0.55),
+    ("Generic - APM Tools", "Performance Monitoring", 0.45),
+    ("Generic - Observability Discovery", "Open Source Stack", 0.40),
+    ("Generic - Observability Discovery", "Logs and Metrics", 0.60),
+    ("Retargeting - Trial Users", "Trial Reactivation", 1.0),
+)
+
+
+# Search terms: most healthy mid-funnel, one is the HIDDEN CHAMPION
+# in the low-priority "Open Source Stack" ad group.
+_GADS_SEARCH_TERMS = (
+    # Brand - Exact (steady, comparison + core)
+    ("pulsegrid", "Brand - Exact", "Brand - Exact - Core", 38000, 7600, 2660000, 1216),
+    (
+        "pulsegrid pricing",
+        "Brand - Exact",
+        "Brand - Exact - Core",
+        9200,
+        1840,
+        644000,
+        294,
+    ),
+    (
+        "pulsegrid login",
+        "Brand - Exact",
+        "Brand - Exact - Core",
+        4800,
+        960,
+        336000,
+        154,
+    ),
+    (
+        "pulsegrid review",
+        "Brand - Exact",
+        "Brand - Exact - Comparison",
+        7500,
+        1500,
+        525000,
+        240,
+    ),
+    (
+        "pulsegrid vs newrelic",
+        "Brand - Exact",
+        "Brand - Exact - Comparison",
+        5200,
+        1040,
+        364000,
+        166,
+    ),
+    # Generic - APM Tools (competitive, healthy ~4% CVR territory)
+    (
+        "application performance monitoring",
+        "Generic - APM Tools",
+        "Application Monitoring",
+        88000,
+        4400,
+        4840000,
+        176,
+    ),
+    (
+        "best apm tools",
+        "Generic - APM Tools",
+        "Application Monitoring",
+        56000,
+        2800,
+        3080000,
+        112,
+    ),
+    (
+        "node js apm",
+        "Generic - APM Tools",
+        "Application Monitoring",
+        24000,
+        1200,
+        1320000,
+        48,
+    ),
+    (
+        "performance monitoring tools",
+        "Generic - APM Tools",
+        "Performance Monitoring",
+        72000,
+        3600,
+        3960000,
+        144,
+    ),
+    (
+        "site reliability monitoring",
+        "Generic - APM Tools",
+        "Performance Monitoring",
+        18000,
+        900,
+        990000,
+        36,
+    ),
+    # Generic - Observability Discovery — Open Source Stack ad group
+    # is where the HIDDEN CHAMPION lives.
+    (
+        # *** HIDDEN CHAMPION *** — CVR ~18% vs ad-group avg ~4%
+        "kubernetes monitoring open source",
+        "Generic - Observability Discovery",
+        "Open Source Stack",
+        5400,
+        432,
+        410400,
+        78,
+    ),
+    (
+        "self hosted observability",
+        "Generic - Observability Discovery",
+        "Open Source Stack",
+        14000,
+        630,
+        598500,
+        25,
+    ),
+    (
+        "prometheus alternative",
+        "Generic - Observability Discovery",
+        "Open Source Stack",
+        22000,
+        990,
+        940500,
+        40,
+    ),
+    # Generic - Observability Discovery — Logs and Metrics ad group (healthy 4-5%)
+    (
+        "log management tools",
+        "Generic - Observability Discovery",
+        "Logs and Metrics",
+        45000,
+        2025,
+        1923750,
+        81,
+    ),
+    (
+        "metrics dashboard saas",
+        "Generic - Observability Discovery",
+        "Logs and Metrics",
+        38000,
+        1710,
+        1624500,
+        77,
+    ),
+    (
+        "centralized logging",
+        "Generic - Observability Discovery",
+        "Logs and Metrics",
+        28000,
+        1260,
+        1197000,
+        50,
+    ),
+    # Retargeting - Trial Users (healthy)
+    (
+        "pulsegrid free trial",
+        "Retargeting - Trial Users",
+        "Trial Reactivation",
+        8800,
+        880,
+        352000,
+        158,
+    ),
+    (
+        "pulsegrid sign up",
+        "Retargeting - Trial Users",
+        "Trial Reactivation",
+        4200,
+        420,
+        168000,
+        76,
+    ),
+)
+
+
+_GADS_KEYWORDS = (
+    (
+        "[pulsegrid]",
+        "EXACT",
+        10,
+        "Brand - Exact",
+        "Brand - Exact - Core",
+        52000,
+        10400,
+        3640000,
+        1664,
+    ),
+    (
+        "[pulsegrid pricing]",
+        "EXACT",
+        10,
+        "Brand - Exact",
+        "Brand - Exact - Core",
+        9200,
+        1840,
+        644000,
+        294,
+    ),
+    (
+        "application performance monitoring",
+        "PHRASE",
+        7,
+        "Generic - APM Tools",
+        "Application Monitoring",
+        168000,
+        8400,
+        9240000,
+        336,
+    ),
+    (
+        "performance monitoring tools",
+        "PHRASE",
+        7,
+        "Generic - APM Tools",
+        "Performance Monitoring",
+        90000,
+        4500,
+        4950000,
+        180,
+    ),
+    (
+        "kubernetes monitoring",
+        "PHRASE",
+        6,
+        "Generic - Observability Discovery",
+        "Open Source Stack",
+        41400,
+        2052,
+        1948500,
+        143,
+    ),
+    (
+        "log management",
+        "PHRASE",
+        7,
+        "Generic - Observability Discovery",
+        "Logs and Metrics",
+        73000,
+        3285,
+        3120750,
+        131,
+    ),
+    (
+        "metrics monitoring",
+        "PHRASE",
+        7,
+        "Generic - Observability Discovery",
+        "Logs and Metrics",
+        38000,
+        1710,
+        1624500,
+        77,
+    ),
+    (
+        '"pulsegrid"',
+        "PHRASE",
+        9,
+        "Retargeting - Trial Users",
+        "Trial Reactivation",
+        13000,
+        1300,
+        520000,
+        234,
+    ),
+)
+
+
+def _build_google_campaigns_rows() -> list[list[object]]:
+    rows: list[list[object]] = [
+        ["day", "campaign", "impressions", "clicks", "cost", "conversions"]
+    ]
+    for c in _GADS_CAMPAIGNS:
+        for d in range(_DAYS):
+            day_iso = _date_for_day(d).isoformat()
+            clicks = int(round(c.daily_impr * c.ctr))
+            cost = round(clicks * c.cpc, 2)
+            conv = round(clicks * c.cvr, 2)
+            rows.append([day_iso, c.name, c.daily_impr, clicks, cost, conv])
+    return rows
+
+
+def _build_google_ad_groups_rows() -> list[list[object]]:
+    rows: list[list[object]] = [
+        [
+            "day",
+            "campaign",
+            "ad_group",
+            "impressions",
+            "clicks",
+            "cost",
+            "conversions",
+        ]
+    ]
+    by_camp = {c.name: c for c in _GADS_CAMPAIGNS}
+    for camp_name, ag_name, share in _GADS_AD_GROUPS:
+        c = by_camp[camp_name]
+        for d in range(_DAYS):
+            day_iso = _date_for_day(d).isoformat()
+            impr = int(round(c.daily_impr * share))
+            clicks = int(round(impr * c.ctr))
+            cost = round(clicks * c.cpc, 2)
+            conv = round(clicks * c.cvr, 2)
+            rows.append([day_iso, camp_name, ag_name, impr, clicks, cost, conv])
+    return rows
+
+
+def _build_google_search_terms_rows() -> list[list[object]]:
+    rows: list[list[object]] = [
+        [
+            "search_term",
+            "campaign",
+            "ad_group",
+            "impressions",
+            "clicks",
+            "cost",
+            "conversions",
+        ]
+    ]
+    for term, camp, ag, impr, clicks, cost, conv in _GADS_SEARCH_TERMS:
+        rows.append([term, camp, ag, impr, clicks, cost, conv])
+    return rows
+
+
+def _build_google_keywords_rows() -> list[list[object]]:
+    rows: list[list[object]] = [
+        [
+            "keyword",
+            "match_type",
+            "quality_score",
+            "campaign",
+            "ad_group",
+            "impressions",
+            "clicks",
+            "cost",
+            "conversions",
+        ]
+    ]
+    for kw, mt, qs, camp, ag, impr, clicks, cost, conv in _GADS_KEYWORDS:
+        rows.append([kw, mt, qs, camp, ag, impr, clicks, cost, conv])
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Meta Ads — steady state across 90 days
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _MetaAdSpec:
+    ad: str
+    campaign: str
+    adset: str
+    ctr: float
+    cpc: int
+    rpc: float
+    daily_spend: int
+
+
+_META_ADS: tuple[_MetaAdSpec, ...] = (
+    _MetaAdSpec(
+        ad="Video - Engineering Pain Points",
+        campaign="Awareness - Engineer Education",
+        adset="Engineers JP/EN 28-50",
+        ctr=0.013,
+        cpc=180,
+        rpc=0.025,
+        daily_spend=22000,
+    ),
+    _MetaAdSpec(
+        ad="Image - Trial CTA Generic",
+        campaign="Conversion - Free Trial",
+        adset="LAL 1% Trial Users",
+        ctr=0.018,
+        cpc=240,
+        rpc=0.060,
+        daily_spend=42000,
+    ),
+    _MetaAdSpec(
+        ad="Image - Open Source Friendly Story",
+        campaign="Conversion - Free Trial",
+        adset="Custom - GitHub Visitors",
+        ctr=0.022,
+        cpc=210,
+        rpc=0.075,
+        daily_spend=28000,
+    ),
+    _MetaAdSpec(
+        ad="Carousel - Trial Drop-off Recovery",
+        campaign="Retargeting - Trial Drop-off",
+        adset="Started trial, no conversion",
+        ctr=0.030,
+        cpc=160,
+        rpc=0.12,
+        daily_spend=18000,
+    ),
+    _MetaAdSpec(
+        ad="Image - Annual Plan Promo",
+        campaign="Lead Form - Sales Outreach",
+        adset="VP Engineering / SRE Lead",
+        ctr=0.012,
+        cpc=320,
+        rpc=0.18,
+        daily_spend=12000,
+    ),
+)
+
+
+def _build_meta_ads_rows() -> list[list[object]]:
+    rows: list[list[object]] = [
+        [
+            "Day",
+            "Campaign name",
+            "Ad set name",
+            "Ad name",
+            "Impressions",
+            "Clicks (all)",
+            "Amount spent (JPY)",
+            "Results",
+        ]
+    ]
+    for d in range(_DAYS):
+        date_iso = _date_for_day(d).isoformat()
+        for ad in _META_ADS:
+            spend = ad.daily_spend
+            clicks = int(round(spend / ad.cpc))
+            impressions = int(round(clicks / ad.ctr))
+            results = round(clicks * ad.rpc, 1)
+            rows.append(
+                [
+                    date_iso,
+                    ad.campaign,
+                    ad.adset,
+                    ad.ad,
+                    impressions,
+                    clicks,
+                    spend,
+                    results,
+                ]
+            )
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# STATE.json
+# ---------------------------------------------------------------------------
+
+
+_GOOGLE_ADS_STATE_CAMPAIGNS = (
+    {
+        "campaign_id": campaign_id("Brand - Exact"),
+        "campaign_name": "Brand - Exact",
+        "status": "ENABLED",
+        "daily_budget": 65000,
+        "campaign_goal": (
+            "Capture branded demand at high efficiency "
+            "(target cost-per-trial <= JPY 3,500)."
+        ),
+    },
+    {
+        "campaign_id": campaign_id("Generic - APM Tools"),
+        "campaign_name": "Generic - APM Tools",
+        "status": "ENABLED",
+        "daily_budget": 280000,
+        "campaign_goal": (
+            "Compete in the APM tools category; target cost-per-trial " "<= JPY 28,000."
+        ),
+    },
+    {
+        "campaign_id": campaign_id("Generic - Observability Discovery"),
+        "campaign_name": "Generic - Observability Discovery",
+        "status": "ENABLED",
+        "daily_budget": 95000,
+        "campaign_goal": (
+            "Top-of-funnel discovery for adjacent categories "
+            "(open-source stacks, logs, metrics). Lower-priority spend cap."
+        ),
+    },
+    {
+        "campaign_id": campaign_id("Retargeting - Trial Users"),
+        "campaign_name": "Retargeting - Trial Users",
+        "status": "ENABLED",
+        "daily_budget": 50000,
+        "campaign_goal": (
+            "Recover dropped trial signups; target cost-per-conversion " "<= JPY 2,500."
+        ),
+    },
+)
+
+_META_ADS_STATE_CAMPAIGNS = (
+    {
+        "campaign_id": campaign_id("Awareness - Engineer Education"),
+        "campaign_name": "Awareness - Engineer Education",
+        "status": "ENABLED",
+        "daily_budget": 22000,
+        "campaign_goal": "Top-of-funnel engineer education content.",
+    },
+    {
+        "campaign_id": campaign_id("Conversion - Free Trial"),
+        "campaign_name": "Conversion - Free Trial",
+        "status": "ENABLED",
+        "daily_budget": 70000,
+        "campaign_goal": ("Drive Free Trial signups at <= JPY 4,000 cost-per-trial."),
+    },
+    {
+        "campaign_id": campaign_id("Retargeting - Trial Drop-off"),
+        "campaign_name": "Retargeting - Trial Drop-off",
+        "status": "ENABLED",
+        "daily_budget": 18000,
+        "campaign_goal": (
+            "Re-engage users who started but did not complete trial; "
+            "target conversion rate >= 8%."
+        ),
+    },
+    {
+        "campaign_id": campaign_id("Lead Form - Sales Outreach"),
+        "campaign_name": "Lead Form - Sales Outreach",
+        "status": "ENABLED",
+        "daily_budget": 12000,
+        "campaign_goal": (
+            "Build qualified-lead list for outbound sales (Annual Plan)."
+        ),
+    },
+)
+
+
+def _action_iso(day: int, hour: int = 10, minute: int = 0) -> str:
+    d = _date_for_day(day)
+    dt = datetime(
+        d.year, d.month, d.day, hour, minute, tzinfo=timezone(timedelta(hours=9))
+    )
+    return dt.isoformat(timespec="seconds")
+
+
+_ACTION_LOG = (
+    {
+        "timestamp": _action_iso(15, 10, 30),
+        "action": "Increased Generic - APM Tools daily_budget by +20%",
+        "platform": "google_ads",
+        "campaign_id": campaign_id("Generic - APM Tools"),
+        "summary": (
+            "Strong APM-category growth signal; bumped budget to capture "
+            "more trial volume. (Manual action — pre-mureo. Did not touch "
+            "Generic - Observability Discovery.)"
+        ),
+        "metrics_at_action": {
+            "google_apm_cost_per_trial": 27500,
+            "google_blended_cost_per_trial": 18800,
+        },
+        "observation_due": _date_for_day(29).isoformat(),
+    },
+    {
+        "timestamp": _action_iso(40, 14, 0),
+        "action": "Paused 3 underperforming creative variants on Conversion - Free Trial",
+        "platform": "meta_ads",
+        "campaign_id": campaign_id("Conversion - Free Trial"),
+        "summary": (
+            "Routine creative cleanup; consolidated to LAL 1% + GitHub "
+            "Custom Audience. (Manual action — pre-mureo.)"
+        ),
+        "metrics_at_action": {
+            "meta_conversion_results_per_day": 88,
+            "meta_blended_cost_per_result": 4200,
+        },
+        "observation_due": _date_for_day(54).isoformat(),
+    },
+    {
+        "timestamp": _action_iso(70, 9, 15),
+        "action": "Added 12 negative keywords to Generic - APM Tools",
+        "platform": "google_ads",
+        "campaign_id": campaign_id("Generic - APM Tools"),
+        "summary": (
+            "Cleaned up irrelevant queries (mostly 'apm car repair' "
+            "noise). (Manual action — pre-mureo. Did not investigate "
+            "search-term-level CVR distribution.)"
+        ),
+        "metrics_at_action": {
+            "google_apm_cost_per_trial": 27500,
+            "google_blended_cost_per_trial": 18500,
+        },
+        "observation_due": _date_for_day(84).isoformat(),
+    },
+)
+
+
+_LAST_SYNCED_AT = datetime.combine(
+    _END_DATE, datetime.min.time(), tzinfo=timezone.utc
+).isoformat(timespec="seconds")
+
+
+_STATE_DOC: Mapping[str, object] = {
+    "version": "2",
+    "last_synced_at": _LAST_SYNCED_AT,
+    "platforms": {
+        "google_ads": {
+            "account_id": "demo-pulsegrid-google-ads",
+            "campaigns": list(_GOOGLE_ADS_STATE_CAMPAIGNS),
+        },
+        "meta_ads": {
+            "account_id": "demo-pulsegrid-meta-ads",
+            "campaigns": list(_META_ADS_STATE_CAMPAIGNS),
+        },
+    },
+    "action_log": list(_ACTION_LOG),
+}
+
+
+# ---------------------------------------------------------------------------
+# STRATEGY.md
+# ---------------------------------------------------------------------------
+
+_STRATEGY_MD = """# STRATEGY — PulseGrid (demo: Hidden Champion)
+
+> Synthetic B2B SaaS observability scenario shipped with `mureo demo init --scenario hidden-champion`.
+> Replace with your real strategy when you switch to a live account.
+
+## Business
+- **Brand:** PulseGrid
+- **Vertical:** B2B SaaS observability / monitoring (APM + logs + metrics)
+- **ICP:** Engineering teams (10-200 engineers) at Series B+ companies, primary buyer = SRE Lead / VP Engineering
+- **ARR per customer:** ~JPY 1.4M ACV, 18-month median tenure
+- **Trial-to-paid rate:** ~22%
+- **Total ad budget:** ~JPY 6M / month (Google + Meta)
+
+## Quarterly goals
+- **Cost-per-trial <= JPY 22,000** blended across Google + Meta
+- **Free Trial signups >= 600 / month** (top-of-funnel pipeline)
+- **Brand-search CTR >= 18%** (brand health)
+- **Blended ROAS >= 1.5x** at 12-month attribution window (long sales cycle)
+
+## Channel mix
+- **Google Ads:** Brand - Exact, Generic - APM Tools (primary spend), Generic - Observability Discovery (lower-priority discovery), Retargeting - Trial Users
+- **Meta Ads:** Awareness Engineer Education, Conversion Free Trial (LAL + GitHub Custom Audience), Retargeting Trial Drop-off, Lead Form Sales Outreach
+
+## Operation Mode
+**GROWTH** — prioritize trial-volume growth over cost efficiency. We want top-of-funnel scale to feed the sales motion.
+
+## Constraints
+- **Outlier search terms must be promoted.** When a search term inside a generic ad group converts at 3x+ the ad-group average, escalate it to its own ad group or campaign with budget protection — do not leave high-intent queries capped by a generic ad group's budget.
+- **No competitor-name bidding** on either platform.
+- **Pause-then-diagnose** before pause-then-replace: paused campaigns should be re-enabled, not cut from inventory, until root cause is established.
+- **Trial-quality matters.** Optimize for "started trial" only when downstream trial-to-paid rate stays above 18%; if a high-volume source drops below that, demote it.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Public scenario instance
+# ---------------------------------------------------------------------------
+
+
+_SHEET_ROWS: Mapping[str, Sequence[Sequence[object]]] = {
+    "campaigns": _build_google_campaigns_rows(),
+    "ad_groups": _build_google_ad_groups_rows(),
+    "search_terms": _build_google_search_terms_rows(),
+    "keywords": _build_google_keywords_rows(),
+    "meta_ads": _build_meta_ads_rows(),
+}
+
+
+SCENARIO = Scenario(
+    name=_NAME,
+    title=_TITLE,
+    blurb=_BLURB,
+    days=_DAYS,
+    end_date=_END_DATE,
+    brand=_BRAND,
+    sheet_rows=_SHEET_ROWS,
+    state_doc=_STATE_DOC,
+    strategy_md=_STRATEGY_MD,
+)

--- a/mureo/demo/scenarios/seasonality_trap.py
+++ b/mureo/demo/scenarios/seasonality_trap.py
@@ -111,6 +111,7 @@ _GADS_SEARCH_TERMS = (
     ("flavorbox", "Brand - Exact", "Brand - Exact", 32000, 7040, 422400, 985),
     ("flavorbox 敏感肌", "Brand - Exact", "Brand - Exact", 8400, 2100, 126000, 273),
     ("flavorbox クーポン", "Brand - Exact", "Brand - Exact", 4200, 1050, 63000, 105),
+    ("flavorbox 評判", "Brand - Exact", "Brand - Exact", 3600, 900, 54000, 81),
     # HIDDEN WINNER — high CVR vs ad-group average.
     (
         "敏感肌 化粧水 おすすめ",
@@ -281,6 +282,28 @@ _GADS_KEYWORDS = (
         1320,
         297000,
         177,
+    ),
+    (
+        "flavorbox レビュー",
+        "PHRASE",
+        9,
+        "Retargeting - Search",
+        "Cart Abandoners",
+        13500,
+        1080,
+        243000,
+        151,
+    ),
+    (
+        "化粧品 比較",
+        "PHRASE",
+        6,
+        "Generic - Discovery",
+        "Cosmetic Reviews",
+        140000,
+        3500,
+        612500,
+        88,
     ),
 )
 

--- a/mureo/demo/scenarios/strategy_drift.py
+++ b/mureo/demo/scenarios/strategy_drift.py
@@ -1,0 +1,882 @@
+"""The "Strategy Drift" demo scenario — PulseFit fitness app subscription.
+
+A subscription-based fitness app running ~JPY 5M / month. STRATEGY.md
+explicitly forbids three things, codified after past lessons:
+
+  1. No competitor-name bidding on either platform
+  2. Conversion campaigns optimize for "Subscribed" (paid signup),
+     never for "Started trial" (LTV signal is too thin on trials)
+  3. Meta Lookalike stack capped at 3 active variants (audience
+     overlap collapses CTR past that point)
+
+A new growth manager joined on Day 30 and made three changes
+without logging them — each one violates exactly one of the rules
+above:
+
+  Day 30 — Launched a "Competitor Names" Google campaign targeting
+           rivals' brand terms (violates rule 1)
+  Day 45 — Switched Meta Conversion campaigns from "Subscribed" to
+           "7-day trial" optimization (violates rule 2). Apparent CV
+           count surges, downstream trial-to-paid rate collapses.
+  Day 60 — Added LAL 4%, 7%, 10% on top of the existing 1%, 2%, 5%
+           stack (violates rule 3). Frequency rises, CTR drops.
+
+action_log around these changes is empty. That silence is itself a
+signal: STRATEGY.md says all actions must be logged.
+
+The "wow": mureo's STRATEGY-vs-STATE compliance audit reads each
+constraint, walks STATE.json campaigns, and produces a list of
+violations with start dates and JPY-impact estimates. None of these
+are reachable through ordinary metric dashboards because each
+violation is paired with a *better-looking* surface metric (apparent
+CPA improvement, trial-volume uplift, "more LAL = more reach").
+
+Detection caveat: rule 1 (competitor-name campaign) and rule 3 (LAL
+stack > 3) are detectable from the bundle data alone (campaign /
+ad-set name patterns). Rule 2 (optimization-target swap) is not —
+the conversion-event label is not a CSV column; only the Day-45 rpc
+jump is observable, which could equally be a creative refresh. The
+audit relies on STATE.json ``campaign_goal`` text to make rule 2
+machine-detectable. In a real account that text would come from the
+agent's own log of optimization-target changes; for the demo it is
+pre-seeded.
+
+All numbers deterministic; re-running ``mureo demo init`` produces
+an identical bundle.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+from typing import TYPE_CHECKING
+
+from mureo.demo.scenarios._base import Scenario, campaign_id
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+# ---------------------------------------------------------------------------
+# Scenario constants
+# ---------------------------------------------------------------------------
+
+_NAME = "strategy-drift"
+_TITLE = "Strategy Drift (PulseFit / Fitness app subscription)"
+_BLURB = (
+    "New manager since Day 30 silently violated 3 explicit STRATEGY rules "
+    "(competitor bidding, optimization-target swap, LAL stack >3). "
+    "action_log empty — that silence is itself the signal. mureo's "
+    "compliance audit produces a violation list with start dates and JPY impact."
+)
+_DAYS = 90
+_END_DATE = date(2026, 4, 29)
+_BRAND = "PulseFit"
+
+# Violation timeline
+_VIOLATION_COMPETITOR_DAY = 30  # rule 1: competitor-name campaign launched
+_VIOLATION_OPTIMIZATION_SWAP_DAY = 45  # rule 2: conversion event changed
+_VIOLATION_LAL_STACK_DAY = 60  # rule 3: LAL 4%/7%/10% added
+
+
+def _date_for_day(d: int) -> date:
+    return _END_DATE - timedelta(days=_DAYS - 1 - d)
+
+
+# ---------------------------------------------------------------------------
+# Google Ads — 4 baseline campaigns + 1 violating "Competitor Names"
+# (the violator is ENABLED from Day 30 onward, zero before that)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _GAdsCampaignSpec:
+    name: str
+    daily_impr: int
+    ctr: float
+    cpc: float
+    cvr: float
+    start_day: int = 0  # 0 = active from Day 0
+
+
+_GADS_CAMPAIGNS = (
+    _GAdsCampaignSpec("Brand - Exact", 600, 0.22, 90.0, 0.18),
+    _GAdsCampaignSpec("Generic - Fitness Apps", 4000, 0.04, 220.0, 0.06),
+    _GAdsCampaignSpec("Generic - Workout Plans", 5500, 0.03, 180.0, 0.045),
+    _GAdsCampaignSpec("Retargeting - App Visitors", 1000, 0.10, 150.0, 0.12),
+    # *** STRATEGY VIOLATION (rule 1) — competitor-name bidding ***
+    # Active only from Day 30 (the new manager's launch day).
+    _GAdsCampaignSpec(
+        "Competitor Names",
+        2400,
+        0.025,
+        380.0,
+        0.012,
+        start_day=_VIOLATION_COMPETITOR_DAY,
+    ),
+)
+
+
+_GADS_AD_GROUPS = (
+    ("Brand - Exact", "Brand - Exact - Core", 1.0),
+    ("Generic - Fitness Apps", "Fitness App General", 0.55),
+    ("Generic - Fitness Apps", "Workout Tracker", 0.45),
+    ("Generic - Workout Plans", "Beginner Workouts", 0.50),
+    ("Generic - Workout Plans", "Home Workouts", 0.50),
+    ("Retargeting - App Visitors", "Site Visitors 30d", 1.0),
+    # Competitor Names ad group is only present in Days 30-89
+    ("Competitor Names", "Rival Brand Terms", 1.0),
+)
+
+
+_GADS_SEARCH_TERMS = (
+    # Brand - Exact
+    ("pulsefit", "Brand - Exact", "Brand - Exact - Core", 22000, 4840, 435600, 871),
+    (
+        "pulsefit app",
+        "Brand - Exact",
+        "Brand - Exact - Core",
+        6800,
+        1496,
+        134640,
+        269,
+    ),
+    (
+        "pulsefit subscription",
+        "Brand - Exact",
+        "Brand - Exact - Core",
+        3200,
+        704,
+        63360,
+        127,
+    ),
+    # Generic - Fitness Apps
+    (
+        "fitness app japan",
+        "Generic - Fitness Apps",
+        "Fitness App General",
+        62000,
+        2480,
+        545600,
+        149,
+    ),
+    (
+        "best fitness app subscription",
+        "Generic - Fitness Apps",
+        "Fitness App General",
+        38000,
+        1520,
+        334400,
+        91,
+    ),
+    (
+        "workout tracker app",
+        "Generic - Fitness Apps",
+        "Workout Tracker",
+        45000,
+        1800,
+        396000,
+        108,
+    ),
+    (
+        "fitness tracking subscription",
+        "Generic - Fitness Apps",
+        "Workout Tracker",
+        18000,
+        720,
+        158400,
+        43,
+    ),
+    # Generic - Workout Plans
+    (
+        "beginner workout plan",
+        "Generic - Workout Plans",
+        "Beginner Workouts",
+        78000,
+        2340,
+        421200,
+        105,
+    ),
+    (
+        "30 day fitness plan",
+        "Generic - Workout Plans",
+        "Beginner Workouts",
+        42000,
+        1260,
+        226800,
+        57,
+    ),
+    (
+        "home workout no equipment",
+        "Generic - Workout Plans",
+        "Home Workouts",
+        88000,
+        2640,
+        475200,
+        119,
+    ),
+    (
+        "home gym workout app",
+        "Generic - Workout Plans",
+        "Home Workouts",
+        34000,
+        1020,
+        183600,
+        46,
+    ),
+    # Retargeting (healthy)
+    (
+        "pulsefit free trial",
+        "Retargeting - App Visitors",
+        "Site Visitors 30d",
+        7200,
+        720,
+        108000,
+        86,
+    ),
+    (
+        "pulsefit cancel",
+        "Retargeting - App Visitors",
+        "Site Visitors 30d",
+        2800,
+        280,
+        42000,
+        34,
+    ),
+    # *** Competitor Names campaign — STRATEGY violation ***
+    # Aggregate values reflect 60 days of spend (Day 30-89). Tuned so
+    # search-term aggregate clicks (~3840) cover ~107% of the
+    # campaign-row total clicks (60 days × 60 clicks/day = 3600), so
+    # /search-term-cleanup sees full coverage rather than appearing
+    # to be missing query data on this campaign.
+    (
+        "muscle mate app",  # competitor brand term
+        "Competitor Names",
+        "Rival Brand Terms",
+        72000,
+        1800,
+        684000,
+        22,
+    ),
+    (
+        "fitnow subscription",  # competitor brand term
+        "Competitor Names",
+        "Rival Brand Terms",
+        48000,
+        1200,
+        456000,
+        14,
+    ),
+    (
+        "trainerly app review",  # competitor brand term
+        "Competitor Names",
+        "Rival Brand Terms",
+        33600,
+        840,
+        319200,
+        10,
+    ),
+)
+
+
+_GADS_KEYWORDS = (
+    (
+        "[pulsefit]",
+        "EXACT",
+        10,
+        "Brand - Exact",
+        "Brand - Exact - Core",
+        32000,
+        7040,
+        633600,
+        1267,
+    ),
+    (
+        "fitness app",
+        "PHRASE",
+        7,
+        "Generic - Fitness Apps",
+        "Fitness App General",
+        100000,
+        4000,
+        880000,
+        240,
+    ),
+    (
+        "workout tracker",
+        "PHRASE",
+        7,
+        "Generic - Fitness Apps",
+        "Workout Tracker",
+        63000,
+        2520,
+        554400,
+        151,
+    ),
+    (
+        "beginner workout",
+        "PHRASE",
+        7,
+        "Generic - Workout Plans",
+        "Beginner Workouts",
+        120000,
+        3600,
+        648000,
+        162,
+    ),
+    (
+        "home workout",
+        "PHRASE",
+        7,
+        "Generic - Workout Plans",
+        "Home Workouts",
+        122000,
+        3660,
+        658800,
+        165,
+    ),
+    (
+        '"pulsefit"',
+        "PHRASE",
+        9,
+        "Retargeting - App Visitors",
+        "Site Visitors 30d",
+        10000,
+        1000,
+        150000,
+        120,
+    ),
+    # *** Competitor brand keywords — VIOLATION ***
+    (
+        "muscle mate",
+        "PHRASE",
+        4,
+        "Competitor Names",
+        "Rival Brand Terms",
+        72000,
+        1800,
+        684000,
+        22,
+    ),
+    (
+        "fitnow",
+        "PHRASE",
+        4,
+        "Competitor Names",
+        "Rival Brand Terms",
+        48000,
+        1200,
+        456000,
+        14,
+    ),
+)
+
+
+def _gads_campaign_active(spec: _GAdsCampaignSpec, day: int) -> bool:
+    return day >= spec.start_day
+
+
+def _build_google_campaigns_rows() -> list[list[object]]:
+    rows: list[list[object]] = [
+        ["day", "campaign", "impressions", "clicks", "cost", "conversions"]
+    ]
+    for c in _GADS_CAMPAIGNS:
+        for d in range(_DAYS):
+            if not _gads_campaign_active(c, d):
+                continue
+            day_iso = _date_for_day(d).isoformat()
+            clicks = int(round(c.daily_impr * c.ctr))
+            cost = round(clicks * c.cpc, 2)
+            conv = round(clicks * c.cvr, 2)
+            rows.append([day_iso, c.name, c.daily_impr, clicks, cost, conv])
+    return rows
+
+
+def _build_google_ad_groups_rows() -> list[list[object]]:
+    rows: list[list[object]] = [
+        [
+            "day",
+            "campaign",
+            "ad_group",
+            "impressions",
+            "clicks",
+            "cost",
+            "conversions",
+        ]
+    ]
+    by_camp = {c.name: c for c in _GADS_CAMPAIGNS}
+    for camp_name, ag_name, share in _GADS_AD_GROUPS:
+        c = by_camp[camp_name]
+        for d in range(_DAYS):
+            if not _gads_campaign_active(c, d):
+                continue
+            day_iso = _date_for_day(d).isoformat()
+            impr = int(round(c.daily_impr * share))
+            clicks = int(round(impr * c.ctr))
+            cost = round(clicks * c.cpc, 2)
+            conv = round(clicks * c.cvr, 2)
+            rows.append([day_iso, camp_name, ag_name, impr, clicks, cost, conv])
+    return rows
+
+
+def _build_google_search_terms_rows() -> list[list[object]]:
+    rows: list[list[object]] = [
+        [
+            "search_term",
+            "campaign",
+            "ad_group",
+            "impressions",
+            "clicks",
+            "cost",
+            "conversions",
+        ]
+    ]
+    for term, camp, ag, impr, clicks, cost, conv in _GADS_SEARCH_TERMS:
+        rows.append([term, camp, ag, impr, clicks, cost, conv])
+    return rows
+
+
+def _build_google_keywords_rows() -> list[list[object]]:
+    rows: list[list[object]] = [
+        [
+            "keyword",
+            "match_type",
+            "quality_score",
+            "campaign",
+            "ad_group",
+            "impressions",
+            "clicks",
+            "cost",
+            "conversions",
+        ]
+    ]
+    for kw, mt, qs, camp, ag, impr, clicks, cost, conv in _GADS_KEYWORDS:
+        rows.append([kw, mt, qs, camp, ag, impr, clicks, cost, conv])
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Meta Ads — optimization-target swap on Day 45 + LAL stack expansion Day 60
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _MetaAdSpec:
+    ad: str
+    campaign: str
+    adset: str
+    ctr: float
+    cpc: int
+    rpc: float
+    daily_spend: int
+    start_day: int = 0
+    # Day 45+ optimization swap: ``rpc_post_swap`` overrides rpc on
+    # the conversion campaign. Reflects "more shallow conversions
+    # (trial starts) being counted as Results".
+    rpc_post_swap: float | None = None
+
+
+_META_ADS: tuple[_MetaAdSpec, ...] = (
+    # Awareness — unchanged throughout
+    _MetaAdSpec(
+        ad="Video - Daily Workout Routines",
+        campaign="Awareness - Workout Routines",
+        adset="JP 25-44 Active",
+        ctr=0.014,
+        cpc=85,
+        rpc=0.04,
+        daily_spend=22000,
+    ),
+    # Conversion - LAL 1% (existing, allowed by rule 3)
+    _MetaAdSpec(
+        ad="Image - LAL 1% Subscribers",
+        campaign="Conversion - Subscription",
+        adset="LAL 1% Paid Subscribers",
+        ctr=0.018,
+        cpc=180,
+        rpc=0.06,
+        daily_spend=28000,
+        rpc_post_swap=0.18,
+    ),
+    # Conversion - LAL 2% (existing, allowed)
+    _MetaAdSpec(
+        ad="Image - LAL 2% Subscribers",
+        campaign="Conversion - Subscription",
+        adset="LAL 2% Paid Subscribers",
+        ctr=0.016,
+        cpc=200,
+        rpc=0.05,
+        daily_spend=18000,
+        rpc_post_swap=0.16,
+    ),
+    # Conversion - LAL 5% (existing, allowed — at the cap)
+    _MetaAdSpec(
+        ad="Image - LAL 5% Subscribers",
+        campaign="Conversion - Subscription",
+        adset="LAL 5% Paid Subscribers",
+        ctr=0.014,
+        cpc=220,
+        rpc=0.04,
+        daily_spend=12000,
+        rpc_post_swap=0.14,
+    ),
+    # *** STRATEGY VIOLATION (rule 3) — LAL stack > 3 ***
+    # Added Day 60. Three more LAL ads launched simultaneously.
+    _MetaAdSpec(
+        ad="Image - LAL 4% Subscribers",
+        campaign="Conversion - Subscription",
+        adset="LAL 4% Paid Subscribers",
+        ctr=0.013,
+        cpc=240,
+        rpc=0.030,
+        daily_spend=8000,
+        start_day=_VIOLATION_LAL_STACK_DAY,
+        rpc_post_swap=0.10,
+    ),
+    _MetaAdSpec(
+        ad="Image - LAL 7% Subscribers",
+        campaign="Conversion - Subscription",
+        adset="LAL 7% Paid Subscribers",
+        ctr=0.011,
+        cpc=260,
+        rpc=0.022,
+        daily_spend=8000,
+        start_day=_VIOLATION_LAL_STACK_DAY,
+        rpc_post_swap=0.08,
+    ),
+    _MetaAdSpec(
+        ad="Image - LAL 10% Subscribers",
+        campaign="Conversion - Subscription",
+        adset="LAL 10% Paid Subscribers",
+        ctr=0.010,
+        cpc=280,
+        rpc=0.018,
+        daily_spend=8000,
+        start_day=_VIOLATION_LAL_STACK_DAY,
+        rpc_post_swap=0.06,
+    ),
+    # Retargeting - unchanged
+    _MetaAdSpec(
+        ad="Carousel - Cart Abandoner Reminder",
+        campaign="Retargeting - Cart Abandoners",
+        adset="App-installed, no subscription",
+        ctr=0.025,
+        cpc=140,
+        rpc=0.10,
+        daily_spend=14000,
+    ),
+)
+
+
+def _meta_active(ad: _MetaAdSpec, day: int) -> bool:
+    return day >= ad.start_day
+
+
+def _meta_rpc_for_day(ad: _MetaAdSpec, day: int) -> float:
+    """Apply Day 45 optimization-target swap on Conversion campaigns."""
+    if ad.rpc_post_swap is not None and day >= _VIOLATION_OPTIMIZATION_SWAP_DAY:
+        return ad.rpc_post_swap
+    return ad.rpc
+
+
+def _build_meta_ads_rows() -> list[list[object]]:
+    rows: list[list[object]] = [
+        [
+            "Day",
+            "Campaign name",
+            "Ad set name",
+            "Ad name",
+            "Impressions",
+            "Clicks (all)",
+            "Amount spent (JPY)",
+            "Results",
+        ]
+    ]
+    for d in range(_DAYS):
+        date_iso = _date_for_day(d).isoformat()
+        for ad in _META_ADS:
+            if not _meta_active(ad, d):
+                continue
+            spend = ad.daily_spend
+            clicks = int(round(spend / ad.cpc))
+            impressions = int(round(clicks / ad.ctr))
+            rpc = _meta_rpc_for_day(ad, d)
+            results = round(clicks * rpc, 1)
+            rows.append(
+                [
+                    date_iso,
+                    ad.campaign,
+                    ad.adset,
+                    ad.ad,
+                    impressions,
+                    clicks,
+                    spend,
+                    results,
+                ]
+            )
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# STATE.json
+# ---------------------------------------------------------------------------
+
+
+_GOOGLE_ADS_STATE_CAMPAIGNS = (
+    {
+        "campaign_id": campaign_id("Brand - Exact"),
+        "campaign_name": "Brand - Exact",
+        "status": "ENABLED",
+        "daily_budget": 12000,
+        "campaign_goal": (
+            "Capture branded demand at high efficiency "
+            "(target cost-per-subscription <= JPY 600)."
+        ),
+    },
+    {
+        "campaign_id": campaign_id("Generic - Fitness Apps"),
+        "campaign_name": "Generic - Fitness Apps",
+        "status": "ENABLED",
+        "daily_budget": 40000,
+        "campaign_goal": (
+            "Acquire net-new subscribers in fitness-app category "
+            "(target cost-per-subscription <= JPY 4,500)."
+        ),
+    },
+    {
+        "campaign_id": campaign_id("Generic - Workout Plans"),
+        "campaign_name": "Generic - Workout Plans",
+        "status": "ENABLED",
+        "daily_budget": 35000,
+        "campaign_goal": (
+            "Top-of-funnel workout-plan demand; target "
+            "cost-per-subscription <= JPY 4,500."
+        ),
+    },
+    {
+        "campaign_id": campaign_id("Retargeting - App Visitors"),
+        "campaign_name": "Retargeting - App Visitors",
+        "status": "ENABLED",
+        "daily_budget": 16000,
+        "campaign_goal": (
+            "Recover 30-day site visitors at <= JPY 1,500 " "cost-per-subscription."
+        ),
+    },
+    # *** STRATEGY VIOLATION (rule 1) — appears in STATE because it's
+    # currently ENABLED and consuming budget. mureo's compliance audit
+    # cross-references against the STRATEGY constraint to flag it.
+    {
+        "campaign_id": campaign_id("Competitor Names"),
+        "campaign_name": "Competitor Names",
+        "status": "ENABLED",
+        "daily_budget": 15000,
+        "campaign_goal": (
+            "VIOLATES STRATEGY rule 1 (no competitor-name bidding). "
+            "Launched Day 30 by new manager; never reviewed."
+        ),
+    },
+)
+
+_META_ADS_STATE_CAMPAIGNS = (
+    {
+        "campaign_id": campaign_id("Awareness - Workout Routines"),
+        "campaign_name": "Awareness - Workout Routines",
+        "status": "ENABLED",
+        "daily_budget": 22000,
+        "campaign_goal": "Top-of-funnel awareness in active-lifestyle segment.",
+    },
+    {
+        "campaign_id": campaign_id("Conversion - Subscription"),
+        "campaign_name": "Conversion - Subscription",
+        "status": "ENABLED",
+        "daily_budget": 90000,
+        "campaign_goal": (
+            "Drive paid Subscriptions. Note: optimization target was "
+            "switched on Day 45 to '7-day trial' (VIOLATES STRATEGY rule 2). "
+            "LAL stack expanded to 6 variants on Day 60 (VIOLATES "
+            "STRATEGY rule 3)."
+        ),
+    },
+    {
+        "campaign_id": campaign_id("Retargeting - Cart Abandoners"),
+        "campaign_name": "Retargeting - Cart Abandoners",
+        "status": "ENABLED",
+        "daily_budget": 14000,
+        "campaign_goal": "Re-engage app-installed users who did not subscribe.",
+    },
+)
+
+
+def _action_iso(day: int, hour: int = 10, minute: int = 0) -> str:
+    d = _date_for_day(day)
+    dt = datetime(
+        d.year, d.month, d.day, hour, minute, tzinfo=timezone(timedelta(hours=9))
+    )
+    return dt.isoformat(timespec="seconds")
+
+
+# action_log: only routine entries from BEFORE the new manager joined
+# Day 30. The silence after Day 30 — three concurrent strategy
+# violations with zero log entries — is itself the diagnostic signal,
+# because STRATEGY says all actions must be logged.
+_ACTION_LOG = (
+    {
+        "timestamp": _action_iso(8, 9, 0),
+        "action": "Increased Generic - Fitness Apps daily_budget by +15%",
+        "platform": "google_ads",
+        "campaign_id": campaign_id("Generic - Fitness Apps"),
+        "summary": (
+            "Routine seasonality bump for Q1 New Year fitness peak. "
+            "(Manual action — pre-mureo, pre-new-manager.)"
+        ),
+        "metrics_at_action": {
+            "google_blended_cost_per_subscription": 4100,
+            "meta_blended_cost_per_subscription": 3800,
+        },
+        "observation_due": _date_for_day(22).isoformat(),
+    },
+    {
+        "timestamp": _action_iso(20, 11, 30),
+        "action": "Paused 2 underperforming creative variants on Awareness - Workout Routines",
+        "platform": "meta_ads",
+        "campaign_id": campaign_id("Awareness - Workout Routines"),
+        "summary": (
+            "Routine creative cleanup. (Manual action — pre-mureo, " "pre-new-manager.)"
+        ),
+        "metrics_at_action": {
+            "meta_awareness_results_per_day": 36,
+            "meta_blended_cost_per_subscription": 3700,
+        },
+        "observation_due": _date_for_day(34).isoformat(),
+    },
+    {
+        "timestamp": _action_iso(28, 14, 0),
+        "action": "Approved hire: new growth manager (start date Day 30)",
+        "platform": "meta_ads",
+        "campaign_id": None,
+        "summary": (
+            "New manager onboarded with admin access on Day 30. Briefed on "
+            "STRATEGY.md including rules 1-3 (no competitor bidding, "
+            "Subscribed-only optimization, LAL cap 3). Subsequent campaign "
+            "changes by this user must be reflected in action_log per "
+            "STRATEGY policy. (Manual action — pre-mureo. As of "
+            "today, action_log shows ZERO entries since Day 30.)"
+        ),
+        "metrics_at_action": {
+            "headcount_growth_team": 3,
+        },
+        "observation_due": _date_for_day(89).isoformat(),
+    },
+)
+
+
+_LAST_SYNCED_AT = datetime.combine(
+    _END_DATE, datetime.min.time(), tzinfo=timezone.utc
+).isoformat(timespec="seconds")
+
+
+_STATE_DOC: Mapping[str, object] = {
+    "version": "2",
+    "last_synced_at": _LAST_SYNCED_AT,
+    "platforms": {
+        "google_ads": {
+            "account_id": "demo-pulsefit-google-ads",
+            "campaigns": list(_GOOGLE_ADS_STATE_CAMPAIGNS),
+        },
+        "meta_ads": {
+            "account_id": "demo-pulsefit-meta-ads",
+            "campaigns": list(_META_ADS_STATE_CAMPAIGNS),
+        },
+    },
+    "action_log": list(_ACTION_LOG),
+}
+
+
+# ---------------------------------------------------------------------------
+# STRATEGY.md — explicit numeric goals + the three rules being violated.
+# ---------------------------------------------------------------------------
+
+_STRATEGY_MD = """# STRATEGY — PulseFit (demo: Strategy Drift)
+
+> Synthetic fitness-app subscription scenario shipped with `mureo demo init --scenario strategy-drift`.
+> Replace with your real strategy when you switch to a live account.
+
+## Business
+- **Brand:** PulseFit
+- **Vertical:** Subscription fitness app (workout plans + tracking)
+- **ICP:** JP 25-44, urban, fitness-curious, willing to pay JPY 1,200/month
+- **Subscription LTV:** ~JPY 14,400 (12-month median tenure)
+- **Trial-to-paid rate (industry-standard 7-day trial):** ~12%
+- **Total ad budget:** ~JPY 5M / month (Google + Meta)
+
+## Quarterly goals
+- **Cost-per-subscription <= JPY 4,500** blended across Google + Meta
+- **Net new paid subscriptions >= 800 / month**
+- **Brand-search CTR >= 18%** (brand health proxy)
+- **Trial-to-paid rate >= 12%** (quality floor)
+
+## Channel mix
+- **Google Ads:** Brand - Exact, Generic - Fitness Apps, Generic - Workout Plans, Retargeting - App Visitors
+- **Meta Ads:** Awareness Workout Routines, Conversion Subscription (LAL 1/2/5 + Custom), Retargeting Cart Abandoners
+
+## Operation Mode
+**MAINTAIN** — Q1 peak has passed. No major launches this quarter. Steady-state efficiency focus.
+
+## Constraints
+
+These three rules are non-negotiable. Each is codified after a past
+incident; violations require explicit Operation Mode change + leadership
+approval.
+
+1. **No competitor-name bidding** on either platform. Past attempt cost
+   JPY 600K/quarter and produced 8 subscriptions at JPY 75K CPS — 16x
+   worse than baseline. Industry policy is now to compete on category
+   intent, not on rivals' brand names.
+2. **Conversion campaigns optimize for "Subscribed" (paid signup),
+   never for "Started trial".** Trial-volume optimization trains the
+   ad platforms toward shallow signups whose downstream trial-to-paid
+   rate falls below the 12% quality floor. Lifetime value is too
+   sensitive to allow the swap.
+3. **Meta Lookalike stack capped at 3 active variants**, and the
+   variants must be 1%, 2%, 5% (or smaller). Past stacking of LAL 7%
+   and 10% caused audience overlap, frequency above 8x, and CTR
+   collapse within 14 days.
+
+## Action-logging policy
+
+Every change to STATE (campaign create / pause / budget / optimization
+target / audience set) must be recorded in ``action_log`` with a
+``summary``, ``metrics_at_action``, and ``observation_due``. Empty
+action_log around active changes is a process violation, not just a
+data-quality issue.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Public scenario instance
+# ---------------------------------------------------------------------------
+
+
+_SHEET_ROWS: Mapping[str, Sequence[Sequence[object]]] = {
+    "campaigns": _build_google_campaigns_rows(),
+    "ad_groups": _build_google_ad_groups_rows(),
+    "search_terms": _build_google_search_terms_rows(),
+    "keywords": _build_google_keywords_rows(),
+    "meta_ads": _build_meta_ads_rows(),
+}
+
+
+SCENARIO = Scenario(
+    name=_NAME,
+    title=_TITLE,
+    blurb=_BLURB,
+    days=_DAYS,
+    end_date=_END_DATE,
+    brand=_BRAND,
+    sheet_rows=_SHEET_ROWS,
+    state_doc=_STATE_DOC,
+    strategy_md=_STRATEGY_MD,
+    # Empty action_log around the new manager's changes IS the
+    # diagnostic signal here, so this scenario opts out of the
+    # contract test's ">=3 action_log entries" floor.
+    requires_action_log=False,
+)

--- a/tests/test_demo_scenarios.py
+++ b/tests/test_demo_scenarios.py
@@ -162,6 +162,73 @@ def test_scenario_state_campaign_names_appear_in_bundle(scenario) -> None:
         )
 
 
+def test_scenario_has_minimum_data_breadth(scenario) -> None:
+    """Each scenario must carry enough data for every workflow skill.
+
+    Without these floors, ``/search-term-cleanup`` could legitimately
+    say "nothing to clean up", ``/budget-rebalance`` could see one
+    campaign and decline to act, etc. The numbers are picked so that
+    every skill in mureo's catalog sees enough data to reach a
+    non-trivial conclusion.
+    """
+    rows = scenario.sheet_rows
+
+    # Header is always row 0; subtract it.
+    n_campaigns_unique = len({row[1] for row in rows["campaigns"][1:]})
+    n_ad_groups_unique = len({(row[1], row[2]) for row in rows["ad_groups"][1:]})
+    n_search_terms = len(rows["search_terms"]) - 1
+    n_keywords = len(rows["keywords"]) - 1
+    n_meta_ads_unique = len({row[3] for row in rows["meta_ads"][1:]})
+
+    assert n_campaigns_unique >= 4, (
+        f"{scenario.name}: needs >=4 Google campaigns "
+        f"for /budget-rebalance to have signal (have {n_campaigns_unique})"
+    )
+    assert (
+        n_ad_groups_unique >= 6
+    ), f"{scenario.name}: needs >=6 ad groups (have {n_ad_groups_unique})"
+    assert n_search_terms >= 15, (
+        f"{scenario.name}: needs >=15 search terms for "
+        f"/search-term-cleanup outlier detection (have {n_search_terms})"
+    )
+    assert n_keywords >= 8, f"{scenario.name}: needs >=8 keywords (have {n_keywords})"
+    assert n_meta_ads_unique >= 4, (
+        f"{scenario.name}: needs >=4 unique Meta ads for "
+        f"/creative-refresh to have signal (have {n_meta_ads_unique})"
+    )
+
+    n_action_log = len(scenario.state_doc.get("action_log", []))
+    # Scenarios that opt out via ``requires_action_log=False`` do so
+    # because a sparse / absent action_log is itself part of their
+    # diagnostic signal (see ``Scenario.requires_action_log`` docs).
+    if scenario.requires_action_log:
+        assert n_action_log >= 3, (
+            f"{scenario.name}: needs >=3 action_log entries so "
+            f"/learn and /sync-state have history to evaluate "
+            f"(have {n_action_log})"
+        )
+
+
+def test_scenario_strategy_md_has_required_sections(scenario) -> None:
+    """STRATEGY.md must include the load-bearing sections workflow skills read.
+
+    ``/goal-review`` reads numeric goals; ``/competitive-scan`` and
+    ``/daily-check`` read constraints; multiple commands branch on
+    Operation Mode. A scenario missing any of these silently
+    underperforms in the matching skill.
+    """
+    text = scenario.strategy_md.lower()
+    assert (
+        "goal" in text or "目標" in text
+    ), f"{scenario.name}: STRATEGY.md missing Goals section"
+    assert (
+        "constraint" in text or "制約" in text
+    ), f"{scenario.name}: STRATEGY.md missing Constraints section"
+    assert (
+        "operation mode" in text or "運用モード" in text
+    ), f"{scenario.name}: STRATEGY.md missing Operation Mode"
+
+
 def test_byod_synthetic_id_helpers_consistent() -> None:
     """The Google and Meta adapters' ``_synthetic_id`` must agree.
 


### PR DESCRIPTION
## Summary

Stage 2 of the multi-scenario demo plan (#69, #70, #71 were Stage 0 and Stage 1).

Adds **3 new scenarios** with distinct narrative angles so users can demo mureo's range across multiple skill workflows, not just `/daily-check`.

| Scenario | Angle | Hero skills |
|---|---|---|
| seasonality-trap (existing) | Tracking diagnosis | `/daily-check`, `/learn` |
| **halo-effect** (new) | Cross-platform halo, counter-intuitive | `/daily-check` time-series, `/budget-rebalance` |
| **hidden-champion** (new) | Outlier discovery, optimistic | `/search-term-cleanup`, `/budget-rebalance` |
| **strategy-drift** (new) | STRATEGY-vs-STATE compliance audit | `/competitive-scan`, `/weekly-report`, `/goal-review` |

## The 3 stories

### 1. Halo Effect — SkyRoof local roofing
Owner believed Google Search was the workhorse. Day 50-54 he paused Meta retargeting "as a controlled test". Day 53-57 Google Brand-Exact volume dropped 40% (3-day lag), recovered Day 58. mureo connects the lagged dip to the action_log pause: Meta retargeting was upstream of the brand searches he was crediting to Google. Recommendation: do NOT cut Meta retargeting.

### 2. Hidden Champion — PulseGrid B2B SaaS observability
Search term `kubernetes monitoring open source` has CVR ~18% (vs ad-group average ~4%) but is throttled by the ad group's budget cap, producing only ~5 clicks/day. 90 days of routine optimization actions in action_log; none touched it. mureo's outlier detection isolates the term and projects +104 trial signups/month if promoted to its own campaign with 5x budget.

### 3. Strategy Drift — PulseFit fitness app
New manager joined Day 30 and silently violated 3 explicit STRATEGY rules: launched a Competitor Names campaign (Day 30), switched Meta Conversion campaigns from "Subscribed" to "7-day trial" optimization (Day 45), expanded LAL stack from 3 to 6 variants (Day 60). action_log around these changes is empty — that silence is itself part of the diagnostic signal. mureo's compliance audit reads each STRATEGY constraint, walks STATE.json campaigns, produces a violation list with start dates and JPY impact.

## Code review address

`python-reviewer` flagged 1 HIGH and 3 MEDIUM issues — all addressed:

1. **HIGH** Hidden Champion volume framing — docstring reworded to be precise about "~1 trial/day today, +104/month at 5x budget" rather than implying "5 trials/day"
2. **MEDIUM** Strategy Drift competitor search-term coverage was 26% of campaign-row clicks (vs Stage 1's ~93%) — bumped 4x to ~107% so `/search-term-cleanup` does not flag the campaign as missing query data
3. **MEDIUM** `requires_action_log` field added to `Scenario` dataclass — replaces magic substring exemption for scenarios where empty action_log IS the diagnostic signal
4. **MEDIUM** Strategy Drift docstring acknowledges rule 2 (optimization-target swap) detection relies on `campaign_goal` text in STATE.json, since the conversion-event label is not a CSV column

## New contract tests

Per-scenario parametrized assertions:
- `test_scenario_has_minimum_data_breadth` — at-least 4 campaigns, 6 ad groups, 15 search terms, 8 keywords, 4 unique Meta ads, 3 action_log entries (gated by `requires_action_log`)
- `test_scenario_strategy_md_has_required_sections` — Goals + Constraints + Operation Mode

These run automatically on every registered scenario, so future Stage 3+ scenarios get the same coverage with no extra test code.

## Files

- `mureo/demo/scenarios/_base.py` — Scenario gains `requires_action_log: bool = True` field
- `mureo/demo/scenarios/halo_effect.py` (new)
- `mureo/demo/scenarios/hidden_champion.py` (new)
- `mureo/demo/scenarios/strategy_drift.py` (new)
- `mureo/demo/scenarios/__init__.py` — registers 3 new scenarios
- `mureo/demo/scenarios/seasonality_trap.py` — +1 search term + 2 keywords to satisfy new floors
- `tests/test_demo_scenarios.py` — adds 2 new contract tests, replaces substring exemption with explicit field check

## Data fidelity verification

Verified by direct Python REPL execution against the row-builders:
- Halo Effect: Brand-Exact 50 clicks/day Day 49-52 → 30 clicks/day Day 53-57 → 50 clicks/day Day 58. Meta Retargeting omitted Day 50-54.
- Hidden Champion: 78/432 = 18.06% (HIDDEN CHAMPION); other Open Source Stack terms 25/630 = 3.97%, 40/990 = 4.04%. Outlier unambiguous.
- Strategy Drift: Competitor Names 60 active days starting 2026-03-01. LAL stack: 3 baseline ads (90 days) + 3 violation ads (30 days) + 2 unrelated = 8 unique Meta ads.

## Test plan

- [x] `pytest tests/test_demo_scenarios.py tests/test_demo_init.py` — 64/64 green
- [x] `pytest tests/test_cli.py tests/test_byod.py tests/test_byod_bundle.py tests/test_cli_rollback.py tests/test_setup_cmd.py` — 101/101 green
- [x] `ruff check`, `black --check`, `mypy --strict` — all clean
- [ ] Manual smoke per scenario via `mureo demo init --scenario <name>`

## Try it locally

```bash
mureo demo list                                            # see all 4 scenarios
mureo demo init /tmp/demo-halo --scenario halo-effect
mureo demo init /tmp/demo-champ --scenario hidden-champion --force
mureo demo init /tmp/demo-drift --scenario strategy-drift --force
```

## Out of scope

- Registry hardening against per-scenario import failures (Stage 1 review HIGH #4) — small follow-up
- Skill-side adjustments to surface scenario-specific findings (data in place; skill output quality is next to validate)
