### PR TITLE
chore: add .mailmap to fold the Claude co-author identity

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,9 @@
+# Canonicalize commit/co-author identities for git shortlog, blame, and
+# the GitHub contributors graph (all honor .mailmap).
+#
+# A few early commits carried a `Co-Authored-By: Claude … <noreply@anthropic.com>`
+# trailer (Claude Code attribution, since disabled). The human author is
+# the maintainer; fold that co-author identity into the canonical one so
+# tooling does not list a spurious "claude" contributor. No history is
+# rewritten — this only affects how identities are displayed.
+Hirokazu Yoshinaga <4027404+hyoshi@users.noreply.github.com> <noreply@anthropic.com>


### PR DESCRIPTION
## Why
GitHub's contributors graph listed a `claude` contributor. Cause: a few early commits (e.g. PR #100) carried a `Co-Authored-By: Claude … <noreply@anthropic.com>` trailer; GitHub counts co-authors. No commit is *authored* by Claude.

## Fix (non-destructive)
Add `.mailmap` mapping `<noreply@anthropic.com>` → the maintainer's canonical identity. `git shortlog`/`blame` and the **GitHub contributors graph all honor .mailmap**, so the spurious contributor disappears with **no history rewrite** — tags, the v0.9.0 GitHub Release, and PyPI are completely untouched.

Verified locally: `git check-mailmap "Claude Opus 4.7 (1M context) <noreply@anthropic.com>"` → `Hirokazu Yoshinaga <…@users.noreply.github.com>`; `git shortlog -sne --all` no longer lists claude/anthropic.

## Future prevention
`~/.claude/settings.json` → `includeCoAuthoredBy: false` (separate, user-global) so new commits/PRs never add the trailer.