### PR TITLE
feat(adapters/meta_ads): add Protocol adapter (P1-10, #89)

### DIFF
--- a/mureo/adapters/meta_ads/__init__.py
+++ b/mureo/adapters/meta_ads/__init__.py
@@ -1,0 +1,18 @@
+"""Meta Ads provider adapter.
+
+Re-exports the public surface so callers can ``from
+mureo.adapters.meta_ads import MetaAdsAdapter`` without reaching into
+submodules.
+"""
+
+from mureo.adapters.meta_ads.adapter import MetaAdsAdapter
+from mureo.adapters.meta_ads.errors import (
+    MetaAdsAdapterError,
+    UnsupportedOperation,
+)
+
+__all__ = [
+    "MetaAdsAdapter",
+    "MetaAdsAdapterError",
+    "UnsupportedOperation",
+]

--- a/mureo/adapters/meta_ads/adapter.py
+++ b/mureo/adapters/meta_ads/adapter.py
@@ -1,0 +1,507 @@
+"""``MetaAdsAdapter`` — Protocol-conformant wrapper over ``MetaAdsApiClient``.
+
+The adapter implements two runtime-checkable Protocols
+(:class:`CampaignProvider`, :class:`AudienceProvider`) by delegating
+each Phase 1 method to the existing :class:`MetaAdsApiClient`.
+:class:`KeywordProvider` and :class:`ExtensionProvider` are deliberately
+NOT implemented — Meta has no keyword targeting and no
+sitelink / callout / conversion-extension surface.
+
+Sync ↔ async bridge
+-------------------
+The Protocols are synchronous; the underlying client methods are
+``async``. Each Protocol method calls ``asyncio.run`` on the relevant
+coroutine. If a caller is already inside a running event loop,
+``asyncio.run`` itself raises :class:`RuntimeError` — this is exactly
+the documented Phase 1 contract.
+
+AdSet flattening
+----------------
+Meta's hierarchy is Campaign → AdSet → Ad; the Protocol is Campaign →
+Ad direct. Phase 1 hides the AdSet level inside the adapter:
+``list_ads(campaign_id)`` makes an N+1 fan-out (one ``list_ad_sets`` +
+one ``list_ads`` per ad set). ``create_ad`` interprets
+``request.ad_group_id`` as the ``ad_set_id`` (caller responsibility).
+``request.headlines[0]`` is the pre-built creative_id (Phase 1
+overload; rejected with :class:`UnsupportedOperation` for any other
+``headlines`` length).
+
+Module foundation rule
+----------------------
+Imports are restricted to stdlib, ``mureo.core.providers.*``,
+``mureo.meta_ads.client`` (only the public :class:`MetaAdsApiClient`),
+and the intra-package ``mappers`` / ``errors`` modules. The AST scan
+in ``tests/adapters/meta_ads/test_imports.py`` enforces this allowlist.
+"""
+
+# ruff: noqa: TC003
+# ``date`` must stay at module top-level so ``typing.get_type_hints()``
+# can resolve method annotations (Protocol structural checks).
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable
+from datetime import date
+from typing import Any, TypeVar
+
+from mureo.adapters.meta_ads.errors import UnsupportedOperation
+from mureo.adapters.meta_ads.mappers import (
+    to_ad,
+    to_audience,
+    to_campaign,
+    to_campaigns,
+    to_daily_report_row,
+)
+from mureo.core.providers.capabilities import Capability
+from mureo.core.providers.models import (
+    Ad,
+    AdStatus,
+    Audience,
+    AudienceStatus,
+    Campaign,
+    CampaignFilters,
+    CampaignStatus,
+    CreateAdRequest,
+    CreateAudienceRequest,
+    CreateCampaignRequest,
+    DailyReportRow,
+    UpdateAdRequest,
+    UpdateCampaignRequest,
+)
+from mureo.meta_ads.client import MetaAdsApiClient
+
+_T = TypeVar("_T")
+
+
+logger = logging.getLogger(__name__)
+
+
+# Phase 1: Meta campaign creation requires an objective; we hardcode
+# the most general traffic objective. Future iteration may surface this
+# on ``CreateCampaignRequest`` (CTO Open Question #2; deferred).
+_DEFAULT_OBJECTIVE: str = "OUTCOME_TRAFFIC"
+
+# Phase 1 lookalike defaults — JP-only, 1% audience similarity ratio.
+# A future iteration may surface country / ratio on
+# ``CreateAudienceRequest`` (CTO Open Question #4; deferred).
+_LOOKALIKE_COUNTRY: str = "JP"
+_LOOKALIKE_RATIO: float = 0.01
+
+
+# Adapter-internal write-direction mapping (canonical enum → Meta wire).
+# The read-direction inverse lives in ``mappers.py``.
+_CAMPAIGN_STATUS_TO_WIRE: dict[CampaignStatus, str] = {
+    CampaignStatus.ENABLED: "ACTIVE",
+    CampaignStatus.PAUSED: "PAUSED",
+    CampaignStatus.REMOVED: "DELETED",
+}
+
+
+def _validate_campaign_id(value: str) -> str:
+    """Return ``value`` if it is a bare digit string, else raise ``ValueError``.
+
+    Meta node IDs are integers under the hood; the digits-only check
+    blocks query-parameter injection (mirror of P1-09's GAQL safety).
+    """
+    if not isinstance(value, str) or not value or not value.isdigit():
+        raise ValueError(
+            f"invalid campaign_id: {value!r} (must be digits-only for the "
+            "Meta insights endpoint)"
+        )
+    return value
+
+
+class MetaAdsAdapter:
+    """Adapter that exposes :class:`MetaAdsApiClient` as Phase 1 Protocols.
+
+    Implements :class:`CampaignProvider` + :class:`AudienceProvider`.
+    Does NOT implement :class:`KeywordProvider` (no Meta keyword surface)
+    or :class:`ExtensionProvider` (no Meta sitelink/callout/conversion-
+    extension surface). BaseProvider attributes are class attributes so
+    the registry can introspect them without instantiation.
+    """
+
+    name: str = "meta_ads"
+    display_name: str = "Meta Ads"
+    capabilities: frozenset[Capability] = frozenset(
+        {
+            Capability.READ_CAMPAIGNS,
+            Capability.READ_PERFORMANCE,
+            Capability.READ_AUDIENCES,
+            Capability.WRITE_BUDGET,
+            Capability.WRITE_CREATIVE,
+            Capability.WRITE_CAMPAIGN_STATUS,
+            Capability.WRITE_AUDIENCES,
+        }
+    )
+
+    def __init__(self, client: MetaAdsApiClient) -> None:
+        if not isinstance(client, MetaAdsApiClient):
+            raise TypeError(
+                f"MetaAdsAdapter requires a MetaAdsApiClient instance, "
+                f"got {type(client).__name__}"
+            )
+        self._client: MetaAdsApiClient = client
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @property
+    def _account_id(self) -> str:
+        # CTO-approved single private-attribute read; tracked for a
+        # follow-up rename of ``MetaAdsApiClient._ad_account_id`` →
+        # public.
+        return self._client._ad_account_id  # noqa: SLF001
+
+    @staticmethod
+    def _run(coro: Awaitable[_T]) -> _T:
+        """Run ``coro`` to completion on a fresh event loop.
+
+        ``asyncio.run`` raises :class:`RuntimeError` when called from
+        inside a running loop — that is the documented Phase 1 behaviour
+        for async callers and is allowed to propagate.
+        """
+        return asyncio.run(coro)  # type: ignore[arg-type]
+
+    # ------------------------------------------------------------------
+    # CampaignProvider — campaigns
+    # ------------------------------------------------------------------
+
+    def list_campaigns(
+        self, filters: CampaignFilters | None = None
+    ) -> tuple[Campaign, ...]:
+        """List campaigns, applying optional client-side filters.
+
+        ``filters.status`` is forwarded to the underlying client as the
+        Meta wire-string (e.g. ``"ACTIVE"`` / ``"PAUSED"``).
+        ``filters.name_contains`` is honored **client-side** after fetch.
+        """
+        status_filter: str | None = None
+        if filters is not None and filters.status is not None:
+            status_filter = _CAMPAIGN_STATUS_TO_WIRE[filters.status]
+        rows = self._run(self._client.list_campaigns(status_filter=status_filter))
+        campaigns = to_campaigns(rows, account_id=self._account_id)
+        if filters is not None and filters.name_contains is not None:
+            needle = filters.name_contains
+            campaigns = tuple(c for c in campaigns if needle in c.name)
+        return campaigns
+
+    def get_campaign(self, campaign_id: str) -> Campaign:
+        raw = self._run(self._client.get_campaign(campaign_id))
+        if raw is None:
+            raise KeyError(campaign_id)
+        return to_campaign(raw, account_id=self._account_id)
+
+    def create_campaign(self, request: CreateCampaignRequest) -> Campaign:
+        """Create a campaign and return the post-create refreshed entity.
+
+        Phase 1 limitations
+        -------------------
+        * ``request.start_date`` / ``request.end_date`` are NOT wired
+          through to Meta's ``start_time`` / ``stop_time`` yet.
+          Supplying either field raises :class:`UnsupportedOperation`.
+        * ``request.bidding_strategy`` would require an AdSet
+          ``bid_strategy`` mapping which is out of scope; supplying it
+          raises :class:`UnsupportedOperation`.
+        * ``objective`` is hardcoded to ``"OUTCOME_TRAFFIC"`` (CTO
+          decision #2; future iteration may surface it on the request).
+        """
+        self._reject_unsupported_create_fields(request)
+
+        daily_budget_cents = _micros_to_cents(request.daily_budget_micros)
+        created = self._run(
+            self._client.create_campaign(
+                name=request.name,
+                objective=_DEFAULT_OBJECTIVE,
+                status="PAUSED",
+                daily_budget=daily_budget_cents,
+            )
+        )
+        new_campaign_id = self._extract_new_id(created, key="id")
+        return self.get_campaign(new_campaign_id)
+
+    @staticmethod
+    def _reject_unsupported_create_fields(request: CreateCampaignRequest) -> None:
+        """Raise :class:`UnsupportedOperation` for any deferred field."""
+        if request.start_date is not None:
+            raise UnsupportedOperation(
+                "create_campaign: start_date is not wired in Phase 1; "
+                "Meta start_time/stop_time mapping deferred."
+            )
+        if request.end_date is not None:
+            raise UnsupportedOperation(
+                "create_campaign: end_date is not wired in Phase 1; "
+                "Meta start_time/stop_time mapping deferred."
+            )
+        if request.bidding_strategy is not None:
+            raise UnsupportedOperation(
+                "create_campaign: bidding_strategy is not wired in Phase 1; "
+                "Meta AdSet bid_strategy mapping deferred."
+            )
+
+    def update_campaign(
+        self, campaign_id: str, request: UpdateCampaignRequest
+    ) -> Campaign:
+        """Apply the partial ``request`` and return the refreshed campaign.
+
+        Unlike Google Ads, Meta supports ``daily_budget`` mutation on the
+        campaign resource directly — the adapter converts micros → cents
+        (``micros // 10_000``) at the boundary.
+
+        ``status`` transitions are wired through ``update_campaign`` with
+        the inverse mapping (ENABLED → ``"ACTIVE"``, PAUSED → ``"PAUSED"``,
+        REMOVED → ``"DELETED"``).
+        """
+        params: dict[str, Any] = {}
+        if request.name is not None:
+            params["name"] = request.name
+        if request.daily_budget_micros is not None:
+            params["daily_budget"] = _micros_to_cents(request.daily_budget_micros)
+        if request.status is not None:
+            params["status"] = _CAMPAIGN_STATUS_TO_WIRE[request.status]
+        if request.bidding_strategy is not None:
+            raise UnsupportedOperation(
+                "update_campaign: bidding_strategy is not wired in Phase 1."
+            )
+
+        self._run(self._client.update_campaign(campaign_id, **params))
+        return self.get_campaign(campaign_id)
+
+    # ------------------------------------------------------------------
+    # CampaignProvider — ads (AdSet hierarchy hidden)
+    # ------------------------------------------------------------------
+
+    def list_ads(self, campaign_id: str) -> tuple[Ad, ...]:
+        """List every ad under ``campaign_id`` by flattening the AdSet level.
+
+        Phase 1 cost: N+1 calls (one ``list_ad_sets`` + one ``list_ads``
+        per ad set). Documented trade-off; a campaign-scoped Meta
+        endpoint is not exposed by the current mixin surface.
+        """
+        ad_sets = self._run(self._client.list_ad_sets(campaign_id))
+        all_ads: list[Ad] = []
+        for ad_set in ad_sets:
+            ad_set_id = str(ad_set["id"])
+            rows = self._run(self._client.list_ads(ad_set_id))
+            for row in rows:
+                all_ads.append(
+                    to_ad(row, account_id=self._account_id, campaign_id=campaign_id)
+                )
+        return tuple(all_ads)
+
+    def get_ad(self, campaign_id: str, ad_id: str) -> Ad:
+        """Return a single ad; raise ``KeyError`` on campaign mismatch."""
+        raw = self._run(self._client.get_ad(ad_id))
+        if raw is None:
+            raise KeyError(ad_id)
+        if str(raw.get("campaign_id")) != campaign_id:
+            raise KeyError(f"ad {ad_id!r} does not belong to campaign {campaign_id!r}")
+        return to_ad(raw, account_id=self._account_id, campaign_id=campaign_id)
+
+    def create_ad(self, campaign_id: str, request: CreateAdRequest) -> Ad:
+        """Create an ad under ``request.ad_group_id`` (interpreted as ad_set_id).
+
+        Phase 1 overload (CTO decision #3): ``request.headlines[0]`` is
+        interpreted as the pre-built ``creative_id``. Any other tuple
+        length raises :class:`UnsupportedOperation`. ``request.ad_group_id``
+        is interpreted as the parent ``ad_set_id``.
+        """
+        if len(request.headlines) != 1:
+            raise UnsupportedOperation(
+                f"create_ad: Phase 1 expects exactly one element in "
+                f"headlines (interpreted as creative_id); got "
+                f"{len(request.headlines)} element(s). Pre-build the "
+                "creative with creatives.create and pass its id as the "
+                "sole headline."
+            )
+        creative_id = request.headlines[0]
+        ad_set_id = request.ad_group_id
+
+        created = self._run(
+            self._client.create_ad(
+                ad_set_id=ad_set_id,
+                name=f"ad-{creative_id}",
+                creative_id=creative_id,
+            )
+        )
+        new_ad_id = self._extract_new_id(created, key="id")
+        return self.get_ad(campaign_id, new_ad_id)
+
+    def update_ad(self, campaign_id: str, ad_id: str, request: UpdateAdRequest) -> Ad:
+        """Apply the partial ``request`` to an existing ad.
+
+        Phase 1 limitation: Meta cannot mutate a live ad's creative
+        without recreating the ad. Supplying ANY creative field
+        (``headlines`` / ``descriptions`` / ``final_urls`` / ``path1`` /
+        ``path2``) raises :class:`UnsupportedOperation`. Status changes
+        flow through :meth:`set_ad_status`.
+        """
+        self._reject_unsupported_update_fields(request)
+        # No mutable fields left in Phase 1 — return the current state.
+        return self.get_ad(campaign_id, ad_id)
+
+    @staticmethod
+    def _reject_unsupported_update_fields(request: UpdateAdRequest) -> None:
+        """Raise :class:`UnsupportedOperation` for any deferred field."""
+        if request.headlines is not None:
+            raise UnsupportedOperation(
+                "update_ad: headlines mutation is not supported by Meta "
+                "(creative is immutable post-creation; recreate the ad)."
+            )
+        if request.descriptions is not None:
+            raise UnsupportedOperation(
+                "update_ad: descriptions mutation is not supported by Meta."
+            )
+        if request.final_urls is not None:
+            raise UnsupportedOperation(
+                "update_ad: final_urls mutation is not supported by Meta."
+            )
+        if request.path1 is not None or request.path2 is not None:
+            raise UnsupportedOperation(
+                "update_ad: path1/path2 are Google Ads concepts; Meta has "
+                "no counterpart."
+            )
+
+    def set_ad_status(self, campaign_id: str, ad_id: str, status: AdStatus) -> Ad:
+        """Route the status transition to the right Meta mutate verb.
+
+        - ``PAUSED`` → :meth:`MetaAdsApiClient.pause_ad`
+        - ``ENABLED`` → :meth:`MetaAdsApiClient.enable_ad`
+        - ``REMOVED`` → :meth:`MetaAdsApiClient.update_ad(status="DELETED")`
+        """
+        if status is AdStatus.PAUSED:
+            self._run(self._client.pause_ad(ad_id))
+        elif status is AdStatus.ENABLED:
+            self._run(self._client.enable_ad(ad_id))
+        elif status is AdStatus.REMOVED:
+            self._run(self._client.update_ad(ad_id, status="DELETED"))
+        else:  # pragma: no cover — AdStatus is exhaustive
+            raise UnsupportedOperation(f"set_ad_status: unsupported status {status!r}")
+        return self.get_ad(campaign_id, ad_id)
+
+    # ------------------------------------------------------------------
+    # CampaignProvider — daily report
+    # ------------------------------------------------------------------
+
+    def daily_report(
+        self, campaign_id: str, start_date: date, end_date: date
+    ) -> tuple[DailyReportRow, ...]:
+        """Return day-grain rows via ``client.insights_time_range``.
+
+        ``campaign_id`` is digit-validated before being interpolated
+        into the Meta insights URL path — mirrors P1-09's GAQL safety
+        check. ``start_date`` / ``end_date`` are ISO-formatted via
+        ``date.isoformat()`` (locked by Python to ``YYYY-MM-DD``).
+        """
+        validated_id = _validate_campaign_id(campaign_id)
+        rows = self._run(
+            self._client.insights_time_range(
+                validated_id,
+                since=start_date.isoformat(),
+                until=end_date.isoformat(),
+                time_increment=1,
+                level="campaign",
+            )
+        )
+        return tuple(to_daily_report_row(row) for row in rows)
+
+    # ------------------------------------------------------------------
+    # AudienceProvider
+    # ------------------------------------------------------------------
+
+    def list_audiences(self) -> tuple[Audience, ...]:
+        rows = self._run(self._client.list_custom_audiences())
+        return tuple(to_audience(row, account_id=self._account_id) for row in rows)
+
+    def get_audience(self, audience_id: str) -> Audience:
+        raw = self._run(self._client.get_custom_audience(audience_id))
+        if raw is None:
+            raise KeyError(audience_id)
+        return to_audience(raw, account_id=self._account_id)
+
+    def create_audience(self, request: CreateAudienceRequest) -> Audience:
+        """Create a Custom or Lookalike audience.
+
+        ``request.seed_audience_id`` is the branching signal:
+        - ``None`` → Custom audience (``client.create_custom_audience``).
+        - present → Lookalike with Phase 1 defaults ``country="JP"``,
+          ``ratio=0.01`` (CTO decision #4).
+        """
+        if request.seed_audience_id is None:
+            created = self._run(
+                self._client.create_custom_audience(
+                    request.name,
+                    "CUSTOM",
+                    description=request.description,
+                )
+            )
+        else:
+            created = self._run(
+                self._client.create_lookalike_audience(
+                    request.name,
+                    request.seed_audience_id,
+                    _LOOKALIKE_COUNTRY,
+                    _LOOKALIKE_RATIO,
+                )
+            )
+        new_id = self._extract_new_id(created, key="id")
+        return self.get_audience(new_id)
+
+    def set_audience_status(self, audience_id: str, status: AudienceStatus) -> Audience:
+        """Route the status transition to the right Meta mutate verb.
+
+        - ``REMOVED`` → :meth:`MetaAdsApiClient.delete_custom_audience`.
+        - ``ENABLED`` → :class:`UnsupportedOperation` (Meta has no
+          re-enable counterpart for deleted audiences).
+        """
+        if status is AudienceStatus.REMOVED:
+            self._run(self._client.delete_custom_audience(audience_id))
+            # The audience is gone — return a synthesized post-delete
+            # snapshot rather than a fresh fetch (which would 404).
+            return Audience(
+                id=audience_id,
+                account_id=self._account_id,
+                name="",
+                status=AudienceStatus.REMOVED,
+            )
+        raise UnsupportedOperation(
+            f"set_audience_status: {status.value} transition is not supported "
+            "by Meta in Phase 1 (audience status is derived from "
+            "delivery_status, not set directly)."
+        )
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _extract_new_id(response: dict[str, Any], *, key: str) -> str:
+        """Extract a new entity id from a Meta mutate response.
+
+        Meta's mutate endpoints return ``{"id": ...}`` (sometimes with a
+        ``success`` flag). The ``key`` arg lets callers pick a specific
+        field; ``id`` is the standard fallback.
+        """
+        explicit = response.get(key)
+        if explicit is not None:
+            return str(explicit)
+        # Fall back to the canonical Meta "id" field if a different key
+        # was requested and is absent.
+        fallback = response.get("id")
+        if fallback is not None:
+            return str(fallback)
+        raise KeyError(f"mutate response missing {key!r}: {response!r}")
+
+
+def _micros_to_cents(micros: int) -> int:
+    """Convert a micros amount to a Meta cents integer (``micros // 10_000``).
+
+    Negative / zero values are passed through; the caller is responsible
+    for surfacing zero-budget semantics to Meta.
+    """
+    return micros // 10_000
+
+
+__all__ = ["MetaAdsAdapter"]

--- a/mureo/adapters/meta_ads/errors.py
+++ b/mureo/adapters/meta_ads/errors.py
@@ -1,0 +1,49 @@
+"""Adapter-originated exceptions for ``mureo.adapters.meta_ads``.
+
+These exceptions are raised by the adapter itself when it detects an
+operation it cannot fulfil — for example, a Protocol method that has no
+counterpart on the underlying :class:`MetaAdsApiClient`. ``RuntimeError``
+raised by the underlying client passes through unchanged (Phase 1 CTO
+decision: error wrapping is deferred).
+
+Module foundation rule
+----------------------
+This module imports nothing from ``mureo.*``. The exception types are
+deliberately minimal so the AST import-allowlist test can pin them.
+"""
+
+from __future__ import annotations
+
+
+class MetaAdsAdapterError(RuntimeError):
+    """Base class for errors raised inside ``MetaAdsAdapter``.
+
+    Subclasses ``RuntimeError`` so callers that already catch the broad
+    ``RuntimeError`` raised by :class:`MetaAdsApiClient` continue to
+    work. Callers that want to discriminate adapter-origin errors can
+    catch this class instead.
+    """
+
+
+class UnsupportedOperation(MetaAdsAdapterError):  # noqa: N818
+    # Naming: the public surface is intentionally ``UnsupportedOperation``
+    # (matching the standard-library style, e.g. ``io.UnsupportedOperation``)
+    # rather than ``UnsupportedOperationError``; tests and callers pin
+    # this name. ``N818`` is suppressed locally.
+    """Raised when a Protocol method has no Meta Ads counterpart in Phase 1.
+
+    Phase 1 triggers:
+        * ``create_campaign`` with ``start_date`` / ``end_date`` /
+          ``bidding_strategy`` — Meta uses ``start_time`` / ``stop_time``
+          and an AdSet-level bid strategy, not yet wired through.
+        * ``create_ad`` with ``len(headlines) != 1`` — Phase 1 overloads
+          ``headlines[0]`` as the pre-built ``creative_id``.
+        * ``update_ad`` with any creative field (``headlines`` /
+          ``descriptions`` / ``final_urls`` / ``path1`` / ``path2``) —
+          Meta cannot mutate a live ad's creative without recreation.
+        * ``set_audience_status(..., AudienceStatus.ENABLED)`` — Meta
+          has no re-enable counterpart for deleted audiences.
+    """
+
+
+__all__ = ["MetaAdsAdapterError", "UnsupportedOperation"]

--- a/mureo/adapters/meta_ads/mappers.py
+++ b/mureo/adapters/meta_ads/mappers.py
@@ -1,0 +1,307 @@
+"""Pure ``dict`` → frozen-dataclass converters for the Meta Ads adapter.
+
+Every function in this module is side-effect-free: it consumes the raw
+``dict`` / ``list[dict]`` returned by ``MetaAdsApiClient`` mixins and
+returns a frozen dataclass from :mod:`mureo.core.providers.models`.
+
+Module foundation rule
+----------------------
+Imports are restricted to stdlib plus
+:mod:`mureo.core.providers.models` /
+:mod:`mureo.core.providers.capabilities`. No ``mureo.meta_ads.*`` import
+— the mapper is intentionally decoupled from the heavyweight client
+package so it can be exercised in isolation.
+
+Phase 1 conversions
+-------------------
+- Budget: Meta returns ``daily_budget`` as a **cents** string; this
+  mapper converts to **micros** (``int(cents) * 10_000``).
+- Spend: Meta returns ``spend`` as a **dollars** string; this mapper
+  converts to **micros** (``int(round(float(s) * 1_000_000))``).
+- Status: Meta wire-strings (``ACTIVE`` / ``PAUSED`` / ``DELETED`` /
+  ``ARCHIVED`` / ``CAMPAIGN_PAUSED`` / ``ADSET_PAUSED``) map to the
+  canonical ``CampaignStatus`` / ``AdStatus`` enum members.
+- Unknown / unparseable values raise :class:`ValueError` — no silent
+  fallback to a default member.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import TYPE_CHECKING, Any
+
+from mureo.core.providers.models import (
+    Ad,
+    AdStatus,
+    Audience,
+    AudienceStatus,
+    Campaign,
+    CampaignStatus,
+    DailyReportRow,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+# ---------------------------------------------------------------------------
+# Status mapping (Meta wire-string → canonical enum)
+# ---------------------------------------------------------------------------
+
+
+_CAMPAIGN_STATUS_MAP: dict[str, CampaignStatus] = {
+    "ACTIVE": CampaignStatus.ENABLED,
+    "PAUSED": CampaignStatus.PAUSED,
+    "CAMPAIGN_PAUSED": CampaignStatus.PAUSED,
+    "ADSET_PAUSED": CampaignStatus.PAUSED,
+    "DELETED": CampaignStatus.REMOVED,
+    "ARCHIVED": CampaignStatus.REMOVED,
+}
+
+
+_AD_STATUS_MAP: dict[str, AdStatus] = {
+    "ACTIVE": AdStatus.ENABLED,
+    "PAUSED": AdStatus.PAUSED,
+    "CAMPAIGN_PAUSED": AdStatus.PAUSED,
+    "ADSET_PAUSED": AdStatus.PAUSED,
+    "DELETED": AdStatus.REMOVED,
+    "ARCHIVED": AdStatus.REMOVED,
+}
+
+
+# Conversion-like Meta action_types (Phase 1). The full Meta catalogue
+# is enormous; Phase 1 recognises the most common purchase-style event
+# and treats it as the canonical ``conversions`` source. A future
+# refactor can broaden this (lead, complete_registration, etc.).
+_CONVERSION_ACTION_TYPES: frozenset[str] = frozenset({"purchase"})
+
+
+def map_campaign_status(meta_wire: Any) -> CampaignStatus:
+    """Return the canonical :class:`CampaignStatus` for ``meta_wire``.
+
+    Raises:
+        ValueError: ``meta_wire`` is ``None`` or not a known Meta value.
+            The error message embeds the offending value for debuggability.
+    """
+    if meta_wire is None:
+        raise ValueError("missing campaign status (got None)")
+    key = str(meta_wire).upper()
+    try:
+        return _CAMPAIGN_STATUS_MAP[key]
+    except KeyError as exc:
+        raise ValueError(
+            f"unknown campaign status: {meta_wire!r} "
+            f"(expected one of {sorted(_CAMPAIGN_STATUS_MAP)})"
+        ) from exc
+
+
+def map_ad_status(meta_wire: Any) -> AdStatus:
+    """Return the canonical :class:`AdStatus` for ``meta_wire``.
+
+    Raises:
+        ValueError: ``meta_wire`` is ``None`` or not a known Meta value.
+    """
+    if meta_wire is None:
+        raise ValueError("missing ad status (got None)")
+    key = str(meta_wire).upper()
+    try:
+        return _AD_STATUS_MAP[key]
+    except KeyError as exc:
+        raise ValueError(
+            f"unknown ad status: {meta_wire!r} "
+            f"(expected one of {sorted(_AD_STATUS_MAP)})"
+        ) from exc
+
+
+# ---------------------------------------------------------------------------
+# Campaign
+# ---------------------------------------------------------------------------
+
+
+def to_campaign(raw: dict[str, Any], *, account_id: str) -> Campaign:
+    """Build a :class:`Campaign` from a Meta campaign row.
+
+    ``daily_budget`` is returned by Meta as a cents-denominated string
+    (e.g. ``"1500"`` for 15.00 USD). This mapper converts to micros via
+    ``int(cents) * 10_000`` — exact integer arithmetic, no float
+    round-trip.
+    """
+    return Campaign(
+        id=str(raw["id"]),
+        account_id=account_id,
+        name=str(raw["name"]),
+        status=map_campaign_status(raw.get("status")),
+        daily_budget_micros=_cents_to_micros(raw.get("daily_budget")),
+    )
+
+
+def to_campaigns(
+    rows: Iterable[dict[str, Any]], *, account_id: str
+) -> tuple[Campaign, ...]:
+    """Build a tuple of :class:`Campaign` from any iterable of rows."""
+    return tuple(to_campaign(row, account_id=account_id) for row in rows)
+
+
+def _cents_to_micros(cents_value: Any) -> int:
+    """Convert a Meta cents value (str or int, possibly missing) to micros.
+
+    Returns 0 when the field is absent (e.g. lifetime-budget campaigns).
+    """
+    if cents_value is None or cents_value == "":
+        return 0
+    return int(cents_value) * 10_000
+
+
+# ---------------------------------------------------------------------------
+# Ad
+# ---------------------------------------------------------------------------
+
+
+def to_ad(raw: dict[str, Any], *, account_id: str, campaign_id: str) -> Ad:
+    """Build an :class:`Ad` from a Meta ad row.
+
+    ``final_url`` is extracted from
+    ``creative.object_story_spec.link_data.link`` when present (the
+    standard Meta shape for a single-link ad creative); absent → ``""``.
+
+    ``headlines`` / ``descriptions`` are always empty tuples in Phase 1 —
+    Meta does NOT expose the creative's headline / description text on
+    the ad resource (it lives on the AdCreative resource and is not yet
+    fetched). The Protocol contract is satisfied via empty tuples.
+    """
+    return Ad(
+        id=str(raw["id"]),
+        account_id=account_id,
+        campaign_id=campaign_id,
+        status=map_ad_status(raw.get("status")),
+        headlines=(),
+        descriptions=(),
+        final_url=_extract_creative_link(raw.get("creative")),
+    )
+
+
+def _extract_creative_link(creative: Any) -> str:
+    """Return the ``link_data.link`` from a Meta creative dict; ``""`` on miss."""
+    if not isinstance(creative, dict):
+        return ""
+    spec = creative.get("object_story_spec")
+    if not isinstance(spec, dict):
+        return ""
+    link_data = spec.get("link_data")
+    if not isinstance(link_data, dict):
+        return ""
+    link = link_data.get("link")
+    return str(link) if link else ""
+
+
+# ---------------------------------------------------------------------------
+# Audience
+# ---------------------------------------------------------------------------
+
+
+def to_audience(raw: dict[str, Any], *, account_id: str) -> Audience:
+    """Build an :class:`Audience` from a Meta custom-audience row.
+
+    Phase 1 status mapping: Meta's ``delivery_status.code == 200``
+    (or any healthy code) → :class:`AudienceStatus.ENABLED`. There is no
+    PAUSED audience status in the canonical model — Phase 1 collapses
+    all live audiences to ENABLED. Deleted audiences are returned by
+    Meta as 404 and surface as :class:`KeyError` at the adapter layer.
+    """
+    return Audience(
+        id=str(raw["id"]),
+        account_id=account_id,
+        name=str(raw.get("name") or ""),
+        status=AudienceStatus.ENABLED,
+        size_estimate=_extract_size_estimate(raw),
+    )
+
+
+def _extract_size_estimate(raw: dict[str, Any]) -> int | None:
+    """Return the average of lower/upper bounds, or ``None`` when absent.
+
+    Phase 1 treats a missing size estimate as ``None`` rather than 0
+    (zero is a meaningful "no audience matched" value distinct from
+    "Meta did not return the field at all").
+    """
+    lower = raw.get("approximate_count_lower_bound")
+    upper = raw.get("approximate_count_upper_bound")
+    if lower is None and upper is None:
+        return None
+    if lower is None:
+        return int(upper) if upper is not None else None
+    if upper is None:
+        return int(lower)
+    return (int(lower) + int(upper)) // 2
+
+
+# ---------------------------------------------------------------------------
+# DailyReportRow
+# ---------------------------------------------------------------------------
+
+
+def to_daily_report_row(raw: dict[str, Any]) -> DailyReportRow:
+    """Build a :class:`DailyReportRow` from a Meta insights row.
+
+    Field conventions
+    -----------------
+    - ``date_start``: ``YYYY-MM-DD`` ISO date string.
+    - ``impressions`` / ``clicks``: integer-valued strings.
+    - ``spend``: dollar-valued string (e.g. ``"12.34"``). Converted to
+      micros via ``int(round(float(spend) * 1_000_000))``.
+    - ``actions``: optional list of ``{"action_type", "value"}`` dicts;
+      the ``purchase`` action_type value populates ``conversions``.
+    """
+    return DailyReportRow(
+        date=_parse_iso_date(raw.get("date_start")),
+        impressions=int(raw.get("impressions") or 0),
+        clicks=int(raw.get("clicks") or 0),
+        cost_micros=_spend_to_micros(raw.get("spend")),
+        conversions=_extract_conversions(raw.get("actions")),
+    )
+
+
+def _parse_iso_date(value: Any) -> date:
+    """Parse an ISO ``YYYY-MM-DD`` date; raise :class:`ValueError` otherwise."""
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str):
+        # ``datetime.strptime`` rejects malformed strings with a clean
+        # ``ValueError`` — exactly the contract the mapper tests rely on.
+        return datetime.strptime(value, "%Y-%m-%d").date()  # noqa: DTZ007
+    raise ValueError(f"unparseable date value: {value!r}")
+
+
+def _spend_to_micros(spend_value: Any) -> int:
+    """Convert a Meta dollar-string spend to micros (rounded to nearest int)."""
+    if spend_value is None or spend_value == "":
+        return 0
+    return int(round(float(spend_value) * 1_000_000))
+
+
+def _extract_conversions(actions: Any) -> float:
+    """Sum the ``value`` field of every Phase 1 conversion-style action."""
+    if not isinstance(actions, list):
+        return 0.0
+    total = 0.0
+    for action in actions:
+        if not isinstance(action, dict):
+            continue
+        action_type = action.get("action_type")
+        if action_type in _CONVERSION_ACTION_TYPES:
+            try:
+                total += float(action.get("value") or 0)
+            except (TypeError, ValueError):
+                continue
+    return total
+
+
+__all__ = [
+    "map_ad_status",
+    "map_campaign_status",
+    "to_ad",
+    "to_audience",
+    "to_campaign",
+    "to_campaigns",
+    "to_daily_report_row",
+]

--- a/mureo/meta_ads/_insights.py
+++ b/mureo/meta_ads/_insights.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 from typing import Any
 
@@ -22,6 +23,12 @@ _INSIGHTS_FIELDS = (
     "actions,cost_per_action_type,"
     "reach,frequency"
 )
+
+# Day-grain insights fields used by ``insights_time_range`` (the Protocol
+# adapter surface). Smaller than ``_INSIGHTS_FIELDS`` because the
+# Protocol's ``DailyReportRow`` only needs date, volume, cost, and
+# action counts.
+_TIME_RANGE_INSIGHTS_FIELDS = "impressions,clicks,spend,actions,date_start,date_stop"
 
 
 class InsightsMixin:
@@ -68,6 +75,44 @@ class InsightsMixin:
             path = f"/{account_id}/insights"
 
         result = await self._get(path, params)
+        return result.get("data", [])  # type: ignore[no-any-return]
+
+    async def insights_time_range(
+        self,
+        node_id: str,
+        *,
+        since: str,
+        until: str,
+        time_increment: int = 1,
+        level: str = "campaign",
+    ) -> list[dict[str, Any]]:
+        """Get insights for an explicit date range with day-level granularity.
+
+        The Protocol-layer ``CampaignProvider.daily_report`` requires
+        arbitrary ``start_date`` / ``end_date`` plus one row per day —
+        ``get_performance_report`` only supports named ``date_preset``
+        values, so this companion method fills the gap.
+
+        Args:
+            node_id: Meta node id (campaign / ad-set / ad). Interpolated
+                directly into the URL path; callers (notably the
+                ``MetaAdsAdapter``) are responsible for digit-validating
+                user-controlled values before passing them here.
+            since: Start date, ``YYYY-MM-DD``.
+            until: End date, ``YYYY-MM-DD``.
+            time_increment: Bucket size in days (default: 1 = day-grain).
+            level: Aggregation level (``campaign``, ``adset``, ``ad``).
+
+        Returns:
+            List of insight rows, one per day in the range.
+        """
+        params: dict[str, Any] = {
+            "fields": _TIME_RANGE_INSIGHTS_FIELDS,
+            "time_range": json.dumps({"since": since, "until": until}),
+            "time_increment": time_increment,
+            "level": level,
+        }
+        result = await self._get(f"/{node_id}/insights", params)
         return result.get("data", [])  # type: ignore[no-any-return]
 
     async def analyze_performance(

--- a/tests/adapters/meta_ads/test_adapter.py
+++ b/tests/adapters/meta_ads/test_adapter.py
@@ -1,0 +1,1129 @@
+"""RED-phase tests for ``mureo.adapters.meta_ads.MetaAdsAdapter``.
+
+Pins the Protocol-conformant wrapping behaviour of the Meta Ads adapter
+(Issue #89, P1-10). Every external Meta Marketing API call is mocked via
+``Mock(spec=MetaAdsApiClient)`` + ``AsyncMock`` — no live httpx request
+is issued; no real Meta Graph API call is made.
+
+CTO decisions encoded in these tests
+------------------------------------
+1. ``MetaAdsApiClient.insights_time_range`` is a new public method on
+   the existing client (implementer adds it during GREEN). Tests
+   pre-attach an ``AsyncMock`` for that name on the spec'd Mock so the
+   adapter can call it without raising ``AttributeError``.
+2. ``objective`` for ``create_campaign`` is hard-coded to
+   ``"OUTCOME_TRAFFIC"`` in Phase 1.
+3. ``CreateAdRequest.headlines[0]`` is interpreted as the ``creative_id``
+   in Phase 1 (documented hack). Any other tuple length raises
+   ``UnsupportedOperation``.
+4. Lookalike audiences default to ``country="JP"`` and ``ratio=0.01``
+   when ``CreateAudienceRequest.seed_audience_id`` is set.
+5. ``AdSet`` hierarchy is hidden behind the adapter — ``list_ads``
+   flattens AdSet→Ad with N+1 client calls in Phase 1.
+
+Marks: every test is ``@pytest.mark.unit``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from datetime import date
+from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+# NOTE: These imports are expected to FAIL during the RED phase — the
+# module ``mureo.adapters.meta_ads`` does not exist yet. That is correct.
+# The implementer (GREEN phase) will create it.
+from mureo.adapters.meta_ads import MetaAdsAdapter
+from mureo.adapters.meta_ads.errors import (
+    MetaAdsAdapterError,
+    UnsupportedOperation,
+)
+from mureo.core.providers.audience import AudienceProvider
+from mureo.core.providers.base import BaseProvider, validate_provider
+from mureo.core.providers.campaign import CampaignProvider
+from mureo.core.providers.capabilities import Capability
+from mureo.core.providers.extension import ExtensionProvider
+from mureo.core.providers.keyword import KeywordProvider
+from mureo.core.providers.models import (
+    Ad,
+    AdStatus,
+    Audience,
+    AudienceStatus,
+    BidStrategy,
+    Campaign,
+    CampaignFilters,
+    CampaignStatus,
+    CreateAdRequest,
+    CreateAudienceRequest,
+    CreateCampaignRequest,
+    DailyReportRow,
+    UpdateAdRequest,
+    UpdateCampaignRequest,
+)
+from mureo.core.providers.registry import (
+    clear_registry,
+    get_provider,
+    list_providers_by_capability,
+    register_provider_class,
+)
+from mureo.meta_ads.client import MetaAdsApiClient
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+_FAKE_AD_ACCOUNT_ID = "act_1234567890"
+
+
+def _make_mock_client() -> Mock:
+    """Return a ``Mock(spec=MetaAdsApiClient)`` with stub async methods.
+
+    Every public async method that the adapter is expected to call is
+    pre-attached as an ``AsyncMock`` so attribute typos in the adapter
+    surface immediately as ``AttributeError`` (rather than silent
+    auto-attribute creation).
+    """
+    client = Mock(spec=MetaAdsApiClient)
+    client._ad_account_id = _FAKE_AD_ACCOUNT_ID
+    for name in (
+        "list_campaigns",
+        "get_campaign",
+        "create_campaign",
+        "update_campaign",
+        "pause_campaign",
+        "enable_campaign",
+        "list_ad_sets",
+        "get_ad_set",
+        "list_ads",
+        "get_ad",
+        "create_ad",
+        "update_ad",
+        "pause_ad",
+        "enable_ad",
+        "list_custom_audiences",
+        "get_custom_audience",
+        "create_custom_audience",
+        "delete_custom_audience",
+        "create_lookalike_audience",
+        # NEW public method added in P1-10 GREEN (CTO decision #1).
+        "insights_time_range",
+    ):
+        setattr(client, name, AsyncMock())
+    return client
+
+
+@pytest.fixture
+def mock_client() -> Mock:
+    return _make_mock_client()
+
+
+@pytest.fixture
+def adapter(mock_client: Mock) -> MetaAdsAdapter:
+    return MetaAdsAdapter(client=mock_client)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_registry() -> Iterator[None]:
+    """Reset the module-level registry around each test to prevent
+    cross-test contamination of the ``meta_ads`` slot."""
+    clear_registry()
+    yield
+    clear_registry()
+
+
+# ---------------------------------------------------------------------------
+# Row factories (dicts that mirror the real Meta API shape)
+# ---------------------------------------------------------------------------
+
+
+def _campaign_row(
+    *,
+    cid: str = "c111",
+    name: str = "Brand Awareness — JP",
+    status: str = "ACTIVE",
+    daily_budget_cents: str = "1500",  # Meta returns budget as cents-string
+) -> dict[str, Any]:
+    return {
+        "id": cid,
+        "name": name,
+        "status": status,
+        "daily_budget": daily_budget_cents,
+        "objective": "OUTCOME_TRAFFIC",
+    }
+
+
+def _ad_set_row(*, ad_set_id: str = "as1", campaign_id: str = "c111") -> dict[str, Any]:
+    return {
+        "id": ad_set_id,
+        "campaign_id": campaign_id,
+        "name": f"AdSet {ad_set_id}",
+        "status": "ACTIVE",
+    }
+
+
+def _ad_row(
+    *,
+    ad_id: str = "ad1",
+    ad_set_id: str = "as1",
+    campaign_id: str = "c111",
+    status: str = "ACTIVE",
+) -> dict[str, Any]:
+    return {
+        "id": ad_id,
+        "adset_id": ad_set_id,
+        "campaign_id": campaign_id,
+        "status": status,
+        "name": f"Ad {ad_id}",
+        "creative": {
+            "object_story_spec": {
+                "link_data": {"link": "https://example.com"},
+            }
+        },
+    }
+
+
+def _audience_row(
+    *,
+    aud_id: str = "aud_1",
+    name: str = "Site visitors 30d",
+    subtype: str = "CUSTOM",
+    size: int | None = 12_345,
+) -> dict[str, Any]:
+    return {
+        "id": aud_id,
+        "name": name,
+        "subtype": subtype,
+        "approximate_count_lower_bound": size,
+        "approximate_count_upper_bound": size,
+        "delivery_status": {"code": 200, "description": "Ready"},
+        "description": "test",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Case 1 — Class attributes + Protocol conformance
+# ---------------------------------------------------------------------------
+
+
+_EXPECTED_CAPABILITIES: frozenset[Capability] = frozenset(
+    {
+        Capability.READ_CAMPAIGNS,
+        Capability.READ_PERFORMANCE,
+        Capability.READ_AUDIENCES,
+        Capability.WRITE_BUDGET,
+        Capability.WRITE_CREATIVE,
+        Capability.WRITE_CAMPAIGN_STATUS,
+        Capability.WRITE_AUDIENCES,
+    }
+)
+
+# Capabilities explicitly NOT declared (Meta has no counterpart):
+_FORBIDDEN_CAPABILITIES: frozenset[Capability] = frozenset(
+    {
+        Capability.READ_KEYWORDS,
+        Capability.READ_SEARCH_TERMS,
+        Capability.READ_EXTENSIONS,
+        Capability.WRITE_KEYWORDS,
+        Capability.WRITE_EXTENSIONS,
+        Capability.WRITE_BID,
+    }
+)
+
+
+@pytest.mark.unit
+def test_class_attributes_match_baseprovider_contract() -> None:
+    assert MetaAdsAdapter.name == "meta_ads"
+    assert MetaAdsAdapter.display_name == "Meta Ads"
+    assert isinstance(MetaAdsAdapter.capabilities, frozenset)
+
+
+@pytest.mark.unit
+def test_capabilities_match_exact_expected_set() -> None:
+    """Capabilities are EXACTLY the 7 CTO-approved members — no extras,
+    no missing."""
+    assert MetaAdsAdapter.capabilities == _EXPECTED_CAPABILITIES
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("forbidden", sorted(_FORBIDDEN_CAPABILITIES, key=str))
+def test_forbidden_capabilities_not_declared(forbidden: Capability) -> None:
+    """Keyword / extension / bid capabilities are explicitly NOT declared
+    (Meta has no counterpart)."""
+    assert forbidden not in MetaAdsAdapter.capabilities
+
+
+@pytest.mark.unit
+def test_validate_provider_on_class_succeeds() -> None:
+    validate_provider(MetaAdsAdapter)
+
+
+@pytest.mark.unit
+def test_adapter_instance_is_base_provider(adapter: MetaAdsAdapter) -> None:
+    assert isinstance(adapter, BaseProvider)
+
+
+@pytest.mark.unit
+def test_adapter_instance_is_campaign_provider(adapter: MetaAdsAdapter) -> None:
+    assert isinstance(adapter, CampaignProvider)
+
+
+@pytest.mark.unit
+def test_adapter_instance_is_audience_provider(adapter: MetaAdsAdapter) -> None:
+    """``AudienceProvider`` IS implemented (Meta has Custom + Lookalike
+    audiences). This is the headline difference vs. P1-09."""
+    assert isinstance(adapter, AudienceProvider)
+
+
+@pytest.mark.unit
+def test_adapter_instance_is_not_keyword_provider(adapter: MetaAdsAdapter) -> None:
+    """Meta has no keyword surface — structural check naturally fails
+    because ``list_keywords`` / ``add_keywords`` / ``set_keyword_status``
+    are not defined on the adapter."""
+    assert not isinstance(adapter, KeywordProvider)
+
+
+@pytest.mark.unit
+def test_adapter_instance_is_not_extension_provider(adapter: MetaAdsAdapter) -> None:
+    """Meta has no sitelink/callout/conversion-extension surface."""
+    assert not isinstance(adapter, ExtensionProvider)
+
+
+# ---------------------------------------------------------------------------
+# Case 2 — Constructor validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_init_rejects_non_client() -> None:
+    """``__init__`` rejects a non-``MetaAdsApiClient`` value with
+    ``TypeError``."""
+    with pytest.raises(TypeError):
+        MetaAdsAdapter(client="not a client")  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+def test_init_does_no_io(mock_client: Mock) -> None:
+    """``__init__`` is pure — no async call is invoked on the client."""
+    MetaAdsAdapter(client=mock_client)
+    for attr_name in (
+        "list_campaigns",
+        "list_ad_sets",
+        "list_ads",
+        "list_custom_audiences",
+        "insights_time_range",
+    ):
+        method = getattr(mock_client, attr_name)
+        assert method.await_count == 0
+        assert method.call_count == 0
+
+
+@pytest.mark.unit
+def test_init_stores_client_privately(mock_client: Mock) -> None:
+    """Adapter stores the injected client on a private attribute."""
+    a = MetaAdsAdapter(client=mock_client)
+    assert getattr(a, "_client") is mock_client  # noqa: B009
+    assert not hasattr(a, "client")  # no public attribute
+
+
+# ---------------------------------------------------------------------------
+# Case 3 — Registry round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_registry_round_trip_includes_meta_ads() -> None:
+    """``register_provider_class(MetaAdsAdapter)`` round-trips through
+    ``get_provider("meta_ads")`` and is listed under READ_AUDIENCES."""
+    entry = register_provider_class(MetaAdsAdapter)
+    assert entry.name == "meta_ads"
+    assert entry.display_name == "Meta Ads"
+    assert entry.provider_class is MetaAdsAdapter
+    assert entry.capabilities == _EXPECTED_CAPABILITIES
+
+    got = get_provider("meta_ads")
+    assert got is entry
+
+    # The big differentiator from P1-09: ``READ_AUDIENCES`` is declared.
+    matches = list_providers_by_capability(Capability.READ_AUDIENCES)
+    assert any(e.name == "meta_ads" for e in matches)
+
+
+# ---------------------------------------------------------------------------
+# Case 4 — CampaignProvider — campaigns
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_list_campaigns_maps_to_frozen_dataclasses(
+    adapter: MetaAdsAdapter, mock_client: Mock
+) -> None:
+    mock_client.list_campaigns.return_value = [
+        _campaign_row(cid="c1", name="A", status="ACTIVE", daily_budget_cents="500"),
+        _campaign_row(cid="c2", name="B", status="PAUSED", daily_budget_cents="1000"),
+    ]
+    result = adapter.list_campaigns()
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+    assert all(isinstance(c, Campaign) for c in result)
+    assert result[0].id == "c1"
+    assert result[0].account_id == _FAKE_AD_ACCOUNT_ID
+    assert result[0].name == "A"
+    assert result[0].status == CampaignStatus.ENABLED
+    # cents → micros conversion (Phase 1 boundary): 500 cents = 5_000_000 micros.
+    assert result[0].daily_budget_micros == 5_000_000
+    assert result[1].status == CampaignStatus.PAUSED
+    assert result[1].daily_budget_micros == 10_000_000
+
+
+@pytest.mark.unit
+def test_list_campaigns_status_filter_upper_wire(
+    adapter: MetaAdsAdapter, mock_client: Mock
+) -> None:
+    """``CampaignFilters.status=PAUSED`` is forwarded to the client as
+    the uppercase Meta wire-string ``"PAUSED"``."""
+    mock_client.list_campaigns.return_value = []
+    adapter.list_campaigns(CampaignFilters(status=CampaignStatus.PAUSED))
+    call = mock_client.list_campaigns.await_args
+    assert call is not None
+    flat = list(call.args) + list(call.kwargs.values())
+    assert "PAUSED" in flat
+
+
+@pytest.mark.unit
+def test_list_campaigns_status_enabled_maps_to_active_wire(
+    adapter: MetaAdsAdapter, mock_client: Mock
+) -> None:
+    """``CampaignStatus.ENABLED`` is converted to Meta's ``"ACTIVE"`` on
+    the way OUT (write-side mapping is the inverse of the read mapping)."""
+    mock_client.list_campaigns.return_value = []
+    adapter.list_campaigns(CampaignFilters(status=CampaignStatus.ENABLED))
+    call = mock_client.list_campaigns.await_args
+    assert call is not None
+    flat = list(call.args) + list(call.kwargs.values())
+    assert "ACTIVE" in flat
+
+
+@pytest.mark.unit
+def test_list_campaigns_applies_name_contains_clientside(
+    adapter: MetaAdsAdapter, mock_client: Mock
+) -> None:
+    mock_client.list_campaigns.return_value = [
+        _campaign_row(cid="1", name="Brand Awareness"),
+        _campaign_row(cid="2", name="Brand Conversion"),
+        _campaign_row(cid="3", name="Retargeting Display"),
+    ]
+    result = adapter.list_campaigns(CampaignFilters(name_contains="Brand"))
+    names = {c.name for c in result}
+    assert names == {"Brand Awareness", "Brand Conversion"}
+
+
+@pytest.mark.unit
+def test_get_campaign_maps_to_dataclass(
+    adapter: MetaAdsAdapter, mock_client: Mock
+) -> None:
+    mock_client.get_campaign.return_value = _campaign_row(cid="c111", name="X")
+    result = adapter.get_campaign("c111")
+    assert isinstance(result, Campaign)
+    assert result.id == "c111"
+    mock_client.get_campaign.assert_awaited_once_with("c111")
+
+
+@pytest.mark.unit
+def test_get_campaign_unknown_status_raises_value_error(
+    adapter: MetaAdsAdapter, mock_client: Mock
+) -> None:
+    """Meta returns ``PENDING_REVIEW`` for in-review campaigns; Phase 1
+    raises ``ValueError`` (no silent fallback)."""
+    mock_client.get_campaign.return_value = _campaign_row(
+        cid="c1", status="PENDING_REVIEW"
+    )
+    with pytest.raises(ValueError):
+        adapter.get_campaign("c1")
+
+
+@pytest.mark.unit
+def test_create_campaign_basic_hardcodes_objective(
+    adapter: MetaAdsAdapter, mock_client: Mock
+) -> None:
+    """CTO decision #2: ``objective`` is hardcoded to ``"OUTCOME_TRAFFIC"``;
+    initial status is ``"PAUSED"``; the budget micros → cents conversion
+    happens at the boundary (``daily_budget = micros // 10_000``)."""
+    mock_client.create_campaign.return_value = {"id": "c777"}
+    mock_client.get_campaign.return_value = _campaign_row(
+        cid="c777", name="New", daily_budget_cents="1500"
+    )
+    out = adapter.create_campaign(
+        CreateCampaignRequest(
+            name="New",
+            daily_budget_micros=15_000_000,  # 15.0 USD → 1500 cents
+        )
+    )
+    assert isinstance(out, Campaign)
+    assert out.id == "c777"
+    mock_client.create_campaign.assert_awaited_once()
+    call_kwargs = mock_client.create_campaign.await_args.kwargs
+    call_args = mock_client.create_campaign.await_args.args
+    flat_values = list(call_args) + list(call_kwargs.values())
+    # Objective is hardcoded.
+    assert "OUTCOME_TRAFFIC" in flat_values
+    # Initial status defaults to PAUSED so users do not accidentally
+    # spend on PAUSED-by-default.
+    assert "PAUSED" in flat_values
+    # Budget: 15_000_000 micros = 1500 cents.
+    if "daily_budget" in call_kwargs:
+        assert call_kwargs["daily_budget"] == 1500
+    else:
+        assert 1500 in flat_values
+    # Refresh.
+    assert mock_client.get_campaign.await_count >= 1
+
+
+@pytest.mark.unit
+def test_create_campaign_with_start_date_unsupported(
+    adapter: MetaAdsAdapter, mock_client: Mock
+) -> None:
+    """Phase 1: ``start_date`` is not yet wired into Meta's
+    ``start_time``/``stop_time`` — supplying it must raise
+    ``UnsupportedOperation`` rather than be silently dropped."""
+    with pytest.raises(UnsupportedOperation, match="start_date"):
+        adapter.create_campaign(
+            CreateCampaignRequest(
+                name="X",
+                daily_budget_micros=1_000_000,
+                start_date=date(2026, 6, 1),
+            )
+        )
+    assert mock_client.create_campaign.await_count == 0
+
+
+@pytest.mark.unit
+def test_create_campaign_with_end_date_unsupported(
+    adapter: MetaAdsAdapter, mock_client: Mock
+) -> None:
+    with pytest.raises(UnsupportedOperation, match="end_date"):
+        adapter.create_campaign(
+            CreateCampaignRequest(
+                name="X",
+                daily_budget_micros=1_000_000,
+                end_date=date(2026, 12, 31),
+            )
+        )
+    assert mock_client.create_campaign.await_count == 0
+
+
+@pytest.mark.unit
+def test_create_campaign_with_bidding_strategy_unsupported(
+    adapter: MetaAdsAdapter, mock_client: Mock
+) -> None:
+    """Phase 1: ``bidding_strategy`` would require AdSet ``bid_strategy``
+    mapping — out of scope. Even MANUAL_CPC is rejected."""
+    with pytest.raises(UnsupportedOperation, match="bidding_strategy"):
+        adapter.create_campaign(
+            CreateCampaignRequest(
+                name="X",
+                daily_budget_micros=1_000_000,
+                bidding_strategy=BidStrategy.MANUAL_CPC,
+            )
+        )
+    assert mock_client.create_campaign.await_count == 0
+
+
+@pytest.mark.unit
+def test_update_campaign_name_only(adapter: MetaAdsAdapter, mock_client: Mock) -> None:
+    """A name-only partial update routes to ``client.update_campaign(c, name=...)``."""
+    mock_client.update_campaign.return_value = {"success": True}
+    mock_client.get_campaign.return_value = _campaign_row(cid="c111", name="Renamed")
+    out = adapter.update_campaign("c111", UpdateCampaignRequest(name="Renamed"))
+    assert isinstance(out, Campaign)
+    mock_client.update_campaign.assert_awaited_once()
+    call = mock_client.update_campaign.await_args
+    assert "c111" in call.args or "c111" in call.kwargs.values()
+    flat = list(call.args) + list(call.kwargs.values())
+    assert "Renamed" in flat
+
+
+@pytest.mark.unit
+def test_update_campaign_status_paused(
+    adapter: MetaAdsAdapter, mock_client: Mock
+) -> None:
+    """``UpdateCampaignRequest(status=PAUSED)`` routes through a single
+    ``client.update_campaign`` call with the wire-string ``"PAUSED"`` —
+    not via a separate ``pause_campaign`` (which is sugar over
+    ``update_campaign``)."""
+    mock_client.update_campaign.return_value = {"success": True}
+    mock_client.get_campaign.return_value = _campaign_row(cid="c111", status="PAUSED")
+    out = adapter.update_campaign(
+        "c111",
+        UpdateCampaignRequest(status=CampaignStatus.PAUSED),
+    )
+    assert isinstance(out, Campaign)
+    mock_client.update_campaign.assert_awaited_once()
+    flat = list(mock_client.update_campaign.await_args.args) + list(
+        mock_client.update_campaign.await_args.kwargs.values()
+    )
+    assert "PAUSED" in flat
+
+
+@pytest.mark.unit
+def test_update_campaign_daily_budget_micros_wired_to_cents(
+    adapter: MetaAdsAdapter, mock_client: Mock
+) -> None:
+    """Unlike Google Ads, Meta supports daily_budget on the campaign
+    resource directly. The adapter converts micros → cents
+    (``micros // 10_000``) at the boundary."""
+    mock_client.update_campaign.return_value = {"success": True}
+    mock_client.get_campaign.return_value = _campaign_row(
+        cid="c111", daily_budget_cents="2000"
+    )
+    adapter.update_campaign(
+        "c111", UpdateCampaignRequest(daily_budget_micros=20_000_000)
+    )
+    call_kwargs = mock_client.update_campaign.await_args.kwargs
+    # The adapter should forward as ``daily_budget=2000`` (cents int).
+    if "daily_budget" in call_kwargs:
+        assert call_kwargs["daily_budget"] == 2000
+    else:
+        flat = list(mock_client.update_campaign.await_args.args) + list(
+            call_kwargs.values()
+        )
+        assert 2000 in flat
+
+
+# ---------------------------------------------------------------------------
+# Case 5 — CampaignProvider — ads (AdSet hierarchy flattening)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_list_ads_flattens_ad_sets(adapter: MetaAdsAdapter, mock_client: Mock) -> None:
+    """``list_ads(campaign_id)`` calls ``list_ad_sets(campaign_id)``,
+    then ``list_ads(ad_set_id)`` per ad set, and flattens the result.
+
+    Phase 1 accepts the N+1 cost; the design decision is to hide AdSet
+    rather than expand the Protocol.
+    """
+    mock_client.list_ad_sets.return_value = [
+        _ad_set_row(ad_set_id="as1"),
+        _ad_set_row(ad_set_id="as2"),
+    ]
+    mock_client.list_ads.side_effect = [
+        [_ad_row(ad_id="ad1", ad_set_id="as1")],
+        [
+            _ad_row(ad_id="ad2", ad_set_id="as2"),
+            _ad_row(ad_id="ad3", ad_set_id="as2"),
+        ],
+    ]
+    result = adapter.list_ads("c111")
+    assert isinstance(result, tuple)
+    assert len(result) == 3
+    assert all(isinstance(a, Ad) for a in result)
+    assert {a.id for a in result} == {"ad1", "ad2", "ad3"}
+    # AdSet listing happened exactly once.
+    assert mock_client.list_ad_sets.await_count == 1
+    # And per-ad-set ad listing happened twice (N+1 pattern, Phase 1).
+    assert mock_client.list_ads.await_count == 2
+    for a in result:
+        assert a.account_id == _FAKE_AD_ACCOUNT_ID
+        assert a.campaign_id == "c111"
+
+
+@pytest.mark.unit
+def test_get_ad_campaign_mismatch_raises_key_error(
+    adapter: MetaAdsAdapter, mock_client: Mock
+) -> None:
+    """``get_ad(campaign_id, ad_id)`` verifies the returned ad's
+    ``campaign_id`` matches the requested one; mismatch is treated as
+    a "not found in this campaign" error → ``KeyError``."""
+    mock_client.get_ad.return_value = _ad_row(
+        ad_id="ad9", ad_set_id="as7", campaign_id="OTHER_CAMPAIGN"
+    )
+    with pytest.raises(KeyError):
+        adapter.get_ad("c111", "ad9")
+
+
+@pytest.mark.unit
+def test_get_ad_returns_match(adapter: MetaAdsAdapter, mock_client: Mock) -> None:
+    mock_client.get_ad.return_value = _ad_row(
+        ad_id="ad9", ad_set_id="as1", campaign_id="c111"
+    )
+    out = adapter.get_ad("c111", "ad9")
+    assert isinstance(out, Ad)
+    assert out.id == "ad9"
+    assert out.campaign_id == "c111"
+
+
+@pytest.mark.unit
+def test_create_ad_uses_first_headline_as_creative_id(
+    adapter: MetaAdsAdapter, mock_client: Mock
+) -> None:
+    """CTO decision #3: Phase 1 interprets ``request.headlines[0]`` as
+    the ``creative_id`` and ``request.ad_group_id`` as the ``ad_set_id``.
+    """
+    mock_client.create_ad.return_value = {"id": "ad9"}
+    mock_client.get_ad.return_value = _ad_row(
+        ad_id="ad9", ad_set_id="as1", campaign_id="c111"
+    )
+    out = adapter.create_ad(
+        "c111",
+        CreateAdRequest(
+            ad_group_id="as1",
+            headlines=("creative_xyz",),
+            descriptions=(),
+        ),
+    )
+    assert isinstance(out, Ad)
+    mock_client.create_ad.assert_awaited_once()
+    call = mock_client.create_ad.await_args
+    flat = list(call.args) + list(call.kwargs.values())
+    assert "as1" in flat
+    assert "creative_xyz" in flat
+
+
+@pytest.mark.unit
+def test_create_ad_empty_headlines_unsupported(
+    adapter: MetaAdsAdapter, mock_client: Mock
+) -> None:
+    """An empty ``headlines`` tuple cannot supply a creative_id; raise
+    ``UnsupportedOperation`` instead of silently dropping the create."""
+    with pytest.raises(UnsupportedOperation):
+        adapter.create_ad(
+            "c111",
+            CreateAdRequest(
+                ad_group_id="as1",
+                headlines=(),
+                descriptions=(),
+            ),
+        )
+    assert mock_client.create_ad.await_count == 0
+
+
+@pytest.mark.unit
+def test_create_ad_multiple_headlines_unsupported(
+    adapter: MetaAdsAdapter, mock_client: Mock
+) -> None:
+    """Phase 1: only ``len(headlines) == 1`` is supported (the overload
+    holds the creative_id)."""
+    with pytest.raises(UnsupportedOperation):
+        adapter.create_ad(
+            "c111",
+            CreateAdRequest(
+                ad_group_id="as1",
+                headlines=("h1", "h2"),
+                descriptions=(),
+            ),
+        )
+    assert mock_client.create_ad.await_count == 0
+
+
+@pytest.mark.unit
+def test_update_ad_with_headlines_unsupported(
+    adapter: MetaAdsAdapter, mock_client: Mock
+) -> None:
+    """Phase 1: Meta cannot mutate an existing ad's creative fields
+    without recreating the ad. Supplying any creative field raises
+    ``UnsupportedOperation``."""
+    with pytest.raises(UnsupportedOperation):
+        adapter.update_ad("c111", "ad9", UpdateAdRequest(headlines=("new",)))
+    assert mock_client.update_ad.await_count == 0
+
+
+@pytest.mark.unit
+def test_update_ad_with_descriptions_unsupported(
+    adapter: MetaAdsAdapter, mock_client: Mock
+) -> None:
+    with pytest.raises(UnsupportedOperation):
+        adapter.update_ad("c111", "ad9", UpdateAdRequest(descriptions=("d1",)))
+    assert mock_client.update_ad.await_count == 0
+
+
+@pytest.mark.unit
+def test_update_ad_with_final_urls_unsupported(
+    adapter: MetaAdsAdapter, mock_client: Mock
+) -> None:
+    with pytest.raises(UnsupportedOperation):
+        adapter.update_ad(
+            "c111", "ad9", UpdateAdRequest(final_urls=("https://example.com",))
+        )
+    assert mock_client.update_ad.await_count == 0
+
+
+@pytest.mark.unit
+def test_set_ad_status_paused_calls_pause_ad(
+    adapter: MetaAdsAdapter, mock_client: Mock
+) -> None:
+    mock_client.pause_ad.return_value = {"success": True}
+    mock_client.get_ad.return_value = _ad_row(
+        ad_id="ad1", ad_set_id="as1", campaign_id="c111", status="PAUSED"
+    )
+    out = adapter.set_ad_status("c111", "ad1", AdStatus.PAUSED)
+    assert isinstance(out, Ad)
+    mock_client.pause_ad.assert_awaited_once()
+    assert mock_client.enable_ad.await_count == 0
+    assert mock_client.update_ad.await_count == 0
+
+
+@pytest.mark.unit
+def test_set_ad_status_enabled_calls_enable_ad(
+    adapter: MetaAdsAdapter, mock_client: Mock
+) -> None:
+    mock_client.enable_ad.return_value = {"success": True}
+    mock_client.get_ad.return_value = _ad_row(
+        ad_id="ad1", ad_set_id="as1", campaign_id="c111", status="ACTIVE"
+    )
+    adapter.set_ad_status("c111", "ad1", AdStatus.ENABLED)
+    mock_client.enable_ad.assert_awaited_once()
+    assert mock_client.pause_ad.await_count == 0
+
+
+@pytest.mark.unit
+def test_set_ad_status_removed_routes_to_update_ad_deleted(
+    adapter: MetaAdsAdapter, mock_client: Mock
+) -> None:
+    """REMOVED → ``client.update_ad(ad_id, status="DELETED")`` — Meta's
+    canonical soft-delete (archive is not used in Phase 1)."""
+    mock_client.update_ad.return_value = {"success": True}
+    mock_client.get_ad.return_value = _ad_row(
+        ad_id="ad1", ad_set_id="as1", campaign_id="c111", status="DELETED"
+    )
+    adapter.set_ad_status("c111", "ad1", AdStatus.REMOVED)
+    mock_client.update_ad.assert_awaited_once()
+    flat = list(mock_client.update_ad.await_args.args) + list(
+        mock_client.update_ad.await_args.kwargs.values()
+    )
+    assert "DELETED" in flat
+
+
+# ---------------------------------------------------------------------------
+# Case 6 — Daily report (via insights_time_range)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_daily_report_calls_insights_time_range(
+    adapter: MetaAdsAdapter, mock_client: Mock
+) -> None:
+    """``daily_report`` delegates to the new
+    ``client.insights_time_range`` method with ISO dates and returns a
+    tuple of ``DailyReportRow``."""
+    mock_client.insights_time_range.return_value = [
+        {
+            "date_start": "2026-04-01",
+            "date_stop": "2026-04-01",
+            "impressions": "100",
+            "clicks": "10",
+            "spend": "5.00",
+            "actions": [],
+        },
+        {
+            "date_start": "2026-04-02",
+            "date_stop": "2026-04-02",
+            "impressions": "150",
+            "clicks": "12",
+            "spend": "6.00",
+            "actions": [],
+        },
+    ]
+    out = adapter.daily_report("111222", date(2026, 4, 1), date(2026, 4, 2))
+    assert isinstance(out, tuple)
+    assert all(isinstance(r, DailyReportRow) for r in out)
+    assert out[0].date == date(2026, 4, 1)
+    # spend dollars → micros: 5.00 USD = 5_000_000 micros.
+    assert out[0].cost_micros == 5_000_000
+
+    mock_client.insights_time_range.assert_awaited_once()
+    call_kwargs = mock_client.insights_time_range.await_args.kwargs
+    call_args = mock_client.insights_time_range.await_args.args
+    # campaign_id is the positional (or keyword) ``node_id``.
+    flat = list(call_args) + list(call_kwargs.values())
+    assert "111222" in flat
+    # ISO since/until appear (accept either kwarg name forms).
+    assert "2026-04-01" in flat
+    assert "2026-04-02" in flat
+
+
+@pytest.mark.unit
+def test_daily_report_passes_iso_kwargs(
+    adapter: MetaAdsAdapter, mock_client: Mock
+) -> None:
+    """The ``since`` and ``until`` arguments are ISO-formatted dates."""
+    mock_client.insights_time_range.return_value = []
+    adapter.daily_report("111222", date(2026, 4, 1), date(2026, 4, 7))
+    kwargs = mock_client.insights_time_range.await_args.kwargs
+    # The canonical kwargs are documented as ``since`` and ``until``.
+    if "since" in kwargs:
+        assert kwargs["since"] == "2026-04-01"
+        assert kwargs["until"] == "2026-04-07"
+    else:
+        # Fall back: ISO strings appear positionally.
+        flat = list(mock_client.insights_time_range.await_args.args) + list(
+            kwargs.values()
+        )
+        assert "2026-04-01" in flat
+        assert "2026-04-07" in flat
+
+
+@pytest.mark.unit
+def test_daily_report_rejects_non_digit_campaign_id(
+    adapter: MetaAdsAdapter, mock_client: Mock
+) -> None:
+    """Phase 1 safety: ``campaign_id`` must be digits-only — an
+    attacker-controlled value MUST be rejected before the request is
+    issued. Mirror of P1-09's GAQL injection guard."""
+    with pytest.raises((ValueError, MetaAdsAdapterError)):
+        adapter.daily_report("' OR 1=1 --", date(2026, 4, 1), date(2026, 4, 2))
+    assert mock_client.insights_time_range.await_count == 0
+
+
+@pytest.mark.unit
+def test_daily_report_extracts_conversions_from_actions(
+    adapter: MetaAdsAdapter, mock_client: Mock
+) -> None:
+    """Meta's `actions` list — when an action of type ``purchase`` (or
+    other Phase 1 conversion-like action_type) is present — populates
+    ``DailyReportRow.conversions``."""
+    mock_client.insights_time_range.return_value = [
+        {
+            "date_start": "2026-04-01",
+            "date_stop": "2026-04-01",
+            "impressions": "100",
+            "clicks": "10",
+            "spend": "5.00",
+            "actions": [
+                {"action_type": "purchase", "value": "3"},
+                {"action_type": "link_click", "value": "10"},
+            ],
+        }
+    ]
+    out = adapter.daily_report("111222", date(2026, 4, 1), date(2026, 4, 1))
+    assert len(out) == 1
+    # Conversions reflect the ``purchase`` action's value.
+    assert out[0].conversions == 3.0
+
+
+# ---------------------------------------------------------------------------
+# Case 7 — AudienceProvider
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_list_audiences_returns_tuple_of_dataclasses(
+    adapter: MetaAdsAdapter, mock_client: Mock
+) -> None:
+    mock_client.list_custom_audiences.return_value = [
+        _audience_row(aud_id="aud_1", name="A"),
+        _audience_row(aud_id="aud_2", name="B"),
+    ]
+    out = adapter.list_audiences()
+    assert isinstance(out, tuple)
+    assert len(out) == 2
+    assert all(isinstance(a, Audience) for a in out)
+    for a in out:
+        assert a.account_id == _FAKE_AD_ACCOUNT_ID
+        # Phase 1: only ENABLED is mapped from a healthy delivery_status.
+        assert a.status == AudienceStatus.ENABLED
+
+
+@pytest.mark.unit
+def test_get_audience_returns_dataclass(
+    adapter: MetaAdsAdapter, mock_client: Mock
+) -> None:
+    mock_client.get_custom_audience.return_value = _audience_row(aud_id="aud_42")
+    out = adapter.get_audience("aud_42")
+    assert isinstance(out, Audience)
+    assert out.id == "aud_42"
+    mock_client.get_custom_audience.assert_awaited_once_with("aud_42")
+
+
+@pytest.mark.unit
+def test_create_audience_custom_when_no_seed(
+    adapter: MetaAdsAdapter, mock_client: Mock
+) -> None:
+    """``CreateAudienceRequest`` without ``seed_audience_id`` →
+    ``client.create_custom_audience`` is invoked (NOT lookalike)."""
+    mock_client.create_custom_audience.return_value = {"id": "aud_new"}
+    mock_client.get_custom_audience.return_value = _audience_row(
+        aud_id="aud_new", name="Visitors"
+    )
+    out = adapter.create_audience(
+        CreateAudienceRequest(name="Visitors", description="Site visitors 30d")
+    )
+    assert isinstance(out, Audience)
+    mock_client.create_custom_audience.assert_awaited_once()
+    assert mock_client.create_lookalike_audience.await_count == 0
+    # ``subtype="CUSTOM"`` is enforced.
+    kwargs = mock_client.create_custom_audience.await_args.kwargs
+    args = mock_client.create_custom_audience.await_args.args
+    flat = list(args) + list(kwargs.values())
+    assert "CUSTOM" in flat
+    assert "Visitors" in flat
+
+
+@pytest.mark.unit
+def test_create_audience_lookalike_when_seed_set(
+    adapter: MetaAdsAdapter, mock_client: Mock
+) -> None:
+    """CTO decision #4: ``seed_audience_id`` present → lookalike branch
+    with hardcoded defaults ``country="JP"`` and ``ratio=0.01``."""
+    mock_client.create_lookalike_audience.return_value = {"id": "aud_la"}
+    mock_client.get_custom_audience.return_value = _audience_row(
+        aud_id="aud_la", subtype="LOOKALIKE"
+    )
+    adapter.create_audience(
+        CreateAudienceRequest(name="LA-JP", seed_audience_id="aud_seed")
+    )
+    mock_client.create_lookalike_audience.assert_awaited_once()
+    assert mock_client.create_custom_audience.await_count == 0
+    call = mock_client.create_lookalike_audience.await_args
+    flat = list(call.args) + list(call.kwargs.values())
+    # All four key Phase-1 args must appear.
+    assert "aud_seed" in flat
+    assert "JP" in flat
+    assert 0.01 in flat
+    assert "LA-JP" in flat
+
+
+@pytest.mark.unit
+def test_set_audience_status_removed_calls_delete(
+    adapter: MetaAdsAdapter, mock_client: Mock
+) -> None:
+    """``REMOVED`` is the canonical delete signal → routes to
+    ``client.delete_custom_audience``."""
+    mock_client.delete_custom_audience.return_value = {"success": True}
+    mock_client.get_custom_audience.return_value = _audience_row(aud_id="aud_x")
+    # Phase 1 contract: returning an ``Audience`` after delete is
+    # acceptable (some adapters refresh, some return the pre-delete
+    # snapshot). The test only pins that the delete call happened.
+    adapter.set_audience_status("aud_x", AudienceStatus.REMOVED)
+    mock_client.delete_custom_audience.assert_awaited_once_with("aud_x")
+
+
+@pytest.mark.unit
+def test_set_audience_status_enabled_unsupported(
+    adapter: MetaAdsAdapter, mock_client: Mock
+) -> None:
+    """Meta has no re-enable for deleted audiences; status is derived
+    from delivery_status. Phase 1 raises ``UnsupportedOperation``."""
+    with pytest.raises(UnsupportedOperation):
+        adapter.set_audience_status("aud_x", AudienceStatus.ENABLED)
+    assert mock_client.delete_custom_audience.await_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Case 8 — Sync/async bridge
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_sync_methods_callable_from_outside_loop(
+    adapter: MetaAdsAdapter, mock_client: Mock
+) -> None:
+    """Sync Protocol methods are callable from a thread with no running
+    loop (the default for pytest sync tests)."""
+    mock_client.list_campaigns.return_value = [_campaign_row()]
+    result = adapter.list_campaigns()
+    assert isinstance(result, tuple)
+
+
+@pytest.mark.unit
+def test_calling_from_running_loop_raises_runtime_error(
+    adapter: MetaAdsAdapter, mock_client: Mock
+) -> None:
+    """Calling an adapter method from inside an active event loop must
+    raise ``RuntimeError`` — Phase 1 sync Protocol cannot reentrantly
+    call ``asyncio.run``."""
+    mock_client.list_campaigns.return_value = []
+
+    async def _inner() -> None:
+        adapter.list_campaigns()
+
+    with pytest.raises(RuntimeError):
+        asyncio.run(_inner())
+
+
+# ---------------------------------------------------------------------------
+# Case 9 — Error pass-through
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_client_runtime_error_passes_through_unwrapped(
+    adapter: MetaAdsAdapter, mock_client: Mock
+) -> None:
+    """A ``RuntimeError`` raised by the underlying client passes through
+    unchanged — it must NOT be wrapped in ``MetaAdsAdapterError``."""
+    mock_client.update_campaign.side_effect = RuntimeError(
+        "Meta API request failed (status=400, path=/c111): boom"
+    )
+    with pytest.raises(RuntimeError) as excinfo:
+        adapter.update_campaign("c111", UpdateCampaignRequest(name="X"))
+    assert not isinstance(excinfo.value, MetaAdsAdapterError)
+    assert "boom" in str(excinfo.value)
+
+
+@pytest.mark.unit
+def test_unsupported_operation_subclasses_adapter_error() -> None:
+    """``UnsupportedOperation`` subclasses ``MetaAdsAdapterError``;
+    ``MetaAdsAdapterError`` subclasses ``RuntimeError``."""
+    assert issubclass(UnsupportedOperation, MetaAdsAdapterError)
+    assert issubclass(MetaAdsAdapterError, RuntimeError)
+
+
+# ---------------------------------------------------------------------------
+# Case 10 — Public surface hygiene
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_protocol_methods_are_sync(adapter: MetaAdsAdapter) -> None:
+    """Every Protocol method on the adapter is synchronous — the
+    sync/async bridge is the adapter's responsibility."""
+    for method_name in (
+        "list_campaigns",
+        "get_campaign",
+        "create_campaign",
+        "update_campaign",
+        "list_ads",
+        "get_ad",
+        "create_ad",
+        "update_ad",
+        "set_ad_status",
+        "daily_report",
+        "list_audiences",
+        "get_audience",
+        "create_audience",
+        "set_audience_status",
+    ):
+        method = getattr(adapter, method_name)
+        assert not inspect.iscoroutinefunction(
+            method
+        ), f"{method_name} must be a sync method on the Phase 1 adapter"
+
+
+@pytest.mark.unit
+def test_adapter_does_not_advertise_keyword_or_extension_methods(
+    adapter: MetaAdsAdapter,
+) -> None:
+    """Phase 1 deferral / non-applicable: keyword / extension Protocol
+    methods are intentionally absent from the adapter (NOT stubs that
+    raise)."""
+    for method_name in (
+        "list_keywords",
+        "add_keywords",
+        "set_keyword_status",
+        "list_extensions",
+        "add_extension",
+        "set_extension_status",
+        "search_terms",
+    ):
+        assert not hasattr(
+            adapter, method_name
+        ), f"{method_name} must NOT be defined (Meta has no counterpart)"

--- a/tests/adapters/meta_ads/test_imports.py
+++ b/tests/adapters/meta_ads/test_imports.py
@@ -1,0 +1,184 @@
+"""RED-phase tests: AST-scan the adapter modules for forbidden imports.
+
+Encapsulation rule (P1-10 acceptance criterion, parity with P1-09):
+
+- ``mureo/adapters/meta_ads/adapter.py`` may import from:
+    - stdlib (any)
+    - ``mureo.core.providers.{base, capabilities, models, registry}``
+    - ``mureo.core.providers.{campaign, audience}`` — the Protocols
+      themselves; allowed for type hints
+    - ``mureo.meta_ads.client`` (the public ``MetaAdsApiClient``)
+    - ``mureo.meta_ads.mappers`` (the existing dict-shaping helpers)
+    - ``mureo.adapters.meta_ads.{mappers, errors}`` (intra-package)
+  …but MUST NOT import any ``mureo.meta_ads._*`` private mixin.
+
+- ``mureo/adapters/meta_ads/mappers.py`` may import only:
+    - stdlib
+    - ``mureo.core.providers.{models, capabilities}``
+    - ``mureo.adapters.meta_ads.errors``
+  …and nothing else inside ``mureo``.
+
+- ``mureo/adapters/meta_ads/errors.py`` may import only stdlib.
+
+Marks: every test is ``@pytest.mark.unit``.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import inspect
+from pathlib import Path
+
+import pytest
+
+_ADAPTER_MODULE = "mureo.adapters.meta_ads.adapter"
+_MAPPERS_MODULE = "mureo.adapters.meta_ads.mappers"
+_ERRORS_MODULE = "mureo.adapters.meta_ads.errors"
+
+_ADAPTER_ALLOWED: frozenset[str] = frozenset(
+    {
+        "mureo.core.providers",
+        "mureo.core.providers.base",
+        "mureo.core.providers.capabilities",
+        "mureo.core.providers.models",
+        "mureo.core.providers.registry",
+        "mureo.core.providers.campaign",
+        "mureo.core.providers.audience",
+        "mureo.meta_ads.client",
+        "mureo.meta_ads.mappers",
+        "mureo.adapters.meta_ads.mappers",
+        "mureo.adapters.meta_ads.errors",
+        "mureo.adapters.meta_ads",
+    }
+)
+
+_MAPPERS_ALLOWED: frozenset[str] = frozenset(
+    {
+        "mureo.core.providers",
+        "mureo.core.providers.models",
+        "mureo.core.providers.capabilities",
+        "mureo.adapters.meta_ads.errors",
+        "mureo.adapters.meta_ads",
+    }
+)
+
+
+def _source_path(dotted: str) -> Path:
+    mod = importlib.import_module(dotted)
+    src = inspect.getsourcefile(mod)
+    assert src is not None, f"cannot locate {dotted} on disk"
+    return Path(src)
+
+
+def _internal_mureo_imports(path: Path) -> list[str]:
+    """Return every ``mureo.*`` import (whether ``import X`` or
+    ``from X import …``) inside ``path``.
+
+    Relative imports (``from .x import …``) are normalized to their
+    absolute dotted form using the module's package prefix.
+    """
+    src = path.read_text(encoding="utf-8")
+    tree = ast.parse(src, filename=str(path))
+    out: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name.startswith("mureo"):
+                    out.append(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            mod = node.module or ""
+            if node.level > 0:
+                out.append(f".{'.' * (node.level - 1)}{mod}")
+            elif mod.startswith("mureo"):
+                out.append(mod)
+    return out
+
+
+@pytest.mark.unit
+def test_adapter_imports_within_allowlist() -> None:
+    path = _source_path(_ADAPTER_MODULE)
+    imports = _internal_mureo_imports(path)
+    offending: list[str] = []
+    for imp in imports:
+        # Reject any private-mixin import explicitly.
+        if imp.startswith("mureo.meta_ads._"):
+            offending.append(imp)
+            continue
+        # Relative imports must resolve to an allowed name.
+        if imp.startswith("."):
+            relative_root = "mureo.adapters.meta_ads"
+            base = imp.lstrip(".")
+            resolved = f"{relative_root}.{base}" if base else relative_root
+            if resolved not in _ADAPTER_ALLOWED:
+                offending.append(f"(relative) {imp} -> {resolved}")
+            continue
+        if imp not in _ADAPTER_ALLOWED:
+            offending.append(imp)
+    assert offending == [], (
+        f"{_ADAPTER_MODULE} has forbidden imports: {offending}. "
+        f"Allowed: {sorted(_ADAPTER_ALLOWED)}"
+    )
+
+
+@pytest.mark.unit
+def test_adapter_does_not_import_private_mixins() -> None:
+    """Explicit check (defense-in-depth alongside the allowlist):
+    NO import of ``mureo.meta_ads._*`` private mixins is permitted."""
+    path = _source_path(_ADAPTER_MODULE)
+    imports = _internal_mureo_imports(path)
+    bad = [imp for imp in imports if imp.startswith("mureo.meta_ads._")]
+    assert bad == [], f"{_ADAPTER_MODULE} must not import private mixins; found: {bad}"
+
+
+@pytest.mark.unit
+def test_mappers_imports_within_allowlist() -> None:
+    path = _source_path(_MAPPERS_MODULE)
+    imports = _internal_mureo_imports(path)
+    offending: list[str] = []
+    for imp in imports:
+        if imp.startswith("."):
+            relative_root = "mureo.adapters.meta_ads"
+            base = imp.lstrip(".")
+            resolved = f"{relative_root}.{base}" if base else relative_root
+            if resolved not in _MAPPERS_ALLOWED:
+                offending.append(f"(relative) {imp} -> {resolved}")
+            continue
+        if imp not in _MAPPERS_ALLOWED:
+            offending.append(imp)
+    assert offending == [], (
+        f"{_MAPPERS_MODULE} has forbidden imports: {offending}. "
+        f"Allowed: {sorted(_MAPPERS_ALLOWED)}"
+    )
+
+
+@pytest.mark.unit
+def test_mappers_does_not_import_meta_ads_client_or_mixins() -> None:
+    """The adapter's mapper module is pure dict-to-dataclass; it must
+    NOT pull in the heavyweight ``mureo.meta_ads.client`` (which
+    transitively imports httpx + every Meta mixin) or any private
+    mixin."""
+    path = _source_path(_MAPPERS_MODULE)
+    imports = _internal_mureo_imports(path)
+    bad = [imp for imp in imports if imp.startswith("mureo.meta_ads.")]
+    assert (
+        bad == []
+    ), f"{_MAPPERS_MODULE} must not depend on mureo.meta_ads.*; found: {bad}"
+
+
+@pytest.mark.unit
+def test_errors_module_imports_no_mureo_internals() -> None:
+    """The errors module is exception types only — no internal imports."""
+    path = _source_path(_ERRORS_MODULE)
+    imports = _internal_mureo_imports(path)
+    assert imports == [], (
+        f"{_ERRORS_MODULE} must not import any internal mureo modules; "
+        f"found: {imports}"
+    )
+
+
+@pytest.mark.unit
+def test_package_init_reexports_adapter_class() -> None:
+    """``mureo.adapters.meta_ads`` re-exports ``MetaAdsAdapter``."""
+    pkg = importlib.import_module("mureo.adapters.meta_ads")
+    assert hasattr(pkg, "MetaAdsAdapter")

--- a/tests/adapters/meta_ads/test_mappers.py
+++ b/tests/adapters/meta_ads/test_mappers.py
@@ -1,0 +1,327 @@
+"""RED-phase tests for ``mureo.adapters.meta_ads.mappers``.
+
+The mapper module is a pile of pure functions that turn the raw
+``dict`` / ``list[dict]`` returned by ``MetaAdsApiClient`` mixins into
+the frozen-dataclass entities defined in
+``mureo.core.providers.models``.
+
+Phase 1 conversions enforced here
+---------------------------------
+- Budget: Meta returns ``daily_budget`` as a **cents** string; mapper
+  converts to **micros** (``int(cents) * 10_000``).
+- Spend: Meta returns ``spend`` as a **dollars** string; mapper
+  converts to **micros** (``int(round(float(s) * 1_000_000))``).
+- Status: Meta wire-strings (``ACTIVE`` / ``PAUSED`` / ``DELETED`` /
+  ``ARCHIVED`` / ``CAMPAIGN_PAUSED`` / ``ADSET_PAUSED``) are mapped
+  to the canonical ``CampaignStatus`` / ``AdStatus`` enum members.
+- Unknown / unparseable values raise ``ValueError`` — no silent
+  fallback to a default.
+
+Marks: every test is ``@pytest.mark.unit``.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+import pytest
+
+# NOTE: These imports are expected to FAIL during the RED phase — the
+# module ``mureo.adapters.meta_ads.mappers`` does not exist yet.
+from mureo.adapters.meta_ads.mappers import (
+    map_ad_status,
+    map_campaign_status,
+    to_ad,
+    to_audience,
+    to_campaign,
+    to_campaigns,
+    to_daily_report_row,
+)
+from mureo.core.providers.models import (
+    Ad,
+    AdStatus,
+    Audience,
+    AudienceStatus,
+    Campaign,
+    CampaignStatus,
+    DailyReportRow,
+)
+
+_ACCOUNT_ID = "act_1234567890"
+
+
+# ---------------------------------------------------------------------------
+# Status mapping (parametrized: Meta wire-string → mureo canonical)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("meta_wire", "expected"),
+    [
+        ("ACTIVE", CampaignStatus.ENABLED),
+        ("PAUSED", CampaignStatus.PAUSED),
+        ("CAMPAIGN_PAUSED", CampaignStatus.PAUSED),
+        ("ADSET_PAUSED", CampaignStatus.PAUSED),
+        ("DELETED", CampaignStatus.REMOVED),
+        ("ARCHIVED", CampaignStatus.REMOVED),
+    ],
+)
+def test_map_campaign_status_known_values(
+    meta_wire: str, expected: CampaignStatus
+) -> None:
+    assert map_campaign_status(meta_wire) == expected
+
+
+@pytest.mark.unit
+def test_map_campaign_status_unknown_raises_value_error() -> None:
+    """No silent fallback — unknown Meta wire-strings raise
+    ``ValueError`` with the offending value."""
+    with pytest.raises(ValueError) as excinfo:
+        map_campaign_status("PENDING_REVIEW")
+    # Offending value must be in the message for debuggability.
+    assert "PENDING_REVIEW" in str(excinfo.value)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("meta_wire", "expected"),
+    [
+        ("ACTIVE", AdStatus.ENABLED),
+        ("PAUSED", AdStatus.PAUSED),
+        ("CAMPAIGN_PAUSED", AdStatus.PAUSED),
+        ("ADSET_PAUSED", AdStatus.PAUSED),
+        ("DELETED", AdStatus.REMOVED),
+        ("ARCHIVED", AdStatus.REMOVED),
+    ],
+)
+def test_map_ad_status_known_values(meta_wire: str, expected: AdStatus) -> None:
+    assert map_ad_status(meta_wire) == expected
+
+
+@pytest.mark.unit
+def test_map_ad_status_unknown_raises_value_error() -> None:
+    with pytest.raises(ValueError):
+        map_ad_status("WITH_ISSUES")
+
+
+# ---------------------------------------------------------------------------
+# Campaign mapper — cents → micros boundary
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_to_campaign_maps_required_fields_and_cents_to_micros() -> None:
+    """``daily_budget="1500"`` (cents string) → ``daily_budget_micros=15_000_000``."""
+    raw: dict[str, Any] = {
+        "id": "c1",
+        "name": "Test",
+        "status": "ACTIVE",
+        "daily_budget": "1500",
+    }
+    out = to_campaign(raw, account_id=_ACCOUNT_ID)
+    assert isinstance(out, Campaign)
+    assert out.id == "c1"
+    assert out.account_id == _ACCOUNT_ID
+    assert out.name == "Test"
+    assert out.status == CampaignStatus.ENABLED
+    assert out.daily_budget_micros == 15_000_000
+    # Exact integer arithmetic (no float round-trip).
+    assert isinstance(out.daily_budget_micros, int)
+
+
+@pytest.mark.unit
+def test_to_campaign_missing_daily_budget_defaults_to_zero() -> None:
+    """Phase 1: when Meta returns no ``daily_budget`` (e.g. lifetime-only
+    campaigns), the mapper produces ``daily_budget_micros=0`` rather
+    than raising."""
+    raw: dict[str, Any] = {
+        "id": "c1",
+        "name": "Lifetime",
+        "status": "ACTIVE",
+    }
+    out = to_campaign(raw, account_id=_ACCOUNT_ID)
+    assert out.daily_budget_micros == 0
+
+
+@pytest.mark.unit
+def test_to_campaign_unknown_status_raises_value_error() -> None:
+    raw: dict[str, Any] = {
+        "id": "c1",
+        "name": "x",
+        "status": "PENDING_REVIEW",
+        "daily_budget": "0",
+    }
+    with pytest.raises(ValueError):
+        to_campaign(raw, account_id=_ACCOUNT_ID)
+
+
+@pytest.mark.unit
+def test_to_campaigns_returns_tuple_of_campaign() -> None:
+    rows = [
+        {"id": "1", "name": "a", "status": "ACTIVE", "daily_budget": "100"},
+        {"id": "2", "name": "b", "status": "PAUSED", "daily_budget": "200"},
+    ]
+    out = to_campaigns(rows, account_id=_ACCOUNT_ID)
+    assert isinstance(out, tuple)
+    assert len(out) == 2
+    assert all(isinstance(c, Campaign) for c in out)
+    assert out[0].daily_budget_micros == 1_000_000
+    assert out[1].daily_budget_micros == 2_000_000
+
+
+# ---------------------------------------------------------------------------
+# Ad mapper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_to_ad_with_creative_link_data() -> None:
+    """The ``creative.object_story_spec.link_data.link`` field populates
+    ``Ad.final_url`` when present."""
+    raw: dict[str, Any] = {
+        "id": "ad1",
+        "status": "ACTIVE",
+        "creative": {
+            "object_story_spec": {
+                "link_data": {"link": "https://example.com/landing"},
+            }
+        },
+    }
+    out = to_ad(raw, account_id=_ACCOUNT_ID, campaign_id="c1")
+    assert isinstance(out, Ad)
+    assert out.id == "ad1"
+    assert out.account_id == _ACCOUNT_ID
+    assert out.campaign_id == "c1"
+    assert out.status == AdStatus.ENABLED
+    assert out.final_url == "https://example.com/landing"
+    # Immutability — headlines / descriptions are tuples (empty in Phase 1).
+    assert isinstance(out.headlines, tuple)
+    assert isinstance(out.descriptions, tuple)
+
+
+@pytest.mark.unit
+def test_to_ad_without_creative_uses_empty_final_url() -> None:
+    raw: dict[str, Any] = {
+        "id": "ad2",
+        "status": "PAUSED",
+    }
+    out = to_ad(raw, account_id=_ACCOUNT_ID, campaign_id="c1")
+    assert out.final_url == ""
+
+
+@pytest.mark.unit
+def test_to_ad_unknown_status_raises() -> None:
+    raw: dict[str, Any] = {
+        "id": "ad3",
+        "status": "WITH_ISSUES",
+    }
+    with pytest.raises(ValueError):
+        to_ad(raw, account_id=_ACCOUNT_ID, campaign_id="c1")
+
+
+# ---------------------------------------------------------------------------
+# Audience mapper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_to_audience_maps_required_fields() -> None:
+    raw: dict[str, Any] = {
+        "id": "aud_1",
+        "name": "Site visitors",
+        "approximate_count_lower_bound": 10_000,
+        "approximate_count_upper_bound": 10_000,
+        "delivery_status": {"code": 200, "description": "Ready"},
+    }
+    out = to_audience(raw, account_id=_ACCOUNT_ID)
+    assert isinstance(out, Audience)
+    assert out.id == "aud_1"
+    assert out.account_id == _ACCOUNT_ID
+    assert out.name == "Site visitors"
+    assert out.status == AudienceStatus.ENABLED
+
+
+@pytest.mark.unit
+def test_to_audience_missing_size_estimate_is_none() -> None:
+    """When Meta omits size estimate fields, ``size_estimate`` is
+    ``None`` rather than 0."""
+    raw: dict[str, Any] = {
+        "id": "aud_2",
+        "name": "Tiny audience",
+        "delivery_status": {"code": 200, "description": "Ready"},
+    }
+    out = to_audience(raw, account_id=_ACCOUNT_ID)
+    assert out.size_estimate is None
+
+
+# ---------------------------------------------------------------------------
+# DailyReportRow mapper — dollars → micros, date parsing, action conv.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_to_daily_report_row_parses_date_and_converts_dollars_to_micros() -> None:
+    raw: dict[str, Any] = {
+        "date_start": "2026-04-15",
+        "date_stop": "2026-04-15",
+        "impressions": "100",
+        "clicks": "10",
+        "spend": "12.34",
+        "actions": [],
+    }
+    out = to_daily_report_row(raw)
+    assert isinstance(out, DailyReportRow)
+    assert isinstance(out.date, date)
+    assert out.date == date(2026, 4, 15)
+    assert out.impressions == 100
+    assert out.clicks == 10
+    # 12.34 USD → 12_340_000 micros (rounded to nearest integer).
+    assert out.cost_micros == 12_340_000
+    assert isinstance(out.cost_micros, int)
+
+
+@pytest.mark.unit
+def test_to_daily_report_row_unparseable_date_raises_value_error() -> None:
+    raw: dict[str, Any] = {
+        "date_start": "not-a-date",
+        "impressions": "0",
+        "clicks": "0",
+        "spend": "0",
+        "actions": [],
+    }
+    with pytest.raises(ValueError):
+        to_daily_report_row(raw)
+
+
+@pytest.mark.unit
+def test_to_daily_report_row_extracts_purchase_conversions_from_actions() -> None:
+    raw: dict[str, Any] = {
+        "date_start": "2026-04-15",
+        "impressions": "100",
+        "clicks": "10",
+        "spend": "0",
+        "actions": [
+            {"action_type": "purchase", "value": "5"},
+            {"action_type": "link_click", "value": "20"},
+        ],
+    }
+    out = to_daily_report_row(raw)
+    # The mapper recognises ``purchase`` as the conversion action_type
+    # (Phase 1 convention).
+    assert out.conversions == 5.0
+    assert isinstance(out.conversions, float)
+
+
+@pytest.mark.unit
+def test_to_daily_report_row_no_actions_zero_conversions() -> None:
+    raw: dict[str, Any] = {
+        "date_start": "2026-04-15",
+        "impressions": "1",
+        "clicks": "0",
+        "spend": "0",
+        # ``actions`` may be absent entirely on days with no events.
+    }
+    out = to_daily_report_row(raw)
+    assert out.conversions == 0.0


### PR DESCRIPTION
## Summary

Implements P1-10 of Issue #89 Phase 1: the **meta_ads adapter** — wraps `mureo.meta_ads.MetaAdsApiClient` (async, mixin-composed) and exposes the P1-02..P1-06 Protocols synchronously. Parallel structure to P1-09 (`mureo/adapters/google_ads/`), with Meta-specific design choices.

### Capabilities declared (7)

```python
frozenset({
    Capability.READ_CAMPAIGNS,    Capability.READ_PERFORMANCE,
    Capability.READ_AUDIENCES,    Capability.WRITE_BUDGET,
    Capability.WRITE_CREATIVE,    Capability.WRITE_CAMPAIGN_STATUS,
    Capability.WRITE_AUDIENCES,
})
```

**Notable differences from P1-09 (google_ads)**:
- `READ_AUDIENCES` / `WRITE_AUDIENCES` are **declared** here (Meta has rich Custom + Lookalike audience APIs). Google adapter omits these (no audience mixin upstream).
- `READ_KEYWORDS` / `WRITE_KEYWORDS` are **omitted** (Meta has no search keywords).
- `READ_EXTENSIONS` / `WRITE_EXTENSIONS` are **omitted** (Meta has no sitelinks/callouts).
- `WRITE_BID` omitted in both adapters — Phase 1 deferred.

### Adapter package layout

```
mureo/adapters/meta_ads/
├── __init__.py       # ABI-locked re-exports
├── adapter.py        # 507 LOC — MetaAdsAdapter
├── mappers.py        # 307 LOC — dict → frozen dataclass converters
└── errors.py         # 49 LOC — MetaAdsAdapterError + UnsupportedOperation
```

### AdSet hierarchy hidden

Meta has Campaign → AdSet → Ad. The Protocol assumes Campaign → Ad directly. The adapter hides AdSet inside `list_ads`:

```python
def list_ads(self, campaign_id):
    ad_sets = self._run(self._client.list_ad_sets(campaign_id=campaign_id, ...))
    ads = []
    for ad_set in ad_sets:
        ads.extend(self._run(self._client.list_ads(ad_set_id=ad_set["id"], ...)))
    return _map_ads(ads, ...)
```

Cost: N+1 calls per campaign. Acceptable for Phase 1; Phase 2 can batch via `asyncio.gather`.

### Existing client edit (additive only)

Single addition to `mureo/meta_ads/_insights.py`:

```python
async def insights_time_range(
    self, node_id: str, *, since: str, until: str,
    time_increment: int = 1, level: str = "campaign",
) -> list[dict[str, Any]]:
    """Public insights surface with explicit since/until (adapter use)."""
```

Mirrors P1-09's `search_gaql` pattern. `_insights.py` is a private mixin file, but the method is auto-exposed via `MetaAdsApiClient` mixin inheritance — adapter consumes through `client.insights_time_range(...)`, not via direct mixin import. Encapsulation rule preserved (AST scan locks this).

### UnsupportedOperation contract

- `create_campaign(start_date|end_date|bidding_strategy=...)` — Phase 1 deferred
- `create_ad(headlines length != 1)` — Phase 1 hack: `headlines[0]` is interpreted as `creative_id`
- `update_ad(headlines|descriptions|final_urls|path1|path2=...)` — Meta cannot mutate live creatives without recreation
- `set_audience_status(audience_id, ENABLED)` — Meta has no enable; only delete

### Encapsulation rule (AST-enforced)

Production adapter modules import only from:
- `mureo.core.providers.{base, capabilities, models, registry}` (foundation)
- `mureo.meta_ads.client` (public surface)
- `mureo.meta_ads.mappers` (existing dict mappers)

Direct import of `mureo.meta_ads._*` mixins is **forbidden** and tested by `test_imports.py`.

## Stacked on PR #95

`feat/p1-10-meta-ads-adapter` → `feat/p1-09-google-ads-adapter` → `feat/p1-08-skill-matcher` → `feat/p1-07-entry-points-registry` → `feat/p1-03-to-06-domain-protocols` → `feat/p1-02-base-provider` → `feat/p1-01-capabilities` → `main`. Merge order: #90 → #91 → #92 → #93 → #94 → #95 → this PR.

## Test plan

- [x] `pytest tests/adapters/meta_ads/` — 92/92 passed
- [x] `pytest tests/core/ tests/adapters/google_ads/` — 397/397 regression
- [x] Coverage `mureo/adapters/meta_ads/`: 90.65% (adapter.py 93%, mappers.py 86%)
- [x] `ruff check mureo/adapters/ mureo/meta_ads/ tests/adapters/` — clean
- [x] `black --check` — clean
- [x] `mypy mureo/adapters/meta_ads/` — clean
- [x] python-reviewer agent: **APPROVE** (0 CRITICAL/HIGH/MEDIUM; 3 LOW deferred to P2)

## Follow-ups (deferred — file as P2 issues)

### Reviewer LOWs

- [ ] **P2-ADAPTER-13**: Replace `asyncio.run` per-call with `asyncio.gather` for `list_ads` N+1 batching.
- [ ] **P2-ADAPTER-14**: Tighten `_run` parameter type to `Coroutine[Any, Any, _T]` and drop the `# type: ignore[arg-type]`.
- [ ] **P2-ADAPTER-15**: Promote `MetaAdsApiClient._ad_account_id` → public `account_id` property (clean up the `# noqa: SLF001` in `_account_id`).

### Phase 1 deferrals (intentional, documented in adapter)

- [ ] **P2-ADAPTER-16**: Surface `objective` on `CreateCampaignRequest`; remove `OUTCOME_TRAFFIC` hardcode.
- [ ] **P2-ADAPTER-17**: Surface `country`/`ratio` on `CreateAudienceRequest`; remove Lookalike `JP`/`0.01` hardcode.
- [ ] **P2-ADAPTER-18**: Wire `create_campaign(start_date|end_date)` once client supports them.
- [ ] **P2-ADAPTER-19**: Surface `bidding_strategy` on Meta create/update once Meta side supports the corresponding strategy.
- [ ] **P2-ADAPTER-20**: Pre-fetch the audience snapshot before `delete_custom_audience` to preserve `name`/`size_estimate` in the return value of `set_audience_status(REMOVED)`.

## Refs

Closes part of #89 (Phase 1 P1-10). Next: **P1-11** (docs: plugin author guide + ABI stability promise) — the final Phase 1 subtask.
