### PR TITLE
chore(release): v0.9.5

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mureo",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Your local-first AI ad ops crew for Google Ads, Meta Ads, Search Console & GA4. mureo sits on top of the official ad-platform MCPs, gates every change against your strategy, correlates outcomes locally, and keeps an auditable decision log — credentials never leave your machine.",
   "author": {
     "name": "Logly Inc.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.5] - 2026-05-21
+
 ### Added — Web extensions: third-party tabs and API routes for `mureo configure`
 
 A new entry-point group `mureo.web_extensions` lets a plugin register additional tabs and API routes inside the `mureo configure` wizard without each surface having to know about the plugin. The mechanism mirrors the existing `mureo.providers` / `mureo.runtime_context_factory` entry-point patterns: discovery iterates the group exactly once at startup, isolates per-plugin faults (`WebExtensionWarning`), and exposes survivors as frozen `WebExtensionEntry` records consumed by `mureo.web.handlers`.

--- a/mureo/__init__.py
+++ b/mureo/__init__.py
@@ -1,3 +1,3 @@
 """mureo — your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."""
 
-__version__ = "0.9.4"
+__version__ = "0.9.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mureo"
-version = "0.9.4"
+version = "0.9.5"
 description = "Your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."
 requires-python = ">=3.10"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Releases v0.9.5 covering the web-extension layer for the configure UI (#127).

### New public surface

`mureo.web.extensions` adds:
- `WebExtension` Protocol (`@runtime_checkable`)
- Frozen dataclasses: `RouteContribution`, `ViewContribution`, `StaticAsset`, `WebExtensionEntry`
- `WebExtensionWarning(UserWarning)` for strict-mode opt-in
- `discover_web_extensions()` / `reset_web_extensions()`
- Shared regex constants `NAME_PATTERN`, `SUBPATH_PATTERN`, `FILENAME_PATTERN`
- Entry-point group `mureo.web_extensions`

### HTTP routes added to `mureo.web.handlers`

- `GET /api/extensions` — front-end renderer index
- `GET /api/ext/<name>/<subpath>` — extension GET (query string flattened, first-value-wins)
- `POST /api/ext/<name>/<subpath>` — extension POST (CSRF gated by existing pipeline)
- `GET /static/ext/<name>/<filename>` — in-memory static asset with full security header stack

### Front-end

`mureo/_data/web/extensions.js` fetches `/api/extensions` once when the dashboard opens, renders one nav tab per extension, and lazy-loads `html_fragment` / scripts / styles on the first tab click.

### Plugin author docs

`docs/plugin-authoring.md` §13 documents the contract end-to-end (entry-point setup, sample `WebExtension`, URL surface, CSP / CSRF / fault-isolation model, lazy-load contract, debugging recipe).

### Version bump

- `.claude-plugin/plugin.json`: 0.9.4 → 0.9.5
- `mureo/__init__.py`: 0.9.4 → 0.9.5
- `pyproject.toml`: 0.9.4 → 0.9.5

### Backward compatibility

When no `mureo.web_extensions` entry points are installed, the configure UI is byte-identical to v0.9.4 (zero DOM mutations, `/api/extensions` returns `[]`, renderer creates zero nav items).

## Test plan

- [ ] All CI jobs green (lint, test 3.10/3.11/3.12, test-windows, CodeQL, Analyze)
- [ ] Version parity test (`tests/test_plugin_manifests.py::test_plugin_version_matches_pyproject`) passes
- [ ] Tag `v0.9.5` after merge → GitHub Release published → `release.yml` workflow pushes to PyPI
