### PR TITLE
feat(core): add BaseProvider Protocol + validators (#89)

### DIFF
--- a/mureo/core/providers/__init__.py
+++ b/mureo/core/providers/__init__.py
@@ -1,10 +1,16 @@
 """Public provider abstraction surface.
 
-Re-exports the stable ABI from :mod:`mureo.core.providers.capabilities`.
+Re-exports the stable ABI from :mod:`mureo.core.providers.capabilities`
+and :mod:`mureo.core.providers.base`.
 """
 
 from __future__ import annotations
 
+from mureo.core.providers.base import (
+    BaseProvider,
+    validate_provider,
+    validate_provider_name,
+)
 from mureo.core.providers.capabilities import (
     CAPABILITY_NAMES,
     Capability,
@@ -14,7 +20,10 @@ from mureo.core.providers.capabilities import (
 
 __all__ = [
     "CAPABILITY_NAMES",
+    "BaseProvider",
     "Capability",
     "parse_capabilities",
     "parse_capability",
+    "validate_provider",
+    "validate_provider_name",
 ]

--- a/mureo/core/providers/base.py
+++ b/mureo/core/providers/base.py
@@ -1,0 +1,210 @@
+"""``BaseProvider`` Protocol and structural validators.
+
+This module defines the runtime-checkable :class:`BaseProvider` Protocol
+that every mureo provider plugin (built-in ``google_ads``, ``meta_ads``,
+and third-party plugins discovered via entry points) must satisfy. It is
+the second foundational layer of the provider abstraction (Issue #89,
+P1-02), built on top of :mod:`mureo.core.providers.capabilities`.
+
+Foundation rule
+---------------
+This module's only allowed internal import is
+:mod:`mureo.core.providers.capabilities`. Everything else may depend on
+it; it depends on nothing else inside ``mureo``. This rule is enforced by
+an AST scan in the test suite.
+
+Class-attribute recommendation
+------------------------------
+``name`` and ``capabilities`` are part of a provider's static identity.
+Real provider implementations should declare them as **class attributes**
+so the registry, the skill matcher, and tooling can introspect them
+without instantiating the provider. ``display_name`` is also typically a
+class attribute. The Protocol itself permits either class or instance
+attributes (``runtime_checkable`` uses structural ``hasattr`` checks).
+
+``runtime_checkable`` is structural only
+----------------------------------------
+``isinstance(obj, BaseProvider)`` returns ``True`` for *any* object
+exposing the three named attributes regardless of their types. For deep
+type validation, use :func:`validate_provider`. ``isinstance`` is the
+cheap discriminator; ``validate_provider`` is the contract enforcer.
+
+Capabilities are the *declared* set
+-----------------------------------
+``capabilities`` lists the capabilities the provider *declares it can*
+serve. Some real providers expose more capabilities once authenticated
+(e.g., write scopes); for Phase 1 the registry / skill matcher gates
+purely against this declared set. Runtime authorization checks happen
+elsewhere (future ``permit()`` API).
+
+Non-goal: authentication
+------------------------
+Authentication is intentionally **not** part of this contract. Phase 1
+keeps :class:`BaseProvider` minimal so adapters can wrap existing
+``GoogleAdsApiClient`` / ``MetaAdsApiClient`` instances without churn.
+A future ``AuthenticatedProvider`` Protocol (or credentials abstraction)
+will layer on top.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Protocol, runtime_checkable
+
+from mureo.core.providers.capabilities import Capability
+
+# Snake_case identifier: starts with a lowercase ASCII letter, followed
+# by lowercase letters, digits, or underscores. Anchored both ends; no
+# user-controlled regex pattern, so no ReDoS risk.
+_PROVIDER_NAME_PATTERN: re.Pattern[str] = re.compile(r"^[a-z][a-z0-9_]*$")
+
+
+@runtime_checkable
+class BaseProvider(Protocol):
+    """Structural contract for a mureo provider plugin.
+
+    Every provider — built-in or third-party — must expose these three
+    attributes. They form the public ABI consumed by the registry, the
+    skill matcher, and any tooling that introspects providers.
+
+    Attributes:
+        name: Stable snake_case identifier (e.g., ``"google_ads"``).
+            Used as the registry key and in skill frontmatter. Must
+            match ``^[a-z][a-z0-9_]*$``. Recommended to be a class
+            attribute.
+        display_name: Human-readable provider label (e.g.,
+            ``"Google Ads"``). Used in CLI output and error messages.
+            Must be a non-empty string.
+        capabilities: The set of capabilities the provider declares it
+            can serve. ``frozenset`` (not ``set``) so it is hashable and
+            cannot be mutated after construction. Recommended to be a
+            class attribute.
+
+    No methods are declared in Phase 1. Adding required methods later
+    would be a breaking change for installed plugins; new behaviour
+    should be added via secondary Protocols rather than expanding this
+    one.
+    """
+
+    name: str
+    display_name: str
+    capabilities: frozenset[Capability]
+
+
+def validate_provider_name(name: str) -> str:
+    """Validate a provider's ``name`` against the snake_case contract.
+
+    The contract — ``^[a-z][a-z0-9_]*$`` — matches the snake_case rule
+    that :class:`Capability` values already follow, so a single style
+    spans both halves of the ABI.
+
+    Args:
+        name: The candidate provider name.
+
+    Returns:
+        The validated name unchanged (handy for inline use).
+
+    Raises:
+        ValueError: If ``name`` is not a non-empty string matching the
+            pattern. The error message includes ``repr(name)`` so the
+            offending input is locatable in logs.
+    """
+    if not isinstance(name, str) or not _PROVIDER_NAME_PATTERN.match(name):
+        raise ValueError(
+            f"invalid provider name: {name!r} "
+            f"(must match {_PROVIDER_NAME_PATTERN.pattern!r})"
+        )
+    return name
+
+
+def _identity_hint(provider: object) -> str:
+    """Return a short identifier for ``provider`` to embed in errors.
+
+    Prefers the provider's own ``name`` (when it is a non-empty string),
+    falling back to ``repr(provider)`` so callers can always locate the
+    bad provider in logs even when ``name`` itself is malformed.
+    """
+    raw_name = getattr(provider, "name", None)
+    if isinstance(raw_name, str) and raw_name:
+        return raw_name
+    return repr(provider)
+
+
+def validate_provider(provider: object) -> None:
+    """Deeply validate a provider object against :class:`BaseProvider`.
+
+    Goes beyond the structural ``isinstance(obj, BaseProvider)`` check
+    by verifying attribute *types* and *values*. Use this whenever a
+    provider crosses a trust boundary (registration, plugin discovery,
+    test fixtures asserting contract conformance).
+
+    Args:
+        provider: The object to validate.
+
+    Returns:
+        ``None`` on success.
+
+    Raises:
+        TypeError: If any attribute has the wrong type — e.g., ``name``
+            is not ``str``, ``display_name`` is not ``str``,
+            ``capabilities`` is not a ``frozenset``, or ``capabilities``
+            contains a non-:class:`Capability` element.
+        ValueError: If a string attribute is empty or fails its value
+            contract — e.g., ``name`` does not match
+            ``^[a-z][a-z0-9_]*$``, or ``display_name`` is the empty
+            string.
+
+    All error messages embed an identity hint (the provider's ``name``
+    when valid, otherwise ``repr(provider)``) so the offending provider
+    is locatable.
+    """
+    identity = _identity_hint(provider)
+
+    # ---- name -----------------------------------------------------------
+    name = getattr(provider, "name", None)
+    if not isinstance(name, str):
+        raise TypeError(
+            f"provider {identity}: 'name' must be str, " f"got {type(name).__name__}"
+        )
+    # Reuse the regex validator; surface the bad provider's identity.
+    try:
+        validate_provider_name(name)
+    except ValueError as exc:
+        raise ValueError(f"provider {identity}: 'name' is invalid — {exc}") from exc
+
+    # ---- display_name ---------------------------------------------------
+    display_name = getattr(provider, "display_name", None)
+    if not isinstance(display_name, str):
+        raise TypeError(
+            f"provider {identity}: 'display_name' must be str, "
+            f"got {type(display_name).__name__}"
+        )
+    if display_name == "":
+        raise ValueError(
+            f"provider {identity}: 'display_name' must be a non-empty string"
+        )
+
+    # ---- capabilities ---------------------------------------------------
+    # Order matters: the frozenset type check must precede element
+    # inspection so that a plain ``set`` produces a 'frozenset' hint
+    # rather than triggering element-type checks.
+    capabilities = getattr(provider, "capabilities", None)
+    if not isinstance(capabilities, frozenset):
+        raise TypeError(
+            f"provider {identity}: 'capabilities' must be a frozenset, "
+            f"got {type(capabilities).__name__}"
+        )
+    bad_members = [c for c in capabilities if not isinstance(c, Capability)]
+    if bad_members:
+        bad_repr = ", ".join(repr(m) for m in bad_members)
+        raise TypeError(
+            f"provider {identity}: 'capabilities' must contain only "
+            f"Capability members; got non-Capability element(s): {bad_repr}"
+        )
+
+
+__all__ = [
+    "BaseProvider",
+    "validate_provider",
+    "validate_provider_name",
+]

--- a/tests/core/providers/test_base.py
+++ b/tests/core/providers/test_base.py
@@ -1,0 +1,408 @@
+"""Tests for ``mureo.core.providers.base``.
+
+RED phase tests for Issue #89 Phase 1 subtask P1-02.
+
+These tests pin the stable structural contract for ``BaseProvider`` — the
+runtime-checkable Protocol every mureo provider plugin (built-in
+``google_ads``, ``meta_ads``, and third-party plugins via entry points)
+must satisfy. Authentication is intentionally **not** part of this
+contract (deferred to subclasses / a future ``AuthenticatedProvider``).
+
+Marks: all tests are ``@pytest.mark.unit`` — pure logic, no I/O, no
+mocks needed.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import re
+import types
+from dataclasses import dataclass
+from typing import Protocol
+
+import pytest
+
+# NOTE: This import is expected to FAIL during the RED phase — the module
+# does not exist yet. That is correct. The implementer (GREEN phase) will
+# create ``mureo/core/providers/base.py``.
+from mureo.core.providers.base import (  # noqa: E402
+    BaseProvider,
+    validate_provider,
+    validate_provider_name,
+)
+from mureo.core.providers.capabilities import Capability
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _FakeProvider:
+    """Minimal frozen-dataclass fixture satisfying the BaseProvider shape.
+
+    Used across cases to verify both ``isinstance`` (structural duck
+    typing) and ``validate_provider`` (deeper structural validation) on
+    a well-formed provider object.
+    """
+
+    name: str
+    display_name: str
+    capabilities: frozenset[Capability]
+
+
+# ---------------------------------------------------------------------------
+# Case 1 — BaseProvider is a runtime-checkable Protocol
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_base_provider_is_runtime_checkable_protocol() -> None:
+    """``BaseProvider`` is a ``Protocol`` decorated with ``@runtime_checkable``.
+
+    The ``runtime_checkable`` decorator sets the private attribute
+    ``_is_runtime_protocol = True`` on the Protocol class. This test
+    pins that attribute so the implementer cannot drop the decorator
+    without failing the suite.
+    """
+    assert issubclass(
+        BaseProvider, Protocol
+    ), "BaseProvider must be a typing.Protocol subclass"
+    assert getattr(BaseProvider, "_is_runtime_protocol", False) is True, (
+        "BaseProvider must be decorated with @runtime_checkable so "
+        "isinstance() can perform structural checks at runtime."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Case 2 — isinstance passes for an object with all required attributes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_isinstance_passes_for_object_with_required_attributes() -> None:
+    """An object exposing ``name``, ``display_name``, and ``capabilities``
+    satisfies ``isinstance(obj, BaseProvider)`` (AC #4).
+    """
+    fake = _FakeProvider(
+        name="google_ads",
+        display_name="Google Ads",
+        capabilities=frozenset({Capability.READ_CAMPAIGNS}),
+    )
+    assert isinstance(fake, BaseProvider) is True
+
+
+# ---------------------------------------------------------------------------
+# Case 3 — isinstance fails when any required attribute is missing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "missing_attr",
+    ["name", "display_name", "capabilities"],
+)
+def test_isinstance_fails_when_attribute_missing(missing_attr: str) -> None:
+    """Removing any one of the three required attributes makes
+    ``isinstance(obj, BaseProvider)`` return ``False``.
+
+    Uses ``types.SimpleNamespace`` so attribute removal is trivial.
+    """
+    attrs: dict[str, object] = {
+        "name": "google_ads",
+        "display_name": "Google Ads",
+        "capabilities": frozenset({Capability.READ_CAMPAIGNS}),
+    }
+    del attrs[missing_attr]
+    obj = types.SimpleNamespace(**attrs)
+    assert (
+        isinstance(obj, BaseProvider) is False
+    ), f"Object missing {missing_attr!r} should not satisfy BaseProvider"
+
+
+# ---------------------------------------------------------------------------
+# Case 4 — validate_provider_name accepts valid snake_case identifiers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "value",
+    [
+        "google_ads",
+        "meta_ads",
+        "tiktok_ads",
+        "x",
+        "x1",
+        "long_provider_name_42",
+    ],
+)
+def test_validate_provider_name_accepts_valid(value: str) -> None:
+    """``validate_provider_name`` returns the input unchanged for
+    snake_case identifiers matching ``^[a-z][a-z0-9_]*$`` (AC #5).
+    """
+    assert validate_provider_name(value) == value
+
+
+# ---------------------------------------------------------------------------
+# Case 5 — validate_provider_name rejects invalid names with ValueError
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",
+        "Google_Ads",
+        "1google",
+        "_google",
+        "google-ads",
+        "google ads",
+        "google.ads",
+        "GOOGLE_ADS",
+        "google_ads ",
+        " google_ads",
+    ],
+)
+def test_validate_provider_name_rejects_invalid(value: str) -> None:
+    """Invalid provider names raise ``ValueError`` whose message
+    contains the offending input (AC #5).
+    """
+    with pytest.raises(ValueError, match=re.escape(repr(value))):
+        validate_provider_name(value)
+
+
+# ---------------------------------------------------------------------------
+# Case 6 — validate_provider accepts a well-formed provider
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_validate_provider_accepts_well_formed() -> None:
+    """``validate_provider`` returns ``None`` and raises nothing for a
+    well-formed provider whose name passes regex, display_name is
+    non-empty, and capabilities is a ``frozenset[Capability]`` (AC #6).
+    """
+    fake = _FakeProvider(
+        name="google_ads",
+        display_name="Google Ads",
+        capabilities=frozenset({Capability.READ_CAMPAIGNS, Capability.WRITE_BUDGET}),
+    )
+    assert validate_provider(fake) is None
+
+
+# ---------------------------------------------------------------------------
+# Case 7 — validate_provider rejects each ill-formed shape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("name", "display_name", "capabilities", "exc_type", "field_token"),
+    [
+        # name not str
+        (
+            123,
+            "Display",
+            frozenset({Capability.READ_CAMPAIGNS}),
+            TypeError,
+            "name",
+        ),
+        # name fails regex (uppercase)
+        (
+            "Google_Ads",
+            "Display",
+            frozenset({Capability.READ_CAMPAIGNS}),
+            ValueError,
+            "name",
+        ),
+        # name empty (also fails regex)
+        (
+            "",
+            "Display",
+            frozenset({Capability.READ_CAMPAIGNS}),
+            ValueError,
+            "name",
+        ),
+        # display_name not str
+        (
+            "google_ads",
+            42,
+            frozenset({Capability.READ_CAMPAIGNS}),
+            TypeError,
+            "display_name",
+        ),
+        # display_name empty string
+        (
+            "google_ads",
+            "",
+            frozenset({Capability.READ_CAMPAIGNS}),
+            ValueError,
+            "display_name",
+        ),
+        # capabilities is a regular set, not frozenset
+        (
+            "google_ads",
+            "Display",
+            {Capability.READ_CAMPAIGNS},
+            TypeError,
+            "capabilities",
+        ),
+        # capabilities frozenset contains a non-Capability member
+        (
+            "google_ads",
+            "Display",
+            frozenset({"read_campaigns"}),
+            TypeError,
+            "capabilities",
+        ),
+    ],
+    ids=[
+        "name_not_str",
+        "name_fails_regex_uppercase",
+        "name_empty",
+        "display_name_not_str",
+        "display_name_empty",
+        "capabilities_set_not_frozenset",
+        "capabilities_contains_non_capability",
+    ],
+)
+def test_validate_provider_rejects_bad_shape(
+    name: object,
+    display_name: object,
+    capabilities: object,
+    exc_type: type[Exception],
+    field_token: str,
+) -> None:
+    """Each malformed provider raises the documented exception type and
+    the message mentions both the provider's identifying ``name`` (or
+    ``repr``) and the offending field (AC #6).
+
+    Additional pin: when ``capabilities`` is a plain ``set``, the
+    message must mention ``frozenset``; when it contains a non-Capability
+    element, the message must mention ``Capability``.
+    """
+    obj = types.SimpleNamespace(
+        name=name,
+        display_name=display_name,
+        capabilities=capabilities,
+    )
+
+    with pytest.raises(exc_type) as excinfo:
+        validate_provider(obj)
+
+    msg = str(excinfo.value)
+    assert field_token in msg, (
+        f"exception message must mention the offending field "
+        f"{field_token!r}; got: {msg!r}"
+    )
+
+    # Identity hint: either the provider's name (when str) or its repr
+    # must appear in the message so the user can locate the bad provider.
+    name_hint = name if isinstance(name, str) and name else repr(obj)
+    if isinstance(name_hint, str) and name_hint:
+        # Allow either the bare name or its repr in the message.
+        assert name_hint in msg or repr(name_hint) in msg or repr(obj) in msg, (
+            f"exception message must include provider identity "
+            f"({name_hint!r} or repr); got: {msg!r}"
+        )
+
+    # Field-specific hints required by the HANDOFF.
+    if (
+        field_token == "capabilities"
+        and isinstance(capabilities, set)
+        and not isinstance(capabilities, frozenset)
+    ):
+        assert "frozenset" in msg, (
+            "when capabilities is a plain set, message must mention "
+            f"'frozenset'; got: {msg!r}"
+        )
+    if (
+        field_token == "capabilities"
+        and isinstance(capabilities, frozenset)
+        and any(not isinstance(c, Capability) for c in capabilities)
+    ):
+        assert "Capability" in msg, (
+            "when capabilities frozenset has a non-Capability member, "
+            f"message must mention 'Capability'; got: {msg!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Case 8 — base.py has no internal mureo.* imports other than capabilities
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_base_module_has_no_internal_mureo_imports_other_than_capabilities() -> None:
+    """``base.py`` is a foundation-layer module — its only allowed
+    internal import is ``mureo.core.providers.capabilities`` (AC #7).
+
+    Uses ``ast.parse`` on the module's source to scan every ``Import``
+    and ``ImportFrom`` node. ``TYPE_CHECKING``-guarded imports are
+    intentionally treated identically to runtime imports for this
+    foundation module — only ``capabilities`` may be referenced.
+
+    Note: AST scan covers static ``import`` / ``from ... import`` only.
+    ``importlib.import_module(...)`` and ``__import__(...)`` bypass
+    detection (out of scope for this test).
+    """
+    import mureo.core.providers.base as base_module
+
+    source_path = inspect.getsourcefile(base_module)
+    assert source_path is not None, "Could not locate base.py on disk"
+
+    with open(source_path, encoding="utf-8") as fh:
+        tree = ast.parse(fh.read(), filename=source_path)
+
+    own_module = base_module.__name__  # "mureo.core.providers.base"
+    allowed = {"mureo.core.providers.capabilities"}
+    offending: list[str] = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if (
+                    alias.name.startswith("mureo.")
+                    and alias.name != own_module
+                    and alias.name not in allowed
+                ):
+                    offending.append(f"import {alias.name}")
+        elif isinstance(node, ast.ImportFrom):
+            mod = node.module or ""
+            if node.level > 0:
+                # Relative imports are still internal mureo.* — forbidden
+                # unless they resolve to ``capabilities``. Even then, the
+                # implementer should prefer the absolute form for clarity.
+                offending.append(f"from {'.' * node.level}{mod} import ... (relative)")
+            elif mod.startswith("mureo.") and mod != own_module and mod not in allowed:
+                offending.append(f"from {mod} import ...")
+            elif mod == "mureo":
+                offending.append("from mureo import ...")
+
+    assert offending == [], (
+        "base.py may only import from mureo.core.providers.capabilities "
+        f"among internal mureo.* modules. Found: {offending}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bonus — re-export check: the public package exposes the new API
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_re_export_from_package() -> None:
+    """``mureo.core.providers`` re-exports ``BaseProvider``,
+    ``validate_provider``, and ``validate_provider_name`` (AC #1).
+
+    The re-exported objects must be the same identities as those defined
+    in ``base.py`` (no wrapping / aliasing).
+    """
+    import mureo.core.providers as pkg
+
+    assert pkg.BaseProvider is BaseProvider
+    assert pkg.validate_provider is validate_provider
+    assert pkg.validate_provider_name is validate_provider_name


### PR DESCRIPTION
## Summary

Implements P1-02 of Issue #89 Phase 1: the `BaseProvider` Protocol that every plugin / built-in provider must satisfy.

- **`BaseProvider`** — `@runtime_checkable` Protocol with three attributes:
  - `name: str` — snake_case stable identifier
  - `display_name: str` — human label
  - `capabilities: frozenset[Capability]` — declared from P1-01's enum
- **`validate_provider_name(name) -> str`** — regex-gated (`^[a-z][a-z0-9_]*$`); returns the validated input so call sites can `self.name = validate_provider_name(raw)`.
- **`validate_provider(provider) -> None`** — deep type+value validation. `TypeError` for type violations, `ValueError` for value violations.
- Module-level `__all__` locks the public surface; `_identity_hint` produces consistent error labels.

## Stacked on PR #90

This branch is stacked on `feat/p1-01-capabilities`. Merge order: #90 first, then this PR (which will rebase to `main`).

## Design notes

- **`runtime_checkable` is structural-only.** `isinstance(obj, BaseProvider)` checks attribute presence, not types/values. Deep enforcement is `validate_provider`'s job — documented in the module docstring.
- **HANDOFF deviation (intentional, idiomatic):** `validate_provider_name` returns the validated string instead of `None`. Matches CPython `int()` / `str.encode()` patterns and enables `self.x = validate_x(raw)` in call sites.
- **Empty `frozenset()` is currently valid** for `capabilities`. Stub providers and test fixtures need this; tightening later is a value-violation change for previously-valid input (technically breaking) but the affected callers are internal.
- **Foundation rule preserved:** AST-scan test asserts that `mureo.core.providers.base` imports nothing from `mureo.*` other than `mureo.core.providers.capabilities`.

## Follow-up to track separately (LOW from review)

- **Repr-leak risk in `_identity_hint` fallback** — when a provider lacks a valid `name`, error messages embed `repr(provider)`, which may include credentials once Phase 2 introduces `AuthenticatedProvider`. Track and resolve before any auth-bearing provider attribute lands. Possible mitigations: clamp to `f"<{type().__name__} at {hex(id())}>"`, use `reprlib.repr`, or require credential-bearing providers to define a redacting `__repr__`.

## Test plan

- [x] `pytest tests/core/providers/test_base.py` — 31/31 passed
- [x] `pytest tests/core/providers/` — 77/77 passed (P1-01 + P1-02)
- [x] Coverage on `mureo/core/providers/base.py` — 100%
- [x] `ruff check mureo/core/ tests/core/` — clean
- [x] `black --check mureo/core/ tests/core/` — clean
- [x] `mypy --strict mureo/core/providers/` — clean
- [x] AST scan test asserts zero internal imports beyond `mureo.core.providers.capabilities`
- [x] python-reviewer agent: APPROVE (no CRITICAL/HIGH/MEDIUM; 4 LOW noted, 1 tracked as follow-up above, 3 cosmetic)

## Refs

Closes part of #89 (Phase 1 subtask P1-02). Next subtasks (P1-03..P1-06: domain Protocols) can proceed in parallel once this lands.
