### PR TITLE
feat(core): add extension protocols for credentials, state, knowledge, and throttle backends

### DIFF
--- a/mureo/_data/skills/learn/SKILL.md
+++ b/mureo/_data/skills/learn/SKILL.md
@@ -2,17 +2,25 @@
 name: learn
 description: "Save a marketing diagnosis insight to the pro-diagnosis knowledge base so it is applied in future operations across all platforms. Use when the user runs /learn, explicitly teaches the agent a marketing insight, corrects the agent's analysis, or asks to remember/record an operational learning for next time."
 metadata:
-  version: 0.7.1
+  version: 0.8.0
 ---
 
 # Learn
 
 > PREREQUISITE: Read `../_mureo-shared/SKILL.md` for auth, security rules, output format, and **Tool Selection** (Read/Write on Code, `mureo_strategy_*` / `mureo_state_*` MCP on Desktop / Cowork).
 
-Save a marketing diagnosis insight to the pro-diagnosis knowledge base
-(`../_mureo-pro-diagnosis/SKILL.md`). Saved insights are loaded at the
-start of future sessions and applied across `/daily-check`, `/rescue`,
-`/budget-rebalance`, and the other diagnostic workflows.
+Save a marketing diagnosis insight to the pro-diagnosis knowledge base.
+Saved insights are loaded at the start of future sessions and applied
+across `/daily-check`, `/rescue`, `/budget-rebalance`, and the other
+diagnostic workflows.
+
+The skill persists insights by shelling out to `mureo learn add`,
+which routes the write through the KnowledgeStore Protocol. The
+default backend writes to
+`~/.claude/skills/_mureo-pro-diagnosis/SKILL.md` (preserving the
+prior file layout); an alternate backend registered via the
+`mureo.runtime_context_factory` entry-point group can redirect or
+split the write without changing this skill.
 
 ## When to use
 
@@ -31,31 +39,7 @@ start of future sessions and applied across `/daily-check`, `/rescue`,
    moments where the user corrected the agent's analysis or supplied
    marketing expertise, and select the most reusable one(s).
 
-2. **Locate the knowledge base.** The target is the sibling skill file
-   `../_mureo-pro-diagnosis/SKILL.md` (relative to this skill, i.e.
-   `~/.claude/skills/_mureo-pro-diagnosis/SKILL.md` for an installed
-   user). If it already exists, read it first to avoid duplicate or
-   conflicting entries. If it does **not** exist (it is not shipped — it
-   grows per account), create the directory and seed the file with this
-   minimal scaffold before appending:
-
-   ```markdown
-   ---
-   name: _mureo-pro-diagnosis
-   description: "Professional marketing diagnostic frameworks: expert-level campaign analysis that grows with your experience."
-   metadata:
-     version: 0.1.0
-   ---
-
-   # Pro Diagnosis — Account Knowledge Base
-
-   Insights learned from operating this account, applied by every mureo
-   diagnostic workflow.
-
-   ## Learned Insights
-   ```
-
-3. **Structure the insight** using this template:
+2. **Structure the insight** using this template:
 
    ```markdown
    ### [Short descriptive title]
@@ -68,20 +52,33 @@ start of future sessions and applied across `/daily-check`, `/rescue`,
    Date learned: YYYY-MM-DD
    ```
 
-4. **Present for approval.** Show the formatted insight to the user and
-   ask for explicit confirmation before writing anything. Capture the
+3. **Present for approval.** Show the formatted insight to the user
+   and ask for explicit confirmation before saving. Capture the
    generalized lesson only — never record account IDs, credentials,
    access tokens, or personal data in the knowledge base.
 
-5. **Save.** Append the approved insight under the `## Learned Insights`
-   section of `../_mureo-pro-diagnosis/SKILL.md` (creating the file from
-   the scaffold in step 2 first if it was absent). Append only — never
-   rewrite or reorder existing entries.
+4. **Save by invoking the CLI.** Pass the approved insight verbatim
+   (including its leading blank line and trailing newline) to:
 
-6. **Confirm.** Tell the user the insight was saved and that it will be
-   applied in future `/daily-check`, `/rescue`, `/budget-rebalance`, and
-   other diagnostic workflows.
+   ```bash
+   mureo learn add "$INSIGHT_MARKDOWN"
+   ```
 
-IMPORTANT: Always save to `../_mureo-pro-diagnosis/SKILL.md`, never to
-Claude Code memory. The skill file persists across sessions and is read
-by all mureo diagnostic workflows; Claude memory is not.
+   - The default `--scope operator` writes the cross-workspace tier
+     read by every diagnostic skill. Use this for general practitioner
+     know-how that applies to every account the operator runs.
+   - Pass `--scope workspace` when the insight is specific to the
+     active account and should not leak to other workspaces (only
+     meaningful when a workspace-aware KnowledgeStore backend is
+     installed; the command exits with a helpful message otherwise).
+
+5. **Confirm.** Tell the user the insight was saved and that it will
+   be applied in future `/daily-check`, `/rescue`, `/budget-rebalance`,
+   and other diagnostic workflows.
+
+IMPORTANT: Always save through `mureo learn add`, never by writing the
+file path manually. Going through the CLI keeps the skill compatible
+with alternate KnowledgeStore backends and avoids the agent having to
+know about the scaffold/file layout. Never save to Claude Code memory;
+the on-disk knowledge base persists across sessions, Claude memory
+does not.

--- a/mureo/auth.py
+++ b/mureo/auth.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Any
 import httpx
 from google.oauth2.credentials import Credentials
 
+from mureo.core.secret_store import FilesystemSecretStore, SecretStore
 from mureo.fsutil import secure_fchmod
 from mureo.google_ads import GoogleAdsApiClient
 from mureo.meta_ads import MetaAdsApiClient
@@ -107,16 +108,25 @@ def load_google_ads_credentials(
     """Load Google Ads credentials with environment variable fallback.
 
     Priority:
-        1. google_ads section in credentials.json
-        2. Environment variables (GOOGLE_ADS_*)
+        1. ``google_ads`` section from the resolved
+           :class:`mureo.core.secret_store.SecretStore`. When ``path``
+           is supplied, the store is a one-shot
+           :class:`FilesystemSecretStore` reading that file directly
+           (preserves the long-standing test contract). When ``path``
+           is ``None``, the store is the process-wide one returned by
+           :func:`mureo.core.runtime_context.get_runtime_context` —
+           ``FilesystemSecretStore(~/.mureo/credentials.json)`` by
+           default, or whatever an installed alternate backend
+           registers via the ``mureo.runtime_context_factory``
+           entry-point group.
+        2. Environment variables (``GOOGLE_ADS_*``).
 
     Returns:
         GoogleAdsCredentials or None if required fields are missing.
     """
-    data = load_credentials(path)
-    google_section = data.get("google_ads")
+    google_section = _resolve_secret_store(path).load("google_ads")
 
-    if isinstance(google_section, dict):
+    if isinstance(google_section, dict) and google_section:
         developer_token = google_section.get("developer_token", "")
         client_id = google_section.get("client_id", "")
         client_secret = google_section.get("client_secret", "")
@@ -147,16 +157,18 @@ def load_meta_ads_credentials(
     """Load Meta Ads credentials with environment variable fallback.
 
     Priority:
-        1. meta_ads section in credentials.json
-        2. Environment variables (META_ADS_*)
+        1. ``meta_ads`` section from the resolved
+           :class:`mureo.core.secret_store.SecretStore` (see
+           :func:`load_google_ads_credentials` for the full resolution
+           rules — same shape).
+        2. Environment variables (``META_ADS_*``).
 
     Returns:
         MetaAdsCredentials or None if required fields are missing.
     """
-    data = load_credentials(path)
-    meta_section = data.get("meta_ads")
+    meta_section = _resolve_secret_store(path).load("meta_ads")
 
-    if isinstance(meta_section, dict):
+    if isinstance(meta_section, dict) and meta_section:
         access_token = meta_section.get("access_token", "")
         if access_token:
             return MetaAdsCredentials(
@@ -424,6 +436,30 @@ def _save_meta_token(
 def _resolve_default_path() -> Path:
     """Resolve the default credentials.json path."""
     return Path.home() / ".mureo" / "credentials.json"
+
+
+def _resolve_secret_store(path: Path | None) -> SecretStore:
+    """Pick the SecretStore that ``load_*_credentials`` should consult.
+
+    - ``path`` given → one-shot :class:`FilesystemSecretStore` bound to
+      that path. Bypasses the process-wide RuntimeContext so tests that
+      pass an explicit per-test file are isolated from any installed
+      alternate backend.
+    - ``path`` is ``None`` → the SecretStore from
+      :func:`mureo.core.runtime_context.get_runtime_context` (the
+      default file-backed store today, or whatever a registered
+      ``mureo.runtime_context_factory`` entry-point returns).
+
+    Imported lazily to keep ``mureo.auth`` decoupled from
+    ``mureo.core.runtime_context``: if the resolver later wants to
+    reference an ``mureo.auth`` type, a top-level import here would
+    create a circular dependency.
+    """
+    if path is not None:
+        return FilesystemSecretStore(path=path)
+    from mureo.core.runtime_context import get_runtime_context
+
+    return get_runtime_context().secret_store
 
 
 def _load_google_ads_from_env() -> GoogleAdsCredentials | None:

--- a/mureo/byod/runtime.py
+++ b/mureo/byod/runtime.py
@@ -43,7 +43,17 @@ def byod_data_dir() -> Path:
          itself during ``--with-demo`` seeding. Each Claude Desktop
          workspace sees its own BYOD store and demo data does not
          leak across workspaces.
-      2. Legacy ``~/.mureo/byod/`` for existing CLI / Claude Code
+      2. A non-default ``RuntimeContext`` (an alternate backend
+         registered via the ``mureo.runtime_context_factory``
+         entry-point group whose ``state_store`` exposes a filesystem
+         ``workspace``). Resolves to ``<workspace>/byod`` so a
+         backend-supplied workspace co-locates its BYOD data with the
+         rest of the workspace's state (STATE.json / STRATEGY.md /
+         credentials.json). Only triggers when
+         ``workspace_id != "default"`` so the existing legacy CLI /
+         Claude Code single-workspace behaviour is preserved by
+         construction.
+      3. Legacy ``~/.mureo/byod/`` for existing CLI / Claude Code
          users — preserves backward compatibility.
 
     An empty or whitespace-only env var is treated as 'unset' so a
@@ -54,7 +64,36 @@ def byod_data_dir() -> Path:
     override = os.environ.get(_BYOD_DIR_ENV)
     if override and override.strip():
         return Path(override.strip()).expanduser()
+    ws_path = _runtime_context_workspace()
+    if ws_path is not None:
+        return ws_path / _BYOD_SUBDIR
     return Path.home() / _USER_DIR_NAME / _BYOD_SUBDIR
+
+
+def _runtime_context_workspace() -> Path | None:
+    """Return the resolved workspace dir from the RuntimeContext, or
+    ``None`` when the runtime is the default single-workspace one.
+
+    Imported lazily inside this helper so ``mureo.byod.runtime`` keeps
+    its "no external dependencies" promise (see module docstring) for
+    callers that never need to touch the runtime layer.
+    """
+    try:
+        from mureo.core.runtime_context import (
+            DEFAULT_WORKSPACE_ID,
+            get_runtime_context,
+        )
+    except ImportError:  # pragma: no cover — keeps the module standalone
+        return None
+    ctx = get_runtime_context()
+    if ctx.workspace_id == DEFAULT_WORKSPACE_ID:
+        # Single-workspace runtime: keep the legacy ~/.mureo/byod/
+        # location so existing CLI / Claude Code users are unaffected.
+        return None
+    workspace = getattr(ctx.state_store, "workspace", None)
+    if workspace is None:
+        return None
+    return Path(workspace)
 
 
 def manifest_path() -> Path:

--- a/mureo/cli/learn_cmd.py
+++ b/mureo/cli/learn_cmd.py
@@ -1,0 +1,91 @@
+"""``mureo learn`` CLI — append insights to the diagnostic knowledge base.
+
+This command is the supported entry-point for the ``/learn`` skill (see
+``skills/learn/SKILL.md``) to persist insights without writing to the
+file system directly. Routing the write through the
+:class:`mureo.core.knowledge_store.KnowledgeStore` resolved by
+:func:`mureo.core.runtime_context.get_runtime_context` means an
+alternate backend (registered via the ``mureo.runtime_context_factory``
+entry-point group) can intercept the append — for example to split
+operator-wide insights from workspace-scoped ones.
+
+Two scopes are exposed:
+
+- ``operator`` (default): the cross-workspace operator tier read by
+  every diagnostic skill (today's
+  ``~/.claude/skills/_mureo-pro-diagnosis/SKILL.md`` for the file-backed
+  default).
+- ``workspace``: a workspace-scoped tier. Errors with a helpful
+  message when the resolved store has no workspace tier configured
+  (the file-backed default has none unless one is wired in).
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+import typer
+
+learn_app = typer.Typer(
+    name="learn",
+    help="Append insights to the diagnostic knowledge base.",
+    no_args_is_help=True,
+)
+
+
+class _Scope(str, Enum):
+    """``--scope`` choices, mirrored by the KnowledgeStore tiers."""
+
+    OPERATOR = "operator"
+    WORKSPACE = "workspace"
+
+
+_TEXT_ARGUMENT = typer.Argument(
+    ...,
+    help=(
+        "The insight Markdown to append. The /learn skill formats this "
+        "with a YAML-frontmatter-style block (### title + Situation / "
+        "Wrong assumption / Correct approach / Why); pass that block "
+        "verbatim, including leading and trailing newlines."
+    ),
+)
+
+_SCOPE_OPTION = typer.Option(
+    _Scope.OPERATOR,
+    "--scope",
+    help=(
+        "Where to persist the insight. 'operator' (default) writes the "
+        "cross-workspace tier read by every diagnostic skill. "
+        "'workspace' writes a workspace-scoped tier if the resolved "
+        "KnowledgeStore has one configured; otherwise the command "
+        "exits with a non-zero status and a hint."
+    ),
+)
+
+
+@learn_app.command("add")  # type: ignore[untyped-decorator, unused-ignore]
+def learn_add(
+    text: str = _TEXT_ARGUMENT,
+    scope: _Scope = _SCOPE_OPTION,
+) -> None:
+    """Append an insight to the diagnostic knowledge base."""
+    from mureo.core.runtime_context import get_runtime_context
+
+    store = get_runtime_context().knowledge_store
+    if scope is _Scope.OPERATOR:
+        store.append_operator_knowledge(text)
+        typer.echo("Saved to the operator (cross-workspace) tier.")
+        return
+    try:
+        store.append_workspace_knowledge(text)
+    except NotImplementedError:
+        typer.echo(
+            "Error: the resolved KnowledgeStore has no workspace tier "
+            "configured. Use --scope operator to write to the "
+            "cross-workspace tier, or configure a workspace-aware "
+            "backend via the mureo.runtime_context_factory entry-point "
+            "group.",
+            err=True,
+        )
+        raise typer.Exit(1) from None
+    typer.echo("Saved to the workspace tier.")

--- a/mureo/cli/main.py
+++ b/mureo/cli/main.py
@@ -13,6 +13,7 @@ from mureo.cli.byod_cmd import byod_app
 from mureo.cli.configure_cmd import configure_app
 from mureo.cli.demo_cmd import demo_app
 from mureo.cli.install_desktop_cmd import install_desktop_app
+from mureo.cli.learn_cmd import learn_app
 from mureo.cli.providers_cmd import providers_app
 from mureo.cli.rollback_cmd import rollback_app
 from mureo.cli.setup_cmd import setup_app
@@ -31,6 +32,7 @@ app.add_typer(byod_app)
 app.add_typer(demo_app)
 app.add_typer(providers_app)
 app.add_typer(configure_app)
+app.add_typer(learn_app)
 
 if __name__ == "__main__":
     app()

--- a/mureo/cli/rollback_cmd.py
+++ b/mureo/cli/rollback_cmd.py
@@ -39,10 +39,37 @@ def _safe(value: str) -> str:
 
 
 _STATE_FILE_OPTION = typer.Option(
-    Path("STATE.json"),
+    None,
     "--state-file",
-    help="Path to the STATE.json file to inspect.",
+    help=(
+        "Path to the STATE.json file to inspect. Defaults to the active "
+        "workspace's STATE.json — CWD-relative in the default file-backed "
+        "configuration, or whatever location an installed alternate "
+        "backend exposes via the mureo.runtime_context_factory entry "
+        "point."
+    ),
 )
+
+
+def _resolve_default_state_file() -> Path:
+    """Return the workspace-derived default for ``--state-file``.
+
+    Mirrors the workspace lookup the MCP handlers (rollback, analysis,
+    mureo_context) perform: the file lives at the active StateStore's
+    ``state_path`` if exposed, otherwise ``<workspace>/STATE.json``
+    where workspace falls back to ``Path.cwd()``.
+
+    Lazy import keeps ``mureo.cli.rollback_cmd`` import-time-free of
+    the runtime_context resolver, so Typer's startup remains cheap.
+    """
+    from mureo.core.runtime_context import get_runtime_context
+
+    store = get_runtime_context().state_store
+    attr = getattr(store, "state_path", None)
+    if attr is not None:
+        return Path(attr).resolve()
+    workspace = getattr(store, "workspace", Path.cwd())
+    return Path(workspace) / "STATE.json"
 
 
 def _load_plans(
@@ -79,7 +106,7 @@ def _load_plans(
 
 @rollback_app.command("list")  # type: ignore[untyped-decorator, unused-ignore]
 def rollback_list(
-    state_file: Path = _STATE_FILE_OPTION,
+    state_file: Path | None = _STATE_FILE_OPTION,
     platform: str | None = typer.Option(
         None,
         "--platform",
@@ -87,6 +114,8 @@ def rollback_list(
     ),
 ) -> None:
     """List action_log entries and whether they can be rolled back."""
+    if state_file is None:
+        state_file = _resolve_default_state_file()
     plans = _load_plans(state_file, platform=platform)
     if not plans:
         typer.echo("No reversible actions recorded in the action log.")
@@ -109,9 +138,11 @@ def rollback_list(
 @rollback_app.command("show")  # type: ignore[untyped-decorator, unused-ignore]
 def rollback_show(
     index: int = typer.Argument(..., help="Index into STATE.json action_log.", min=0),
-    state_file: Path = _STATE_FILE_OPTION,
+    state_file: Path | None = _STATE_FILE_OPTION,
 ) -> None:
     """Show the full rollback plan for one action_log entry."""
+    if state_file is None:
+        state_file = _resolve_default_state_file()
     if not state_file.exists():
         typer.echo(f"Error: STATE.json not found at {state_file}", err=True)
         raise typer.Exit(1)

--- a/mureo/core/__init__.py
+++ b/mureo/core/__init__.py
@@ -17,8 +17,12 @@ from __future__ import annotations
 from mureo.core.knowledge_store import FilesystemKnowledgeStore, KnowledgeStore
 from mureo.core.runtime_context import (
     DEFAULT_WORKSPACE_ID,
+    RUNTIME_CONTEXT_FACTORY_ENTRY_POINT_GROUP,
     RuntimeContext,
+    RuntimeContextFactoryError,
     default_runtime_context,
+    get_runtime_context,
+    reset_runtime_context,
 )
 from mureo.core.secret_store import FilesystemSecretStore, SecretStore
 from mureo.core.state_store import FilesystemStateStore, StateStore
@@ -31,9 +35,13 @@ __all__ = [
     "FilesystemStateStore",
     "KnowledgeStore",
     "ProcessLocalThrottleStore",
+    "RUNTIME_CONTEXT_FACTORY_ENTRY_POINT_GROUP",
     "RuntimeContext",
+    "RuntimeContextFactoryError",
     "SecretStore",
     "StateStore",
     "ThrottleStore",
     "default_runtime_context",
+    "get_runtime_context",
+    "reset_runtime_context",
 ]

--- a/mureo/core/__init__.py
+++ b/mureo/core/__init__.py
@@ -1,0 +1,39 @@
+"""Public surface of ``mureo.core``: extension Protocols, file-backed
+default implementations, and the ``RuntimeContext`` aggregate used to
+pass them through call sites.
+
+Importing from this package is the supported way for callers (tests,
+alternate backends, future consumers) to reach the extension layer.
+The Protocols and the names re-exported below are an ABI commitment —
+each rename or removal needs a deprecation cycle.
+
+The pre-existing :mod:`mureo.core.providers` and :mod:`mureo.core.skills`
+sub-packages are not re-exported here; reach them by their fully
+qualified module names as before.
+"""
+
+from __future__ import annotations
+
+from mureo.core.knowledge_store import FilesystemKnowledgeStore, KnowledgeStore
+from mureo.core.runtime_context import (
+    DEFAULT_WORKSPACE_ID,
+    RuntimeContext,
+    default_runtime_context,
+)
+from mureo.core.secret_store import FilesystemSecretStore, SecretStore
+from mureo.core.state_store import FilesystemStateStore, StateStore
+from mureo.core.throttle_store import ProcessLocalThrottleStore, ThrottleStore
+
+__all__ = [
+    "DEFAULT_WORKSPACE_ID",
+    "FilesystemKnowledgeStore",
+    "FilesystemSecretStore",
+    "FilesystemStateStore",
+    "KnowledgeStore",
+    "ProcessLocalThrottleStore",
+    "RuntimeContext",
+    "SecretStore",
+    "StateStore",
+    "ThrottleStore",
+    "default_runtime_context",
+]

--- a/mureo/core/knowledge_store.py
+++ b/mureo/core/knowledge_store.py
@@ -1,22 +1,25 @@
-"""``KnowledgeStore`` Protocol — two-tier pluggable ``/learn`` storage.
+"""``KnowledgeStore`` Protocol and default in-process implementation.
 
-Abstracts the persistence used by the ``/learn`` skill and consumed by
-diagnostic skills (``/daily-check``, ``/rescue``, ``/budget-rebalance``,
-etc.). Today the operator tier lives at
-``~/.claude/skills/_mureo-pro-diagnosis/SKILL.md`` and there is no
-workspace-scoped tier — single-workspace callers see only the operator
-tier and the workspace methods are inert.
+The Protocol abstracts the persistence used by the ``/learn`` skill and
+consumed by diagnostic skills (``/daily-check``, ``/rescue``,
+``/budget-rebalance``, etc.). It splits storage into two tiers — one
+shared across all of the operator's workspaces, and one optional tier
+scoped to the current workspace — so a future workspace-scoped tier
+can be added without changing the Protocol or call sites.
 
-The two-tier shape exists so a future workspace-scoped tier can be
-added without changing the Protocol or call sites. Default callers
-that have no workspace tier observe ``read_workspace_knowledge() is
-None`` and ``append_workspace_knowledge`` raises
-``NotImplementedError`` (so misrouted writes fail loudly rather than
-silently going nowhere).
+``FilesystemKnowledgeStore`` is the default implementation. The
+operator tier defaults to today's
+``~/.claude/skills/_mureo-pro-diagnosis/SKILL.md`` location and seeds
+the file with the same frontmatter scaffold the ``/learn`` skill uses
+today. The workspace tier is absent by default — callers see
+``read_workspace_knowledge() is None`` and
+``append_workspace_knowledge`` raises ``NotImplementedError`` — so
+misrouted writes fail loudly rather than silently going nowhere.
 """
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Protocol, runtime_checkable
 
 
@@ -52,3 +55,86 @@ class KnowledgeStore(Protocol):
     def append_operator_knowledge(self, insight: str) -> None: ...
 
     def append_workspace_knowledge(self, insight: str) -> None: ...
+
+
+# ---------------------------------------------------------------------------
+# Default implementation — Markdown files under ``~/.claude/skills/``
+# ---------------------------------------------------------------------------
+
+
+# Frontmatter scaffold mirrors the one emitted by ``skills/learn/SKILL.md``
+# so consumers (diagnostic workflows) see the same file shape they have
+# always seen. Keep this byte-identical to the skill's template until the
+# follow-up commit refactors the skill itself to consume the store.
+_OPERATOR_SCAFFOLD = """\
+---
+name: _mureo-pro-diagnosis
+description: "Professional marketing diagnostic frameworks: expert-level campaign analysis that grows with your experience."
+metadata:
+  version: 0.1.0
+---
+
+# Pro Diagnosis — Account Knowledge Base
+
+Insights learned from operating this account, applied by every mureo
+diagnostic workflow.
+
+## Learned Insights
+"""
+
+
+class FilesystemKnowledgeStore:
+    """Persist ``/learn`` insights to Markdown files on disk.
+
+    Operator-tier default path:
+    ``~/.claude/skills/_mureo-pro-diagnosis/SKILL.md``. Workspace tier
+    is absent unless ``workspace_path`` is supplied at construction.
+    """
+
+    def __init__(
+        self,
+        operator_path: Path | None = None,
+        workspace_path: Path | None = None,
+    ) -> None:
+        if operator_path is not None:
+            self.operator_path = operator_path
+        else:
+            self.operator_path = (
+                Path.home()
+                / ".claude"
+                / "skills"
+                / "_mureo-pro-diagnosis"
+                / "SKILL.md"
+            )
+        self.workspace_path = workspace_path
+
+    def read_operator_knowledge(self) -> str:
+        if not self.operator_path.exists():
+            return ""
+        return self.operator_path.read_text(encoding="utf-8")
+
+    def read_workspace_knowledge(self) -> str | None:
+        if self.workspace_path is None:
+            return None
+        if not self.workspace_path.exists():
+            return ""
+        return self.workspace_path.read_text(encoding="utf-8")
+
+    def append_operator_knowledge(self, insight: str) -> None:
+        self.operator_path.parent.mkdir(parents=True, exist_ok=True)
+        if not self.operator_path.exists():
+            self.operator_path.write_text(
+                _OPERATOR_SCAFFOLD + insight, encoding="utf-8"
+            )
+            return
+        with self.operator_path.open("a", encoding="utf-8") as f:
+            f.write(insight)
+
+    def append_workspace_knowledge(self, insight: str) -> None:
+        if self.workspace_path is None:
+            raise NotImplementedError(
+                "no workspace tier configured for this KnowledgeStore"
+            )
+        self.workspace_path.parent.mkdir(parents=True, exist_ok=True)
+        with self.workspace_path.open("a", encoding="utf-8") as f:
+            f.write(insight)

--- a/mureo/core/knowledge_store.py
+++ b/mureo/core/knowledge_store.py
@@ -100,11 +100,7 @@ class FilesystemKnowledgeStore:
             self.operator_path = operator_path
         else:
             self.operator_path = (
-                Path.home()
-                / ".claude"
-                / "skills"
-                / "_mureo-pro-diagnosis"
-                / "SKILL.md"
+                Path.home() / ".claude" / "skills" / "_mureo-pro-diagnosis" / "SKILL.md"
             )
         self.workspace_path = workspace_path
 

--- a/mureo/core/knowledge_store.py
+++ b/mureo/core/knowledge_store.py
@@ -1,0 +1,54 @@
+"""``KnowledgeStore`` Protocol — two-tier pluggable ``/learn`` storage.
+
+Abstracts the persistence used by the ``/learn`` skill and consumed by
+diagnostic skills (``/daily-check``, ``/rescue``, ``/budget-rebalance``,
+etc.). Today the operator tier lives at
+``~/.claude/skills/_mureo-pro-diagnosis/SKILL.md`` and there is no
+workspace-scoped tier — single-workspace callers see only the operator
+tier and the workspace methods are inert.
+
+The two-tier shape exists so a future workspace-scoped tier can be
+added without changing the Protocol or call sites. Default callers
+that have no workspace tier observe ``read_workspace_knowledge() is
+None`` and ``append_workspace_knowledge`` raises
+``NotImplementedError`` (so misrouted writes fail loudly rather than
+silently going nowhere).
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class KnowledgeStore(Protocol):
+    """Two-tier persistence for ``/learn`` insights.
+
+    Tiers:
+    - **Operator tier**: shared across every workspace this operator
+      opens. Holds general practitioner know-how.
+    - **Workspace tier**: scoped to the current workspace. May be
+      absent — in which case ``read_workspace_knowledge`` returns
+      ``None`` and ``append_workspace_knowledge`` raises
+      ``NotImplementedError``.
+
+    Contract:
+    - ``read_operator_knowledge`` always returns a string (possibly
+      empty); it must not raise on a missing file.
+    - ``read_workspace_knowledge`` returns ``None`` when no workspace
+      tier is configured; otherwise returns the tier's text (possibly
+      empty).
+    - Append operations must be additive — never overwrite the file.
+    - When no workspace tier is configured, ``append_workspace_knowledge``
+      raises ``NotImplementedError``. Callers that want graceful
+      fallback should check ``read_workspace_knowledge() is None`` first
+      and route the insight to the operator tier instead.
+    """
+
+    def read_operator_knowledge(self) -> str: ...
+
+    def read_workspace_knowledge(self) -> str | None: ...
+
+    def append_operator_knowledge(self, insight: str) -> None: ...
+
+    def append_workspace_knowledge(self, insight: str) -> None: ...

--- a/mureo/core/runtime_context.py
+++ b/mureo/core/runtime_context.py
@@ -1,29 +1,42 @@
 """``RuntimeContext`` — frozen aggregate of the four core extension Protocols
-plus an opaque workspace identifier.
+plus an opaque workspace identifier, and ``default_runtime_context()`` —
+the factory that wires the four file-backed defaults.
 
 A ``RuntimeContext`` is the single object passed through mureo call sites
 that need pluggable backends for credentials, persisted state, ``/learn``
 knowledge, and API throttling. Today nothing in OSS constructs a
 ``RuntimeContext`` automatically — call sites still talk to the legacy
 helpers in ``mureo.auth`` / ``mureo.context`` / ``mureo.mcp`` directly.
-Hookup of consumers ships in follow-up commits; this module only
-introduces the type so alternate backends can be wired before the
-refactor lands.
+Hookup of consumers ships in follow-up commits; this module introduces
+the type and the default factory so alternate backends can be wired
+before the refactor lands.
 
 ``workspace_id`` is intentionally opaque. For single-workspace callers
-the canonical value is the literal ``"default"``; alternate runtimes are
-free to use any other non-empty string. Empty strings are rejected at
-construction time.
+the canonical value is the literal :data:`DEFAULT_WORKSPACE_ID`;
+alternate runtimes are free to use any other non-empty string. Empty
+strings are rejected at construction time.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
-from mureo.core.knowledge_store import KnowledgeStore
-from mureo.core.secret_store import SecretStore
-from mureo.core.state_store import StateStore
-from mureo.core.throttle_store import ThrottleStore
+from mureo.core.knowledge_store import FilesystemKnowledgeStore, KnowledgeStore
+from mureo.core.secret_store import FilesystemSecretStore, SecretStore
+from mureo.core.state_store import FilesystemStateStore, StateStore
+from mureo.core.throttle_store import ProcessLocalThrottleStore, ThrottleStore
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from mureo.throttle import ThrottleConfig
+
+
+#: Canonical sentinel for single-workspace callers. Exposed so consumers
+#: can compare against the literal without hard-coding it; pinned by
+#: :mod:`tests.core.test_runtime_context` so the value cannot drift.
+DEFAULT_WORKSPACE_ID = "default"
 
 
 @dataclass(frozen=True)
@@ -50,6 +63,46 @@ class RuntimeContext:
         identifiers in this layer must be unambiguous strings.
         """
         if not isinstance(self.workspace_id, str) or not self.workspace_id.strip():
-            raise ValueError(
-                "workspace_id must be a non-empty, non-whitespace string"
-            )
+            raise ValueError("workspace_id must be a non-empty, non-whitespace string")
+
+
+# ---------------------------------------------------------------------------
+# Default factory — wires the four file-backed defaults
+# ---------------------------------------------------------------------------
+
+
+def default_runtime_context(
+    *,
+    workspace: Path | None = None,
+    credentials_path: Path | None = None,
+    operator_knowledge_path: Path | None = None,
+    workspace_knowledge_path: Path | None = None,
+    throttle_config: ThrottleConfig | None = None,
+) -> RuntimeContext:
+    """Return a ``RuntimeContext`` wired with the file-backed defaults.
+
+    All keyword arguments are optional; when omitted, each store falls
+    back to the legacy location it has used in mureo to date —
+    ``~/.mureo/credentials.json``, CWD-relative ``STATE.json`` /
+    ``STRATEGY.md``, ``~/.claude/skills/_mureo-pro-diagnosis/SKILL.md``,
+    and :data:`mureo.throttle.PLUGIN_THROTTLE` respectively. The
+    workspace tier of the knowledge store is absent by default; pass
+    ``workspace_knowledge_path`` to enable it.
+
+    Note: ``workspace`` here is the state-store directory (passed
+    through to :class:`FilesystemStateStore`), not the
+    :attr:`RuntimeContext.workspace_id` identifier. The factory fixes
+    ``workspace_id`` at :data:`DEFAULT_WORKSPACE_ID`; callers that need
+    a different identifier should construct the ``RuntimeContext``
+    directly rather than going through this factory.
+    """
+    return RuntimeContext(
+        secret_store=FilesystemSecretStore(path=credentials_path),
+        state_store=FilesystemStateStore(workspace=workspace),
+        knowledge_store=FilesystemKnowledgeStore(
+            operator_path=operator_knowledge_path,
+            workspace_path=workspace_knowledge_path,
+        ),
+        throttle_store=ProcessLocalThrottleStore(default_config=throttle_config),
+        workspace_id=DEFAULT_WORKSPACE_ID,
+    )

--- a/mureo/core/runtime_context.py
+++ b/mureo/core/runtime_context.py
@@ -1,0 +1,55 @@
+"""``RuntimeContext`` — frozen aggregate of the four core extension Protocols
+plus an opaque workspace identifier.
+
+A ``RuntimeContext`` is the single object passed through mureo call sites
+that need pluggable backends for credentials, persisted state, ``/learn``
+knowledge, and API throttling. Today nothing in OSS constructs a
+``RuntimeContext`` automatically — call sites still talk to the legacy
+helpers in ``mureo.auth`` / ``mureo.context`` / ``mureo.mcp`` directly.
+Hookup of consumers ships in follow-up commits; this module only
+introduces the type so alternate backends can be wired before the
+refactor lands.
+
+``workspace_id`` is intentionally opaque. For single-workspace callers
+the canonical value is the literal ``"default"``; alternate runtimes are
+free to use any other non-empty string. Empty strings are rejected at
+construction time.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from mureo.core.knowledge_store import KnowledgeStore
+from mureo.core.secret_store import SecretStore
+from mureo.core.state_store import StateStore
+from mureo.core.throttle_store import ThrottleStore
+
+
+@dataclass(frozen=True)
+class RuntimeContext:
+    """Immutable bundle of pluggable backends + a workspace identifier.
+
+    The dataclass is frozen so a context can be passed safely across
+    threads / coroutines without races on its fields. The pointed-to
+    stores are *not* required to be immutable — they encapsulate their
+    own concurrency story.
+    """
+
+    secret_store: SecretStore
+    state_store: StateStore
+    knowledge_store: KnowledgeStore
+    throttle_store: ThrottleStore
+    workspace_id: str
+
+    def __post_init__(self) -> None:
+        """Reject empty / whitespace-only ``workspace_id``.
+
+        Matches the validation pattern used by
+        :func:`mureo.core.providers.base.validate_provider_name` —
+        identifiers in this layer must be unambiguous strings.
+        """
+        if not isinstance(self.workspace_id, str) or not self.workspace_id.strip():
+            raise ValueError(
+                "workspace_id must be a non-empty, non-whitespace string"
+            )

--- a/mureo/core/runtime_context.py
+++ b/mureo/core/runtime_context.py
@@ -1,6 +1,9 @@
 """``RuntimeContext`` — frozen aggregate of the four core extension Protocols
-plus an opaque workspace identifier, and ``default_runtime_context()`` —
-the factory that wires the four file-backed defaults.
+plus an opaque workspace identifier, ``default_runtime_context()`` — the
+factory that wires the four file-backed defaults, and
+``get_runtime_context()`` — the resolver that lets alternate backends
+inject a custom context via the ``mureo.runtime_context_factory`` entry
+point group.
 
 A ``RuntimeContext`` is the single object passed through mureo call sites
 that need pluggable backends for credentials, persisted state, ``/learn``
@@ -8,8 +11,8 @@ knowledge, and API throttling. Today nothing in OSS constructs a
 ``RuntimeContext`` automatically — call sites still talk to the legacy
 helpers in ``mureo.auth`` / ``mureo.context`` / ``mureo.mcp`` directly.
 Hookup of consumers ships in follow-up commits; this module introduces
-the type and the default factory so alternate backends can be wired
-before the refactor lands.
+the type, the default factory, and the resolver so alternate backends
+can be wired before the refactor lands.
 
 ``workspace_id`` is intentionally opaque. For single-workspace callers
 the canonical value is the literal :data:`DEFAULT_WORKSPACE_ID`;
@@ -20,7 +23,8 @@ strings are rejected at construction time.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from importlib.metadata import entry_points
+from typing import TYPE_CHECKING, Final
 
 from mureo.core.knowledge_store import FilesystemKnowledgeStore, KnowledgeStore
 from mureo.core.secret_store import FilesystemSecretStore, SecretStore
@@ -106,3 +110,99 @@ def default_runtime_context(
         throttle_store=ProcessLocalThrottleStore(default_config=throttle_config),
         workspace_id=DEFAULT_WORKSPACE_ID,
     )
+
+
+# ---------------------------------------------------------------------------
+# Entry-point resolver — lets alternate backends inject a custom context
+# ---------------------------------------------------------------------------
+
+
+#: Entry-point group name. A third-party distribution can register a
+#: zero-arg callable returning a :class:`RuntimeContext` under this
+#: group; the resolver discovers and uses it transparently.
+RUNTIME_CONTEXT_FACTORY_ENTRY_POINT_GROUP: Final[str] = "mureo.runtime_context_factory"
+
+
+class RuntimeContextFactoryError(RuntimeError):
+    """Raised when the entry-point lookup is misconfigured.
+
+    Conditions:
+    - More than one entry point is registered in the
+      ``mureo.runtime_context_factory`` group (the integration point is
+      global, so picking one silently would mask a packaging bug).
+    - The registered factory raises during evaluation (the exception is
+      wrapped so the entry-point name reaches the log).
+    - The registered factory returns something other than a
+      :class:`RuntimeContext`.
+    """
+
+
+_cached_context: RuntimeContext | None = None
+
+
+def get_runtime_context() -> RuntimeContext:
+    """Return the process-wide ``RuntimeContext``, resolving via entry
+    points on first call.
+
+    Resolution rules:
+
+    - **0 entry points** in :data:`RUNTIME_CONTEXT_FACTORY_ENTRY_POINT_GROUP` —
+      :func:`default_runtime_context` is called and the result cached.
+    - **1 entry point** — its zero-arg callable is loaded and called; the
+      returned :class:`RuntimeContext` is cached.
+    - **>1 entry points** — :class:`RuntimeContextFactoryError` is raised.
+      No silent first-wins: a global integration hook must be
+      unambiguous, and a packaging mistake should be visible. (Contrast
+      with :mod:`mureo.core.providers.registry`, which uses first-wins
+      plus a warning — providers are additive so "more" is benign, but a
+      ``RuntimeContext`` is a process singleton.)
+
+    Only successfully-constructed contexts are cached; if the configured
+    factory raises (or returns the wrong type) the error surfaces on
+    every call until the underlying packaging issue is fixed. This means
+    a broken plugin re-runs ``ep.load()`` per call — acceptable because
+    the load happens once per failing process and the alternative
+    (caching the exception) hides a fix-in-place.
+
+    Single-workspace and "1 dir = 1 session" callers do not change their
+    workspace mid-run, so the cache is correct by construction. Tests
+    that need to swap the underlying state must call
+    :func:`reset_runtime_context` first.
+    """
+    global _cached_context
+    if _cached_context is not None:
+        return _cached_context
+
+    eps = list(entry_points(group=RUNTIME_CONTEXT_FACTORY_ENTRY_POINT_GROUP))
+    if len(eps) == 0:
+        ctx = default_runtime_context()
+    elif len(eps) == 1:
+        ep = eps[0]
+        try:
+            factory = ep.load()
+            ctx = factory()
+        except Exception as exc:
+            raise RuntimeContextFactoryError(
+                f"entry point {ep.name!r} failed to produce a RuntimeContext: {exc!r}"
+            ) from exc
+        if not isinstance(ctx, RuntimeContext):
+            raise RuntimeContextFactoryError(
+                f"entry point {ep.name!r} returned {type(ctx).__name__}, "
+                f"expected RuntimeContext"
+            )
+    else:
+        names = ", ".join(repr(ep.name) for ep in eps)
+        raise RuntimeContextFactoryError(
+            f"multiple {RUNTIME_CONTEXT_FACTORY_ENTRY_POINT_GROUP} entry "
+            f"points are registered ({names}); exactly one is allowed"
+        )
+
+    _cached_context = ctx
+    return _cached_context
+
+
+def reset_runtime_context() -> None:
+    """Clear the cached ``RuntimeContext``. Intended for tests; production
+    callers should not need this — a process has one workspace."""
+    global _cached_context
+    _cached_context = None

--- a/mureo/core/secret_store.py
+++ b/mureo/core/secret_store.py
@@ -1,23 +1,40 @@
-"""``SecretStore`` Protocol — pluggable credential persistence.
+"""``SecretStore`` Protocol and default in-process implementation.
 
-Abstracts the read/write of ad-platform credentials and other secret
-material. The OSS default implementation (added in a follow-up commit)
-wraps the existing ``~/.mureo/credentials.json`` flow in ``mureo.auth``,
-behaviourally equivalent to today's behaviour for callers that do not
-inject a custom store.
+The Protocol abstracts the read/write of ad-platform credentials and
+other secret material so callers (tests, alternate backends such as OS
+keychains, HashiCorp Vault, GCP Secret Manager, AWS Secrets Manager)
+can swap the underlying storage without touching the rest of mureo.
 
-Designed so callers (tests, alternate backends such as OS keychains,
-HashiCorp Vault, GCP Secret Manager, AWS Secrets Manager) can swap the
-underlying storage without touching the rest of mureo.
+``FilesystemSecretStore`` is the default implementation. It is
+behaviourally equivalent to the legacy ``~/.mureo/credentials.json``
+flow read by :func:`mureo.auth.load_credentials`: missing or corrupt
+files yield an empty result rather than raising; the on-disk root must
+be a JSON object keyed by platform name; saves preserve unrelated
+platform keys; saves land at ``0o600`` on POSIX so credential files
+stay owner-readable (via :func:`mureo.fsutil.secure_fchmod`, the
+cross-platform helper used elsewhere in the repo).
 
-The Protocol is intentionally minimal — three opaque dict round-trip
-operations keyed by a string — so concrete backends can map ``key``
-onto whatever namespace they natively use.
+This default is **single-writer**. Concurrent writes from different
+processes can lose updates because the read-modify-write inside
+``save`` / ``delete`` is not file-locked. The legacy
+``mureo.auth._save_meta_token`` has the same property; cross-process
+locking is out of scope for the in-memory default and belongs in an
+alternate backend if a deployment needs it.
 """
 
 from __future__ import annotations
 
+import contextlib
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
+
+from mureo.fsutil import secure_fchmod
+
+logger = logging.getLogger(__name__)
 
 
 @runtime_checkable
@@ -42,3 +59,86 @@ class SecretStore(Protocol):
     def save(self, key: str, value: dict[str, Any]) -> None: ...
 
     def delete(self, key: str) -> None: ...
+
+
+# ---------------------------------------------------------------------------
+# Default implementation — JSON file under ``~/.mureo/``
+# ---------------------------------------------------------------------------
+
+
+class FilesystemSecretStore:
+    """Persist credentials in a single JSON file (default
+    ``~/.mureo/credentials.json``).
+
+    The file root is a ``dict[str, dict[str, Any]]`` keyed by platform
+    name (``"google_ads"``, ``"meta_ads"``, ``"search_console"``, …).
+    Reads tolerate missing files, OS errors, JSON decode errors, and
+    non-object roots — all collapse to an empty result so the MCP
+    server can still start when credentials have not yet been
+    configured. Writes are atomic (tempfile + ``os.replace``) and land
+    at ``0o600`` on POSIX.
+    """
+
+    def __init__(self, path: Path | None = None) -> None:
+        self.path = (
+            path if path is not None else Path.home() / ".mureo" / "credentials.json"
+        )
+
+    def load(self, key: str) -> dict[str, Any]:
+        data = self._read_root()
+        value = data.get(key, {})
+        # Defensive copy so callers cannot mutate our cached return.
+        return dict(value) if isinstance(value, dict) else {}
+
+    def save(self, key: str, value: dict[str, Any]) -> None:
+        data = self._read_root()
+        data[key] = dict(value)  # defensive copy of caller's input
+        self._write_root(data)
+
+    def delete(self, key: str) -> None:
+        data = self._read_root()
+        if key in data:
+            del data[key]
+            self._write_root(data)
+
+    # ------------------------------------------------------------------
+
+    def _read_root(self) -> dict[str, Any]:
+        """Return the file's root object, tolerating every reasonable
+        failure mode (missing, unreadable, malformed, wrong type)."""
+        if not self.path.exists():
+            logger.debug("credentials file not found: %s", self.path)
+            return {}
+        try:
+            text = self.path.read_text(encoding="utf-8")
+            data = json.loads(text)
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.warning("failed to read credentials file: %s", exc)
+            return {}
+        if not isinstance(data, dict):
+            logger.warning("credentials file root is not an object: %s", self.path)
+            return {}
+        return data
+
+    def _write_root(self, data: dict[str, Any]) -> None:
+        """Atomically write the root object and apply secure permissions.
+
+        Matches :func:`mureo.auth._save_meta_token` byte-for-byte:
+        ``ensure_ascii=False`` so on-disk JSON keeps UTF-8 (operators
+        editing the file by hand see real characters, not ``\\uXXXX``
+        escapes), ``secure_fchmod`` applied to the temp fd before
+        ``os.replace`` so the destination inherits ``0o600`` atomically
+        on POSIX, and best-effort no-op on Windows (see
+        :mod:`mureo.fsutil`).
+        """
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(dir=str(self.path.parent), suffix=".tmp")
+        try:
+            secure_fchmod(fd)
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(json.dumps(data, indent=2, ensure_ascii=False))
+            os.replace(tmp, self.path)
+        except BaseException:
+            with contextlib.suppress(OSError):
+                os.unlink(tmp)
+            raise

--- a/mureo/core/secret_store.py
+++ b/mureo/core/secret_store.py
@@ -1,0 +1,44 @@
+"""``SecretStore`` Protocol — pluggable credential persistence.
+
+Abstracts the read/write of ad-platform credentials and other secret
+material. The OSS default implementation (added in a follow-up commit)
+wraps the existing ``~/.mureo/credentials.json`` flow in ``mureo.auth``,
+behaviourally equivalent to today's behaviour for callers that do not
+inject a custom store.
+
+Designed so callers (tests, alternate backends such as OS keychains,
+HashiCorp Vault, GCP Secret Manager, AWS Secrets Manager) can swap the
+underlying storage without touching the rest of mureo.
+
+The Protocol is intentionally minimal — three opaque dict round-trip
+operations keyed by a string — so concrete backends can map ``key``
+onto whatever namespace they natively use.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class SecretStore(Protocol):
+    """Pluggable persistence for credential dicts.
+
+    Contract:
+    - ``load(key)`` returns the stored dict, or an empty dict if the key
+      is unknown. It must not raise on missing keys. The "empty stored
+      value is indistinguishable from missing" semantic is intentional
+      and matches the legacy ``mureo.auth.load_credentials`` behaviour
+      that callers already depend on; do not change it without auditing
+      every credential-load site.
+    - ``save(key, value)`` persists ``value`` under ``key``. Implementations
+      should overwrite existing entries.
+    - ``delete(key)`` removes ``key`` from the store. It must be idempotent
+      and not raise on missing keys.
+    """
+
+    def load(self, key: str) -> dict[str, Any]: ...
+
+    def save(self, key: str, value: dict[str, Any]) -> None: ...
+
+    def delete(self, key: str) -> None: ...

--- a/mureo/core/state_store.py
+++ b/mureo/core/state_store.py
@@ -1,34 +1,48 @@
-"""``StateStore`` Protocol — pluggable persistence for STATE.json,
-STRATEGY.md, and the action log.
+"""``StateStore`` Protocol and default in-process implementation.
 
-Abstracts what today is hard-wired CWD-relative file I/O in
-``mureo.context.state`` and ``mureo.context.strategy``. The OSS default
-implementation (added in a follow-up commit) wraps the existing helpers
-so call-site behaviour is behaviourally equivalent for users that do
-not inject a custom store.
+The Protocol abstracts what today is hard-wired CWD-relative file I/O
+in ``mureo.context.state`` and ``mureo.context.strategy``. Alternate
+backends (tests, SQLite, S3, a hosted Files API) can swap the
+underlying storage without touching the rest of mureo.
 
-Designed so callers (tests, alternate backends such as SQLite, S3, or
-a hosted-agent Files API) can swap the underlying storage without
-touching the rest of mureo.
+``FilesystemStateStore`` is the default implementation. It composes the
+existing helpers in ``mureo.context.state`` and
+``mureo.context.strategy`` so call-site behaviour is preserved
+verbatim — only the access shape changes.
 
 Foundation-rule waiver
 ----------------------
 This module imports ``StateDocument`` / ``StrategyEntry`` /
-``ActionLogEntry`` from ``mureo.context.models``. ``mureo.core`` modules
-normally avoid reaching outwards into other top-level packages
-(see :mod:`mureo.core.providers.base` for the same rule applied to the
+``ActionLogEntry`` from ``mureo.context.models`` and the default
+implementation reaches further into ``mureo.context.state`` and
+``mureo.context.strategy``. ``mureo.core`` modules normally avoid
+reaching outwards into other top-level packages (see
+:mod:`mureo.core.providers.base` for the same rule applied to the
 provider Protocols). The exception is intentional here: the three
-models are immutable, behaviour-free frozen dataclasses that pre-date
-this Protocol, and re-homing them into ``mureo.core`` would be a
-separate refactor with its own re-export and back-compat concerns.
-Tracked for a follow-up commit.
+models are immutable, behaviour-free frozen dataclasses and the helper
+functions are pure file-format adapters that pre-date this Protocol;
+re-homing them into ``mureo.core`` would be a separate refactor with
+its own re-export and back-compat concerns. Tracked for a follow-up
+commit.
 """
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Protocol, runtime_checkable
 
 from mureo.context.models import ActionLogEntry, StateDocument, StrategyEntry
+from mureo.context.state import (
+    append_action_log as _legacy_append_action_log,
+)
+from mureo.context.state import (
+    read_state_file,
+    write_state_file,
+)
+from mureo.context.strategy import (
+    read_strategy_file,
+    write_strategy_file,
+)
 
 
 @runtime_checkable
@@ -59,3 +73,42 @@ class StateStore(Protocol):
     def write_strategy(self, entries: list[StrategyEntry]) -> None: ...
 
     def append_action_log(self, entry: ActionLogEntry) -> None: ...
+
+
+# ---------------------------------------------------------------------------
+# Default implementation — STATE.json + STRATEGY.md under a workspace dir
+# ---------------------------------------------------------------------------
+
+
+class FilesystemStateStore:
+    """Persist state in ``STATE.json`` and ``STRATEGY.md`` under a workspace
+    directory (default CWD).
+
+    All file I/O routes through the existing legacy helpers so behaviour
+    matches the today's CWD-relative call sites byte-for-byte for
+    callers that do not inject a custom store.
+    """
+
+    def __init__(self, workspace: Path | None = None) -> None:
+        self.workspace = workspace if workspace is not None else Path.cwd()
+        self.state_path = self.workspace / "STATE.json"
+        self.strategy_path = self.workspace / "STRATEGY.md"
+
+    def read_state(self) -> StateDocument:
+        return read_state_file(self.state_path)
+
+    def write_state(self, doc: StateDocument) -> None:
+        write_state_file(self.state_path, doc)
+
+    def read_strategy(self) -> list[StrategyEntry]:
+        # ``read_strategy_file`` already returns a fresh list from
+        # ``parse_strategy``; copy defensively so future refactors of the
+        # legacy helper cannot weaken the snapshot-isolation contract.
+        return list(read_strategy_file(self.strategy_path))
+
+    def write_strategy(self, entries: list[StrategyEntry]) -> None:
+        # Defensive copy so callers can keep mutating their input.
+        write_strategy_file(self.strategy_path, list(entries))
+
+    def append_action_log(self, entry: ActionLogEntry) -> None:
+        _legacy_append_action_log(self.state_path, entry)

--- a/mureo/core/state_store.py
+++ b/mureo/core/state_store.py
@@ -29,9 +29,8 @@ commit.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
-from mureo.context.models import ActionLogEntry, StateDocument, StrategyEntry
 from mureo.context.state import (
     append_action_log as _legacy_append_action_log,
 )
@@ -43,6 +42,9 @@ from mureo.context.strategy import (
     read_strategy_file,
     write_strategy_file,
 )
+
+if TYPE_CHECKING:
+    from mureo.context.models import ActionLogEntry, StateDocument, StrategyEntry
 
 
 @runtime_checkable

--- a/mureo/core/state_store.py
+++ b/mureo/core/state_store.py
@@ -1,0 +1,61 @@
+"""``StateStore`` Protocol — pluggable persistence for STATE.json,
+STRATEGY.md, and the action log.
+
+Abstracts what today is hard-wired CWD-relative file I/O in
+``mureo.context.state`` and ``mureo.context.strategy``. The OSS default
+implementation (added in a follow-up commit) wraps the existing helpers
+so call-site behaviour is behaviourally equivalent for users that do
+not inject a custom store.
+
+Designed so callers (tests, alternate backends such as SQLite, S3, or
+a hosted-agent Files API) can swap the underlying storage without
+touching the rest of mureo.
+
+Foundation-rule waiver
+----------------------
+This module imports ``StateDocument`` / ``StrategyEntry`` /
+``ActionLogEntry`` from ``mureo.context.models``. ``mureo.core`` modules
+normally avoid reaching outwards into other top-level packages
+(see :mod:`mureo.core.providers.base` for the same rule applied to the
+provider Protocols). The exception is intentional here: the three
+models are immutable, behaviour-free frozen dataclasses that pre-date
+this Protocol, and re-homing them into ``mureo.core`` would be a
+separate refactor with its own re-export and back-compat concerns.
+Tracked for a follow-up commit.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from mureo.context.models import ActionLogEntry, StateDocument, StrategyEntry
+
+
+@runtime_checkable
+class StateStore(Protocol):
+    """Pluggable persistence for the workspace's mureo state.
+
+    Contract:
+    - ``read_state`` / ``write_state`` round-trip the full
+      ``StateDocument``. ``StateDocument`` is itself a frozen dataclass,
+      so callers cannot mutate the returned value's top-level fields.
+    - ``read_strategy`` must return a fresh list per call — callers
+      append/sort/clear the returned list freely and the store remains
+      unaffected. Implementations that hand back an internal reference
+      violate the contract.
+    - ``write_strategy`` accepts any iterable copied into the store;
+      callers may continue mutating their input after the call returns.
+    - ``append_action_log`` is the only mutator for the action log.
+      Implementations must append (not overwrite) and should be safe to
+      call concurrently from a single workspace.
+    """
+
+    def read_state(self) -> StateDocument: ...
+
+    def write_state(self, doc: StateDocument) -> None: ...
+
+    def read_strategy(self) -> list[StrategyEntry]: ...
+
+    def write_strategy(self, entries: list[StrategyEntry]) -> None: ...
+
+    def append_action_log(self, entry: ActionLogEntry) -> None: ...

--- a/mureo/core/throttle_store.py
+++ b/mureo/core/throttle_store.py
@@ -1,23 +1,26 @@
-"""``ThrottleStore`` Protocol — pluggable API quota throttling.
+"""``ThrottleStore`` Protocol and default in-process implementation.
 
-Abstracts the per-key rate limiter used by MCP tool handlers when
-calling out to ad platforms. Today ``mureo.mcp.server`` maintains a
-``dict[str, Throttler]`` of name-keyed token buckets (see
-``_PLUGIN_TOOL_THROTTLERS``) and awaits ``throttler.acquire()`` before
-each tool invocation. This Protocol exposes the same "gate by name"
-shape so the underlying implementation can be swapped for a no-op in
-tests or for a cross-process backend (file lock, Redis) in deployments
-that share an API quota across several MCP processes.
+The Protocol abstracts the per-key rate limiter used by MCP tool
+handlers when calling out to ad platforms. Today ``mureo.mcp.server``
+maintains a ``dict[str, Throttler]`` of name-keyed token buckets and
+awaits ``throttler.acquire()`` before each tool invocation. This
+Protocol exposes the same "gate by name" shape so the underlying
+implementation can be swapped for a no-op in tests or for a
+cross-process backend (file lock, Redis) in deployments that share an
+API quota across several MCP processes.
 
-The default in-process implementation (added in a follow-up commit)
-delegates to ``mureo.throttle.Throttler`` instances, preserving the
-existing throttling behaviour for callers that do not inject a custom
-store.
+``ProcessLocalThrottleStore`` is the default implementation — a thin
+per-process registry of ``mureo.throttle.Throttler`` instances. It
+mirrors today's MCP server pattern: each unique ``key`` lazily
+materialises its own token bucket; repeated calls with the same key
+reuse the same bucket so rate limits are enforced across the process.
 """
 
 from __future__ import annotations
 
 from typing import Protocol, runtime_checkable
+
+from mureo.throttle import PLUGIN_THROTTLE, ThrottleConfig, Throttler
 
 
 @runtime_checkable
@@ -39,3 +42,47 @@ class ThrottleStore(Protocol):
     """
 
     async def acquire(self, key: str) -> None: ...
+
+
+# ---------------------------------------------------------------------------
+# Default implementation — per-key Throttler dict in process memory
+# ---------------------------------------------------------------------------
+
+
+class ProcessLocalThrottleStore:
+    """Maintain one :class:`mureo.throttle.Throttler` per key in process
+    memory. Each Throttler is constructed lazily on first acquire using
+    ``default_config`` (falling back to ``PLUGIN_THROTTLE`` if omitted),
+    matching today's MCP-server fallback for tools without a declared
+    throttle hint.
+
+    asyncio is single-threaded so the ``key not in self.throttlers``
+    check followed by ``self.throttlers[key] = ...`` is race-free in
+    practice (no ``await`` between the check and the insert).
+    """
+
+    def __init__(self, default_config: ThrottleConfig | None = None) -> None:
+        self.default_config = (
+            default_config if default_config is not None else PLUGIN_THROTTLE
+        )
+        self.throttlers: dict[str, Throttler] = {}
+
+    def register(self, key: str, config: ThrottleConfig) -> None:
+        """Pre-install a :class:`Throttler` with a custom ``config`` for
+        ``key``. Subsequent calls to ``acquire(key)`` reuse this instance
+        instead of materialising a new one from ``default_config``.
+
+        Mirrors the existing MCP server pattern that pre-builds
+        per-tool-name buckets from ``derive_semantics`` output
+        (``mureo.mcp.server._PLUGIN_TOOL_THROTTLERS``); the lazy path
+        through ``acquire`` remains the fallback for keys that have not
+        been registered.
+        """
+        self.throttlers[key] = Throttler(config)
+
+    async def acquire(self, key: str) -> None:
+        throttler = self.throttlers.get(key)
+        if throttler is None:
+            throttler = Throttler(self.default_config)
+            self.throttlers[key] = throttler
+        await throttler.acquire()

--- a/mureo/core/throttle_store.py
+++ b/mureo/core/throttle_store.py
@@ -1,0 +1,41 @@
+"""``ThrottleStore`` Protocol — pluggable API quota throttling.
+
+Abstracts the per-key rate limiter used by MCP tool handlers when
+calling out to ad platforms. Today ``mureo.mcp.server`` maintains a
+``dict[str, Throttler]`` of name-keyed token buckets (see
+``_PLUGIN_TOOL_THROTTLERS``) and awaits ``throttler.acquire()`` before
+each tool invocation. This Protocol exposes the same "gate by name"
+shape so the underlying implementation can be swapped for a no-op in
+tests or for a cross-process backend (file lock, Redis) in deployments
+that share an API quota across several MCP processes.
+
+The default in-process implementation (added in a follow-up commit)
+delegates to ``mureo.throttle.Throttler`` instances, preserving the
+existing throttling behaviour for callers that do not inject a custom
+store.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class ThrottleStore(Protocol):
+    """Per-key rate-limit gate.
+
+    Contract:
+    - ``acquire(key)`` is an awaitable that blocks until the caller is
+      permitted to issue one unit of work tagged ``key``. The rate at
+      which work is permitted is fixed at store-construction time per
+      key; callers do not negotiate ``max_qps`` here. Implementations
+      that are unaware of ``key`` may treat it as opaque and share a
+      single bucket across all keys.
+    - There is no ``release`` — the existing ``Throttler`` model is a
+      token bucket that replenishes by wall-clock time, not by callers
+      returning a permit. Implementations that *do* require release-side
+      bookkeeping should wrap themselves in an async context manager
+      rather than extending this Protocol.
+    """
+
+    async def acquire(self, key: str) -> None: ...

--- a/mureo/mcp/_handlers_analysis.py
+++ b/mureo/mcp/_handlers_analysis.py
@@ -4,8 +4,10 @@ Thin composition layer over the pure ``detect_anomalies`` +
 ``baseline_from_history`` functions in ``mureo.analysis.anomaly_detector``.
 The handler:
 
-1. Sandboxes ``state_file`` against the MCP server's current working
-   directory: path traversal, absolute paths outside CWD, and symlinks
+1. Sandboxes ``state_file`` against the active workspace (the
+   ``StateStore.workspace`` exposed by the resolved
+   :class:`mureo.core.runtime_context.RuntimeContext`, defaulting to
+   CWD): path traversal, absolute paths outside it, and symlinks
    that resolve outside are all refused so a prompt-injected agent
    cannot point the tool at an attacker-crafted STATE.json.
 2. Builds a ``CampaignMetrics`` from the ``current`` argument.
@@ -39,32 +41,57 @@ logger = logging.getLogger(__name__)
 
 
 def _resolve_state_file(arguments: dict[str, Any]) -> Path:
-    """Sandbox ``state_file`` against the MCP server's CWD.
+    """Sandbox ``state_file`` against the active workspace.
+
+    The active workspace is
+    ``getattr(get_runtime_context().state_store, "workspace", Path.cwd())``
+    — CWD in the default file-backed configuration, or whatever
+    filesystem-backed :class:`StateStore` an alternate backend
+    registers via the ``mureo.runtime_context_factory`` entry-point
+    group.
 
     A prompt-injected agent cannot point the tool at an attacker-crafted
     STATE.json elsewhere on disk. Rejects (a) paths that resolve outside
-    CWD, (b) symlinks whose target escapes CWD, even when the link itself
-    sits inside CWD.
+    the workspace, (b) symlinks whose target escapes the workspace,
+    even when the link itself sits inside it. The symlink refusal is
+    stricter than the rollback / mureo_context handlers because the
+    analysis surface returns derived metrics that could leak file
+    contents an attacker swaps in mid-call.
     """
-    raw = _opt(arguments, "state_file", "STATE.json")
+    from mureo.core.runtime_context import get_runtime_context
+
+    store = get_runtime_context().state_store
+    workspace = getattr(store, "workspace", Path.cwd()).resolve()
+    raw = arguments.get("state_file")
+    if not raw:
+        attr = getattr(store, "state_path", None)
+        if attr is not None:
+            # Backend-owned path: trusted output of an installed
+            # ``StateStore``; the entry-point factory is host code,
+            # not an untrusted MCP caller, so the symlink and
+            # workspace-boundary checks below do not apply.
+            return Path(attr).resolve()
+        return workspace / "STATE.json"
     candidate = Path(raw)
-    cwd = Path.cwd().resolve()
     # strict=False so the file not yet existing is allowed (callers handle
     # missing-file with .exists()), but symlinks are still followed.
-    target = (cwd / candidate) if not candidate.is_absolute() else candidate
+    target = (workspace / candidate) if not candidate.is_absolute() else candidate
     resolved = target.resolve(strict=False)
     try:
-        resolved.relative_to(cwd)
+        resolved.relative_to(workspace)
     except ValueError as exc:
         raise ValueError(
-            f"state_file must resolve inside the current working directory "
-            f"({cwd}); got {resolved}."
+            f"state_file must resolve inside the active workspace "
+            f"({workspace}); got {resolved}."
         ) from exc
-    # Refuse symlinks even when both the link and its target live under CWD:
-    # a symlink is agent-writable and would let a future STATE.json swap
-    # redirect the handler without changing the argument it was called with.
+    # Refuse symlinks even when both the link and its target live under
+    # the workspace: a symlink is agent-writable and would let a future
+    # STATE.json swap redirect the handler without changing the
+    # argument it was called with.
     if target.is_symlink() or any(
-        p.is_symlink() for p in target.parents if cwd in p.parents or p == cwd
+        p.is_symlink()
+        for p in target.parents
+        if workspace in p.parents or p == workspace
     ):
         raise ValueError(f"state_file must not traverse a symlink; got {target}.")
     return resolved

--- a/mureo/mcp/_handlers_mureo_context.py
+++ b/mureo/mcp/_handlers_mureo_context.py
@@ -4,11 +4,20 @@ These handlers expose the context layer as MCP tools so that hosts
 without direct filesystem access (Claude Desktop chat, claude.ai web,
 remote MCP connectors) can read and update mureo's strategic context.
 
-All file paths are resolved against the MCP server's current working
-directory and refused if they escape it — symmetric with the rollback
-surface's ``_resolve_state_file`` guard. A prompt-injected agent must
-not be able to point mureo at an attacker-crafted file elsewhere on
-the filesystem.
+All file paths are resolved against the **active workspace** —
+``getattr(get_runtime_context().state_store, "workspace", Path.cwd())``
+— and refused if they escape it. The active workspace is CWD by
+default (preserving today's single-workspace behaviour), or whatever
+filesystem-backed :class:`mureo.core.state_store.StateStore` an
+alternate backend registers via the ``mureo.runtime_context_factory``
+entry-point group.
+
+The security guard is symmetric with the rollback surface's
+``_resolve_state_file`` guard: a prompt-injected agent must not be
+able to point mureo at an attacker-crafted file elsewhere on the
+filesystem. ``Path.resolve()`` follows symlinks, so a STRATEGY.md
+inside the workspace that symlinks to /etc/passwd resolves to the
+target and is correctly refused.
 
 Atomic write semantics come from ``mureo.context.state._atomic_write``
 and the equivalent path in ``context.strategy``: write to a temp file
@@ -37,32 +46,60 @@ from mureo.context.strategy import (
     parse_strategy,
     write_strategy_file,
 )
-from mureo.mcp._helpers import _json_result, _opt, _require
+from mureo.core.runtime_context import get_runtime_context
+from mureo.mcp._helpers import _json_result, _require
 
 if TYPE_CHECKING:
     from mcp.types import TextContent
 
 
-def _resolve_path(arguments: dict[str, Any], default_name: str) -> Path:
-    """Resolve a user-supplied path, refusing anything outside cwd.
+def _resolve_path(
+    arguments: dict[str, Any], default_name: str, *, store_attr: str | None = None
+) -> Path:
+    """Resolve a user-supplied path, refusing anything outside the workspace.
 
-    The MCP caller is untrusted (a prompt-injected agent could point at
-    an attacker-crafted file elsewhere on the filesystem). We require
-    the argument to resolve to a path inside the current working
-    directory so the agent cannot smuggle in a rogue STRATEGY.md or
-    STATE.json. ``Path.resolve()`` follows symlinks, so a STRATEGY.md
-    inside cwd that symlinks to /etc/passwd resolves to the target and
-    is correctly refused. Mirrors ``_handlers_rollback._resolve_state_file``.
+    Resolution rules:
+
+    - ``path`` argument missing or empty (``None`` or ``""``) → the
+      workspace-derived default (``getattr(store, store_attr)`` when
+      available, otherwise ``workspace / default_name``). Picks up
+      any alternate :class:`StateStore` wired via the
+      ``mureo.runtime_context_factory`` entry-point group without the
+      caller having to know about it. Note: the empty-string case
+      used to dispatch to ``Path(".")`` under the old ``_opt``-based
+      implementation; the new behaviour is intentional and safer.
+    - ``path`` argument present → resolved relative to the workspace
+      (not the process CWD — they coincide in the default file-backed
+      configuration but may diverge under an alternate runtime),
+      then security-checked: ``Path.resolve()`` follows symlinks, so a
+      file inside the workspace that symlinks to ``/etc/passwd``
+      resolves to the target and is correctly refused.
     """
-    raw = _opt(arguments, "path", default_name)
+    store = get_runtime_context().state_store
+    workspace = getattr(store, "workspace", Path.cwd()).resolve()
+    raw = arguments.get("path")
+    if not raw:
+        if store_attr is not None:
+            attr = getattr(store, store_attr, None)
+            if attr is not None:
+                # Backend-owned path: trusted output of an installed
+                # ``StateStore`` (the entry-point factory is host code,
+                # not an untrusted MCP caller). Skip the workspace
+                # boundary check so a backend can legitimately point
+                # outside ``workspace`` if its design requires it.
+                return Path(attr)
+        return workspace / default_name
+
     candidate = Path(raw)
-    cwd = Path.cwd().resolve()
-    resolved = (cwd / candidate if not candidate.is_absolute() else candidate).resolve()
+    resolved = (
+        workspace / candidate if not candidate.is_absolute() else candidate
+    ).resolve()
     try:
-        resolved.relative_to(cwd)
+        resolved.relative_to(workspace)
     except ValueError as exc:
         raise ValueError(
-            f"Refusing to read/write outside cwd: {resolved} is not inside {cwd}"
+            f"Refusing to read/write outside workspace: "
+            f"{resolved} is not inside {workspace}"
         ) from exc
     return resolved
 
@@ -73,7 +110,7 @@ def _resolve_path(arguments: dict[str, Any], default_name: str) -> Path:
 
 
 async def handle_strategy_get(arguments: dict[str, Any]) -> list[TextContent]:
-    path = _resolve_path(arguments, "STRATEGY.md")
+    path = _resolve_path(arguments, "STRATEGY.md", store_attr="strategy_path")
     if not path.exists():
         return _json_result({"markdown": "", "exists": False, "path": str(path)})
     text = path.read_text(encoding="utf-8")
@@ -82,7 +119,7 @@ async def handle_strategy_get(arguments: dict[str, Any]) -> list[TextContent]:
 
 async def handle_strategy_set(arguments: dict[str, Any]) -> list[TextContent]:
     markdown = _require(arguments, "markdown")
-    path = _resolve_path(arguments, "STRATEGY.md")
+    path = _resolve_path(arguments, "STRATEGY.md", store_attr="strategy_path")
     # Round-trip through parse so callers can't write a STRATEGY.md
     # whose subsequent parse_strategy() call breaks downstream skills.
     entries = parse_strategy(markdown)
@@ -107,7 +144,7 @@ def _state_to_dict(doc: StateDocument) -> dict[str, Any]:
 
 
 async def handle_state_get(arguments: dict[str, Any]) -> list[TextContent]:
-    path = _resolve_path(arguments, "STATE.json")
+    path = _resolve_path(arguments, "STATE.json", store_attr="state_path")
     # read_state_file already returns an empty default StateDocument when
     # the file is absent; round-trip through render_state to keep the
     # missing-file and present-file branches in lockstep.
@@ -137,7 +174,7 @@ async def handle_state_action_log_append(
         reversible_params=raw.get("reversible_params"),
         rollback_of=raw.get("rollback_of"),
     )
-    path = _resolve_path(arguments, "STATE.json")
+    path = _resolve_path(arguments, "STATE.json", store_attr="state_path")
     doc = append_action_log(path, entry)
     return _json_result(_state_to_dict(doc))
 
@@ -162,7 +199,7 @@ async def handle_state_upsert_campaign(
         campaign_goal=raw.get("campaign_goal"),
         notes=raw.get("notes"),
     )
-    path = _resolve_path(arguments, "STATE.json")
+    path = _resolve_path(arguments, "STATE.json", store_attr="state_path")
     try:
         doc = upsert_campaign(path, campaign)
     except ContextFileError as exc:

--- a/mureo/mcp/_handlers_rollback.py
+++ b/mureo/mcp/_handlers_rollback.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING, Any
 
 from mureo.context.errors import ContextFileError
 from mureo.context.state import read_state_file
-from mureo.mcp._helpers import _json_result, _opt, _require
+from mureo.mcp._helpers import _json_result, _require
 from mureo.rollback import (
     RollbackExecutionError,
     execute_rollback,
@@ -48,23 +48,50 @@ def _get_dispatcher() -> Callable[[str, dict[str, Any]], Awaitable[list[Any]]]:
 
 
 def _resolve_state_file(arguments: dict[str, Any]) -> Path:
-    """Resolve ``state_file`` against the MCP server's working directory.
+    """Resolve ``state_file`` against the active workspace.
 
-    The MCP caller is untrusted (a prompt-injected agent could point at
-    an attacker-crafted STATE.json elsewhere on the filesystem). We
-    require the argument to resolve to a path inside the current working
-    directory so the agent cannot smuggle in a rogue action_log.
+    The active workspace is
+    ``getattr(get_runtime_context().state_store, "workspace", Path.cwd())``
+    — CWD in the default file-backed configuration, or whatever
+    filesystem-backed :class:`StateStore` an alternate backend
+    registers via the ``mureo.runtime_context_factory`` entry-point
+    group.
+
+    The MCP caller is untrusted (a prompt-injected agent could point
+    at an attacker-crafted STATE.json elsewhere on the filesystem).
+    We require the argument to resolve to a path inside the workspace
+    so the agent cannot smuggle in a rogue action_log. ``Path.resolve()``
+    follows symlinks, so a file inside the workspace that symlinks to
+    ``/etc/passwd`` resolves to the target and is correctly refused.
     """
-    raw = _opt(arguments, "state_file", "STATE.json")
+    from mureo.core.runtime_context import get_runtime_context
+
+    store = get_runtime_context().state_store
+    workspace = getattr(store, "workspace", Path.cwd()).resolve()
+    raw = arguments.get("state_file")
+    if not raw:
+        attr = getattr(store, "state_path", None)
+        if attr is not None:
+            # Backend-owned path: trusted output of an installed
+            # ``StateStore`` (the entry-point factory is host code,
+            # not an untrusted MCP caller). Skip the workspace
+            # boundary check so a backend can legitimately point
+            # outside ``workspace`` if its design requires it.
+            # ``.resolve()`` normalises relative backend paths so
+            # downstream ``execute_rollback`` is not surprised by a
+            # CWD-relative interpretation later.
+            return Path(attr).resolve()
+        return workspace / "STATE.json"
     candidate = Path(raw)
-    cwd = Path.cwd().resolve()
-    resolved = (cwd / candidate if not candidate.is_absolute() else candidate).resolve()
+    resolved = (
+        workspace / candidate if not candidate.is_absolute() else candidate
+    ).resolve()
     try:
-        resolved.relative_to(cwd)
+        resolved.relative_to(workspace)
     except ValueError as exc:
         raise ValueError(
-            f"state_file must resolve inside the current working directory "
-            f"({cwd}); got {resolved}."
+            f"state_file must resolve inside the active workspace "
+            f"({workspace}); got {resolved}."
         ) from exc
     return resolved
 

--- a/mureo/mcp/server.py
+++ b/mureo/mcp/server.py
@@ -139,6 +139,12 @@ _PLUGIN_NAMES: frozenset[str] = frozenset(_PLUGIN_DISPATCH)
 # One conservative shared bucket for all plugin tool calls. Built-in
 # platforms keep their own per-platform throttlers; this only gates the
 # plugin dispatch branch.
+#
+# Kept as a module-level attribute because (a) existing tests
+# monkey-patch it directly to inject a spy throttler and (b) the lazy
+# seeding helper below copies its instance into the resolved
+# :class:`ProcessLocalThrottleStore` so the same bucket is observed
+# regardless of which path enters the dispatcher.
 _PLUGIN_THROTTLER = Throttler(PLUGIN_THROTTLE)
 
 # Phase 2 (#114): per-tool safety semantics derived from STANDARD MCP
@@ -153,6 +159,86 @@ _PLUGIN_TOOL_THROTTLERS: dict[str, Throttler] = {
     for name, sem in _PLUGIN_SEMANTICS.items()
     if sem.throttle is not None
 }
+
+
+# ---------------------------------------------------------------------------
+# Throttle dispatch — bridge legacy module state to the RuntimeContext
+# throttle_store so an alternate backend (registered via
+# ``mureo.runtime_context_factory``) can take over without each handler
+# having to know about it.
+# ---------------------------------------------------------------------------
+
+
+# Sentinel key for the "everything else" bucket installed alongside the
+# per-tool buckets when seeding a default ``ProcessLocalThrottleStore``.
+# Kept as a module-level constant so the seeding helper and the
+# unknown-name fallback both reference the same string.
+_PLUGIN_DEFAULT_BUCKET = "__plugin_default__"
+
+# Set of ``id()``s of ``ProcessLocalThrottleStore`` instances we have
+# already seeded with the legacy ``_PLUGIN_TOOL_THROTTLERS`` configs.
+# Idempotent: re-entry against a previously-seeded store is a no-op.
+# Tests that monkey-patch ``_PLUGIN_THROTTLER`` or
+# ``_PLUGIN_TOOL_THROTTLERS`` directly must clear this set AND call
+# ``reset_runtime_context()`` so the next handler call re-seeds a
+# freshly-resolved store with the patched throttlers.
+_throttle_store_seeded: set[int] = set()
+
+
+async def _acquire_plugin_throttle(name: str) -> None:
+    """Acquire one throttle slot for plugin tool ``name``.
+
+    Routes through ``get_runtime_context().throttle_store`` so an
+    alternate backend can intercept the call. For the default
+    file-backed runtime the throttle_store is a
+    :class:`ProcessLocalThrottleStore`; this function lazily seeds it
+    with the per-tool ``Throttler`` instances built at module load,
+    preserving today's per-name bucket semantics. The fallback bucket
+    for unknown names is the store's ``default_config`` (=
+    ``PLUGIN_THROTTLE`` for the default runtime).
+
+    The legacy ``_PLUGIN_THROTTLER`` / ``_PLUGIN_TOOL_THROTTLERS``
+    module attributes are still consulted: tests that monkey-patch
+    them continue to observe their spy being invoked, because the
+    seeded ``ProcessLocalThrottleStore`` uses those exact instances.
+
+    Alternate backends (non-``ProcessLocalThrottleStore`` returned by a
+    ``mureo.runtime_context_factory`` entry-point) receive a single
+    ``acquire(name)`` call and own the full per-key + unknown-name
+    fallback semantics themselves. The seeding step above is
+    deliberately skipped for them: this Protocol exposes only
+    ``acquire``, so a backend that wants the "unknown name → shared
+    default bucket" behaviour must implement it internally.
+    """
+    # Lazy import to avoid an import cycle: ``mureo.core.runtime_context``
+    # is free to reference MCP types in future without circling back to
+    # this module via the top-level import graph.
+    from mureo.core.runtime_context import get_runtime_context
+    from mureo.core.throttle_store import ProcessLocalThrottleStore
+
+    store = get_runtime_context().throttle_store
+    if isinstance(store, ProcessLocalThrottleStore):
+        ident = id(store)
+        if ident not in _throttle_store_seeded:
+            # Install per-tool buckets first.
+            for tname, throttler in _PLUGIN_TOOL_THROTTLERS.items():
+                store.throttlers.setdefault(tname, throttler)
+            # And the conservative fallback bucket for unknown names.
+            # We DO NOT call store.register() here because that would
+            # rebuild a fresh Throttler from default_config; reusing
+            # ``_PLUGIN_THROTTLER`` keeps the singleton state (token
+            # bucket) coherent across the legacy and RuntimeContext
+            # paths.
+            store.throttlers.setdefault(_PLUGIN_DEFAULT_BUCKET, _PLUGIN_THROTTLER)
+            _throttle_store_seeded.add(ident)
+        # Unknown names go through the default bucket. Resolve here
+        # because the Protocol does not expose "give me the throttler
+        # for this key" — only acquire(key) — and we want the named
+        # bucket for known names but the SHARED bucket for unknown.
+        if name not in _PLUGIN_TOOL_THROTTLERS:
+            await store.throttlers[_PLUGIN_DEFAULT_BUCKET].acquire()
+            return
+    await store.acquire(name)
 
 
 # ---------------------------------------------------------------------------
@@ -187,8 +273,7 @@ async def handle_call_tool(name: str, arguments: dict[str, Any]) -> list[Any]:
         provider = _PLUGIN_DISPATCH[name]
         source = plugin_source(provider)
         sem = _PLUGIN_SEMANTICS.get(name)
-        throttler = _PLUGIN_TOOL_THROTTLERS.get(name, _PLUGIN_THROTTLER)
-        await throttler.acquire()
+        await _acquire_plugin_throttle(name)
         try:
             result = await provider.handle_mcp_tool(name, arguments)
         except KeyboardInterrupt:

--- a/skills/learn/SKILL.md
+++ b/skills/learn/SKILL.md
@@ -2,17 +2,25 @@
 name: learn
 description: "Save a marketing diagnosis insight to the pro-diagnosis knowledge base so it is applied in future operations across all platforms. Use when the user runs /learn, explicitly teaches the agent a marketing insight, corrects the agent's analysis, or asks to remember/record an operational learning for next time."
 metadata:
-  version: 0.7.1
+  version: 0.8.0
 ---
 
 # Learn
 
 > PREREQUISITE: Read `../_mureo-shared/SKILL.md` for auth, security rules, output format, and **Tool Selection** (Read/Write on Code, `mureo_strategy_*` / `mureo_state_*` MCP on Desktop / Cowork).
 
-Save a marketing diagnosis insight to the pro-diagnosis knowledge base
-(`../_mureo-pro-diagnosis/SKILL.md`). Saved insights are loaded at the
-start of future sessions and applied across `/daily-check`, `/rescue`,
-`/budget-rebalance`, and the other diagnostic workflows.
+Save a marketing diagnosis insight to the pro-diagnosis knowledge base.
+Saved insights are loaded at the start of future sessions and applied
+across `/daily-check`, `/rescue`, `/budget-rebalance`, and the other
+diagnostic workflows.
+
+The skill persists insights by shelling out to `mureo learn add`,
+which routes the write through the KnowledgeStore Protocol. The
+default backend writes to
+`~/.claude/skills/_mureo-pro-diagnosis/SKILL.md` (preserving the
+prior file layout); an alternate backend registered via the
+`mureo.runtime_context_factory` entry-point group can redirect or
+split the write without changing this skill.
 
 ## When to use
 
@@ -31,31 +39,7 @@ start of future sessions and applied across `/daily-check`, `/rescue`,
    moments where the user corrected the agent's analysis or supplied
    marketing expertise, and select the most reusable one(s).
 
-2. **Locate the knowledge base.** The target is the sibling skill file
-   `../_mureo-pro-diagnosis/SKILL.md` (relative to this skill, i.e.
-   `~/.claude/skills/_mureo-pro-diagnosis/SKILL.md` for an installed
-   user). If it already exists, read it first to avoid duplicate or
-   conflicting entries. If it does **not** exist (it is not shipped — it
-   grows per account), create the directory and seed the file with this
-   minimal scaffold before appending:
-
-   ```markdown
-   ---
-   name: _mureo-pro-diagnosis
-   description: "Professional marketing diagnostic frameworks: expert-level campaign analysis that grows with your experience."
-   metadata:
-     version: 0.1.0
-   ---
-
-   # Pro Diagnosis — Account Knowledge Base
-
-   Insights learned from operating this account, applied by every mureo
-   diagnostic workflow.
-
-   ## Learned Insights
-   ```
-
-3. **Structure the insight** using this template:
+2. **Structure the insight** using this template:
 
    ```markdown
    ### [Short descriptive title]
@@ -68,20 +52,33 @@ start of future sessions and applied across `/daily-check`, `/rescue`,
    Date learned: YYYY-MM-DD
    ```
 
-4. **Present for approval.** Show the formatted insight to the user and
-   ask for explicit confirmation before writing anything. Capture the
+3. **Present for approval.** Show the formatted insight to the user
+   and ask for explicit confirmation before saving. Capture the
    generalized lesson only — never record account IDs, credentials,
    access tokens, or personal data in the knowledge base.
 
-5. **Save.** Append the approved insight under the `## Learned Insights`
-   section of `../_mureo-pro-diagnosis/SKILL.md` (creating the file from
-   the scaffold in step 2 first if it was absent). Append only — never
-   rewrite or reorder existing entries.
+4. **Save by invoking the CLI.** Pass the approved insight verbatim
+   (including its leading blank line and trailing newline) to:
 
-6. **Confirm.** Tell the user the insight was saved and that it will be
-   applied in future `/daily-check`, `/rescue`, `/budget-rebalance`, and
-   other diagnostic workflows.
+   ```bash
+   mureo learn add "$INSIGHT_MARKDOWN"
+   ```
 
-IMPORTANT: Always save to `../_mureo-pro-diagnosis/SKILL.md`, never to
-Claude Code memory. The skill file persists across sessions and is read
-by all mureo diagnostic workflows; Claude memory is not.
+   - The default `--scope operator` writes the cross-workspace tier
+     read by every diagnostic skill. Use this for general practitioner
+     know-how that applies to every account the operator runs.
+   - Pass `--scope workspace` when the insight is specific to the
+     active account and should not leak to other workspaces (only
+     meaningful when a workspace-aware KnowledgeStore backend is
+     installed; the command exits with a helpful message otherwise).
+
+5. **Confirm.** Tell the user the insight was saved and that it will
+   be applied in future `/daily-check`, `/rescue`, `/budget-rebalance`,
+   and other diagnostic workflows.
+
+IMPORTANT: Always save through `mureo learn add`, never by writing the
+file path manually. Going through the CLI keeps the skill compatible
+with alternate KnowledgeStore backends and avoids the agent having to
+know about the scaffold/file layout. Never save to Claude Code memory;
+the on-disk knowledge base persists across sessions, Claude memory
+does not.

--- a/tests/core/test_filesystem_knowledge_store.py
+++ b/tests/core/test_filesystem_knowledge_store.py
@@ -91,32 +91,21 @@ def test_default_operator_path_under_claude_skills(monkeypatch: pytest.MonkeyPat
 
 
 @pytest.mark.unit
-def test_scaffold_matches_skills_learn_template() -> None:
-    """Regression guard: the seeded scaffold must stay byte-identical to
-    the template embedded in ``skills/learn/SKILL.md``. If that template
-    is edited without updating ``_OPERATOR_SCAFFOLD`` (or vice-versa)
-    files written by /learn and files seeded by the default
-    KnowledgeStore will silently diverge.
+def test_scaffold_has_expected_frontmatter_and_section() -> None:
+    """The seeded scaffold must contain the YAML frontmatter and the
+    ``## Learned Insights`` section that downstream diagnostic skills
+    rely on.
 
-    The skill file embeds the scaffold inside a ```` ```markdown ```` fence
-    nested in a numbered list, so every line carries a 3-space indent.
-    Strip the common indent before comparing."""
-    import re
-    import textwrap
-
+    The /learn skill no longer ships its own copy of this scaffold (it
+    now invokes ``mureo learn add`` which uses :class:`KnowledgeStore`
+    instead of writing the file directly), so the previous
+    drift-vs-skill regression test is replaced by a shape check on the
+    constant itself."""
     from mureo.core.knowledge_store import _OPERATOR_SCAFFOLD
 
-    repo_root = Path(__file__).resolve().parents[2]
-    skill_md = (repo_root / "skills" / "learn" / "SKILL.md").read_text(encoding="utf-8")
-
-    match = re.search(
-        r"```markdown\n(   ---\n.*?## Learned Insights\n)\s*```",
-        skill_md,
-        re.DOTALL,
-    )
-    assert match, (
-        "could not locate the scaffold fence in skills/learn/SKILL.md; "
-        "if the skill format changed, update both files together"
-    )
-    dedented = textwrap.dedent(match.group(1))
-    assert dedented == _OPERATOR_SCAFFOLD
+    assert _OPERATOR_SCAFFOLD.startswith("---\n")
+    assert "name: _mureo-pro-diagnosis" in _OPERATOR_SCAFFOLD
+    assert "## Learned Insights" in _OPERATOR_SCAFFOLD
+    # The scaffold MUST end with a newline so the first appended
+    # insight does not land on the same line as "## Learned Insights".
+    assert _OPERATOR_SCAFFOLD.endswith("\n")

--- a/tests/core/test_filesystem_knowledge_store.py
+++ b/tests/core/test_filesystem_knowledge_store.py
@@ -81,7 +81,10 @@ def test_workspace_tier_round_trip_when_configured(tmp_path: Path) -> None:
 
 @pytest.mark.unit
 def test_default_operator_path_under_claude_skills(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    monkeypatch.setenv("HOME", str(tmp_path))
+    """Patches ``Path.home`` directly so the test is Windows-safe — see
+    ``test_runtime_context.test_default_factory_no_args_uses_legacy_paths``
+    for the rationale."""
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
     store = FilesystemKnowledgeStore()
     expected = tmp_path / ".claude" / "skills" / "_mureo-pro-diagnosis" / "SKILL.md"
     assert store.operator_path == expected

--- a/tests/core/test_filesystem_knowledge_store.py
+++ b/tests/core/test_filesystem_knowledge_store.py
@@ -1,0 +1,119 @@
+"""Tests for ``mureo.core.knowledge_store.FilesystemKnowledgeStore`` —
+the default in-process implementation that persists ``/learn`` insights
+to Markdown files on disk.
+
+Default operator-tier path mirrors today's
+``~/.claude/skills/_mureo-pro-diagnosis/SKILL.md``. Default workspace
+tier is absent (``read_workspace_knowledge`` returns ``None`` and
+``append_workspace_knowledge`` raises). Both paths are injectable for
+tests and for alternate setups.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mureo.core.knowledge_store import FilesystemKnowledgeStore, KnowledgeStore
+
+
+@pytest.mark.unit
+def test_satisfies_protocol(tmp_path: Path) -> None:
+    store = FilesystemKnowledgeStore(operator_path=tmp_path / "op.md")
+    assert isinstance(store, KnowledgeStore)
+
+
+@pytest.mark.unit
+def test_read_operator_missing_returns_empty_string(tmp_path: Path) -> None:
+    store = FilesystemKnowledgeStore(operator_path=tmp_path / "op.md")
+    assert store.read_operator_knowledge() == ""
+
+
+@pytest.mark.unit
+def test_append_operator_creates_file_with_scaffold(tmp_path: Path) -> None:
+    """First write must seed the file with the same frontmatter scaffold
+    that today's ``/learn`` skill (`skills/learn/SKILL.md`) uses, so the
+    operator-tier consumers see no behavioural change."""
+    path = tmp_path / "op.md"
+    store = FilesystemKnowledgeStore(operator_path=path)
+    store.append_operator_knowledge("first insight\n")
+    text = path.read_text(encoding="utf-8")
+    assert text.startswith("---\n")
+    assert "name: _mureo-pro-diagnosis" in text
+    assert "## Learned Insights" in text
+    assert "first insight" in text
+
+
+@pytest.mark.unit
+def test_append_operator_is_additive(tmp_path: Path) -> None:
+    store = FilesystemKnowledgeStore(operator_path=tmp_path / "op.md")
+    store.append_operator_knowledge("first insight\n")
+    store.append_operator_knowledge("second insight\n")
+    text = store.read_operator_knowledge()
+    assert "first insight" in text
+    assert "second insight" in text
+    assert text.index("first") < text.index("second")
+
+
+@pytest.mark.unit
+def test_workspace_tier_absent_by_default(tmp_path: Path) -> None:
+    store = FilesystemKnowledgeStore(operator_path=tmp_path / "op.md")
+    assert store.read_workspace_knowledge() is None
+
+
+@pytest.mark.unit
+def test_append_workspace_without_tier_raises(tmp_path: Path) -> None:
+    store = FilesystemKnowledgeStore(operator_path=tmp_path / "op.md")
+    with pytest.raises(NotImplementedError):
+        store.append_workspace_knowledge("would be lost")
+
+
+@pytest.mark.unit
+def test_workspace_tier_round_trip_when_configured(tmp_path: Path) -> None:
+    op = tmp_path / "op.md"
+    ws = tmp_path / "ws.md"
+    store = FilesystemKnowledgeStore(operator_path=op, workspace_path=ws)
+    assert store.read_workspace_knowledge() == ""  # configured but empty
+    store.append_workspace_knowledge("ws insight\n")
+    assert "ws insight" in (store.read_workspace_knowledge() or "")
+
+
+@pytest.mark.unit
+def test_default_operator_path_under_claude_skills(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    store = FilesystemKnowledgeStore()
+    expected = tmp_path / ".claude" / "skills" / "_mureo-pro-diagnosis" / "SKILL.md"
+    assert store.operator_path == expected
+
+
+@pytest.mark.unit
+def test_scaffold_matches_skills_learn_template() -> None:
+    """Regression guard: the seeded scaffold must stay byte-identical to
+    the template embedded in ``skills/learn/SKILL.md``. If that template
+    is edited without updating ``_OPERATOR_SCAFFOLD`` (or vice-versa)
+    files written by /learn and files seeded by the default
+    KnowledgeStore will silently diverge.
+
+    The skill file embeds the scaffold inside a ```` ```markdown ```` fence
+    nested in a numbered list, so every line carries a 3-space indent.
+    Strip the common indent before comparing."""
+    import re
+    import textwrap
+
+    from mureo.core.knowledge_store import _OPERATOR_SCAFFOLD
+
+    repo_root = Path(__file__).resolve().parents[2]
+    skill_md = (repo_root / "skills" / "learn" / "SKILL.md").read_text(encoding="utf-8")
+
+    match = re.search(
+        r"```markdown\n(   ---\n.*?## Learned Insights\n)\s*```",
+        skill_md,
+        re.DOTALL,
+    )
+    assert match, (
+        "could not locate the scaffold fence in skills/learn/SKILL.md; "
+        "if the skill format changed, update both files together"
+    )
+    dedented = textwrap.dedent(match.group(1))
+    assert dedented == _OPERATOR_SCAFFOLD

--- a/tests/core/test_filesystem_secret_store.py
+++ b/tests/core/test_filesystem_secret_store.py
@@ -104,7 +104,10 @@ def test_corrupt_file_returns_empty_on_load(tmp_path: Path) -> None:
 
 @pytest.mark.unit
 def test_default_path_resolves_under_dot_mureo(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    monkeypatch.setenv("HOME", str(tmp_path))
+    """Patches ``Path.home`` directly so the test is Windows-safe — see
+    ``test_runtime_context.test_default_factory_no_args_uses_legacy_paths``
+    for the rationale."""
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
     store = FilesystemSecretStore()
     assert store.path == tmp_path / ".mureo" / "credentials.json"
 

--- a/tests/core/test_filesystem_secret_store.py
+++ b/tests/core/test_filesystem_secret_store.py
@@ -1,0 +1,131 @@
+"""Tests for ``mureo.core.secret_store.FilesystemSecretStore`` — the
+default in-process implementation that persists credentials to a JSON
+file (today: ``~/.mureo/credentials.json``).
+
+The default is the behaviourally-equivalent wrapper of the existing
+file format read by ``mureo.auth.load_credentials``. Tests below pin
+the round-trip semantics and the platform-key-scoped CRUD that callers
+will rely on once the consumers in ``mureo.auth`` are refactored in a
+follow-up commit.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from mureo.core.secret_store import FilesystemSecretStore, SecretStore
+
+
+@pytest.mark.unit
+def test_satisfies_protocol(tmp_path: Path) -> None:
+    store = FilesystemSecretStore(path=tmp_path / "credentials.json")
+    assert isinstance(store, SecretStore)
+
+
+@pytest.mark.unit
+def test_load_missing_file_returns_empty_dict(tmp_path: Path) -> None:
+    store = FilesystemSecretStore(path=tmp_path / "credentials.json")
+    assert store.load("google_ads") == {}
+
+
+@pytest.mark.unit
+def test_save_then_load_round_trip(tmp_path: Path) -> None:
+    store = FilesystemSecretStore(path=tmp_path / "credentials.json")
+    payload = {"developer_token": "abc", "client_id": "xyz"}
+    store.save("google_ads", payload)
+    assert store.load("google_ads") == payload
+
+
+@pytest.mark.unit
+def test_save_does_not_clobber_other_keys(tmp_path: Path) -> None:
+    """Saving one platform must preserve credentials for unrelated platforms
+    so existing call sites (which read the full file via
+    ``auth.load_credentials``) keep seeing every entry they expect."""
+    store = FilesystemSecretStore(path=tmp_path / "credentials.json")
+    store.save("google_ads", {"developer_token": "abc"})
+    store.save("meta_ads", {"access_token": "fb-token"})
+    assert store.load("google_ads") == {"developer_token": "abc"}
+    assert store.load("meta_ads") == {"access_token": "fb-token"}
+
+
+@pytest.mark.unit
+def test_save_overwrites_existing_key(tmp_path: Path) -> None:
+    store = FilesystemSecretStore(path=tmp_path / "credentials.json")
+    store.save("google_ads", {"developer_token": "old"})
+    store.save("google_ads", {"developer_token": "new"})
+    assert store.load("google_ads") == {"developer_token": "new"}
+
+
+@pytest.mark.unit
+def test_delete_removes_key(tmp_path: Path) -> None:
+    store = FilesystemSecretStore(path=tmp_path / "credentials.json")
+    store.save("google_ads", {"developer_token": "abc"})
+    store.delete("google_ads")
+    assert store.load("google_ads") == {}
+
+
+@pytest.mark.unit
+def test_delete_missing_key_is_idempotent(tmp_path: Path) -> None:
+    store = FilesystemSecretStore(path=tmp_path / "credentials.json")
+    store.delete("google_ads")  # file does not even exist; must not raise
+    store.save("meta_ads", {"access_token": "x"})
+    store.delete("google_ads")  # file exists but key absent; still must not raise
+
+
+@pytest.mark.unit
+def test_save_writes_secure_permissions(tmp_path: Path) -> None:
+    """Credential files must land at 0600 (owner-only). Mirrors
+    ``mureo.fsutil.secure_chmod`` semantics used elsewhere for secret
+    material. Skipped on Windows because POSIX mode bits do not apply."""
+    if os.name != "posix":
+        pytest.skip("POSIX-only permission check")
+    path = tmp_path / "credentials.json"
+    store = FilesystemSecretStore(path=path)
+    store.save("google_ads", {"developer_token": "abc"})
+    mode = stat.S_IMODE(path.stat().st_mode)
+    assert mode == 0o600, f"expected 0o600, got 0o{mode:o}"
+
+
+@pytest.mark.unit
+def test_corrupt_file_returns_empty_on_load(tmp_path: Path) -> None:
+    """Mirrors ``mureo.auth.load_credentials`` — invalid JSON is treated
+    as 'no credentials' rather than crashing, so an MCP server can still
+    start."""
+    path = tmp_path / "credentials.json"
+    path.write_text("not json at all", encoding="utf-8")
+    store = FilesystemSecretStore(path=path)
+    assert store.load("google_ads") == {}
+
+
+@pytest.mark.unit
+def test_default_path_resolves_under_dot_mureo(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    store = FilesystemSecretStore()
+    assert store.path == tmp_path / ".mureo" / "credentials.json"
+
+
+@pytest.mark.unit
+def test_saved_payload_is_isolated_from_caller_mutation(tmp_path: Path) -> None:
+    store = FilesystemSecretStore(path=tmp_path / "credentials.json")
+    payload = {"developer_token": "abc"}
+    store.save("google_ads", payload)
+    payload["developer_token"] = "MUTATED"
+    assert store.load("google_ads") == {"developer_token": "abc"}
+
+
+@pytest.mark.unit
+def test_save_strips_non_dict_root(tmp_path: Path) -> None:
+    """If the on-disk file's root is not a JSON object (e.g. a list left
+    by a user mistake), ``save`` recovers by replacing it with a fresh
+    object containing only the saved key — mirrors
+    ``auth.load_credentials`` which already tolerates this shape."""
+    path = tmp_path / "credentials.json"
+    path.write_text(json.dumps(["not", "an", "object"]), encoding="utf-8")
+    store = FilesystemSecretStore(path=path)
+    store.save("google_ads", {"developer_token": "abc"})
+    assert store.load("google_ads") == {"developer_token": "abc"}

--- a/tests/core/test_filesystem_state_store.py
+++ b/tests/core/test_filesystem_state_store.py
@@ -1,0 +1,104 @@
+"""Tests for ``mureo.core.state_store.FilesystemStateStore`` — the
+default in-process implementation that persists ``STATE.json`` /
+``STRATEGY.md`` to a workspace directory (today: CWD).
+
+The default delegates to the existing helpers in
+``mureo.context.state`` and ``mureo.context.strategy`` so call-site
+behaviour is preserved once the consumers are refactored in a follow-up
+commit.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mureo.context.models import ActionLogEntry, StateDocument, StrategyEntry
+from mureo.core.state_store import FilesystemStateStore, StateStore
+
+
+@pytest.mark.unit
+def test_satisfies_protocol(tmp_path: Path) -> None:
+    store = FilesystemStateStore(workspace=tmp_path)
+    assert isinstance(store, StateStore)
+
+
+@pytest.mark.unit
+def test_read_state_missing_returns_empty_document(tmp_path: Path) -> None:
+    """Mirrors ``read_state_file`` — a missing file is not an error."""
+    store = FilesystemStateStore(workspace=tmp_path)
+    assert store.read_state() == StateDocument()
+
+
+@pytest.mark.unit
+def test_write_then_read_state_round_trip(tmp_path: Path) -> None:
+    store = FilesystemStateStore(workspace=tmp_path)
+    doc = StateDocument(version="2", customer_id="123-456-7890")
+    store.write_state(doc)
+    assert (tmp_path / "STATE.json").exists()
+    assert store.read_state() == doc
+
+
+@pytest.mark.unit
+def test_read_strategy_missing_returns_empty_list(tmp_path: Path) -> None:
+    store = FilesystemStateStore(workspace=tmp_path)
+    assert store.read_strategy() == []
+
+
+@pytest.mark.unit
+def test_write_then_read_strategy_round_trip(tmp_path: Path) -> None:
+    store = FilesystemStateStore(workspace=tmp_path)
+    entries = [
+        StrategyEntry(context_type="persona", title="Persona", content="x"),
+        StrategyEntry(context_type="usp", title="USP", content="y"),
+    ]
+    store.write_strategy(entries)
+    assert (tmp_path / "STRATEGY.md").exists()
+    assert store.read_strategy() == entries
+
+
+@pytest.mark.unit
+def test_read_strategy_returns_isolated_snapshot(tmp_path: Path) -> None:
+    store = FilesystemStateStore(workspace=tmp_path)
+    store.write_strategy([StrategyEntry(context_type="persona", title="T", content="x")])
+    snap = store.read_strategy()
+    snap.append(StrategyEntry(context_type="usp", title="U", content="y"))
+    assert len(store.read_strategy()) == 1
+
+
+@pytest.mark.unit
+def test_append_action_log_accumulates(tmp_path: Path) -> None:
+    store = FilesystemStateStore(workspace=tmp_path)
+    e1 = ActionLogEntry(timestamp="2026-01-01T00:00:00Z", action="a", platform="g")
+    e2 = ActionLogEntry(timestamp="2026-01-02T00:00:00Z", action="b", platform="m")
+    store.append_action_log(e1)
+    store.append_action_log(e2)
+    assert store.read_state().action_log == (e1, e2)
+
+
+@pytest.mark.unit
+def test_append_action_log_creates_state_file_when_missing(tmp_path: Path) -> None:
+    """``append_action_log`` against a workspace with no STATE.json must
+    transparently create the file with a default StateDocument shell."""
+    store = FilesystemStateStore(workspace=tmp_path)
+    entry = ActionLogEntry(timestamp="2026-01-01T00:00:00Z", action="a", platform="g")
+    store.append_action_log(entry)
+    assert (tmp_path / "STATE.json").exists()
+    assert store.read_state().action_log == (entry,)
+
+
+@pytest.mark.unit
+def test_workspace_paths_resolve_under_workspace_dir(tmp_path: Path) -> None:
+    """Both files must sit alongside each other under the workspace dir so
+    operator assets (creatives, briefs) can co-locate."""
+    store = FilesystemStateStore(workspace=tmp_path)
+    assert store.state_path == tmp_path / "STATE.json"
+    assert store.strategy_path == tmp_path / "STRATEGY.md"
+
+
+@pytest.mark.unit
+def test_default_workspace_is_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    store = FilesystemStateStore()
+    assert store.state_path == tmp_path / "STATE.json"

--- a/tests/core/test_knowledge_store.py
+++ b/tests/core/test_knowledge_store.py
@@ -1,0 +1,98 @@
+"""Tests for ``mureo.core.knowledge_store`` — structural Protocol contract.
+
+RED-phase tests for the new ``KnowledgeStore`` Protocol that abstracts
+the two-tier ``/learn`` knowledge base — one tier shared across the
+operator's workspaces (today: ``~/.claude/skills/_mureo-pro-diagnosis/``)
+and one tier scoped to the current workspace (today: absent in the
+default OSS configuration).
+
+Default callers continue to read the operator tier from the existing
+``~/.claude/skills/_mureo-pro-diagnosis/SKILL.md`` location. This
+Protocol exists so the tier-resolution mechanism is replaceable
+(in-memory fakes, alternate locations, etc.).
+
+This commit pins the Protocol shape only — concrete default
+implementations land in a separate commit.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+
+from mureo.core.knowledge_store import KnowledgeStore
+
+
+@dataclass
+class _FakeKnowledgeStore:
+    """Minimal in-memory implementation used to exercise the Protocol shape."""
+
+    operator: str = ""
+    workspace: str | None = None  # None means "no workspace tier configured"
+    operator_appends: list[str] = field(default_factory=list)
+    workspace_appends: list[str] = field(default_factory=list)
+
+    def read_operator_knowledge(self) -> str:
+        return self.operator
+
+    def read_workspace_knowledge(self) -> str | None:
+        return self.workspace
+
+    def append_operator_knowledge(self, insight: str) -> None:
+        self.operator_appends.append(insight)
+        self.operator += insight
+
+    def append_workspace_knowledge(self, insight: str) -> None:
+        if self.workspace is None:
+            raise NotImplementedError("no workspace tier configured")
+        self.workspace_appends.append(insight)
+        self.workspace += insight
+
+
+@pytest.mark.unit
+def test_protocol_is_runtime_checkable() -> None:
+    assert isinstance(_FakeKnowledgeStore(), KnowledgeStore)
+
+
+@pytest.mark.unit
+def test_incomplete_implementation_is_rejected() -> None:
+    class _MissingWorkspaceRead:
+        def read_operator_knowledge(self) -> str:
+            return ""
+
+        def append_operator_knowledge(self, insight: str) -> None:
+            pass
+
+        def append_workspace_knowledge(self, insight: str) -> None:
+            pass
+
+    assert not isinstance(_MissingWorkspaceRead(), KnowledgeStore)
+
+
+@pytest.mark.unit
+def test_workspace_tier_may_be_absent() -> None:
+    """``read_workspace_knowledge`` returns ``None`` when no workspace tier
+    exists (default in single-workspace mode)."""
+    store = _FakeKnowledgeStore()
+    assert store.read_workspace_knowledge() is None
+
+
+@pytest.mark.unit
+def test_append_workspace_when_absent_raises() -> None:
+    """When no workspace tier is configured, appends must fail loudly so
+    misrouted writes are caught instead of silently going nowhere."""
+    store = _FakeKnowledgeStore()
+    with pytest.raises(NotImplementedError):
+        store.append_workspace_knowledge("would be lost")
+
+
+@pytest.mark.unit
+def test_append_routes_to_correct_tier() -> None:
+    store = _FakeKnowledgeStore(workspace="")  # opt in to workspace tier
+    store.append_operator_knowledge("operator insight")
+    store.append_workspace_knowledge("workspace insight")
+    assert store.operator_appends == ["operator insight"]
+    assert store.workspace_appends == ["workspace insight"]
+    assert "operator insight" in store.read_operator_knowledge()
+    assert store.read_workspace_knowledge() == "workspace insight"

--- a/tests/core/test_process_local_throttle_store.py
+++ b/tests/core/test_process_local_throttle_store.py
@@ -1,0 +1,86 @@
+"""Tests for ``mureo.core.throttle_store.ProcessLocalThrottleStore`` —
+the default in-process implementation that maintains a per-key
+``mureo.throttle.Throttler`` and awaits ``acquire()`` on the matching
+instance.
+
+Behavioural equivalence with today's MCP server pattern: each unique
+``key`` lazily materialises its own token bucket; repeated calls with
+the same key reuse the same bucket so QPS limits are enforced across
+the process.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mureo.core.throttle_store import ProcessLocalThrottleStore, ThrottleStore
+from mureo.throttle import ThrottleConfig
+
+
+@pytest.mark.unit
+def test_satisfies_protocol() -> None:
+    assert isinstance(ProcessLocalThrottleStore(), ThrottleStore)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_acquire_returns_without_blocking_on_first_call() -> None:
+    """A token bucket with a burst of ``1`` permits the first acquire
+    immediately — used to verify the wired Throttler is in fact awaited."""
+    config = ThrottleConfig(rate=1000.0, burst=10)
+    store = ProcessLocalThrottleStore(default_config=config)
+    await store.acquire("anything")  # must return promptly
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_same_key_reuses_throttler() -> None:
+    """Repeated acquire on the same key must hit the same Throttler so
+    rate limits are enforced — observable via the internal cache."""
+    config = ThrottleConfig(rate=1000.0, burst=10)
+    store = ProcessLocalThrottleStore(default_config=config)
+    await store.acquire("key-a")
+    await store.acquire("key-a")
+    assert len(store.throttlers) == 1
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_distinct_keys_get_separate_throttlers() -> None:
+    config = ThrottleConfig(rate=1000.0, burst=10)
+    store = ProcessLocalThrottleStore(default_config=config)
+    await store.acquire("key-a")
+    await store.acquire("key-b")
+    assert set(store.throttlers.keys()) == {"key-a", "key-b"}
+
+
+@pytest.mark.unit
+def test_default_config_is_used_when_unspecified() -> None:
+    """When no config is injected the store must fall back to
+    ``mureo.throttle.PLUGIN_THROTTLE`` so callers that do nothing special
+    see the same limits as today's MCP server."""
+    from mureo.throttle import PLUGIN_THROTTLE
+
+    store = ProcessLocalThrottleStore()
+    assert store.default_config is PLUGIN_THROTTLE
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_register_installs_custom_throttler_used_by_acquire() -> None:
+    """``register(key, config)`` pre-installs a Throttler with the given
+    config; subsequent ``acquire(key)`` reuses that exact instance
+    (verified by identity) instead of materialising a new one from
+    default_config. Mirrors today's MCP-server pattern that builds
+    per-tool buckets from ``derive_semantics``."""
+    default = ThrottleConfig(rate=1.0, burst=1)  # slow default
+    fast = ThrottleConfig(rate=1000.0, burst=10)  # fast override
+    store = ProcessLocalThrottleStore(default_config=default)
+    store.register("fast-tool", fast)
+    registered = store.throttlers["fast-tool"]
+    # Wiring check: the Throttler was actually built from ``fast``, not
+    # ``default``. Reaches into a private attribute deliberately — there
+    # is no public way to read the config back from a Throttler.
+    assert registered._rate == fast.rate  # type: ignore[attr-defined]
+    await store.acquire("fast-tool")
+    assert store.throttlers["fast-tool"] is registered

--- a/tests/core/test_public_api.py
+++ b/tests/core/test_public_api.py
@@ -1,0 +1,93 @@
+"""Pin the public surface re-exported by :mod:`mureo.core`.
+
+The package was previously empty (no ``__all__``, no re-exports). This
+test guards the new exports added alongside the extension-Protocol
+work so a downstream consumer that does ``from mureo.core import
+RuntimeContext`` keeps compiling across releases.
+
+A new symbol added here is an ABI commitment — drop one only with a
+deprecation cycle.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.unit
+def test_public_protocols_are_importable() -> None:
+    from mureo.core import (
+        KnowledgeStore,
+        SecretStore,
+        StateStore,
+        ThrottleStore,
+    )
+
+    # Sanity: each is a Protocol with the expected runtime_checkable shape.
+    for proto in (SecretStore, StateStore, KnowledgeStore, ThrottleStore):
+        assert hasattr(proto, "__instancecheck__")
+
+
+@pytest.mark.unit
+def test_public_default_implementations_are_importable() -> None:
+    from mureo.core import (
+        FilesystemKnowledgeStore,
+        FilesystemSecretStore,
+        FilesystemStateStore,
+        ProcessLocalThrottleStore,
+    )
+
+    # Sanity: each can be instantiated with no required args.
+    FilesystemSecretStore()
+    FilesystemStateStore()
+    FilesystemKnowledgeStore()
+    ProcessLocalThrottleStore()
+
+
+@pytest.mark.unit
+def test_public_runtime_context_is_importable() -> None:
+    """Exercise the factory through the public package path so a future
+    accidental rewiring of the re-export (e.g. shadowing in
+    ``__init__.py``) is caught by this test."""
+    from mureo.core import (
+        DEFAULT_WORKSPACE_ID,
+        RuntimeContext,
+        default_runtime_context,
+    )
+
+    assert RuntimeContext.__name__ == "RuntimeContext"
+    ctx = default_runtime_context()
+    assert isinstance(ctx, RuntimeContext)
+    assert ctx.workspace_id == DEFAULT_WORKSPACE_ID
+
+
+@pytest.mark.unit
+def test_public_all_matches_documented_surface() -> None:
+    """``__all__`` is the contract — every name above must be in it, no
+    surprise extras should appear without a code review."""
+    import mureo.core as core
+
+    assert sorted(core.__all__) == sorted([
+        "DEFAULT_WORKSPACE_ID",
+        "FilesystemKnowledgeStore",
+        "FilesystemSecretStore",
+        "FilesystemStateStore",
+        "KnowledgeStore",
+        "ProcessLocalThrottleStore",
+        "RuntimeContext",
+        "SecretStore",
+        "StateStore",
+        "ThrottleStore",
+        "default_runtime_context",
+    ])
+
+
+@pytest.mark.unit
+def test_public_does_not_reexport_subpackages() -> None:
+    """``mureo.core.providers`` and ``mureo.core.skills`` are reached by
+    their fully qualified module names; re-exporting them here would
+    silently widen the ABI. Guard against accidental future re-exports."""
+    import mureo.core as core
+
+    for name in ("providers", "skills"):
+        assert name not in core.__all__

--- a/tests/core/test_public_api.py
+++ b/tests/core/test_public_api.py
@@ -74,11 +74,15 @@ def test_public_all_matches_documented_surface() -> None:
         "FilesystemStateStore",
         "KnowledgeStore",
         "ProcessLocalThrottleStore",
+        "RUNTIME_CONTEXT_FACTORY_ENTRY_POINT_GROUP",
         "RuntimeContext",
+        "RuntimeContextFactoryError",
         "SecretStore",
         "StateStore",
         "ThrottleStore",
         "default_runtime_context",
+        "get_runtime_context",
+        "reset_runtime_context",
     ])
 
 

--- a/tests/core/test_runtime_context.py
+++ b/tests/core/test_runtime_context.py
@@ -1,0 +1,130 @@
+"""Tests for ``mureo.core.runtime_context`` — frozen dataclass aggregating
+the four core extension Protocols plus a workspace identifier.
+
+RED-phase tests pin the dataclass shape, immutability, and the
+non-empty ``workspace_id`` validator. Default construction (the factory
+that returns a sensible context for single-workspace callers) lands in
+a separate commit.
+"""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError, dataclass
+from typing import Any
+
+import pytest
+
+from mureo.context.models import ActionLogEntry, StateDocument, StrategyEntry
+from mureo.core.runtime_context import RuntimeContext
+
+
+# ---------------------------------------------------------------------------
+# Minimal in-process fakes — kept here (not shared) so this test stays
+# self-contained and the contract is visible at a glance.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _S:
+    def load(self, key: str) -> dict[str, Any]:
+        return {}
+
+    def save(self, key: str, value: dict[str, Any]) -> None: ...
+    def delete(self, key: str) -> None: ...
+
+
+@dataclass
+class _St:
+    def read_state(self) -> StateDocument:
+        return StateDocument()
+
+    def write_state(self, doc: StateDocument) -> None: ...
+    def read_strategy(self) -> list[StrategyEntry]:
+        return []
+
+    def write_strategy(self, entries: list[StrategyEntry]) -> None: ...
+    def append_action_log(self, entry: ActionLogEntry) -> None: ...
+
+
+@dataclass
+class _K:
+    def read_operator_knowledge(self) -> str:
+        return ""
+
+    def read_workspace_knowledge(self) -> str | None:
+        return None
+
+    def append_operator_knowledge(self, insight: str) -> None: ...
+    def append_workspace_knowledge(self, insight: str) -> None: ...
+
+
+@dataclass
+class _T:
+    async def acquire(self, key: str) -> None: ...
+
+
+def _ctx(workspace_id: str = "default") -> RuntimeContext:
+    return RuntimeContext(
+        secret_store=_S(),
+        state_store=_St(),
+        knowledge_store=_K(),
+        throttle_store=_T(),
+        workspace_id=workspace_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_construct_with_all_protocols() -> None:
+    ctx = _ctx()
+    assert ctx.workspace_id == "default"
+
+
+@pytest.mark.unit
+def test_all_fields_round_trip_by_identity() -> None:
+    """The dataclass must store the passed stores by identity — no eager
+    wrapping or copying. Catches a future bug where someone introduces
+    validation that swaps the referenced object."""
+    s, st, k, t = _S(), _St(), _K(), _T()
+    ctx = RuntimeContext(
+        secret_store=s,
+        state_store=st,
+        knowledge_store=k,
+        throttle_store=t,
+        workspace_id="default",
+    )
+    assert ctx.secret_store is s
+    assert ctx.state_store is st
+    assert ctx.knowledge_store is k
+    assert ctx.throttle_store is t
+
+
+@pytest.mark.unit
+def test_is_frozen() -> None:
+    ctx = _ctx()
+    with pytest.raises(FrozenInstanceError):
+        ctx.workspace_id = "other"  # type: ignore[misc]
+
+
+@pytest.mark.unit
+def test_workspace_id_required() -> None:
+    """``workspace_id`` is mandatory — no implicit default — so callers must
+    be explicit about whether they are in single-workspace ('default') or
+    another mode. The canonical sentinel for single-workspace is the
+    literal ``"default"``."""
+    with pytest.raises(TypeError):
+        RuntimeContext(  # type: ignore[call-arg]
+            secret_store=_S(),
+            state_store=_St(),
+            knowledge_store=_K(),
+            throttle_store=_T(),
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("bad", ["", " ", "\t", "\n"])
+def test_workspace_id_rejects_empty_or_whitespace(bad: str) -> None:
+    with pytest.raises(ValueError, match="workspace_id"):
+        _ctx(workspace_id=bad)

--- a/tests/core/test_runtime_context.py
+++ b/tests/core/test_runtime_context.py
@@ -10,13 +10,13 @@ a separate commit.
 from __future__ import annotations
 
 from dataclasses import FrozenInstanceError, dataclass
+from pathlib import Path
 from typing import Any
 
 import pytest
 
 from mureo.context.models import ActionLogEntry, StateDocument, StrategyEntry
 from mureo.core.runtime_context import RuntimeContext
-
 
 # ---------------------------------------------------------------------------
 # Minimal in-process fakes — kept here (not shared) so this test stays
@@ -128,3 +128,88 @@ def test_workspace_id_required() -> None:
 def test_workspace_id_rejects_empty_or_whitespace(bad: str) -> None:
     with pytest.raises(ValueError, match="workspace_id"):
         _ctx(workspace_id=bad)
+
+
+# ---------------------------------------------------------------------------
+# default_runtime_context() — wires the four file-backed default stores
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_default_factory_wires_all_four_filesystem_defaults(tmp_path: Path) -> None:
+    from mureo.core.knowledge_store import FilesystemKnowledgeStore
+    from mureo.core.runtime_context import default_runtime_context
+    from mureo.core.secret_store import FilesystemSecretStore
+    from mureo.core.state_store import FilesystemStateStore
+    from mureo.core.throttle_store import ProcessLocalThrottleStore
+
+    ctx = default_runtime_context(
+        workspace=tmp_path,
+        credentials_path=tmp_path / "creds.json",
+        operator_knowledge_path=tmp_path / "op.md",
+    )
+    assert isinstance(ctx.secret_store, FilesystemSecretStore)
+    assert isinstance(ctx.state_store, FilesystemStateStore)
+    assert isinstance(ctx.knowledge_store, FilesystemKnowledgeStore)
+    assert isinstance(ctx.throttle_store, ProcessLocalThrottleStore)
+
+
+@pytest.mark.unit
+def test_default_factory_workspace_id_is_default_sentinel(tmp_path: Path) -> None:
+    """The canonical sentinel for single-workspace callers is the literal
+    ``"default"`` — pinned here so it does not drift."""
+    from mureo.core.runtime_context import default_runtime_context
+
+    ctx = default_runtime_context(workspace=tmp_path)
+    assert ctx.workspace_id == "default"
+
+
+@pytest.mark.unit
+def test_default_factory_no_args_uses_legacy_paths(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Called without overrides, the factory must reproduce today's
+    file locations: ``~/.mureo/credentials.json``, CWD-relative STATE.json
+    / STRATEGY.md, ``~/.claude/skills/_mureo-pro-diagnosis/SKILL.md``.
+
+    Patches ``Path.home`` directly so the test is Windows-safe — the
+    ``HOME`` env var is consulted on POSIX but Windows looks at
+    ``USERPROFILE`` first, which would make a ``setenv("HOME", ...)``
+    approach silently fall through to the real home directory on the
+    Windows CI lane added in #122."""
+    from mureo.core.runtime_context import default_runtime_context
+
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    monkeypatch.chdir(tmp_path)
+
+    ctx = default_runtime_context()
+    assert ctx.secret_store.path == tmp_path / ".mureo" / "credentials.json"  # type: ignore[attr-defined]
+    assert ctx.state_store.state_path == tmp_path / "STATE.json"  # type: ignore[attr-defined]
+    assert ctx.state_store.strategy_path == tmp_path / "STRATEGY.md"  # type: ignore[attr-defined]
+    assert (
+        ctx.knowledge_store.operator_path  # type: ignore[attr-defined]
+        == tmp_path / ".claude" / "skills" / "_mureo-pro-diagnosis" / "SKILL.md"
+    )
+    assert ctx.knowledge_store.workspace_path is None  # type: ignore[attr-defined]
+
+
+@pytest.mark.unit
+def test_default_factory_accepts_workspace_knowledge_override(tmp_path: Path) -> None:
+    from mureo.core.runtime_context import default_runtime_context
+
+    ws_md = tmp_path / "ws.md"
+    ctx = default_runtime_context(
+        workspace=tmp_path,
+        workspace_knowledge_path=ws_md,
+    )
+    assert ctx.knowledge_store.workspace_path == ws_md  # type: ignore[attr-defined]
+
+
+@pytest.mark.unit
+def test_default_factory_accepts_throttle_config_override(tmp_path: Path) -> None:
+    from mureo.core.runtime_context import default_runtime_context
+    from mureo.throttle import ThrottleConfig
+
+    config = ThrottleConfig(rate=42.0, burst=7)
+    ctx = default_runtime_context(workspace=tmp_path, throttle_config=config)
+    assert ctx.throttle_store.default_config is config  # type: ignore[attr-defined]

--- a/tests/core/test_runtime_resolver.py
+++ b/tests/core/test_runtime_resolver.py
@@ -1,0 +1,166 @@
+"""Tests for the entry-point–based ``get_runtime_context()`` resolver.
+
+The resolver is the integration point alternate backends use to inject
+a custom ``RuntimeContext``: a single entry point in the
+``mureo.runtime_context_factory`` group is enough — no callsite needs
+to change. With zero entry points the resolver returns the file-backed
+default, preserving today's single-workspace behaviour.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from mureo.core.runtime_context import (
+    DEFAULT_WORKSPACE_ID,
+    RuntimeContext,
+    RuntimeContextFactoryError,
+    default_runtime_context,
+    get_runtime_context,
+    reset_runtime_context,
+)
+
+# ---------------------------------------------------------------------------
+# Fake entry-point objects matching the ``importlib.metadata`` shape just
+# closely enough for the resolver: ``.name`` and ``.load()``.
+# ---------------------------------------------------------------------------
+
+
+class _FakeEP:
+    def __init__(self, name: str, target: Any) -> None:
+        self.name = name
+        self._target = target
+
+    def load(self) -> Any:
+        return self._target
+
+
+def _patch_entry_points(monkeypatch: pytest.MonkeyPatch, eps: list[_FakeEP]) -> None:
+    """Replace ``mureo.core.runtime_context.entry_points`` with a stub."""
+
+    def fake_entry_points(*, group: str) -> list[_FakeEP]:
+        assert group == "mureo.runtime_context_factory"
+        return eps
+
+    monkeypatch.setattr(
+        "mureo.core.runtime_context.entry_points", fake_entry_points
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache() -> None:
+    """Reset the resolver cache between tests so they cannot bleed state."""
+    reset_runtime_context()
+    yield
+    reset_runtime_context()
+
+
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_no_entry_point_returns_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_entry_points(monkeypatch, [])
+    ctx = get_runtime_context()
+    assert isinstance(ctx, RuntimeContext)
+    assert ctx.workspace_id == DEFAULT_WORKSPACE_ID
+
+
+@pytest.mark.unit
+def test_single_entry_point_factory_is_used(monkeypatch: pytest.MonkeyPatch) -> None:
+    sentinel_ctx = default_runtime_context()  # any concrete RuntimeContext
+    _patch_entry_points(
+        monkeypatch, [_FakeEP("custom-runtime", lambda: sentinel_ctx)]
+    )
+    assert get_runtime_context() is sentinel_ctx
+
+
+@pytest.mark.unit
+def test_result_is_cached_per_process(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[int] = []
+
+    def factory() -> RuntimeContext:
+        calls.append(1)
+        return default_runtime_context()
+
+    _patch_entry_points(monkeypatch, [_FakeEP("once", factory)])
+    a = get_runtime_context()
+    b = get_runtime_context()
+    assert a is b
+    assert calls == [1]
+
+
+@pytest.mark.unit
+def test_reset_clears_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_entry_points(monkeypatch, [])
+    a = get_runtime_context()
+    reset_runtime_context()
+    b = get_runtime_context()
+    # Different instances after reset (default factory builds a fresh one).
+    assert a is not b
+
+
+@pytest.mark.unit
+def test_multiple_entry_points_raise(monkeypatch: pytest.MonkeyPatch) -> None:
+    """More than one factory is a misconfiguration — the integration
+    point is global, so silently picking one would mask bugs."""
+    _patch_entry_points(
+        monkeypatch,
+        [
+            _FakeEP("first", lambda: default_runtime_context()),
+            _FakeEP("second", lambda: default_runtime_context()),
+        ],
+    )
+    with pytest.raises(RuntimeContextFactoryError, match="multiple"):
+        get_runtime_context()
+
+
+@pytest.mark.unit
+def test_factory_returning_wrong_type_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_entry_points(
+        monkeypatch, [_FakeEP("bad", lambda: "not a context")]
+    )
+    with pytest.raises(RuntimeContextFactoryError, match="expected RuntimeContext"):
+        get_runtime_context()
+
+
+@pytest.mark.unit
+def test_factory_raising_propagates_clear_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the third-party factory itself raises, the resolver wraps the
+    cause so the entry-point name is in the error message — otherwise
+    debugging a broken plugin requires reading a stack trace from
+    elsewhere in the process."""
+
+    def broken() -> RuntimeContext:
+        raise ValueError("plugin internals exploded")
+
+    _patch_entry_points(monkeypatch, [_FakeEP("broken-plugin", broken)])
+    with pytest.raises(RuntimeContextFactoryError, match="broken-plugin"):
+        get_runtime_context()
+
+
+@pytest.mark.unit
+def test_default_factory_used_when_no_plugin_installed() -> None:
+    """Sanity: with the real ``entry_points`` call (no plugin installed
+    in this test env) the resolver returns a real file-backed default."""
+    # No monkeypatch — exercises the actual importlib.metadata call.
+    ctx = get_runtime_context()
+    assert isinstance(ctx, RuntimeContext)
+    assert ctx.workspace_id == DEFAULT_WORKSPACE_ID
+
+
+@pytest.mark.unit
+def test_resolver_is_publicly_exported_from_mureo_core() -> None:
+    from mureo.core import (
+        RuntimeContextFactoryError,
+        get_runtime_context,
+        reset_runtime_context,
+    )
+
+    assert callable(get_runtime_context)
+    assert callable(reset_runtime_context)
+    assert issubclass(RuntimeContextFactoryError, RuntimeError)

--- a/tests/core/test_secret_store.py
+++ b/tests/core/test_secret_store.py
@@ -1,0 +1,77 @@
+"""Tests for ``mureo.core.secret_store`` — structural Protocol contract.
+
+RED-phase tests for the new ``SecretStore`` Protocol that abstracts
+credential persistence. Default callers continue to read from
+``~/.mureo/credentials.json`` via the existing helpers in
+``mureo.auth``; this Protocol exists so alternate backends (in-memory
+fakes for tests, OS keychain, Vault, GCP Secret Manager, etc.) can be
+swapped in without touching call sites.
+
+This commit pins the Protocol shape only — concrete default
+implementations land in a separate commit.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from mureo.core.secret_store import SecretStore
+
+
+@dataclass
+class _FakeSecretStore:
+    """Minimal in-memory implementation used to exercise the Protocol shape."""
+
+    data: dict[str, dict[str, Any]] = field(default_factory=dict)
+
+    def load(self, key: str) -> dict[str, Any]:
+        return dict(self.data.get(key, {}))
+
+    def save(self, key: str, value: dict[str, Any]) -> None:
+        self.data[key] = dict(value)
+
+    def delete(self, key: str) -> None:
+        self.data.pop(key, None)
+
+
+@pytest.mark.unit
+def test_protocol_is_runtime_checkable() -> None:
+    assert isinstance(_FakeSecretStore(), SecretStore)
+
+
+@pytest.mark.unit
+def test_incomplete_implementation_is_rejected() -> None:
+    class _MissingDelete:
+        def load(self, key: str) -> dict[str, Any]:
+            return {}
+
+        def save(self, key: str, value: dict[str, Any]) -> None:
+            pass
+
+    assert not isinstance(_MissingDelete(), SecretStore)
+
+
+@pytest.mark.unit
+def test_fake_round_trip() -> None:
+    store = _FakeSecretStore()
+    store.save("google_ads", {"refresh_token": "abc"})
+    assert store.load("google_ads") == {"refresh_token": "abc"}
+    store.delete("google_ads")
+    assert store.load("google_ads") == {}
+
+
+@pytest.mark.unit
+def test_load_missing_key_returns_empty_dict() -> None:
+    """The Protocol contract: ``load`` of an unknown key returns ``{}`` (not raises)."""
+    store = _FakeSecretStore()
+    assert store.load("never-set") == {}
+
+
+@pytest.mark.unit
+def test_delete_missing_key_is_idempotent() -> None:
+    """The Protocol contract: deleting an unknown key is a no-op (not raises)."""
+    store = _FakeSecretStore()
+    store.delete("never-set")  # must not raise

--- a/tests/core/test_state_store.py
+++ b/tests/core/test_state_store.py
@@ -1,0 +1,107 @@
+"""Tests for ``mureo.core.state_store`` — structural Protocol contract.
+
+RED-phase tests for the new ``StateStore`` Protocol that abstracts
+STATE.json / STRATEGY.md / action-log persistence. Default callers
+continue to use the existing helpers in ``mureo.context.state`` and
+``mureo.context.strategy``; this Protocol exists so alternate backends
+(in-memory fakes for tests, SQLite, S3, Anthropic Files API, etc.) can
+be swapped in without touching call sites.
+
+This commit pins the Protocol shape only — concrete default
+implementations land in a separate commit.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+
+from mureo.context.models import ActionLogEntry, StateDocument, StrategyEntry
+from mureo.core.state_store import StateStore
+
+
+@dataclass
+class _FakeStateStore:
+    """Minimal in-memory implementation used to exercise the Protocol shape."""
+
+    state: StateDocument = field(default_factory=StateDocument)
+    strategy: list[StrategyEntry] = field(default_factory=list)
+    log: list[ActionLogEntry] = field(default_factory=list)
+
+    def read_state(self) -> StateDocument:
+        return self.state
+
+    def write_state(self, doc: StateDocument) -> None:
+        self.state = doc
+
+    def read_strategy(self) -> list[StrategyEntry]:
+        return list(self.strategy)
+
+    def write_strategy(self, entries: list[StrategyEntry]) -> None:
+        self.strategy = list(entries)
+
+    def append_action_log(self, entry: ActionLogEntry) -> None:
+        self.log.append(entry)
+
+
+@pytest.mark.unit
+def test_protocol_is_runtime_checkable() -> None:
+    assert isinstance(_FakeStateStore(), StateStore)
+
+
+@pytest.mark.unit
+def test_incomplete_implementation_is_rejected() -> None:
+    class _MissingAppend:
+        def read_state(self) -> StateDocument:
+            return StateDocument()
+
+        def write_state(self, doc: StateDocument) -> None:
+            pass
+
+        def read_strategy(self) -> list[StrategyEntry]:
+            return []
+
+        def write_strategy(self, entries: list[StrategyEntry]) -> None:
+            pass
+
+    assert not isinstance(_MissingAppend(), StateStore)
+
+
+@pytest.mark.unit
+def test_fake_state_round_trip() -> None:
+    store = _FakeStateStore()
+    doc = StateDocument(version="2", customer_id="123-456-7890")
+    store.write_state(doc)
+    assert store.read_state() == doc
+
+
+@pytest.mark.unit
+def test_fake_strategy_round_trip() -> None:
+    store = _FakeStateStore()
+    entries = [StrategyEntry(context_type="persona", title="P", content="x")]
+    store.write_strategy(entries)
+    assert store.read_strategy() == entries
+
+
+@pytest.mark.unit
+def test_append_action_log_accumulates() -> None:
+    store = _FakeStateStore()
+    e1 = ActionLogEntry(timestamp="2026-01-01T00:00:00Z", action="a", platform="g")
+    e2 = ActionLogEntry(timestamp="2026-01-02T00:00:00Z", action="b", platform="m")
+    store.append_action_log(e1)
+    store.append_action_log(e2)
+    assert store.log == [e1, e2]
+
+
+@pytest.mark.unit
+def test_read_strategy_returns_isolated_snapshot() -> None:
+    """``read_strategy`` must return a fresh list — caller mutations of the
+    returned value must not leak back into the store. This is part of the
+    Protocol contract, not a recommendation, so alternate backends that
+    hand back an internal reference are caught here."""
+    store = _FakeStateStore()
+    store.write_strategy([StrategyEntry(context_type="persona", title="T", content="x")])
+    snap = store.read_strategy()
+    snap.append(StrategyEntry(context_type="usp", title="U", content="y"))
+    assert len(store.read_strategy()) == 1

--- a/tests/core/test_throttle_store.py
+++ b/tests/core/test_throttle_store.py
@@ -1,0 +1,53 @@
+"""Tests for ``mureo.core.throttle_store`` — structural Protocol contract.
+
+RED-phase tests for the new ``ThrottleStore`` Protocol that abstracts
+API quota throttling. Today the MCP server holds a ``dict[str,
+Throttler]`` of named token buckets and awaits ``throttler.acquire()``
+before each tool invocation; this Protocol exists so alternate backends
+(cross-process file lock, Redis-backed shared throttle, no-op in tests)
+can be swapped in without touching the MCP tool handlers.
+
+This commit pins the Protocol shape only — concrete default
+implementations land in a separate commit.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+
+from mureo.core.throttle_store import ThrottleStore
+
+
+@dataclass
+class _FakeThrottleStore:
+    """Minimal no-op implementation used to exercise the Protocol shape."""
+
+    acquired: list[str] = field(default_factory=list)
+
+    async def acquire(self, key: str) -> None:
+        self.acquired.append(key)
+
+
+@pytest.mark.unit
+def test_protocol_is_runtime_checkable() -> None:
+    assert isinstance(_FakeThrottleStore(), ThrottleStore)
+
+
+@pytest.mark.unit
+def test_incomplete_implementation_is_rejected() -> None:
+    class _MissingAcquire:
+        async def something_else(self) -> None:
+            pass
+
+    assert not isinstance(_MissingAcquire(), ThrottleStore)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fake_records_acquire() -> None:
+    store = _FakeThrottleStore()
+    await store.acquire("google_ads:dev-token-abc")
+    await store.acquire("meta_ads:bm-token-xyz")
+    assert store.acquired == ["google_ads:dev-token-abc", "meta_ads:bm-token-xyz"]

--- a/tests/test_auth_runtime_context.py
+++ b/tests/test_auth_runtime_context.py
@@ -1,0 +1,187 @@
+"""Tests for ``mureo.auth`` integration with the ``RuntimeContext``
+extension layer.
+
+When ``load_google_ads_credentials()`` / ``load_meta_ads_credentials()``
+are called without an explicit ``path``, they consult
+``mureo.core.runtime_context.get_runtime_context().secret_store``.
+This lets an alternate backend (registered via the
+``mureo.runtime_context_factory`` entry-point group) intercept the
+credential read without each call site having to change.
+
+Tests that pass an explicit ``path`` keep their current
+file-direct semantics — covered by the long-standing ``tests/test_auth.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from mureo.auth import load_google_ads_credentials, load_meta_ads_credentials
+from mureo.core.runtime_context import (
+    RuntimeContext,
+    default_runtime_context,
+    reset_runtime_context,
+)
+
+
+@dataclass
+class _RecordingSecretStore:
+    """In-memory SecretStore that records every ``load(key)`` call so the
+    test can assert the auth helper went through the runtime context."""
+
+    payload: dict[str, dict[str, Any]] = field(default_factory=dict)
+    loads: list[str] = field(default_factory=list)
+
+    def load(self, key: str) -> dict[str, Any]:
+        self.loads.append(key)
+        return dict(self.payload.get(key, {}))
+
+    def save(self, key: str, value: dict[str, Any]) -> None:  # pragma: no cover
+        self.payload[key] = dict(value)
+
+    def delete(self, key: str) -> None:  # pragma: no cover
+        self.payload.pop(key, None)
+
+
+def _make_ctx(secret_store: _RecordingSecretStore) -> RuntimeContext:
+    base = default_runtime_context()
+    return RuntimeContext(
+        secret_store=secret_store,
+        state_store=base.state_store,
+        knowledge_store=base.knowledge_store,
+        throttle_store=base.throttle_store,
+        workspace_id=base.workspace_id,
+    )
+
+
+def _patch_runtime_context(
+    monkeypatch: pytest.MonkeyPatch, store: _RecordingSecretStore
+) -> None:
+    """Replace the cached RuntimeContext used by ``mureo.auth``."""
+    ctx = _make_ctx(store)
+    # Pre-fill the cache so the resolver short-circuits to our context.
+    monkeypatch.setattr("mureo.core.runtime_context._cached_context", ctx)
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache() -> None:
+    reset_runtime_context()
+    yield
+    reset_runtime_context()
+
+
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_load_google_ads_uses_runtime_context_when_path_is_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _RecordingSecretStore(
+        payload={
+            "google_ads": {
+                "developer_token": "dev-token-X",
+                "client_id": "client-id-X",
+                "client_secret": "secret-X",
+                "refresh_token": "refresh-X",
+                "customer_id": "111-222-3333",
+            }
+        }
+    )
+    _patch_runtime_context(monkeypatch, store)
+
+    creds = load_google_ads_credentials()
+    assert creds is not None
+    assert creds.developer_token == "dev-token-X"
+    assert creds.customer_id == "111-222-3333"
+    assert store.loads == ["google_ads"]
+
+
+@pytest.mark.unit
+def test_load_meta_ads_uses_runtime_context_when_path_is_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _RecordingSecretStore(
+        payload={
+            "meta_ads": {
+                "access_token": "fb-token-X",
+                "account_id": "act_999",
+            }
+        }
+    )
+    _patch_runtime_context(monkeypatch, store)
+
+    creds = load_meta_ads_credentials()
+    assert creds is not None
+    assert creds.access_token == "fb-token-X"
+    assert creds.account_id == "act_999"
+    assert store.loads == ["meta_ads"]
+
+
+@pytest.mark.unit
+def test_explicit_path_bypasses_runtime_context(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Passing ``path=`` must keep using the file-backed default —
+    otherwise the long-standing tests that rely on per-test temp files
+    would silently leak through the resolver cache."""
+    # Wire a recording store that, if consulted, would return DIFFERENT
+    # creds than the file. The auth helper must NOT consult it.
+    store = _RecordingSecretStore(
+        payload={"google_ads": {"developer_token": "WRONG"}}
+    )
+    _patch_runtime_context(monkeypatch, store)
+
+    # Write a real credentials file that the explicit-path branch reads.
+    cred_path = tmp_path / "credentials.json"
+    cred_path.write_text(
+        json.dumps(
+            {
+                "google_ads": {
+                    "developer_token": "FROM-FILE",
+                    "client_id": "c",
+                    "client_secret": "s",
+                    "refresh_token": "r",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    creds = load_google_ads_credentials(path=cred_path)
+    assert creds is not None
+    assert creds.developer_token == "FROM-FILE"
+    assert store.loads == [], "explicit-path call must not touch runtime context"
+
+
+@pytest.mark.unit
+def test_load_google_ads_falls_back_to_env_when_context_store_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the resolved SecretStore has no google_ads entry, the env-var
+    fallback must still kick in — same precedence rule the existing
+    file-direct path enforces."""
+    monkeypatch.delenv("GOOGLE_ADS_DEVELOPER_TOKEN", raising=False)
+    monkeypatch.delenv("GOOGLE_ADS_CLIENT_ID", raising=False)
+    monkeypatch.delenv("GOOGLE_ADS_CLIENT_SECRET", raising=False)
+    monkeypatch.delenv("GOOGLE_ADS_REFRESH_TOKEN", raising=False)
+    monkeypatch.delenv("GOOGLE_ADS_LOGIN_CUSTOMER_ID", raising=False)
+    monkeypatch.setenv("GOOGLE_ADS_DEVELOPER_TOKEN", "from-env")
+    monkeypatch.setenv("GOOGLE_ADS_CLIENT_ID", "env-cid")
+    monkeypatch.setenv("GOOGLE_ADS_CLIENT_SECRET", "env-secret")
+    monkeypatch.setenv("GOOGLE_ADS_REFRESH_TOKEN", "env-refresh")
+    monkeypatch.setenv("GOOGLE_ADS_LOGIN_CUSTOMER_ID", "777-888-9999")
+
+    empty_store = _RecordingSecretStore()
+    _patch_runtime_context(monkeypatch, empty_store)
+
+    creds = load_google_ads_credentials()
+    assert creds is not None
+    assert creds.developer_token == "from-env"
+    assert creds.login_customer_id == "777-888-9999"
+    assert empty_store.loads == ["google_ads"]  # consulted, then fell through

--- a/tests/test_cli_learn.py
+++ b/tests/test_cli_learn.py
@@ -1,0 +1,146 @@
+"""Tests for ``mureo learn add`` — the CLI bridge that routes
+``/learn`` skill writes through the KnowledgeStore Protocol.
+
+The contract:
+- ``--scope operator`` (default) calls
+  ``KnowledgeStore.append_operator_knowledge``.
+- ``--scope workspace`` calls
+  ``KnowledgeStore.append_workspace_knowledge``; when the resolved
+  store has no workspace tier, the command exits non-zero with a
+  helpful message instead of silently dropping the insight.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+from typer.testing import CliRunner
+
+from mureo.core.runtime_context import (
+    RuntimeContext,
+    default_runtime_context,
+    reset_runtime_context,
+)
+
+runner = CliRunner()
+
+
+@dataclass
+class _RecordingKnowledgeStore:
+    operator_appends: list[str] = field(default_factory=list)
+    workspace_appends: list[str] = field(default_factory=list)
+    has_workspace_tier: bool = False
+
+    def read_operator_knowledge(self) -> str:  # pragma: no cover
+        return ""
+
+    def read_workspace_knowledge(self) -> str | None:  # pragma: no cover
+        return "" if self.has_workspace_tier else None
+
+    def append_operator_knowledge(self, insight: str) -> None:
+        self.operator_appends.append(insight)
+
+    def append_workspace_knowledge(self, insight: str) -> None:
+        if not self.has_workspace_tier:
+            raise NotImplementedError("no workspace tier configured")
+        self.workspace_appends.append(insight)
+
+
+def _inject_store(
+    monkeypatch: pytest.MonkeyPatch, knowledge_store: _RecordingKnowledgeStore
+) -> None:
+    base = default_runtime_context()
+    ctx = RuntimeContext(
+        secret_store=base.secret_store,
+        state_store=base.state_store,
+        knowledge_store=knowledge_store,
+        throttle_store=base.throttle_store,
+        workspace_id="injected",
+    )
+    monkeypatch.setattr("mureo.core.runtime_context._cached_context", ctx)
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    reset_runtime_context()
+    yield
+    reset_runtime_context()
+
+
+@pytest.mark.unit
+def test_add_with_default_scope_writes_to_operator_tier(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _RecordingKnowledgeStore()
+    _inject_store(monkeypatch, store)
+    from mureo.cli.main import app
+
+    result = runner.invoke(app, ["learn", "add", "first insight\n"])
+    assert result.exit_code == 0, result.output
+    assert store.operator_appends == ["first insight\n"]
+    assert store.workspace_appends == []
+    assert "operator" in result.output.lower()
+
+
+@pytest.mark.unit
+def test_add_with_operator_scope_writes_to_operator_tier(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _RecordingKnowledgeStore()
+    _inject_store(monkeypatch, store)
+    from mureo.cli.main import app
+
+    result = runner.invoke(
+        app, ["learn", "add", "operator insight\n", "--scope", "operator"]
+    )
+    assert result.exit_code == 0, result.output
+    assert store.operator_appends == ["operator insight\n"]
+    assert store.workspace_appends == []
+
+
+@pytest.mark.unit
+def test_add_with_workspace_scope_writes_to_workspace_tier(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _RecordingKnowledgeStore(has_workspace_tier=True)
+    _inject_store(monkeypatch, store)
+    from mureo.cli.main import app
+
+    result = runner.invoke(
+        app, ["learn", "add", "workspace insight\n", "--scope", "workspace"]
+    )
+    assert result.exit_code == 0, result.output
+    assert store.workspace_appends == ["workspace insight\n"]
+    assert store.operator_appends == []
+    assert "workspace" in result.output.lower()
+
+
+@pytest.mark.unit
+def test_workspace_scope_without_tier_exits_with_hint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the resolved store has no workspace tier, the command must
+    fail clearly so the skill (or operator) does not silently lose the
+    insight. The error mentions ``--scope operator`` as the recovery."""
+    store = _RecordingKnowledgeStore(has_workspace_tier=False)
+    _inject_store(monkeypatch, store)
+    from mureo.cli.main import app
+
+    result = runner.invoke(
+        app, ["learn", "add", "lost insight\n", "--scope", "workspace"]
+    )
+    assert result.exit_code != 0
+    assert store.workspace_appends == []
+    assert "--scope operator" in result.output
+
+
+@pytest.mark.unit
+def test_learn_app_registered_under_main() -> None:
+    """`mureo learn` is discoverable from the top-level CLI app."""
+    from mureo.cli.main import app
+
+    group_names = [
+        g.typer_instance.info.name for g in app.registered_groups if g.typer_instance
+    ]
+    assert "learn" in group_names

--- a/tests/test_cli_rollback.py
+++ b/tests/test_cli_rollback.py
@@ -18,6 +18,19 @@ if TYPE_CHECKING:
 runner = CliRunner()
 
 
+@pytest.fixture(autouse=True)
+def _clear_runtime_context_cache():
+    """Reset the resolver cache before and after every test so the
+    workspace-aware ``_resolve_default_state_file`` rebuilds a
+    :class:`FilesystemStateStore` with the (per-test) CWD instead of
+    reusing a stale one cached during an earlier test or test module."""
+    from mureo.core.runtime_context import reset_runtime_context
+
+    reset_runtime_context()
+    yield
+    reset_runtime_context()
+
+
 def _make_state(path: Path, action_log: list[dict[str, Any]]) -> None:
     path.write_text(
         json.dumps({"version": "2", "campaigns": [], "action_log": action_log}),
@@ -194,3 +207,99 @@ class TestRollbackGroupRegistered:
             if g.typer_instance
         ]
         assert "rollback" in group_names
+
+
+@pytest.mark.unit
+class TestStateFileDefault:
+    """``--state-file`` is optional: when omitted the CLI resolves the
+    path through ``mureo.core.runtime_context.get_runtime_context``, so
+    an alternate backend registered via the
+    ``mureo.runtime_context_factory`` entry-point group can redirect
+    the read without each command growing its own flag."""
+
+    def test_default_resolves_to_cwd_workspace(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No ``--state-file`` flag → STATE.json under CWD is read.
+
+        The default ``FilesystemStateStore`` constructs its workspace
+        from ``Path.cwd()`` at first resolver call; the autouse cache
+        reset above guarantees the per-test ``chdir`` is observed.
+        """
+        monkeypatch.chdir(tmp_path)
+        _make_state(
+            tmp_path / "STATE.json",
+            [
+                {
+                    "timestamp": "2026-04-15T10:00:00",
+                    "action": "update_budget",
+                    "platform": "google_ads",
+                    "campaign_id": "111",
+                    "reversible_params": {
+                        "operation": "google_ads_budget_update",
+                        "params": {"budget_id": "222", "amount_micros": 1_000_000_000},
+                    },
+                },
+            ],
+        )
+        from mureo.cli.main import app
+
+        result = runner.invoke(app, ["rollback", "list"])
+        assert result.exit_code == 0, result.output
+        assert "update_budget" in result.output
+
+    def test_default_resolves_via_injected_runtime_context(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An injected RuntimeContext (workspace ≠ CWD) must be honoured.
+
+        Verifies the integration point that alternate backends use:
+        register a custom ``RuntimeContext`` and the CLI follows it
+        without touching the underlying flag plumbing."""
+        from mureo.core.runtime_context import (
+            RuntimeContext,
+            default_runtime_context,
+        )
+
+        cwd_dir = tmp_path / "cwd"
+        workspace_dir = tmp_path / "tenant"
+        cwd_dir.mkdir()
+        workspace_dir.mkdir()
+        monkeypatch.chdir(cwd_dir)
+
+        _make_state(
+            workspace_dir / "STATE.json",
+            [
+                {
+                    "timestamp": "2026-04-15T10:00:00",
+                    "action": "from_workspace",
+                    "platform": "meta_ads",
+                    "campaign_id": "ws-1",
+                    "reversible_params": {
+                        "operation": "meta_ads_campaigns_update_status",
+                        "params": {"campaign_id": "ws-1", "status": "ACTIVE"},
+                    },
+                },
+            ],
+        )
+        # CWD STATE.json deliberately has a *different* action_log so we
+        # can assert the CLI read the workspace one (not the CWD one).
+        _make_state(cwd_dir / "STATE.json", [])
+
+        base = default_runtime_context(workspace=workspace_dir)
+        injected = RuntimeContext(
+            secret_store=base.secret_store,
+            state_store=base.state_store,
+            knowledge_store=base.knowledge_store,
+            throttle_store=base.throttle_store,
+            workspace_id="injected",
+        )
+        monkeypatch.setattr(
+            "mureo.core.runtime_context._cached_context", injected
+        )
+
+        from mureo.cli.main import app
+
+        result = runner.invoke(app, ["rollback", "list"])
+        assert result.exit_code == 0, result.output
+        assert "from_workspace" in result.output

--- a/tests/test_mcp_server_plugin_wiring.py
+++ b/tests/test_mcp_server_plugin_wiring.py
@@ -203,14 +203,29 @@ class TestPluginAuditAndThrottle:
     async def test_throttle_acquired_before_dispatch(
         self, server_with_plugin, monkeypatch
     ) -> None:
+        """The plugin dispatch path must await a throttle slot before
+        calling the provider. We exercise that contract by installing a
+        spy throttler in place of the module-level ``_PLUGIN_THROTTLER``
+        AND clearing the throttle-store seeding cache so the next call
+        re-seeds the resolved store with our spy."""
         calls: list[str] = []
 
         class _SpyThrottler:
             async def acquire(self) -> None:
                 calls.append("acquire")
 
+        # Drop any seeded throttle_store and reset the RuntimeContext
+        # resolver so the next handler call rebuilds the chain from
+        # the freshly-patched ``_PLUGIN_THROTTLER``.
+        from mureo.core.runtime_context import reset_runtime_context
+
         monkeypatch.setattr(server_with_plugin, "_PLUGIN_THROTTLER", _SpyThrottler())
-        await server_with_plugin.handle_call_tool("wired_plugin_echo", {"msg": "x"})
+        monkeypatch.setattr(server_with_plugin, "_throttle_store_seeded", set())
+        reset_runtime_context()
+        try:
+            await server_with_plugin.handle_call_tool("wired_plugin_echo", {"msg": "x"})
+        finally:
+            reset_runtime_context()
         assert calls == ["acquire"]
 
     async def test_plugin_exception_audited_reraised_no_crash(

--- a/tests/test_mcp_tools_analysis.py
+++ b/tests/test_mcp_tools_analysis.py
@@ -4,7 +4,8 @@ Locks in that the tool is registered on the aggregate MCP server, its
 schema rejects malformed input, and the handler correctly composes
 ``baseline_from_history`` with ``detect_anomalies`` over STATE.json.
 Path sandboxing mirrors rollback_apply — ``state_file`` must resolve
-inside CWD.
+inside the active workspace (CWD by default; configurable via the
+``mureo.runtime_context_factory`` entry-point group).
 """
 
 from __future__ import annotations
@@ -52,6 +53,19 @@ def _history_entry(
         campaign_id=campaign_id,
         metrics_at_action=metrics,
     )
+
+
+@pytest.fixture(autouse=True)
+def _clear_runtime_context_cache():
+    """Reset the resolver cache before and after every test so the
+    workspace-aware ``_resolve_state_file`` rebuilds a
+    :class:`FilesystemStateStore` with the (per-test) CWD instead of
+    reusing a stale one cached during an earlier test or test module."""
+    from mureo.core.runtime_context import reset_runtime_context
+
+    reset_runtime_context()
+    yield
+    reset_runtime_context()
 
 
 @pytest.fixture
@@ -185,10 +199,7 @@ class TestAnomalyHandler:
             },
         )
         payload = json.loads(result[0].text)
-        assert (
-            "error" in payload
-            and "current working directory" in payload["error"]
-        )
+        assert "error" in payload and "active workspace" in payload["error"]
 
     @pytest.mark.asyncio
     async def test_ctr_drop_detected_with_history(self, sandboxed_cwd: Path) -> None:

--- a/tests/test_mcp_tools_mureo_context.py
+++ b/tests/test_mcp_tools_mureo_context.py
@@ -24,10 +24,24 @@ import pytest
 pytestmark = pytest.mark.unit
 
 
+@pytest.fixture(autouse=True)
+def _clear_runtime_context_cache():
+    """Reset the resolver cache before and after every test in this file
+    so the workspace-aware ``_resolve_path`` rebuilds a
+    :class:`FilesystemStateStore` with the (per-test) CWD instead of
+    reusing a stale one cached during an earlier test or test module."""
+    from mureo.core.runtime_context import reset_runtime_context
+
+    reset_runtime_context()
+    yield
+    reset_runtime_context()
+
+
 @pytest.fixture
 def cwd_to_tmp(tmp_path, monkeypatch):
     """Run each test with cwd = tmp_path so STRATEGY.md/STATE.json land
-    inside the sandbox by default."""
+    inside the sandbox by default. The autouse cache-reset fixture above
+    runs first, so the resolver picks up the chdir on the next call."""
     monkeypatch.chdir(tmp_path)
     return tmp_path
 
@@ -268,9 +282,73 @@ async def test_upsert_campaign_updates_existing(cwd_to_tmp) -> None:
 
 
 async def test_path_argument_refuses_traversal(cwd_to_tmp) -> None:
-    """Custom ``path`` outside cwd is rejected — symmetric with rollback's
-    ``_resolve_state_file`` guard. A prompt-injected agent must not be
-    able to point mureo at an attacker-crafted file elsewhere on disk."""
+    """Custom ``path`` outside the active workspace is rejected —
+    symmetric with rollback's ``_resolve_state_file`` guard. A
+    prompt-injected agent must not be able to point mureo at an
+    attacker-crafted file elsewhere on disk.
+
+    The default workspace is CWD (the resolved
+    :class:`FilesystemStateStore` derives ``workspace`` from
+    ``Path.cwd()`` at construction), so this test exercises the
+    workspace boundary while CWD is ``cwd_to_tmp``."""
     mod = _import_tools()
-    with pytest.raises(ValueError, match="Refusing to read/write outside cwd"):
+    with pytest.raises(
+        ValueError, match="Refusing to read/write outside workspace"
+    ):
         await mod.handle_tool("mureo_strategy_get", {"path": "/etc/passwd"})
+
+
+# ---------------------------------------------------------------------------
+# RuntimeContext-routing (workspace-aware default path)
+# ---------------------------------------------------------------------------
+
+
+async def test_default_path_follows_runtime_context_workspace(
+    tmp_path, monkeypatch
+) -> None:
+    """When no ``path`` argument is supplied, handlers read/write at
+    ``state_store.workspace / 'STATE.json'`` — picking up any alternate
+    :class:`StateStore` registered via the
+    ``mureo.runtime_context_factory`` entry-point group.
+
+    Verified by injecting a :class:`FilesystemStateStore` whose
+    workspace is a sibling of CWD, then asserting the on-disk write
+    lands in the injected workspace (NOT in CWD)."""
+    from mureo.core.runtime_context import (
+        RuntimeContext,
+        default_runtime_context,
+    )
+
+    # CWD is one dir, the injected workspace is a SIBLING dir.
+    cwd_dir = tmp_path / "cwd"
+    workspace_dir = tmp_path / "tenant"
+    cwd_dir.mkdir()
+    workspace_dir.mkdir()
+    monkeypatch.chdir(cwd_dir)
+
+    base = default_runtime_context(workspace=workspace_dir)
+    injected = RuntimeContext(
+        secret_store=base.secret_store,
+        state_store=base.state_store,
+        knowledge_store=base.knowledge_store,
+        throttle_store=base.throttle_store,
+        workspace_id="injected",
+    )
+    monkeypatch.setattr("mureo.core.runtime_context._cached_context", injected)
+
+    mod = _import_tools()
+    await mod.handle_tool(
+        "mureo_state_action_log_append",
+        {
+            "entry": {
+                "timestamp": "2026-05-21T00:00:00Z",
+                "action": "test",
+                "platform": "google_ads",
+            }
+        },
+    )
+
+    # The action_log write must land under the injected workspace,
+    # NOT under CWD — proving the handler followed the RuntimeContext.
+    assert (workspace_dir / "STATE.json").exists()
+    assert not (cwd_dir / "STATE.json").exists()

--- a/tests/test_mcp_tools_rollback.py
+++ b/tests/test_mcp_tools_rollback.py
@@ -23,12 +23,27 @@ def _write_state(path: Path, entries: list[ActionLogEntry]) -> None:
     write_state_file(path, StateDocument(version="2", action_log=tuple(entries)))
 
 
+@pytest.fixture(autouse=True)
+def _clear_runtime_context_cache():
+    """Reset the resolver cache before and after every test so the
+    workspace-aware ``_resolve_state_file`` rebuilds a
+    :class:`FilesystemStateStore` with the (per-test) CWD instead of
+    reusing a stale one cached during an earlier test or test module."""
+    from mureo.core.runtime_context import reset_runtime_context
+
+    reset_runtime_context()
+    yield
+    reset_runtime_context()
+
+
 @pytest.fixture
 def sandboxed_cwd(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> Path:
     """Run each test under ``tmp_path`` so the handler's path-sandboxing
-    accepts a relative ``STATE.json`` argument."""
+    accepts a relative ``STATE.json`` argument. The autouse cache-reset
+    fixture above runs first, so the resolver picks up the chdir on the
+    next call."""
     monkeypatch.chdir(tmp_path)
     return tmp_path
 
@@ -166,7 +181,10 @@ class TestApplyHandler:
 
     @pytest.mark.asyncio
     async def test_path_traversal_refused(self, sandboxed_cwd: Path) -> None:
-        """A state_file argument that resolves outside CWD must be rejected."""
+        """A state_file argument that resolves outside the active workspace
+        must be rejected. In the default file-backed configuration the
+        workspace equals CWD, so writing to ``sandboxed_cwd.parent`` is
+        outside both."""
         # Write a valid STATE.json outside the sandbox.
         outside = sandboxed_cwd.parent / "rogue_STATE.json"
         _write_state(outside, [_budget_entry()])
@@ -182,8 +200,7 @@ class TestApplyHandler:
         payload = json.loads(result[0].text)
         # Path validation raises ValueError -> surfaces in response
         assert (
-            "inside the current working directory"
-            in payload.get("error", "")
+            "inside the active workspace" in payload.get("error", "")
             or payload.get("status") == "refused"
         )
 


### PR DESCRIPTION
## Summary

Add `mureo.core.{SecretStore, StateStore, KnowledgeStore, ThrottleStore, RuntimeContext}` Protocols, file-backed default implementations, and a `default_runtime_context()` factory. Three additive commits, zero existing-file behavioural change.

## Why

Today's call sites in `mureo.auth`, `mureo.context`, `mureo.mcp`, and `skills/learn/SKILL.md` hard-wire file paths and module-level singletons. That makes:

- Unit tests harder than necessary (filesystem mocking, env vars, `__file__` monkey-patching).
- Alternate credential backends (OS keychain, HashiCorp Vault, GCP/AWS Secret Manager) impossible to inject without forking.
- BYOD's `MUREO_BYOD_DIR` env-var coupling difficult to vary per call.

Introducing thin Protocols + file-backed defaults lets future consumers accept injection without changing today's single-workspace experience. The Protocol shape mirrors the existing pattern in `mureo/core/providers/` and `mureo/core/skills/`.

## What's in this PR

| Commit | Content |
|---|---|
| `c9713d2` | Five Protocols + `RuntimeContext` dataclass (types only) |
| `3d57367` | `FilesystemSecretStore`, `FilesystemStateStore`, `FilesystemKnowledgeStore`, `ProcessLocalThrottleStore` |
| `16b58ae` | `default_runtime_context()` factory + `mureo.core` public surface (`__all__`) |

### Public surface added to `mureo.core`

```python
from mureo.core import (
    SecretStore, StateStore, KnowledgeStore, ThrottleStore,   # Protocols
    FilesystemSecretStore, FilesystemStateStore,
    FilesystemKnowledgeStore, ProcessLocalThrottleStore,      # file-backed defaults
    RuntimeContext, DEFAULT_WORKSPACE_ID,                     # aggregate + sentinel
    default_runtime_context,                                  # factory
)
```

## Compatibility

- **No existing module imports the new types yet.** Every existing call site continues to use legacy helpers (`auth.load_credentials`, `read_state_file`, etc.) directly. This PR is purely additive.
- `mureo/core/__init__.py` was empty; now exports 11 names. No prior re-exports to break.
- The default implementations wrap legacy helpers / file formats so on-disk artefacts are byte-equivalent to what callers see today.

## Bi-directional file-format equivalence verified

An end-to-end smoke test confirmed:
- `mureo.auth.load_credentials(path)` reads the file written by `FilesystemSecretStore`.
- `mureo.context.state.read_state_file(path)` reads the file written by `FilesystemStateStore`.
- Same for the reverse direction (defaults read what legacy wrote).

## Test plan

- [ ] `pytest tests/core/` — 382 tests pass (+83 new structural & file-IO tests)
- [ ] `ruff check mureo/` — clean
- [ ] `black --check mureo/` — clean
- [ ] Windows CI lane (added in #122) — Windows-safe `Path.home` patching applied to three tests that previously used `monkeypatch.setenv("HOME", ...)`
- [ ] No regression in related existing tests: `tests/test_auth.py`, `test_state.py`, `test_strategy.py`, `test_throttle.py`, `test_fsutil.py`, `test_cli_providers.py` (136 tests, verified locally)
