### PR TITLE
docs(ja): translate 'Pillar' table header to '柱'

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -33,7 +33,7 @@ mureoは、**AI 広告運用のためのローカル制御平面（control plane
 
 各広告プラットフォームの公式 MCP（Meta Ads MCP / Google Ads MCP など）が出揃うと、mureo はそれらをドライバとして利用します。mureo の価値は API 接続そのものではなく、**その周辺で起きること**にあります。
 
-| 柱 | mureo がやること | 公式MCPには作れない理由 |
+| 役割 | mureo がやること | 公式MCPには作れない理由 |
 |---|---|---|
 | **Strategy Enforcer** | `STRATEGY.md` と `policy.yaml` を読み、ペルソナ・USP・ブランドボイス・予算ルール・運用モードに照らして全変更をゲートする | 公式 MCP はあなたのビジネスを知らない |
 | **Outcome Ledger** | プラットフォーム指標と CRM / 売上 / LTV をローカルで相関付ける | 公式 MCP はプラットフォーム側の数字しか見ない |

--- a/README.ja.md
+++ b/README.ja.md
@@ -33,7 +33,7 @@ mureoは、**AI 広告運用のためのローカル制御平面（control plane
 
 各広告プラットフォームの公式 MCP（Meta Ads MCP / Google Ads MCP など）が出揃うと、mureo はそれらをドライバとして利用します。mureo の価値は API 接続そのものではなく、**その周辺で起きること**にあります。
 
-| Pillar | mureo がやること | 公式MCPには作れない理由 |
+| 柱 | mureo がやること | 公式MCPには作れない理由 |
 |---|---|---|
 | **Strategy Enforcer** | `STRATEGY.md` と `policy.yaml` を読み、ペルソナ・USP・ブランドボイス・予算ルール・運用モードに照らして全変更をゲートする | 公式 MCP はあなたのビジネスを知らない |
 | **Outcome Ledger** | プラットフォーム指標と CRM / 売上 / LTV をローカルで相関付ける | 公式 MCP はプラットフォーム側の数字しか見ない |


### PR DESCRIPTION
## Summary

The English column header `Pillar` did not read naturally in the Japanese README — replace with `柱` so the table header matches the surrounding Japanese prose.

The Pillar names themselves (`Strategy Enforcer` / `Outcome Ledger` / `Audit & Provenance`) stay in English as cross-language brand terms (same as the English README and `docs/architecture.md`).

## Why

Reported by user after #81 merged: "Pillarは日本語ではつうじません".

## Scope

- `README.ja.md` line 36 only (one column header).
- No other JP doc had this issue (`git grep -i pillar` on `*.ja.md` confirms one hit).
- The English `README.md` table header stays as `Pillar` — that's natural in English.

## Test plan

- [x] `git grep -i 'pillar' -- '*.ja.md'` → 0 matches after fix
- [ ] CI green