### PR TITLE
fix(configure): free the terminal on finish / Ctrl+C (stop event + signals)

### DIFF
--- a/mureo/_data/web/i18n.json
+++ b/mureo/_data/web/i18n.json
@@ -185,7 +185,9 @@
     "dashboard.byod_mode_not_configured": "Not configured",
     "auth_wizard.google.already_authenticated": "Already authenticated for Google (Search Console / Google Ads shared scope).",
     "auth_wizard.google_ads.scope_note": "Use the “Authenticate with Google” button below — mureo requests the required Google Ads scope (https://www.googleapis.com/auth/adwords) plus Search Console automatically. If you instead reuse a refresh token minted elsewhere, it MUST include the Google Ads (AdWords) scope, or API calls fail with ACCESS_TOKEN_SCOPE_INSUFFICIENT. Official scope reference:",
-    "auth_wizard.google_ads.scope_doc_link": "Google Ads API — OAuth 2.0 scopes (official docs)"
+    "auth_wizard.google_ads.scope_doc_link": "Google Ads API — OAuth 2.0 scopes (official docs)",
+    "wizard.completed.finish_button": "Finish & free the terminal",
+    "wizard.completed.finished_note": "Done — the mureo configure server has stopped and your terminal is free. You can close this tab."
   },
   "ja": {
     "nav.dashboard": "ダッシュボード",
@@ -373,6 +375,8 @@
     "dashboard.byod_mode_not_configured": "未設定",
     "auth_wizard.google.already_authenticated": "Google は認証済みです（Search Console / Google Ads 共通スコープ）。",
     "auth_wizard.google_ads.scope_note": "下の「Authenticate with Google」ボタンを使ってください — mureo は必要な Google Ads スコープ（https://www.googleapis.com/auth/adwords）と Search Console を自動的に要求します。他で発行した refresh token を流用する場合は、Google Ads（AdWords）スコープを必ず含めてください。含まないと API 呼び出しが ACCESS_TOKEN_SCOPE_INSUFFICIENT で失敗します。公式スコープ説明:",
-    "auth_wizard.google_ads.scope_doc_link": "Google Ads API — OAuth 2.0 スコープ（公式ドキュメント）"
+    "auth_wizard.google_ads.scope_doc_link": "Google Ads API — OAuth 2.0 スコープ（公式ドキュメント）",
+    "wizard.completed.finish_button": "終了してターミナルを解放",
+    "wizard.completed.finished_note": "完了 — mureo configure サーバを停止しました。ターミナルは解放されています。このタブは閉じて構いません。"
   }
 }

--- a/mureo/_data/web/wizard.js
+++ b/mureo/_data/web/wizard.js
@@ -458,6 +458,34 @@
       MUREO.navigateToDashboard();
     });
     wrap.appendChild(btn);
+
+    // Free the terminal: the CLI blocks until the user finishes (or
+    // --timeout-seconds). This button POSTs /api/shutdown so the
+    // `mureo configure` process exits immediately instead of leaving
+    // the terminal "stuck".
+    const finishBtn = document.createElement("button");
+    finishBtn.type = "button";
+    finishBtn.className = "btn btn-secondary";
+    finishBtn.style.marginLeft = "8px";
+    finishBtn.textContent = MUREO.t("wizard.completed.finish_button");
+    finishBtn.setAttribute("data-i18n", "wizard.completed.finish_button");
+    const finishNote = document.createElement("p");
+    finishNote.className = "dashboard-provider-hosted-note";
+    finishNote.hidden = true;
+    finishNote.setAttribute("data-i18n", "wizard.completed.finished_note");
+    finishBtn.addEventListener("click", async function () {
+      finishBtn.disabled = true;
+      try {
+        await MUREO.postJson("/api/shutdown", {});
+      } catch (_e) {
+        // The server may close the socket before the response is read;
+        // that's success, not failure — fall through to the note.
+      }
+      finishNote.hidden = false;
+      finishNote.textContent = MUREO.t("wizard.completed.finished_note");
+    });
+    wrap.appendChild(finishBtn);
+    wrap.appendChild(finishNote);
     return wrap;
   }
 

--- a/mureo/cli/configure_cmd.py
+++ b/mureo/cli/configure_cmd.py
@@ -26,7 +26,11 @@ def configure(
     timeout_seconds: float = typer.Option(
         600.0,
         "--timeout-seconds",
-        help="Stop the server after this many seconds of inactivity.",
+        help=(
+            "Hard cap: auto-stop after this many seconds even if you "
+            "never finish. Normally it exits the moment you finish in "
+            "the browser or press Ctrl+C."
+        ),
     ),
 ) -> None:
     """Open the local mureo configuration UI in a browser."""

--- a/mureo/web/handlers.py
+++ b/mureo/web/handlers.py
@@ -448,6 +448,17 @@ class ConfigureHandler(BaseHTTPRequestHandler):
     def _post_byod_clear(self, payload: dict[str, Any]) -> None:  # noqa: ARG002
         send_json(self, byod_clear().as_dict())
 
+    def _post_shutdown(self, payload: dict[str, Any]) -> None:  # noqa: ARG002
+        """Stop the configure server so the terminal is freed.
+
+        The user finished in the browser; ask the CLI loop to return
+        instead of blocking until ``--timeout-seconds``. Reply first,
+        then signal — the response still flushes because the daemon
+        request thread outlives ``serve_forever`` returning.
+        """
+        send_json(self, {"status": "stopping"})
+        self.wizard.request_stop()
+
     def _post_pick_directory(self, payload: dict[str, Any]) -> None:
         title = str(payload.get("title", "Select a folder"))
         send_json(self, pick_directory(title=title).as_dict())
@@ -500,6 +511,7 @@ class ConfigureHandler(BaseHTTPRequestHandler):
         "/api/byod/import": _post_byod_import,
         "/api/byod/remove": _post_byod_remove,
         "/api/byod/clear": _post_byod_clear,
+        "/api/shutdown": _post_shutdown,
         "/api/pick/directory": _post_pick_directory,
         "/api/pick/file": _post_pick_file,
     }

--- a/mureo/web/server.py
+++ b/mureo/web/server.py
@@ -194,7 +194,7 @@ def run_configure_wizard(
     # thread) where bare KeyboardInterrupt delivery is not. Signal
     # handlers can only be registered from the main thread, so degrade
     # gracefully (e.g. under pytest) to a plain timed wait.
-    prev_handlers: dict[int, object] = {}
+    prev_handlers: list[tuple[int, object]] = []
 
     def _on_signal(_signum: int, _frame: object) -> None:
         wizard.request_stop()
@@ -202,15 +202,15 @@ def run_configure_wizard(
     try:
         for sig in (signal.SIGINT, signal.SIGTERM):
             with contextlib.suppress(ValueError, OSError):
-                prev_handlers[sig] = signal.signal(sig, _on_signal)
+                prev_handlers.append((sig, signal.signal(sig, _on_signal)))
         wizard.stop_event.wait(timeout=timeout_seconds)
     except KeyboardInterrupt:
         # Belt-and-braces: if a KeyboardInterrupt still surfaces (e.g.
         # the handler could not be installed), treat it as a stop.
         pass
     finally:
-        for sig, prev in prev_handlers.items():
+        for signum, prev in prev_handlers:
             with contextlib.suppress(ValueError, OSError):
-                signal.signal(sig, prev)  # type: ignore[arg-type]
+                signal.signal(signum, prev)  # type: ignore[arg-type]
         wizard.shutdown()
         thread.join(timeout=2.0)

--- a/mureo/web/server.py
+++ b/mureo/web/server.py
@@ -11,9 +11,9 @@ from __future__ import annotations
 import contextlib
 import http.server
 import logging
+import signal
 import socketserver
 import threading
-import time
 import webbrowser
 from importlib import resources
 from pathlib import Path
@@ -76,6 +76,7 @@ class ConfigureWizard:
 
         self._server: _ConfigureServer | None = None
         self._ready = threading.Event()
+        self._stop = threading.Event()
         self._lock = threading.Lock()
 
     # ------------------------------------------------------------------
@@ -126,6 +127,20 @@ class ConfigureWizard:
         if not self._ready.wait(timeout=timeout):
             raise TimeoutError("configure wizard failed to bind within timeout")
 
+    @property
+    def stop_event(self) -> threading.Event:
+        """Set when the CLI loop should stop serving and exit."""
+        return self._stop
+
+    def request_stop(self) -> None:
+        """Ask ``run_configure_wizard`` to stop serving and return.
+
+        Called from a SIGINT/SIGTERM handler or the ``/api/shutdown``
+        route so the terminal is freed the moment the user finishes (or
+        presses Ctrl+C) instead of blocking until ``timeout_seconds``.
+        """
+        self._stop.set()
+
     def shutdown(self) -> None:
         with self._lock:
             server = self._server
@@ -171,10 +186,31 @@ def run_configure_wizard(
         with contextlib.suppress(Exception):
             webbrowser.open(url)
 
-    deadline = time.monotonic() + timeout_seconds
+    # Stop the moment the user finishes (UI POSTs /api/shutdown ->
+    # request_stop), presses Ctrl+C (SIGINT) or the process is asked to
+    # terminate (SIGTERM); fall back to timeout_seconds as a hard cap.
+    # An explicit signal handler that sets the stop Event is reliable in
+    # this multi-threaded process (the HTTP server runs on a daemon
+    # thread) where bare KeyboardInterrupt delivery is not. Signal
+    # handlers can only be registered from the main thread, so degrade
+    # gracefully (e.g. under pytest) to a plain timed wait.
+    prev_handlers: dict[int, object] = {}
+
+    def _on_signal(_signum: int, _frame: object) -> None:
+        wizard.request_stop()
+
     try:
-        while time.monotonic() < deadline:
-            time.sleep(0.5)
+        for sig in (signal.SIGINT, signal.SIGTERM):
+            with contextlib.suppress(ValueError, OSError):
+                prev_handlers[sig] = signal.signal(sig, _on_signal)
+        wizard.stop_event.wait(timeout=timeout_seconds)
+    except KeyboardInterrupt:
+        # Belt-and-braces: if a KeyboardInterrupt still surfaces (e.g.
+        # the handler could not be installed), treat it as a stop.
+        pass
     finally:
+        for sig, prev in prev_handlers.items():
+            with contextlib.suppress(ValueError, OSError):
+                signal.signal(sig, prev)  # type: ignore[arg-type]
         wizard.shutdown()
         thread.join(timeout=2.0)

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -245,6 +245,80 @@ class TestRunConfigureWizardCli:
 
 
 @pytest.mark.unit
+class TestStopLifecycle:
+    """``request_stop`` / ``/api/shutdown`` free the terminal instead of
+    blocking until ``--timeout-seconds`` (regression: closing the
+    browser left the CLI hung for up to 10 minutes; Ctrl+C unreliable)."""
+
+    def test_request_stop_sets_event(self, home_dir: Path) -> None:
+        wiz = ConfigureWizard(home=home_dir)
+        assert not wiz.stop_event.is_set()
+        wiz.request_stop()
+        assert wiz.stop_event.is_set()
+
+    def test_run_configure_wizard_returns_immediately_when_stopped(
+        self, home_dir: Path
+    ) -> None:
+        """With a 60s cap, ``request_stop()`` must end the CLI loop in
+        well under a second — not wait out the timeout."""
+        captured: dict[str, ConfigureWizard] = {}
+        real_ctor = ConfigureWizard
+
+        def _spy(**kwargs: object) -> ConfigureWizard:
+            wiz = real_ctor(**kwargs)  # type: ignore[arg-type]
+            captured["wiz"] = wiz
+            return wiz
+
+        with (
+            patch("mureo.web.server.webbrowser.open"),
+            patch("mureo.web.server.ConfigureWizard", side_effect=_spy),
+        ):
+            thread = threading.Thread(
+                target=run_configure_wizard,
+                kwargs={
+                    "home": home_dir,
+                    "open_browser": False,
+                    "timeout_seconds": 60.0,
+                },
+                daemon=True,
+            )
+            thread.start()
+            for _ in range(50):
+                if "wiz" in captured:
+                    break
+                time.sleep(0.05)
+            captured["wiz"].wait_until_ready(timeout=5.0)
+
+            start = time.monotonic()
+            captured["wiz"].request_stop()
+            thread.join(timeout=5.0)
+            elapsed = time.monotonic() - start
+
+        assert not thread.is_alive(), "CLI loop did not stop on request_stop"
+        assert elapsed < 3.0, f"stop took {elapsed:.2f}s (should be ~instant)"
+
+    def test_api_shutdown_route_triggers_stop(
+        self, served_wizard: ConfigureWizard
+    ) -> None:
+        import json
+        import urllib.request
+
+        base = f"http://127.0.0.1:{served_wizard.port}"
+        token = served_wizard.session.csrf_token
+        req = urllib.request.Request(
+            f"{base}/api/shutdown",
+            data=b"{}",
+            method="POST",
+            headers={"Content-Type": "application/json", "X-CSRF-Token": token},
+        )
+        with urllib.request.urlopen(req, timeout=5.0) as resp:
+            body = json.loads(resp.read().decode("utf-8"))
+
+        assert body == {"status": "stopping"}
+        assert served_wizard.stop_event.is_set()
+
+
+@pytest.mark.unit
 class TestResolveStaticDir:
     def test_falls_back_when_resources_raises(self, home_dir: Path) -> None:
         """Force the importlib.resources path to fail and verify the


### PR DESCRIPTION
## Problem
`mureo configure` busy-slept for a fixed `--timeout-seconds` (default **600s**) with **no signal handler** and **no completion trigger**. Closing the browser left the terminal hung for up to 10 minutes; **Ctrl+C did not work**.

## Fix
- `ConfigureWizard`: `stop_event` + `request_stop()`
- `run_configure_wizard`: install SIGINT/SIGTERM handlers (set the event), wait on the event instead of busy-sleeping, restore prior handlers + graceful shutdown in `finally`; `timeout_seconds` is now only a hard cap
- `POST /api/shutdown` (Host + CSRF gated like every POST) → `request_stop`
- Completed step: a **"Finish & free the terminal"** button (EN/JA) that POSTs `/api/shutdown`
- `--timeout-seconds` help reworded (it was never "inactivity")

## Verification
- Real subprocess: **SIGINT 0.23s / SIGTERM 0.25s** graceful exit (was: hang up to 600s)
- **Real Chrome tab** loaded the configure SPA; the button's exact `MUREO.postJson('/api/shutdown')` (same-origin, real CSRF) → terminal freed in **0.09s**, response `{ok:true,{status:stopping}}`
- pytest **3212 passed** in a clean env (3 new lifecycle tests); ruff/black/JS/i18n-parity clean
- code-reviewer **APPROVE** (no CRITICAL/HIGH)
- Confirmed PyPI 0.9.0 lacks the route (404) → bug is real