### PR TITLE
chore(release): v0.9.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mureo",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Your local-first AI ad ops crew for Google Ads, Meta Ads, Search Console & GA4. mureo sits on top of the official ad-platform MCPs, gates every change against your strategy, correlates outcomes locally, and keeps an auditable decision log — credentials never leave your machine.",
   "author": {
     "name": "Logly Inc.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.2] - 2026-05-18
+
+### Fixed — `mureo configure` no longer misroutes Claude Desktop users on the Meta connector finalize (#118)
+- A Claude **Desktop** user who had connected the Meta hosted MCP saw the misleading *"not connected yet — finish the Meta login"* when clicking *finalize*. The in-memory `session.host` could reset to the `claude-code` default (configure process restart; `/api/host` was sent only on a radio change, fire-and-forget, errors swallowed), so `confirm_hosted_provider` ran the Claude **Code** `claude mcp list` verification path for a Desktop user; with no Claude Code CLI present, a bare `False` became an accusatory dead-end. The official Meta MCP itself was always usable — only the *switch-native-off* step was wrongly blocked (tool ambiguity, never a strand).
+  - **Client-authoritative host:** `/api/providers/confirm` and `/api/providers/native-toggle` resolve `host` from the request payload (validated against the supported hosts, written back to self-heal a stale session); the finalize button now sends the UI's known host.
+  - **Host-sync hardening:** the wizard persists the explicit host choice to `localStorage` and prefers it over the server-echoed value; the `/api/host` sync retries once and surfaces a toast instead of silently swallowing a failure; the host is re-asserted on host-step entry and on load.
+  - **Tri-state connectivity:** `hosted_provider_connectivity` now distinguishes `connected` / `not_connected` / `unknown`. `unknown` (no Claude Code CLI, `claude mcp list` timeout, or non-zero exit) is **not** reported as "not connected". `confirm_hosted_provider` gained an explicit-affirmation path: on Desktop, or when connectivity is `unknown`, the user can confirm "I've verified it" to apply the native↔official switch — preserving the no-strand guarantee (the switch still requires a positive signal: an auto-verified `connected` or a deliberate user affirmation). Existing no-strand guards are unchanged (`is_hosted_provider_connected` kept as a `== "connected"` wrapper). New EN/JA strings + an affirm button; reworded the Desktop "manual" copy so it no longer dead-ends.
+
 ## [0.9.1] - 2026-05-18
 
 ### Added — mureo safety layer for third-party plugin tools (#114, #116)

--- a/mureo/__init__.py
+++ b/mureo/__init__.py
@@ -1,3 +1,3 @@
 """mureo — your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."""
 
-__version__ = "0.9.1"
+__version__ = "0.9.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mureo"
-version = "0.9.1"
+version = "0.9.2"
 description = "Your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."
 requires-python = ">=3.10"
 license = "Apache-2.0"


### PR DESCRIPTION
Release v0.9.2 — patch.

Only change since v0.9.1: **#118** — `mureo configure` no longer misroutes Claude Desktop users on the Meta connector finalize (client-authoritative host, host-sync hardening, tri-state connectivity + explicit affirm, no-strand preserved).

- Version bump 0.9.1 → 0.9.2 across pyproject / `mureo/__init__.py` / `.claude-plugin/plugin.json` (manifest-parity test green)
- CHANGELOG [0.9.2]

Release-prep only (chore/docs). Merge → tag `v0.9.2` → GitHub Release triggers `release.yml` → PyPI.