### PR TITLE
chore: remove .mailmap (ineffective for the goal)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,9 +1,0 @@
-# Canonicalize commit/co-author identities for git shortlog, blame, and
-# the GitHub contributors graph (all honor .mailmap).
-#
-# A few early commits carried a `Co-Authored-By: Claude … <noreply@anthropic.com>`
-# trailer (Claude Code attribution, since disabled). The human author is
-# the maintainer; fold that co-author identity into the canonical one so
-# tooling does not list a spurious "claude" contributor. No history is
-# rewritten — this only affects how identities are displayed.
-Hirokazu Yoshinaga <4027404+hyoshi@users.noreply.github.com> <noreply@anthropic.com>


### PR DESCRIPTION
`.mailmap` was added in #107 to drop the spurious `claude` contributor from the GitHub graph. In practice GitHub does **not** remap `Co-authored-by:` trailer attribution via `.mailmap`, so it had no effect. Decision was to accept the single legacy co-author trailer (#100) as-is and prevent future attribution at the source (`~/.claude/settings.json`: `includeCoAuthoredBy: false` + empty `attribution.commit/pr`). Removing the dead file. No history rewrite; tags/release/PyPI untouched.