### PR TITLE
chore(release): v0.9.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mureo",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Your local-first AI ad ops crew for Google Ads, Meta Ads, Search Console & GA4. mureo sits on top of the official ad-platform MCPs, gates every change against your strategy, correlates outcomes locally, and keeps an auditable decision log — credentials never leave your machine.",
   "author": {
     "name": "Logly Inc.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.3] - 2026-05-19
+
+### Fixed — Windows compatibility (#122)
+- mureo crashed on Windows: `os.fchmod` is Unix-only (`AttributeError`) in **every** credential/config write path (credentials.json save, provider-config write, settings rewrite, OAuth token store, plugin audit). New `mureo/fsutil.py` (`secure_fchmod` / `secure_chmod`) applies owner-only `0o600` on POSIX (byte-identical — no Linux/macOS change) and a best-effort, never-raising no-op on Windows. All 6 call sites migrated. On NTFS, file confidentiality relies on the `%USERPROFILE%` profile ACL (documented best-effort, not a silent regression).
+- The interactive setup menu (`simple_term_menu`) imports Unix-only `termios` and raises `NotImplementedError` (not `ImportError`) on Windows, so the plain number-input fallback was unreachable. Both fallbacks now `except (ImportError, NotImplementedError)` — also degrades gracefully in non-terminal environments (CI, pipes, PyCharm console) instead of crashing.
+- `mureo configure` resolved the wrong Claude Desktop config location on Windows. `host_paths` now returns `%APPDATA%\Claude\claude_desktop_config.json` on Windows (macOS unchanged; Linux keeps the Code-style fallback — Claude Desktop has no Linux build).
+
+### CI
+- Added a `windows-latest` CI job. mureo has no Windows dev machines, so this is the real-Windows verification (the fixes were otherwise only simulated on Linux) and an automatic regression guard. POSIX-only test assertions (file-mode, absolute paths, the macOS-only `install-desktop` `.sh` wrapper, a Windows socket-close timing difference) were made platform-aware.
+
+### Known limitations (out of scope; not crashes)
+- `mureo install-desktop` (CLI) is still macOS-only by explicit design — a Windows launcher is a separate feature; it errors gracefully off macOS.
+- Real-desktop UX not exercisable by headless CI (browser auto-open, the native file/folder picker dialog) is not yet end-to-end verified on Windows.
+
 ## [0.9.2] - 2026-05-18
 
 ### Fixed — `mureo configure` no longer misroutes Claude Desktop users on the Meta connector finalize (#118)

--- a/mureo/__init__.py
+++ b/mureo/__init__.py
@@ -1,3 +1,3 @@
 """mureo — your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."""
 
-__version__ = "0.9.2"
+__version__ = "0.9.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mureo"
-version = "0.9.2"
+version = "0.9.3"
 description = "Your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -315,7 +315,13 @@ class TestStopLifecycle:
             body = json.loads(resp.read().decode("utf-8"))
 
         assert body == {"status": "stopping"}
-        assert served_wizard.stop_event.is_set()
+        # The handler returns "stopping" and the server thread sets the
+        # stop event; sampling is_set() immediately races that thread
+        # (flaky on CI). stop_event is a threading.Event — wait for it
+        # with a bounded timeout instead.
+        assert served_wizard.stop_event.wait(
+            timeout=5.0
+        ), "/api/shutdown did not trigger stop within 5s"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Release v0.9.3 — patch.

Only change since v0.9.2: **#122** Windows compatibility — `os.fchmod` crash fix (new `mureo/fsutil.py`), `simple_term_menu`/`NotImplementedError` fallback, `%APPDATA%` Claude Desktop path, plus a real `windows-latest` CI job + platform-aware tests.

- Version bump 0.9.2 → 0.9.3 (pyproject / `mureo/__init__.py` / `.claude-plugin/plugin.json`; manifest-parity test green)
- CHANGELOG [0.9.3]

Release-prep only (chore). Merge → tag `v0.9.3` → GitHub Release triggers `release.yml` → PyPI.