### PR TITLE
chore(release): v0.9.4

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mureo",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Your local-first AI ad ops crew for Google Ads, Meta Ads, Search Console & GA4. mureo sits on top of the official ad-platform MCPs, gates every change against your strategy, correlates outcomes locally, and keeps an auditable decision log — credentials never leave your machine.",
   "author": {
     "name": "Logly Inc.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.4] - 2026-05-21
+
+### Added — Extension Protocols and `mureo learn` CLI (#125)
+
+A new public surface under `mureo.core` lets alternate backends and tests inject pluggable persistence without forking call sites. The shape mirrors the existing `mureo.core.providers` and `mureo.core.skills` extension patterns. Every default reproduces today's file-backed behaviour, so existing users see no change.
+
+- **`mureo.core.SecretStore`** — `Protocol` for credential round-trip (load / save / delete). Default `FilesystemSecretStore` reads and writes `~/.mureo/credentials.json` byte-for-byte equivalent to the previous flow (atomic write, `0o600` via `mureo.fsutil.secure_fchmod`, `ensure_ascii=False`).
+- **`mureo.core.StateStore`** — `Protocol` for `STATE.json` / `STRATEGY.md` / action_log persistence. Default `FilesystemStateStore` composes the existing helpers in `mureo.context.state` / `mureo.context.strategy`.
+- **`mureo.core.KnowledgeStore`** — two-tier `Protocol` for `/learn` insights (operator + workspace). Default `FilesystemKnowledgeStore` writes to today's `~/.claude/skills/_mureo-pro-diagnosis/SKILL.md` location with the same frontmatter scaffold.
+- **`mureo.core.ThrottleStore`** — `Protocol` for per-key API rate limiting. Default `ProcessLocalThrottleStore` wraps `mureo.throttle.Throttler`; `register(key, config)` pre-installs custom buckets matching the MCP server's `_PLUGIN_TOOL_THROTTLERS` pattern.
+- **`mureo.core.RuntimeContext`** — frozen dataclass aggregating the four stores plus a `workspace_id`. `DEFAULT_WORKSPACE_ID = "default"` is the canonical single-workspace sentinel.
+- **`mureo.core.default_runtime_context()`** — factory wiring the four file-backed defaults.
+- **`mureo.core.get_runtime_context()`** — process-cached resolver that discovers a single zero-arg factory under the `mureo.runtime_context_factory` entry-point group; raises `RuntimeContextFactoryError` on multiple registrations or a returning-non-`RuntimeContext` factory.
+
+### Added — `mureo learn add` CLI
+
+`mureo learn add <text> [--scope {operator,workspace}]` persists `/learn` insights through `RuntimeContext.knowledge_store` rather than writing files directly. Default scope `operator` writes the cross-workspace tier (today's pro-diagnosis location); `--scope workspace` writes a workspace-scoped tier if one is configured. The `/learn` skill (`skills/learn/SKILL.md`) now invokes the CLI instead of carrying its own copy of the file scaffold.
+
+### Changed — Consumers routed through the new Protocols
+
+These refactors are call-site changes only; all on-disk artefacts and CLI behaviour are byte-equivalent in the default file-backed runtime.
+
+- `mureo.auth.load_google_ads_credentials` / `load_meta_ads_credentials` read through `SecretStore` (`get_runtime_context().secret_store` when `path` is not passed; one-shot `FilesystemSecretStore(path=…)` when it is).
+- MCP handlers `mureo_strategy_*`, `mureo_state_*`, `rollback_*`, `analysis_anomalies_check` resolve their `path` / `state_file` argument against `state_store.workspace` rather than raw CWD. Error messages and traversal-refusal semantics are preserved; symlink refusal in the analysis handler is unchanged.
+- MCP plugin dispatch acquires its throttle slot via `RuntimeContext.throttle_store`. The default `ProcessLocalThrottleStore` is seeded with the existing per-tool `Throttler` instances (`_PLUGIN_TOOL_THROTTLERS`) on first call; alternate backends receive `acquire(name)` and own per-key fallback semantics.
+- `mureo.cli.rollback_cmd` `--state-file` default is now resolved through `RuntimeContext` (rather than the literal `Path("STATE.json")`).
+- `mureo.byod.runtime.byod_data_dir()` adds a middle-priority resolution path: when a non-default `RuntimeContext` exposes a filesystem `workspace`, BYOD data lives at `<workspace>/byod/`. `MUREO_BYOD_DIR` env var and the legacy `~/.mureo/byod/` fallback are unchanged.
+
 ## [0.9.3] - 2026-05-19
 
 ### Fixed — Windows compatibility (#122)

--- a/mureo/__init__.py
+++ b/mureo/__init__.py
@@ -1,3 +1,3 @@
 """mureo — your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."""
 
-__version__ = "0.9.3"
+__version__ = "0.9.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mureo"
-version = "0.9.3"
+version = "0.9.4"
 description = "Your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."
 requires-python = ">=3.10"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Releases v0.9.4 covering the extension-protocols work in #125.

### Public surface added to `mureo.core`

- Protocols: `SecretStore`, `StateStore`, `KnowledgeStore`, `ThrottleStore`
- File-backed defaults: `FilesystemSecretStore`, `FilesystemStateStore`, `FilesystemKnowledgeStore`, `ProcessLocalThrottleStore`
- Aggregate + sentinel: `RuntimeContext`, `DEFAULT_WORKSPACE_ID`
- Factory + resolver: `default_runtime_context()`, `get_runtime_context()`, `reset_runtime_context()`
- Errors / constants: `RuntimeContextFactoryError`, `RUNTIME_CONTEXT_FACTORY_ENTRY_POINT_GROUP`

### New CLI

`mureo learn add <text> [--scope {operator,workspace}]` routes `/learn` writes through the `KnowledgeStore` Protocol. The `/learn` skill (`skills/learn/SKILL.md`) now invokes the CLI instead of writing the file path manually.

### Refactored consumers (no observable behaviour change)

`auth.py`, `mureo_context` / `rollback` / `analysis` MCP handlers, `rollback` CLI, `byod/runtime.py`, and MCP plugin dispatch throttle now route through `RuntimeContext`. With the default file-backed runtime the on-disk artefacts and CLI behaviour are byte-equivalent to v0.9.3.

### Version bump

- `.claude-plugin/plugin.json`: 0.9.3 → 0.9.4
- `mureo/__init__.py`: 0.9.3 → 0.9.4
- `pyproject.toml`: 0.9.3 → 0.9.4

## Test plan

- [ ] All CI jobs green (lint, test 3.10/3.11/3.12, test-windows, CodeQL, Analyze)
- [ ] Version parity test (`tests/test_plugin_manifests.py::test_plugin_version_matches_pyproject`) passes
- [ ] Tag `v0.9.4` after merge → GitHub Release published → release.yml workflow pushes to PyPI
