### PR TITLE
feat(mcp): expose STRATEGY.md / STATE.json via 5 new MCP tools

### DIFF
--- a/mureo/mcp/_handlers_mureo_context.py
+++ b/mureo/mcp/_handlers_mureo_context.py
@@ -1,0 +1,173 @@
+"""MCP handlers for mureo's STRATEGY.md / STATE.json surface.
+
+These handlers expose the context layer as MCP tools so that hosts
+without direct filesystem access (Claude Desktop chat, claude.ai web,
+remote MCP connectors) can read and update mureo's strategic context.
+
+All file paths are resolved against the MCP server's current working
+directory and refused if they escape it — symmetric with the rollback
+surface's ``_resolve_state_file`` guard. A prompt-injected agent must
+not be able to point mureo at an attacker-crafted file elsewhere on
+the filesystem.
+
+Atomic write semantics come from ``mureo.context.state._atomic_write``
+and the equivalent path in ``context.strategy``: write to a temp file
+in the same directory, then ``os.replace`` over the target. A failure
+mid-flight leaves the original intact.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from mureo.context.errors import ContextFileError
+from mureo.context.models import (
+    ActionLogEntry,
+    CampaignSnapshot,
+    StateDocument,
+)
+from mureo.context.state import (
+    append_action_log,
+    read_state_file,
+    render_state,
+    upsert_campaign,
+)
+from mureo.context.strategy import (
+    parse_strategy,
+    write_strategy_file,
+)
+from mureo.mcp._helpers import _json_result, _opt, _require
+
+if TYPE_CHECKING:
+    from mcp.types import TextContent
+
+
+def _resolve_path(arguments: dict[str, Any], default_name: str) -> Path:
+    """Resolve a user-supplied path, refusing anything outside cwd.
+
+    The MCP caller is untrusted (a prompt-injected agent could point at
+    an attacker-crafted file elsewhere on the filesystem). We require
+    the argument to resolve to a path inside the current working
+    directory so the agent cannot smuggle in a rogue STRATEGY.md or
+    STATE.json. ``Path.resolve()`` follows symlinks, so a STRATEGY.md
+    inside cwd that symlinks to /etc/passwd resolves to the target and
+    is correctly refused. Mirrors ``_handlers_rollback._resolve_state_file``.
+    """
+    raw = _opt(arguments, "path", default_name)
+    candidate = Path(raw)
+    cwd = Path.cwd().resolve()
+    resolved = (cwd / candidate if not candidate.is_absolute() else candidate).resolve()
+    try:
+        resolved.relative_to(cwd)
+    except ValueError as exc:
+        raise ValueError(
+            f"Refusing to read/write outside cwd: {resolved} is not inside {cwd}"
+        ) from exc
+    return resolved
+
+
+# ---------------------------------------------------------------------------
+# STRATEGY.md
+# ---------------------------------------------------------------------------
+
+
+async def handle_strategy_get(arguments: dict[str, Any]) -> list[TextContent]:
+    path = _resolve_path(arguments, "STRATEGY.md")
+    if not path.exists():
+        return _json_result({"markdown": "", "exists": False, "path": str(path)})
+    text = path.read_text(encoding="utf-8")
+    return _json_result({"markdown": text, "exists": True, "path": str(path)})
+
+
+async def handle_strategy_set(arguments: dict[str, Any]) -> list[TextContent]:
+    markdown = _require(arguments, "markdown")
+    path = _resolve_path(arguments, "STRATEGY.md")
+    # Round-trip through parse so callers can't write a STRATEGY.md
+    # whose subsequent parse_strategy() call breaks downstream skills.
+    entries = parse_strategy(markdown)
+    write_strategy_file(path, entries)
+    rewritten = path.read_text(encoding="utf-8")
+    return _json_result(
+        {"markdown": rewritten, "entries_count": len(entries), "path": str(path)}
+    )
+
+
+# ---------------------------------------------------------------------------
+# STATE.json
+# ---------------------------------------------------------------------------
+
+
+def _state_to_dict(doc: StateDocument) -> dict[str, Any]:
+    """Serialize a StateDocument back to the dict shape callers expect."""
+    import json as _json
+
+    parsed: dict[str, Any] = _json.loads(render_state(doc))
+    return parsed
+
+
+async def handle_state_get(arguments: dict[str, Any]) -> list[TextContent]:
+    path = _resolve_path(arguments, "STATE.json")
+    # read_state_file already returns an empty default StateDocument when
+    # the file is absent; round-trip through render_state to keep the
+    # missing-file and present-file branches in lockstep.
+    doc = read_state_file(path)
+    return _json_result(_state_to_dict(doc))
+
+
+async def handle_state_action_log_append(
+    arguments: dict[str, Any],
+) -> list[TextContent]:
+    raw = _require(arguments, "entry")
+    if not isinstance(raw, dict):
+        raise ValueError("entry must be an object")
+    # Required per ActionLogEntry contract.
+    timestamp = _require(raw, "timestamp")
+    action = _require(raw, "action")
+    platform = _require(raw, "platform")
+    entry = ActionLogEntry(
+        timestamp=timestamp,
+        action=action,
+        platform=platform,
+        campaign_id=raw.get("campaign_id"),
+        summary=raw.get("summary"),
+        command=raw.get("command"),
+        metrics_at_action=raw.get("metrics_at_action"),
+        observation_due=raw.get("observation_due"),
+        reversible_params=raw.get("reversible_params"),
+        rollback_of=raw.get("rollback_of"),
+    )
+    path = _resolve_path(arguments, "STATE.json")
+    doc = append_action_log(path, entry)
+    return _json_result(_state_to_dict(doc))
+
+
+async def handle_state_upsert_campaign(
+    arguments: dict[str, Any],
+) -> list[TextContent]:
+    raw = _require(arguments, "campaign")
+    if not isinstance(raw, dict):
+        raise ValueError("campaign must be an object")
+    device_targeting = (
+        tuple(raw["device_targeting"]) if raw.get("device_targeting") else None
+    )
+    campaign = CampaignSnapshot(
+        campaign_id=_require(raw, "campaign_id"),
+        campaign_name=_require(raw, "campaign_name"),
+        status=_require(raw, "status"),
+        bidding_strategy_type=raw.get("bidding_strategy_type"),
+        bidding_details=raw.get("bidding_details"),
+        daily_budget=raw.get("daily_budget"),
+        device_targeting=device_targeting,
+        campaign_goal=raw.get("campaign_goal"),
+        notes=raw.get("notes"),
+    )
+    path = _resolve_path(arguments, "STATE.json")
+    try:
+        doc = upsert_campaign(path, campaign)
+    except ContextFileError as exc:
+        # Surface as ValueError so the MCP dispatcher's standard error
+        # path translates this into a clean tool-error response rather
+        # than a 500-style server error.
+        raise ValueError(str(exc)) from exc
+    return _json_result(_state_to_dict(doc))

--- a/mureo/mcp/server.py
+++ b/mureo/mcp/server.py
@@ -24,6 +24,8 @@ from mureo.mcp.tools_google_ads import TOOLS as GOOGLE_ADS_TOOLS
 from mureo.mcp.tools_google_ads import handle_tool as handle_google_ads_tool
 from mureo.mcp.tools_meta_ads import TOOLS as META_ADS_TOOLS
 from mureo.mcp.tools_meta_ads import handle_tool as handle_meta_ads_tool
+from mureo.mcp.tools_mureo_context import TOOLS as MUREO_CONTEXT_TOOLS
+from mureo.mcp.tools_mureo_context import handle_tool as handle_mureo_context_tool
 from mureo.mcp.tools_rollback import TOOLS as ROLLBACK_TOOLS
 from mureo.mcp.tools_rollback import handle_tool as handle_rollback_tool
 from mureo.mcp.tools_search_console import TOOLS as SEARCH_CONSOLE_TOOLS
@@ -42,12 +44,14 @@ _ALL_TOOLS: list[Tool] = [
     *SEARCH_CONSOLE_TOOLS,
     *ROLLBACK_TOOLS,
     *ANALYSIS_TOOLS,
+    *MUREO_CONTEXT_TOOLS,
 ]
 _GOOGLE_ADS_NAMES: frozenset[str] = frozenset(t.name for t in GOOGLE_ADS_TOOLS)
 _META_ADS_NAMES: frozenset[str] = frozenset(t.name for t in META_ADS_TOOLS)
 _SEARCH_CONSOLE_NAMES: frozenset[str] = frozenset(t.name for t in SEARCH_CONSOLE_TOOLS)
 _ROLLBACK_NAMES: frozenset[str] = frozenset(t.name for t in ROLLBACK_TOOLS)
 _ANALYSIS_NAMES: frozenset[str] = frozenset(t.name for t in ANALYSIS_TOOLS)
+_MUREO_CONTEXT_NAMES: frozenset[str] = frozenset(t.name for t in MUREO_CONTEXT_TOOLS)
 
 
 # ---------------------------------------------------------------------------
@@ -76,6 +80,8 @@ async def handle_call_tool(name: str, arguments: dict[str, Any]) -> list[Any]:
         return await handle_rollback_tool(name, arguments)
     if name in _ANALYSIS_NAMES:
         return await handle_analysis_tool(name, arguments)
+    if name in _MUREO_CONTEXT_NAMES:
+        return await handle_mureo_context_tool(name, arguments)
     raise ValueError(f"Unknown tool: {name}")
 
 

--- a/mureo/mcp/tools_mureo_context.py
+++ b/mureo/mcp/tools_mureo_context.py
@@ -1,0 +1,192 @@
+"""mureo's STRATEGY.md / STATE.json MCP tool surface.
+
+Five tools that expose mureo's context layer over MCP, so any MCP host
+(Claude Desktop chat, claude.ai web, Codex/Cursor, …) can read and
+update STRATEGY.md / STATE.json without direct filesystem access.
+
+The Claude Code path keeps working through its built-in ``Read`` tool;
+these MCP tools are additive — they unlock the same capability for
+hosts that lack ``Read``. Workflow skills can be migrated to call
+these tools (Phase 2/3) so a single skill prompt runs everywhere.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from mcp.types import Tool
+
+from mureo.mcp._handlers_mureo_context import (
+    handle_state_action_log_append,
+    handle_state_get,
+    handle_state_upsert_campaign,
+    handle_strategy_get,
+    handle_strategy_set,
+)
+
+if TYPE_CHECKING:
+    from mcp.types import TextContent
+
+
+_PATH_PROPERTY = {
+    "type": "string",
+    "description": (
+        "Optional path to the file. Defaults to STRATEGY.md / STATE.json "
+        "in the MCP server's current working directory. Paths outside "
+        "cwd are refused."
+    ),
+}
+
+
+_ACTION_LOG_ENTRY_PROPERTY = {
+    "type": "object",
+    "description": (
+        "An action_log entry. Required: timestamp (ISO 8601), action "
+        "(short description), platform (google_ads / meta_ads / etc.). "
+        "Optional: campaign_id, summary, command, metrics_at_action, "
+        "observation_due, reversible_params, rollback_of."
+    ),
+    "properties": {
+        "timestamp": {"type": "string"},
+        "action": {"type": "string"},
+        "platform": {"type": "string"},
+        "campaign_id": {"type": "string"},
+        "summary": {"type": "string"},
+        "command": {"type": "string"},
+        "metrics_at_action": {"type": "object"},
+        "observation_due": {"type": "string"},
+        "reversible_params": {"type": "object"},
+        "rollback_of": {"type": "integer"},
+    },
+    "required": ["timestamp", "action", "platform"],
+}
+
+
+_CAMPAIGN_PROPERTY = {
+    "type": "object",
+    "description": (
+        "A CampaignSnapshot for STATE.json. Required: campaign_id, "
+        "campaign_name, status. Optional fields mirror the snapshot "
+        "schema in docs/strategy-context.md."
+    ),
+    "properties": {
+        "campaign_id": {"type": "string"},
+        "campaign_name": {"type": "string"},
+        "status": {"type": "string"},
+        "bidding_strategy_type": {"type": "string"},
+        "bidding_details": {"type": "object"},
+        "daily_budget": {"type": "number"},
+        "device_targeting": {"type": "array"},
+        "campaign_goal": {"type": "string"},
+        "notes": {"type": "string"},
+    },
+    "required": ["campaign_id", "campaign_name", "status"],
+}
+
+
+TOOLS: list[Tool] = [
+    Tool(
+        name="mureo_strategy_get",
+        description=(
+            "Read STRATEGY.md and return its raw markdown text plus an "
+            "exists flag. Returns empty markdown when the file is "
+            "absent (skills should treat that as 'no strategy yet', "
+            "not as an error). Use this when the host has no direct "
+            "filesystem access (Claude Desktop chat, web, remote MCP)."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {"path": _PATH_PROPERTY},
+        },
+    ),
+    Tool(
+        name="mureo_strategy_set",
+        description=(
+            "Atomically replace STRATEGY.md with the provided markdown. "
+            "The content is parsed via parse_strategy() before writing "
+            "to ensure it is well-formed; a malformed input raises "
+            "rather than corrupts the file. Use this to update goals, "
+            "constraints, or operation mode from a chat-only host."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "markdown": {
+                    "type": "string",
+                    "description": "The full new content of STRATEGY.md.",
+                },
+                "path": _PATH_PROPERTY,
+            },
+            "required": ["markdown"],
+        },
+    ),
+    Tool(
+        name="mureo_state_get",
+        description=(
+            "Read STATE.json and return its parsed v2 document: "
+            "version, last_synced_at, platforms (per-platform "
+            "campaigns), legacy v1 campaigns, and action_log. Returns "
+            "an empty default doc when the file is absent."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {"path": _PATH_PROPERTY},
+        },
+    ),
+    Tool(
+        name="mureo_state_action_log_append",
+        description=(
+            "Atomically append a single action_log entry to STATE.json. "
+            "Use this whenever a workflow takes an action that should "
+            "be evaluable later (budget changes, campaign pauses, "
+            "negative-keyword adds). Returns the updated state document."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "entry": _ACTION_LOG_ENTRY_PROPERTY,
+                "path": _PATH_PROPERTY,
+            },
+            "required": ["entry"],
+        },
+    ),
+    Tool(
+        name="mureo_state_upsert_campaign",
+        description=(
+            "Atomically upsert a CampaignSnapshot into STATE.json (root "
+            "campaigns array). Use this to keep STATE.json in sync with "
+            "campaign metadata changes the agent observes via vendor "
+            "MCPs or BYOD imports."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "campaign": _CAMPAIGN_PROPERTY,
+                "path": _PATH_PROPERTY,
+            },
+            "required": ["campaign"],
+        },
+    ),
+]
+
+
+_HANDLERS = {
+    "mureo_strategy_get": handle_strategy_get,
+    "mureo_strategy_set": handle_strategy_set,
+    "mureo_state_get": handle_state_get,
+    "mureo_state_action_log_append": handle_state_action_log_append,
+    "mureo_state_upsert_campaign": handle_state_upsert_campaign,
+}
+
+
+async def handle_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
+    """Dispatch a tool call to its handler.
+
+    Raises:
+        ValueError: when the tool name is unknown or required parameters
+            are missing.
+    """
+    handler = _HANDLERS.get(name)
+    if handler is None:
+        raise ValueError(f"Unknown tool: {name}")
+    return await handler(arguments)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -42,10 +42,10 @@ class TestListTools:
 
     async def test_list_tools_returns_all_tools(self) -> None:
         """list_tools は全ツール（Google Ads 83 + Meta Ads 77 + Search Console 10
-        + Rollback 2 + Analysis 1 = 173）を返す"""
+        + Rollback 2 + Analysis 1 + Mureo Context 5 = 178）を返す"""
         mod = _import_server_module()
         tools = await mod.handle_list_tools()
-        assert len(tools) == 173
+        assert len(tools) == 178
 
     async def test_list_tools_contains_google_and_meta(self) -> None:
         """Google Ads と Meta Ads のツールが含まれること"""

--- a/tests/test_mcp_tool_name_spec.py
+++ b/tests/test_mcp_tool_name_spec.py
@@ -23,6 +23,7 @@ def _all_registered_tools():
         tools_analysis,
         tools_google_ads,
         tools_meta_ads,
+        tools_mureo_context,
         tools_rollback,
         tools_search_console,
     )
@@ -32,6 +33,7 @@ def _all_registered_tools():
         tools_analysis,
         tools_google_ads,
         tools_meta_ads,
+        tools_mureo_context,
         tools_rollback,
         tools_search_console,
     ):

--- a/tests/test_mcp_tools_mureo_context.py
+++ b/tests/test_mcp_tools_mureo_context.py
@@ -1,0 +1,276 @@
+"""Tests for mureo's STRATEGY.md / STATE.json MCP tool surface.
+
+These tools expose mureo's context layer (STRATEGY.md and STATE.json)
+to MCP hosts that lack direct filesystem access — Claude Desktop chat,
+claude.ai web, Codex/Cursor over remote MCP, etc. Without them, those
+hosts can't read mureo's strategic context, which forces the user to
+paste files into chat manually.
+
+Coverage:
+  - mureo_strategy_get        — read STRATEGY.md as markdown text
+  - mureo_strategy_set        — replace STRATEGY.md (atomic write)
+  - mureo_state_get           — read STATE.json as a dict
+  - mureo_state_action_log_append — atomic action_log append
+  - mureo_state_upsert_campaign   — atomic campaign snapshot upsert
+  - path traversal refusal (security gate symmetric with rollback)
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def cwd_to_tmp(tmp_path, monkeypatch):
+    """Run each test with cwd = tmp_path so STRATEGY.md/STATE.json land
+    inside the sandbox by default."""
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+def _import_tools():
+    from mureo.mcp import tools_mureo_context
+
+    return tools_mureo_context
+
+
+# ---------------------------------------------------------------------------
+# Tool definitions
+# ---------------------------------------------------------------------------
+
+
+def test_tools_module_exports_five_tools() -> None:
+    mod = _import_tools()
+    assert len(mod.TOOLS) == 5
+    expected = {
+        "mureo_strategy_get",
+        "mureo_strategy_set",
+        "mureo_state_get",
+        "mureo_state_action_log_append",
+        "mureo_state_upsert_campaign",
+    }
+    assert {t.name for t in mod.TOOLS} == expected
+
+
+def test_tools_have_input_schema() -> None:
+    mod = _import_tools()
+    for tool in mod.TOOLS:
+        assert tool.inputSchema["type"] == "object"
+        assert "properties" in tool.inputSchema
+
+
+# ---------------------------------------------------------------------------
+# mureo_strategy_get / set
+# ---------------------------------------------------------------------------
+
+
+async def test_strategy_get_returns_file_text(cwd_to_tmp) -> None:
+    (cwd_to_tmp / "STRATEGY.md").write_text(
+        "# STRATEGY\n\n## Goals\n- Hit JPY 4500 CPA\n", encoding="utf-8"
+    )
+    mod = _import_tools()
+    result = await mod.handle_tool("mureo_strategy_get", {})
+    payload = json.loads(result[0].text)
+    assert "# STRATEGY" in payload["markdown"]
+    assert "JPY 4500" in payload["markdown"]
+
+
+async def test_strategy_get_missing_file_returns_empty(cwd_to_tmp) -> None:
+    """Missing STRATEGY.md is not an error — we return empty markdown.
+
+    Many workflow skills run before the user has set up STRATEGY.md;
+    they should see "no strategy yet" rather than a hard failure.
+    """
+    mod = _import_tools()
+    result = await mod.handle_tool("mureo_strategy_get", {})
+    payload = json.loads(result[0].text)
+    assert payload["markdown"] == ""
+    assert payload["exists"] is False
+
+
+async def test_strategy_set_writes_file(cwd_to_tmp) -> None:
+    mod = _import_tools()
+    new_md = (
+        "# STRATEGY\n\n## Operation Mode\nReview-only — no autonomous spend changes.\n"
+    )
+    await mod.handle_tool("mureo_strategy_set", {"markdown": new_md})
+    written = (cwd_to_tmp / "STRATEGY.md").read_text(encoding="utf-8")
+    assert "Review-only" in written
+
+
+async def test_strategy_set_is_atomic(cwd_to_tmp, monkeypatch) -> None:
+    """A failed write mid-flight must not leave a half-written file."""
+    (cwd_to_tmp / "STRATEGY.md").write_text("# Original\n", encoding="utf-8")
+    mod = _import_tools()
+
+    def fail_replace(*args, **kwargs):
+        raise OSError("simulated rename failure")
+
+    monkeypatch.setattr("os.replace", fail_replace)
+    with pytest.raises(OSError, match="simulated rename failure"):
+        await mod.handle_tool("mureo_strategy_set", {"markdown": "# Broken\n"})
+
+    # Reading does not call os.replace, so the patched failure stays
+    # active without affecting this assertion. The original file must
+    # be intact because the failed os.replace never overwrote it.
+    assert (cwd_to_tmp / "STRATEGY.md").read_text(encoding="utf-8") == "# Original\n"
+
+
+# ---------------------------------------------------------------------------
+# mureo_state_get
+# ---------------------------------------------------------------------------
+
+
+async def test_state_get_returns_parsed_doc(cwd_to_tmp) -> None:
+    state = {
+        "version": "2",
+        "last_synced_at": "2026-04-29T00:00:00+00:00",
+        "platforms": {
+            "google_ads": {
+                "account_id": "demo",
+                "campaigns": [
+                    {
+                        "campaign_id": "camp_abc",
+                        "campaign_name": "Brand",
+                        "status": "ENABLED",
+                    }
+                ],
+            }
+        },
+        "action_log": [],
+    }
+    (cwd_to_tmp / "STATE.json").write_text(json.dumps(state), encoding="utf-8")
+    mod = _import_tools()
+    result = await mod.handle_tool("mureo_state_get", {})
+    payload = json.loads(result[0].text)
+    assert payload["version"] == "2"
+    assert "google_ads" in payload["platforms"]
+    assert (
+        payload["platforms"]["google_ads"]["campaigns"][0]["campaign_id"] == "camp_abc"
+    )
+
+
+async def test_state_get_missing_file_returns_default(cwd_to_tmp) -> None:
+    mod = _import_tools()
+    result = await mod.handle_tool("mureo_state_get", {})
+    payload = json.loads(result[0].text)
+    assert payload["version"] in ("1", "2")
+    assert payload["action_log"] == []
+
+
+# ---------------------------------------------------------------------------
+# mureo_state_action_log_append
+# ---------------------------------------------------------------------------
+
+
+async def test_action_log_append_writes_entry(cwd_to_tmp) -> None:
+    initial = {
+        "version": "2",
+        "platforms": {},
+        "action_log": [],
+    }
+    (cwd_to_tmp / "STATE.json").write_text(json.dumps(initial), encoding="utf-8")
+    mod = _import_tools()
+    entry = {
+        "timestamp": "2026-04-29T10:00:00+09:00",
+        "action": "Increased budget +20%",
+        "platform": "google_ads",
+        "campaign_id": "camp_abc",
+        "summary": "Test entry",
+    }
+    result = await mod.handle_tool("mureo_state_action_log_append", {"entry": entry})
+    payload = json.loads(result[0].text)
+    assert len(payload["action_log"]) == 1
+    assert payload["action_log"][0]["action"] == "Increased budget +20%"
+    on_disk = json.loads((cwd_to_tmp / "STATE.json").read_text(encoding="utf-8"))
+    assert len(on_disk["action_log"]) == 1
+
+
+async def test_action_log_append_validates_required_fields(cwd_to_tmp) -> None:
+    mod = _import_tools()
+    with pytest.raises(ValueError):
+        await mod.handle_tool(
+            "mureo_state_action_log_append", {"entry": {"summary": "x"}}
+        )
+
+
+# ---------------------------------------------------------------------------
+# mureo_state_upsert_campaign
+# ---------------------------------------------------------------------------
+
+
+async def test_upsert_campaign_creates_when_missing(cwd_to_tmp) -> None:
+    initial = {"version": "2", "platforms": {}, "action_log": []}
+    (cwd_to_tmp / "STATE.json").write_text(json.dumps(initial), encoding="utf-8")
+    mod = _import_tools()
+    campaign = {
+        "campaign_id": "camp_xyz",
+        "campaign_name": "Generic",
+        "status": "ENABLED",
+        "daily_budget": 5000,
+    }
+    result = await mod.handle_tool(
+        "mureo_state_upsert_campaign", {"campaign": campaign}
+    )
+    payload = json.loads(result[0].text)
+    # Either v1 (root campaigns) or v2 (platforms) shape is acceptable
+    # depending on how the underlying upsert helper reconciles.
+    flat = list(payload.get("campaigns", []))
+    plats = payload.get("platforms") or {}
+    found_in_platforms = any(
+        c["campaign_id"] == "camp_xyz"
+        for plat in plats.values()
+        for c in plat.get("campaigns", [])
+    )
+    found_in_flat = any(c["campaign_id"] == "camp_xyz" for c in flat)
+    assert found_in_flat or found_in_platforms
+
+
+async def test_upsert_campaign_updates_existing(cwd_to_tmp) -> None:
+    """Upserting the same campaign_id replaces the prior snapshot in place
+    — the count stays at 1 and changed fields propagate."""
+    mod = _import_tools()
+    initial_campaign = {
+        "campaign_id": "camp_xyz",
+        "campaign_name": "Generic",
+        "status": "ENABLED",
+        "daily_budget": 5000,
+    }
+    await mod.handle_tool("mureo_state_upsert_campaign", {"campaign": initial_campaign})
+
+    updated = {
+        "campaign_id": "camp_xyz",
+        "campaign_name": "Generic",
+        "status": "PAUSED",
+        "daily_budget": 8000,
+    }
+    result = await mod.handle_tool("mureo_state_upsert_campaign", {"campaign": updated})
+    payload = json.loads(result[0].text)
+
+    flat = list(payload.get("campaigns", []))
+    plats = payload.get("platforms") or {}
+    all_snaps = list(flat) + [
+        c for plat in plats.values() for c in plat.get("campaigns", [])
+    ]
+    matches = [c for c in all_snaps if c["campaign_id"] == "camp_xyz"]
+    assert len(matches) == 1, f"expected exactly one snapshot, got {len(matches)}"
+    assert matches[0]["status"] == "PAUSED"
+    assert matches[0]["daily_budget"] == 8000
+
+
+# ---------------------------------------------------------------------------
+# Path traversal gate (security)
+# ---------------------------------------------------------------------------
+
+
+async def test_path_argument_refuses_traversal(cwd_to_tmp) -> None:
+    """Custom ``path`` outside cwd is rejected — symmetric with rollback's
+    ``_resolve_state_file`` guard. A prompt-injected agent must not be
+    able to point mureo at an attacker-crafted file elsewhere on disk."""
+    mod = _import_tools()
+    with pytest.raises(ValueError, match="Refusing to read/write outside cwd"):
+        await mod.handle_tool("mureo_strategy_get", {"path": "/etc/passwd"})


### PR DESCRIPTION
## Summary

Add 5 MCP tools that expose mureo's context layer (STRATEGY.md and STATE.json) so MCP hosts without filesystem access can read and update strategic context:

| Tool | Purpose |
|---|---|
| `mureo_strategy_get` | Read STRATEGY.md as markdown |
| `mureo_strategy_set` | Atomically replace STRATEGY.md (validates via `parse_strategy`) |
| `mureo_state_get` | Read STATE.json as a parsed v2 doc |
| `mureo_state_action_log_append` | Atomically append an action_log entry |
| `mureo_state_upsert_campaign` | Atomically upsert a CampaignSnapshot |

## Why now

- Claude Desktop chat / claude.ai web have **no `Read` tool** — without these MCP tools, users have to paste STRATEGY.md / STATE.json into chat manually.
- Meta's official MCP has shipped; Google's is likely next. When raw API access becomes a commodity, mureo's value sits in the **orchestration layer** (strategy + state + action_log + rollback + synthesis). That layer needs its own MCP surface so mureo isn't invisible from non-Code hosts.
- This is Phase 1 of the MCP-ization plan — Phase 2 (skill migration) and Phase 3 (synthesis tools) come later.

## Security

- `_resolve_path` refuses any path that resolves outside cwd, mirroring `mureo/mcp/_handlers_rollback.py:_resolve_state_file`. `Path.resolve()` follows symlinks, so a STRATEGY.md inside cwd that symlinks to `/etc/passwd` resolves to the target and is rejected.
- All writes go through pre-existing atomic helpers in `mureo.context.state` / `mureo.context.strategy` (temp file + `os.replace`). A failed write leaves the original file intact (covered by `test_strategy_set_is_atomic`).
- `mureo_strategy_set` round-trips input through `parse_strategy()` so a malformed payload raises before the file is overwritten.

## Test plan

- [x] `tests/test_mcp_tools_mureo_context.py` — 13 unit tests covering all 5 tools, including atomic-write failure, missing-file defaults, required-field validation, upsert-create + upsert-update, and the path-traversal refusal.
- [x] `tests/test_mcp_tool_name_spec.py` — regression guard updated to include `tools_mureo_context`; all 5 names match `^[a-zA-Z0-9_-]{1,64}$`.
- [x] `tests/test_mcp_server.py::TestListTools::test_list_tools_returns_all_tools` — total tool count updated 173 → 178.
- [x] `ruff check`, `black --check`, `mypy --strict` all pass on new files.
- [x] python-reviewer agent: addressed HIGH (unify path-resolve gate with rollback's `relative_to` idiom) and MEDIUM (drop redundant default in `handle_state_get`, add upsert-update test).

## Out of scope

Pre-existing test failures in `tests/test_mcp_tools_meta_ads_*` and 4 tests in `test_mcp_server.py` (BYOD demo data leaking into expected "no credentials" assertions) are unrelated to this change and exist on the branch base.
