### PR TITLE
feat(core/providers): add entry-points discovery registry (P1-07, #89)

### DIFF
--- a/mureo/core/providers/__init__.py
+++ b/mureo/core/providers/__init__.py
@@ -3,8 +3,9 @@
 Re-exports the stable ABI from :mod:`mureo.core.providers.capabilities`,
 :mod:`mureo.core.providers.base`, the four Phase 1 domain Protocols
 (:mod:`mureo.core.providers.campaign`, :mod:`~.keyword`, :mod:`~.audience`,
-:mod:`~.extension`), and the shared domain models / enums in
-:mod:`mureo.core.providers.models`.
+:mod:`~.extension`), the shared domain models / enums in
+:mod:`mureo.core.providers.models`, and the entry-points-based discovery
+:mod:`mureo.core.providers.registry`.
 """
 
 from __future__ import annotations
@@ -49,9 +50,24 @@ from mureo.core.providers.models import (
     UpdateAdRequest,
     UpdateCampaignRequest,
 )
+from mureo.core.providers.registry import (
+    PROVIDERS_ENTRY_POINT_GROUP,
+    SKILLS_ENTRY_POINT_GROUP,
+    ProviderEntry,
+    Registry,
+    RegistryWarning,
+    clear_registry,
+    default_registry,
+    discover_providers,
+    get_provider,
+    list_providers_by_capability,
+    register_provider_class,
+)
 
 __all__ = [
     "CAPABILITY_NAMES",
+    "PROVIDERS_ENTRY_POINT_GROUP",
+    "SKILLS_ENTRY_POINT_GROUP",
     "Ad",
     "AdStatus",
     "Audience",
@@ -78,11 +94,20 @@ __all__ = [
     "KeywordProvider",
     "KeywordSpec",
     "KeywordStatus",
+    "ProviderEntry",
+    "Registry",
+    "RegistryWarning",
     "SearchTerm",
     "UpdateAdRequest",
     "UpdateCampaignRequest",
+    "clear_registry",
+    "default_registry",
+    "discover_providers",
+    "get_provider",
+    "list_providers_by_capability",
     "parse_capabilities",
     "parse_capability",
+    "register_provider_class",
     "validate_provider",
     "validate_provider_name",
 ]

--- a/mureo/core/providers/registry.py
+++ b/mureo/core/providers/registry.py
@@ -1,0 +1,559 @@
+"""Entry-points-based provider discovery registry.
+
+This module is the discovery + lookup layer for the mureo provider
+abstraction (Issue #89, P1-07). It turns Python's
+:func:`importlib.metadata.entry_points` plus an in-process registration
+API into a single source of truth for "which providers exist, what they
+can do, and where they came from."
+
+Public surface
+--------------
+- :class:`ProviderEntry` — frozen dataclass capturing a registered
+  provider's identity, declared capabilities, class object, and the pip
+  distribution that supplied it.
+- :class:`Registry` — explicit container with discovery, lookup, and
+  capability-filter methods. The module exposes a single shared
+  ``default_registry`` instance plus thin module-level wrappers.
+- :class:`RegistryWarning` — :class:`UserWarning` subclass emitted on
+  recoverable conditions (broken plugin, duplicate name, malformed
+  shape). Callers can opt into strict mode with
+  ``warnings.filterwarnings("error", category=RegistryWarning)``.
+- :data:`PROVIDERS_ENTRY_POINT_GROUP` — the ``"mureo.providers"`` group
+  iterated by :meth:`Registry.discover`.
+- :data:`SKILLS_ENTRY_POINT_GROUP` — the ``"mureo.skills"`` group name,
+  reserved for P1-08; this module does NOT iterate it.
+
+Security posture
+----------------
+Discovery loads third-party Python code (``ep.load()`` triggers the
+plugin's top-level module import). This is a known trust boundary. The
+registry mitigates the risk by:
+
+1. Wrapping every ``ep.load()`` plus the subsequent structural check in
+   a per-entry try/except so one broken plugin cannot break discovery.
+2. Validating loaded classes against :func:`validate_provider` before
+   registration; malformed plugins are skipped with a warning.
+3. Tracking ``source_distribution`` so users / support can identify the
+   pip package each provider came from.
+4. Following first-wins on duplicate names so a malicious plugin
+   installed AFTER a legitimate one cannot silently take over the slot.
+5. Deferring instantiation entirely; ``ProviderEntry.provider_class`` is
+   the class object, not an instance, so plugin ``__init__`` side
+   effects (network, FS, credential checks) are not invoked here.
+
+Warning volume / log flood considerations:
+    Each broken or duplicate plugin emits a :class:`RegistryWarning`.
+    Since the warning message embeds attacker-controllable strings
+    (entry point name, distribution name, exception ``repr``), Python's
+    default warning deduplication does not coalesce them — every
+    unique message is a fresh warning. A hostile environment that
+    installs many malformed plugins can therefore flood logs by sheer
+    volume even though no individual warning is malicious. Production
+    deployments should either:
+
+    * apply rate limits at the log sink layer (preferred), or
+    * set ``warnings.filterwarnings("error", category=RegistryWarning)``
+      to fail closed — the first malformed plugin becomes a startup
+      failure instead of N log entries.
+
+    Phase 2 may add in-module rate limiting (cap N warnings per
+    discovery pass) — tracked separately and not addressed here.
+
+Thread safety
+-------------
+The registry is NOT thread-safe (Phase 1 non-goal). Concurrent
+discovery/registration is undefined behaviour. The documented use is
+single-threaded CLI / MCP-server-startup discovery.
+
+Foundation rule
+---------------
+Internal imports are restricted to :mod:`mureo.core.providers.base`,
+:mod:`mureo.core.providers.capabilities`, and
+:mod:`mureo.core.providers.models`. No imports of the four domain
+Protocol modules — the registry treats providers structurally.
+"""
+
+from __future__ import annotations
+
+import warnings
+from dataclasses import dataclass
+from importlib.metadata import entry_points
+from typing import TYPE_CHECKING, Any, Final, cast
+
+from mureo.core.providers.base import (
+    BaseProvider,
+    validate_provider,
+    validate_provider_name,
+)
+from mureo.core.providers.capabilities import Capability
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+PROVIDERS_ENTRY_POINT_GROUP: Final[str] = "mureo.providers"
+SKILLS_ENTRY_POINT_GROUP: Final[str] = "mureo.skills"
+
+
+class RegistryWarning(UserWarning):
+    """Emitted when a registered provider is skipped, shadowed, or
+    otherwise mishandled at discovery / registration time.
+
+    Distinct subclass of :class:`UserWarning` so security-conscious
+    deployments can opt into strict mode via
+    ``warnings.filterwarnings("error", category=RegistryWarning)``.
+    """
+
+
+@dataclass(frozen=True)
+class ProviderEntry:
+    """Frozen record of a registered provider.
+
+    The field set and order are part of the public ABI; third-party
+    callers may destructure positionally. Do not reorder or remove
+    fields without a major-version bump.
+
+    Attributes:
+        name: Snake_case provider identifier (matches
+            ``^[a-z][a-z0-9_]*$``). Used as the registry key.
+        display_name: Human-readable provider label. Non-empty string.
+        capabilities: Capabilities the provider declares it can serve.
+            Must be a :class:`frozenset` of :class:`Capability` members.
+        provider_class: The class object itself (NOT an instance).
+            Instantiation is deferred to consumers.
+        source_distribution: PEP 503 normalized pip package name that
+            supplied this entry, or ``None`` when unknown (in-process
+            registrations without an explicit hint, or entry points
+            whose ``ep.dist`` is ``None``). Treat as untrusted data
+            downstream — do not interpolate into shell commands.
+    """
+
+    name: str
+    display_name: str
+    capabilities: frozenset[Capability]
+    provider_class: type
+    source_distribution: str | None
+
+    def __post_init__(self) -> None:
+        """Validate the entry's identity attributes at construction.
+
+        Raises:
+            TypeError: ``name`` / ``display_name`` is not a ``str``,
+                ``capabilities`` is not a ``frozenset[Capability]``, or
+                ``provider_class`` is not a class.
+            ValueError: ``name`` fails the snake_case regex, or
+                ``display_name`` is empty.
+        """
+        if not isinstance(self.name, str):
+            raise TypeError(
+                f"ProviderEntry.name must be str, " f"got {type(self.name).__name__}"
+            )
+        validate_provider_name(self.name)
+
+        if not isinstance(self.display_name, str):
+            raise TypeError(
+                f"ProviderEntry.display_name must be str, "
+                f"got {type(self.display_name).__name__}"
+            )
+        if self.display_name == "":
+            raise ValueError("ProviderEntry.display_name must be a non-empty string")
+
+        if not isinstance(self.capabilities, frozenset):
+            raise TypeError(
+                f"ProviderEntry.capabilities must be a frozenset, "
+                f"got {type(self.capabilities).__name__}"
+            )
+        bad_members = [c for c in self.capabilities if not isinstance(c, Capability)]
+        if bad_members:
+            bad_repr = ", ".join(repr(m) for m in bad_members)
+            raise TypeError(
+                f"ProviderEntry.capabilities must contain only Capability "
+                f"members; got non-Capability element(s): {bad_repr}"
+            )
+
+        if not isinstance(self.provider_class, type):
+            raise TypeError(
+                f"ProviderEntry.provider_class must be a class, "
+                f"got {type(self.provider_class).__name__}"
+            )
+
+        if self.source_distribution is not None and not isinstance(
+            self.source_distribution, str
+        ):
+            raise TypeError(
+                f"ProviderEntry.source_distribution must be str | None, "
+                f"got {type(self.source_distribution).__name__}"
+            )
+
+
+def _is_provider_class(cls: object) -> bool:
+    """Return ``True`` iff ``cls`` is a class satisfying the BaseProvider
+    contract via :func:`validate_provider`.
+
+    Calls ``validate_provider`` on the class object itself (BaseProvider
+    recommends ``name`` / ``display_name`` / ``capabilities`` as class
+    attributes, so ``getattr`` on the class works). Any exception is
+    treated as "not a provider class".
+
+    Note: a malicious plugin could ship a metaclass with a side-effectful
+    ``__getattribute__`` that fires during these ``getattr`` calls. That
+    is an accepted Phase 1 risk — the class is already loaded by this
+    point, so arbitrary code execution has already happened at
+    ``ep.load()``. The broad ``except Exception`` below is intentional
+    fault isolation: third-party plugin code may raise arbitrary
+    exception types (``RuntimeError`` from a malicious metaclass
+    ``__getattribute__``, ``AttributeError`` from a half-built subclass,
+    descriptors that raise on access, etc.); narrowing to
+    ``(TypeError, ValueError)`` would let those escape and abort the
+    discovery loop, violating the per-plugin fault-isolation contract.
+    """
+    if not isinstance(cls, type):
+        return False
+    try:
+        validate_provider(cls)
+    except Exception:  # noqa: BLE001 — fault isolation: see docstring above
+        return False
+    return True
+
+
+def _warn_skip(message: str) -> None:
+    """Emit a :class:`RegistryWarning` from inside the discovery loop.
+
+    Centralizes the ``stacklevel=4`` so callers stay at one level above
+    ``Registry.discover`` in user warning output.
+    """
+    warnings.warn(message, RegistryWarning, stacklevel=4)
+
+
+def _resolve_source(ep: Any) -> str | None:
+    """Extract ``ep.dist.name`` defensively; ``None`` when unresolvable."""
+    dist = getattr(ep, "dist", None)
+    if dist is None:
+        return None
+    name = getattr(dist, "name", None)
+    return name if isinstance(name, str) else None
+
+
+class Registry:
+    """In-process registry of discovered providers.
+
+    Most callers should use the module-level wrapper functions
+    (``register_provider_class``, ``discover_providers``,
+    ``get_provider``, ``list_providers_by_capability``,
+    ``clear_registry``) which delegate to the shared
+    :data:`default_registry`. The :class:`Registry` class is exposed for
+    tests and advanced cases that need an isolated instance.
+    """
+
+    def __init__(self) -> None:
+        self._entries: dict[str, ProviderEntry] = {}
+        self._discovered: bool = False
+        self._cached_result: tuple[ProviderEntry, ...] = ()
+
+    # ------------------------------------------------------------------
+    # Dunder methods — exposed in the public ABI for ergonomic checks.
+    # ------------------------------------------------------------------
+
+    def __contains__(self, name: object) -> bool:
+        return isinstance(name, str) and name in self._entries
+
+    def __iter__(self) -> Iterator[ProviderEntry]:
+        return iter(self._entries.values())
+
+    def __len__(self) -> int:
+        return len(self._entries)
+
+    # ------------------------------------------------------------------
+    # Registration
+    # ------------------------------------------------------------------
+
+    def register(self, entry: ProviderEntry) -> None:
+        """Insert a pre-built :class:`ProviderEntry`.
+
+        Follows first-wins: if ``entry.name`` is already registered, a
+        :class:`RegistryWarning` is emitted and the new entry is dropped.
+
+        Raises:
+            TypeError: ``entry`` is not a :class:`ProviderEntry`.
+        """
+        if not isinstance(entry, ProviderEntry):
+            raise TypeError(
+                f"Registry.register requires a ProviderEntry, "
+                f"got {type(entry).__name__}"
+            )
+        self._insert_or_warn(entry)
+
+    def register_provider_class(
+        self,
+        cls: type,
+        *,
+        source_distribution: str | None = None,
+    ) -> ProviderEntry:
+        """Validate and register ``cls`` against :func:`validate_provider`.
+
+        Unlike entry-point discovery (warn + skip on failure), this
+        explicit registration API raises on a malformed class so callers
+        get fast feedback.
+
+        Args:
+            cls: A class with class attributes ``name`` / ``display_name``
+                / ``capabilities``.
+            source_distribution: Pip package name that owns ``cls``.
+                ``None`` when called for in-process / built-in providers.
+
+        Returns:
+            The newly created :class:`ProviderEntry`. When a duplicate
+            name was detected, returns the EXISTING entry (first-wins).
+
+        Raises:
+            TypeError: ``cls`` is not a class.
+            TypeError | ValueError: ``cls`` fails
+                :func:`validate_provider`. The error message includes
+                ``cls.__qualname__`` so the offending class is locatable.
+        """
+        if not isinstance(cls, type):
+            raise TypeError(
+                f"register_provider_class requires a class, "
+                f"got {type(cls).__name__}"
+            )
+        try:
+            validate_provider(cls)
+        except (TypeError, ValueError) as exc:
+            qualname = getattr(cls, "__qualname__", cls.__name__)
+            raise type(exc)(f"register_provider_class({qualname}): {exc}") from exc
+
+        # validate_provider guarantees the BaseProvider class attributes
+        # are present and well-typed; cast for mypy.
+        provider = cast("BaseProvider", cls)
+        entry = ProviderEntry(
+            name=provider.name,
+            display_name=provider.display_name,
+            capabilities=provider.capabilities,
+            provider_class=cls,
+            source_distribution=source_distribution,
+        )
+        return self._insert_or_warn(entry)
+
+    def _insert_or_warn(self, entry: ProviderEntry) -> ProviderEntry:
+        """Insert ``entry`` under ``entry.name``; warn + skip on duplicate.
+
+        Returns the entry actually stored (the existing one on
+        duplicate, the new one on first insertion). All three
+        registration paths (``register``, ``register_provider_class``,
+        the entry-points loop) funnel through here so the first-wins
+        rule has a single source of truth.
+        """
+        existing = self._entries.get(entry.name)
+        if existing is not None:
+            warnings.warn(
+                (
+                    f"duplicate provider name {entry.name!r}: "
+                    f"first-registered from {existing.source_distribution!r} "
+                    f"wins; later registration from "
+                    f"{entry.source_distribution!r} is dropped"
+                ),
+                RegistryWarning,
+                stacklevel=3,
+            )
+            return existing
+        self._entries[entry.name] = entry
+        return entry
+
+    # ------------------------------------------------------------------
+    # Discovery
+    # ------------------------------------------------------------------
+
+    def discover(self, *, refresh: bool = False) -> tuple[ProviderEntry, ...]:
+        """Iterate ``mureo.providers`` entry points and register the
+        well-formed classes.
+
+        Idempotent + cached: a second call without ``refresh=True`` does
+        NOT re-iterate ``entry_points``. ``refresh=True`` clears the
+        cache flag (but not the registration map) and re-iterates.
+
+        For each entry point, the per-entry try/except isolates faults:
+        a broken plugin (``ep.load()`` raises) or a malformed plugin
+        (validation fails) emits :class:`RegistryWarning` and is
+        skipped. ``# noqa: BLE001`` is required on the load-step
+        ``except Exception`` because broad catching is the intended
+        fault-isolation boundary.
+
+        Args:
+            refresh: When ``True``, re-iterate entry points even if a
+                previous discovery cached a result.
+
+        Returns:
+            Tuple of registered entries from this discovery pass. The
+            tuple reflects the registrations actually inserted into the
+            registry (excluding those skipped due to duplicates).
+        """
+        if self._discovered and not refresh:
+            return self._cached_result
+
+        discovered: list[ProviderEntry] = []
+        for ep in entry_points(group=PROVIDERS_ENTRY_POINT_GROUP):
+            entry = self._load_entry_point(ep)
+            if entry is not None:
+                discovered.append(entry)
+
+        self._cached_result = tuple(discovered)
+        self._discovered = True
+        return self._cached_result
+
+    def _load_entry_point(self, ep: Any) -> ProviderEntry | None:
+        """Load, validate, and register a single entry point.
+
+        Returns the stored entry on success, ``None`` when the entry was
+        skipped (load failure, validation failure, or duplicate-name
+        first-wins drop).
+
+        The try/except spans the entire load → validate → construct
+        sequence (not just ``ep.load()``) so that adversarial plugins
+        cannot bypass fault isolation via a TOCTOU pattern in which the
+        class passes :func:`_is_provider_class` but a metaclass-driven
+        side effect raises during attribute access in the
+        :class:`ProviderEntry` constructor. ``# noqa: BLE001`` is
+        required: broad catching is the intended fault-isolation
+        boundary, not a code smell.
+        """
+        ep_name = getattr(ep, "name", "<unknown>")
+        try:
+            loaded = ep.load()
+            if not _is_provider_class(loaded):
+                _warn_skip(
+                    f"entry point {ep_name!r} did not yield a valid "
+                    f"provider class (got {type(loaded).__name__}); skipped"
+                )
+                return None
+
+            # _is_provider_class guarantees `loaded` is a type satisfying
+            # validate_provider; the cast is safe because the helper just
+            # verified isinstance(loaded, type) and validate_provider(loaded).
+            cls = cast("type", loaded)
+            provider = cast("BaseProvider", cls)
+
+            entry = ProviderEntry(
+                name=provider.name,
+                display_name=provider.display_name,
+                capabilities=provider.capabilities,
+                provider_class=cls,
+                source_distribution=_resolve_source(ep),
+            )
+        except Exception as exc:  # noqa: BLE001 — per-plugin fault isolation
+            _warn_skip(
+                f"failed to load entry point {ep_name!r} in group "
+                f"{PROVIDERS_ENTRY_POINT_GROUP!r}: {exc!r}"
+            )
+            return None
+
+        stored = self._insert_or_warn(entry)
+        # If a duplicate was rejected, _insert_or_warn returns the
+        # pre-existing entry — exclude it from this discovery pass's
+        # tuple to avoid double-counting.
+        return stored if stored is entry else None
+
+    # ------------------------------------------------------------------
+    # Lookup
+    # ------------------------------------------------------------------
+
+    def get(self, name: str) -> ProviderEntry:
+        """Return the entry registered under ``name``.
+
+        Raises:
+            KeyError: ``name`` is not registered. The error message
+                includes the requested name and the sorted list of
+                known providers (mirrors ``parse_capability`` style).
+        """
+        entry = self._entries.get(name)
+        if entry is None:
+            known = sorted(self._entries.keys())
+            raise KeyError(f"unknown provider: {name!r}. Known providers: {known}")
+        return entry
+
+    def list_by_capability(self, cap: Capability) -> tuple[ProviderEntry, ...]:
+        """Return entries declaring ``cap``, sorted by ``name`` ascending.
+
+        Args:
+            cap: A :class:`Capability` member.
+
+        Returns:
+            Tuple of matching entries (empty when none match).
+
+        Raises:
+            TypeError: ``cap`` is not a :class:`Capability` member.
+                Defensive contract for third-party callers who may pass
+                a string token.
+        """
+        if not isinstance(cap, Capability):
+            raise TypeError(
+                f"list_by_capability requires a Capability member, "
+                f"got {type(cap).__name__}"
+            )
+        matches = [e for e in self._entries.values() if cap in e.capabilities]
+        matches.sort(key=lambda e: e.name)
+        return tuple(matches)
+
+    def clear(self) -> None:
+        """Remove all registrations AND invalidate the discovery cache.
+
+        Used by tests to enforce isolation between cases and by callers
+        who need a clean slate before a manual re-registration sequence.
+        """
+        self._entries.clear()
+        self._discovered = False
+        self._cached_result = ()
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton + thin wrappers
+# ---------------------------------------------------------------------------
+
+
+default_registry: Registry = Registry()
+
+
+def register_provider_class(
+    cls: type,
+    *,
+    source_distribution: str | None = None,
+) -> ProviderEntry:
+    """Module-level wrapper around :meth:`Registry.register_provider_class`."""
+    return default_registry.register_provider_class(
+        cls, source_distribution=source_distribution
+    )
+
+
+def discover_providers(*, refresh: bool = False) -> tuple[ProviderEntry, ...]:
+    """Module-level wrapper around :meth:`Registry.discover`."""
+    return default_registry.discover(refresh=refresh)
+
+
+def get_provider(name: str) -> ProviderEntry:
+    """Module-level wrapper around :meth:`Registry.get`."""
+    return default_registry.get(name)
+
+
+def list_providers_by_capability(
+    cap: Capability,
+) -> tuple[ProviderEntry, ...]:
+    """Module-level wrapper around :meth:`Registry.list_by_capability`."""
+    return default_registry.list_by_capability(cap)
+
+
+def clear_registry() -> None:
+    """Module-level wrapper around :meth:`Registry.clear`."""
+    default_registry.clear()
+
+
+__all__ = [
+    "PROVIDERS_ENTRY_POINT_GROUP",
+    "SKILLS_ENTRY_POINT_GROUP",
+    "ProviderEntry",
+    "Registry",
+    "RegistryWarning",
+    "clear_registry",
+    "default_registry",
+    "discover_providers",
+    "get_provider",
+    "list_providers_by_capability",
+    "register_provider_class",
+]

--- a/tests/core/providers/test_registry.py
+++ b/tests/core/providers/test_registry.py
@@ -1,0 +1,511 @@
+"""Tests for ``mureo.core.providers.registry`` (in-process path).
+
+RED phase tests for Issue #89 Phase 1 subtask P1-07.
+
+These tests pin the stable in-process surface for the entry-points-based
+provider discovery registry — ``ProviderEntry``, the module-level
+``register_provider_class`` / ``get_provider`` / ``list_providers_by_capability``
+/ ``clear_registry`` wrappers, the duplicate-name first-wins policy, and
+the validation contract enforced by ``register_provider_class``.
+
+This file deliberately exercises only the in-process / ``register_provider_class``
+code path. The entry-points discovery path (which requires mocking
+``importlib.metadata.entry_points``) is exercised in the sibling file
+``test_registry_discovery.py``.
+
+Marks: every test in this file is ``@pytest.mark.unit`` — pure logic,
+no I/O, no entry-points mocking.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+
+import pytest
+
+# NOTE: These imports are expected to FAIL during the RED phase — the
+# module ``mureo.core.providers.registry`` does not exist yet. That is
+# correct. The implementer (GREEN phase) will create it.
+from mureo.core.providers.capabilities import Capability
+from mureo.core.providers.registry import (  # noqa: E402
+    ProviderEntry,
+    RegistryWarning,
+    clear_registry,
+    default_registry,
+    get_provider,
+    list_providers_by_capability,
+    register_provider_class,
+)
+
+# ---------------------------------------------------------------------------
+# Test fixtures and helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolated_registry() -> Any:
+    """Reset the global ``default_registry`` before and after each test.
+
+    Without this, registrations leak between tests and the order of
+    insertion would alter assertions about ``first-wins`` semantics and
+    capability listings.
+    """
+    clear_registry()
+    yield
+    clear_registry()
+
+
+class _FakeProvider:
+    """Well-formed provider class with three class attributes.
+
+    Mirrors the recommended provider-implementation style documented in
+    ``mureo.core.providers.base`` — name / display_name / capabilities
+    declared as class attributes so the registry can introspect without
+    instantiating.
+    """
+
+    name = "fake_provider"
+    display_name = "Fake Provider"
+    capabilities = frozenset({Capability.READ_CAMPAIGNS})
+
+
+class _AnotherFakeProvider:
+    """Second well-formed provider for capability-filter / sort tests."""
+
+    name = "another_fake"
+    display_name = "Another Fake"
+    capabilities = frozenset({Capability.READ_AUDIENCES})
+
+
+# ---------------------------------------------------------------------------
+# Case 1 — ProviderEntry is a frozen dataclass with the pinned field set
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_provider_entry_is_frozen_dataclass() -> None:
+    """``ProviderEntry`` is a ``@dataclass(frozen=True)`` whose field set
+    and order are the pinned ABI (AC line 1).
+
+    Field order is part of the ABI: third-party callers may destructure
+    via positional ``ProviderEntry(*tup)`` so we pin both the set and the
+    order. Frozenness is verified by attempting an assignment and
+    expecting ``dataclasses.FrozenInstanceError``.
+    """
+    assert dataclasses.is_dataclass(ProviderEntry), "ProviderEntry must be a dataclass"
+
+    fields = [f.name for f in dataclasses.fields(ProviderEntry)]
+    assert fields == [
+        "name",
+        "display_name",
+        "capabilities",
+        "provider_class",
+        "source_distribution",
+    ], (
+        "ProviderEntry field set/order is part of the public ABI; "
+        f"expected the documented five fields in order, got {fields!r}"
+    )
+
+    entry = ProviderEntry(
+        name="fake_provider",
+        display_name="Fake Provider",
+        capabilities=frozenset({Capability.READ_CAMPAIGNS}),
+        provider_class=_FakeProvider,
+        source_distribution="mureo-fake",
+    )
+
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        entry.name = "mutated"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Case 2 — ProviderEntry.__post_init__ validates name / display_name / caps
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("name", "display_name", "capabilities", "exc_type"),
+    [
+        # name not str
+        (
+            123,
+            "Display",
+            frozenset({Capability.READ_CAMPAIGNS}),
+            (TypeError, ValueError),
+        ),
+        # name fails regex (uppercase)
+        (
+            "Google_Ads",
+            "Display",
+            frozenset({Capability.READ_CAMPAIGNS}),
+            ValueError,
+        ),
+        # name empty
+        (
+            "",
+            "Display",
+            frozenset({Capability.READ_CAMPAIGNS}),
+            ValueError,
+        ),
+        # display_name not str
+        (
+            "fake_provider",
+            42,
+            frozenset({Capability.READ_CAMPAIGNS}),
+            (TypeError, ValueError),
+        ),
+        # display_name empty
+        (
+            "fake_provider",
+            "",
+            frozenset({Capability.READ_CAMPAIGNS}),
+            (TypeError, ValueError),
+        ),
+        # capabilities is a plain set, not frozenset
+        (
+            "fake_provider",
+            "Display",
+            {Capability.READ_CAMPAIGNS},
+            (TypeError, ValueError),
+        ),
+    ],
+    ids=[
+        "name_not_str",
+        "name_fails_regex_uppercase",
+        "name_empty",
+        "display_name_not_str",
+        "display_name_empty",
+        "capabilities_set_not_frozenset",
+    ],
+)
+def test_provider_entry_validates_in_post_init(
+    name: object,
+    display_name: object,
+    capabilities: object,
+    exc_type: type[Exception] | tuple[type[Exception], ...],
+) -> None:
+    """``ProviderEntry.__post_init__`` rejects malformed shapes.
+
+    Asserts each malformed value triggers ``ValueError`` or ``TypeError``
+    at construction time — before the entry can poison the registry.
+    """
+    with pytest.raises(exc_type):
+        ProviderEntry(
+            name=name,  # type: ignore[arg-type]
+            display_name=display_name,  # type: ignore[arg-type]
+            capabilities=capabilities,  # type: ignore[arg-type]
+            provider_class=_FakeProvider,
+            source_distribution=None,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Case 3 — register_provider_class succeeds for a compliant class
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_register_provider_class_succeeds_for_compliant_class() -> None:
+    """``register_provider_class`` returns a ``ProviderEntry`` whose fields
+    mirror the registered class and whose ``source_distribution`` is
+    captured from the keyword argument (AC line 13).
+    """
+    entry = register_provider_class(_FakeProvider, source_distribution="mureo-fake")
+
+    assert isinstance(entry, ProviderEntry)
+    assert entry.name == _FakeProvider.name
+    assert entry.display_name == _FakeProvider.display_name
+    assert entry.capabilities == _FakeProvider.capabilities
+    assert entry.provider_class is _FakeProvider
+    assert entry.source_distribution == "mureo-fake"
+
+    # The class is now retrievable from the default registry.
+    assert _FakeProvider.name in default_registry
+
+
+# ---------------------------------------------------------------------------
+# Case 4 — register_provider_class rejects non-class arguments
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "bad_value",
+    [
+        # An *instance* of a well-formed provider class, not the class
+        # itself. Catches the common mistake of registering an instance.
+        _FakeProvider(),
+        # A function, not a class.
+        (lambda: None),
+        # A plain dict that happens to have the three required keys.
+        {
+            "name": "fake_provider",
+            "display_name": "Fake",
+            "capabilities": frozenset({Capability.READ_CAMPAIGNS}),
+        },
+    ],
+    ids=["instance", "function", "dict"],
+)
+def test_register_provider_class_rejects_non_class(bad_value: object) -> None:
+    """Passing a non-class to ``register_provider_class`` raises
+    ``TypeError`` with a message mentioning "class" or "type" (AC line 13,
+    case 4 in the test plan).
+    """
+    with pytest.raises(TypeError) as excinfo:
+        register_provider_class(bad_value)  # type: ignore[arg-type]
+
+    msg = str(excinfo.value).lower()
+    assert (
+        "class" in msg or "type" in msg
+    ), f"TypeError message must mention 'class' or 'type'; got: {msg!r}"
+
+
+# ---------------------------------------------------------------------------
+# Case 5 — register_provider_class rejects classes failing validate_provider
+# ---------------------------------------------------------------------------
+
+
+class _BadProvider_NoDisplayName:  # noqa: N801 — semantic fixture name
+    """Class missing ``display_name`` — must be rejected."""
+
+    name = "bad_no_display"
+    capabilities = frozenset({Capability.READ_CAMPAIGNS})
+
+
+class _BadProvider_BadCapabilitiesType:  # noqa: N801 — semantic fixture name
+    """``capabilities`` is a plain set, not a frozenset — must be rejected."""
+
+    name = "bad_caps_type"
+    display_name = "Bad Caps Type"
+    capabilities = {Capability.READ_CAMPAIGNS}  # type: ignore[assignment]
+
+
+class _BadProvider_BadName:  # noqa: N801 — semantic fixture name
+    """``name`` fails the snake_case regex — must be rejected."""
+
+    name = "Bad-Name"
+    display_name = "Bad Name"
+    capabilities = frozenset({Capability.READ_CAMPAIGNS})
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "bad_class",
+    [
+        _BadProvider_NoDisplayName,
+        _BadProvider_BadCapabilitiesType,
+        _BadProvider_BadName,
+    ],
+    ids=["missing_display_name", "capabilities_not_frozenset", "bad_name_regex"],
+)
+def test_register_provider_class_rejects_invalid_provider_shape(
+    bad_class: type,
+) -> None:
+    """Classes failing the ``validate_provider`` contract are rejected by
+    the explicit registration API (raise, not warn — only entry-point
+    discovery uses warn+skip; AC: validation failure semantics).
+
+    The error message must include the class ``__qualname__`` so the
+    caller can locate the offending class.
+    """
+    with pytest.raises((TypeError, ValueError)) as excinfo:
+        register_provider_class(bad_class)
+
+    msg = str(excinfo.value)
+    assert bad_class.__qualname__ in msg or bad_class.__name__ in msg, (
+        f"error message must include the class qualname "
+        f"({bad_class.__qualname__!r}); got: {msg!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Case 6 — duplicate name first-wins with RegistryWarning
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_duplicate_name_first_wins_with_warning() -> None:
+    """Registering two classes under the same ``name`` keeps the first
+    and warns on the second (AC: duplicate-name handling).
+
+    The warning category must be ``RegistryWarning``; the message must
+    mention both source_distribution values when provided so the user can
+    decide which plugin to uninstall.
+    """
+
+    class FirstProvider:
+        name = "google_ads"
+        display_name = "Google Ads (First)"
+        capabilities = frozenset({Capability.READ_CAMPAIGNS})
+
+    class SecondProvider:
+        name = "google_ads"  # deliberate duplicate
+        display_name = "Google Ads (Second)"
+        capabilities = frozenset({Capability.READ_CAMPAIGNS})
+
+    register_provider_class(FirstProvider, source_distribution="mureo-first")
+
+    with pytest.warns(RegistryWarning, match="google_ads") as recorded:
+        register_provider_class(SecondProvider, source_distribution="mureo-second")
+
+    # First-wins: the registered entry is the FIRST one.
+    resolved = get_provider("google_ads")
+    assert resolved.provider_class is FirstProvider, (
+        "duplicate registration must follow first-wins semantics; "
+        "the second registration should have been dropped."
+    )
+
+    # Both source_distribution values should appear in the warning text
+    # so the user can locate both contenders.
+    combined_msg = " ".join(str(w.message) for w in recorded)
+    assert (
+        "mureo-first" in combined_msg
+    ), f"warning must mention first plugin's distribution; got: {combined_msg!r}"
+    assert (
+        "mureo-second" in combined_msg
+    ), f"warning must mention second plugin's distribution; got: {combined_msg!r}"
+
+
+# ---------------------------------------------------------------------------
+# Case 7 — get_provider raises KeyError with helpful listing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_get_provider_unknown_raises_key_error_with_listing() -> None:
+    """``get_provider("nope")`` raises ``KeyError`` whose message includes
+    the missing name and the sorted list of known names (AC: get_provider
+    error semantics, mirrors ``parse_capability`` style).
+    """
+    # Register two providers so the listing has content.
+    register_provider_class(_FakeProvider, source_distribution="mureo-fake")
+    register_provider_class(_AnotherFakeProvider, source_distribution="mureo-another")
+
+    with pytest.raises(KeyError) as excinfo:
+        get_provider("nope")
+
+    # KeyError stringifies with surrounding quotes; assert against the
+    # underlying ``.args[0]`` AND ``str(excinfo.value)`` so the test does
+    # not over-specify which the implementer chooses to populate.
+    msg = str(excinfo.value)
+    assert "nope" in msg, f"KeyError must mention the missing name; got: {msg!r}"
+    # The error message references that the name is unknown.
+    assert (
+        "known" in msg.lower() or "available" in msg.lower()
+    ), f"KeyError must hint at known/available providers; got: {msg!r}"
+    # At least one registered provider name must appear in the listing.
+    assert (
+        _FakeProvider.name in msg or _AnotherFakeProvider.name in msg
+    ), f"KeyError must list at least one known provider name; got: {msg!r}"
+
+
+# ---------------------------------------------------------------------------
+# Case 8 — list_by_capability filters and sorts
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_list_by_capability_filters_and_is_sorted() -> None:
+    """``list_providers_by_capability(cap)`` returns the matching entries
+    sorted by ``name`` ascending; empty tuple when no provider declares
+    the requested capability (AC: list-by-capability semantics).
+    """
+
+    class GoogleAds:
+        name = "google_ads"
+        display_name = "Google Ads"
+        capabilities = frozenset({Capability.READ_CAMPAIGNS, Capability.READ_KEYWORDS})
+
+    class MetaAds:
+        name = "meta_ads"
+        display_name = "Meta Ads"
+        capabilities = frozenset({Capability.READ_CAMPAIGNS, Capability.READ_AUDIENCES})
+
+    class TikTokAds:
+        name = "tiktok_ads"
+        display_name = "TikTok Ads"
+        capabilities = frozenset({Capability.READ_AUDIENCES})
+
+    # Deliberately register out of alphabetical order to exercise sorting.
+    register_provider_class(MetaAds, source_distribution="mureo-meta")
+    register_provider_class(TikTokAds, source_distribution="mureo-tiktok")
+    register_provider_class(GoogleAds, source_distribution="mureo-google")
+
+    by_read_campaigns = list_providers_by_capability(Capability.READ_CAMPAIGNS)
+    names = [e.name for e in by_read_campaigns]
+    assert names == ["google_ads", "meta_ads"], (
+        f"READ_CAMPAIGNS filter must return google_ads and meta_ads in "
+        f"alphabetical order; got: {names!r}"
+    )
+
+    # Capability nobody declared — empty tuple, not None.
+    by_write_budget = list_providers_by_capability(Capability.WRITE_BUDGET)
+    assert by_write_budget == ()
+    assert isinstance(by_write_budget, tuple)
+
+
+# ---------------------------------------------------------------------------
+# Case 9 — list_by_capability rejects non-Capability arguments
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "bad_cap",
+    ["read_campaigns", 42, None, ["read_campaigns"]],
+    ids=["string", "int", "none", "list_of_strings"],
+)
+def test_list_by_capability_rejects_non_capability_argument(
+    bad_cap: object,
+) -> None:
+    """``list_providers_by_capability`` is defensive against third-party
+    callers passing strings or other non-Capability values; it raises
+    ``TypeError`` mentioning ``Capability`` (AC: list-by-capability type
+    guard).
+    """
+    with pytest.raises(TypeError) as excinfo:
+        list_providers_by_capability(bad_cap)  # type: ignore[arg-type]
+
+    assert "Capability" in str(
+        excinfo.value
+    ), f"TypeError must mention 'Capability'; got: {str(excinfo.value)!r}"
+
+
+# ---------------------------------------------------------------------------
+# Case 10 — clear_registry resets state including discovery cache
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_clear_registry_resets_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``clear_registry()`` empties both the registration map and the
+    discovery cache so a fresh ``discover_providers()`` re-iterates
+    ``entry_points`` (AC: clear semantics).
+    """
+    from mureo.core.providers import registry as registry_module
+
+    register_provider_class(_FakeProvider, source_distribution="mureo-fake")
+    register_provider_class(_AnotherFakeProvider, source_distribution="mureo-another")
+    assert len(default_registry) == 2
+
+    clear_registry()
+    assert len(default_registry) == 0
+
+    # After clearing, a discovery call must hit the (mocked) entry_points
+    # rather than returning a stale cache.
+    call_count = {"n": 0}
+
+    def _empty_entry_points(group: str) -> tuple[object, ...]:  # noqa: ARG001
+        call_count["n"] += 1
+        return ()
+
+    monkeypatch.setattr(registry_module, "entry_points", _empty_entry_points)
+
+    result = registry_module.discover_providers()
+    assert result == ()
+    assert call_count["n"] == 1, (
+        "clear_registry() must also invalidate the discovery cache so "
+        "the next discover_providers() re-iterates entry_points."
+    )

--- a/tests/core/providers/test_registry_discovery.py
+++ b/tests/core/providers/test_registry_discovery.py
@@ -1,0 +1,300 @@
+"""Entry-points-based discovery tests for ``mureo.core.providers.registry``.
+
+RED phase tests for Issue #89 Phase 1 subtask P1-07 (discovery path).
+
+These tests exercise the entry-points iteration loop inside
+``discover_providers`` / ``Registry.discover``. They mock the registry's
+imported reference to ``importlib.metadata.entry_points`` (not the
+upstream stdlib symbol — the patch target is the *local name* inside
+``mureo.core.providers.registry``) and feed in synthetic ``EntryPoint``
+objects built from :class:`types.SimpleNamespace`.
+
+Why ``SimpleNamespace``: the real ``importlib.metadata.EntryPoint`` is a
+NamedTuple that is intentionally hard to construct directly; duck-typing
+via ``SimpleNamespace`` with the same attribute shape (``name``,
+``group``, ``dist``, ``load``) is the standard recommended pattern, is
+simpler than installing real distributions, and is fully deterministic.
+
+Marks: every test in this file is ``@pytest.mark.integration`` —
+although the mocks keep everything in-process, the surface under test is
+the cross-module entry-points integration boundary.
+"""
+
+from __future__ import annotations
+
+import types
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+# NOTE: These imports are expected to FAIL during the RED phase — the
+# module ``mureo.core.providers.registry`` does not exist yet.
+from mureo.core.providers.capabilities import Capability
+from mureo.core.providers.registry import (  # noqa: E402
+    PROVIDERS_ENTRY_POINT_GROUP,
+    RegistryWarning,
+    clear_registry,
+    default_registry,
+    discover_providers,
+    get_provider,
+)
+
+# ---------------------------------------------------------------------------
+# Test fixtures and helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolated_registry() -> Any:
+    """Reset the global registry (and its discovery cache) per test.
+
+    Discovery is cached for the lifetime of the process, so even an
+    accidental cross-test ``discover_providers()`` call would otherwise
+    leak between tests.
+    """
+    clear_registry()
+    yield
+    clear_registry()
+
+
+class _FakeProvider:
+    """Well-formed provider class returned by the well-formed fake EP."""
+
+    name = "fake_provider"
+    display_name = "Fake Provider"
+    capabilities = frozenset({Capability.READ_CAMPAIGNS})
+
+
+class _BadProvider_NoCapabilities:  # noqa: N801 — semantic fixture name
+    """Missing the ``capabilities`` class attribute — must be skipped."""
+
+    name = "bad_no_caps"
+    display_name = "Bad No Caps"
+
+
+class _BadProvider_PlainSetCapabilities:  # noqa: N801 — semantic fixture name
+    """``capabilities`` is a plain ``set`` (not a frozenset) — must be
+    skipped because ``validate_provider`` rejects it.
+    """
+
+    name = "bad_plain_set"
+    display_name = "Bad Plain Set"
+    capabilities = {Capability.READ_CAMPAIGNS}  # type: ignore[assignment]
+
+
+def _make_fake_entry_point(
+    *,
+    name: str,
+    distribution: str | None,
+    load_result: object | None = None,
+    load_exception: BaseException | None = None,
+) -> types.SimpleNamespace:
+    """Build a duck-typed ``EntryPoint`` for the registry to consume.
+
+    The registry only touches ``ep.name``, ``ep.dist.name``, and
+    ``ep.load()`` so ``SimpleNamespace`` with those attributes is
+    sufficient. ``dist`` may be ``None`` (rare in real installations,
+    but documented behaviour) or a namespace with a ``.name``.
+    """
+
+    def _load() -> object:
+        if load_exception is not None:
+            raise load_exception
+        return load_result
+
+    dist: types.SimpleNamespace | None = (
+        None if distribution is None else types.SimpleNamespace(name=distribution)
+    )
+
+    return types.SimpleNamespace(
+        name=name,
+        group=PROVIDERS_ENTRY_POINT_GROUP,
+        dist=dist,
+        load=_load,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Case 11 — discover_providers finds a well-formed entry-point class
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_discover_finds_well_formed_entry_point_class() -> None:
+    """A well-formed entry-point class is loaded, validated, and exposed
+    via ``get_provider``. ``source_distribution`` is captured from the
+    EP's ``dist.name``. The second call to ``discover_providers`` does
+    NOT re-call ``entry_points`` — cached idempotence (AC: idempotence).
+    """
+    fake_ep = _make_fake_entry_point(
+        name="fake_provider",
+        distribution="mureo-fake-plugin",
+        load_result=_FakeProvider,
+    )
+
+    call_counter = {"n": 0}
+
+    def _fake_entry_points(group: str) -> tuple[Any, ...]:
+        assert group == PROVIDERS_ENTRY_POINT_GROUP, (
+            "discover must iterate the providers group only; " f"got group={group!r}"
+        )
+        call_counter["n"] += 1
+        return (fake_ep,)
+
+    with patch(
+        "mureo.core.providers.registry.entry_points",
+        side_effect=_fake_entry_points,
+    ):
+        result = discover_providers()
+        assert len(result) == 1
+        (entry,) = result
+        assert entry.name == "fake_provider"
+        assert entry.provider_class is _FakeProvider
+        assert entry.source_distribution == "mureo-fake-plugin"
+        assert entry.capabilities == _FakeProvider.capabilities
+
+        # Lookup via the public API resolves.
+        resolved = get_provider("fake_provider")
+        assert resolved.provider_class is _FakeProvider
+
+        # Idempotence: a second call without refresh=True must NOT
+        # re-iterate entry_points.
+        result2 = discover_providers()
+        assert result2 == result
+        assert call_counter["n"] == 1, (
+            "discover_providers() must be cached; "
+            f"entry_points was called {call_counter['n']}x, expected 1"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Case 12 — discover_providers warns and skips on load failure
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_discover_warns_and_skips_on_load_failure() -> None:
+    """A broken plugin (whose ``ep.load()`` raises) must not break
+    discovery for the rest. The registry emits ``RegistryWarning`` and
+    skips the offender. The well-formed sibling EP is still registered.
+
+    This is the critical fault-isolation invariant.
+    """
+    broken_ep = _make_fake_entry_point(
+        name="broken_plugin",
+        distribution="mureo-broken-plugin",
+        load_exception=ImportError("simulated broken plugin"),
+    )
+    good_ep = _make_fake_entry_point(
+        name="fake_provider",
+        distribution="mureo-good-plugin",
+        load_result=_FakeProvider,
+    )
+
+    def _fake_entry_points(group: str) -> tuple[Any, ...]:  # noqa: ARG001
+        return (broken_ep, good_ep)
+
+    with patch(
+        "mureo.core.providers.registry.entry_points",
+        side_effect=_fake_entry_points,
+    ):
+        with pytest.warns(RegistryWarning) as recorded:
+            result = discover_providers()
+
+        # The good plugin survived discovery.
+        assert len(result) == 1
+        (entry,) = result
+        assert entry.name == "fake_provider"
+        assert len(default_registry) == 1
+
+        # The warning must mention the offending EP name and the
+        # underlying exception message so the user can diagnose.
+        combined = " ".join(str(w.message) for w in recorded)
+        assert (
+            "broken_plugin" in combined
+        ), f"warning must include the EP name; got: {combined!r}"
+        assert "simulated broken plugin" in combined, (
+            f"warning must include the underlying exception message; "
+            f"got: {combined!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Case 13 — discover_providers warns and skips on validation failure
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    ("loaded_obj", "skip_reason"),
+    [
+        # The EP loaded a *function*, not a class. Must be rejected.
+        (lambda: None, "non_class"),
+        # The EP loaded a class missing ``capabilities``.
+        (_BadProvider_NoCapabilities, "missing_attr"),
+        # The EP loaded a class whose ``capabilities`` is a plain set.
+        (_BadProvider_PlainSetCapabilities, "bad_frozenset"),
+    ],
+    ids=["non_class", "missing_attr", "bad_frozenset"],
+)
+def test_discover_warns_and_skips_on_validation_failure(
+    loaded_obj: object,
+    skip_reason: str,  # noqa: ARG001 — id-only param
+) -> None:
+    """Validation failures in entry-point discovery emit
+    ``RegistryWarning`` and skip the offending entry. The registry is
+    NOT poisoned: no partial-state insertion before validation passes.
+    """
+    fake_ep = _make_fake_entry_point(
+        name="malformed",
+        distribution="mureo-malformed-plugin",
+        load_result=loaded_obj,
+    )
+
+    def _fake_entry_points(group: str) -> tuple[Any, ...]:  # noqa: ARG001
+        return (fake_ep,)
+
+    with patch(
+        "mureo.core.providers.registry.entry_points",
+        side_effect=_fake_entry_points,
+    ):
+        with pytest.warns(RegistryWarning):
+            result = discover_providers()
+
+        assert result == (), "validation-failing EP must be skipped, not registered"
+        assert len(default_registry) == 0
+
+
+# ---------------------------------------------------------------------------
+# Case 14 — discover_providers coerces non-str dist.name to None
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_discover_resolves_source_distribution_to_none_when_dist_name_non_str() -> None:
+    """Defensive: weird ``Distribution`` shims (custom finders, build
+    backends, or test stubs) may return a non-``str`` ``.name``. The
+    registry must coerce that to ``None`` rather than propagating an
+    untyped value into :class:`ProviderEntry.source_distribution`.
+
+    Covers the ``isinstance(name, str)`` branch in
+    :func:`_resolve_source`.
+    """
+    fake_ep = types.SimpleNamespace(
+        name="weird_dist_provider",
+        group=PROVIDERS_ENTRY_POINT_GROUP,
+        dist=types.SimpleNamespace(name=123),  # non-str on purpose
+        load=lambda: _FakeProvider,
+    )
+
+    def _fake_entry_points(group: str) -> tuple[Any, ...]:  # noqa: ARG001
+        return (fake_ep,)
+
+    with patch(
+        "mureo.core.providers.registry.entry_points",
+        side_effect=_fake_entry_points,
+    ):
+        entries = discover_providers()
+        assert len(entries) == 1
+        assert entries[0].source_distribution is None


### PR DESCRIPTION
## Summary

Implements P1-07 of Issue #89 Phase 1: the entry-points-based provider discovery registry. Third-party `pip install <plugin-package>` automatically registers providers under the `mureo.providers` group; mureo discovers them at startup with `importlib.metadata.entry_points()`. Install-source agnostic (public PyPI, private index, git URL, vendored wheel).

### Public ABI

```python
from mureo.core.providers import (
    # Registry
    Registry, default_registry,
    register_provider_class, discover_providers,
    get_provider, list_providers_by_capability, clear_registry,
    # Types
    ProviderEntry, RegistryWarning,
    # Group constants
    PROVIDERS_ENTRY_POINT_GROUP,  # "mureo.providers"
    SKILLS_ENTRY_POINT_GROUP,     # "mureo.skills" (consumed by P1-08)
)
```

### Security posture

Per-plugin fault isolation: broken or malicious plugins emit `RegistryWarning` and are skipped, never aborting discovery. The broad `except` scope spans `ep.load()` + `_is_provider_class()` + `ProviderEntry(...)` construction, closing the TOCTOU gap where hostile metaclass `__getattribute__` could escape validation.

- **`RegistryWarning(UserWarning)`** subclass — strict deployments can set `warnings.filterwarnings("error", category=RegistryWarning)` to fail closed (first broken plugin → startup failure).
- **Duplicate-name first-wins** — supply-chain hardening: a later-installed hostile plugin cannot silently shadow an already-registered trusted one.
- **`source_distribution` provenance** — every `ProviderEntry` carries its pip package name for debug / support / future audit-log integration.
- **Deferred instantiation** — discovery retains class objects only; `__init__` is never invoked during enumeration.
- **Trust boundary documented**: `pip install` itself is the upstream auth boundary; mureo does NOT add import sandboxing, signature verification, or allow-listing in Phase 1.

### Test surface

- `tests/core/providers/test_registry.py` — 22 unit tests covering `ProviderEntry` frozen invariants, `register_provider_class` happy path + invalid-class/instance/non-frozenset rejection, duplicate first-wins, `get_provider` `KeyError` with hint, `list_providers_by_capability` filter, `clear_registry`, cache idempotence.
- `tests/core/providers/test_registry_discovery.py` — 5 integration tests with `importlib.metadata.entry_points` mocked: happy path + idempotence, `ep.load()` exceptions → warn+skip, `validate_provider` failure modes (parametrized 3-way), `_resolve_source` non-str-dist branch.

## Stacked on PR #92

`feat/p1-07-entry-points-registry` → `feat/p1-03-to-06-domain-protocols` → `feat/p1-02-base-provider` → `feat/p1-01-capabilities` → `main`. Merge order: #90 → #91 → #92 → this PR.

## Test plan

- [x] `pytest tests/core/providers/` — 199/199 passed (171 P1-01..06 + 27 P1-07)
- [x] Coverage on `mureo/core/providers/registry.py`: 93%
- [x] `ruff check mureo/core/ tests/core/` — clean
- [x] `black --check mureo/core/ tests/core/` — clean
- [x] `mypy --strict mureo/core/providers/` — clean
- [x] python-reviewer agent: **APPROVE** (only deferred LOW-2 stacklevel diagnostic remains, defensive-only)
- [x] security-reviewer agent: **APPROVE** (mitigation checklist 6/6 met after fault-isolation scope expansion; documented residual risks accepted for Phase 1)

## Follow-ups (deferred — file as separate Phase 2 issues)

Security hardening tracked separately:

- [ ] **P2-SEC-01**: Allow-list configuration for entry-point distributions (env-var or config gate over which pip packages register; mitigates the `pip install` trust boundary for production deployments).
- [ ] **P2-SEC-02**: In-module warning rate-limit / dedup (cap N `RegistryWarning` emissions per discovery pass; mitigates documented log-flood DoS surface).
- [ ] **P2-SEC-03**: Hostile-metaclass integration test (real-world entry-point with side-effectful `__getattribute__` / descriptors to validate fault-isolation contract end-to-end).
- [ ] **P2-SEC-04**: Signature verification hook (optional callable to verify plugin authenticity before insertion).
- [ ] **P2-SEC-05**: Discovery audit log (structured log of every load attempt: ep name, distribution, outcome, exception type — independent of `warnings` channel).

Other deferred polish:

- [ ] **PY-LOW-2**: `_warn_skip` / `_insert_or_warn` `stacklevel` tuning — defensive diagnostic-only, not test-asserted.

## Refs

Closes part of #89 (Phase 1 P1-07). Next: **P1-08** (skill matcher: capability → provider resolver using this registry) → **P1-09** (google_ads adapter) → **P1-10** (meta_ads adapter) → **P1-11** (docs).
