### PR TITLE
fix(byod): anchor demo/BYOD relative windows on the dataset, not today

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — BYOD/demo relative windows silently went empty over time
+- The CSV-backed BYOD/demo clients resolved relative MCP query windows (`LAST_7_DAYS`, …) against `date.today()`. The demo dataset has fixed historical dates, so as wall-clock time moved past it the demo silently returned `[]` — `LAST_7_DAYS` first, then every window — making Meta insights / anomaly checks / Search Console appear broken even though the data was present.
+- `_period_to_range` now accepts an optional `anchor`; the BYOD/demo metrics readers anchor relative windows on the **dataset's own latest date** (same span, ending at the most recent available day) so the demo stays non-empty regardless of the current date. `anchor=None` preserves the exact legacy wall-clock behaviour, so live-API and non-demo callers are completely unaffected.
+
 ### Added — `mureo providers` CLI (Issue #86, Phase 1: Claude Code)
 - **`mureo providers list / add / remove`** — one-command install of the official platform MCP servers into Claude Code's `~/.claude/settings.json`. mureo owns both package acquisition and config registration. `add` is idempotent; `add --all` installs every catalog entry and continues past per-provider failures (non-zero exit overall). `--dry-run` prints the planned `pipx`/`npm` argv (or, for hosted endpoints, the "no local install step" notice) plus the JSON delta without touching disk or subprocess. `remove` only edits the settings file (it does not uninstall the underlying pipx/npm package; no-op for hosted-HTTP entries which have none).
 - Phase 1 catalog (3 entries):

--- a/mureo/byod/clients.py
+++ b/mureo/byod/clients.py
@@ -66,20 +66,54 @@ def _parse_date(v: str) -> date | None:
         return None
 
 
-def _period_to_range(period: str) -> tuple[date, date]:
-    today = date.today()
-    if period == "LAST_7_DAYS":
+def _max_date(rows: list[dict[str, Any]], key: str = "date") -> date | None:
+    """Latest parseable ``key`` value across ``rows`` (``None`` if none)."""
+    best: date | None = None
+    for r in rows:
+        d = _parse_date(r.get(key, ""))
+        if d is not None and (best is None or d > best):
+            best = d
+    return best
+
+
+def _period_to_range(period: str, *, anchor: date | None = None) -> tuple[date, date]:
+    """Resolve a relative ``period`` to a concrete ``(start, end)``.
+
+    ``anchor=None`` preserves the legacy wall-clock behaviour (windows
+    end *yesterday* relative to ``date.today()``) — unchanged for any
+    caller that does not opt in.
+
+    When ``anchor`` is given (the BYOD/demo dataset's own latest date),
+    the window is rebased to END at ``anchor`` with the same span, so a
+    fixed historical demo dataset keeps returning its most-recent N days
+    no matter how far wall-clock time has drifted past it. ``YESTERDAY``
+    / ``TODAY`` collapse to the anchor day itself (the latest data we
+    have). This is what stops the demo silently going empty over time.
+    """
+    if anchor is None:
+        today = date.today()
+        if period == "LAST_14_DAYS":
+            return today - timedelta(days=14), today - timedelta(days=1)
+        if period == "LAST_30_DAYS":
+            return today - timedelta(days=30), today - timedelta(days=1)
+        if period == "YESTERDAY":
+            d = today - timedelta(days=1)
+            return d, d
+        if period == "TODAY":
+            return today, today
+        # LAST_7_DAYS and the default fall-through.
         return today - timedelta(days=7), today - timedelta(days=1)
-    if period == "LAST_14_DAYS":
-        return today - timedelta(days=14), today - timedelta(days=1)
-    if period == "LAST_30_DAYS":
-        return today - timedelta(days=30), today - timedelta(days=1)
-    if period == "YESTERDAY":
-        d = today - timedelta(days=1)
-        return d, d
-    if period == "TODAY":
-        return today, today
-    return today - timedelta(days=7), today - timedelta(days=1)
+
+    span = {
+        "LAST_7_DAYS": 7,
+        "LAST_14_DAYS": 14,
+        "LAST_30_DAYS": 30,
+    }.get(period)
+    if span is not None:
+        return anchor - timedelta(days=span - 1), anchor
+    if period in ("YESTERDAY", "TODAY"):
+        return anchor, anchor
+    return anchor - timedelta(days=6), anchor  # default: last 7 days
 
 
 # Verb prefixes that should never silently no-op in BYOD mode.
@@ -322,8 +356,8 @@ class ByodGoogleAdsClient:
         period: str = "LAST_30_DAYS",
         **_: Any,
     ) -> list[dict[str, Any]]:
-        start, end = _period_to_range(period)
         rows = self._metrics()
+        start, end = _period_to_range(period, anchor=_max_date(rows))
         if campaign_id:
             rows = [r for r in rows if r.get("campaign_id") == str(campaign_id)]
         agg = self._aggregate_metrics(rows, start, end, group_by="campaign_id")
@@ -639,8 +673,8 @@ class ByodMetaAdsClient:
         period: str = "LAST_30_DAYS",
         **_: Any,
     ) -> list[dict[str, Any]]:
-        start, end = _period_to_range(period)
         rows = self._metrics()
+        start, end = _period_to_range(period, anchor=_max_date(rows))
         if campaign_id:
             rows = [r for r in rows if r.get("campaign_id") == str(campaign_id)]
 
@@ -722,8 +756,8 @@ class ByodMetaAdsClient:
         impressions / clicks / spend / conversions / reach / frequency
         / result_indicator for a single (date, campaign).
         """
-        start, end = _period_to_range(period)
         rows = self._metrics()
+        start, end = _period_to_range(period, anchor=_max_date(rows))
         if campaign_id:
             rows = [r for r in rows if r.get("campaign_id") == str(campaign_id)]
         out: list[dict[str, Any]] = []
@@ -755,8 +789,8 @@ class ByodMetaAdsClient:
     ) -> list[dict[str, Any]]:
         """Per-day ad-set metrics — populated when the source export
         has Ad set name + Day breakdown. Empty list when absent."""
-        start, end = _period_to_range(period)
         rows = self._ad_set_metrics()
+        start, end = _period_to_range(period, anchor=_max_date(rows))
         if campaign_id:
             rows = [r for r in rows if r.get("campaign_id") == str(campaign_id)]
         if ad_set_id:
@@ -789,8 +823,8 @@ class ByodMetaAdsClient:
     ) -> list[dict[str, Any]]:
         """Per-day per-ad metrics — populated when the source export
         has Ad name + Day breakdown. Empty list when absent."""
-        start, end = _period_to_range(period)
         rows = self._ad_metrics()
+        start, end = _period_to_range(period, anchor=_max_date(rows))
         if ad_set_id:
             rows = [r for r in rows if r.get("ad_set_id") == str(ad_set_id)]
         if ad_id:
@@ -828,8 +862,8 @@ class ByodMetaAdsClient:
         ``dimension`` filters to a single breakdown axis when set.
         Empty list when the source export carried no breakdown columns.
         """
-        start, end = _period_to_range(period)
         rows = self._demographics()
+        start, end = _period_to_range(period, anchor=_max_date(rows))
         if campaign_id:
             rows = [r for r in rows if r.get("campaign_id") == str(campaign_id)]
         if dimension:

--- a/tests/test_byod_date_rebase.py
+++ b/tests/test_byod_date_rebase.py
@@ -1,0 +1,146 @@
+"""Unit tests: BYOD/demo relative windows rebase onto the dataset.
+
+The demo/BYOD dataset has fixed historical dates. The MCP tools query
+relative windows ("LAST_7_DAYS" etc.). Anchoring those on
+``date.today()`` (the pre-fix behaviour) makes the demo silently return
+``[]`` as wall-clock time moves past the dataset — exactly the reported
+symptom. The read clients must instead anchor relative windows on the
+dataset's own latest date so the demo is immune to date drift.
+
+``@pytest.mark.unit``; all FS via ``tmp_path``.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# _period_to_range anchor semantics
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestPeriodToRangeAnchor:
+    def test_anchor_none_preserves_legacy_today_behaviour(self) -> None:
+        from mureo.byod.clients import _period_to_range
+
+        today = date.today()
+        assert _period_to_range("LAST_7_DAYS") == (
+            today - timedelta(days=7),
+            today - timedelta(days=1),
+        )
+        assert _period_to_range("LAST_30_DAYS", anchor=None) == (
+            today - timedelta(days=30),
+            today - timedelta(days=1),
+        )
+
+    def test_anchor_rebases_window_end_to_anchor(self) -> None:
+        from mureo.byod.clients import _period_to_range
+
+        anchor = date(2026, 4, 25)
+        assert _period_to_range("LAST_7_DAYS", anchor=anchor) == (
+            date(2026, 4, 19),
+            anchor,
+        )
+        assert _period_to_range("LAST_30_DAYS", anchor=anchor) == (
+            date(2026, 3, 27),
+            anchor,
+        )
+
+    def test_yesterday_today_collapse_to_anchor(self) -> None:
+        from mureo.byod.clients import _period_to_range
+
+        anchor = date(2026, 4, 25)
+        assert _period_to_range("YESTERDAY", anchor=anchor) == (anchor, anchor)
+        assert _period_to_range("TODAY", anchor=anchor) == (anchor, anchor)
+
+
+# ---------------------------------------------------------------------------
+# Clients rebase a stale dataset so windows are non-empty
+# ---------------------------------------------------------------------------
+
+
+_FAR_PAST_END = date(2026, 4, 25)  # well before any plausible test "today"
+
+
+def _google_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "g"
+    _write(
+        d / "campaigns.csv",
+        "campaign_id,name,status,objective,daily_budget_jpy,start_date\n"
+        "1,Demo Camp,ENABLED,SALES,5000,2026-03-01\n",
+    )
+    # 10 consecutive days ending 2026-04-25 (stale relative to today).
+    lines = ["date,campaign_id,ad_group_id,impressions,clicks,cost_jpy,conversions"]
+    for i in range(10):
+        day = _FAR_PAST_END - timedelta(days=i)
+        lines.append(f"{day.isoformat()},1,11,1000,50,3000,2.0")
+    _write(d / "metrics_daily.csv", "\n".join(lines) + "\n")
+    return d
+
+
+def _meta_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "m"
+    _write(
+        d / "campaigns.csv",
+        "campaign_id,name,status,objective,daily_budget_jpy,start_date\n"
+        "9,Demo Meta,ACTIVE,OUTCOME_LEADS,4000,2026-03-01\n",
+    )
+    lines = ["date,campaign_id,ad_set_id,impressions,clicks,cost_jpy,conversions"]
+    for i in range(10):
+        day = _FAR_PAST_END - timedelta(days=i)
+        lines.append(f"{day.isoformat()},9,99,2000,80,5000,4.0")
+    _write(d / "metrics_daily.csv", "\n".join(lines) + "\n")
+    return d
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_google_perf_report_non_empty_despite_stale_dates(
+    tmp_path: Path,
+) -> None:
+    from mureo.byod.clients import ByodGoogleAdsClient
+
+    client = ByodGoogleAdsClient(_google_dir(tmp_path))
+    # LAST_7_DAYS would be empty under today-anchored filtering (data ends
+    # 2026-04-25). Rebased on the dataset it must return data.
+    rows = await client.get_performance_report(period="LAST_7_DAYS")
+    assert rows, "stale demo data must still return the last 7 dataset days"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_meta_metrics_daily_non_empty_despite_stale_dates(
+    tmp_path: Path,
+) -> None:
+    from mureo.byod.clients import ByodMetaAdsClient
+
+    client = ByodMetaAdsClient(_meta_dir(tmp_path))
+    rows = await client.get_metrics_daily(period="LAST_7_DAYS")
+    assert rows, "stale Meta demo data must still return the last 7 days"
+    # Window must be the dataset's last 7 days, not wall-clock anchored.
+    days = sorted({r["date"] for r in rows})
+    assert days[-1] == _FAR_PAST_END.isoformat()
+    assert len(days) == 7
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_meta_get_performance_report_non_empty(tmp_path: Path) -> None:
+    from mureo.byod.clients import ByodMetaAdsClient
+
+    client = ByodMetaAdsClient(_meta_dir(tmp_path))
+    rows = await client.get_performance_report(period="LAST_30_DAYS")
+    assert rows


### PR DESCRIPTION
## Summary

The CSV-backed BYOD/demo clients resolved relative MCP query windows (`LAST_7_DAYS`, `LAST_30_DAYS`, …) against `date.today()`. The demo dataset ships **fixed historical dates**, so as wall-clock time moves past it the demo silently returns `[]` — `LAST_7_DAYS` first, then eventually **every** window — making Meta insights / anomaly checks / Search Console look broken even though the data is present.

### Fix
- `_period_to_range(period, *, anchor=None)`:
  - `anchor=None` → **exact legacy wall-clock behaviour** (windows end yesterday relative to `today`). Live-API / non-demo callers are completely unaffected.
  - `anchor` given (the dataset's own latest date) → window rebased to **end at that date with the same span**, so a fixed historical demo keeps returning its most-recent N days regardless of the current date.
- New `_max_date(rows, key="date")` helper (latest parseable date; `None` if none → safe legacy fallback).
- All six metrics readers (Google `get_performance_report`; Meta `get_performance_report` / `get_metrics_daily` / `get_ad_set_insights_daily` / `get_ad_insights_daily` / `get_breakdown_report`) compute the anchor from the **full metric file before any campaign/ad filtering**, so every entity shares one window.

### Out of scope (follow-up)
Demo dataset *completeness* (Meta ad-set/ad-level metrics, demographics, creatives; Search Console property aligned to STRATEGY; longer history for anomaly baselines) is a separate concern, not addressed here.

## Test plan
- [x] New `tests/test_byod_date_rebase.py` — anchor semantics + stale-dataset non-empty (Google/Meta)
- [x] Full suite **2447 passed, 0 failed**
- [x] `ruff check mureo/` + `black --check mureo/` clean
- [x] code-reviewer agent: **APPROVE** (no CRITICAL/HIGH/new MEDIUM; legacy path byte-identical, no off-by-one, robust to malformed dates)
