### PR TITLE
feat(core/providers): add domain Protocols (P1-03..P1-06, #89)

### DIFF
--- a/mureo/core/providers/__init__.py
+++ b/mureo/core/providers/__init__.py
@@ -1,27 +1,86 @@
 """Public provider abstraction surface.
 
-Re-exports the stable ABI from :mod:`mureo.core.providers.capabilities`
-and :mod:`mureo.core.providers.base`.
+Re-exports the stable ABI from :mod:`mureo.core.providers.capabilities`,
+:mod:`mureo.core.providers.base`, the four Phase 1 domain Protocols
+(:mod:`mureo.core.providers.campaign`, :mod:`~.keyword`, :mod:`~.audience`,
+:mod:`~.extension`), and the shared domain models / enums in
+:mod:`mureo.core.providers.models`.
 """
 
 from __future__ import annotations
 
+from mureo.core.providers.audience import AudienceProvider
 from mureo.core.providers.base import (
     BaseProvider,
     validate_provider,
     validate_provider_name,
 )
+from mureo.core.providers.campaign import CampaignProvider
 from mureo.core.providers.capabilities import (
     CAPABILITY_NAMES,
     Capability,
     parse_capabilities,
     parse_capability,
 )
+from mureo.core.providers.extension import ExtensionProvider
+from mureo.core.providers.keyword import KeywordProvider
+from mureo.core.providers.models import (
+    Ad,
+    AdStatus,
+    Audience,
+    AudienceStatus,
+    BidStrategy,
+    Campaign,
+    CampaignFilters,
+    CampaignStatus,
+    CreateAdRequest,
+    CreateAudienceRequest,
+    CreateCampaignRequest,
+    DailyReportRow,
+    Extension,
+    ExtensionKind,
+    ExtensionRequest,
+    ExtensionStatus,
+    Keyword,
+    KeywordMatchType,
+    KeywordSpec,
+    KeywordStatus,
+    SearchTerm,
+    UpdateAdRequest,
+    UpdateCampaignRequest,
+)
 
 __all__ = [
     "CAPABILITY_NAMES",
+    "Ad",
+    "AdStatus",
+    "Audience",
+    "AudienceProvider",
+    "AudienceStatus",
     "BaseProvider",
+    "BidStrategy",
+    "Campaign",
+    "CampaignFilters",
+    "CampaignProvider",
+    "CampaignStatus",
     "Capability",
+    "CreateAdRequest",
+    "CreateAudienceRequest",
+    "CreateCampaignRequest",
+    "DailyReportRow",
+    "Extension",
+    "ExtensionKind",
+    "ExtensionProvider",
+    "ExtensionRequest",
+    "ExtensionStatus",
+    "Keyword",
+    "KeywordMatchType",
+    "KeywordProvider",
+    "KeywordSpec",
+    "KeywordStatus",
+    "SearchTerm",
+    "UpdateAdRequest",
+    "UpdateCampaignRequest",
     "parse_capabilities",
     "parse_capability",
     "validate_provider",

--- a/mureo/core/providers/audience.py
+++ b/mureo/core/providers/audience.py
@@ -1,0 +1,73 @@
+"""``AudienceProvider`` Protocol — audience / segment operations.
+
+The runtime-checkable Protocol every adapter that supports audience or
+segment management must satisfy.
+
+Capability gate
+---------------
+Implementing this Protocol does NOT automatically grant capabilities.
+The provider's ``capabilities`` frozenset must explicitly include the
+relevant ``Capability`` members for any given method to be callable:
+
+================================  ====================
+Method                            Required capability
+================================  ====================
+``list_audiences`` /              ``READ_AUDIENCES``
+``get_audience``
+``create_audience`` /             ``WRITE_AUDIENCES``
+``set_audience_status``
+================================  ====================
+
+Delete-via-status convention
+----------------------------
+There is no ``delete_audience`` method. The canonical delete signal is
+``set_audience_status(audience_id, AudienceStatus.REMOVED)``; adapters
+translate ``REMOVED`` to a platform-native delete call (e.g., the Meta
+Custom Audiences delete endpoint).
+"""
+
+# ruff: noqa: TC001
+# Model imports must stay at module top-level (NOT under
+# ``TYPE_CHECKING``) so ``typing.get_type_hints(Protocol.method)`` can
+# resolve them at test/registry introspection time on Python 3.10.
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from mureo.core.providers.base import BaseProvider
+from mureo.core.providers.models import (
+    Audience,
+    AudienceStatus,
+    CreateAudienceRequest,
+)
+
+
+@runtime_checkable
+class AudienceProvider(BaseProvider, Protocol):
+    """Structural contract for audience / segment operations.
+
+    See the module docstring for the capability gate map and the
+    delete-via-status convention.
+    """
+
+    def list_audiences(self) -> tuple[Audience, ...]:
+        """Return all audiences scoped to this provider's account."""
+        ...
+
+    def get_audience(self, audience_id: str) -> Audience:
+        """Return a single audience by id."""
+        ...
+
+    def create_audience(self, request: CreateAudienceRequest) -> Audience:
+        """Create a new audience from ``request`` and return it."""
+        ...
+
+    def set_audience_status(self, audience_id: str, status: AudienceStatus) -> Audience:
+        """Set the status of ``audience_id``; use
+        ``AudienceStatus.REMOVED`` to delete (delete-via-status
+        convention).
+        """
+        ...
+
+
+__all__ = ["AudienceProvider"]

--- a/mureo/core/providers/campaign.py
+++ b/mureo/core/providers/campaign.py
@@ -1,0 +1,121 @@
+"""``CampaignProvider`` Protocol — campaigns, ads, and daily reports.
+
+The runtime-checkable Protocol every adapter that supports campaign /
+ad / daily-report operations must satisfy. Method signatures only;
+implementations live in adapters (P1-09/10) and third-party plugins.
+
+Capability gate
+---------------
+Implementing this Protocol does NOT automatically grant capabilities.
+The provider's ``capabilities`` frozenset must explicitly include the
+relevant ``Capability`` members for any given method to be callable:
+
+==============================  =================================
+Method                          Required capability
+==============================  =================================
+``list_campaigns`` /            ``READ_CAMPAIGNS``
+``get_campaign``
+``create_campaign`` /           ``WRITE_BUDGET`` (for budget) +
+``update_campaign``             ``WRITE_CAMPAIGN_STATUS``
+``list_ads`` / ``get_ad``       ``READ_CAMPAIGNS``
+``create_ad`` / ``update_ad``   ``WRITE_CREATIVE``
+``set_ad_status``               ``WRITE_CAMPAIGN_STATUS``
+``daily_report``                ``READ_PERFORMANCE``
+==============================  =================================
+
+Delete-via-status convention
+----------------------------
+There is no ``delete_ad`` method. Per the Capability ABI rule
+("Deletion operations are folded into write capabilities"), the
+canonical delete signal is
+``set_ad_status(campaign_id, ad_id, AdStatus.REMOVED)``. Adapters
+translate ``REMOVED`` to a platform-native delete call.
+"""
+
+# ruff: noqa: TC001, TC003
+# Model + stdlib imports must stay at module top-level (NOT under
+# ``TYPE_CHECKING``) so ``typing.get_type_hints(Protocol.method)`` can
+# resolve them at test/registry introspection time on Python 3.10.
+from __future__ import annotations
+
+from datetime import date
+from typing import Protocol, runtime_checkable
+
+from mureo.core.providers.base import BaseProvider
+from mureo.core.providers.models import (
+    Ad,
+    AdStatus,
+    Campaign,
+    CampaignFilters,
+    CreateAdRequest,
+    CreateCampaignRequest,
+    DailyReportRow,
+    UpdateAdRequest,
+    UpdateCampaignRequest,
+)
+
+
+@runtime_checkable
+class CampaignProvider(BaseProvider, Protocol):
+    """Structural contract for campaign / ad / daily-report operations.
+
+    See the module docstring for the capability gate map and the
+    delete-via-status convention.
+    """
+
+    def list_campaigns(
+        self, filters: CampaignFilters | None = None
+    ) -> tuple[Campaign, ...]:
+        """Return campaigns, optionally narrowed by ``filters``."""
+        ...
+
+    def get_campaign(self, campaign_id: str) -> Campaign:
+        """Return a single campaign by id."""
+        ...
+
+    def create_campaign(self, request: CreateCampaignRequest) -> Campaign:
+        """Create a new campaign from ``request`` and return it."""
+        ...
+
+    def update_campaign(
+        self, campaign_id: str, request: UpdateCampaignRequest
+    ) -> Campaign:
+        """Apply the partial ``request`` to ``campaign_id`` and return the
+        updated campaign.
+        """
+        ...
+
+    def list_ads(self, campaign_id: str) -> tuple[Ad, ...]:
+        """Return all ads under ``campaign_id``."""
+        ...
+
+    def get_ad(self, campaign_id: str, ad_id: str) -> Ad:
+        """Return a single ad scoped to ``campaign_id``."""
+        ...
+
+    def create_ad(self, campaign_id: str, request: CreateAdRequest) -> Ad:
+        """Create a new ad under ``campaign_id`` and return it."""
+        ...
+
+    def update_ad(self, campaign_id: str, ad_id: str, request: UpdateAdRequest) -> Ad:
+        """Apply the partial ``request`` to ``ad_id`` and return the
+        updated ad.
+        """
+        ...
+
+    def set_ad_status(self, campaign_id: str, ad_id: str, status: AdStatus) -> Ad:
+        """Set the status of ``ad_id``; use ``AdStatus.REMOVED`` to
+        delete (delete-via-status convention).
+        """
+        ...
+
+    def daily_report(
+        self, campaign_id: str, start_date: date, end_date: date
+    ) -> tuple[DailyReportRow, ...]:
+        """Return day-grain performance rows for ``campaign_id`` over the
+        inclusive ``[start_date, end_date]`` window.
+        """
+        ...
+
+
+__all__ = ["CampaignProvider"]

--- a/mureo/core/providers/extension.py
+++ b/mureo/core/providers/extension.py
@@ -1,0 +1,91 @@
+"""``ExtensionProvider`` Protocol — ad extensions (sitelinks / callouts /
+conversions).
+
+The runtime-checkable Protocol search-platform adapters (Google Ads,
+Microsoft/Bing Ads) use for ad-extension management. Social / display
+platforms typically do NOT implement this Protocol — for example, the
+Meta Ads adapter does not.
+
+Capability gate
+---------------
+Implementing this Protocol does NOT automatically grant capabilities.
+The provider's ``capabilities`` frozenset must explicitly include the
+relevant ``Capability`` members for any given method to be callable:
+
+================================  ====================
+Method                            Required capability
+================================  ====================
+``list_extensions``               ``READ_EXTENSIONS``
+``add_extension`` /               ``WRITE_EXTENSIONS``
+``set_extension_status``
+================================  ====================
+
+Delete-via-status convention
+----------------------------
+There is no ``delete_extension`` method. The canonical delete signal is
+``set_extension_status(campaign_id, extension_id, ExtensionStatus.REMOVED)``.
+
+Type-safe dispatch
+------------------
+The ``kind`` parameter on ``list_extensions`` and ``add_extension`` is
+the ``ExtensionKind`` enum (never a bare ``str``) so adapters cannot
+accept arbitrary platform-specific category strings.
+"""
+
+# ruff: noqa: TC001
+# Model imports must stay at module top-level (NOT under
+# ``TYPE_CHECKING``) so ``typing.get_type_hints(Protocol.method)`` can
+# resolve them at test/registry introspection time on Python 3.10.
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from mureo.core.providers.base import BaseProvider
+from mureo.core.providers.models import (
+    Extension,
+    ExtensionKind,
+    ExtensionRequest,
+    ExtensionStatus,
+)
+
+
+@runtime_checkable
+class ExtensionProvider(BaseProvider, Protocol):
+    """Structural contract for ad-extension operations.
+
+    See the module docstring for the capability gate map, the
+    delete-via-status convention, and the type-safe-dispatch rule for
+    ``kind``.
+    """
+
+    def list_extensions(
+        self, campaign_id: str, kind: ExtensionKind
+    ) -> tuple[Extension, ...]:
+        """Return all extensions of ``kind`` attached to ``campaign_id``."""
+        ...
+
+    def add_extension(
+        self,
+        campaign_id: str,
+        kind: ExtensionKind,
+        request: ExtensionRequest,
+    ) -> Extension:
+        """Attach a new extension of ``kind`` to ``campaign_id`` and
+        return the created entity.
+        """
+        ...
+
+    def set_extension_status(
+        self,
+        campaign_id: str,
+        extension_id: str,
+        status: ExtensionStatus,
+    ) -> Extension:
+        """Set the status of ``extension_id``; use
+        ``ExtensionStatus.REMOVED`` to delete (delete-via-status
+        convention).
+        """
+        ...
+
+
+__all__ = ["ExtensionProvider"]

--- a/mureo/core/providers/keyword.py
+++ b/mureo/core/providers/keyword.py
@@ -1,0 +1,88 @@
+"""``KeywordProvider`` Protocol — keywords and search-term reports.
+
+The runtime-checkable Protocol search-platform adapters (Google Ads,
+Microsoft/Bing Ads, Apple Search Ads) must satisfy. Social / display
+platforms typically do NOT implement this Protocol — for example, the
+Meta Ads adapter does not.
+
+Capability gate
+---------------
+Implementing this Protocol does NOT automatically grant capabilities.
+The provider's ``capabilities`` frozenset must explicitly include the
+relevant ``Capability`` members for any given method to be callable:
+
+================================  ====================
+Method                            Required capability
+================================  ====================
+``list_keywords``                 ``READ_KEYWORDS``
+``add_keywords`` /                ``WRITE_KEYWORDS``
+``set_keyword_status``
+``search_terms``                  ``READ_SEARCH_TERMS``
+================================  ====================
+
+Delete-via-status convention
+----------------------------
+There is no ``remove_keyword`` method. The canonical delete signal is
+``set_keyword_status(campaign_id, keyword_id, KeywordStatus.REMOVED)``.
+"""
+
+# ruff: noqa: TC001, TC003
+# Model + stdlib imports must stay at module top-level (NOT under
+# ``TYPE_CHECKING``) so ``typing.get_type_hints(Protocol.method)`` can
+# resolve them at test/registry introspection time on Python 3.10.
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import date
+from typing import Protocol, runtime_checkable
+
+from mureo.core.providers.base import BaseProvider
+from mureo.core.providers.models import (
+    Keyword,
+    KeywordSpec,
+    KeywordStatus,
+    SearchTerm,
+)
+
+
+@runtime_checkable
+class KeywordProvider(BaseProvider, Protocol):
+    """Structural contract for keyword / search-term operations.
+
+    See the module docstring for the capability gate map and the
+    delete-via-status convention.
+    """
+
+    def list_keywords(self, campaign_id: str) -> tuple[Keyword, ...]:
+        """Return all keywords under ``campaign_id``."""
+        ...
+
+    def add_keywords(
+        self, campaign_id: str, keywords: Sequence[KeywordSpec]
+    ) -> tuple[Keyword, ...]:
+        """Add the given keywords to ``campaign_id`` and return the
+        created entities.
+
+        ``keywords`` is typed ``Sequence[KeywordSpec]`` (covariant,
+        read-only view) — adapters must not assume mutability.
+        """
+        ...
+
+    def set_keyword_status(
+        self, campaign_id: str, keyword_id: str, status: KeywordStatus
+    ) -> Keyword:
+        """Set the status of ``keyword_id``; use ``KeywordStatus.REMOVED`` to
+        delete (delete-via-status convention).
+        """
+        ...
+
+    def search_terms(
+        self, campaign_id: str, start_date: date, end_date: date
+    ) -> tuple[SearchTerm, ...]:
+        """Return actual user-query rows for ``campaign_id`` over the
+        inclusive ``[start_date, end_date]`` window.
+        """
+        ...
+
+
+__all__ = ["KeywordProvider"]

--- a/mureo/core/providers/models.py
+++ b/mureo/core/providers/models.py
@@ -1,0 +1,355 @@
+"""Shared frozen dataclasses and enums for the domain Protocols.
+
+This module is the shared entity vocabulary consumed by the four Phase 1
+domain Protocols (``CampaignProvider``, ``KeywordProvider``,
+``AudienceProvider``, ``ExtensionProvider``) and by adapters / third-party
+plugins implementing them. Every model is ``@dataclass(frozen=True)`` and
+every enum is a ``StrEnum`` (or the 3.10 shim from
+:mod:`mureo.core.providers.capabilities`) — collection-typed fields use
+``tuple[T, ...]``, never ``list[T]``.
+
+Foundation rule
+---------------
+The only allowed internal import is
+:mod:`mureo.core.providers.capabilities` (re-using its ``StrEnum`` shim).
+Everything else is stdlib.
+
+Currency convention (Phase 1)
+-----------------------------
+Monetary amounts use ``int`` micros (1/1,000,000 of the account currency),
+matching the existing Google Ads convention in ``mureo/AGENTS.md``. The
+Meta adapter is responsible for converting to/from cents at its boundary.
+A future ``Money(amount_minor: int, currency: str)`` abstraction may
+replace these raw ``_micros: int`` fields in Phase 2.
+
+Date / datetime convention
+--------------------------
+Day-grain reporting fields use ``datetime.date``. No ``int`` epoch
+seconds at the Protocol boundary.
+
+Capability ↔ Protocol mapping (informational)
+---------------------------------------------
+Implementing a Protocol does NOT grant the corresponding capabilities;
+the provider's ``capabilities`` frozenset must explicitly include them.
+See the per-Protocol docstrings in ``campaign.py``, ``keyword.py``,
+``audience.py``, ``extension.py`` for the canonical table.
+"""
+
+# ruff: noqa: TC003
+# ``date`` must stay at module top-level (NOT under ``TYPE_CHECKING``) so
+# ``typing.get_type_hints()`` can resolve the field annotations at test /
+# registry introspection time on Python 3.10.
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+
+from mureo.core.providers.capabilities import StrEnum
+
+# ---------------------------------------------------------------------------
+# Enums (StrEnum — values are snake_case strings forming the public ABI)
+# ---------------------------------------------------------------------------
+
+
+class AdStatus(StrEnum):
+    """Stable status values for ads and (re-used) campaigns.
+
+    The ``REMOVED`` member is the canonical delete signal: per the
+    Capability enum convention, deletion is folded into status updates.
+    """
+
+    ENABLED = "enabled"
+    PAUSED = "paused"
+    REMOVED = "removed"
+
+
+class CampaignStatus(StrEnum):
+    """Stable status values for campaigns."""
+
+    ENABLED = "enabled"
+    PAUSED = "paused"
+    REMOVED = "removed"
+
+
+class KeywordStatus(StrEnum):
+    """Stable status values for keywords."""
+
+    ENABLED = "enabled"
+    PAUSED = "paused"
+    REMOVED = "removed"
+
+
+class AudienceStatus(StrEnum):
+    """Stable status values for audiences.
+
+    ``REMOVED`` is the canonical delete signal — adapters translate this
+    to a platform-native delete call.
+    """
+
+    ENABLED = "enabled"
+    REMOVED = "removed"
+
+
+class ExtensionStatus(StrEnum):
+    """Stable status values for ad extensions."""
+
+    ENABLED = "enabled"
+    PAUSED = "paused"
+    REMOVED = "removed"
+
+
+class ExtensionKind(StrEnum):
+    """Stable identifiers for ad extension categories.
+
+    Matches the existing MCP extension categories in
+    ``mureo/AGENTS.md``: sitelinks, callouts, and conversion extensions.
+    """
+
+    SITELINK = "sitelink"
+    CALLOUT = "callout"
+    CONVERSION = "conversion"
+
+
+class KeywordMatchType(StrEnum):
+    """Stable identifiers for keyword match types (search platforms)."""
+
+    EXACT = "exact"
+    PHRASE = "phrase"
+    BROAD = "broad"
+
+
+class BidStrategy(StrEnum):
+    """Stable identifiers for campaign bidding strategies."""
+
+    MANUAL_CPC = "manual_cpc"
+    TARGET_CPA = "target_cpa"
+    MAXIMIZE_CONVERSIONS = "maximize_conversions"
+
+
+# ---------------------------------------------------------------------------
+# Entity dataclasses (read-side surface — what providers return)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Campaign:
+    """A single campaign as returned by a provider.
+
+    ``account_id`` scopes the campaign to a single ad account; the
+    provider instance is assumed to be scoped to one account already, so
+    Protocol method signatures do not take ``account_id`` separately.
+    """
+
+    id: str
+    account_id: str
+    name: str
+    status: CampaignStatus
+    daily_budget_micros: int
+
+
+@dataclass(frozen=True)
+class Ad:
+    """A single ad as returned by a provider.
+
+    ``headlines`` and ``descriptions`` are immutable tuples (never
+    ``list``) per the Protocol-boundary immutability rule.
+    """
+
+    id: str
+    account_id: str
+    campaign_id: str
+    status: AdStatus
+    headlines: tuple[str, ...]
+    descriptions: tuple[str, ...]
+    final_url: str
+
+
+@dataclass(frozen=True)
+class Keyword:
+    """A single keyword as returned by a provider."""
+
+    id: str
+    account_id: str
+    campaign_id: str
+    text: str
+    match_type: KeywordMatchType
+    status: KeywordStatus
+
+
+@dataclass(frozen=True)
+class KeywordSpec:
+    """Creation DTO for a new keyword.
+
+    The ``text`` field must be non-empty; the Protocol layer is purely
+    structural (no ``__post_init__`` validation in Phase 1), but adapter
+    implementations are responsible for enforcing the non-empty
+    invariant at their boundary.
+    """
+
+    # Future: enforce via __post_init__ when adapter validation lands (P2-tracked)
+    text: str
+    match_type: KeywordMatchType
+    cpc_bid_micros: int | None = None
+
+
+@dataclass(frozen=True)
+class SearchTerm:
+    """A single search-term row (actual user query) for reporting."""
+
+    text: str
+    campaign_id: str
+    impressions: int
+    clicks: int
+
+
+@dataclass(frozen=True)
+class Audience:
+    """A single audience as returned by a provider."""
+
+    id: str
+    account_id: str
+    name: str
+    status: AudienceStatus
+    size_estimate: int | None = None
+
+
+@dataclass(frozen=True)
+class Extension:
+    """A single ad extension as returned by a provider."""
+
+    id: str
+    account_id: str
+    kind: ExtensionKind
+    status: ExtensionStatus
+    text: str
+
+
+@dataclass(frozen=True)
+class DailyReportRow:
+    """One day's reporting row.
+
+    ``date`` is ``datetime.date`` (day-grain in the account's timezone) —
+    never an ``int`` epoch.
+    """
+
+    date: date
+    impressions: int
+    clicks: int
+    cost_micros: int
+    conversions: float
+
+
+# ---------------------------------------------------------------------------
+# Request / Filter DTOs (write-side surface — what providers accept)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CampaignFilters:
+    """All-optional filter DTO for narrowing ``list_campaigns`` results."""
+
+    status: CampaignStatus | None = None
+    name_contains: str | None = None
+
+
+@dataclass(frozen=True)
+class CreateCampaignRequest:
+    """Required fields for creating a campaign.
+
+    ``daily_budget_micros`` follows the micros convention (see module
+    docstring). A future ``Money`` abstraction may replace it in Phase 2.
+    """
+
+    name: str
+    daily_budget_micros: int
+    start_date: date | None = None
+    end_date: date | None = None
+    bidding_strategy: BidStrategy | None = None
+
+
+@dataclass(frozen=True)
+class UpdateCampaignRequest:
+    """Partial-update DTO for campaign mutation — all fields optional.
+
+    Adapters interpret ``None`` as "do not touch this field".
+    """
+
+    name: str | None = None
+    daily_budget_micros: int | None = None
+    status: CampaignStatus | None = None
+    bidding_strategy: BidStrategy | None = None
+
+
+@dataclass(frozen=True)
+class CreateAdRequest:
+    """Required fields for creating an ad.
+
+    ``headlines`` and ``descriptions`` are immutable tuples — adapters
+    that internally hold lists must ``tuple(...)``-convert before
+    constructing this DTO.
+    """
+
+    ad_group_id: str
+    headlines: tuple[str, ...]
+    descriptions: tuple[str, ...]
+    final_urls: tuple[str, ...] | None = None
+    path1: str | None = None
+    path2: str | None = None
+
+
+@dataclass(frozen=True)
+class UpdateAdRequest:
+    """Partial-update DTO for ad mutation — all fields optional."""
+
+    headlines: tuple[str, ...] | None = None
+    descriptions: tuple[str, ...] | None = None
+    final_urls: tuple[str, ...] | None = None
+    path1: str | None = None
+    path2: str | None = None
+
+
+@dataclass(frozen=True)
+class CreateAudienceRequest:
+    """Required fields for creating an audience."""
+
+    name: str
+    description: str | None = None
+    seed_audience_id: str | None = None
+
+
+@dataclass(frozen=True)
+class ExtensionRequest:
+    """Required fields for creating / updating an ad extension."""
+
+    kind: ExtensionKind
+    text: str
+    url: str | None = None
+    description1: str | None = None
+    description2: str | None = None
+
+
+__all__ = [
+    "Ad",
+    "AdStatus",
+    "Audience",
+    "AudienceStatus",
+    "BidStrategy",
+    "Campaign",
+    "CampaignFilters",
+    "CampaignStatus",
+    "CreateAdRequest",
+    "CreateAudienceRequest",
+    "CreateCampaignRequest",
+    "DailyReportRow",
+    "Extension",
+    "ExtensionKind",
+    "ExtensionRequest",
+    "ExtensionStatus",
+    "Keyword",
+    "KeywordMatchType",
+    "KeywordSpec",
+    "KeywordStatus",
+    "SearchTerm",
+    "UpdateAdRequest",
+    "UpdateCampaignRequest",
+]

--- a/tests/core/providers/test_audience.py
+++ b/tests/core/providers/test_audience.py
@@ -1,0 +1,102 @@
+"""Tests for ``mureo.core.providers.audience``.
+
+RED phase tests for Issue #89 Phase 1 subtask P1-05.
+
+Pins the structural contract for ``AudienceProvider`` — the
+runtime-checkable Protocol audience-supporting adapters must satisfy.
+
+Per the HANDOFF Open Question resolution, the canonical delete signal
+is ``set_audience_status(audience_id, AudienceStatus.REMOVED)`` rather
+than a separate ``delete_audience`` method. This keeps the Capability
+enum locked and matches ``CampaignProvider.set_ad_status`` /
+``KeywordProvider.set_keyword_status``.
+
+Marks: all tests are ``@pytest.mark.unit`` — pure logic, no I/O, no
+mocks needed.
+"""
+
+from __future__ import annotations
+
+import inspect
+import typing
+from typing import Protocol
+
+import pytest
+
+# NOTE: These imports are expected to FAIL during the RED phase — the
+# module does not exist yet. The implementer (GREEN phase) will create
+# ``mureo/core/providers/audience.py``.
+from mureo.core.providers.audience import AudienceProvider
+from mureo.core.providers.base import BaseProvider
+
+_REQUIRED_METHODS: tuple[str, ...] = (
+    "list_audiences",
+    "get_audience",
+    "create_audience",
+    "set_audience_status",
+)
+
+
+# ---------------------------------------------------------------------------
+# Case 1 — AudienceProvider is a runtime-checkable Protocol
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_audience_provider_is_runtime_checkable_protocol() -> None:
+    """``AudienceProvider`` is a ``Protocol`` decorated with
+    ``@runtime_checkable``.
+    """
+    assert issubclass(
+        AudienceProvider, Protocol
+    ), "AudienceProvider must be a typing.Protocol subclass"
+    assert (
+        getattr(AudienceProvider, "_is_runtime_protocol", False) is True
+    ), "AudienceProvider must be decorated with @runtime_checkable"
+
+
+# ---------------------------------------------------------------------------
+# Case 2 — AudienceProvider extends BaseProvider
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_audience_provider_extends_base_provider() -> None:
+    """``AudienceProvider`` structurally extends ``BaseProvider``.
+    The three BaseProvider attributes must appear in its type hints, AND
+    BaseProvider must be in the MRO.
+    """
+    assert BaseProvider in AudienceProvider.__mro__, (
+        "AudienceProvider must declare ``class AudienceProvider"
+        "(BaseProvider, Protocol): ...``"
+    )
+    hints = typing.get_type_hints(AudienceProvider)
+    for attr in ("name", "display_name", "capabilities"):
+        assert attr in hints, (
+            f"AudienceProvider must inherit attribute {attr!r} from "
+            f"BaseProvider; got hints keys: {sorted(hints.keys())}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Case 3 — All required methods are declared on the Protocol
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("method_name", _REQUIRED_METHODS)
+def test_required_methods_present(method_name: str) -> None:
+    """``AudienceProvider`` declares the four documented method names.
+
+    Note: ``set_audience_status`` is preferred over ``delete_audience``
+    per the HANDOFF Open Question resolution (matches the
+    delete-via-status convention used elsewhere in the provider ABI).
+    """
+    assert hasattr(
+        AudienceProvider, method_name
+    ), f"AudienceProvider must declare method {method_name!r}"
+    attr = getattr(AudienceProvider, method_name)
+    assert inspect.isfunction(attr) or callable(attr), (
+        f"AudienceProvider.{method_name} must be a function / callable; "
+        f"got {type(attr).__name__}"
+    )

--- a/tests/core/providers/test_campaign.py
+++ b/tests/core/providers/test_campaign.py
@@ -1,0 +1,245 @@
+"""Tests for ``mureo.core.providers.campaign``.
+
+RED phase tests for Issue #89 Phase 1 subtask P1-03.
+
+Pins the structural contract for ``CampaignProvider`` — the
+runtime-checkable Protocol every adapter that supports campaign /
+ad / daily-report operations must satisfy.
+
+Marks: all tests are ``@pytest.mark.unit`` — pure logic, no I/O, no
+mocks needed.
+"""
+
+# ruff: noqa: TC003
+# ``date`` and ``Callable`` must stay at module top-level so
+# ``typing.get_type_hints()`` and dataclass-time annotation resolution
+# work for the runtime assertions and the ``_FakeCampaignProvider`` fixture.
+from __future__ import annotations
+
+import inspect
+import typing
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import date
+from typing import Protocol
+
+import pytest
+
+# NOTE: These imports are expected to FAIL during the RED phase — the
+# module does not exist yet. The implementer (GREEN phase) will create
+# ``mureo/core/providers/campaign.py``.
+from mureo.core.providers.base import BaseProvider
+from mureo.core.providers.campaign import CampaignProvider
+from mureo.core.providers.capabilities import Capability
+from mureo.core.providers.models import (
+    Ad,
+    AdStatus,
+    Campaign,
+    CampaignFilters,
+    CreateAdRequest,
+    CreateCampaignRequest,
+    DailyReportRow,
+    UpdateAdRequest,
+    UpdateCampaignRequest,
+)
+
+# Names every CampaignProvider must declare (per HANDOFF AC P1-03).
+_REQUIRED_METHODS: tuple[str, ...] = (
+    "list_campaigns",
+    "get_campaign",
+    "create_campaign",
+    "update_campaign",
+    "list_ads",
+    "get_ad",
+    "create_ad",
+    "update_ad",
+    "set_ad_status",
+    "daily_report",
+)
+
+
+# ---------------------------------------------------------------------------
+# Local _FakeCampaignProvider fixture — frozen dataclass that satisfies the
+# Protocol attribute-wise (3 BaseProvider attrs + 10 method stubs).
+# ---------------------------------------------------------------------------
+
+
+def _noop(*args: object, **kwargs: object) -> object:  # pragma: no cover
+    """Generic stub returning ``None``; satisfies callable-attribute checks."""
+    return None
+
+
+@dataclass(frozen=True)
+class _FakeCampaignProvider:
+    """Minimal frozen-dataclass fixture satisfying the CampaignProvider
+    structural shape — three BaseProvider attributes plus the ten
+    Protocol methods as instance-attribute callables.
+    """
+
+    name: str = "fake_ads"
+    display_name: str = "Fake Ads"
+    capabilities: frozenset[Capability] = field(
+        default_factory=lambda: frozenset({Capability.READ_CAMPAIGNS})
+    )
+    list_campaigns: Callable[..., object] = field(default_factory=lambda: _noop)
+    get_campaign: Callable[..., object] = field(default_factory=lambda: _noop)
+    create_campaign: Callable[..., object] = field(default_factory=lambda: _noop)
+    update_campaign: Callable[..., object] = field(default_factory=lambda: _noop)
+    list_ads: Callable[..., object] = field(default_factory=lambda: _noop)
+    get_ad: Callable[..., object] = field(default_factory=lambda: _noop)
+    create_ad: Callable[..., object] = field(default_factory=lambda: _noop)
+    update_ad: Callable[..., object] = field(default_factory=lambda: _noop)
+    set_ad_status: Callable[..., object] = field(default_factory=lambda: _noop)
+    daily_report: Callable[..., object] = field(default_factory=lambda: _noop)
+
+
+# ---------------------------------------------------------------------------
+# Case 1 — CampaignProvider is a runtime-checkable Protocol
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_campaign_provider_is_runtime_checkable_protocol() -> None:
+    """``CampaignProvider`` is a ``Protocol`` decorated with
+    ``@runtime_checkable``.
+    """
+    assert issubclass(
+        CampaignProvider, Protocol
+    ), "CampaignProvider must be a typing.Protocol subclass"
+    assert getattr(CampaignProvider, "_is_runtime_protocol", False) is True, (
+        "CampaignProvider must be decorated with @runtime_checkable so "
+        "isinstance() can perform structural checks at runtime."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Case 2 — CampaignProvider extends BaseProvider attribute-wise
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_campaign_provider_extends_base_provider() -> None:
+    """``CampaignProvider`` structurally extends ``BaseProvider`` — the
+    three BaseProvider attributes (``name``, ``display_name``,
+    ``capabilities``) must appear as annotated attributes on the
+    Protocol, AND ``BaseProvider`` must be in the MRO.
+    """
+    assert BaseProvider in CampaignProvider.__mro__, (
+        "CampaignProvider must declare ``class CampaignProvider"
+        "(BaseProvider, Protocol): ...`` so BaseProvider is in its MRO."
+    )
+
+    hints = typing.get_type_hints(CampaignProvider)
+    for attr in ("name", "display_name", "capabilities"):
+        assert attr in hints, (
+            f"CampaignProvider must inherit attribute {attr!r} from "
+            f"BaseProvider; got hints keys: {sorted(hints.keys())}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Case 3 — isinstance passes for a compliant fake (structural duck typing)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_isinstance_passes_for_compliant_fake() -> None:
+    """A frozen-dataclass fixture exposing all BaseProvider attributes
+    plus all CampaignProvider method attributes satisfies both
+    ``isinstance(obj, CampaignProvider)`` and
+    ``isinstance(obj, BaseProvider)``.
+    """
+    fake = _FakeCampaignProvider()
+    assert isinstance(fake, BaseProvider) is True
+    assert isinstance(fake, CampaignProvider) is True
+
+
+# ---------------------------------------------------------------------------
+# Case 4 — All required methods are declared on the Protocol
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("method_name", _REQUIRED_METHODS)
+def test_required_methods_present(method_name: str) -> None:
+    """``CampaignProvider`` declares every method named in the HANDOFF
+    AC for P1-03. The attribute must be present and callable
+    (Protocol methods are stored as function objects).
+    """
+    assert hasattr(
+        CampaignProvider, method_name
+    ), f"CampaignProvider must declare method {method_name!r}"
+    attr = getattr(CampaignProvider, method_name)
+    assert inspect.isfunction(attr) or callable(attr), (
+        f"CampaignProvider.{method_name} must be a function / callable; "
+        f"got {type(attr).__name__}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Case 5 — daily_report uses datetime.date for start_date / end_date params
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_method_signatures_use_date_not_int() -> None:
+    """``CampaignProvider.daily_report`` takes ``start_date`` and
+    ``end_date`` typed as ``datetime.date`` — never ``int`` (no epoch
+    seconds at the Protocol boundary).
+    """
+    hints = typing.get_type_hints(CampaignProvider.daily_report)
+
+    for param in ("start_date", "end_date"):
+        assert param in hints, (
+            f"CampaignProvider.daily_report must declare parameter "
+            f"{param!r}; got hints: {sorted(hints.keys())}"
+        )
+        param_type = hints[param]
+        # Resolve Optional[date] / date | None to its non-None member.
+        args = typing.get_args(param_type)
+        if type(None) in args:
+            non_none = [a for a in args if a is not type(None)]
+            assert len(non_none) == 1
+            inner = non_none[0]
+        else:
+            inner = param_type
+
+        assert inner is date, (
+            f"CampaignProvider.daily_report.{param} must be typed as "
+            f"datetime.date; got {inner!r}"
+        )
+        assert inner is not int, (
+            f"CampaignProvider.daily_report.{param} must NOT be int "
+            f"(no epoch seconds at the Protocol boundary)"
+        )
+
+    # Return type must be tuple[DailyReportRow, ...] for immutability.
+    return_type = hints.get("return")
+    assert (
+        return_type is not None
+    ), "CampaignProvider.daily_report must declare a return annotation"
+    origin = typing.get_origin(return_type)
+    assert origin is tuple, (
+        f"CampaignProvider.daily_report must return tuple[DailyReportRow, "
+        f"...] (immutable); got origin {origin!r}, type {return_type!r}"
+    )
+    type_args = typing.get_args(return_type)
+    assert DailyReportRow in type_args, (
+        f"CampaignProvider.daily_report return tuple must carry "
+        f"DailyReportRow elements; got args {type_args!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Silence linter for imports used only for type resolution by ``get_type_hints``
+# ---------------------------------------------------------------------------
+_ = (
+    Ad,
+    AdStatus,
+    Campaign,
+    CampaignFilters,
+    CreateAdRequest,
+    CreateCampaignRequest,
+    UpdateAdRequest,
+    UpdateCampaignRequest,
+)

--- a/tests/core/providers/test_domain_protocol_invariants.py
+++ b/tests/core/providers/test_domain_protocol_invariants.py
@@ -1,0 +1,207 @@
+"""Cross-Protocol invariant tests for the four Phase 1 domain Protocols.
+
+RED phase tests for Issue #89 Phase 1 subtasks P1-03..P1-06.
+
+These tests parametrize over the four domain Protocols
+(``CampaignProvider``, ``KeywordProvider``, ``AudienceProvider``,
+``ExtensionProvider``) and verify invariants that must hold for ALL of
+them. Anything specific to a single Protocol lives in the dedicated
+``test_<protocol>.py`` file.
+
+Marks: all tests are ``@pytest.mark.unit`` — pure logic, no I/O, no
+mocks needed.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import typing
+
+import pytest
+
+# NOTE: These imports are expected to FAIL during the RED phase — the
+# leaf modules do not exist yet. The implementer (GREEN phase) will
+# create them.
+from mureo.core.providers.audience import AudienceProvider
+from mureo.core.providers.base import BaseProvider
+from mureo.core.providers.campaign import CampaignProvider
+from mureo.core.providers.extension import ExtensionProvider
+from mureo.core.providers.keyword import KeywordProvider
+
+_DOMAIN_PROTOCOLS: tuple[type, ...] = (
+    CampaignProvider,
+    KeywordProvider,
+    AudienceProvider,
+    ExtensionProvider,
+)
+
+_PROTOCOL_NAMES: tuple[str, ...] = (
+    "CampaignProvider",
+    "KeywordProvider",
+    "AudienceProvider",
+    "ExtensionProvider",
+)
+
+# Internal mureo.* imports each domain Protocol leaf module is allowed
+# to make (per HANDOFF AC). The own module is always implicitly allowed.
+_ALLOWED_INTERNAL_IMPORTS: frozenset[str] = frozenset(
+    {
+        "mureo.core.providers.base",
+        "mureo.core.providers.capabilities",
+        "mureo.core.providers.models",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Case 1 — All four domain Protocols are runtime-checkable
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "protocol_cls",
+    _DOMAIN_PROTOCOLS,
+    ids=lambda c: c.__name__,
+)
+def test_all_domain_protocols_are_runtime_checkable(
+    protocol_cls: type,
+) -> None:
+    """Every Phase 1 domain Protocol is decorated with
+    ``@runtime_checkable``.
+    """
+    assert (
+        getattr(protocol_cls, "_is_runtime_protocol", False) is True
+    ), f"{protocol_cls.__name__} must be decorated with @runtime_checkable"
+
+
+# ---------------------------------------------------------------------------
+# Case 2 — All four inherit the BaseProvider attribute set
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "protocol_cls",
+    _DOMAIN_PROTOCOLS,
+    ids=lambda c: c.__name__,
+)
+def test_all_domain_protocols_inherit_base_provider_attributes(
+    protocol_cls: type,
+) -> None:
+    """Every Phase 1 domain Protocol structurally extends
+    ``BaseProvider`` — the three attributes ``name``, ``display_name``,
+    and ``capabilities`` must all appear in its resolved type hints, and
+    ``BaseProvider`` must be in the MRO.
+    """
+    assert BaseProvider in protocol_cls.__mro__, (
+        f"{protocol_cls.__name__} must declare ``class {protocol_cls.__name__}"
+        "(BaseProvider, Protocol): ...``"
+    )
+    hints = typing.get_type_hints(protocol_cls)
+    for attr in ("name", "display_name", "capabilities"):
+        assert attr in hints, (
+            f"{protocol_cls.__name__} must inherit attribute {attr!r} "
+            f"from BaseProvider; got hints keys: {sorted(hints.keys())}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Case 3 — All four leaf modules have allowed-imports only (AST scan)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "module_dotted",
+    [
+        "mureo.core.providers.campaign",
+        "mureo.core.providers.keyword",
+        "mureo.core.providers.audience",
+        "mureo.core.providers.extension",
+    ],
+)
+def test_all_domain_protocol_modules_have_allowed_imports_only(
+    module_dotted: str,
+) -> None:
+    """Each domain Protocol leaf module may only import from
+    ``{base, capabilities, models}`` among internal ``mureo.*`` paths.
+
+    Uses ``ast.parse`` on the module's source. ``TYPE_CHECKING``-guarded
+    imports are intentionally treated identically to runtime imports —
+    the import allow-list is total.
+    """
+    module = __import__(module_dotted, fromlist=["_dummy"])
+    source_path = inspect.getsourcefile(module)
+    assert source_path is not None, f"Could not locate {module_dotted} on disk"
+
+    with open(source_path, encoding="utf-8") as fh:
+        tree = ast.parse(fh.read(), filename=source_path)
+
+    own_module = module.__name__
+    offending: list[str] = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if (
+                    alias.name.startswith("mureo.")
+                    and alias.name != own_module
+                    and alias.name not in _ALLOWED_INTERNAL_IMPORTS
+                ):
+                    offending.append(f"import {alias.name}")
+        elif isinstance(node, ast.ImportFrom):
+            mod = node.module or ""
+            if node.level > 0:
+                offending.append(f"from {'.' * node.level}{mod} import ... (relative)")
+            elif (
+                mod.startswith("mureo.")
+                and mod != own_module
+                and mod not in _ALLOWED_INTERNAL_IMPORTS
+            ):
+                offending.append(f"from {mod} import ...")
+            elif mod == "mureo":
+                offending.append("from mureo import ...")
+
+    assert offending == [], (
+        f"{module_dotted} may only import from "
+        f"{sorted(_ALLOWED_INTERNAL_IMPORTS)} among internal mureo.* "
+        f"modules. Found: {offending}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Case 4 — All four Protocols are re-exported from the package init
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("protocol_name", _PROTOCOL_NAMES)
+def test_all_domain_protocols_are_reexported_from_package(
+    protocol_name: str,
+) -> None:
+    """Each domain Protocol is re-exported from
+    ``mureo.core.providers`` and is the **same object identity** as the
+    one defined in the leaf module (no wrapping / aliasing).
+    """
+    import mureo.core.providers as pkg
+
+    assert hasattr(
+        pkg, protocol_name
+    ), f"mureo.core.providers must re-export {protocol_name!r}"
+
+    # Map name -> leaf-module symbol for identity comparison.
+    leaf_symbols: dict[str, type] = {
+        "CampaignProvider": CampaignProvider,
+        "KeywordProvider": KeywordProvider,
+        "AudienceProvider": AudienceProvider,
+        "ExtensionProvider": ExtensionProvider,
+    }
+    expected = leaf_symbols[protocol_name]
+    actual = getattr(pkg, protocol_name)
+
+    assert actual is expected, (
+        f"mureo.core.providers.{protocol_name} must be the same object "
+        f"as the leaf-module symbol (identity check failed)"
+    )

--- a/tests/core/providers/test_extension.py
+++ b/tests/core/providers/test_extension.py
@@ -1,0 +1,123 @@
+"""Tests for ``mureo.core.providers.extension``.
+
+RED phase tests for Issue #89 Phase 1 subtask P1-06.
+
+Pins the structural contract for ``ExtensionProvider`` — the
+runtime-checkable Protocol search-platform adapters use for sitelinks /
+callouts / conversion extensions. Social / display platforms typically
+do NOT implement this Protocol.
+
+Marks: all tests are ``@pytest.mark.unit`` — pure logic, no I/O, no
+mocks needed.
+"""
+
+from __future__ import annotations
+
+import inspect
+import typing
+from typing import Protocol
+
+import pytest
+
+# NOTE: These imports are expected to FAIL during the RED phase — the
+# module does not exist yet. The implementer (GREEN phase) will create
+# ``mureo/core/providers/extension.py``.
+from mureo.core.providers.base import BaseProvider
+from mureo.core.providers.extension import ExtensionProvider
+from mureo.core.providers.models import ExtensionKind
+
+_REQUIRED_METHODS: tuple[str, ...] = (
+    "list_extensions",
+    "add_extension",
+    "set_extension_status",
+)
+
+
+# ---------------------------------------------------------------------------
+# Case 1 — ExtensionProvider is a runtime-checkable Protocol
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_extension_provider_is_runtime_checkable_protocol() -> None:
+    """``ExtensionProvider`` is a ``Protocol`` decorated with
+    ``@runtime_checkable``.
+    """
+    assert issubclass(
+        ExtensionProvider, Protocol
+    ), "ExtensionProvider must be a typing.Protocol subclass"
+    assert (
+        getattr(ExtensionProvider, "_is_runtime_protocol", False) is True
+    ), "ExtensionProvider must be decorated with @runtime_checkable"
+
+
+# ---------------------------------------------------------------------------
+# Case 2 — ExtensionProvider extends BaseProvider
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_extension_provider_extends_base_provider() -> None:
+    """``ExtensionProvider`` structurally extends ``BaseProvider``.
+    The three BaseProvider attributes must appear in its type hints, AND
+    BaseProvider must be in the MRO.
+    """
+    assert BaseProvider in ExtensionProvider.__mro__, (
+        "ExtensionProvider must declare ``class ExtensionProvider"
+        "(BaseProvider, Protocol): ...``"
+    )
+    hints = typing.get_type_hints(ExtensionProvider)
+    for attr in ("name", "display_name", "capabilities"):
+        assert attr in hints, (
+            f"ExtensionProvider must inherit attribute {attr!r} from "
+            f"BaseProvider; got hints keys: {sorted(hints.keys())}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Case 3 — All required methods are declared on the Protocol
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("method_name", _REQUIRED_METHODS)
+def test_required_methods_present(method_name: str) -> None:
+    """``ExtensionProvider`` declares the three documented method names."""
+    assert hasattr(
+        ExtensionProvider, method_name
+    ), f"ExtensionProvider must declare method {method_name!r}"
+    attr = getattr(ExtensionProvider, method_name)
+    assert inspect.isfunction(attr) or callable(attr), (
+        f"ExtensionProvider.{method_name} must be a function / callable; "
+        f"got {type(attr).__name__}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Case 4 — list_extensions ``kind`` param is ExtensionKind, not str
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_extension_kind_parameter_is_extensionkind_enum() -> None:
+    """``ExtensionProvider.list_extensions`` declares its ``kind``
+    parameter as ``ExtensionKind`` — never ``str``. Forces type-safe
+    dispatch so adapter implementations cannot accept arbitrary strings.
+    """
+    hints = typing.get_type_hints(ExtensionProvider.list_extensions)
+
+    assert "kind" in hints, (
+        "ExtensionProvider.list_extensions must declare a 'kind' parameter; "
+        f"got hints: {sorted(hints.keys())}"
+    )
+    kind_type = hints["kind"]
+
+    assert kind_type is ExtensionKind, (
+        f"ExtensionProvider.list_extensions.kind must be typed as "
+        f"ExtensionKind enum (type-safe dispatch); got {kind_type!r}"
+    )
+    assert kind_type is not str, (
+        "ExtensionProvider.list_extensions.kind must NOT be bare str "
+        "(use the ExtensionKind enum so adapters cannot accept "
+        "arbitrary strings)"
+    )

--- a/tests/core/providers/test_keyword.py
+++ b/tests/core/providers/test_keyword.py
@@ -1,0 +1,140 @@
+"""Tests for ``mureo.core.providers.keyword``.
+
+RED phase tests for Issue #89 Phase 1 subtask P1-04.
+
+Pins the structural contract for ``KeywordProvider`` — the
+runtime-checkable Protocol search-platform adapters (Google Ads,
+Bing/Microsoft Ads, Apple Search Ads) must satisfy. Social / display
+platforms typically do NOT implement this Protocol.
+
+Marks: all tests are ``@pytest.mark.unit`` — pure logic, no I/O, no
+mocks needed.
+"""
+
+from __future__ import annotations
+
+import collections.abc
+import inspect
+import typing
+from typing import Protocol
+
+import pytest
+
+# NOTE: These imports are expected to FAIL during the RED phase — the
+# module does not exist yet. The implementer (GREEN phase) will create
+# ``mureo/core/providers/keyword.py``.
+from mureo.core.providers.base import BaseProvider
+from mureo.core.providers.keyword import KeywordProvider
+from mureo.core.providers.models import KeywordSpec
+
+_REQUIRED_METHODS: tuple[str, ...] = (
+    "list_keywords",
+    "add_keywords",
+    "set_keyword_status",
+    "search_terms",
+)
+
+
+# ---------------------------------------------------------------------------
+# Case 1 — KeywordProvider is a runtime-checkable Protocol
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_keyword_provider_is_runtime_checkable_protocol() -> None:
+    """``KeywordProvider`` is a ``Protocol`` decorated with
+    ``@runtime_checkable``.
+    """
+    assert issubclass(
+        KeywordProvider, Protocol
+    ), "KeywordProvider must be a typing.Protocol subclass"
+    assert (
+        getattr(KeywordProvider, "_is_runtime_protocol", False) is True
+    ), "KeywordProvider must be decorated with @runtime_checkable"
+
+
+# ---------------------------------------------------------------------------
+# Case 2 — KeywordProvider extends BaseProvider
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_keyword_provider_extends_base_provider() -> None:
+    """``KeywordProvider`` structurally extends ``BaseProvider``.
+    The three BaseProvider attributes must appear in its type hints, AND
+    BaseProvider must be in the MRO.
+    """
+    assert BaseProvider in KeywordProvider.__mro__, (
+        "KeywordProvider must declare ``class KeywordProvider"
+        "(BaseProvider, Protocol): ...``"
+    )
+    hints = typing.get_type_hints(KeywordProvider)
+    for attr in ("name", "display_name", "capabilities"):
+        assert attr in hints, (
+            f"KeywordProvider must inherit attribute {attr!r} from "
+            f"BaseProvider; got hints keys: {sorted(hints.keys())}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Case 3 — All required methods are declared on the Protocol
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("method_name", _REQUIRED_METHODS)
+def test_required_methods_present(method_name: str) -> None:
+    """``KeywordProvider`` declares the four documented method names."""
+    assert hasattr(
+        KeywordProvider, method_name
+    ), f"KeywordProvider must declare method {method_name!r}"
+    attr = getattr(KeywordProvider, method_name)
+    assert inspect.isfunction(attr) or callable(attr), (
+        f"KeywordProvider.{method_name} must be a function / callable; "
+        f"got {type(attr).__name__}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Case 4 — add_keywords accepts Sequence[KeywordSpec], not list[KeywordSpec]
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_add_keywords_accepts_sequence_not_list() -> None:
+    """``KeywordProvider.add_keywords`` declares its ``keywords``
+    parameter as ``Sequence[KeywordSpec]`` (covariant, read-only input
+    view) — NOT ``list[KeywordSpec]``. Inputs that are collections must
+    use ``Sequence`` per the immutability convention.
+
+    The return type must also be ``tuple[Keyword, ...]`` — never
+    ``list[Keyword]`` — per the same convention.
+    """
+    hints = typing.get_type_hints(KeywordProvider.add_keywords)
+
+    assert "keywords" in hints, (
+        "KeywordProvider.add_keywords must declare a 'keywords' parameter; "
+        f"got hints: {sorted(hints.keys())}"
+    )
+    param_type = hints["keywords"]
+    origin = typing.get_origin(param_type)
+
+    # Origin should be collections.abc.Sequence (typing.Sequence aliases to
+    # it on Python 3.9+).
+    assert origin is collections.abc.Sequence, (
+        f"KeywordProvider.add_keywords.keywords must be typed as "
+        f"Sequence[KeywordSpec] (read-only input view), NOT list[...]; "
+        f"got origin {origin!r}, type {param_type!r}"
+    )
+
+    # Defensive: explicit list rejection.
+    assert origin is not list, (
+        "KeywordProvider.add_keywords.keywords must NOT be list[...] "
+        "(violates input-immutability rule)"
+    )
+
+    type_args = typing.get_args(param_type)
+    assert KeywordSpec in type_args, (
+        f"KeywordProvider.add_keywords.keywords must carry KeywordSpec "
+        f"elements; got args {type_args!r}"
+    )

--- a/tests/core/providers/test_models.py
+++ b/tests/core/providers/test_models.py
@@ -1,0 +1,518 @@
+"""Tests for ``mureo.core.providers.models``.
+
+RED phase tests for Issue #89 Phase 1 subtasks P1-03..P1-06.
+
+These tests pin the stable ABI surface for the shared domain models
+consumed by the four domain Protocols (``CampaignProvider``,
+``KeywordProvider``, ``AudienceProvider``, ``ExtensionProvider``) and by
+adapters / third-party plugins.
+
+Marks: all tests are ``@pytest.mark.unit`` — pure logic, no I/O, no
+mocks needed.
+"""
+
+from __future__ import annotations
+
+import ast
+import dataclasses
+import inspect
+import re
+import typing
+from enum import Enum
+
+import pytest
+
+# NOTE: These imports are expected to FAIL during the RED phase — the
+# module does not exist yet. That is correct. The implementer (GREEN
+# phase) will create ``mureo/core/providers/models.py``.
+from mureo.core.providers.models import (  # noqa: E402
+    Ad,
+    AdStatus,
+    Audience,
+    AudienceStatus,
+    Campaign,
+    CampaignFilters,
+    CampaignStatus,
+    CreateAdRequest,
+    CreateAudienceRequest,
+    CreateCampaignRequest,
+    DailyReportRow,
+    Extension,
+    ExtensionKind,
+    ExtensionRequest,
+    ExtensionStatus,
+    Keyword,
+    KeywordMatchType,
+    KeywordSpec,
+    KeywordStatus,
+    SearchTerm,
+    UpdateAdRequest,
+    UpdateCampaignRequest,
+)
+
+# ---------------------------------------------------------------------------
+# Reference tables (single source of truth used across cases below)
+# ---------------------------------------------------------------------------
+
+_ALL_MODELS: tuple[type, ...] = (
+    Campaign,
+    Ad,
+    Keyword,
+    KeywordSpec,
+    SearchTerm,
+    Audience,
+    Extension,
+    DailyReportRow,
+    CampaignFilters,
+    CreateCampaignRequest,
+    UpdateCampaignRequest,
+    CreateAdRequest,
+    UpdateAdRequest,
+    CreateAudienceRequest,
+    ExtensionRequest,
+)
+
+_STATUS_ENUMS: tuple[type[Enum], ...] = (
+    AdStatus,
+    AudienceStatus,
+    CampaignStatus,
+    ExtensionStatus,
+    ExtensionKind,
+    KeywordMatchType,
+    KeywordStatus,
+)
+
+_SNAKE_CASE_RE: re.Pattern[str] = re.compile(r"^[a-z_]+$")
+
+
+# ---------------------------------------------------------------------------
+# Case 1 — All domain models are frozen dataclasses
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("model_cls", _ALL_MODELS, ids=lambda c: c.__name__)
+def test_all_models_are_frozen_dataclasses(model_cls: type) -> None:
+    """Every domain model is a ``@dataclass(frozen=True)`` with at least
+    one field, and attempting to mutate an instance raises
+    ``FrozenInstanceError``.
+    """
+    assert dataclasses.is_dataclass(
+        model_cls
+    ), f"{model_cls.__name__} must be a dataclass"
+
+    fields = dataclasses.fields(model_cls)
+    assert len(fields) > 0, f"{model_cls.__name__} must declare at least one field"
+
+    # Frozen check: every dataclass must reject ``__setattr__`` post-init.
+    # We construct a minimal instance by providing the smallest plausible
+    # value for each required field. We do this by inspecting field types
+    # at the typing-string level — not perfect, but sufficient to build a
+    # frozen smoke instance.
+    try:
+        kwargs: dict[str, object] = {}
+        hints = typing.get_type_hints(model_cls)
+        for f in fields:
+            if f.default is not dataclasses.MISSING:
+                continue
+            if f.default_factory is not dataclasses.MISSING:  # type: ignore[misc]
+                continue
+            # Required field — synthesize a value based on the resolved
+            # type hint. The exact value does not matter; we only need an
+            # instance to attempt mutation on.
+            kwargs[f.name] = _synthesize_value(hints.get(f.name, str))
+        instance = model_cls(**kwargs)
+    except Exception as exc:  # pragma: no cover - synthesis fallback
+        pytest.skip(f"Could not synthesize instance for {model_cls.__name__}: {exc}")
+
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        # Field name doesn't matter — any attribute assignment must fail.
+        instance.__setattr__(fields[0].name, kwargs.get(fields[0].name))
+
+
+def _synthesize_value(hint: object) -> object:
+    """Best-effort minimal value for a type hint, used only to build a
+    smoke-test instance for the frozen-check.
+    """
+    from datetime import date, datetime, timezone
+
+    origin = typing.get_origin(hint)
+    args = typing.get_args(hint)
+
+    # Optional[T] / T | None
+    if origin is typing.Union or (origin is not None and type(None) in args):
+        non_none = [a for a in args if a is not type(None)]
+        if non_none:
+            return _synthesize_value(non_none[0])
+        return None
+
+    # tuple[T, ...]
+    if origin in (tuple,):
+        return tuple()
+
+    if hint is str:
+        return ""
+    if hint is int:
+        return 0
+    if hint is float:
+        return 0.0
+    if hint is bool:
+        return False
+    if hint is date:
+        return date(2024, 1, 1)
+    if hint is datetime:
+        return datetime(2024, 1, 1, tzinfo=timezone.utc)
+    if isinstance(hint, type) and issubclass(hint, Enum):
+        return next(iter(hint))
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Case 2 — Status / kind enums are StrEnum with snake_case values
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("enum_cls", _STATUS_ENUMS, ids=lambda c: c.__name__)
+def test_status_enums_are_strenum_snake_case(enum_cls: type[Enum]) -> None:
+    """Every status / kind enum mixes ``str`` (StrEnum semantics) and
+    every member's ``.value`` matches ``^[a-z_]+$``.
+    """
+    assert issubclass(
+        enum_cls, str
+    ), f"{enum_cls.__name__} must subclass str (StrEnum semantics)"
+    assert issubclass(enum_cls, Enum), f"{enum_cls.__name__} must be an Enum"
+
+    for member in enum_cls:
+        assert isinstance(member, str)
+        assert _SNAKE_CASE_RE.fullmatch(member.value), (
+            f"{enum_cls.__name__}.{member.name}={member.value!r} " f"is not snake_case"
+        )
+        # Strict StrEnum: ``str(member)`` must equal the raw value (no
+        # ``ClassName.MEMBER`` leak).
+        assert str(member) == member.value
+
+
+# ---------------------------------------------------------------------------
+# Case 3 — Required enum members are present
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("enum_cls", "required_members"),
+    [
+        (AdStatus, {"ENABLED", "PAUSED", "REMOVED"}),
+        (AudienceStatus, {"ENABLED", "REMOVED"}),
+        (CampaignStatus, {"ENABLED", "PAUSED", "REMOVED"}),
+        (ExtensionStatus, {"ENABLED", "PAUSED", "REMOVED"}),
+        (ExtensionKind, {"SITELINK", "CALLOUT", "CONVERSION"}),
+        (KeywordMatchType, {"EXACT", "PHRASE", "BROAD"}),
+        (KeywordStatus, {"ENABLED", "PAUSED", "REMOVED"}),
+    ],
+    ids=lambda v: v.__name__ if isinstance(v, type) else "members",
+)
+def test_required_enum_members(
+    enum_cls: type[Enum],
+    required_members: set[str],
+) -> None:
+    """Each enum must contain at least the documented required members
+    (additional members are allowed; this is a subset check, not equality).
+    """
+    actual = {m.name for m in enum_cls}
+    missing = required_members - actual
+    assert not missing, (
+        f"{enum_cls.__name__} is missing required members: {sorted(missing)}; "
+        f"has: {sorted(actual)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Case 4 — Date / datetime contract: dates are date-typed, not int epoch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("model_cls", "date_field_names"),
+    [
+        (DailyReportRow, ("date",)),
+        # CreateCampaignRequest has optional start_date / end_date — when
+        # present, must be ``date | None``, never ``int`` / ``float``.
+        (CreateCampaignRequest, ("start_date", "end_date")),
+    ],
+    ids=lambda v: v.__name__ if isinstance(v, type) else "fields",
+)
+def test_dates_are_date_typed_not_int_epoch(
+    model_cls: type,
+    date_field_names: tuple[str, ...],
+) -> None:
+    """Date fields must be typed as ``datetime.date`` (or ``datetime``),
+    never ``int`` / ``float`` (no epoch ints, no ISO strings).
+    """
+    from datetime import date, datetime
+
+    hints = typing.get_type_hints(model_cls)
+
+    for field_name in date_field_names:
+        assert field_name in hints, (
+            f"{model_cls.__name__} must declare field {field_name!r} "
+            f"(per Phase 1 ABI)"
+        )
+        hint = hints[field_name]
+        # Resolve Optional[date] / date | None to its non-None member.
+        args = typing.get_args(hint)
+        if type(None) in args:
+            non_none = [a for a in args if a is not type(None)]
+            assert len(non_none) == 1, (
+                f"{model_cls.__name__}.{field_name} optional must wrap "
+                f"a single date-like type; got {hint!r}"
+            )
+            inner = non_none[0]
+        else:
+            inner = hint
+
+        assert inner in (date, datetime), (
+            f"{model_cls.__name__}.{field_name} must be typed as "
+            f"datetime.date or datetime.datetime; got {inner!r}"
+        )
+        # Explicitly forbid int / float to make the failure mode obvious
+        # if a future implementer regresses to epoch seconds.
+        assert inner is not int, (
+            f"{model_cls.__name__}.{field_name} must NOT be int "
+            f"(no epoch seconds at the Protocol boundary)"
+        )
+        assert inner is not float, (
+            f"{model_cls.__name__}.{field_name} must NOT be float "
+            f"(no epoch seconds at the Protocol boundary)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Case 5 — Required vs optional field boundaries for DTOs
+# ---------------------------------------------------------------------------
+
+
+# Curated required/optional split from the HANDOFF "Models design decisions"
+# table. Additional optional fields are allowed; required fields must have
+# no default; named optional fields must have a default.
+_REQUIRED_OPTIONAL_TABLE: tuple[tuple[type, frozenset[str], frozenset[str]], ...] = (
+    (
+        CreateCampaignRequest,
+        frozenset({"name", "daily_budget_micros"}),
+        frozenset({"start_date", "end_date", "bidding_strategy"}),
+    ),
+    (
+        UpdateCampaignRequest,
+        frozenset(),  # all-optional, partial-update semantics
+        frozenset({"name", "daily_budget_micros", "status", "bidding_strategy"}),
+    ),
+    (
+        CreateAdRequest,
+        frozenset({"ad_group_id", "headlines", "descriptions"}),
+        frozenset({"final_urls", "path1", "path2"}),
+    ),
+    (
+        UpdateAdRequest,
+        frozenset(),
+        frozenset({"headlines", "descriptions", "final_urls", "path1", "path2"}),
+    ),
+    (
+        CreateAudienceRequest,
+        frozenset({"name"}),
+        frozenset({"description", "seed_audience_id"}),
+    ),
+    (
+        ExtensionRequest,
+        frozenset({"kind", "text"}),
+        frozenset({"url", "description1", "description2"}),
+    ),
+    (
+        KeywordSpec,
+        frozenset({"text", "match_type"}),
+        frozenset({"cpc_bid_micros"}),
+    ),
+    (
+        CampaignFilters,
+        frozenset(),
+        frozenset({"status", "name_contains"}),
+    ),
+)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("model_cls", "required_fields", "optional_fields"),
+    _REQUIRED_OPTIONAL_TABLE,
+    ids=lambda v: v.__name__ if isinstance(v, type) else "fields",
+)
+def test_required_vs_optional_field_boundaries(
+    model_cls: type,
+    required_fields: frozenset[str],
+    optional_fields: frozenset[str],
+) -> None:
+    """Required fields must have NO default; the named optional fields
+    must each carry a default (so partial-update semantics work).
+    Additional unrelated optional fields are allowed (forward compat).
+    """
+    fields_by_name = {f.name: f for f in dataclasses.fields(model_cls)}
+
+    for name in required_fields:
+        assert (
+            name in fields_by_name
+        ), f"{model_cls.__name__} must declare required field {name!r}"
+        f = fields_by_name[name]
+        no_default = (
+            f.default is dataclasses.MISSING
+            and f.default_factory is dataclasses.MISSING  # type: ignore[misc]
+        )
+        assert no_default, (
+            f"{model_cls.__name__}.{name} is documented as REQUIRED but "
+            f"has a default; remove it."
+        )
+
+    for name in optional_fields:
+        assert (
+            name in fields_by_name
+        ), f"{model_cls.__name__} must declare optional field {name!r}"
+        f = fields_by_name[name]
+        has_default = (
+            f.default is not dataclasses.MISSING
+            or f.default_factory is not dataclasses.MISSING  # type: ignore[misc]
+        )
+        assert has_default, (
+            f"{model_cls.__name__}.{name} is documented as OPTIONAL but "
+            f"has no default; add one (likely ``= None``)."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Case 6 — models.py allows only ``mureo.core.providers.capabilities``
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_models_module_has_no_internal_mureo_imports_other_than_capabilities() -> None:
+    """``models.py`` is a foundation-layer module sitting alongside
+    ``capabilities.py`` and ``base.py``. The only allowed internal
+    ``mureo.*`` import is ``mureo.core.providers.capabilities`` (and only
+    if needed — the implementer may not need it).
+
+    Uses ``ast.parse`` on the module's source to scan every ``Import``
+    and ``ImportFrom`` node. ``TYPE_CHECKING``-guarded imports are
+    intentionally treated identically to runtime imports.
+    """
+    import mureo.core.providers.models as models_module
+
+    source_path = inspect.getsourcefile(models_module)
+    assert source_path is not None, "Could not locate models.py on disk"
+
+    with open(source_path, encoding="utf-8") as fh:
+        tree = ast.parse(fh.read(), filename=source_path)
+
+    own_module = models_module.__name__  # "mureo.core.providers.models"
+    allowed = {"mureo.core.providers.capabilities"}
+    offending: list[str] = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if (
+                    alias.name.startswith("mureo.")
+                    and alias.name != own_module
+                    and alias.name not in allowed
+                ):
+                    offending.append(f"import {alias.name}")
+        elif isinstance(node, ast.ImportFrom):
+            mod = node.module or ""
+            if node.level > 0:
+                offending.append(f"from {'.' * node.level}{mod} import ... (relative)")
+            elif mod.startswith("mureo.") and mod != own_module and mod not in allowed:
+                offending.append(f"from {mod} import ...")
+            elif mod == "mureo":
+                offending.append("from mureo import ...")
+
+    assert offending == [], (
+        "models.py may only import from mureo.core.providers.capabilities "
+        f"among internal mureo.* modules. Found: {offending}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Case 7 — KeywordSpec.text non-empty invariant is documented in docstring
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_keyword_spec_text_non_empty_invariant_documented() -> None:
+    """``KeywordSpec`` has no ``__post_init__`` validator in Phase 1
+    (the Protocol layer is purely structural), but its docstring MUST
+    mention the non-empty-text contract so adapter authors know to
+    enforce it.
+    """
+    doc = inspect.getdoc(KeywordSpec) or ""
+    assert "non-empty" in doc.lower(), (
+        "KeywordSpec docstring must mention the 'non-empty' text contract "
+        "so adapter authors enforce it at the adapter layer. "
+        f"Got docstring: {doc!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Case 8 — collection fields use tuple[T, ...], never list[T]
+# ---------------------------------------------------------------------------
+
+
+# Field-level "collection of T" annotations across the Phase 1 models.
+# When in doubt, the adapter must `tuple(...)`-convert before returning.
+_COLLECTION_FIELDS: tuple[tuple[type, str], ...] = (
+    (CreateAdRequest, "headlines"),
+    (CreateAdRequest, "descriptions"),
+    (UpdateAdRequest, "headlines"),
+    (UpdateAdRequest, "descriptions"),
+)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("model_cls", "field_name"),
+    _COLLECTION_FIELDS,
+    ids=lambda v: v.__name__ if isinstance(v, type) else v,
+)
+def test_dataclass_immutability_via_tuple_for_collections(
+    model_cls: type,
+    field_name: str,
+) -> None:
+    """Any model field whose semantic is "a collection of T" must be
+    annotated as ``tuple[T, ...]`` (or ``tuple[T, ...] | None`` for
+    optional collections), never ``list[T]``. This mirrors the existing
+    ``mureo/context/models.py`` immutability convention.
+    """
+    hints = typing.get_type_hints(model_cls)
+    assert (
+        field_name in hints
+    ), f"{model_cls.__name__} must declare field {field_name!r}"
+    hint = hints[field_name]
+
+    # Unwrap Optional[T] / T | None
+    args = typing.get_args(hint)
+    if type(None) in args:
+        non_none = [a for a in args if a is not type(None)]
+        assert len(non_none) == 1, (
+            f"{model_cls.__name__}.{field_name} optional must wrap a "
+            f"single collection type; got {hint!r}"
+        )
+        inner = non_none[0]
+    else:
+        inner = hint
+
+    origin = typing.get_origin(inner)
+    assert origin is tuple, (
+        f"{model_cls.__name__}.{field_name} must be typed as "
+        f"tuple[T, ...] (immutable); got {inner!r}. Use tuple, not list."
+    )
+    # Defensive: explicitly reject list at the origin level.
+    assert origin is not list, (
+        f"{model_cls.__name__}.{field_name} must NOT be list[...] "
+        f"(immutability rule)"
+    )


### PR DESCRIPTION
## Summary

Implements P1-03〜P1-06 of Issue #89 Phase 1: four domain Protocols + the shared models module that adapters and third-party plugins will implement.

| Protocol | Methods | Capability gates (declared by provider) |
|---|---|---|
| `CampaignProvider` | 10 | `READ_CAMPAIGNS`, `WRITE_BUDGET`, `WRITE_BID`, `WRITE_CREATIVE`, `WRITE_CAMPAIGN_STATUS`, `READ_PERFORMANCE` |
| `KeywordProvider` | 4 | `READ_KEYWORDS`, `WRITE_KEYWORDS`, `READ_SEARCH_TERMS` |
| `AudienceProvider` | 4 | `READ_AUDIENCES`, `WRITE_AUDIENCES` |
| `ExtensionProvider` | 3 | `READ_EXTENSIONS`, `WRITE_EXTENSIONS` |

All Protocols extend `BaseProvider`, are `@runtime_checkable`, and define the minimum-common-denominator cross-platform surface (Google Ads / Meta / display-and-native DSPs). Implementing a Protocol does **not** automatically grant capabilities — the provider's `capabilities` frozenset must explicitly include them. Capability gates which methods may be invoked even when the Protocol contract is satisfied.

### Shared models (`mureo/core/providers/models.py`)

- 11 frozen dataclasses: `Campaign`, `Ad`, `Keyword`, `KeywordSpec`, `SearchTerm`, `Audience`, `Extension`, `DailyReportRow`, `CampaignFilters`, `CreateCampaignRequest`, `UpdateCampaignRequest`, plus 5 more `Create*Request` / `Update*Request` DTOs
- 8 `StrEnum`s (3.10 shim via P1-01): `CampaignStatus`, `AdStatus`, `KeywordStatus`, `KeywordMatchType`, `BidStrategy`, `AudienceStatus`, `ExtensionStatus`, `ExtensionKind`
- All collections are `tuple[T, ...]` (immutable); all inputs are `Sequence[T]`
- `account_id` is on entities; absent from method signatures (provider is account-scoped at construction)
- `datetime.date` for day-grain reporting; `int micros` for money (Phase 2 → `Money` abstraction)

### Delete-via-status convention

No `delete_*` methods. `set_*_status(...REMOVED)` represents deletion across all Protocols. Adapters for platforms with native DELETE (e.g., LOGLY) translate this convention.

### AST-enforced foundation rule

Production Protocol modules import only from `mureo.core.providers.{base, capabilities, models}`. Enforced by `test_domain_protocol_invariants.test_allowed_imports_only` (parametrized over the 4 modules).

## Stacked on PR #91

Branch `feat/p1-03-to-06-domain-protocols` → `feat/p1-02-base-provider` → `feat/p1-01-capabilities` → `main`. Merge order: #90 → #91 → this PR.

## Follow-ups (deferred — file as issues / handle in P1-07+)

- [ ] **M-3**: `CreateAdRequest.ad_group_id` is a Google-Ads-specific concept leaking into the cross-platform DTO. Options: rename to `group_id`, make optional, or move to a Google-only extension DTO. Resolve before P1-09 (Google Ads adapter) compiles against this field.
- [ ] **L-5**: Enrich `SearchTerm` with `date`, `cost_micros`, `conversions` in Phase 2 (ABI-additive, non-breaking).
- [ ] **L-6**: Document Python 3.10 vs 3.11 `StrEnum` story for third-party plugin authors, OR bump minimum Python to 3.11 in Phase 2 and drop the shim.
- [ ] **Future**: Replace `_micros: int` fields with `Money(amount_minor: int, currency: str)` abstraction in Phase 2 (already noted in `models.py` docstring).

## Test plan

- [x] `pytest tests/core/providers/` — 171/171 passed (P1-01 46 + P1-02 31 + P1-03..06 ~94)
- [x] Coverage on `mureo/core/providers/`: 98.97%
- [x] `ruff check mureo/core/ tests/core/` — clean
- [x] `black --check mureo/core/ tests/core/` — clean
- [x] `mypy --strict mureo/core/providers/` — clean
- [x] AST scan tests pin foundation rule (imports limited to {base, capabilities, models})
- [x] `runtime_checkable` `isinstance` tests for each Protocol via frozen-dataclass fakes
- [x] `typing.get_type_hints` introspection verifies `date` typing for `daily_report`
- [x] `Sequence[T]` (not `list`) enforced for `add_keywords` batch input
- [x] All collection returns are `tuple[T, ...]` (immutable; tested via `add_keywords` headlines/descriptions invariant)
- [x] StrEnum snake_case + required-member coverage for all 8 enums (`CampaignStatus`, `KeywordStatus` added per L-3 in review fix iteration)
- [x] python-reviewer agent: APPROVE after addressing 6 findings (M-1 ABI type mismatch, M-2 BidStrategy wiring, L-1..L-4 cleanups). M-3 / L-5 / L-6 deferred to follow-ups above.

## Refs

Closes part of #89 (Phase 1 P1-03..P1-06). Next: P1-07 (entry-points registry) → P1-08 (skill matcher) → P1-09 (google_ads adapter) → P1-10 (meta_ads adapter) → P1-11 (docs).
