### PR TITLE
feat(web): add entry-point–based extension layer for the configure UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — Web extensions: third-party tabs and API routes for `mureo configure`
+
+A new entry-point group `mureo.web_extensions` lets a plugin register additional tabs and API routes inside the `mureo configure` wizard without each surface having to know about the plugin. The mechanism mirrors the existing `mureo.providers` / `mureo.runtime_context_factory` entry-point patterns: discovery iterates the group exactly once at startup, isolates per-plugin faults (`WebExtensionWarning`), and exposes survivors as frozen `WebExtensionEntry` records consumed by `mureo.web.handlers`.
+
+- **`mureo.web.extensions`** — public surface: `WebExtension` Protocol (`name`, `display_name`, `routes()`, `view()`), frozen dataclasses `RouteContribution(method, subpath, handler)`, `ViewContribution(html_fragment, scripts, styles)`, `StaticAsset(filename, content_type, body)`, plus `discover_web_extensions()` / `reset_web_extensions()` and the regex constants (`NAME_PATTERN`, `SUBPATH_PATTERN`, `FILENAME_PATTERN`) shared with the dispatch layer.
+- **HTTP surface** in `mureo.web.handlers`:
+  - `GET /api/extensions` — index for the front-end renderer (one entry per extension; `view` is `null` for headless / route-only plugins).
+  - `GET /api/ext/<name>/<subpath>` — extension GET route; payload is the flattened query string (first-value-wins).
+  - `POST /api/ext/<name>/<subpath>` — extension POST route, gated by the existing Host + body-cap + CSRF pipeline (the plugin author inherits CSRF protection for free).
+  - `GET /static/ext/<name>/<filename>` — extension-shipped static asset served from in-memory bytes with the same Content-Security-Policy + X-Frame-Options + Cache-Control header stack as the bundled static files.
+- **Front-end** (`mureo/_data/web/extensions.js`): the configure UI fetches `/api/extensions` once when the dashboard opens, renders one nav tab per extension, and lazy-loads each extension's `html_fragment` / scripts / styles on first tab activation. Operators who never visit a given tab pay zero added page weight.
+- **Plugin author guide**: `docs/plugin-authoring.md` §13 documents the contract end-to-end (entry-point setup, sample `WebExtension`, URL surface, CSP / CSRF / fault-isolation model, lazy-load behaviour, debugging recipe).
+- **Security**: subpaths and filenames are regex-validated at both registration and dispatch so `..`, double-slash, trailing slash, `?`, `#`, and directory separators cannot smuggle the dispatcher outside `/api/ext/<name>/` or `/static/ext/<name>/`. Static asset bodies stay in memory; the dispatcher never reads from disk so filesystem traversal is impossible by construction. `html_fragment` is rejected at registration if it contains `<script>`, `<style>`, `on*=` event handlers, or `javascript:` URLs — the CSP (`script-src 'self'; style-src 'self'`) is the runtime enforcement, the regex is the explicit author-feedback signal. Handler exceptions are caught by the dispatcher and surfaced as a generic `{"error": "extension_handler_error"}` 500 envelope; exception details are logged server-side only (they may carry secrets the handler touched).
+
+Backward compatibility: when no third-party `mureo.web_extensions` entry points are installed, `discover_web_extensions()` returns an empty tuple, `/api/extensions` returns `[]`, the renderer creates zero DOM nodes, and the configure UI is byte-identical to v0.9.4.
+
 ## [0.9.4] - 2026-05-21
 
 ### Added — Extension Protocols and `mureo learn` CLI (#125)

--- a/docs/plugin-authoring.md
+++ b/docs/plugin-authoring.md
@@ -28,6 +28,7 @@ and which are not, see [ABI-stability.md](./ABI-stability.md).
 10. [Security considerations](#10-security-considerations)
 11. [End-to-end example](#11-end-to-end-example)
 12. [Troubleshooting](#12-troubleshooting)
+13. [Web extensions](#13-web-extensions)
 
 ---
 
@@ -1281,6 +1282,177 @@ clear_skills_cache()
 
 Both wipe the in-process cache; the next `discover_*` call
 re-iterates entry points.
+
+---
+
+## 13. Web extensions
+
+Configure-UI extensions let a plugin add tabs / API routes to the
+`mureo configure` wizard without each surface having to know about the
+plugin. The mechanism mirrors §3 (provider Protocols) and §8 (entry-points
+registration): you implement a small `WebExtension` Protocol, register
+it under a dedicated entry-point group, and the configure server picks
+it up at startup.
+
+### When to use a web extension
+
+- Setup UI for an alternate backend the user must configure
+  (Vault / cloud secret manager credentials, custom state store
+  connection strings).
+- A connection-test or diagnostic panel that operators run from the
+  same wizard they use for the built-in setup.
+- Any custom data source / panel that benefits from being reachable
+  inside `mureo configure` rather than via a separate CLI.
+
+The mechanism only covers the configure wizard. For MCP tools see §3
+(provider Protocols); for slash-command skills see §9.
+
+### `WebExtension` Protocol
+
+```python
+# my_plugin/web_extension.py
+from typing import Any
+
+from mureo.web.extensions import (
+    RouteContribution,
+    StaticAsset,
+    ViewContribution,
+)
+
+
+def _ping(_request: Any, payload: dict[str, Any]) -> None:
+    from mureo.web._helpers import send_json
+    send_json(_request, {"echo": payload})
+
+
+class MyExtension:
+    name = "acme-vault"
+    display_name = "Acme Vault setup"
+
+    def routes(self) -> tuple[RouteContribution, ...]:
+        return (
+            RouteContribution(method="GET", subpath="/ping", handler=_ping),
+        )
+
+    def view(self) -> ViewContribution | None:
+        return ViewContribution(
+            html_fragment=(
+                '<section><h2>Acme Vault</h2>'
+                '<button id="acme-vault-ping">Ping</button></section>'
+            ),
+            scripts=(
+                StaticAsset(
+                    filename="acme-vault.js",
+                    content_type="application/javascript",
+                    body=(
+                        b"document.getElementById('acme-vault-ping')"
+                        b".addEventListener('click', () =>"
+                        b" fetch('/api/ext/acme-vault/ping?x=1')"
+                        b".then(r => r.json()).then(console.log));"
+                    ),
+                ),
+            ),
+        )
+```
+
+### `pyproject.toml`
+
+```toml
+[project.entry-points."mureo.web_extensions"]
+acme-vault = "my_plugin.web_extension:MyExtension"
+```
+
+The entry-point value can resolve to either:
+
+- the **class** (instantiated zero-arg by the loader; the example
+  above), or
+- a **callable** that returns an instance.
+
+Discovery happens once at `ConfigureWizard` construction; if your
+plugin is installed (`pip install`) and your entry-point resolves
+cleanly, the extension appears as an extra tab in the dashboard the
+next time the user runs `mureo configure`.
+
+### URL surface
+
+| URL | Notes |
+|---|---|
+| `GET /api/extensions` | Index consumed by the front-end renderer. |
+| `GET /api/ext/<name>/<subpath>` | Your GET routes. Payload is the flattened query string. |
+| `POST /api/ext/<name>/<subpath>` | Your POST routes. Body is the parsed JSON object. CSRF + Host gate already applied. |
+| `GET /static/ext/<name>/<filename>` | Your `StaticAsset` bodies, served verbatim with the Content-Type you declared. |
+
+Subpaths and filenames are regex-validated at both registration and
+dispatch (`NAME_PATTERN` / `SUBPATH_PATTERN` / `FILENAME_PATTERN` in
+`mureo.web.extensions`): the dispatcher refuses subpaths containing
+`..`, double-slash, trailing slash, `?`, or `#`, and filenames
+containing directory separators or starting with a dot. Real query
+strings appear AFTER the URL path and are handled by the dispatcher's
+`_flatten_query` helper (first-value-wins).
+
+### Security model
+
+Every response inherits the configure-UI Content-Security-Policy
+(`default-src 'none'; script-src 'self'; style-src 'self'`). Your
+extension UI MUST therefore ship its JavaScript and CSS via
+`StaticAsset` (served from `/static/ext/<name>/<file>`, same origin as
+the CSP allows) and MUST NOT embed inline `<script>` / `<style>` /
+`on*=` event handlers / `javascript:` URLs in `html_fragment`.
+Discovery rejects html fragments that include any of these patterns
+so the failure surfaces explicitly instead of producing a silently
+inert UI under the CSP.
+
+CSRF protection applies automatically to your POST routes: the
+dispatcher runs the same Host-header + CSRF check the built-in routes
+use before calling your handler, so you do not need to add any token
+plumbing.
+
+Handler exceptions are caught by the dispatcher and surfaced as a
+generic `500 {"error": "extension_handler_error"}` JSON envelope; the
+exception `repr` is logged server-side only (it may contain secrets
+the handler touched). Your handler MUST NOT raise after starting to
+write the response — the dispatcher cannot retroactively suppress a
+partial response that has already shipped bytes to the wire.
+
+### Lazy loading
+
+The configure UI fetches `/api/extensions` once when the dashboard
+opens and renders one tab per extension. The `html_fragment` and
+`scripts` / `styles` of any specific extension are only injected into
+the DOM the first time the user clicks that extension's tab. Operators
+who never visit your tab pay zero extra page weight; once visited,
+your assets persist for the rest of the configure session.
+
+### Debugging discovery
+
+- `pip show <your-dist>` confirms the install.
+- `importlib.metadata.entry_points(group="mureo.web_extensions")` lists
+  the registered entry points in the running interpreter.
+- `mureo configure --log-level=DEBUG` (if your shell respects it via
+  `MUREO_LOG_LEVEL=DEBUG mureo configure`) surfaces
+  `WebExtensionWarning` messages explaining why an entry point was
+  skipped (bad name, broken `ep.load()`, `routes()` / `view()`
+  exception, duplicate name shadowed by an earlier registration).
+
+Strict-mode deployments can convert warnings into hard failures with:
+
+```python
+import warnings
+from mureo.web.extensions import WebExtensionWarning
+
+warnings.filterwarnings("error", category=WebExtensionWarning)
+```
+
+### Programmatic registration (tests)
+
+```python
+from mureo.web.extensions import reset_web_extensions
+
+# clear the process-wide cache so the next discover_web_extensions()
+# call re-iterates entry points (which your test fixtures might have
+# monkeypatched).
+reset_web_extensions()
+```
 
 ---
 

--- a/mureo/_data/web/app.html
+++ b/mureo/_data/web/app.html
@@ -216,5 +216,6 @@
   <script src="/static/wizard.js"></script>
   <script src="/static/auth_wizards.js"></script>
   <script src="/static/dashboard.js"></script>
+  <script src="/static/extensions.js"></script>
 </body>
 </html>

--- a/mureo/_data/web/dashboard.js
+++ b/mureo/_data/web/dashboard.js
@@ -114,6 +114,11 @@
     document.querySelector("[data-landing]").hidden = true;
     document.querySelector("[data-dashboard]").hidden = false;
     selectNavGroup(DEFAULT_NAV);
+    // Render third-party extension tabs (if any). The init call is
+    // idempotent — see ``mureo/_data/web/extensions.js``.
+    if (MUREO.extensions && typeof MUREO.extensions.init === "function") {
+      MUREO.extensions.init();
+    }
   }
 
   function hide() {

--- a/mureo/_data/web/extensions.js
+++ b/mureo/_data/web/extensions.js
@@ -1,0 +1,192 @@
+// Renders third-party web extensions discovered by the configure
+// server (see ``mureo.web.extensions``) as additional dashboard tabs.
+//
+// Each extension with a non-null ``view`` becomes:
+//   * one ``<li><a data-dashboard-nav="ext-<name>">…</a></li>`` appended
+//     to the dashboard nav, sitting after the built-in tabs
+//   * one ``<div class="dashboard-group" data-dashboard-group="ext-<name>"
+//     hidden></div>`` appended to the dashboard pane, populated lazily
+//     on first selection
+//
+// Lazy load: scripts / styles / html_fragment are injected the first
+// time the user clicks the extension's tab. The CSP only permits
+// ``script-src 'self'`` / ``style-src 'self'``; every asset URL is
+// ``/static/ext/<name>/<filename>`` (same origin) so the loads pass.
+
+(function () {
+  "use strict";
+
+  const _populated = new Set();
+  let _extensions = [];
+  // Single source of truth for "init() has already run". Set
+  // synchronously at the top of init() so concurrent show() calls
+  // collapse to one /api/extensions fetch even before the first
+  // response resolves, and so the no-extensions case (_extensions
+  // stays []) does not re-fetch on every dashboard open.
+  let _initialised = false;
+
+  function _navList() {
+    return document.querySelector(".dashboard-nav ul");
+  }
+
+  function _pane() {
+    return document.querySelector(".dashboard-pane");
+  }
+
+  function _navItemId(name) {
+    return "ext-" + name;
+  }
+
+  function _scriptId(name, filename) {
+    return "ext-script-" + name + "-" + filename;
+  }
+
+  function _styleId(name, filename) {
+    return "ext-style-" + name + "-" + filename;
+  }
+
+  function _injectStyles(name, filenames) {
+    filenames.forEach(function (fn) {
+      const id = _styleId(name, fn);
+      if (document.getElementById(id)) return;
+      const link = document.createElement("link");
+      link.rel = "stylesheet";
+      link.href = "/static/ext/" + name + "/" + fn;
+      link.id = id;
+      document.head.appendChild(link);
+    });
+  }
+
+  function _injectScripts(name, filenames) {
+    filenames.forEach(function (fn) {
+      const id = _scriptId(name, fn);
+      if (document.getElementById(id)) return;
+      const script = document.createElement("script");
+      script.src = "/static/ext/" + name + "/" + fn;
+      script.id = id;
+      script.defer = true;
+      document.body.appendChild(script);
+    });
+  }
+
+  function _populate(extension) {
+    if (_populated.has(extension.name)) return;
+    const group = document.querySelector(
+      '[data-dashboard-group="' + _navItemId(extension.name) + '"]',
+    );
+    if (!group || !extension.view) return;
+    // innerHTML is fine here: the server has already rejected
+    // inline script / style / event handlers; the CSP refuses any
+    // that slip through. The renderer's job is only to attach the
+    // approved fragment to the DOM.
+    group.innerHTML = extension.view.html_fragment;
+    _injectStyles(extension.name, extension.view.styles || []);
+    _injectScripts(extension.name, extension.view.scripts || []);
+    _populated.add(extension.name);
+  }
+
+  function _onTabClick(extension) {
+    return function (evt) {
+      evt.preventDefault();
+      _populate(extension);
+      _selectGroup(_navItemId(extension.name));
+    };
+  }
+
+  function _selectGroup(name) {
+    // Mirror dashboard.js#selectNavGroup so extension tabs use the
+    // same visibility + aria-current contract as the built-ins.
+    const groups = document.querySelectorAll("[data-dashboard-group]");
+    groups.forEach(function (g) {
+      g.hidden = g.getAttribute("data-dashboard-group") !== name;
+    });
+    const items = document.querySelectorAll("[data-dashboard-nav]");
+    items.forEach(function (item) {
+      const active = item.getAttribute("data-dashboard-nav") === name;
+      if (active) {
+        item.setAttribute("aria-current", "page");
+      } else {
+        item.removeAttribute("aria-current");
+      }
+    });
+    const rerun = document.querySelector("[data-dashboard-rerun-wizard]");
+    if (rerun) {
+      rerun.style.display = name === "setup" ? "" : "none";
+    }
+  }
+
+  function _renderNavItem(extension) {
+    const nav = _navList();
+    const pane = _pane();
+    if (!nav || !pane) return;
+    if (nav.querySelector('[data-dashboard-nav="' + _navItemId(extension.name) + '"]')) {
+      return;
+    }
+
+    const li = document.createElement("li");
+    const a = document.createElement("a");
+    a.href = "#";
+    a.className = "dashboard-nav-item";
+    a.setAttribute("data-dashboard-nav", _navItemId(extension.name));
+    a.setAttribute("role", "button");
+    a.setAttribute("tabindex", "0");
+    a.textContent = extension.display_name;
+    const onActivate = _onTabClick(extension);
+    a.addEventListener("click", onActivate);
+    a.addEventListener("keydown", function (evt) {
+      if (evt.key === "Enter" || evt.key === " " || evt.key === "Spacebar") {
+        onActivate(evt);
+      }
+    });
+    li.appendChild(a);
+    nav.appendChild(li);
+
+    const group = document.createElement("div");
+    group.className = "dashboard-group";
+    group.setAttribute("data-dashboard-group", _navItemId(extension.name));
+    group.hidden = true;
+    pane.appendChild(group);
+  }
+
+  async function init() {
+    if (_initialised) return;
+    _initialised = true;
+    let res;
+    try {
+      res = await fetch("/api/extensions");
+    } catch (err) {
+      console.warn("[mureo] /api/extensions fetch failed", err);
+      return;
+    }
+    if (!res || !res.ok) {
+      console.warn(
+        "[mureo] /api/extensions returned non-OK",
+        res && res.status,
+      );
+      return;
+    }
+    let payload;
+    try {
+      payload = await res.json();
+    } catch (err) {
+      console.warn("[mureo] /api/extensions returned invalid JSON", err);
+      return;
+    }
+    if (!Array.isArray(payload)) {
+      console.warn(
+        "[mureo] /api/extensions returned non-array payload",
+        payload,
+      );
+      return;
+    }
+    _extensions = payload.filter(function (item) {
+      return item && item.view; // skip headless / route-only extensions
+    });
+    _extensions.forEach(_renderNavItem);
+  }
+
+  window.MUREO = window.MUREO || {};
+  window.MUREO.extensions = {
+    init: init,
+  };
+})();

--- a/mureo/_data/web/extensions.js
+++ b/mureo/_data/web/extensions.js
@@ -23,6 +23,9 @@
   // collapse to one /api/extensions fetch even before the first
   // response resolves, and so the no-extensions case (_extensions
   // stays []) does not re-fetch on every dashboard open.
+  // Exception paths intentionally leave this true: a failed discovery
+  // requires a full page reload (not a silent retry) so the operator
+  // can investigate the root cause via the console.warn diagnostics.
   let _initialised = false;
 
   function _navList() {

--- a/mureo/web/extensions.py
+++ b/mureo/web/extensions.py
@@ -1,0 +1,414 @@
+"""Entry-point–based extension layer for the configure-UI HTTP server.
+
+A third-party distribution can register a zero-arg callable returning
+a class (or instance) satisfying :class:`WebExtension` under the
+``mureo.web_extensions`` entry-point group; discovery iterates that
+group exactly once, isolates faults per entry, and exposes survivors
+as frozen :class:`WebExtensionEntry` records consumed by
+``mureo.web.handlers``.
+
+Design mirrors :mod:`mureo.core.providers.registry`:
+
+* per-plugin try/except around the whole load → introspect → validate
+  pipeline so a broken plugin cannot break discovery for the rest
+* :class:`WebExtensionWarning` so strict-mode deployments can opt into
+  ``warnings.filterwarnings("error", category=WebExtensionWarning)``
+* first-wins on duplicate names (deterministic; a malicious plugin
+  installed after a legitimate one cannot silently take its slot)
+* result cached for the process lifetime — entry points are populated
+  by ``pip install`` and do not change at runtime
+
+Security posture:
+
+* ``RouteContribution.subpath`` is regex-validated at construction so
+  ``..`` / double-slash / ``?`` / ``#`` cannot smuggle the dispatcher
+  outside ``/api/ext/<name>/``.
+* ``StaticAsset.filename`` is regex-validated for the same reason.
+  Bodies are kept in memory; the dispatcher never reads from disk so
+  filesystem traversal is impossible by construction.
+* ``ViewContribution.html_fragment`` is rejected if it contains
+  ``<script>``, ``<style>``, ``on*=`` event handlers, or
+  ``javascript:`` URLs. The configure-UI CSP only allows ``script-src
+  'self'`` / ``style-src 'self'``; extensions ship assets via
+  ``/static/ext/<name>/<file>`` so the CSP never has to relax. The
+  regex check is an author-feedback signal — the **CSP is the actual
+  enforcement** — so HTML-entity-encoded bypasses
+  (``&#x6A;avascript:``) that skip the regex are blocked at runtime.
+
+Warning-flood note (mirrors
+:class:`mureo.core.providers.registry.RegistryWarning`):
+:class:`WebExtensionWarning` messages embed attacker-controllable
+strings (entry-point name, distribution name, exception ``repr``).
+Python's default warning deduplication does not coalesce them — every
+unique message is a fresh warning — so a hostile environment that
+installs many malformed plugins can flood operator logs. Strict-mode
+deployments should opt into
+``warnings.filterwarnings("error", category=WebExtensionWarning)``.
+"""
+
+from __future__ import annotations
+
+import re
+import warnings
+from dataclasses import dataclass
+from importlib.metadata import entry_points
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Final,
+    Literal,
+    Protocol,
+    runtime_checkable,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from http.server import BaseHTTPRequestHandler
+
+#: Entry-point group iterated by :func:`discover_web_extensions`.
+WEB_EXTENSIONS_ENTRY_POINT_GROUP: Final[str] = "mureo.web_extensions"
+
+#: ``WebExtension.name`` and ``WebExtensionEntry.name`` — kebab-case,
+#: 1–33 chars, must start with a lowercase letter. Used as the
+#: URL-path segment (``/api/ext/<name>/...``) and as the dict key for
+#: duplicate-name detection.
+_NAME_RE: Final[re.Pattern[str]] = re.compile(r"^[a-z][a-z0-9-]{0,32}$")
+
+#: ``StaticAsset.filename`` — lowercase, alphanumeric + ``._-``, no
+#: directory separator, must start with a letter, must contain at
+#: least one dot. Internal dots are permitted (``app.min.js``,
+#: ``vendor.bundle.js``, ``i18n.en-us.json``) — modern JS toolchain
+#: outputs use them routinely. Leading dot, ``..``, ``/``, ``\``,
+#: whitespace, and uppercase remain rejected.
+_FILENAME_RE: Final[re.Pattern[str]] = re.compile(
+    r"^[a-z][a-z0-9_-]*(\.[a-z0-9_-]+)*\.[a-z0-9]+$"
+)
+
+#: ``RouteContribution.subpath`` — leading slash, then one or more
+#: segments of ``[A-Za-z0-9_-]``, separated by single slashes. No
+#: query string, no fragment, no traversal, no double-slash.
+_SUBPATH_RE: Final[re.Pattern[str]] = re.compile(r"^(/[A-Za-z0-9_-]+)+$")
+
+#: Inline-executable patterns banned in ``html_fragment``. The
+#: configure-UI CSP forbids ``unsafe-inline`` so these would not
+#: execute anyway, but discovery refuses them so plugin authors get
+#: an explicit failure instead of a silently inert UI.
+_BANNED_HTML_PATTERNS: Final[tuple[re.Pattern[str], ...]] = (
+    re.compile(r"<\s*script\b", re.IGNORECASE),
+    re.compile(r"<\s*style\b", re.IGNORECASE),
+    re.compile(r"\bon[a-z]+\s*=", re.IGNORECASE),
+    re.compile(r"\bjavascript\s*:", re.IGNORECASE),
+)
+
+
+class WebExtensionWarning(UserWarning):
+    """Emitted when a discovered web extension is skipped or shadowed.
+
+    Mirrors :class:`mureo.core.providers.registry.RegistryWarning`
+    so strict-mode deployments can opt into
+    ``warnings.filterwarnings("error", category=WebExtensionWarning)``.
+    """
+
+
+@dataclass(frozen=True)
+class StaticAsset:
+    """One static asset (JS / CSS / image / JSON) served verbatim under
+    ``/static/ext/<extension-name>/<filename>``.
+
+    ``body`` is in-memory ``bytes``; the dispatcher never reads from
+    disk so filesystem traversal is impossible by construction. Plugin
+    authors that want to ship a large CSS/JS file should read it with
+    :mod:`importlib.resources` at import time and pass the bytes here.
+    """
+
+    filename: str
+    content_type: str
+    body: bytes
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.filename, str) or not _FILENAME_RE.match(self.filename):
+            raise ValueError(
+                f"StaticAsset.filename must match {_FILENAME_RE.pattern!r}; "
+                f"got {self.filename!r}"
+            )
+        if not isinstance(self.content_type, str) or not self.content_type:
+            raise ValueError("StaticAsset.content_type must be a non-empty string")
+        if not isinstance(self.body, (bytes, bytearray)):
+            raise TypeError("StaticAsset.body must be bytes")
+
+
+@dataclass(frozen=True)
+class RouteContribution:
+    """One HTTP route registered by a :class:`WebExtension`.
+
+    Mounted under ``/api/ext/<extension-name>``: a route with
+    ``subpath="/ping"`` becomes ``GET /api/ext/<name>/ping``.
+
+    ``handler`` signature:
+        ``def handler(request: BaseHTTPRequestHandler,
+                      payload: dict[str, str | Any]) -> None``
+
+    For ``GET`` the payload is the flattened query string
+    (``urllib.parse.parse_qs`` with ``first-value-wins``); for ``POST``
+    it is the parsed JSON object body. Multi-value query strings or
+    raw bodies are reachable via ``request.path`` / ``request.rfile``;
+    no rich Request abstraction is provided in v0 (YAGNI).
+
+    The dispatcher runs the existing Host-header + CSRF gate before
+    calling ``handler`` (POST only — GET has no CSRF requirement).
+    Errors raised by ``handler`` are caught by the dispatcher and
+    surfaced as a 500 JSON envelope; the dispatcher never lets one
+    extension crash the configure server.
+    """
+
+    method: Literal["GET", "POST"]
+    subpath: str
+    handler: Callable[[BaseHTTPRequestHandler, dict[str, Any]], None]
+
+    def __post_init__(self) -> None:
+        if self.method not in ("GET", "POST"):
+            raise ValueError(
+                f"RouteContribution.method must be 'GET' or 'POST'; got {self.method!r}"
+            )
+        if not isinstance(self.subpath, str) or not _SUBPATH_RE.match(self.subpath):
+            raise ValueError(
+                f"RouteContribution.subpath must match {_SUBPATH_RE.pattern!r}; "
+                f"got {self.subpath!r}"
+            )
+        if not callable(self.handler):
+            raise TypeError("RouteContribution.handler must be callable")
+
+
+@dataclass(frozen=True)
+class ViewContribution:
+    """Optional UI fragment + asset list shown in the configure UI.
+
+    ``html_fragment`` is injected verbatim into the main area when the
+    user selects the extension's tab. It must NOT contain
+    ``<script>`` / ``<style>`` / ``on*=`` event handlers /
+    ``javascript:`` URLs — the configure-UI Content-Security-Policy
+    forbids ``unsafe-inline`` so those would not execute, but we
+    reject them at discovery time so the plugin author sees the
+    failure instead of a silently inert UI.
+
+    ``scripts`` / ``styles`` reference :class:`StaticAsset`s shipped
+    by the same extension. The renderer emits ``<script>`` /
+    ``<link rel="stylesheet">`` tags pointing at
+    ``/static/ext/<name>/<filename>``; the CSP's ``script-src 'self'``
+    / ``style-src 'self'`` rules permit the load.
+    """
+
+    html_fragment: str
+    scripts: tuple[StaticAsset, ...] = ()
+    styles: tuple[StaticAsset, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.html_fragment, str):
+            raise TypeError("ViewContribution.html_fragment must be str")
+        for pat in _BANNED_HTML_PATTERNS:
+            if pat.search(self.html_fragment):
+                raise ValueError(
+                    "ViewContribution.html_fragment may not contain "
+                    "<script>, <style>, on*= handlers, or javascript: URLs; "
+                    f"matched {pat.pattern!r}"
+                )
+        if not isinstance(self.scripts, tuple) or not all(
+            isinstance(s, StaticAsset) for s in self.scripts
+        ):
+            raise TypeError("ViewContribution.scripts must be tuple[StaticAsset, ...]")
+        if not isinstance(self.styles, tuple) or not all(
+            isinstance(s, StaticAsset) for s in self.styles
+        ):
+            raise TypeError("ViewContribution.styles must be tuple[StaticAsset, ...]")
+
+
+@runtime_checkable
+class WebExtension(Protocol):
+    """Structural type a third-party web extension must satisfy.
+
+    Discovery calls :py:meth:`routes` and :py:meth:`view` exactly once
+    per entry point during startup; their return values are stored in
+    a :class:`WebExtensionEntry`. Exceptions raised by either method
+    skip the extension (with :class:`WebExtensionWarning`) without
+    affecting other extensions or the configure server.
+    """
+
+    @property
+    def name(self) -> str: ...
+
+    @property
+    def display_name(self) -> str: ...
+
+    def routes(self) -> tuple[RouteContribution, ...]: ...
+
+    def view(self) -> ViewContribution | None: ...
+
+
+@dataclass(frozen=True)
+class WebExtensionEntry:
+    """Frozen record of one successfully-discovered extension."""
+
+    name: str
+    display_name: str
+    routes: tuple[RouteContribution, ...]
+    view: ViewContribution | None
+    source_distribution: str | None
+
+
+# ---------------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------------
+
+
+_cached_entries: tuple[WebExtensionEntry, ...] | None = None
+
+
+def reset_web_extensions() -> None:
+    """Clear the discovery cache. Intended for tests; production
+    callers should not need this — entry points do not change at
+    runtime."""
+    global _cached_entries
+    _cached_entries = None
+
+
+def discover_web_extensions() -> tuple[WebExtensionEntry, ...]:
+    """Discover and validate every entry point in
+    :data:`WEB_EXTENSIONS_ENTRY_POINT_GROUP`.
+
+    The result is cached for the process lifetime; subsequent calls
+    return the same tuple by identity. Tests that need to re-run
+    discovery against a different entry-point set must call
+    :func:`reset_web_extensions` first.
+
+    Per-plugin fault isolation: any exception raised by ``ep.load()``,
+    by the extension's ``routes()`` / ``view()`` method, or by
+    construction of a :class:`WebExtensionEntry` (e.g. when an
+    extension returns a ``RouteContribution`` that fails its own
+    ``__post_init__`` check) is converted to a
+    :class:`WebExtensionWarning` and skips just that one entry.
+    Duplicate names are first-wins with a warning.
+    """
+    global _cached_entries
+    if _cached_entries is not None:
+        return _cached_entries
+
+    by_name: dict[str, WebExtensionEntry] = {}
+    for ep in entry_points(group=WEB_EXTENSIONS_ENTRY_POINT_GROUP):
+        entry = _load_entry_point(ep)
+        if entry is None:
+            continue
+        if entry.name in by_name:
+            warnings.warn(
+                f"duplicate web extension name {entry.name!r} "
+                f"(first registration wins; rejected "
+                f"{entry.source_distribution!r})",
+                WebExtensionWarning,
+                stacklevel=2,
+            )
+            continue
+        by_name[entry.name] = entry
+
+    _cached_entries = tuple(by_name.values())
+    return _cached_entries
+
+
+def _load_entry_point(ep: Any) -> WebExtensionEntry | None:
+    """Load, validate, and freeze one entry point.
+
+    The try/except spans the entire load → introspect → freeze
+    sequence so an adversarial plugin cannot bypass fault isolation
+    via a metaclass side effect or a property that raises.
+    """
+    ep_name = getattr(ep, "name", "<unknown>")
+    try:
+        loaded = ep.load()
+        extension = loaded() if isinstance(loaded, type) else loaded
+        # ``isinstance(extension, WebExtension)`` only verifies method
+        # presence (``@runtime_checkable`` Protocol semantics); the
+        # deeper validation (regex-checked name, type-checked routes
+        # tuple, etc.) lives in the explicit blocks below.
+        if not isinstance(extension, WebExtension):
+            warnings.warn(
+                f"entry point {ep_name!r} did not yield a WebExtension "
+                f"(got {type(extension).__name__}); skipped",
+                WebExtensionWarning,
+                stacklevel=3,
+            )
+            return None
+        name = extension.name
+        if not isinstance(name, str) or not _NAME_RE.match(name):
+            warnings.warn(
+                f"entry point {ep_name!r} has invalid web-extension "
+                f"name {name!r} (must match {_NAME_RE.pattern!r}); "
+                f"skipped",
+                WebExtensionWarning,
+                stacklevel=3,
+            )
+            return None
+        display_name = extension.display_name
+        if not isinstance(display_name, str) or not display_name:
+            warnings.warn(
+                f"web extension {name!r} has empty display_name; skipped",
+                WebExtensionWarning,
+                stacklevel=3,
+            )
+            return None
+        routes_value = extension.routes()
+        if not isinstance(routes_value, tuple):
+            raise TypeError(
+                f"routes() must return tuple, got {type(routes_value).__name__}"
+            )
+        for r in routes_value:
+            if not isinstance(r, RouteContribution):
+                raise TypeError(
+                    f"routes() returned {type(r).__name__}, expected RouteContribution"
+                )
+        view_value = extension.view()
+        if view_value is not None and not isinstance(view_value, ViewContribution):
+            raise TypeError(
+                f"view() returned {type(view_value).__name__}, "
+                f"expected ViewContribution or None"
+            )
+    except Exception as exc:  # noqa: BLE001 — per-plugin fault isolation
+        warnings.warn(
+            f"failed to load web extension {ep_name!r}: {exc!r}",
+            WebExtensionWarning,
+            stacklevel=3,
+        )
+        return None
+
+    return WebExtensionEntry(
+        name=name,
+        display_name=display_name,
+        routes=routes_value,
+        view=view_value,
+        source_distribution=_resolve_source(ep),
+    )
+
+
+def _resolve_source(ep: Any) -> str | None:
+    """Best-effort extraction of the source pip distribution name.
+
+    Returns ``None`` for in-process registrations whose ``ep.dist`` is
+    absent, and also for adversarial ``dist`` objects exposing a
+    non-``str`` ``name`` (matches the defensive posture in
+    :func:`mureo.core.providers.registry._resolve_source`).
+    """
+    dist = getattr(ep, "dist", None)
+    if dist is None:
+        return None
+    name = getattr(dist, "name", None)
+    return name if isinstance(name, str) else None
+
+
+__all__ = [
+    "RouteContribution",
+    "StaticAsset",
+    "ViewContribution",
+    "WEB_EXTENSIONS_ENTRY_POINT_GROUP",
+    "WebExtension",
+    "WebExtensionEntry",
+    "WebExtensionWarning",
+    "discover_web_extensions",
+    "reset_web_extensions",
+]

--- a/mureo/web/extensions.py
+++ b/mureo/web/extensions.py
@@ -71,8 +71,10 @@ WEB_EXTENSIONS_ENTRY_POINT_GROUP: Final[str] = "mureo.web_extensions"
 #: ``WebExtension.name`` and ``WebExtensionEntry.name`` — kebab-case,
 #: 1–33 chars, must start with a lowercase letter. Used as the
 #: URL-path segment (``/api/ext/<name>/...``) and as the dict key for
-#: duplicate-name detection.
-_NAME_RE: Final[re.Pattern[str]] = re.compile(r"^[a-z][a-z0-9-]{0,32}$")
+#: duplicate-name detection. Exposed as a bare string so the dispatch
+#: layer in :mod:`mureo.web.handlers` can build its URL-matching
+#: regex from the same source of truth.
+NAME_PATTERN: Final[str] = r"[a-z][a-z0-9-]{0,32}"
 
 #: ``StaticAsset.filename`` — lowercase, alphanumeric + ``._-``, no
 #: directory separator, must start with a letter, must contain at
@@ -80,14 +82,17 @@ _NAME_RE: Final[re.Pattern[str]] = re.compile(r"^[a-z][a-z0-9-]{0,32}$")
 #: ``vendor.bundle.js``, ``i18n.en-us.json``) — modern JS toolchain
 #: outputs use them routinely. Leading dot, ``..``, ``/``, ``\``,
 #: whitespace, and uppercase remain rejected.
-_FILENAME_RE: Final[re.Pattern[str]] = re.compile(
-    r"^[a-z][a-z0-9_-]*(\.[a-z0-9_-]+)*\.[a-z0-9]+$"
-)
+FILENAME_PATTERN: Final[str] = r"[a-z][a-z0-9_-]*(?:\.[a-z0-9_-]+)*\.[a-z0-9]+"
 
 #: ``RouteContribution.subpath`` — leading slash, then one or more
 #: segments of ``[A-Za-z0-9_-]``, separated by single slashes. No
-#: query string, no fragment, no traversal, no double-slash.
-_SUBPATH_RE: Final[re.Pattern[str]] = re.compile(r"^(/[A-Za-z0-9_-]+)+$")
+#: query string, no fragment, no traversal, no double-slash, no
+#: trailing slash.
+SUBPATH_PATTERN: Final[str] = r"(?:/[A-Za-z0-9_-]+)+"
+
+_NAME_RE: Final[re.Pattern[str]] = re.compile(rf"^{NAME_PATTERN}$")
+_FILENAME_RE: Final[re.Pattern[str]] = re.compile(rf"^{FILENAME_PATTERN}$")
+_SUBPATH_RE: Final[re.Pattern[str]] = re.compile(rf"^{SUBPATH_PATTERN}$")
 
 #: Inline-executable patterns banned in ``html_fragment``. The
 #: configure-UI CSP forbids ``unsafe-inline`` so these would not
@@ -402,7 +407,10 @@ def _resolve_source(ep: Any) -> str | None:
 
 
 __all__ = [
+    "FILENAME_PATTERN",
+    "NAME_PATTERN",
     "RouteContribution",
+    "SUBPATH_PATTERN",
     "StaticAsset",
     "ViewContribution",
     "WEB_EXTENSIONS_ENTRY_POINT_GROUP",

--- a/mureo/web/handlers.py
+++ b/mureo/web/handlers.py
@@ -118,6 +118,7 @@ _STATIC_ALLOWLIST: tuple[str, ...] = (
     "wizard.js",
     "auth_wizards.js",
     "dashboard.js",
+    "extensions.js",
     "i18n.json",
     "logo.png",
     "logo-dark.png",

--- a/mureo/web/handlers.py
+++ b/mureo/web/handlers.py
@@ -29,12 +29,17 @@ Routes
 ``POST /api/byod/import``        → import a Sheet bundle XLSX
 ``POST /api/byod/remove``        → drop one platform's BYOD data
 ``POST /api/byod/clear``         → wipe all BYOD data
+``GET  /api/extensions``         → list registered web extensions
+``GET  /api/ext/<n>/<sub>``      → dispatch to extension GET handler
+``POST /api/ext/<n>/<sub>``      → dispatch to extension POST handler
+``GET  /static/ext/<n>/<file>``  → serve extension-shipped static asset
 """
 
 from __future__ import annotations
 
 import logging
 import re
+import urllib.parse
 from http.server import BaseHTTPRequestHandler
 from typing import TYPE_CHECKING, Any
 
@@ -59,6 +64,11 @@ from mureo.web.env_var_writer import (
     remove_credential_section,
     write_credential_env_var,
 )
+from mureo.web.extensions import (
+    FILENAME_PATTERN,
+    NAME_PATTERN,
+    SUBPATH_PATTERN,
+)
 from mureo.web.legacy_commands import remove_legacy_commands
 from mureo.web.native_picker import pick_directory, pick_file
 from mureo.web.session import OAUTH_PROVIDERS, SUPPORTED_HOSTS
@@ -79,6 +89,11 @@ from mureo.web.status_collector import collect_status
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from mureo.web.extensions import (
+        RouteContribution,
+        StaticAsset,
+        WebExtensionEntry,
+    )
     from mureo.web.server import ConfigureWizard
 
 logger = logging.getLogger(__name__)
@@ -112,6 +127,64 @@ _STATIC_ALLOWLIST: tuple[str, ...] = (
 _OAUTH_PROVIDER_RE = re.compile(
     r"^/api/oauth/(?P<provider>[a-z_]+)/(?P<verb>status|start)$"
 )
+
+# Third-party web-extension dispatch (see ``mureo.web.extensions``).
+# Path components reuse the bare patterns exported by
+# ``mureo.web.extensions`` so the registration-side validation and the
+# dispatch-side URL match share a single source of truth — a future
+# tweak to ``NAME_PATTERN`` etc. flows through both layers in lockstep.
+_EXTENSION_API_RE = re.compile(
+    rf"^/api/ext/(?P<name>{NAME_PATTERN})(?P<subpath>{SUBPATH_PATTERN})$"
+)
+_EXTENSION_STATIC_RE = re.compile(
+    rf"^/static/ext/(?P<name>{NAME_PATTERN})/(?P<filename>{FILENAME_PATTERN})$"
+)
+
+
+def _find_extension(
+    extensions: tuple[WebExtensionEntry, ...], name: str
+) -> WebExtensionEntry | None:
+    """Linear scan; the registered set is small (single digits typical)."""
+    for entry in extensions:
+        if entry.name == name:
+            return entry
+    return None
+
+
+def _find_extension_route(
+    entry: WebExtensionEntry, method: str, subpath: str
+) -> RouteContribution | None:
+    for route in entry.routes:
+        if route.method == method and route.subpath == subpath:
+            return route
+    return None
+
+
+def _find_extension_static(
+    entry: WebExtensionEntry, filename: str
+) -> StaticAsset | None:
+    if entry.view is None:
+        return None
+    for asset in entry.view.scripts:
+        if asset.filename == filename:
+            return asset
+    for asset in entry.view.styles:
+        if asset.filename == filename:
+            return asset
+    return None
+
+
+def _flatten_query(path: str) -> dict[str, str]:
+    """Parse a URL's query string into ``{key: first_value}``.
+
+    Multi-value handlers can still reach the raw query via
+    ``request.path`` — this helper is the lightweight default the
+    extension API contract documents.
+    """
+    if "?" not in path:
+        return {}
+    parsed = urllib.parse.parse_qs(path.split("?", 1)[1], keep_blank_values=True)
+    return {k: v[0] for k, v in parsed.items() if v}
 
 
 def _resolve_static_body(wizard: ConfigureWizard, filename: str) -> bytes | None:
@@ -171,6 +244,16 @@ class ConfigureHandler(BaseHTTPRequestHandler):
         if path == "/" or path == "/index.html":
             self._serve_app_html()
             return
+        # Extension static assets are matched BEFORE the generic
+        # ``/static/`` branch so the same prefix can route into both
+        # the built-in allowlist and the extension-owned asset set.
+        ext_static_match = _EXTENSION_STATIC_RE.match(path)
+        if ext_static_match is not None:
+            self._serve_extension_static(
+                ext_static_match.group("name"),
+                ext_static_match.group("filename"),
+            )
+            return
         if path.startswith("/static/"):
             self._serve_static(path[len("/static/") :])
             return
@@ -179,6 +262,9 @@ class ConfigureHandler(BaseHTTPRequestHandler):
             return
         if path == "/api/csrf":
             self._serve_csrf()
+            return
+        if path == "/api/extensions":
+            self._serve_extensions_index()
             return
         if path == "/api/demo/scenarios":
             send_json(self, list_demo_scenarios().as_dict())
@@ -189,6 +275,13 @@ class ConfigureHandler(BaseHTTPRequestHandler):
         match = _OAUTH_PROVIDER_RE.match(path)
         if match is not None and match.group("verb") == "status":
             self._serve_oauth_status(match.group("provider"))
+            return
+        ext_api_match = _EXTENSION_API_RE.match(path)
+        if ext_api_match is not None:
+            self._dispatch_extension_get(
+                ext_api_match.group("name"),
+                ext_api_match.group("subpath"),
+            )
             return
         send_error_json(self, 404, "not_found")
 
@@ -208,13 +301,22 @@ class ConfigureHandler(BaseHTTPRequestHandler):
             send_error_json(self, 403, "csrf_invalid")
             return
 
-        route = self._POST_ROUTES.get(self.path.split("?", 1)[0])
+        path = self.path.split("?", 1)[0]
+        route = self._POST_ROUTES.get(path)
         if route is not None:
             route(self, payload)
             return
-        match = _OAUTH_PROVIDER_RE.match(self.path.split("?", 1)[0])
+        match = _OAUTH_PROVIDER_RE.match(path)
         if match is not None and match.group("verb") == "start":
             self._post_oauth_start(match.group("provider"), payload)
+            return
+        ext_api_match = _EXTENSION_API_RE.match(path)
+        if ext_api_match is not None:
+            self._dispatch_extension_post(
+                ext_api_match.group("name"),
+                ext_api_match.group("subpath"),
+                payload,
+            )
             return
         send_error_json(self, 404, "not_found")
 
@@ -507,6 +609,105 @@ class ConfigureHandler(BaseHTTPRequestHandler):
             send_error_json(self, 400, "unknown_provider")
             return
         send_json(self, result.as_dict())
+
+    # ------------------------------------------------------------------
+    # Extension dispatch
+    # ------------------------------------------------------------------
+    def _serve_extensions_index(self) -> None:
+        """Return the renderer-facing index of registered extensions.
+
+        Each item carries enough information for ``app.js`` to render a
+        tab + lazy-load the view: ``name`` is also the URL segment used
+        when calling ``/api/ext/<name>/...`` and ``/static/ext/<name>/...``.
+        ``view`` is ``null`` for headless extensions (route-only).
+        """
+        payload: list[dict[str, Any]] = []
+        for entry in self.wizard.extensions:
+            item: dict[str, Any] = {
+                "name": entry.name,
+                "display_name": entry.display_name,
+            }
+            if entry.view is None:
+                item["view"] = None
+            else:
+                item["view"] = {
+                    "html_fragment": entry.view.html_fragment,
+                    "scripts": [a.filename for a in entry.view.scripts],
+                    "styles": [a.filename for a in entry.view.styles],
+                }
+            payload.append(item)
+        send_json(self, payload)
+
+    def _serve_extension_static(self, name: str, filename: str) -> None:
+        """Serve an extension-shipped static asset by name + filename."""
+        entry = _find_extension(self.wizard.extensions, name)
+        if entry is None:
+            send_error_json(self, 404, "not_found")
+            return
+        asset = _find_extension_static(entry, filename)
+        if asset is None:
+            send_error_json(self, 404, "not_found")
+            return
+        send_bytes(self, asset.body, content_type=asset.content_type)
+
+    def _dispatch_extension_get(self, name: str, subpath: str) -> None:
+        self._dispatch_extension(name, "GET", subpath, payload=None)
+
+    def _dispatch_extension_post(
+        self, name: str, subpath: str, payload: dict[str, Any]
+    ) -> None:
+        self._dispatch_extension(name, "POST", subpath, payload=payload)
+
+    def _dispatch_extension(
+        self,
+        name: str,
+        method: str,
+        subpath: str,
+        *,
+        payload: dict[str, Any] | None,
+    ) -> None:
+        """Common dispatch path for GET + POST extension routes.
+
+        Handler exceptions are caught here so one faulty extension
+        cannot tear down the configure server. The error is logged
+        with the extension/subpath context and a generic 500 envelope
+        is returned to the client — we deliberately do not echo the
+        exception ``repr`` because it may carry secrets (path
+        fragments, token prefixes, etc.) the extension touched.
+
+        A handler that has already begun writing a response before
+        raising puts the 500 envelope in an impossible position (the
+        wire would carry two status lines). We attempt the envelope
+        once and swallow any follow-up failure, downgrading the report
+        to a debug log. The contract documented in
+        :mod:`mureo.web.extensions` is "handler must not raise after
+        starting to write the response" — this branch is the
+        defensive backstop, not a free pass.
+        """
+        entry = _find_extension(self.wizard.extensions, name)
+        if entry is None:
+            send_error_json(self, 404, "not_found")
+            return
+        route = _find_extension_route(entry, method, subpath)
+        if route is None:
+            send_error_json(self, 404, "not_found")
+            return
+        if method == "GET":
+            handler_payload = _flatten_query(self.path)
+        else:
+            handler_payload = payload or {}
+        try:
+            route.handler(self, handler_payload)
+        except Exception:  # noqa: BLE001 — per-extension fault isolation
+            logger.exception("web extension %r raised in %s %s", name, method, subpath)
+            try:
+                send_error_json(self, 500, "extension_handler_error")
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "web extension %r already wrote a partial response; "
+                    "the 500 envelope could not be appended",
+                    name,
+                )
 
     # ------------------------------------------------------------------
     # Route table

--- a/mureo/web/server.py
+++ b/mureo/web/server.py
@@ -18,6 +18,7 @@ import webbrowser
 from importlib import resources
 from pathlib import Path
 
+from mureo.web.extensions import discover_web_extensions
 from mureo.web.handlers import ConfigureHandler
 from mureo.web.host_paths import HostPaths, get_host_paths
 from mureo.web.oauth_bridge import OAuthBridge
@@ -73,6 +74,11 @@ class ConfigureWizard:
         self._commands_path_override = commands_path
         self._apply_commands_override()
         self.oauth_bridge = OAuthBridge()
+        # Discover third-party extensions once at wizard construction.
+        # ``discover_web_extensions`` caches internally, so this call
+        # plus every subsequent call within the same process re-uses
+        # the same tuple — see :mod:`mureo.web.extensions`.
+        self.extensions = discover_web_extensions()
 
         self._server: _ConfigureServer | None = None
         self._ready = threading.Event()

--- a/tests/test_web_extension_routing.py
+++ b/tests/test_web_extension_routing.py
@@ -1,0 +1,443 @@
+"""End-to-end routing tests for the web-extension layer.
+
+Boots a real :class:`ConfigureWizard` on 127.0.0.1:0 with a controlled
+set of extensions pre-seeded into ``mureo.web.extensions._cached_entries``
+and exercises every dispatch branch added by this commit:
+
+* ``GET /api/extensions`` — index for the configure-UI client
+* ``GET /api/ext/<name>/<subpath>`` — extension GET route
+* ``POST /api/ext/<name>/<subpath>`` — extension POST route (CSRF gated)
+* ``GET /static/ext/<name>/<filename>`` — extension-shipped asset
+* 404 / 403 / 500 paths for unknown / unauthorised / faulty routes
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from mureo.web.extensions import (
+    RouteContribution,
+    StaticAsset,
+    ViewContribution,
+    WebExtensionEntry,
+    reset_web_extensions,
+)
+from mureo.web.server import ConfigureWizard
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from http.client import HTTPResponse
+    from http.server import BaseHTTPRequestHandler
+    from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Reference extension used across the suite
+# ---------------------------------------------------------------------------
+
+
+_recorded_calls: list[tuple[str, dict[str, Any]]] = []
+
+
+def _record_ping(
+    _req: BaseHTTPRequestHandler, payload: dict[str, Any]
+) -> None:
+    from mureo.web._helpers import send_json
+
+    _recorded_calls.append(("ping", dict(payload)))
+    send_json(_req, {"echo": payload})
+
+
+def _record_save(
+    _req: BaseHTTPRequestHandler, payload: dict[str, Any]
+) -> None:
+    from mureo.web._helpers import send_json
+
+    _recorded_calls.append(("save", dict(payload)))
+    send_json(_req, {"saved": True, "received": payload})
+
+
+def _record_explode(
+    _req: BaseHTTPRequestHandler, _payload: dict[str, Any]
+) -> None:
+    raise RuntimeError("handler exploded")
+
+
+def _make_entry() -> WebExtensionEntry:
+    return WebExtensionEntry(
+        name="demo",
+        display_name="Demo extension",
+        routes=(
+            RouteContribution(method="GET", subpath="/ping", handler=_record_ping),
+            RouteContribution(method="POST", subpath="/save", handler=_record_save),
+            RouteContribution(
+                method="GET", subpath="/explode", handler=_record_explode
+            ),
+        ),
+        view=ViewContribution(
+            html_fragment='<section><h2 data-demo>Demo</h2></section>',
+            scripts=(
+                StaticAsset(
+                    filename="demo.js",
+                    content_type="application/javascript",
+                    body=b"console.log('demo');",
+                ),
+            ),
+            styles=(
+                StaticAsset(
+                    filename="demo.css",
+                    content_type="text/css",
+                    body=b".demo{color:red}",
+                ),
+            ),
+        ),
+        source_distribution="mureo-demo",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_extensions_state() -> Iterator[None]:
+    """Clean extension cache + call recorder for every test."""
+    reset_web_extensions()
+    _recorded_calls.clear()
+    yield
+    reset_web_extensions()
+    _recorded_calls.clear()
+
+
+@pytest.fixture
+def wizard_with_extensions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Iterator[ConfigureWizard]:
+    """Pre-seed one extension, boot a wizard, yield it."""
+    entry = _make_entry()
+    monkeypatch.setattr("mureo.web.extensions._cached_entries", (entry,))
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".claude").mkdir()
+    (home / ".claude" / "commands").mkdir()
+    (home / ".mureo").mkdir()
+    wiz = ConfigureWizard(home=home)
+    thread = threading.Thread(target=wiz.serve, daemon=True)
+    thread.start()
+    wiz.wait_until_ready(timeout=5.0)
+    try:
+        yield wiz
+    finally:
+        wiz.shutdown()
+        thread.join(timeout=2.0)
+
+
+@pytest.fixture
+def wizard_no_extensions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Iterator[ConfigureWizard]:
+    """Boot a wizard with zero extensions registered."""
+    monkeypatch.setattr("mureo.web.extensions._cached_entries", ())
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".claude").mkdir()
+    (home / ".claude" / "commands").mkdir()
+    (home / ".mureo").mkdir()
+    wiz = ConfigureWizard(home=home)
+    thread = threading.Thread(target=wiz.serve, daemon=True)
+    thread.start()
+    wiz.wait_until_ready(timeout=5.0)
+    try:
+        yield wiz
+    finally:
+        wiz.shutdown()
+        thread.join(timeout=2.0)
+
+
+def _url(wiz: ConfigureWizard, path: str) -> str:
+    return f"http://127.0.0.1:{wiz.port}{path}"
+
+
+def _get(wiz: ConfigureWizard, path: str) -> HTTPResponse:
+    return urllib.request.urlopen(_url(wiz, path), timeout=2.0)
+
+
+def _post(
+    wiz: ConfigureWizard,
+    path: str,
+    payload: dict[str, Any] | None,
+    *,
+    csrf: str | None = "use_session",
+) -> HTTPResponse:
+    body = json.dumps(payload or {}).encode()
+    headers: dict[str, str] = {"Content-Type": "application/json"}
+    if csrf == "use_session":
+        headers["X-CSRF-Token"] = wiz.session.csrf_token
+    elif csrf is not None:
+        headers["X-CSRF-Token"] = csrf
+    req = urllib.request.Request(_url(wiz, path), data=body, method="POST")
+    for k, v in headers.items():
+        req.add_header(k, v)
+    return urllib.request.urlopen(req, timeout=2.0)
+
+
+# ---------------------------------------------------------------------------
+# /api/extensions index
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_extensions_index_empty(wizard_no_extensions: ConfigureWizard) -> None:
+    resp = _get(wizard_no_extensions, "/api/extensions")
+    assert resp.status == 200
+    payload = json.loads(resp.read().decode())
+    assert payload == []
+
+
+@pytest.mark.unit
+def test_extensions_index_lists_registered(
+    wizard_with_extensions: ConfigureWizard,
+) -> None:
+    resp = _get(wizard_with_extensions, "/api/extensions")
+    payload = json.loads(resp.read().decode())
+    assert isinstance(payload, list)
+    assert len(payload) == 1
+    item = payload[0]
+    assert item["name"] == "demo"
+    assert item["display_name"] == "Demo extension"
+    assert item["view"]["html_fragment"].startswith("<section")
+    assert item["view"]["scripts"] == ["demo.js"]
+    assert item["view"]["styles"] == ["demo.css"]
+
+
+@pytest.mark.unit
+def test_extensions_index_view_null_when_extension_has_no_view(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    no_view = WebExtensionEntry(
+        name="nogui",
+        display_name="No GUI",
+        routes=(),
+        view=None,
+        source_distribution=None,
+    )
+    monkeypatch.setattr("mureo.web.extensions._cached_entries", (no_view,))
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".claude").mkdir()
+    (home / ".claude" / "commands").mkdir()
+    (home / ".mureo").mkdir()
+    wiz = ConfigureWizard(home=home)
+    t = threading.Thread(target=wiz.serve, daemon=True)
+    t.start()
+    wiz.wait_until_ready(timeout=5.0)
+    try:
+        resp = _get(wiz, "/api/extensions")
+        payload = json.loads(resp.read().decode())
+        assert payload == [{"name": "nogui", "display_name": "No GUI", "view": None}]
+    finally:
+        wiz.shutdown()
+        t.join(timeout=2.0)
+
+
+# ---------------------------------------------------------------------------
+# GET /api/ext/<name>/<subpath>
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_get_extension_route_dispatches_to_handler(
+    wizard_with_extensions: ConfigureWizard,
+) -> None:
+    resp = _get(wizard_with_extensions, "/api/ext/demo/ping?q=hello&n=42")
+    assert resp.status == 200
+    body = json.loads(resp.read().decode())
+    assert body == {"echo": {"q": "hello", "n": "42"}}
+    assert _recorded_calls == [("ping", {"q": "hello", "n": "42"})]
+
+
+@pytest.mark.unit
+def test_get_extension_route_first_value_wins_for_repeated_keys(
+    wizard_with_extensions: ConfigureWizard,
+) -> None:
+    """``urllib.parse.parse_qs`` lists values; the dispatcher flattens
+    each list to its first element. Handlers that need full multi-value
+    semantics can still read ``self.path`` directly."""
+    _get(wizard_with_extensions, "/api/ext/demo/ping?q=one&q=two&q=three")
+    assert _recorded_calls == [("ping", {"q": "one"})]
+
+
+@pytest.mark.unit
+def test_get_unknown_extension_returns_404(
+    wizard_with_extensions: ConfigureWizard,
+) -> None:
+    with pytest.raises(urllib.error.HTTPError) as exc:
+        _get(wizard_with_extensions, "/api/ext/missing/ping")
+    assert exc.value.code == 404
+
+
+@pytest.mark.unit
+def test_get_unknown_subpath_returns_404(
+    wizard_with_extensions: ConfigureWizard,
+) -> None:
+    with pytest.raises(urllib.error.HTTPError) as exc:
+        _get(wizard_with_extensions, "/api/ext/demo/nope")
+    assert exc.value.code == 404
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/ext/demo/../etc/passwd",
+        "/api/ext/demo/ping/../save",
+        "/api/ext/demo//ping",
+        "/api/ext/DEMO/ping",
+        "/api/ext/demo",
+    ],
+)
+def test_get_traversal_or_malformed_paths_return_404(
+    wizard_with_extensions: ConfigureWizard, path: str
+) -> None:
+    with pytest.raises(urllib.error.HTTPError) as exc:
+        _get(wizard_with_extensions, path)
+    assert exc.value.code == 404
+
+
+@pytest.mark.unit
+def test_get_extension_handler_exception_returns_500(
+    wizard_with_extensions: ConfigureWizard,
+) -> None:
+    with pytest.raises(urllib.error.HTTPError) as exc:
+        _get(wizard_with_extensions, "/api/ext/demo/explode")
+    assert exc.value.code == 500
+    body = json.loads(exc.value.read().decode())
+    assert "error" in body
+
+
+# ---------------------------------------------------------------------------
+# POST /api/ext/<name>/<subpath>
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_post_extension_route_dispatches_with_csrf(
+    wizard_with_extensions: ConfigureWizard,
+) -> None:
+    resp = _post(
+        wizard_with_extensions, "/api/ext/demo/save", {"key": "value"}
+    )
+    assert resp.status == 200
+    body = json.loads(resp.read().decode())
+    assert body == {"saved": True, "received": {"key": "value"}}
+
+
+@pytest.mark.unit
+def test_post_extension_route_rejects_missing_csrf(
+    wizard_with_extensions: ConfigureWizard,
+) -> None:
+    with pytest.raises(urllib.error.HTTPError) as exc:
+        _post(
+            wizard_with_extensions, "/api/ext/demo/save", {"key": "v"}, csrf=None
+        )
+    assert exc.value.code == 403
+
+
+@pytest.mark.unit
+def test_post_extension_route_rejects_bad_csrf(
+    wizard_with_extensions: ConfigureWizard,
+) -> None:
+    with pytest.raises(urllib.error.HTTPError) as exc:
+        _post(
+            wizard_with_extensions,
+            "/api/ext/demo/save",
+            {"key": "v"},
+            csrf="wrong-token",
+        )
+    assert exc.value.code == 403
+
+
+@pytest.mark.unit
+def test_post_unknown_extension_returns_404(
+    wizard_with_extensions: ConfigureWizard,
+) -> None:
+    with pytest.raises(urllib.error.HTTPError) as exc:
+        _post(wizard_with_extensions, "/api/ext/missing/save", {})
+    assert exc.value.code == 404
+
+
+@pytest.mark.unit
+def test_post_get_only_subpath_returns_404(
+    wizard_with_extensions: ConfigureWizard,
+) -> None:
+    """``/api/ext/demo/ping`` is a GET-only route; POSTing must 404."""
+    with pytest.raises(urllib.error.HTTPError) as exc:
+        _post(wizard_with_extensions, "/api/ext/demo/ping", {})
+    assert exc.value.code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET /static/ext/<name>/<filename>
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_static_asset_served_with_correct_content_type(
+    wizard_with_extensions: ConfigureWizard,
+) -> None:
+    resp = _get(wizard_with_extensions, "/static/ext/demo/demo.js")
+    assert resp.status == 200
+    assert resp.headers["Content-Type"].startswith("application/javascript")
+    assert resp.read() == b"console.log('demo');"
+
+
+@pytest.mark.unit
+def test_static_asset_unknown_filename_returns_404(
+    wizard_with_extensions: ConfigureWizard,
+) -> None:
+    with pytest.raises(urllib.error.HTTPError) as exc:
+        _get(wizard_with_extensions, "/static/ext/demo/missing.js")
+    assert exc.value.code == 404
+
+
+@pytest.mark.unit
+def test_static_asset_unknown_extension_returns_404(
+    wizard_with_extensions: ConfigureWizard,
+) -> None:
+    with pytest.raises(urllib.error.HTTPError) as exc:
+        _get(wizard_with_extensions, "/static/ext/missing/demo.js")
+    assert exc.value.code == 404
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/static/ext/demo/../app.html",
+        "/static/ext/demo/sub/dir.js",
+        "/static/ext/demo/.hidden",
+        "/static/ext/DEMO/demo.js",
+    ],
+)
+def test_static_asset_traversal_paths_return_404(
+    wizard_with_extensions: ConfigureWizard, path: str
+) -> None:
+    with pytest.raises(urllib.error.HTTPError) as exc:
+        _get(wizard_with_extensions, path)
+    assert exc.value.code == 404
+
+
+@pytest.mark.unit
+def test_static_asset_response_carries_security_headers(
+    wizard_with_extensions: ConfigureWizard,
+) -> None:
+    """Extension-served assets inherit the same CSP / X-Frame-Options /
+    Cache-Control set the built-in static path applies — they share the
+    ``send_bytes`` helper."""
+    resp = _get(wizard_with_extensions, "/static/ext/demo/demo.css")
+    assert resp.headers["X-Content-Type-Options"] == "nosniff"
+    assert resp.headers["X-Frame-Options"] == "DENY"
+    assert "default-src 'none'" in (resp.headers["Content-Security-Policy"] or "")

--- a/tests/test_web_extensions.py
+++ b/tests/test_web_extensions.py
@@ -1,0 +1,479 @@
+"""Tests for ``mureo.web.extensions`` — types and entry-point discovery.
+
+The web-extension layer is structurally analogous to
+``mureo.core.providers.registry``: a third-party distribution
+registers an entry point in the ``mureo.web_extensions`` group whose
+target satisfies the ``WebExtension`` Protocol; discovery iterates the
+group exactly once at startup, isolates faults per entry, and exposes
+the survivors as frozen ``WebExtensionEntry`` records.
+
+Coverage:
+  - Protocol / dataclass shape (frozen, runtime_checkable, validation)
+  - Identifier regexes (``name``, ``filename``, ``subpath``)
+  - Static-HTML sanitisation (no inline script/style, no on-* attrs)
+  - Entry-point discovery: 0/1/N entry points, broken load,
+    routes()/view() raising, duplicate-name first-wins + warning,
+    discovery caching + refresh
+"""
+
+from __future__ import annotations
+
+import warnings
+from collections.abc import Iterator
+from dataclasses import FrozenInstanceError
+from typing import Any
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Type-shape tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_web_extension_protocol_is_runtime_checkable() -> None:
+    from mureo.web.extensions import (
+        RouteContribution,
+        ViewContribution,
+        WebExtension,
+    )
+
+    class _Fake:
+        name = "demo"
+        display_name = "Demo"
+
+        def routes(self) -> tuple[RouteContribution, ...]:
+            return ()
+
+        def view(self) -> ViewContribution | None:
+            return None
+
+    assert isinstance(_Fake(), WebExtension)
+
+
+@pytest.mark.unit
+def test_web_extension_protocol_rejects_incomplete_impl() -> None:
+    from mureo.web.extensions import WebExtension
+
+    class _Incomplete:
+        name = "demo"
+        display_name = "Demo"
+        # missing routes() and view()
+
+    assert not isinstance(_Incomplete(), WebExtension)
+
+
+@pytest.mark.unit
+def test_route_contribution_is_frozen() -> None:
+    from mureo.web.extensions import RouteContribution
+
+    def _handler(_req: Any, _payload: dict[str, Any]) -> None:
+        return None
+
+    r = RouteContribution(method="GET", subpath="/ping", handler=_handler)
+    with pytest.raises(FrozenInstanceError):
+        r.method = "POST"  # type: ignore[misc]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("method", ["DELETE", "PUT", "PATCH", "get", "post", ""])
+def test_route_contribution_rejects_non_get_post(method: str) -> None:
+    from mureo.web.extensions import RouteContribution
+
+    def _h(_req: Any, _payload: dict[str, Any]) -> None:
+        return None
+
+    with pytest.raises(ValueError, match="method"):
+        RouteContribution(method=method, subpath="/x", handler=_h)  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "subpath",
+    [
+        "ping",
+        "//ping",
+        "/ping/../etc",
+        "/ping//x",
+        "",
+        "/ping?q=1",
+        "/ping#x",
+        "/ping/",  # trailing slash — force canonical form
+        "/",
+    ],
+)
+def test_route_contribution_rejects_unsafe_subpath(subpath: str) -> None:
+    from mureo.web.extensions import RouteContribution
+
+    def _h(_req: Any, _payload: dict[str, Any]) -> None:
+        return None
+
+    with pytest.raises(ValueError, match="subpath"):
+        RouteContribution(method="GET", subpath=subpath, handler=_h)
+
+
+@pytest.mark.unit
+def test_route_contribution_accepts_well_formed_subpath() -> None:
+    from mureo.web.extensions import RouteContribution
+
+    def _h(_req: Any, _payload: dict[str, Any]) -> None:
+        return None
+
+    for sp in ("/ping", "/health/check", "/v1/things/42"):
+        r = RouteContribution(method="GET", subpath=sp, handler=_h)
+        assert r.subpath == sp
+
+
+@pytest.mark.unit
+def test_static_asset_is_frozen() -> None:
+    from mureo.web.extensions import StaticAsset
+
+    a = StaticAsset(filename="app.js", content_type="application/javascript", body=b"")
+    with pytest.raises(FrozenInstanceError):
+        a.filename = "evil.js"  # type: ignore[misc]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "../evil.js",
+        "..\\evil.js",
+        "sub/dir.js",
+        "",
+        ".hidden",
+        "UPPER.js",
+        "name with space.js",
+    ],
+)
+def test_static_asset_rejects_unsafe_filename(filename: str) -> None:
+    from mureo.web.extensions import StaticAsset
+
+    with pytest.raises(ValueError, match="filename"):
+        StaticAsset(filename=filename, content_type="application/javascript", body=b"")
+
+
+@pytest.mark.unit
+def test_static_asset_accepts_well_formed_filename() -> None:
+    from mureo.web.extensions import StaticAsset
+
+    for fn in (
+        "app.js",
+        "app.css",
+        "app-v2.js",
+        "logo.png",
+        "i18n.json",
+        "app.min.js",
+        "vendor.bundle.js",
+        "i18n.en-us.json",
+    ):
+        a = StaticAsset(filename=fn, content_type="text/plain", body=b"")
+        assert a.filename == fn
+
+
+@pytest.mark.unit
+def test_view_contribution_is_frozen() -> None:
+    from mureo.web.extensions import ViewContribution
+
+    v = ViewContribution(html_fragment="<p>hi</p>")
+    with pytest.raises(FrozenInstanceError):
+        v.html_fragment = "<p>evil</p>"  # type: ignore[misc]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "html",
+    [
+        "<script>alert(1)</script>",
+        "  <SCRIPT>x</SCRIPT>  ",
+        "<p onclick=evil()>x</p>",
+        "<p ONCLICK=evil()>x</p>",
+        '<a href="javascript:alert(1)">x</a>',
+        "<style>body{display:none}</style>",
+    ],
+)
+def test_view_contribution_rejects_inline_executable_content(html: str) -> None:
+    from mureo.web.extensions import ViewContribution
+
+    with pytest.raises(ValueError, match="html_fragment"):
+        ViewContribution(html_fragment=html)
+
+
+@pytest.mark.unit
+def test_view_contribution_accepts_safe_html() -> None:
+    from mureo.web.extensions import ViewContribution
+
+    v = ViewContribution(
+        html_fragment='<section><h2>Vault</h2><p class="muted">Connected.</p></section>'
+    )
+    assert "Vault" in v.html_fragment
+
+
+# ---------------------------------------------------------------------------
+# Discovery tests
+# ---------------------------------------------------------------------------
+
+
+class _FakeEP:
+    """Minimal stand-in for ``importlib.metadata.EntryPoint`` — only
+    ``.name``, ``.load()``, and ``.dist`` are read by the resolver."""
+
+    def __init__(self, name: str, target: Any, dist_name: str | None = None) -> None:
+        self.name = name
+        self._target = target
+        if dist_name is not None:
+            self.dist = type("D", (), {"name": dist_name})()
+        else:
+            self.dist = None
+
+    def load(self) -> Any:
+        return self._target
+
+
+def _patch_entry_points(
+    monkeypatch: pytest.MonkeyPatch, eps: list[_FakeEP]
+) -> None:
+    def fake_entry_points(*, group: str) -> list[_FakeEP]:
+        assert group == "mureo.web_extensions"
+        return eps
+
+    monkeypatch.setattr("mureo.web.extensions.entry_points", fake_entry_points)
+
+
+class _DemoExtension:
+    """Reference WebExtension implementation used by discovery tests."""
+
+    name = "demo"
+    display_name = "Demo"
+
+    def routes(self) -> tuple[Any, ...]:
+        from mureo.web.extensions import RouteContribution
+
+        def _h(_req: Any, _payload: dict[str, Any]) -> None:
+            return None
+
+        return (RouteContribution(method="GET", subpath="/ping", handler=_h),)
+
+    def view(self) -> Any:
+        from mureo.web.extensions import ViewContribution
+
+        return ViewContribution(html_fragment="<p>demo</p>")
+
+
+class _BrokenLoad:
+    """Sentinel — load() raises so the entry is skipped."""
+
+
+def _broken_loader() -> Any:
+    raise RuntimeError("plugin import blew up")
+
+
+class _BadRoutes:
+    name = "bad-routes"
+    display_name = "Bad routes"
+
+    def routes(self) -> tuple[Any, ...]:
+        raise RuntimeError("routes() exploded")
+
+    def view(self) -> Any:
+        return None
+
+
+class _BadView:
+    name = "bad-view"
+    display_name = "Bad view"
+
+    def routes(self) -> tuple[Any, ...]:
+        return ()
+
+    def view(self) -> Any:
+        raise RuntimeError("view() exploded")
+
+
+class _UpperName:
+    name = "UPPER"
+    display_name = "Upper"
+
+    def routes(self) -> tuple[Any, ...]:
+        return ()
+
+    def view(self) -> Any:
+        return None
+
+
+@pytest.mark.unit
+def test_discover_returns_empty_when_no_entry_points(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from mureo.web.extensions import discover_web_extensions
+
+    _patch_entry_points(monkeypatch, [])
+    assert discover_web_extensions() == ()
+
+
+@pytest.mark.unit
+def test_discover_registers_well_formed_extension(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from mureo.web.extensions import discover_web_extensions
+
+    _patch_entry_points(
+        monkeypatch, [_FakeEP("demo", _DemoExtension, dist_name="mureo-demo")]
+    )
+    entries = discover_web_extensions()
+    assert len(entries) == 1
+    e = entries[0]
+    assert e.name == "demo"
+    assert e.display_name == "Demo"
+    assert e.source_distribution == "mureo-demo"
+    assert len(e.routes) == 1
+    assert e.view is not None
+    assert e.routes[0].subpath == "/ping"
+
+
+@pytest.mark.unit
+def test_discover_skips_broken_load_and_keeps_others(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from mureo.web.extensions import WebExtensionWarning, discover_web_extensions
+
+    _patch_entry_points(
+        monkeypatch,
+        [
+            _FakeEP("broken", _broken_loader),
+            _FakeEP("demo", _DemoExtension),
+        ],
+    )
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        entries = discover_web_extensions()
+    assert [e.name for e in entries] == ["demo"]
+    assert any(issubclass(w.category, WebExtensionWarning) for w in caught)
+    assert any("broken" in str(w.message) for w in caught)
+
+
+@pytest.mark.unit
+def test_discover_isolates_routes_call_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from mureo.web.extensions import WebExtensionWarning, discover_web_extensions
+
+    _patch_entry_points(
+        monkeypatch,
+        [_FakeEP("bad-routes", _BadRoutes), _FakeEP("demo", _DemoExtension)],
+    )
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        entries = discover_web_extensions()
+    assert [e.name for e in entries] == ["demo"]
+    assert any(
+        issubclass(w.category, WebExtensionWarning) and "bad-routes" in str(w.message)
+        for w in caught
+    )
+
+
+@pytest.mark.unit
+def test_discover_isolates_view_call_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from mureo.web.extensions import WebExtensionWarning, discover_web_extensions
+
+    _patch_entry_points(
+        monkeypatch,
+        [_FakeEP("bad-view", _BadView), _FakeEP("demo", _DemoExtension)],
+    )
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        entries = discover_web_extensions()
+    assert [e.name for e in entries] == ["demo"]
+    assert any("bad-view" in str(w.message) for w in caught)
+
+
+@pytest.mark.unit
+def test_duplicate_names_first_wins_with_warning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from mureo.web.extensions import WebExtensionWarning, discover_web_extensions
+
+    class _Dup:
+        name = "demo"
+        display_name = "Duplicate"
+
+        def routes(self) -> tuple[Any, ...]:
+            return ()
+
+        def view(self) -> Any:
+            return None
+
+    _patch_entry_points(
+        monkeypatch, [_FakeEP("demo", _DemoExtension), _FakeEP("dup", _Dup)]
+    )
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        entries = discover_web_extensions()
+    # first-wins: original 'demo' stays
+    assert len(entries) == 1
+    assert entries[0].display_name == "Demo"
+    assert any(
+        issubclass(w.category, WebExtensionWarning) and "demo" in str(w.message)
+        for w in caught
+    )
+
+
+@pytest.mark.unit
+def test_discover_rejects_invalid_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    from mureo.web.extensions import WebExtensionWarning, discover_web_extensions
+
+    _patch_entry_points(monkeypatch, [_FakeEP("upper", _UpperName)])
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        entries = discover_web_extensions()
+    assert entries == ()
+    assert any(issubclass(w.category, WebExtensionWarning) for w in caught)
+
+
+@pytest.mark.unit
+def test_discover_does_not_consult_entry_points_twice(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Discovery is cached so each ``discover_web_extensions()`` call
+    after the first is a dict lookup, not an entry-points iteration."""
+    from mureo.web.extensions import discover_web_extensions, reset_web_extensions
+
+    reset_web_extensions()
+    calls: list[str] = []
+
+    def fake_entry_points(*, group: str) -> list[_FakeEP]:
+        calls.append(group)
+        return [_FakeEP("demo", _DemoExtension)]
+
+    monkeypatch.setattr("mureo.web.extensions.entry_points", fake_entry_points)
+    first = discover_web_extensions()
+    second = discover_web_extensions()
+    assert first is second  # exact tuple reuse
+    assert len(calls) == 1
+
+
+@pytest.mark.unit
+def test_reset_clears_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    from mureo.web.extensions import discover_web_extensions, reset_web_extensions
+
+    reset_web_extensions()
+    _patch_entry_points(monkeypatch, [_FakeEP("demo", _DemoExtension)])
+    first = discover_web_extensions()
+    reset_web_extensions()
+    _patch_entry_points(monkeypatch, [])
+    second = discover_web_extensions()
+    assert first != second
+    assert second == ()
+
+
+@pytest.fixture(autouse=True)
+def _reset_extensions_cache() -> Iterator[None]:
+    """Every test starts with a clean discovery cache."""
+    from mureo.web.extensions import reset_web_extensions
+
+    reset_web_extensions()
+    yield
+    reset_web_extensions()


### PR DESCRIPTION
## Summary

Adds a new entry-point group `mureo.web_extensions` that lets a third-party plugin register additional tabs / API routes inside the `mureo configure` wizard. The mechanism mirrors the existing `mureo.providers` / `mureo.runtime_context_factory` extension patterns (per-plugin fault isolation, first-wins on duplicates, `*Warning` subclass for strict-mode opt-in) and extends the same Phase 1 extensibility story into the web layer.

### Why

`mureo/web/handlers.py` was the last surface where third-party plugins could not contribute UI / API routes. The OSS provider layer, skill matcher, and `RuntimeContext` resolver are already entry-point–driven; this PR closes the gap so plugins shipping alternate `SecretStore` / `StateStore` backends — or any custom data source — can add their own setup UI inside the same `mureo configure` wizard the operator already uses.

### Public surface added to `mureo.web.extensions`

```python
from mureo.web.extensions import (
    WebExtension,                       # @runtime_checkable Protocol
    WebExtensionEntry,                  # frozen dataclass (discovery result)
    RouteContribution, ViewContribution, StaticAsset,
    WebExtensionWarning,                # subclass of UserWarning
    WEB_EXTENSIONS_ENTRY_POINT_GROUP,   # "mureo.web_extensions"
    NAME_PATTERN, FILENAME_PATTERN, SUBPATH_PATTERN,  # shared regex strings
    discover_web_extensions,            # cached entry-point scan
    reset_web_extensions,               # test helper
)
```

### HTTP surface (`mureo/web/handlers.py`)

| URL | Behaviour |
|---|---|
| `GET /api/extensions` | Index for the front-end renderer (one entry per registered extension; `view` is `null` for headless / route-only plugins). |
| `GET /api/ext/<name>/<subpath>` | Extension GET route; payload is the flattened query string (first-value-wins). |
| `POST /api/ext/<name>/<subpath>` | Extension POST route, gated by the existing Host + body-cap + CSRF pipeline (the plugin author inherits CSRF protection for free). |
| `GET /static/ext/<name>/<filename>` | Extension-shipped static asset served from in-memory bytes with the same Content-Security-Policy + X-Frame-Options + Cache-Control header stack. |

### Front-end (`mureo/_data/web/extensions.js`)

The configure UI fetches `/api/extensions` once when the dashboard opens, renders one nav tab per extension, and lazy-loads each extension's `html_fragment` / `<script>` / `<link rel="stylesheet">` on the first tab activation. Operators who never visit a given tab pay zero added page weight; subsequent visits short-circuit via a `_populated: Set` dedup.

### Security posture

- `RouteContribution.subpath`, `StaticAsset.filename`, and the extension `name` are regex-validated at both registration (`_NAME_RE` / `_FILENAME_RE` / `_SUBPATH_RE`) and dispatch (`_EXTENSION_API_RE` / `_EXTENSION_STATIC_RE`). The two layers share `NAME_PATTERN` / `SUBPATH_PATTERN` / `FILENAME_PATTERN` constants so they cannot drift.
- `..`, double-slash, trailing slash, `?`, `#`, directory separators, leading dots, and uppercase are all refused so a crafted URL falls through to the generic `not_found` branch instead of reaching the extension lookup.
- Static asset bodies stay in memory; the dispatcher never reads from disk so filesystem traversal is impossible by construction.
- `ViewContribution.html_fragment` is rejected at registration if it contains `<script>`, `<style>`, `on*=` event handlers, or `javascript:` URLs. This is an author-feedback signal — the configure-UI CSP (`script-src 'self'; style-src 'self'`) is the actual runtime enforcement, so HTML-entity-encoded bypasses are blocked anyway.
- Handler exceptions are caught by `_dispatch_extension` and surfaced as `{"error": "extension_handler_error"}` 500 envelopes; the exception `repr` is logged server-side only (it may carry secrets the handler touched). A handler that already wrote a partial response before raising is doubly-guarded so the configure server never tries to append a second status line to a half-shipped response.

### Plugin author docs

`docs/plugin-authoring.md` §13 documents the contract end-to-end (entry-point setup, sample `WebExtension`, URL surface table, security model, lazy-load behaviour, debugging recipe).

### Commits

| Hash | Title |
|---|---|
| `b076106` | `feat(web): add entry-point–based extension layer (types + discovery)` |
| `dc443e2` | `feat(web): mount web extensions in the configure server` |
| `f0715e1` | `feat(web): render extension tabs in the configure UI + plugin-authoring §13` |
| `cf33c58` | `docs(web): document _initialised exception-path design in extensions.js` |
| `8bc043b` | `docs(changelog): record web extensions feature under [Unreleased]` |

### Backward compatibility

When no `mureo.web_extensions` entry points are installed:

- `discover_web_extensions()` returns an empty tuple.
- `GET /api/extensions` returns `[]`.
- The renderer's `init()` filters to `[]` and creates zero DOM nodes.
- The configure UI is byte-identical to v0.9.4.

825 existing `tests/test_web_*` tests pass unchanged.

## Test plan

- [ ] CI lint job (`ruff check mureo/`, `black --check mureo/`) — clean locally.
- [ ] CI test jobs (Python 3.10 / 3.11 / 3.12 + Windows) — 71 new tests in `tests/test_web_extensions.py` (45) + `tests/test_web_extension_routing.py` (26) all pass locally.
- [ ] CI test job covers `tests/test_web_handlers.py` etc. unchanged — no regressions in the broader 824-test web suite.
- [ ] CodeQL — no new findings expected; net additions are pure-Python + plain JS, no `eval` / `Function(...)` / subprocess / shell.
- [ ] Manual: launch `mureo configure` with no `mureo.web_extensions` entry points → confirm the dashboard renders exactly as v0.9.4 (no extra tabs, no `/api/extensions` errors in DevTools).
