### PR TITLE
feat(core/skills): add skill matcher with SKILL.md parser (P1-08, #89)

### DIFF
--- a/mureo/core/skills/__init__.py
+++ b/mureo/core/skills/__init__.py
@@ -1,0 +1,66 @@
+"""Skill discovery, parsing, and capability matching (Issue #89 P1-08).
+
+This package introduces the skill layer that pairs declarative skill
+metadata (shipped as ``SKILL.md`` files with YAML frontmatter) with the
+provider registry from P1-07.
+
+Public surface
+--------------
+- :class:`SkillEntry` — frozen dataclass capturing one parsed skill.
+- :class:`SkillMatch` — three-bucket classification of skills against a
+  single provider.
+- :class:`ProviderMatch` — symmetric three-bucket classification of
+  providers against a single skill.
+- :class:`SkillParseError` — raised on any decode / YAML / validation
+  failure inside :func:`parse_skill_md`.
+- :class:`SkillDiscoveryWarning` — :class:`UserWarning` subclass emitted
+  when discovery skips a malformed plugin, file, or duplicate.
+- :func:`parse_skill_md` — read one ``SKILL.md`` from disk into a
+  :class:`SkillEntry`.
+- :func:`discover_skills` — entry-points + built-in directory scan with
+  per-plugin fault isolation.
+- :func:`match_skills` — pure function: ``(skills, provider) ->
+  SkillMatch``.
+- :func:`providers_for_skill` — pure function: ``(skill, registry) ->
+  ProviderMatch``.
+- :data:`SKILLS_ENTRY_POINT_GROUP` — re-exported from
+  :mod:`mureo.core.providers.registry` for convenience.
+
+Foundation rule
+---------------
+This subpackage may only import from
+:mod:`mureo.core.providers.{base,capabilities,registry}`. No imports
+from the four domain Protocol modules; the matcher treats providers
+structurally via :class:`ProviderEntry`.
+"""
+
+from __future__ import annotations
+
+from mureo.core.providers.registry import SKILLS_ENTRY_POINT_GROUP
+from mureo.core.skills.discovery import (
+    SkillDiscoveryWarning,
+    clear_skills_cache,
+    discover_skills,
+)
+from mureo.core.skills.matcher import (
+    ProviderMatch,
+    SkillMatch,
+    match_skills,
+    providers_for_skill,
+)
+from mureo.core.skills.models import SkillEntry
+from mureo.core.skills.parser import SkillParseError, parse_skill_md
+
+__all__ = [
+    "SKILLS_ENTRY_POINT_GROUP",
+    "ProviderMatch",
+    "SkillDiscoveryWarning",
+    "SkillEntry",
+    "SkillMatch",
+    "SkillParseError",
+    "clear_skills_cache",
+    "discover_skills",
+    "match_skills",
+    "parse_skill_md",
+    "providers_for_skill",
+]

--- a/mureo/core/skills/discovery.py
+++ b/mureo/core/skills/discovery.py
@@ -1,0 +1,395 @@
+"""Entry-points-based skill discovery (Issue #89 P1-08).
+
+Discovers ``SKILL.md`` files from two sources:
+
+1. **Built-in skills**: the in-tree directory at
+   ``<mureo package>/_data/skills/``. Resolved relative to
+   :data:`mureo.__file__` so it works for both editable installs and
+   wheel installs. The built-in path is unconditionally scanned (no
+   entry point required); :func:`discover_skills` accepts
+   ``include_builtins=False`` for tests that want to isolate
+   third-party entry points.
+2. **Third-party plugins**: each entry point in the
+   ``mureo.skills`` group must ``load()`` to a directory (a
+   :class:`Path` or ``str``). The discoverer recursively walks that
+   directory looking for ``SKILL.md`` files. This is the documented
+   "Option B" convention (see planner HANDOFF feat-skill-matcher.md):
+   the entry-point value is a directory path, not a module attribute.
+
+Bounds (DoS guards)
+-------------------
+- ``_MAX_RECURSION_DEPTH = 4`` — a ``SKILL.md`` more than 4 directory
+  levels below the entry-point root is skipped with a warning.
+- ``_MAX_SKILLS_PER_ENTRY_POINT = 64`` — once 64 files have been
+  accepted from a single entry-point root the scanner stops with a
+  warning.
+- 64 KiB per file (enforced inside :func:`parse_skill_md`).
+
+Security posture
+----------------
+1. **Per-plugin fault isolation**: every ``ep.load()`` and every
+   per-file parse runs inside a broad try/except so one hostile plugin
+   cannot break discovery of the rest. ``# noqa: BLE001`` is required
+   on these handlers — broad catching is the intended fault-isolation
+   boundary.
+2. **Path traversal guard**: every discovered ``SKILL.md`` is
+   :meth:`Path.resolve` -d and verified to be a descendant of the
+   originating entry-point root. Symlinks that escape the root are
+   skipped with a warning. The built-in directory uses the same guard
+   with itself as the root.
+3. **First-wins on duplicate name**: a later-installed malicious
+   plugin cannot silently take over a built-in skill's name. The
+   second contribution emits a :class:`SkillDiscoveryWarning`.
+4. **Untrusted distribution name**: ``ep.dist.name`` is captured into
+   :attr:`SkillEntry.source_distribution` as display data only.
+
+Caching
+-------
+The result is cached behind a module-level singleton; a second
+:func:`discover_skills` call without ``refresh=True`` does NOT
+re-iterate ``entry_points``. ``refresh=True`` forces re-iteration.
+``clear_skills_cache`` resets the cache for test isolation (mirroring
+the registry's ``clear_registry``).
+
+Foundation rule
+---------------
+Imports from :mod:`mureo.core.providers.registry` (constant only),
+:mod:`mureo.core.skills.models`, and
+:mod:`mureo.core.skills.parser`. No domain Protocol imports.
+"""
+
+from __future__ import annotations
+
+import warnings
+from dataclasses import replace
+from importlib.metadata import EntryPoint, entry_points
+from pathlib import Path
+from typing import TYPE_CHECKING, Final
+
+import mureo
+from mureo.core.providers.registry import SKILLS_ENTRY_POINT_GROUP
+from mureo.core.skills.parser import SkillParseError, parse_skill_md
+
+if TYPE_CHECKING:
+    from mureo.core.skills.models import SkillEntry
+
+_MAX_RECURSION_DEPTH: Final[int] = 4
+_MAX_SKILLS_PER_ENTRY_POINT: Final[int] = 64
+
+_BUILTIN_SKILLS_DIR: Final[Path] = (
+    Path(mureo.__file__).resolve().parent / "_data" / "skills"
+)
+
+
+class SkillDiscoveryWarning(UserWarning):
+    """Emitted when a skill is skipped during discovery.
+
+    Distinct :class:`UserWarning` subclass so security-conscious
+    deployments can opt into strict mode via
+    ``warnings.filterwarnings("error", category=SkillDiscoveryWarning)``.
+    """
+
+
+_cache: tuple[SkillEntry, ...] | None = None
+
+
+def discover_skills(
+    *, refresh: bool = False, include_builtins: bool = True
+) -> tuple[SkillEntry, ...]:
+    """Discover skills from built-in directory + entry-points group.
+
+    Args:
+        refresh: When ``True``, re-iterate ``entry_points`` and
+            re-scan the built-in directory even if a previous call
+            cached a result.
+        include_builtins: When ``False``, skip the built-in directory
+            scan. Defaults to ``True``. Mostly useful in tests that
+            want to isolate behaviour to the third-party entry-points
+            path.
+
+    Returns:
+        Tuple of :class:`SkillEntry`, first-wins on duplicate ``name``.
+    """
+    global _cache
+    if _cache is not None and not refresh:
+        return _cache
+
+    accepted: dict[str, SkillEntry] = {}
+
+    if include_builtins and _BUILTIN_SKILLS_DIR.is_dir():
+        _scan_root(
+            root=_BUILTIN_SKILLS_DIR,
+            distribution=None,
+            accepted=accepted,
+            origin_label="built-in",
+        )
+
+    for ep in entry_points(group=SKILLS_ENTRY_POINT_GROUP):
+        _scan_entry_point(ep, accepted)
+
+    result = tuple(accepted.values())
+    _cache = result
+    return result
+
+
+def clear_skills_cache() -> None:
+    """Invalidate the module-level discovery cache.
+
+    Test-isolation helper; mirrors :func:`mureo.core.providers.registry
+    .clear_registry`.
+    """
+    global _cache
+    _cache = None
+
+
+def _scan_entry_point(ep: EntryPoint, accepted: dict[str, SkillEntry]) -> None:
+    """Load one entry point and scan the directory it returns.
+
+    Per-plugin fault isolation: ``ep.load()`` may execute arbitrary
+    third-party code at import time, so the entire load + structural
+    check + scan is wrapped in a broad except. ``# noqa: BLE001`` is
+    required: broad catching is the intended fault-isolation boundary,
+    not a code smell.
+    """
+    ep_name = getattr(ep, "name", "<unknown>")
+    try:
+        loaded = ep.load()
+    except Exception as exc:  # noqa: BLE001 — per-plugin fault isolation
+        _warn(
+            f"failed to load skill entry point {ep_name!r} in group "
+            f"{SKILLS_ENTRY_POINT_GROUP!r}: {exc!r}"
+        )
+        return
+
+    root = _coerce_to_path(loaded)
+    if root is None:
+        _warn(
+            f"skill entry point {ep_name!r} did not yield a directory path "
+            f"(got {type(loaded).__name__}); skipped"
+        )
+        return
+    if not root.is_dir():
+        _warn(
+            f"skill entry point {ep_name!r} pointed to {root!s} which is not "
+            f"an existing directory; skipped"
+        )
+        return
+
+    distribution = _resolve_distribution(ep)
+    try:
+        _scan_root(
+            root=root,
+            distribution=distribution,
+            accepted=accepted,
+            origin_label=f"entry point {ep_name!r}",
+        )
+    except Exception as exc:  # noqa: BLE001 — per-plugin fault isolation
+        _warn(
+            f"unexpected error while scanning skill entry point "
+            f"{ep_name!r}: {exc!r}"
+        )
+
+
+def _coerce_to_path(value: object) -> Path | None:
+    """Return ``value`` as a resolved :class:`Path`, or ``None``.
+
+    Only :class:`Path` and ``str`` are accepted — anything else (ints,
+    callables, modules) is rejected with the caller emitting a
+    warning. Resolved early so the path-traversal guard has a stable
+    base to compare against.
+    """
+    if isinstance(value, Path):
+        return value.resolve()
+    if isinstance(value, str):
+        return Path(value).resolve()
+    return None
+
+
+def _resolve_distribution(ep: EntryPoint) -> str | None:
+    """Defensively extract ``ep.dist.name``; ``None`` when unresolvable."""
+    dist = getattr(ep, "dist", None)
+    if dist is None:
+        return None
+    name = getattr(dist, "name", None)
+    return name if isinstance(name, str) else None
+
+
+def _scan_root(
+    *,
+    root: Path,
+    distribution: str | None,
+    accepted: dict[str, SkillEntry],
+    origin_label: str,
+) -> None:
+    """Walk ``root`` recursively looking for ``SKILL.md`` files.
+
+    Enforces depth and file-count caps; rejects symlinks that escape
+    ``root``; isolates per-file parse failures.
+    """
+    resolved_root = root.resolve()
+    candidates = _collect_skill_md_paths(root=resolved_root, origin_label=origin_label)
+
+    accepted_count = 0
+    cap_hit = False
+    for candidate in candidates:
+        if accepted_count >= _MAX_SKILLS_PER_ENTRY_POINT:
+            cap_hit = True
+            break
+        entry = _parse_candidate(
+            candidate=candidate,
+            root=resolved_root,
+            distribution=distribution,
+            origin_label=origin_label,
+        )
+        if entry is None:
+            continue
+        if entry.name in accepted:
+            existing = accepted[entry.name]
+            _warn(
+                f"duplicate skill name {entry.name!r}: first-discovered "
+                f"from {existing.source_path!s} "
+                f"(distribution={existing.source_distribution!r}) wins; "
+                f"shadow attempt from {entry.source_path!s} "
+                f"(distribution={entry.source_distribution!r}) dropped"
+            )
+            continue
+        accepted[entry.name] = entry
+        accepted_count += 1
+
+    if cap_hit:
+        _warn(
+            f"skill scan under {origin_label} hit the cap of "
+            f"{_MAX_SKILLS_PER_ENTRY_POINT} SKILL.md files; remaining "
+            f"files in {resolved_root!s} are ignored"
+        )
+
+
+def _collect_skill_md_paths(*, root: Path, origin_label: str) -> list[Path]:
+    """Return the sorted list of ``SKILL.md`` paths under ``root``.
+
+    Honours the depth cap and the path-traversal guard. Emits warnings
+    for symlink escapes and depth violations; never raises out.
+    """
+    collected: list[Path] = []
+    if not root.is_dir():
+        return collected
+
+    # Walk subdirectories depth-first up to the depth cap (the
+    # ``stack.pop()`` below is LIFO). We intentionally avoid
+    # ``Path.rglob`` because it silently follows symlinks and offers no
+    # depth limit.
+    stack: list[tuple[Path, int]] = [(root, 0)]
+    depth_warned = False
+    while stack:
+        current, depth = stack.pop()
+        try:
+            children = list(current.iterdir())
+        except OSError as exc:
+            _warn(f"cannot list directory {current!s} under {origin_label}: {exc}")
+            continue
+
+        for child in children:
+            if not _is_under(root, child):
+                _warn(
+                    f"symlink {child!s} under {origin_label} escapes the "
+                    f"entry-point root {root!s}; skipped"
+                )
+                continue
+            if child.is_dir():
+                if depth + 1 > _MAX_RECURSION_DEPTH:
+                    if not depth_warned:
+                        _warn(
+                            f"skill scan under {origin_label} reached the "
+                            f"maximum recursion depth of "
+                            f"{_MAX_RECURSION_DEPTH}; deeper directories "
+                            f"(such as {child!s}) are ignored"
+                        )
+                        depth_warned = True
+                    continue
+                stack.append((child, depth + 1))
+            elif child.is_file() and child.name == "SKILL.md":
+                collected.append(child)
+
+    collected.sort()
+    return collected
+
+
+def _is_under(root: Path, candidate: Path) -> bool:
+    """Return ``True`` iff ``candidate``'s resolved path is under ``root``.
+
+    Symlink-aware: the candidate is fully resolved before the check so
+    a symlink that points outside ``root`` returns ``False``.
+
+    Portability note: this relies on the Python 3.10 / 3.11 behaviour
+    of :meth:`pathlib.Path.relative_to` — raising :class:`ValueError`
+    when the target is not actually relative to ``root``. Python 3.12+
+    added a ``walk_up`` parameter to ``relative_to`` that could (if
+    enabled) silently return a ``../...`` path instead of raising; we
+    do NOT pass ``walk_up=True``, so current code is unaffected. Keep
+    this guarantee in mind when touching this helper on newer Pythons.
+    """
+    try:
+        resolved = candidate.resolve()
+    except OSError:
+        return False
+    try:
+        resolved.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def _parse_candidate(
+    *,
+    candidate: Path,
+    root: Path,
+    distribution: str | None,
+    origin_label: str,
+) -> SkillEntry | None:
+    """Parse one candidate ``SKILL.md`` and attach ``distribution``.
+
+    Returns ``None`` if the parser failed (a warning is emitted) or if
+    the resolved path escapes ``root`` (defence in depth — the
+    collector already filters, but symlinks could mutate between
+    collection and parse).
+    """
+    resolved = candidate.resolve()
+    try:
+        resolved.relative_to(root)
+    except ValueError:
+        _warn(
+            f"SKILL.md at {candidate!s} resolves outside the "
+            f"{origin_label} root {root!s}; skipped"
+        )
+        return None
+
+    try:
+        entry = parse_skill_md(resolved)
+    except SkillParseError as exc:
+        _warn(
+            f"malformed SKILL.md under {origin_label} at {resolved!s}: "
+            f"{exc}; skipped"
+        )
+        return None
+    except Exception as exc:  # noqa: BLE001 — per-file fault isolation
+        _warn(
+            f"unexpected error parsing SKILL.md at {resolved!s} under "
+            f"{origin_label}: {exc!r}; skipped"
+        )
+        return None
+
+    if distribution is None:
+        return entry
+    return replace(entry, source_distribution=distribution)
+
+
+def _warn(message: str) -> None:
+    """Emit a :class:`SkillDiscoveryWarning` from the discovery loop."""
+    warnings.warn(message, SkillDiscoveryWarning, stacklevel=3)
+
+
+__all__ = [
+    "SkillDiscoveryWarning",
+    "clear_skills_cache",
+    "discover_skills",
+]

--- a/mureo/core/skills/matcher.py
+++ b/mureo/core/skills/matcher.py
@@ -1,0 +1,176 @@
+"""Skill × provider capability matching (Issue #89 P1-08).
+
+Two pure functions form the public surface:
+
+- :func:`match_skills` — given an iterable of :class:`SkillEntry` and
+  one :class:`ProviderEntry`, classify each skill into one of three
+  buckets: ``executable`` / ``advisory_only`` / ``unavailable``.
+- :func:`providers_for_skill` — the inverse: given one skill and a
+  :class:`Registry`, classify each provider into the same three
+  buckets, returned as a :class:`ProviderMatch` for type clarity.
+
+Classification rules (single source of truth)
+---------------------------------------------
+- A skill is **executable** against a provider iff
+  ``skill.required_capabilities <= provider.capabilities``.
+  Skills with an empty ``required_capabilities`` are executable against
+  every provider — this is the regression contract for the 16 shipped
+  in-tree SKILL.md files (none of them declare ``capabilities`` yet).
+- A skill is **advisory_only** when it is NOT executable AND
+  ``skill.advisory_mode_capabilities`` is non-empty AND
+  ``skill.advisory_mode_capabilities <= provider.capabilities``.
+- A skill is **unavailable** otherwise.
+
+Ordering
+--------
+All output tuples are sorted by ``name`` ascending so callers get
+deterministic results.
+
+Foundation rule
+---------------
+Only imports :class:`ProviderEntry` / :class:`Registry` from
+:mod:`mureo.core.providers.registry` and :class:`SkillEntry` from
+:mod:`mureo.core.skills.models`. No domain Protocol imports.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from mureo.core.providers.registry import ProviderEntry, Registry
+    from mureo.core.skills.models import SkillEntry
+
+
+@dataclass(frozen=True)
+class SkillMatch:
+    """Three-bucket classification of skills against one provider.
+
+    All three tuples are sorted by :attr:`SkillEntry.name` ascending.
+
+    Attributes:
+        executable: Skills whose ``required_capabilities`` are a subset
+            of the provider's capabilities (or that declare no
+            requirements at all).
+        advisory_only: Skills the provider cannot execute in full but
+            can serve in advisory mode.
+        unavailable: Skills the provider cannot serve at all.
+    """
+
+    executable: tuple[SkillEntry, ...]
+    advisory_only: tuple[SkillEntry, ...]
+    unavailable: tuple[SkillEntry, ...]
+
+
+@dataclass(frozen=True)
+class ProviderMatch:
+    """Three-bucket classification of providers against one skill.
+
+    Mirror of :class:`SkillMatch` for the inverse query
+    (:func:`providers_for_skill`). All three tuples are sorted by
+    :attr:`ProviderEntry.name` ascending.
+
+    Attributes:
+        executable: Providers that satisfy the skill's
+            ``required_capabilities`` in full.
+        advisory_only: Providers that cannot fully execute the skill
+            but satisfy its declared ``advisory_mode_capabilities``.
+        unavailable: Providers that cannot serve the skill at all.
+    """
+
+    executable: tuple[ProviderEntry, ...]
+    advisory_only: tuple[ProviderEntry, ...]
+    unavailable: tuple[ProviderEntry, ...]
+
+
+def match_skills(skills: Iterable[SkillEntry], provider: ProviderEntry) -> SkillMatch:
+    """Classify ``skills`` against ``provider``'s capabilities.
+
+    Pure function — no I/O, no mutation. See module docstring for the
+    classification rules.
+
+    Args:
+        skills: Iterable of :class:`SkillEntry`. May be empty.
+        provider: A :class:`ProviderEntry` from the registry.
+
+    Returns:
+        A :class:`SkillMatch` with three sorted tuples.
+    """
+    provider_caps = provider.capabilities
+    executable: list[SkillEntry] = []
+    advisory: list[SkillEntry] = []
+    unavailable: list[SkillEntry] = []
+
+    for skill in skills:
+        if skill.required_capabilities <= provider_caps:
+            executable.append(skill)
+        elif (
+            skill.advisory_mode_capabilities
+            and skill.advisory_mode_capabilities <= provider_caps
+        ):
+            advisory.append(skill)
+        else:
+            unavailable.append(skill)
+
+    executable.sort(key=lambda s: s.name)
+    advisory.sort(key=lambda s: s.name)
+    unavailable.sort(key=lambda s: s.name)
+    return SkillMatch(
+        executable=tuple(executable),
+        advisory_only=tuple(advisory),
+        unavailable=tuple(unavailable),
+    )
+
+
+def providers_for_skill(skill: SkillEntry, registry: Registry) -> ProviderMatch:
+    """Classify every provider in ``registry`` against one skill.
+
+    Pure function — iterates ``registry`` read-only via ``__iter__``;
+    does not mutate the registry, does not instantiate any provider
+    class.
+
+    Args:
+        skill: The :class:`SkillEntry` to query.
+        registry: A :class:`Registry` (or any iterable of
+            :class:`ProviderEntry`, since the implementation only uses
+            ``__iter__``).
+
+    Returns:
+        A :class:`ProviderMatch` with three tuples sorted by provider
+        name ascending.
+    """
+    required = skill.required_capabilities
+    advisory_caps = skill.advisory_mode_capabilities
+
+    executable: list[ProviderEntry] = []
+    advisory: list[ProviderEntry] = []
+    unavailable: list[ProviderEntry] = []
+
+    for provider in registry:
+        provider_caps = provider.capabilities
+        if required <= provider_caps:
+            executable.append(provider)
+        elif advisory_caps and advisory_caps <= provider_caps:
+            advisory.append(provider)
+        else:
+            unavailable.append(provider)
+
+    executable.sort(key=lambda p: p.name)
+    advisory.sort(key=lambda p: p.name)
+    unavailable.sort(key=lambda p: p.name)
+    return ProviderMatch(
+        executable=tuple(executable),
+        advisory_only=tuple(advisory),
+        unavailable=tuple(unavailable),
+    )
+
+
+__all__ = [
+    "ProviderMatch",
+    "SkillMatch",
+    "match_skills",
+    "providers_for_skill",
+]

--- a/mureo/core/skills/models.py
+++ b/mureo/core/skills/models.py
@@ -1,0 +1,230 @@
+"""Frozen data model for a parsed mureo skill (Issue #89 P1-08).
+
+Public surface
+--------------
+- :class:`SkillEntry` — immutable record describing one parsed
+  ``SKILL.md`` file. Construct via :func:`mureo.core.skills.parse_skill_md`
+  or manually in tests; both paths enforce the same invariants.
+
+Name regex divergence
+---------------------
+Skill names obey ``^_?[a-z][a-z0-9_-]*$`` (leading underscore + hyphens
+allowed). Provider names obey ``^[a-z][a-z0-9_]*$`` (snake_case only).
+The divergence is deliberate: the 16 shipped in-tree skills already use
+``daily-check`` and ``_mureo-shared`` style names, while provider names
+are exposed as Python identifiers in tool prefixes.
+
+Untrusted ``source_distribution``
+---------------------------------
+``source_distribution`` is the PEP 503 normalized pip package name that
+supplied the skill via the ``mureo.skills`` entry-points group. Treat it
+as **untrusted display data** — never interpolate it into shell commands,
+SQL, log-injection-sensitive sinks, or paths.
+
+Foundation rule
+---------------
+Only imports :class:`Capability` from
+:mod:`mureo.core.providers.capabilities`. No imports from registry,
+domain Protocols, or anything outside the providers foundation.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Final
+
+from mureo.core.providers.capabilities import Capability
+
+# Empty read-only Mapping used as the default value for ``SkillEntry.extra``.
+# A module-level constant guarantees every default-constructed instance shares
+# the same identity-stable, write-locked mapping (no per-instance allocation
+# and no risk of leaking a mutable default across instances).
+_EMPTY_EXTRA: Final[Mapping[str, Any]] = MappingProxyType({})
+
+# ``^_?[a-z][a-z0-9_-]*$``: optional single leading underscore, then a
+# lowercase letter, then any mix of lowercase letters, digits, underscores,
+# and hyphens. Double leading underscore is intentionally rejected.
+_SKILL_NAME_REGEX: Final[re.Pattern[str]] = re.compile(r"^_?[a-z][a-z0-9_-]*$")
+
+
+@dataclass(frozen=True)
+class SkillEntry:
+    """Frozen record describing one parsed ``SKILL.md`` file.
+
+    Attributes:
+        name: Skill identifier matching ``^_?[a-z][a-z0-9_-]*$``. The
+            optional leading underscore and embedded hyphens are
+            permitted to match the 16 shipped in-tree skills.
+        description: Non-empty human-readable description from the
+            ``description`` frontmatter key.
+        required_capabilities: :class:`frozenset` of
+            :class:`Capability` members the skill needs to execute fully.
+            Empty when the skill declares no ``capabilities`` block.
+        advisory_mode_capabilities: Subset of ``required_capabilities``
+            sufficient to produce useful advisory output when a provider
+            cannot satisfy the full ``required`` set. Empty when no
+            advisory mode is declared.
+        source_path: Absolute :class:`Path` to the originating
+            ``SKILL.md`` file. Parser resolves this before construction.
+        source_distribution: Pip distribution name when the skill came
+            from a ``mureo.skills`` entry point, ``None`` for built-ins
+            and tests. Treat as untrusted display data.
+        extra: Read-only :class:`Mapping` of forward-compatible
+            top-level frontmatter keys that the parser did not consume
+            (i.e. anything other than ``name``, ``description``,
+            ``capabilities``, ``advisory_mode_capabilities``). Used to
+            preserve metadata such as the ``metadata.version`` /
+            ``metadata.openclaw`` blocks already present in the 16
+            shipped in-tree SKILL.md files. ``__post_init__`` wraps the
+            incoming mapping in a :class:`types.MappingProxyType` so
+            the frozen invariant extends to this field too — callers
+            cannot mutate it post-construction. Treat as untrusted
+            data: it comes from third-party SKILL.md content.
+    """
+
+    name: str
+    description: str
+    required_capabilities: frozenset[Capability]
+    advisory_mode_capabilities: frozenset[Capability]
+    source_path: Path
+    source_distribution: str | None
+    # ``extra`` carries forward-compatible frontmatter (e.g. ``metadata``
+    # blocks) and intentionally does NOT participate in equality or
+    # hashing — two skills with the same identity/capabilities but a
+    # bumped ``metadata.version`` must still be considered the same
+    # SkillEntry for deduplication purposes. ``compare=False`` excludes
+    # it from both ``__eq__`` and the dataclass-generated ``__hash__``,
+    # which is also necessary because :class:`types.MappingProxyType`
+    # is not hashable.
+    extra: Mapping[str, Any] = field(
+        default_factory=lambda: _EMPTY_EXTRA, compare=False
+    )
+
+    def __post_init__(self) -> None:
+        """Validate every field at construction.
+
+        Raises:
+            TypeError: a field has the wrong type (e.g. a plain ``set``
+                instead of ``frozenset`` for capabilities).
+            ValueError: ``name`` fails the regex, ``description`` is
+                empty, ``source_path`` is not absolute, or
+                ``advisory_mode_capabilities`` is not a subset of
+                ``required_capabilities``.
+        """
+        self._validate_name()
+        self._validate_description()
+        self._validate_capabilities()
+        self._validate_source_path()
+        self._validate_source_distribution()
+        self._wrap_extra()
+
+    def _validate_name(self) -> None:
+        if not isinstance(self.name, str):
+            raise TypeError(
+                f"SkillEntry.name must be str, got {type(self.name).__name__}"
+            )
+        if not _SKILL_NAME_REGEX.match(self.name):
+            raise ValueError(
+                f"SkillEntry.name {self.name!r} does not match "
+                f"{_SKILL_NAME_REGEX.pattern!r}"
+            )
+
+    def _validate_description(self) -> None:
+        if not isinstance(self.description, str):
+            raise TypeError(
+                f"SkillEntry.description must be str, "
+                f"got {type(self.description).__name__}"
+            )
+        if self.description == "":
+            raise ValueError("SkillEntry.description must be a non-empty string")
+
+    def _validate_capabilities(self) -> None:
+        if not isinstance(self.required_capabilities, frozenset):
+            raise TypeError(
+                f"SkillEntry.required_capabilities must be a frozenset, "
+                f"got {type(self.required_capabilities).__name__}"
+            )
+        if not isinstance(self.advisory_mode_capabilities, frozenset):
+            raise TypeError(
+                f"SkillEntry.advisory_mode_capabilities must be a frozenset, "
+                f"got {type(self.advisory_mode_capabilities).__name__}"
+            )
+        bad_req = [
+            c for c in self.required_capabilities if not isinstance(c, Capability)
+        ]
+        bad_adv = [
+            c for c in self.advisory_mode_capabilities if not isinstance(c, Capability)
+        ]
+        if bad_req or bad_adv:
+            bad = bad_req + bad_adv
+            raise TypeError(
+                f"SkillEntry capabilities must contain only Capability "
+                f"members; got non-Capability element(s): "
+                f"{', '.join(repr(m) for m in bad)}"
+            )
+        if not self.advisory_mode_capabilities <= self.required_capabilities:
+            extra = self.advisory_mode_capabilities - self.required_capabilities
+            raise ValueError(
+                f"SkillEntry.advisory_mode_capabilities must be a subset of "
+                f"required_capabilities; extra: "
+                f"{sorted(str(c) for c in extra)}"
+            )
+
+    def _validate_source_path(self) -> None:
+        if not isinstance(self.source_path, Path):
+            raise TypeError(
+                f"SkillEntry.source_path must be a pathlib.Path, "
+                f"got {type(self.source_path).__name__}"
+            )
+        if not self.source_path.is_absolute():
+            raise ValueError(
+                f"SkillEntry.source_path must be absolute, got {self.source_path!s}"
+            )
+
+    def _validate_source_distribution(self) -> None:
+        if self.source_distribution is not None and not isinstance(
+            self.source_distribution, str
+        ):
+            raise TypeError(
+                f"SkillEntry.source_distribution must be str | None, "
+                f"got {type(self.source_distribution).__name__}"
+            )
+
+    def _wrap_extra(self) -> None:
+        """Type-check ``extra`` and wrap it in a :class:`MappingProxyType`.
+
+        The wrap is what extends the frozen-dataclass invariant to this
+        field: even though :class:`Mapping` itself is read-only by
+        protocol, callers may have passed a plain ``dict`` (which is
+        mutable). After wrapping, attempts to assign to keys via
+        ``entry.extra["foo"] = ...`` raise :class:`TypeError`.
+
+        We use ``object.__setattr__`` because the dataclass is frozen —
+        ordinary attribute assignment is rejected by
+        ``__setattr__`` even from inside ``__post_init__``.
+        """
+        if not isinstance(self.extra, Mapping):
+            raise TypeError(
+                f"SkillEntry.extra must be a Mapping, "
+                f"got {type(self.extra).__name__}"
+            )
+        # Re-wrap regardless of input type. ``MappingProxyType`` over an
+        # existing ``MappingProxyType`` is idempotent in behaviour (still
+        # read-only over the same underlying dict).
+        bad_keys = [k for k in self.extra if not isinstance(k, str)]
+        if bad_keys:
+            raise TypeError(
+                f"SkillEntry.extra keys must be str; got non-str key(s): "
+                f"{', '.join(repr(k) for k in bad_keys)}"
+            )
+        # Snapshot into a fresh dict so callers cannot mutate the original
+        # ``extra`` argument and see the change reflected inside the entry.
+        snapshot: dict[str, Any] = dict(self.extra)
+        object.__setattr__(self, "extra", MappingProxyType(snapshot))
+
+
+__all__ = ["SkillEntry"]

--- a/mureo/core/skills/parser.py
+++ b/mureo/core/skills/parser.py
@@ -1,0 +1,303 @@
+"""SKILL.md frontmatter parser (Issue #89 P1-08).
+
+Parses a single ``SKILL.md`` file from disk and returns a frozen
+:class:`SkillEntry`. Every decode / YAML / validation failure is wrapped
+in :class:`SkillParseError` so callers (notably
+:func:`mureo.core.skills.discover_skills`) can isolate per-file faults
+without catching :class:`Exception` directly.
+
+Security posture
+----------------
+SKILL.md content is shipped by third-party pip plugins via the
+``mureo.skills`` entry-points group — the same trust boundary as the
+provider registry, extended to data-as-code. The parser mitigates the
+risk by:
+
+1. **YAML safety**: ``yaml.safe_load`` only — never ``yaml.load`` or
+   ``yaml.unsafe_load``. A YAML tag such as
+   ``!!python/object/apply:os.system [...]`` is rejected by
+   ``safe_load`` and wrapped in :class:`SkillParseError`.
+2. **Bounded input**: 64 KiB max file size enforced *before* the YAML
+   parser runs. Guards against memory-exhaustion DoS.
+3. **UTF-8 strict decode**: ``errors="strict"``; hostile non-UTF-8
+   bytes are rejected, not silently mangled.
+4. **No code execution**: the parser does not ``exec`` anything, does
+   not import anything from the SKILL.md, does not follow external
+   references. Frontmatter is pure data.
+5. **Frontmatter must be at the start of the file**: a stray ``---`` on
+   line 3 does NOT count as a delimiter.
+
+Foundation rule
+---------------
+Imports are restricted to :mod:`mureo.core.providers.capabilities` and
+:mod:`mureo.core.skills.models`. No registry imports, no domain
+Protocol imports.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Final
+
+import yaml
+
+from mureo.core.providers.capabilities import parse_capabilities
+from mureo.core.skills.models import SkillEntry
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from mureo.core.providers.capabilities import Capability
+
+# 64 KiB cap on raw on-disk file size, enforced before any YAML parse.
+# Bumping this is a one-line change; documented in the planner HANDOFF.
+MAX_SKILL_FILE_BYTES: Final[int] = 64 * 1024
+
+# Frontmatter is delimited by lines containing exactly ``---``. The
+# opening delimiter MUST be the first line of the file; the closing
+# delimiter is the next line that is exactly ``---``.
+_FRONTMATTER_DELIM: Final[str] = "---"
+
+# Top-level frontmatter keys consumed by the parser. Anything not in
+# this set is shovelled into :attr:`SkillEntry.extra` for forward
+# compatibility (e.g. ``metadata`` blocks shipped by the 16 in-tree
+# SKILL.md files).
+_RESERVED_TOP_LEVEL_KEYS: Final[frozenset[str]] = frozenset(
+    {"name", "description", "capabilities", "advisory_mode_capabilities"}
+)
+
+
+class SkillParseError(ValueError):
+    """Raised when a SKILL.md file cannot be parsed.
+
+    Subclasses :class:`ValueError` (not :class:`Exception` directly) so
+    callers that already handle ``ValueError`` for capability parsing
+    keep working without changes. The message includes the offending
+    file path when available.
+    """
+
+
+def parse_skill_md(path: Path) -> SkillEntry:
+    """Read ``path`` and return the parsed :class:`SkillEntry`.
+
+    Args:
+        path: Absolute path to a ``SKILL.md`` file on disk.
+
+    Returns:
+        A frozen :class:`SkillEntry` whose ``source_path`` is the
+        resolved absolute form of ``path`` and ``source_distribution``
+        is ``None`` (discovery sets the distribution name; the parser
+        does not know it).
+
+    Raises:
+        SkillParseError: any of: file exceeds
+            :data:`MAX_SKILL_FILE_BYTES`, invalid UTF-8 byte sequence,
+            missing or malformed frontmatter delimiters, missing
+            required ``name`` / ``description`` keys, ``name`` fails the
+            regex, unknown capability token, ``advisory_mode`` not a
+            subset of ``required``, or any YAML parser error.
+    """
+    resolved = path.resolve()
+    raw = _read_bounded(resolved)
+    body = _decode_utf8(resolved, raw)
+    frontmatter_text = _extract_frontmatter(resolved, body)
+    data = _parse_yaml(resolved, frontmatter_text)
+    return _build_entry(resolved, data)
+
+
+def _read_bounded(path: Path) -> bytes:
+    """Read ``path`` as bytes, rejecting files larger than the cap.
+
+    The size check uses :meth:`Path.stat` first (cheap, no read) so a
+    multi-gigabyte hostile file does not even enter memory.
+    """
+    try:
+        size = path.stat().st_size
+    except OSError as exc:
+        raise SkillParseError(f"cannot stat SKILL.md at {path!s}: {exc}") from exc
+    if size > MAX_SKILL_FILE_BYTES:
+        raise SkillParseError(
+            f"SKILL.md at {path!s} exceeds maximum size of "
+            f"{MAX_SKILL_FILE_BYTES} bytes (got {size} bytes); rejected "
+            f"before YAML parse"
+        )
+    try:
+        return path.read_bytes()
+    except OSError as exc:
+        raise SkillParseError(f"cannot read SKILL.md at {path!s}: {exc}") from exc
+
+
+def _decode_utf8(path: Path, raw: bytes) -> str:
+    """Decode ``raw`` as UTF-8 with ``errors='strict'``.
+
+    A leading UTF-8 BOM (``U+FEFF``) is stripped immediately after
+    decode. Some Windows editors (Notepad, older VS Code with
+    auto-detect) silently prepend a BOM when saving UTF-8 files; the
+    BOM would otherwise push the ``---`` frontmatter delimiter past
+    the start-of-file invariant in :func:`_extract_frontmatter` and
+    surface as a confusing "missing frontmatter" error.
+    """
+    try:
+        decoded = raw.decode("utf-8", errors="strict")
+    except UnicodeDecodeError as exc:
+        raise SkillParseError(
+            f"SKILL.md at {path!s} is not valid UTF-8: {exc}"
+        ) from exc
+    return decoded.lstrip("﻿")
+
+
+def _extract_frontmatter(path: Path, body: str) -> str:
+    """Return the YAML frontmatter text between leading ``---`` lines.
+
+    The opening delimiter must be the FIRST line of the file. A
+    ``---`` appearing on any later line without a preceding opener at
+    line 1 does NOT count as a delimiter — this rejects files that try
+    to sneak frontmatter past a leading comment block.
+
+    Coupling note: ``splitlines()`` runs on the full decoded body in
+    memory. The cost is currently bounded by the 64 KiB upstream cap
+    (:data:`MAX_SKILL_FILE_BYTES`). Raising ``MAX_SKILL_FILE_BYTES``
+    requires an audit of both the decode and splitlines memory cost
+    before merging.
+    """
+    lines = body.splitlines()
+    if not lines or lines[0].rstrip() != _FRONTMATTER_DELIM:
+        raise SkillParseError(
+            f"SKILL.md at {path!s} is missing a leading {_FRONTMATTER_DELIM!r} "
+            f"frontmatter delimiter on line 1"
+        )
+    # Find the closing delimiter starting from line 2 (index 1).
+    for idx in range(1, len(lines)):
+        if lines[idx].rstrip() == _FRONTMATTER_DELIM:
+            return "\n".join(lines[1:idx])
+    raise SkillParseError(
+        f"SKILL.md at {path!s} has an opening {_FRONTMATTER_DELIM!r} but no "
+        f"closing frontmatter delimiter"
+    )
+
+
+def _parse_yaml(path: Path, text: str) -> dict[str, Any]:
+    """Run ``yaml.safe_load`` on the frontmatter text.
+
+    Returns a mapping; rejects non-mapping / non-dict YAML documents.
+    Wraps every ``yaml.YAMLError`` (including the ``ConstructorError``
+    raised on rejected ``!!python/object`` tags) in
+    :class:`SkillParseError`.
+    """
+    try:
+        loaded = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise SkillParseError(
+            f"SKILL.md at {path!s} has malformed YAML frontmatter: {exc}"
+        ) from exc
+    if loaded is None:
+        # Empty frontmatter block — treat as an empty mapping so we hit
+        # the "missing required key 'name'" branch with a clearer error.
+        return {}
+    if not isinstance(loaded, dict):
+        raise SkillParseError(
+            f"SKILL.md at {path!s} frontmatter must be a YAML mapping, "
+            f"got {type(loaded).__name__}"
+        )
+    return loaded
+
+
+def _build_entry(path: Path, data: dict[str, Any]) -> SkillEntry:
+    """Validate required fields, parse capabilities, and construct."""
+    name = _require_str(path, data, key="name")
+    description = _require_str(path, data, key="description")
+    if description == "":
+        raise SkillParseError(
+            f"SKILL.md at {path!s}: 'description' must be a non-empty string"
+        )
+
+    required_caps, advisory_caps = _parse_capabilities_block(path, data)
+    extra = {k: v for k, v in data.items() if k not in _RESERVED_TOP_LEVEL_KEYS}
+
+    try:
+        return SkillEntry(
+            name=name,
+            description=description,
+            required_capabilities=required_caps,
+            advisory_mode_capabilities=advisory_caps,
+            source_path=path,
+            source_distribution=None,
+            extra=extra,
+        )
+    except (TypeError, ValueError) as exc:
+        # Re-wrap dataclass invariant failures (bad name regex, advisory
+        # not subset, etc.) as SkillParseError so callers see one
+        # exception class.
+        raise SkillParseError(f"SKILL.md at {path!s} failed validation: {exc}") from exc
+
+
+def _require_str(path: Path, data: dict[str, Any], *, key: str) -> str:
+    """Return ``data[key]`` as ``str`` or raise :class:`SkillParseError`."""
+    if key not in data:
+        raise SkillParseError(
+            f"SKILL.md at {path!s} is missing required frontmatter key {key!r}"
+        )
+    value = data[key]
+    if not isinstance(value, str):
+        raise SkillParseError(
+            f"SKILL.md at {path!s} key {key!r} must be a string, "
+            f"got {type(value).__name__}"
+        )
+    return value
+
+
+def _parse_capabilities_block(
+    path: Path, data: dict[str, Any]
+) -> tuple[frozenset[Capability], frozenset[Capability]]:
+    """Parse the optional ``capabilities`` block.
+
+    Returns ``(required, advisory_mode)`` as two frozensets of
+    :class:`Capability` members. Absent or empty block yields two
+    empty frozensets — the matcher treats these skills as executable
+    against any provider (regression contract for the 16 shipped
+    SKILL.md files).
+    """
+    caps = data.get("capabilities")
+    if caps is None:
+        return frozenset(), frozenset()
+    if not isinstance(caps, dict):
+        raise SkillParseError(
+            f"SKILL.md at {path!s} 'capabilities' must be a mapping, "
+            f"got {type(caps).__name__}"
+        )
+
+    required_raw = caps.get("required", [])
+    advisory_raw = caps.get("advisory_mode", [])
+
+    required = _parse_capability_list(path, required_raw, field="required")
+    advisory = _parse_capability_list(path, advisory_raw, field="advisory_mode")
+    return required, advisory
+
+
+def _parse_capability_list(
+    path: Path, raw: object, *, field: str
+) -> frozenset[Capability]:
+    """Parse a list of capability tokens into a frozenset."""
+    if raw is None:
+        return frozenset()
+    if not isinstance(raw, list):
+        raise SkillParseError(
+            f"SKILL.md at {path!s} capabilities.{field} must be a list, "
+            f"got {type(raw).__name__}"
+        )
+    tokens: list[str] = []
+    for idx, item in enumerate(raw):
+        if not isinstance(item, str):
+            raise SkillParseError(
+                f"SKILL.md at {path!s} capabilities.{field}[{idx}] must be "
+                f"a string, got {type(item).__name__}"
+            )
+        tokens.append(item)
+    try:
+        return parse_capabilities(tokens)
+    except ValueError as exc:
+        raise SkillParseError(
+            f"SKILL.md at {path!s} capabilities.{field}: {exc}"
+        ) from exc
+
+
+__all__ = ["MAX_SKILL_FILE_BYTES", "SkillParseError", "parse_skill_md"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,12 @@ dependencies = [
     # --bundle <xlsx>) to read multi-tab Sheets exported from the
     # mureo Sheet template (Apps Script + Google Ads Script).
     "openpyxl>=3.1,<4",
+    # PyYAML is used by mureo.core.skills.parser to parse SKILL.md
+    # frontmatter via yaml.safe_load (P1-08). Pinned <7 to avoid
+    # unannounced API breaks. The hand-rolled alternative was rejected
+    # — re-implementing YAML escapes is a worse security surface than
+    # the audited safe_load path.
+    "pyyaml>=6.0,<7",
 ]
 
 [project.optional-dependencies]
@@ -103,6 +109,15 @@ strict = true
 
 [[tool.mypy.overrides]]
 module = "google.ads.googleads.*"
+ignore_missing_imports = true
+
+# PyYAML ships no type stubs by default; ``types-PyYAML`` is a separate
+# package on PyPI. Adding it to ``[project.optional-dependencies].dev``
+# would force every contributor to reinstall. The two values we actually
+# touch (``yaml.safe_load`` and ``yaml.YAMLError``) are well-known and
+# narrow — accept the missing-imports override instead.
+[[tool.mypy.overrides]]
+module = "yaml"
 ignore_missing_imports = true
 
 [tool.coverage.run]

--- a/tests/core/skills/test_discovery.py
+++ b/tests/core/skills/test_discovery.py
@@ -1,0 +1,546 @@
+"""Tests for ``mureo.core.skills.discovery`` (RED phase, Issue #89 P1-08).
+
+These tests pin the entry-points-based skill discovery contract:
+
+- Iterates ``importlib.metadata.entry_points(group="mureo.skills")``.
+- Each entry point loads to a ``Path``-like (Option B in the plan); the
+  discoverer recursively walks the directory looking for ``SKILL.md``.
+- Bounded by max recursion depth 4 and max 64 files per entry point.
+- Always also scans the in-tree built-in skills directory.
+- Per-entry try/except: a broken plugin emits
+  :class:`SkillDiscoveryWarning` and is skipped.
+- First-wins on duplicate ``name``.
+- Idempotent + cached behind a module-level singleton; ``refresh=True``
+  re-iterates.
+- Path-traversal guard: symlinks escaping the entry-point root are
+  rejected with a warning.
+
+NOTE: these imports are expected to FAIL during the RED phase — the
+module ``mureo.core.skills.discovery`` does not exist yet.
+"""
+
+from __future__ import annotations
+
+import os
+import types
+from typing import TYPE_CHECKING, Any
+from unittest.mock import patch
+
+import pytest
+
+from mureo.core.providers.registry import SKILLS_ENTRY_POINT_GROUP
+from mureo.core.skills.discovery import (  # noqa: E402 — RED-phase import
+    SkillDiscoveryWarning,
+    discover_skills,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+_MIN_FRONTMATTER_TEMPLATE = (
+    "---\n" "name: {name}\n" 'description: "Test skill {name}."\n' "---\n" "# {name}\n"
+)
+
+
+def _write_skill_md(dir_path: Path, name: str) -> Path:
+    """Create ``dir_path/<name>/SKILL.md`` with a minimal valid frontmatter."""
+    sub = dir_path / name
+    sub.mkdir(parents=True, exist_ok=True)
+    p = sub / "SKILL.md"
+    p.write_text(_MIN_FRONTMATTER_TEMPLATE.format(name=name), encoding="utf-8")
+    return p
+
+
+def _make_fake_entry_point(
+    *,
+    name: str,
+    distribution: str | None,
+    load_result: object | None = None,
+    load_exception: BaseException | None = None,
+) -> types.SimpleNamespace:
+    """Build a duck-typed ``EntryPoint`` for the discoverer to consume.
+
+    Mirrors the pattern used in
+    ``tests/core/providers/test_registry_discovery.py``.
+    """
+
+    def _load() -> object:
+        if load_exception is not None:
+            raise load_exception
+        return load_result
+
+    dist: types.SimpleNamespace | None = (
+        None if distribution is None else types.SimpleNamespace(name=distribution)
+    )
+
+    return types.SimpleNamespace(
+        name=name,
+        group=SKILLS_ENTRY_POINT_GROUP,
+        dist=dist,
+        load=_load,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_discovery_cache() -> Any:
+    """Best-effort reset of the discovery singleton between tests.
+
+    The discovery module exposes ``refresh=True``; we additionally
+    attempt to clear any module-level cache attribute the implementer
+    may add (mirrors the registry's ``clear_registry`` pattern). The
+    ``getattr`` fallback keeps this fixture tolerant of either naming.
+    """
+    from mureo.core.skills import discovery as _discovery  # noqa: PLC0415
+
+    clear = getattr(_discovery, "clear_skills_cache", None)
+    if callable(clear):
+        clear()
+    yield
+    if callable(clear):
+        clear()
+
+
+# ---------------------------------------------------------------------------
+# Case 1 — built-in scan finds the 16 in-tree skills (integration)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_builtin_scan_finds_in_tree_skills() -> None:
+    """Calling :func:`discover_skills` with NO third-party entry points
+    must still surface at least one SKILL.md from the in-tree built-in
+    directory (so built-in skills work without an entry point).
+    """
+
+    def _no_entry_points(group: str) -> tuple[Any, ...]:
+        assert group == SKILLS_ENTRY_POINT_GROUP
+        return ()
+
+    with patch(
+        "mureo.core.skills.discovery.entry_points",
+        side_effect=_no_entry_points,
+    ):
+        entries = discover_skills(refresh=True)
+
+    assert len(entries) >= 1, "built-in scan must yield at least one skill"
+    names = {e.name for e in entries}
+    # daily-check is one of the 16 known built-ins.
+    assert "daily-check" in names, f"expected daily-check among built-ins; got {names}"
+
+
+# ---------------------------------------------------------------------------
+# Case 2 — entry point → directory scan finds both SKILL.md files
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_entry_point_directory_scan_finds_skills(tmp_path: Path) -> None:
+    """A fake entry point whose ``load()`` returns a directory ``Path``
+    containing two ``SKILL.md`` files in subdirs: both surface.
+    """
+    _write_skill_md(tmp_path, "alpha-skill")
+    _write_skill_md(tmp_path, "beta-skill")
+
+    ep = _make_fake_entry_point(
+        name="ep_a",
+        distribution="mureo-fake-plugin",
+        load_result=tmp_path,
+    )
+
+    def _eps(group: str) -> tuple[Any, ...]:  # noqa: ARG001
+        return (ep,)
+
+    with patch(
+        "mureo.core.skills.discovery.entry_points",
+        side_effect=_eps,
+    ):
+        entries = discover_skills(refresh=True)
+
+    names = {e.name for e in entries}
+    assert "alpha-skill" in names
+    assert "beta-skill" in names
+    for e in entries:
+        if e.name in {"alpha-skill", "beta-skill"}:
+            assert e.source_distribution == "mureo-fake-plugin"
+
+
+# ---------------------------------------------------------------------------
+# Case 3 — entry point returns non-Path → warning, skipped
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_entry_point_non_path_load_warns_and_skips(tmp_path: Path) -> None:
+    """An EP whose ``load()`` returns something other than a ``Path | str``
+    must emit :class:`SkillDiscoveryWarning` and contribute zero entries
+    (but not raise).
+    """
+    bad_ep = _make_fake_entry_point(
+        name="bad_value",
+        distribution="mureo-bad-plugin",
+        load_result=42,
+    )
+
+    def _eps(group: str) -> tuple[Any, ...]:  # noqa: ARG001
+        return (bad_ep,)
+
+    with (
+        patch(
+            "mureo.core.skills.discovery.entry_points",
+            side_effect=_eps,
+        ),
+        pytest.warns(SkillDiscoveryWarning),
+    ):
+        entries = discover_skills(refresh=True)
+
+    names = {e.name for e in entries}
+    # Only built-ins should remain; the bad EP contributes nothing.
+    assert all(not n.startswith("bad_value") for n in names)
+
+
+# ---------------------------------------------------------------------------
+# Case 4 — entry point load() raises → warning, skipped
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_entry_point_load_exception_warns_and_skips() -> None:
+    """A broken plugin whose ``ep.load()`` raises emits a warning and is
+    skipped. Discovery does not abort.
+    """
+    broken = _make_fake_entry_point(
+        name="broken",
+        distribution="mureo-broken-plugin",
+        load_exception=ImportError("simulated broken plugin"),
+    )
+
+    def _eps(group: str) -> tuple[Any, ...]:  # noqa: ARG001
+        return (broken,)
+
+    with (
+        patch(
+            "mureo.core.skills.discovery.entry_points",
+            side_effect=_eps,
+        ),
+        pytest.warns(SkillDiscoveryWarning, match="broken"),
+    ):
+        # Must not raise.
+        discover_skills(refresh=True)
+
+
+# ---------------------------------------------------------------------------
+# Case 5 — malformed SKILL.md alongside well-formed siblings
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_malformed_skill_md_skipped_well_formed_surfaces(tmp_path: Path) -> None:
+    """One malformed ``SKILL.md`` warns and is skipped; its well-formed
+    siblings still surface.
+    """
+    _write_skill_md(tmp_path, "good-skill")
+
+    # Malformed sibling: missing required ``description`` key.
+    bad_dir = tmp_path / "bad-skill"
+    bad_dir.mkdir()
+    (bad_dir / "SKILL.md").write_text(
+        "---\nname: bad-skill\n---\nbody\n", encoding="utf-8"
+    )
+
+    ep = _make_fake_entry_point(
+        name="ep_mixed",
+        distribution="mureo-mixed-plugin",
+        load_result=tmp_path,
+    )
+
+    def _eps(group: str) -> tuple[Any, ...]:  # noqa: ARG001
+        return (ep,)
+
+    with (
+        patch(
+            "mureo.core.skills.discovery.entry_points",
+            side_effect=_eps,
+        ),
+        pytest.warns(SkillDiscoveryWarning),
+    ):
+        entries = discover_skills(refresh=True)
+
+    names = {e.name for e in entries}
+    assert "good-skill" in names
+    assert "bad-skill" not in names
+
+
+# ---------------------------------------------------------------------------
+# Case 6 — duplicate skill name: first-wins
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_duplicate_skill_name_first_wins(tmp_path: Path) -> None:
+    """Two entry points contribute a skill with the same name; the first
+    survives and the second emits :class:`SkillDiscoveryWarning`.
+    """
+    dir_a = tmp_path / "a"
+    dir_b = tmp_path / "b"
+    dir_a.mkdir()
+    dir_b.mkdir()
+    _write_skill_md(dir_a, "shared-name")
+    _write_skill_md(dir_b, "shared-name")
+
+    ep_a = _make_fake_entry_point(
+        name="ep_a",
+        distribution="dist-a",
+        load_result=dir_a,
+    )
+    ep_b = _make_fake_entry_point(
+        name="ep_b",
+        distribution="dist-b",
+        load_result=dir_b,
+    )
+
+    def _eps(group: str) -> tuple[Any, ...]:  # noqa: ARG001
+        return (ep_a, ep_b)
+
+    with (
+        patch(
+            "mureo.core.skills.discovery.entry_points",
+            side_effect=_eps,
+        ),
+        pytest.warns(SkillDiscoveryWarning, match="(?i)duplicate|shadow"),
+    ):
+        entries = discover_skills(refresh=True)
+
+    shared = [e for e in entries if e.name == "shared-name"]
+    assert len(shared) == 1, "first-wins must keep exactly one entry"
+    assert shared[0].source_distribution == "dist-a"
+
+
+# ---------------------------------------------------------------------------
+# Case 7 — idempotent caching: second call does NOT re-iterate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_discover_skills_is_cached() -> None:
+    """A second :func:`discover_skills` call without ``refresh=True``
+    must NOT re-call ``entry_points``.
+    """
+    call_counter = {"n": 0}
+
+    def _eps(group: str) -> tuple[Any, ...]:  # noqa: ARG001
+        call_counter["n"] += 1
+        return ()
+
+    with patch(
+        "mureo.core.skills.discovery.entry_points",
+        side_effect=_eps,
+    ):
+        first = discover_skills(refresh=True)
+        second = discover_skills()  # cached
+        assert second == first
+        assert call_counter["n"] == 1, (
+            "entry_points must be iterated exactly once when refresh is "
+            f"not requested; got {call_counter['n']}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Case 8 — refresh=True re-iterates
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_discover_skills_refresh_reiterates() -> None:
+    """``refresh=True`` must force re-iteration of ``entry_points``."""
+    call_counter = {"n": 0}
+
+    def _eps(group: str) -> tuple[Any, ...]:  # noqa: ARG001
+        call_counter["n"] += 1
+        return ()
+
+    with patch(
+        "mureo.core.skills.discovery.entry_points",
+        side_effect=_eps,
+    ):
+        discover_skills(refresh=True)
+        discover_skills(refresh=True)
+        assert (
+            call_counter["n"] >= 2
+        ), f"refresh=True must re-iterate; got call_counter={call_counter['n']}"
+
+
+# ---------------------------------------------------------------------------
+# Case 9 — directory recursion bounded at depth 4
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_discovery_depth_limit_at_4(tmp_path: Path) -> None:
+    """A SKILL.md nested deeper than the configured max depth (4) is NOT
+    picked up; the discoverer emits a warning rather than silently
+    descending.
+
+    The "depth" is measured relative to the entry-point root. A file at
+    ``root/l1/l2/l3/l4/l5/SKILL.md`` (5 levels deep) is too deep; a file
+    at ``root/l1/l2/SKILL.md`` is fine.
+    """
+    too_deep = tmp_path / "l1" / "l2" / "l3" / "l4" / "l5"
+    too_deep.mkdir(parents=True)
+    (too_deep / "SKILL.md").write_text(
+        _MIN_FRONTMATTER_TEMPLATE.format(name="deep-skill"), encoding="utf-8"
+    )
+    # Shallow sibling that MUST surface.
+    _write_skill_md(tmp_path, "shallow-skill")
+
+    ep = _make_fake_entry_point(
+        name="ep_deep",
+        distribution="dist-deep",
+        load_result=tmp_path,
+    )
+
+    def _eps(group: str) -> tuple[Any, ...]:  # noqa: ARG001
+        return (ep,)
+
+    with (
+        patch(
+            "mureo.core.skills.discovery.entry_points",
+            side_effect=_eps,
+        ),
+        pytest.warns(SkillDiscoveryWarning, match="(?i)depth|deep"),
+    ):
+        entries = discover_skills(refresh=True)
+
+    names = {e.name for e in entries}
+    assert "shallow-skill" in names
+    assert "deep-skill" not in names
+
+
+# ---------------------------------------------------------------------------
+# Case 10 — file count cap per entry point at 64
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_discovery_file_count_cap_at_64(tmp_path: Path) -> None:
+    """A directory containing 65 SKILL.md files: only 64 surface, and a
+    :class:`SkillDiscoveryWarning` mentioning the cap is emitted.
+    """
+    for i in range(65):
+        _write_skill_md(tmp_path, f"skill-{i:03d}")
+
+    ep = _make_fake_entry_point(
+        name="ep_many",
+        distribution="dist-many",
+        load_result=tmp_path,
+    )
+
+    def _eps(group: str) -> tuple[Any, ...]:  # noqa: ARG001
+        return (ep,)
+
+    with (
+        patch(
+            "mureo.core.skills.discovery.entry_points",
+            side_effect=_eps,
+        ),
+        pytest.warns(SkillDiscoveryWarning, match="(?i)cap|limit|64"),
+    ):
+        entries = discover_skills(refresh=True)
+
+    from_this_ep = [e for e in entries if e.name.startswith("skill-")]
+    assert (
+        len(from_this_ep) == 64
+    ), f"expected exactly 64 skills under cap; got {len(from_this_ep)}"
+
+
+# ---------------------------------------------------------------------------
+# Case 11 — source_distribution propagated from ep.dist.name
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_source_distribution_propagated_from_ep_dist_name(tmp_path: Path) -> None:
+    """The discoverer captures ``ep.dist.name`` into
+    ``SkillEntry.source_distribution`` for every skill it picks up from
+    that entry point.
+    """
+    _write_skill_md(tmp_path, "branded-skill")
+
+    ep = _make_fake_entry_point(
+        name="ep_branded",
+        distribution="branded-pkg",
+        load_result=tmp_path,
+    )
+
+    def _eps(group: str) -> tuple[Any, ...]:  # noqa: ARG001
+        return (ep,)
+
+    with patch(
+        "mureo.core.skills.discovery.entry_points",
+        side_effect=_eps,
+    ):
+        entries = discover_skills(refresh=True)
+
+    branded = [e for e in entries if e.name == "branded-skill"]
+    assert len(branded) == 1
+    assert branded[0].source_distribution == "branded-pkg"
+
+
+# ---------------------------------------------------------------------------
+# Case 12 — path-traversal guard: symlink escaping ep root is rejected
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_path_traversal_symlink_rejected(tmp_path: Path) -> None:
+    """A symlink that points *outside* the entry-point root is rejected
+    (parser/discovery emits a warning and does not follow it).
+
+    Scenario: the entry point's directory contains a symlink named
+    ``escapee`` pointing at a sibling directory ``../outside/`` that
+    contains a SKILL.md. The traversal must NOT be followed.
+    """
+    ep_root = tmp_path / "ep_root"
+    outside = tmp_path / "outside"
+    ep_root.mkdir()
+    outside.mkdir()
+
+    # SKILL.md outside the ep root — would be a security breach if discovered.
+    (outside / "evil").mkdir()
+    (outside / "evil" / "SKILL.md").write_text(
+        _MIN_FRONTMATTER_TEMPLATE.format(name="evil-skill"), encoding="utf-8"
+    )
+
+    # Symlink inside the ep root pointing at the outside dir.
+    try:
+        os.symlink(outside, ep_root / "escapee", target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("OS does not support symlinks in this test environment")
+
+    # And one legitimate sibling so the test can confirm normal scan still works.
+    _write_skill_md(ep_root, "legit-skill")
+
+    ep = _make_fake_entry_point(
+        name="ep_escape",
+        distribution="dist-escape",
+        load_result=ep_root,
+    )
+
+    def _eps(group: str) -> tuple[Any, ...]:  # noqa: ARG001
+        return (ep,)
+
+    with patch(
+        "mureo.core.skills.discovery.entry_points",
+        side_effect=_eps,
+    ):
+        entries = discover_skills(refresh=True)
+
+    names = {e.name for e in entries}
+    assert "legit-skill" in names
+    assert (
+        "evil-skill" not in names
+    ), "discovery must not follow symlinks that escape the entry-point root"

--- a/tests/core/skills/test_existing_skills_parse.py
+++ b/tests/core/skills/test_existing_skills_parse.py
@@ -1,0 +1,115 @@
+"""Regression tests — every shipped ``skills/*/SKILL.md`` parses cleanly.
+
+These tests guard the contract that the parser (P1-08) accepts every
+SKILL.md currently shipped at the repository root under ``skills/``.
+None of the 16 in-tree files declare a ``capabilities`` block in
+Phase 1, so every parsed entry must report empty capability frozensets.
+This sentinel catches accidental drift if someone adds ``capabilities``
+without going through the dedicated migration PR (planner tracks this
+as a follow-up P1-09).
+
+Marks: every test is ``@pytest.mark.integration`` — touches the real
+on-disk SKILL.md files shipped with the repo.
+
+NOTE: the parser import is expected to FAIL during the RED phase — the
+module ``mureo.core.skills.parser`` does not exist yet.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mureo.core.skills.parser import parse_skill_md  # noqa: E402 — RED-phase
+
+# Repo root is three parents above this test file:
+# tests/core/skills/test_existing_skills_parse.py
+#                       └── parents[3] == repo root
+_REPO_ROOT: Path = Path(__file__).resolve().parents[3]
+_SKILLS_DIR: Path = _REPO_ROOT / "skills"
+_SHIPPED_SKILL_FILES: tuple[Path, ...] = tuple(sorted(_SKILLS_DIR.glob("*/SKILL.md")))
+
+
+# A failsafe — if the test layout changes and we can't find the skills
+# directory, every parametrized case below would silently be 0 cases,
+# turning this regression test into a no-op. Fail loudly instead.
+assert len(_SHIPPED_SKILL_FILES) >= 1, (
+    f"expected at least one SKILL.md under {_SKILLS_DIR}; "
+    f"found {len(_SHIPPED_SKILL_FILES)}"
+)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "skill_path",
+    _SHIPPED_SKILL_FILES,
+    ids=[p.parent.name for p in _SHIPPED_SKILL_FILES],
+)
+def test_shipped_skill_md_parses(skill_path: Path) -> None:
+    """Every shipped ``skills/*/SKILL.md`` parses without raising."""
+    entry = parse_skill_md(skill_path)
+
+    # Sanity: parser returned a SkillEntry-shaped object.
+    assert entry.name, "parsed skill must have a non-empty name"
+    assert entry.description, "parsed skill must have a non-empty description"
+    # Name on disk matches frontmatter ``name``.
+    assert entry.name == skill_path.parent.name, (
+        f"frontmatter name {entry.name!r} does not match directory name "
+        f"{skill_path.parent.name!r}"
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "skill_path",
+    _SHIPPED_SKILL_FILES,
+    ids=[p.parent.name for p in _SHIPPED_SKILL_FILES],
+)
+def test_shipped_skill_md_has_no_capabilities_yet(skill_path: Path) -> None:
+    """Sentinel — until the P1-09 migration PR lands, no shipped
+    SKILL.md should declare ``capabilities``. If this assertion ever
+    starts failing, route the change through the dedicated migration PR
+    instead of bundling it with parser changes.
+    """
+    entry = parse_skill_md(skill_path)
+
+    assert entry.required_capabilities == frozenset(), (
+        f"{skill_path.parent.name}: unexpected required_capabilities "
+        f"{entry.required_capabilities!r} — content drift, route through "
+        "the P1-09 frontmatter-migration PR"
+    )
+    assert entry.advisory_mode_capabilities == frozenset(), (
+        f"{skill_path.parent.name}: unexpected advisory_mode_capabilities "
+        f"{entry.advisory_mode_capabilities!r} — content drift, route through "
+        "the P1-09 frontmatter-migration PR"
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "skill_path",
+    _SHIPPED_SKILL_FILES,
+    ids=[p.parent.name for p in _SHIPPED_SKILL_FILES],
+)
+def test_shipped_skill_md_metadata_captured_in_extra(skill_path: Path) -> None:
+    """Every shipped SKILL.md carries a ``metadata`` block (containing
+    ``version``, ``openclaw``, etc.). The parser must surface it
+    verbatim in ``extra`` for forward compatibility, and must NOT leak
+    reserved keys (``name`` / ``description`` / ``capabilities``) into
+    ``extra``.
+    """
+    entry = parse_skill_md(skill_path)
+
+    # Reserved keys are stripped from extra.
+    assert "name" not in entry.extra
+    assert "description" not in entry.extra
+    assert "capabilities" not in entry.extra
+
+    # The shipped files all ship ``metadata`` — make that the regression
+    # contract for this PR.
+    assert "metadata" in entry.extra, (
+        f"{skill_path.parent.name}: expected a top-level 'metadata' key "
+        f"in extra (forward-compat preservation), got keys "
+        f"{sorted(entry.extra.keys())}"
+    )

--- a/tests/core/skills/test_matcher.py
+++ b/tests/core/skills/test_matcher.py
@@ -1,0 +1,293 @@
+"""Unit tests for ``mureo.core.skills.matcher`` (RED phase, Issue #89 P1-08).
+
+These tests pin the pure-function contracts of:
+
+- :func:`match_skills` — classify an iterable of :class:`SkillEntry` against
+  one :class:`ProviderEntry` into ``executable`` / ``advisory_only`` /
+  ``unavailable`` buckets.
+- :func:`providers_for_skill` — the inverse: classify the providers in a
+  :class:`Registry` against one skill, returning a parallel
+  :class:`ProviderMatch` shaped result.
+
+Marks: every test is ``@pytest.mark.unit`` — pure logic, no I/O, no
+mocks (real :class:`Capability` members + constructed dataclasses).
+
+NOTE: these imports are expected to FAIL during the RED phase — the
+module ``mureo.core.skills.matcher`` does not exist yet.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+
+import pytest
+
+from mureo.core.providers.capabilities import Capability
+from mureo.core.providers.registry import ProviderEntry, Registry
+from mureo.core.skills.matcher import (  # noqa: E402 — RED-phase import
+    ProviderMatch,
+    SkillMatch,
+    match_skills,
+    providers_for_skill,
+)
+from mureo.core.skills.models import SkillEntry  # noqa: E402 — RED-phase import
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _skill(
+    name: str,
+    *,
+    required: frozenset[Capability] = frozenset(),
+    advisory: frozenset[Capability] = frozenset(),
+) -> SkillEntry:
+    return SkillEntry(
+        name=name,
+        description=f"Skill {name}.",
+        required_capabilities=required,
+        advisory_mode_capabilities=advisory,
+        source_path=Path(f"/tmp/skills/{name}/SKILL.md"),
+        source_distribution=None,
+    )
+
+
+class _FakeProvider:
+    """Stand-in provider class for :class:`ProviderEntry` construction."""
+
+    name = "p"
+    display_name = "P"
+    capabilities = frozenset()  # overridden per-entry
+
+
+def _provider(name: str, caps: frozenset[Capability]) -> ProviderEntry:
+    return ProviderEntry(
+        name=name,
+        display_name=name.replace("_", " ").title(),
+        capabilities=caps,
+        provider_class=_FakeProvider,
+        source_distribution=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# match_skills — Case 1: executable when required ⊆ provider.capabilities
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_match_skills_executable_when_required_subset_of_provider() -> None:
+    """Skill needs ``{READ_CAMPAIGNS}`` and provider has
+    ``{READ_CAMPAIGNS, READ_PERFORMANCE}`` → ``executable``.
+    """
+    skill = _skill("s1", required=frozenset({Capability.READ_CAMPAIGNS}))
+    provider = _provider(
+        "p1",
+        frozenset({Capability.READ_CAMPAIGNS, Capability.READ_PERFORMANCE}),
+    )
+
+    result = match_skills([skill], provider)
+
+    assert result.executable == (skill,)
+    assert result.advisory_only == ()
+    assert result.unavailable == ()
+
+
+# ---------------------------------------------------------------------------
+# match_skills — Case 2: advisory_only
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_match_skills_advisory_only_when_advisory_subset_but_required_not() -> None:
+    """Skill needs ``{READ_CAMPAIGNS, WRITE_BUDGET}``, advisory
+    ``{READ_CAMPAIGNS}``; provider has only ``{READ_CAMPAIGNS}`` →
+    ``advisory_only``.
+    """
+    skill = _skill(
+        "s1",
+        required=frozenset({Capability.READ_CAMPAIGNS, Capability.WRITE_BUDGET}),
+        advisory=frozenset({Capability.READ_CAMPAIGNS}),
+    )
+    provider = _provider("p1", frozenset({Capability.READ_CAMPAIGNS}))
+
+    result = match_skills([skill], provider)
+
+    assert result.executable == ()
+    assert result.advisory_only == (skill,)
+    assert result.unavailable == ()
+
+
+# ---------------------------------------------------------------------------
+# match_skills — Case 3: unavailable when neither
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_match_skills_unavailable_when_neither_matches() -> None:
+    """Skill needs ``{WRITE_BUDGET}`` (no advisory); provider has
+    ``{READ_CAMPAIGNS}`` → ``unavailable``.
+    """
+    skill = _skill("s1", required=frozenset({Capability.WRITE_BUDGET}))
+    provider = _provider("p1", frozenset({Capability.READ_CAMPAIGNS}))
+
+    result = match_skills([skill], provider)
+
+    assert result.executable == ()
+    assert result.advisory_only == ()
+    assert result.unavailable == (skill,)
+
+
+# ---------------------------------------------------------------------------
+# match_skills — Case 4: empty required → executable everywhere (regression)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_match_skills_empty_required_is_always_executable() -> None:
+    """Skills with no declared ``required_capabilities`` are always
+    executable regardless of provider. Critical regression guard for the
+    16 existing in-tree SKILL.md files (none of them declare capabilities
+    in Phase 1).
+    """
+    skill = _skill("legacy", required=frozenset(), advisory=frozenset())
+
+    # Two extreme providers: one with no caps at all, one with all caps.
+    bare_provider = _provider("bare", frozenset())
+    fully_loaded = _provider("full", frozenset(Capability))
+
+    assert match_skills([skill], bare_provider).executable == (skill,)
+    assert match_skills([skill], fully_loaded).executable == (skill,)
+
+
+# ---------------------------------------------------------------------------
+# match_skills — Case 5: empty input iterable
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_match_skills_empty_input() -> None:
+    """An empty iterable yields ``SkillMatch((), (), ())``."""
+    provider = _provider("p1", frozenset({Capability.READ_CAMPAIGNS}))
+
+    result = match_skills([], provider)
+
+    assert result.executable == ()
+    assert result.advisory_only == ()
+    assert result.unavailable == ()
+
+
+# ---------------------------------------------------------------------------
+# match_skills — Case 6: deterministic ordering (sorted by name asc)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_match_skills_buckets_sorted_by_name() -> None:
+    """Each bucket is sorted by ``name`` ascending regardless of input
+    order.
+    """
+    s_zeta = _skill("zeta", required=frozenset({Capability.READ_CAMPAIGNS}))
+    s_alpha = _skill("alpha", required=frozenset({Capability.READ_CAMPAIGNS}))
+    s_mid = _skill("mid", required=frozenset({Capability.READ_CAMPAIGNS}))
+    provider = _provider("p1", frozenset({Capability.READ_CAMPAIGNS}))
+
+    result = match_skills([s_zeta, s_alpha, s_mid], provider)
+
+    # All three are executable for this provider; check sort order.
+    assert result.executable == (s_alpha, s_mid, s_zeta)
+
+
+# ---------------------------------------------------------------------------
+# match_skills — Case 7: SkillMatch is immutable
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_skill_match_is_frozen() -> None:
+    """Assigning to a field on :class:`SkillMatch` raises
+    :class:`FrozenInstanceError`.
+    """
+    sm = SkillMatch(executable=(), advisory_only=(), unavailable=())
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        sm.executable = ()  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# providers_for_skill — Case 8: pure read skill across mixed registry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_providers_for_skill_pure_read_across_mixed_registry() -> None:
+    """Skill needs ``{READ_CAMPAIGNS}``; registry has three providers
+    (read-only, read+write, write-only). Result: 2 executable, 0
+    advisory, 1 unavailable.
+    """
+    skill = _skill("read-only", required=frozenset({Capability.READ_CAMPAIGNS}))
+    reg = Registry()
+    p_read = _provider("p_read", frozenset({Capability.READ_CAMPAIGNS}))
+    p_rw = _provider(
+        "p_rw",
+        frozenset({Capability.READ_CAMPAIGNS, Capability.WRITE_BUDGET}),
+    )
+    p_write = _provider("p_write", frozenset({Capability.WRITE_BUDGET}))
+    reg.register(p_read)
+    reg.register(p_rw)
+    reg.register(p_write)
+
+    result = providers_for_skill(skill, reg)
+
+    assert isinstance(result, ProviderMatch)
+    assert set(result.executable) == {p_read, p_rw}
+    assert result.advisory_only == ()
+    assert result.unavailable == (p_write,)
+    # Sorted by name ascending.
+    assert result.executable == tuple(sorted({p_read, p_rw}, key=lambda e: e.name))
+
+
+# ---------------------------------------------------------------------------
+# providers_for_skill — Case 9: advisory split
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_providers_for_skill_advisory_bucket() -> None:
+    """Skill needs ``{READ_CAMPAIGNS, WRITE_BUDGET}``, advisory
+    ``{READ_CAMPAIGNS}``. A provider with only ``{READ_CAMPAIGNS}`` lands
+    in ``advisory_only``.
+    """
+    skill = _skill(
+        "advisory-skill",
+        required=frozenset({Capability.READ_CAMPAIGNS, Capability.WRITE_BUDGET}),
+        advisory=frozenset({Capability.READ_CAMPAIGNS}),
+    )
+    reg = Registry()
+    p_read = _provider("p_read", frozenset({Capability.READ_CAMPAIGNS}))
+    reg.register(p_read)
+
+    result = providers_for_skill(skill, reg)
+
+    assert result.executable == ()
+    assert result.advisory_only == (p_read,)
+    assert result.unavailable == ()
+
+
+# ---------------------------------------------------------------------------
+# providers_for_skill — Case 10: empty registry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_providers_for_skill_empty_registry() -> None:
+    """An empty registry yields ``ProviderMatch((), (), ())``."""
+    skill = _skill("any", required=frozenset({Capability.READ_CAMPAIGNS}))
+    reg = Registry()
+
+    result = providers_for_skill(skill, reg)
+
+    assert result.executable == ()
+    assert result.advisory_only == ()
+    assert result.unavailable == ()

--- a/tests/core/skills/test_models.py
+++ b/tests/core/skills/test_models.py
@@ -1,0 +1,325 @@
+"""Unit tests for ``mureo.core.skills.models.SkillEntry`` (RED phase, P1-08).
+
+These tests pin the invariants of the :class:`SkillEntry` frozen
+dataclass — types, regex on ``name``, ``advisory_mode`` ⊆ ``required``,
+absolute ``source_path``, immutability, and hashability.
+
+Marks: every test is ``@pytest.mark.unit``.
+
+NOTE: these imports are expected to FAIL during the RED phase — the
+module ``mureo.core.skills.models`` does not exist yet.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from collections.abc import Mapping
+from pathlib import Path
+
+import pytest
+
+from mureo.core.providers.capabilities import Capability
+from mureo.core.skills.models import SkillEntry  # noqa: E402 — RED-phase import
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _build(
+    *,
+    name: str = "valid-skill",
+    description: str = "A valid skill.",
+    required: frozenset[Capability] = frozenset(),
+    advisory: frozenset[Capability] = frozenset(),
+    source_path: Path | None = None,
+    source_distribution: str | None = None,
+) -> SkillEntry:
+    if source_path is None:
+        source_path = Path("/tmp/skills/valid-skill/SKILL.md")
+    return SkillEntry(
+        name=name,
+        description=description,
+        required_capabilities=required,
+        advisory_mode_capabilities=advisory,
+        source_path=source_path,
+        source_distribution=source_distribution,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Case 1 — valid construction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_valid_construction() -> None:
+    """All six fields well-typed: construction succeeds and round-trips."""
+    entry = _build(
+        name="cap-skill",
+        description="Declares one cap.",
+        required=frozenset({Capability.READ_CAMPAIGNS}),
+        advisory=frozenset({Capability.READ_CAMPAIGNS}),
+        source_path=Path("/tmp/skills/cap-skill/SKILL.md"),
+        source_distribution="mureo",
+    )
+
+    assert entry.name == "cap-skill"
+    assert entry.description == "Declares one cap."
+    assert entry.required_capabilities == frozenset({Capability.READ_CAMPAIGNS})
+    assert entry.advisory_mode_capabilities == frozenset({Capability.READ_CAMPAIGNS})
+    assert entry.source_path == Path("/tmp/skills/cap-skill/SKILL.md")
+    assert entry.source_distribution == "mureo"
+
+
+# ---------------------------------------------------------------------------
+# Case 2 — frozen mutation rejected
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_frozen_mutation_rejected() -> None:
+    """Assigning to a field on a constructed ``SkillEntry`` raises
+    :class:`dataclasses.FrozenInstanceError`.
+    """
+    entry = _build()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        entry.name = "mutated"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Case 3 — advisory must be a subset of required
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_advisory_must_be_subset_of_required() -> None:
+    """``__post_init__`` raises :class:`ValueError` when
+    ``advisory_mode_capabilities`` is not a subset of
+    ``required_capabilities``.
+    """
+    with pytest.raises(ValueError):
+        _build(
+            required=frozenset({Capability.READ_CAMPAIGNS}),
+            advisory=frozenset({Capability.READ_PERFORMANCE}),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Case 4 — non-frozenset capabilities rejected
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_non_frozenset_capabilities_rejected() -> None:
+    """Passing a plain ``set`` (mutable) for ``required_capabilities``
+    raises :class:`TypeError`.
+    """
+    with pytest.raises(TypeError):
+        SkillEntry(
+            name="bad",
+            description="bad",
+            required_capabilities={Capability.READ_CAMPAIGNS},  # type: ignore[arg-type]
+            advisory_mode_capabilities=frozenset(),
+            source_path=Path("/tmp/skills/bad/SKILL.md"),
+            source_distribution=None,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Case 5 — non-absolute path rejected
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_non_absolute_path_rejected() -> None:
+    """``source_path`` must be absolute; relative paths raise
+    :class:`ValueError`.
+    """
+    with pytest.raises(ValueError):
+        _build(source_path=Path("rel/path/SKILL.md"))
+
+
+# ---------------------------------------------------------------------------
+# Case 6 — invalid name regex rejected
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "bad_name",
+    [
+        "BadName",  # uppercase
+        "1leading-digit",
+        "spaces here",
+        "exclaim!",
+        "",
+        "-leading-hyphen",
+        "__double_underscore",
+    ],
+)
+def test_invalid_name_rejected(bad_name: str) -> None:
+    """Names that do not match ``^_?[a-z][a-z0-9_-]*$`` raise
+    :class:`ValueError`.
+    """
+    with pytest.raises(ValueError):
+        _build(name=bad_name)
+
+
+# ---------------------------------------------------------------------------
+# Case 7 — empty description rejected
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_empty_description_rejected() -> None:
+    """``description`` must be a non-empty string; empty raises
+    :class:`ValueError`.
+    """
+    with pytest.raises(ValueError):
+        _build(description="")
+
+
+# ---------------------------------------------------------------------------
+# Case 8 — equality + hashability
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_equality_and_hashability() -> None:
+    """Two ``SkillEntry`` instances with identical fields compare equal,
+    hash equal, and can be inserted into a ``set``.
+    """
+    a = _build()
+    b = _build()
+
+    assert a == b
+    assert hash(a) == hash(b)
+    assert {a, b} == {a}
+
+
+# ---------------------------------------------------------------------------
+# Case 9 — ``extra`` defaults to an empty read-only Mapping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_extra_defaults_to_empty_mapping() -> None:
+    """When ``extra`` is not supplied, it is a ``Mapping`` with zero keys
+    and rejects writes (the frozen invariant must extend to ``extra``).
+    """
+    entry = _build()
+
+    assert isinstance(entry.extra, Mapping)
+    assert len(entry.extra) == 0
+    with pytest.raises(TypeError):
+        entry.extra["new"] = "value"  # type: ignore[index]
+
+
+# ---------------------------------------------------------------------------
+# Case 10 — ``extra`` preserves supplied keys but rejects post-construction mutation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_extra_preserves_keys_and_is_read_only() -> None:
+    """A non-empty ``extra`` mapping survives construction unchanged but
+    becomes write-locked. Mutating the *original* dict the caller passed
+    must NOT change the entry's view.
+    """
+    payload = {"metadata": {"version": "0.7.1"}, "openclaw": {"category": "ads"}}
+
+    entry = SkillEntry(
+        name="extra-skill",
+        description="Carries forward-compat metadata.",
+        required_capabilities=frozenset(),
+        advisory_mode_capabilities=frozenset(),
+        source_path=Path("/tmp/skills/extra-skill/SKILL.md"),
+        source_distribution=None,
+        extra=payload,
+    )
+
+    # Round-trip: every key supplied is present.
+    assert entry.extra["metadata"] == {"version": "0.7.1"}
+    assert entry.extra["openclaw"] == {"category": "ads"}
+
+    # The view is read-only.
+    with pytest.raises(TypeError):
+        entry.extra["pwn"] = "owned"  # type: ignore[index]
+
+    # Caller mutation of the original dict must not leak into the entry.
+    payload["pwn"] = "owned"
+    assert "pwn" not in entry.extra
+
+
+# ---------------------------------------------------------------------------
+# Case 11 — non-Mapping ``extra`` rejected
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_extra_must_be_mapping() -> None:
+    """Passing a non-``Mapping`` (e.g. a list) for ``extra`` raises
+    :class:`TypeError`.
+    """
+    with pytest.raises(TypeError):
+        SkillEntry(
+            name="bad-extra",
+            description="bad",
+            required_capabilities=frozenset(),
+            advisory_mode_capabilities=frozenset(),
+            source_path=Path("/tmp/skills/bad-extra/SKILL.md"),
+            source_distribution=None,
+            extra=["not", "a", "mapping"],  # type: ignore[arg-type]
+        )
+
+
+# ---------------------------------------------------------------------------
+# Case 12 — non-str ``extra`` keys rejected
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_extra_keys_must_be_strings() -> None:
+    """Frontmatter is YAML, but the parser hands the parser a dict that
+    *should* be ``Mapping[str, Any]``. Defence in depth: a YAML mapping
+    with non-string keys (e.g. integer keys) is rejected at construction.
+    """
+    with pytest.raises(TypeError):
+        SkillEntry(
+            name="bad-extra-keys",
+            description="bad",
+            required_capabilities=frozenset(),
+            advisory_mode_capabilities=frozenset(),
+            source_path=Path("/tmp/skills/bad-extra-keys/SKILL.md"),
+            source_distribution=None,
+            extra={1: "int key not allowed"},  # type: ignore[dict-item]
+        )
+
+
+# ---------------------------------------------------------------------------
+# Case 13 — ``extra`` is excluded from equality + hashing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_extra_does_not_affect_equality_or_hash() -> None:
+    """Two ``SkillEntry`` instances that differ ONLY in ``extra`` (e.g.
+    a bumped ``metadata.version``) compare equal and hash equal. This
+    keeps the dedup behaviour in
+    :func:`mureo.core.skills.discover_skills` stable across
+    forward-compat metadata churn.
+    """
+    base_kwargs = {
+        "name": "same-skill",
+        "description": "same desc",
+        "required_capabilities": frozenset(),
+        "advisory_mode_capabilities": frozenset(),
+        "source_path": Path("/tmp/skills/same-skill/SKILL.md"),
+        "source_distribution": None,
+    }
+    a = SkillEntry(**base_kwargs, extra={"metadata": {"version": "0.1.0"}})
+    b = SkillEntry(**base_kwargs, extra={"metadata": {"version": "0.2.0"}})
+
+    assert a == b
+    assert hash(a) == hash(b)

--- a/tests/core/skills/test_parser.py
+++ b/tests/core/skills/test_parser.py
@@ -1,0 +1,493 @@
+"""Unit tests for ``mureo.core.skills.parser`` (RED phase, Issue #89 P1-08).
+
+These tests pin the contract of :func:`parse_skill_md`:
+
+- Reads the file as UTF-8 strict.
+- Extracts YAML frontmatter delimited by ``^---\\n`` / ``\\n---\\n``.
+- Uses ``yaml.safe_load`` (never ``yaml.load`` / ``yaml.unsafe_load``).
+- Requires ``name`` (matching ``^_?[a-z][a-z0-9_-]*$``) and ``description``
+  (non-empty).
+- Optional ``capabilities`` block with ``required`` + ``advisory_mode``
+  lists; ``advisory_mode`` must be a subset of ``required``.
+- Unknown top-level keys are ignored for forward compatibility.
+- File-size cap of 64 KiB enforced *before* YAML parse.
+- Wraps any decode / YAML / validation failure in
+  :class:`SkillParseError`.
+
+Marks: every test is ``@pytest.mark.unit`` — pure file I/O against
+``tmp_path``; no network, no entry points, no plugin discovery.
+
+NOTE: these imports are expected to FAIL during the RED phase — the
+module ``mureo.core.skills.parser`` does not exist yet.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from mureo.core.providers.capabilities import Capability
+from mureo.core.skills.parser import (  # noqa: E402 — RED-phase import
+    SkillParseError,
+    parse_skill_md,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_skill(tmp_path: Path, body: str, *, name: str = "skill.md") -> Path:
+    """Write ``body`` to ``tmp_path/name`` and return the resolved path."""
+    path = tmp_path / name
+    path.write_text(body, encoding="utf-8")
+    return path.resolve()
+
+
+_MIN_FRONTMATTER = (
+    "---\n"
+    "name: example-skill\n"
+    'description: "An example skill for tests."\n'
+    "---\n"
+    "# Body\n"
+    "Some markdown body content here.\n"
+)
+
+
+# ---------------------------------------------------------------------------
+# Case 1 — well-formed minimal frontmatter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_parse_well_formed_minimal(tmp_path: Path) -> None:
+    """A SKILL.md with only ``name`` + ``description`` parses cleanly and
+    returns empty capability frozensets (no ``capabilities`` block declared).
+    """
+    path = _write_skill(tmp_path, _MIN_FRONTMATTER)
+
+    entry = parse_skill_md(path)
+
+    assert entry.name == "example-skill"
+    assert entry.description == "An example skill for tests."
+    assert entry.required_capabilities == frozenset()
+    assert entry.advisory_mode_capabilities == frozenset()
+    assert entry.source_path == path
+    assert entry.source_distribution is None
+
+
+# ---------------------------------------------------------------------------
+# Case 2 — well-formed with capabilities block
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_parse_well_formed_with_capabilities(tmp_path: Path) -> None:
+    """``capabilities.required`` and ``capabilities.advisory_mode`` are
+    parsed into frozensets of :class:`Capability` members.
+    """
+    body = (
+        "---\n"
+        "name: cap-skill\n"
+        'description: "Skill that declares capabilities."\n'
+        "capabilities:\n"
+        "  required:\n"
+        "    - read_campaigns\n"
+        "    - read_performance\n"
+        "  advisory_mode:\n"
+        "    - read_campaigns\n"
+        "---\n"
+        "body\n"
+    )
+    path = _write_skill(tmp_path, body)
+
+    entry = parse_skill_md(path)
+
+    assert entry.required_capabilities == frozenset(
+        {Capability.READ_CAMPAIGNS, Capability.READ_PERFORMANCE}
+    )
+    assert entry.advisory_mode_capabilities == frozenset({Capability.READ_CAMPAIGNS})
+
+
+# ---------------------------------------------------------------------------
+# Case 3 — missing frontmatter delimiters
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_parse_missing_frontmatter_delimiters(tmp_path: Path) -> None:
+    """A SKILL.md that does NOT start with ``---\\n`` raises
+    :class:`SkillParseError` mentioning ``frontmatter``.
+    """
+    body = "# A skill without frontmatter\n\nNo YAML header at all.\n"
+    path = _write_skill(tmp_path, body)
+
+    with pytest.raises(SkillParseError, match="frontmatter"):
+        parse_skill_md(path)
+
+
+# ---------------------------------------------------------------------------
+# Case 4 — missing required key 'name'
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_parse_missing_name_key(tmp_path: Path) -> None:
+    """The parser raises :class:`SkillParseError` mentioning ``'name'`` if
+    the frontmatter omits the required ``name`` key.
+    """
+    body = "---\n" 'description: "Missing name."\n' "---\n" "body\n"
+    path = _write_skill(tmp_path, body)
+
+    with pytest.raises(SkillParseError, match="name"):
+        parse_skill_md(path)
+
+
+# ---------------------------------------------------------------------------
+# Case 5 — missing required key 'description'
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_parse_missing_description_key(tmp_path: Path) -> None:
+    """Missing ``description`` raises :class:`SkillParseError` mentioning
+    ``'description'``.
+    """
+    body = "---\n" "name: ok-name\n" "---\n" "body\n"
+    path = _write_skill(tmp_path, body)
+
+    with pytest.raises(SkillParseError, match="description"):
+        parse_skill_md(path)
+
+
+# ---------------------------------------------------------------------------
+# Case 6 — invalid name regex
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_parse_invalid_name_regex(tmp_path: Path) -> None:
+    """A name that does not match ``^_?[a-z][a-z0-9_-]*$`` raises
+    :class:`SkillParseError`.
+    """
+    body = (
+        "---\n"
+        'name: "BadName!"\n'
+        'description: "Has invalid name."\n'
+        "---\n"
+        "body\n"
+    )
+    path = _write_skill(tmp_path, body)
+
+    with pytest.raises(SkillParseError):
+        parse_skill_md(path)
+
+
+# ---------------------------------------------------------------------------
+# Case 7 — unknown capability token
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_parse_unknown_capability_token(tmp_path: Path) -> None:
+    """An unknown token under ``capabilities.required`` raises
+    :class:`SkillParseError` mentioning the offending token.
+    """
+    body = (
+        "---\n"
+        "name: bad-cap\n"
+        'description: "Declares an unknown capability."\n'
+        "capabilities:\n"
+        "  required:\n"
+        "    - read_unicorns\n"
+        "---\n"
+        "body\n"
+    )
+    path = _write_skill(tmp_path, body)
+
+    with pytest.raises(SkillParseError, match="read_unicorns"):
+        parse_skill_md(path)
+
+
+# ---------------------------------------------------------------------------
+# Case 8 — advisory_mode not a subset of required
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_parse_advisory_not_subset_of_required(tmp_path: Path) -> None:
+    """If ``advisory_mode`` contains a capability not in ``required`` the
+    parser raises :class:`SkillParseError`.
+    """
+    body = (
+        "---\n"
+        "name: bad-advisory\n"
+        'description: "Advisory not in required."\n'
+        "capabilities:\n"
+        "  required:\n"
+        "    - read_campaigns\n"
+        "  advisory_mode:\n"
+        "    - read_performance\n"
+        "---\n"
+        "body\n"
+    )
+    path = _write_skill(tmp_path, body)
+
+    with pytest.raises(SkillParseError):
+        parse_skill_md(path)
+
+
+# ---------------------------------------------------------------------------
+# Case 9 — unknown top-level keys are ignored (forward compat)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_parse_ignores_unknown_top_level_keys(tmp_path: Path) -> None:
+    """``metadata`` / ``openclaw`` / arbitrary unknown keys are tolerated
+    (matches the 16 in-tree SKILL.md files which already carry
+    ``metadata.version`` and ``metadata.openclaw``).
+    """
+    body = (
+        "---\n"
+        "name: fwd-compat\n"
+        'description: "Forward-compatible parse."\n'
+        "metadata:\n"
+        '  version: "0.7.1"\n'
+        "  openclaw:\n"
+        '    category: "marketing"\n'
+        "future_field:\n"
+        '  hello: "world"\n'
+        "---\n"
+        "body\n"
+    )
+    path = _write_skill(tmp_path, body)
+
+    entry = parse_skill_md(path)
+
+    assert entry.name == "fwd-compat"
+    assert entry.required_capabilities == frozenset()
+    assert entry.advisory_mode_capabilities == frozenset()
+
+
+# ---------------------------------------------------------------------------
+# Case 10 — oversized file rejected before YAML parse
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_parse_oversized_file_rejected(tmp_path: Path) -> None:
+    """A SKILL.md exceeding 64 KiB raises :class:`SkillParseError`
+    mentioning size and is rejected without invoking the YAML parser.
+    """
+    # 65 KiB of padding inside a markdown body — still well-formed
+    # frontmatter, but total file size pushes past the 64 KiB cap.
+    padding = "x" * (65 * 1024)
+    body = (
+        "---\n" "name: too-big\n" 'description: "Oversized."\n' "---\n" f"{padding}\n"
+    )
+    path = _write_skill(tmp_path, body)
+
+    with pytest.raises(SkillParseError, match="(?i)size|large|64"):
+        parse_skill_md(path)
+
+
+# ---------------------------------------------------------------------------
+# Case 11 — malicious YAML tag rejected, no code execution
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_parse_rejects_malicious_yaml_tag(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A YAML tag that would trigger code execution under unsafe loaders
+    (e.g. ``!!python/object/apply:os.system``) must be rejected by
+    ``yaml.safe_load``. The parser wraps the underlying YAML error in
+    :class:`SkillParseError`.
+
+    Defense in depth: we additionally monkeypatch ``os.system`` to a
+    failing sentinel — if the parser is ever switched to an unsafe loader
+    this assertion will fire and surface the regression.
+    """
+    import os as _os  # noqa: PLC0415 — local import for monkeypatch target
+
+    sentinel: dict[str, bool] = {"called": False}
+
+    def _explode(_cmd: str) -> int:
+        sentinel["called"] = True
+        return 0
+
+    monkeypatch.setattr(_os, "system", _explode)
+
+    body = (
+        "---\n"
+        "name: malicious\n"
+        'description: "Tries to execute code via YAML tag."\n'
+        'pwn: !!python/object/apply:os.system ["echo pwned"]\n'
+        "---\n"
+        "body\n"
+    )
+    path = _write_skill(tmp_path, body)
+
+    with pytest.raises(SkillParseError):
+        parse_skill_md(path)
+
+    assert (
+        sentinel["called"] is False
+    ), "os.system was called during parse — parser must use yaml.safe_load"
+
+
+# ---------------------------------------------------------------------------
+# Case 12 — non-UTF-8 bytes rejected
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_parse_rejects_non_utf8_bytes(tmp_path: Path) -> None:
+    """A file containing invalid UTF-8 raises :class:`SkillParseError`
+    (the parser reads with ``errors="strict"``).
+    """
+    path = tmp_path / "bad-utf8.md"
+    # Latin-1 byte 0xff is invalid in UTF-8.
+    path.write_bytes(b"---\nname: ok\ndescription: \xff bad\n---\nbody\n")
+
+    with pytest.raises(SkillParseError):
+        parse_skill_md(path.resolve())
+
+
+# ---------------------------------------------------------------------------
+# Case 13 — frontmatter delimiters must be at start of file
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_parse_rejects_delimiters_not_at_start(tmp_path: Path) -> None:
+    """``---`` appearing on line 3 (after a blank line and a comment) is
+    NOT a valid frontmatter delimiter; the parser must reject it.
+    """
+    body = (
+        "<!-- pre-comment -->\n"
+        "\n"
+        "---\n"
+        "name: late-frontmatter\n"
+        'description: "Frontmatter not at top."\n'
+        "---\n"
+        "body\n"
+    )
+    path = _write_skill(tmp_path, body)
+
+    with pytest.raises(SkillParseError, match="frontmatter"):
+        parse_skill_md(path)
+
+
+# ---------------------------------------------------------------------------
+# Case 14 — unknown top-level keys are surfaced in ``extra``
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_parse_populates_extra_with_unknown_keys(tmp_path: Path) -> None:
+    """The parser collects every top-level frontmatter key that is NOT
+    ``name`` / ``description`` / ``capabilities`` into
+    :attr:`SkillEntry.extra` for forward compatibility.
+    """
+    body = (
+        "---\n"
+        "name: fwd-compat\n"
+        'description: "Forward-compatible parse."\n'
+        "metadata:\n"
+        '  version: "0.7.1"\n'
+        "  openclaw:\n"
+        '    category: "marketing"\n'
+        "future_field:\n"
+        '  hello: "world"\n'
+        "---\n"
+        "body\n"
+    )
+    path = _write_skill(tmp_path, body)
+
+    entry = parse_skill_md(path)
+
+    # Reserved keys are NOT in extra.
+    assert "name" not in entry.extra
+    assert "description" not in entry.extra
+    assert "capabilities" not in entry.extra
+    # Unknown keys ARE in extra, unchanged.
+    assert entry.extra["metadata"] == {
+        "version": "0.7.1",
+        "openclaw": {"category": "marketing"},
+    }
+    assert entry.extra["future_field"] == {"hello": "world"}
+
+
+# ---------------------------------------------------------------------------
+# Case 15 — ``extra`` is empty when no unknown keys are present
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_parse_extra_empty_when_no_unknown_keys(tmp_path: Path) -> None:
+    """A SKILL.md whose frontmatter contains only reserved keys yields
+    an ``extra`` mapping with zero entries.
+    """
+    path = _write_skill(tmp_path, _MIN_FRONTMATTER)
+
+    entry = parse_skill_md(path)
+
+    assert len(entry.extra) == 0
+
+
+# ---------------------------------------------------------------------------
+# Case 16 — capabilities key is consumed, not leaked into ``extra``
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_parse_capabilities_not_leaked_into_extra(tmp_path: Path) -> None:
+    """``capabilities`` is a reserved key — even when present, it does
+    not appear in ``extra``.
+    """
+    body = (
+        "---\n"
+        "name: cap-skill\n"
+        'description: "Cap skill."\n'
+        "capabilities:\n"
+        "  required:\n"
+        "    - read_campaigns\n"
+        "metadata:\n"
+        '  version: "0.1.0"\n'
+        "---\n"
+        "body\n"
+    )
+    path = _write_skill(tmp_path, body)
+
+    entry = parse_skill_md(path)
+
+    assert "capabilities" not in entry.extra
+    assert entry.extra["metadata"] == {"version": "0.1.0"}
+
+
+# ---------------------------------------------------------------------------
+# Case 17 — UTF-8 BOM is tolerated
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_parse_accepts_utf8_bom(tmp_path: Path) -> None:
+    """Some Windows editors prepend a UTF-8 BOM (``\\ufeff``) when
+    saving. The parser strips it after decode so the ``---`` frontmatter
+    delimiter on line 1 is still recognised.
+    """
+    path = tmp_path / "bom.md"
+    # ``utf-8-sig`` writes a leading BOM and then the body as UTF-8.
+    path.write_text(_MIN_FRONTMATTER, encoding="utf-8-sig")
+
+    entry = parse_skill_md(path.resolve())
+
+    assert entry.name == "example-skill"
+    assert entry.description == "An example skill for tests."


### PR DESCRIPTION
## Summary

Implements P1-08 of Issue #89 Phase 1: the **skill matcher** — parser for `SKILL.md` frontmatter + 3-bucket capability resolver bridging skills to providers discovered by the P1-07 Registry.

### Public ABI

```python
from mureo.core.skills import (
    # Models
    SkillEntry, SkillMatch, ProviderMatch, SkillParseError, SkillsWarning,
    # Parser
    parse_skill_md,
    # Matcher
    match_skills, providers_for_skill,
    # Discovery
    discover_skills, clear_skills_cache,
    SKILLS_ENTRY_POINT_GROUP,  # "mureo.skills"
)
```

### How it works

1. **`SkillEntry`** — frozen dataclass: `name`, `description`, `required_capabilities: frozenset[Capability]`, `advisory_mode_capabilities ⊆ required_capabilities`, `source_path`, `source_distribution`, `extra: Mapping[str, Any]` (forward-compat preservation of unknown frontmatter keys, `MappingProxyType`-wrapped).
2. **`parse_skill_md(path)`** — reads `SKILL.md`, strips UTF-8 BOM, decodes strict, enforces 64 KiB cap, parses YAML via `yaml.safe_load`, extracts capability strings via P1-01's `parse_capability`.
3. **`match_skills(skills, provider_capabilities)`** — partitions into three buckets:
   - `executable`: `required ⊆ provider_caps`
   - `advisory_only`: `advisory_mode ⊆ provider_caps` but `required ⊄ provider_caps`
   - `unavailable`: neither
4. **`discover_skills()`** — scans built-in `mureo/_data/skills/` plus entry-points group `mureo.skills`. Per-skill fault isolation, first-wins on duplicates (built-in trumps external).

### Existing SKILL.md regression contract

All 16 shipped `mureo/_data/skills/*/SKILL.md` files parse cleanly today with empty `required_capabilities`, so every one falls into the `executable` bucket against any provider — exactly as Phase 1 should behave. Frontmatter capability migration for these is deferred to its own PR (likely P1-09).

## Stacked on PR #93

`feat/p1-08-skill-matcher` → `feat/p1-07-entry-points-registry` → `feat/p1-03-to-06-domain-protocols` → `feat/p1-02-base-provider` → `feat/p1-01-capabilities` → `main`. Merge order: #90 → #91 → #92 → #93 → this PR.

## Test plan

- [x] `pytest tests/core/skills/` — 106/106 passed
- [x] `pytest tests/core/` (P1-01..P1-08) — 305/305 passed
- [x] Coverage on `mureo/core/skills/`: 86–100% per module
- [x] `ruff check mureo/core/ tests/core/` — clean
- [x] `black --check mureo/core/ tests/core/` — clean
- [x] `mypy mureo/core/` — clean (15 source files, 0 errors)
- [x] python-reviewer agent: **APPROVE** (deferred LOW-5 stacklevel + 3 new micro-polish LOWs A/B/C — all in P2 follow-ups below)
- [x] security-reviewer agent: **APPROVE** (all 9 stated mitigations verified; PyYAML 6.x is CVE-clear for `safe_load` path)

## Security posture

9 mitigations enforced and tested:

1. `yaml.safe_load` only — no `yaml.load` / `unsafe_load` / `load_all` / `full_load` anywhere in `mureo/`
2. 64 KiB file-size cap **before** read (size check on `stat()`)
3. ≤ 64 SKILL.md per entry-point, recursion depth ≤ 4
4. Path-traversal guard (`resolve()` + `relative_to(root)`, symlink-escape rejection with defence-in-depth re-check on `_parse_candidate`)
5. UTF-8 `errors="strict"` decode
6. Per-skill fault isolation (broad `except Exception` with `# noqa: BLE001` at the three documented boundaries)
7. First-wins on duplicate skill name — built-in cannot be silently shadowed
8. `source_distribution` documented as untrusted display data
9. No code execution at parse time — confirmed by `test_parse_rejects_malicious_yaml_tag` (`os.system` not invoked)

## Follow-ups (deferred — file as Phase 2 issues)

### Security hardening (security-reviewer LOWs)

- [ ] **P2-SEC-06**: Sanitize control characters from plugin-supplied strings (entry-point name, distribution name, path components) before interpolating into `SkillsWarning` messages — protects terminal log viewers from escape-code injection.
- [ ] **P2-SEC-07**: Cap total `mureo.skills` entry-point iteration count (e.g. 32 distributions) to bound discovery cost under a hostile environment with many small dists.
- [ ] **P2-SEC-08**: Optional SHA-256 manifest of built-in `SKILL.md` files emitted at build time; CLI subcommand `mureo skills verify` to detect drift in installed wheel.
- [ ] **P2-SEC-09**: Document `warnings.filterwarnings("error", category=SkillsWarning)` strict-mode for hardened deployments.
- [ ] **P2-SEC-10**: Revisit PyYAML upper bound when 7.0 ships; verify `safe_load` API and CVE history before bumping.
- [ ] **P2-SEC-11**: `_MAX_TOTAL_SKILLS` global cap across all entry-points (current per-ep cap is 64; N eps × 64 unbounded).

### Polish (python-reviewer LOWs)

- [ ] **PY-LOW-A**: Replace `decoded.lstrip("﻿")` with `decoded.removeprefix("﻿")` — explicit escape, single-BOM semantics, exact mirror of `utf-8-sig`.
- [ ] **PY-LOW-B**: Resolve `advisory_mode_capabilities` reserved-key asymmetry — either drop reservation, raise on top-level appearance (typo guard), or document the nested-only consumption in parser docstring.
- [ ] **PY-LOW-C**: Tighten `extra` snapshot semantics — either `copy.deepcopy(dict(self.extra))` for full immutability, or loosen the docstring to "top-level keys cannot be added or replaced".
- [ ] **PY-LOW-5** (deferred from previous review): `_warn` `stacklevel` tuning — defensive diagnostic-only, not test-asserted.

## Refs

Closes part of #89 (Phase 1 P1-08). Next: **P1-09** (google_ads adapter wrapping `GoogleAdsApiClient` to satisfy domain Protocols) → **P1-10** (meta_ads adapter) → **P1-11** (docs).
