### PR TITLE
chore(release): v0.9.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mureo",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Your local-first AI ad ops crew for Google Ads, Meta Ads, Search Console & GA4. mureo sits on top of the official ad-platform MCPs, gates every change against your strategy, correlates outcomes locally, and keeps an auditable decision log — credentials never leave your machine.",
   "author": {
     "name": "Logly Inc.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-05-16
+
+### Fixed — `/learn` slash command restored (regression from #77)
+- Phase 3 plugin packaging (#77) migrated every `.claude/commands/*.md` slash command into an operational skill under `skills/` + the bundled `mureo/_data/skills/`, but **dropped `learn` entirely** (deleted `.claude/commands/learn.md`, never created a `learn` skill). `/learn` became uninvocable while every other workflow command kept working, even though README/docs still document it. Restored as an operational skill (`skills/learn/` + byte-identical bundled copy): `name: learn` (no `_` prefix → appears in the picker), saves insights to `../_mureo-pro-diagnosis/SKILL.md` (scaffolding that canonical-only knowledge base on first use), approval-required and append-only, never Claude memory or secrets/PII.
+
+### Changed — `mureo configure` visual refresh + official mureo logo
+- The configure Web UI got a cohesive design-system pass (refined spacing/type/color tokens, light **and** dark via `prefers-color-scheme`, crafted cards/buttons/focus states, system fonts only — strict CSP, no web fonts/CDN/build). The header now shows the official mureo wordmark (bundled `logo.png` / `logo-dark.png`, scheme-swapped). CSS-only; every `data-*` / `data-i18n` hook and EN/JA parity preserved.
+
+### Added — Google Ads OAuth-scope guidance in the auth step
+- The Web UI Google Ads auth step and `docs/authentication.md` now explain that a reused refresh token **must** carry the Google Ads scope `https://www.googleapis.com/auth/adwords` or API calls fail with `ACCESS_TOKEN_SCOPE_INSUFFICIENT`, with a link to the official Google scope reference. mureo's own OAuth already requests it; the note prevents the failure when users supply a hand-minted token.
+
 ### Fixed — Meta hosted MCP on Claude Code goes through the Claude.ai connector (supersedes the earlier "/mcp register" Unreleased note)
 - A prior Unreleased change had `mureo configure` / `mureo providers add` / the wizard **register** `meta-ads-official` into `~/.claude.json` on Claude Code and tell the user to finish OAuth via `/mcp` → Authenticate. Real-environment verification proved this **cannot work**: Meta's hosted MCP (`https://mcp.facebook.com/ads`) does **not** support OAuth Dynamic Client Registration, so Claude Code's `/mcp` OAuth fails with `SDK auth failed: The provided redirect_uris are not registered for this client`. Registering it locally only creates an unauthenticatable user-scope server. Corrected behavior: on Claude Code, mureo now **does not register Meta locally at all** — `install_provider` / `mureo providers add` return `manual_required` (no `~/.claude.json` write, no subprocess) and the UI/CLI point the user to add Meta as a **Claude.ai account connector** (claude.ai → Settings → Connectors → Add custom connector → `https://mcp.facebook.com/ads`; Anthropic brokers the Meta Business sign-in there, requires a paid plan, then works account-wide in Claude Code *and* Claude Desktop and surfaces as `mcp__claude_ai_MetaAds__*`). mureo-native Meta is still **not** auto-disabled (nothing registered/verified — native steps aside only via `mureo providers confirm` once the connector is verified Connected; no-strand preserved). Claude **Desktop** is unchanged (`manual_required`, Settings → Connectors). This re-aligns with the "no dead config entry / Connectors" behavior described in the bullets below; the intervening "/mcp register on Code" wording is withdrawn.
 

--- a/mureo/__init__.py
+++ b/mureo/__init__.py
@@ -1,3 +1,3 @@
 """mureo — your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."""
 
-__version__ = "0.7.1"
+__version__ = "0.9.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mureo"
-version = "0.8.0"
+version = "0.9.0"
 description = "Your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."
 requires-python = ">=3.10"
 license = "Apache-2.0"
@@ -12,7 +12,7 @@ readme = "README.md"
 authors = [{name = "Logly, Inc."}]
 keywords = ["advertising", "google-ads", "meta-ads", "mcp", "cli", "ai-agent", "orchestration", "workflow", "strategy"]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
Release **v0.9.0** (minor; Development Status Alpha → **Beta**).

## Version
- `pyproject.toml` 0.8.0 → 0.9.0; classifier `3 - Alpha` → `4 - Beta`
- `mureo/__init__.py` `__version__` 0.7.1 → 0.9.0 (was stale/mismatched — synced)
- `.claude-plugin/plugin.json` 0.8.0 → 0.9.0
- `CHANGELOG.md` `[Unreleased]` → `[0.9.0] - 2026-05-16` + entries for the `/learn` restore (#105), configure UI visual refresh + official logo, and Google Ads OAuth-scope guidance

## Highlights
`mureo configure` Web UI (Phase 1) + visual refresh & official logo · `mureo providers` CLI · plugin→MCP tool exposure · Meta on Claude Code via the Claude.ai connector · `/learn` restored · BYOD/demo date-anchor fix.

## Verification
- full suite **3209 passed**
- `python -m build` + `twine check` **PASSED** (0.9.0 wheel + sdist)
- plugin manifest version-match test green

On merge: tag `v0.9.0` → GitHub Release → `release.yml` auto-publishes to PyPI (Trusted Publisher).