### PR TITLE
feat(web): localise extension nav-tab labels via optional display_name_i18n

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — Optional per-locale labels for web-extension nav tabs
+
+Web extensions can now ship an optional `display_name_i18n: Mapping[str, str]` class attribute alongside `display_name` so the configure-UI nav tab follows the active locale. Built-in nav tabs (Setup / Demo / BYOD / Danger Zone) are already translated via `data-i18n` keys in `i18n.json`; extension tabs now follow the same convention without extension authors having to touch the OSS `i18n.json` catalog.
+
+- **`mureo.web.extensions`** — `WebExtensionEntry` gains a `display_name_i18n: Mapping[str, str]` field that defaults to `{}` so existing constructors continue to work unchanged. The `WebExtension` Protocol is **unchanged** — the new attribute is read defensively via `getattr` so every pre-feature extension keeps loading without modification. Discovery validates the value as `Mapping[str, str]` (`str` keys and values both required) and skips the extension with a `WebExtensionWarning` if the shape is wrong.
+- **HTTP** — `GET /api/extensions` includes a new `display_name_i18n` field per entry (empty `{}` when the extension did not declare any). JSON-only addition; existing consumers ignore unknown keys.
+- **Front-end** (`mureo/_data/web/extensions.js`) — initial render reads `document.documentElement.lang` and looks up `display_name_i18n[locale]` with a fallback chain `locale → "en" → display_name`. A `mureo:locale_changed` listener (fired by `app.js#setLocale`) re-runs the lookup so every nav label updates the moment the operator toggles 日本語 / English.
+- **Plugin author docs** — `docs/plugin-authoring.md` §13 gains a *Localising the nav-tab label* subsection with the example class attribute and the documented lookup priority.
+
+Backward compatibility: extensions that do not declare `display_name_i18n` get an empty `dict` in their `WebExtensionEntry`; the renderer's fallback chain resolves to `display_name`, so the nav tab looks byte-identical to v0.9.5.
+
 ## [0.9.5] - 2026-05-21
 
 ### Added — Web extensions: third-party tabs and API routes for `mureo configure`

--- a/docs/plugin-authoring.md
+++ b/docs/plugin-authoring.md
@@ -1355,6 +1355,51 @@ class MyExtension:
         )
 ```
 
+### Localising the nav-tab label
+
+`display_name` is the fallback label and is always required. To follow
+the same convention as the built-in nav tabs (Setup / Demo / BYOD /
+Danger Zone — translated via `data-i18n` keys in `i18n.json`), declare
+an optional `display_name_i18n` class attribute keyed by BCP-47
+language code:
+
+```python
+class MyExtension:
+    name = "acme-vault"
+    display_name = "Acme Vault setup"          # fallback for any locale
+    display_name_i18n = {                       # optional, per-locale labels
+        "en": "Acme Vault",
+        "ja": "Acme Vault 設定",
+    }
+    # ...routes() / view() unchanged
+```
+
+Lookup priority on the renderer side: `display_name_i18n[active_locale]`
+→ `display_name_i18n["en"]` → `display_name`. Operators who toggle the
+configure-UI locale see your tab name update without a page reload —
+the renderer listens for `mureo:locale_changed`. Extensions that do
+not declare `display_name_i18n` keep the legacy behaviour: a single
+string shown verbatim in every locale.
+
+The attribute is **optional**: it is read via `getattr` so the
+`WebExtension` Protocol itself stays unchanged and pre-feature
+extensions continue to load without modification. The value must be a
+`Mapping[str, str]` — anything else (a list of pairs, a key of type
+`int`, a value of type `int`, etc.) is a packaging bug and the
+extension is skipped at discovery with a `WebExtensionWarning`.
+
+Currently the configure-UI ships an `en` / `ja` locale toggle; if you
+add labels for other BCP-47 codes they are stored and surfaced via
+`/api/extensions` but never selected by the built-in UI today. The
+contract is forward-compatible — if mureo grows more locales later,
+your existing entries Just Work.
+
+Empty-string values (`{"ja": ""}`) are treated as missing — the
+renderer's `i18n[locale] || i18n.en || display_name` chain skips
+falsy entries and falls through to the next candidate. If you want
+to ship an intentionally blank label, render an explicit zero-width
+character (e.g. `"​"`) instead of `""`.
+
 ### `pyproject.toml`
 
 ```toml

--- a/mureo/_data/web/extensions.js
+++ b/mureo/_data/web/extensions.js
@@ -28,6 +28,23 @@
   // can investigate the root cause via the console.warn diagnostics.
   let _initialised = false;
 
+  function _currentLocale() {
+    // ``document.documentElement.lang`` is the source of truth (set by
+    // ``app.js#setLocale``). Falls back to "en" before app.js has run
+    // and for the rare case where the attribute is removed.
+    return document.documentElement.lang || "en";
+  }
+
+  function _resolveDisplayName(extension, locale) {
+    // Lookup priority mirrors the convention documented in
+    // ``docs/plugin-authoring.md`` §13: localized label for the active
+    // locale, then the English entry as a portable default, then the
+    // legacy ``display_name`` string. Extensions that do not ship a
+    // ``display_name_i18n`` map keep the legacy behaviour exactly.
+    const i18n = extension.display_name_i18n || {};
+    return i18n[locale] || i18n.en || extension.display_name;
+  }
+
   function _navList() {
     return document.querySelector(".dashboard-nav ul");
   }
@@ -133,7 +150,7 @@
     a.setAttribute("data-dashboard-nav", _navItemId(extension.name));
     a.setAttribute("role", "button");
     a.setAttribute("tabindex", "0");
-    a.textContent = extension.display_name;
+    a.textContent = _resolveDisplayName(extension, _currentLocale());
     const onActivate = _onTabClick(extension);
     a.addEventListener("click", onActivate);
     a.addEventListener("keydown", function (evt) {
@@ -187,6 +204,28 @@
     });
     _extensions.forEach(_renderNavItem);
   }
+
+  function _onLocaleChanged(evt) {
+    // Walk every nav <a> we previously rendered and update its label
+    // for the new locale. Resolved via _resolveDisplayName so the
+    // fallback chain (locale → en → display_name) stays consistent
+    // with the initial render path.
+    const locale = (evt && evt.detail && evt.detail.locale) || _currentLocale();
+    _extensions.forEach(function (extension) {
+      const a = document.querySelector(
+        '[data-dashboard-nav="' + _navItemId(extension.name) + '"]',
+      );
+      if (a) {
+        a.textContent = _resolveDisplayName(extension, locale);
+      }
+    });
+  }
+
+  // Registered at module-eval time so a locale change that happens
+  // before ``init()`` finishes still triggers a re-render on the next
+  // matching event — ``_extensions`` is simply empty until init()
+  // populates it, so the listener is harmless until then.
+  document.addEventListener("mureo:locale_changed", _onLocaleChanged);
 
   window.MUREO = window.MUREO || {};
   window.MUREO.extensions = {

--- a/mureo/web/extensions.py
+++ b/mureo/web/extensions.py
@@ -50,7 +50,8 @@ from __future__ import annotations
 
 import re
 import warnings
-from dataclasses import dataclass
+from collections.abc import Mapping
+from dataclasses import dataclass, field
 from importlib.metadata import entry_points
 from typing import (
     TYPE_CHECKING,
@@ -236,6 +237,17 @@ class WebExtension(Protocol):
     a :class:`WebExtensionEntry`. Exceptions raised by either method
     skip the extension (with :class:`WebExtensionWarning`) without
     affecting other extensions or the configure server.
+
+    Optional class attribute (read via :func:`getattr` so the Protocol
+    itself stays backward-compatible):
+
+    * ``display_name_i18n: Mapping[str, str]`` — per-locale labels
+      keyed by BCP-47 language code (``"en"``, ``"ja"``). When the
+      configure-UI swaps locale, the renderer prefers
+      ``display_name_i18n[locale]``, falling back to
+      ``display_name_i18n["en"]``, then to ``display_name``.
+      Extensions that do not declare it behave exactly as before —
+      ``display_name`` is shown unchanged in every locale.
     """
 
     @property
@@ -251,13 +263,21 @@ class WebExtension(Protocol):
 
 @dataclass(frozen=True)
 class WebExtensionEntry:
-    """Frozen record of one successfully-discovered extension."""
+    """Frozen record of one successfully-discovered extension.
+
+    ``display_name_i18n`` defaults to an empty mapping so callers that
+    construct an entry without supplying the field continue to work
+    after the field was added. The renderer treats an empty mapping
+    the same as a missing one — ``display_name`` is the fallback in
+    both cases.
+    """
 
     name: str
     display_name: str
     routes: tuple[RouteContribution, ...]
     view: ViewContribution | None
     source_distribution: str | None
+    display_name_i18n: Mapping[str, str] = field(default_factory=dict)
 
 
 # ---------------------------------------------------------------------------
@@ -374,6 +394,31 @@ def _load_entry_point(ep: Any) -> WebExtensionEntry | None:
                 f"view() returned {type(view_value).__name__}, "
                 f"expected ViewContribution or None"
             )
+        # ``display_name_i18n`` is read defensively so the Protocol
+        # itself does not require the attribute — every pre-feature
+        # extension keeps working without modification. When present
+        # the value must be a mapping of ``str -> str``; anything else
+        # is a packaging bug and the entry is skipped (defence against
+        # mistakes like ``[("en", "Foo")]``, ``{"en": 123}``, or
+        # ``{1: "Foo"}`` reaching the JSON serialiser later).
+        i18n_value = getattr(extension, "display_name_i18n", {})
+        if not isinstance(i18n_value, Mapping):
+            raise TypeError(
+                f"display_name_i18n must be a Mapping, "
+                f"got {type(i18n_value).__name__}"
+            )
+        i18n_normalised: dict[str, str] = {}
+        for key, value in i18n_value.items():
+            if not isinstance(key, str):
+                raise TypeError(
+                    f"display_name_i18n keys must be str, got {type(key).__name__}"
+                )
+            if not isinstance(value, str):
+                raise TypeError(
+                    f"display_name_i18n values must be str, "
+                    f"got {type(value).__name__} for key {key!r}"
+                )
+            i18n_normalised[key] = value
     except Exception as exc:  # noqa: BLE001 — per-plugin fault isolation
         warnings.warn(
             f"failed to load web extension {ep_name!r}: {exc!r}",
@@ -388,6 +433,7 @@ def _load_entry_point(ep: Any) -> WebExtensionEntry | None:
         routes=routes_value,
         view=view_value,
         source_distribution=_resolve_source(ep),
+        display_name_i18n=i18n_normalised,
     )
 
 

--- a/mureo/web/handlers.py
+++ b/mureo/web/handlers.py
@@ -627,6 +627,11 @@ class ConfigureHandler(BaseHTTPRequestHandler):
             item: dict[str, Any] = {
                 "name": entry.name,
                 "display_name": entry.display_name,
+                # Defensive copy — the renderer is free to mutate the
+                # returned dict (the JSON serialiser does not), and an
+                # extension may share the same mapping object across
+                # multiple discovery calls within a process.
+                "display_name_i18n": dict(entry.display_name_i18n),
             }
             if entry.view is None:
                 item["view"] = None

--- a/tests/test_web_extension_routing.py
+++ b/tests/test_web_extension_routing.py
@@ -208,9 +208,44 @@ def test_extensions_index_lists_registered(
     item = payload[0]
     assert item["name"] == "demo"
     assert item["display_name"] == "Demo extension"
+    assert item["display_name_i18n"] == {}
     assert item["view"]["html_fragment"].startswith("<section")
     assert item["view"]["scripts"] == ["demo.js"]
     assert item["view"]["styles"] == ["demo.css"]
+
+
+@pytest.mark.unit
+def test_extensions_index_includes_display_name_i18n(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An extension that ships per-locale labels surfaces them on
+    ``/api/extensions`` so the renderer can swap nav labels when the
+    operator toggles locale without round-tripping the server."""
+    i18n_entry = WebExtensionEntry(
+        name="i18n-demo",
+        display_name="I18n demo",
+        routes=(),
+        view=ViewContribution(html_fragment="<p>i18n</p>"),
+        source_distribution=None,
+        display_name_i18n={"en": "Demo", "ja": "デモ"},
+    )
+    monkeypatch.setattr("mureo.web.extensions._cached_entries", (i18n_entry,))
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".claude").mkdir()
+    (home / ".claude" / "commands").mkdir()
+    (home / ".mureo").mkdir()
+    wiz = ConfigureWizard(home=home)
+    t = threading.Thread(target=wiz.serve, daemon=True)
+    t.start()
+    wiz.wait_until_ready(timeout=5.0)
+    try:
+        resp = _get(wiz, "/api/extensions")
+        payload = json.loads(resp.read().decode())
+        assert payload[0]["display_name_i18n"] == {"en": "Demo", "ja": "デモ"}
+    finally:
+        wiz.shutdown()
+        t.join(timeout=2.0)
 
 
 @pytest.mark.unit
@@ -237,7 +272,14 @@ def test_extensions_index_view_null_when_extension_has_no_view(
     try:
         resp = _get(wiz, "/api/extensions")
         payload = json.loads(resp.read().decode())
-        assert payload == [{"name": "nogui", "display_name": "No GUI", "view": None}]
+        assert payload == [
+            {
+                "name": "nogui",
+                "display_name": "No GUI",
+                "display_name_i18n": {},
+                "view": None,
+            }
+        ]
     finally:
         wiz.shutdown()
         t.join(timeout=2.0)

--- a/tests/test_web_extensions.py
+++ b/tests/test_web_extensions.py
@@ -469,6 +469,224 @@ def test_reset_clears_cache(monkeypatch: pytest.MonkeyPatch) -> None:
     assert second == ()
 
 
+# ---------------------------------------------------------------------------
+# display_name_i18n — optional per-locale labels for the nav tab
+# ---------------------------------------------------------------------------
+
+
+class _DemoI18nExtension:
+    """Extension that ships per-locale labels alongside the English default."""
+
+    name = "demo-i18n"
+    display_name = "Demo (en fallback)"
+    display_name_i18n = {"en": "Demo", "ja": "デモ"}
+
+    def routes(self) -> tuple[Any, ...]:
+        return ()
+
+    def view(self) -> Any:
+        return None
+
+
+class _BadI18nMappingType:
+    name = "bad-i18n-type"
+    display_name = "Bad i18n type"
+    display_name_i18n = ["en", "Foo"]  # list, not mapping
+
+    def routes(self) -> tuple[Any, ...]:
+        return ()
+
+    def view(self) -> Any:
+        return None
+
+
+class _BadI18nValueType:
+    name = "bad-i18n-value"
+    display_name = "Bad i18n value"
+    display_name_i18n = {"en": 123}  # value is not a str
+
+    def routes(self) -> tuple[Any, ...]:
+        return ()
+
+    def view(self) -> Any:
+        return None
+
+
+class _BadI18nKeyType:
+    name = "bad-i18n-key"
+    display_name = "Bad i18n key"
+    display_name_i18n = {1: "Foo"}  # key is not a str
+
+    def routes(self) -> tuple[Any, ...]:
+        return ()
+
+    def view(self) -> Any:
+        return None
+
+
+@pytest.mark.unit
+def test_web_extension_entry_defaults_display_name_i18n_to_empty_dict() -> None:
+    """Existing callers that construct ``WebExtensionEntry`` without the
+    new ``display_name_i18n`` field must continue to work."""
+    from mureo.web.extensions import WebExtensionEntry
+
+    entry = WebExtensionEntry(
+        name="legacy",
+        display_name="Legacy",
+        routes=(),
+        view=None,
+        source_distribution=None,
+    )
+    assert entry.display_name_i18n == {}
+
+
+@pytest.mark.unit
+def test_web_extension_entry_accepts_display_name_i18n() -> None:
+    from mureo.web.extensions import WebExtensionEntry
+
+    entry = WebExtensionEntry(
+        name="i18n",
+        display_name="I18n",
+        routes=(),
+        view=None,
+        source_distribution=None,
+        display_name_i18n={"en": "I18n", "ja": "国際化"},
+    )
+    assert entry.display_name_i18n == {"en": "I18n", "ja": "国際化"}
+
+
+@pytest.mark.unit
+def test_discover_picks_up_display_name_i18n(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from mureo.web.extensions import discover_web_extensions
+
+    _patch_entry_points(monkeypatch, [_FakeEP("demo-i18n", _DemoI18nExtension)])
+    entries = discover_web_extensions()
+    assert len(entries) == 1
+    assert entries[0].display_name_i18n == {"en": "Demo", "ja": "デモ"}
+
+
+@pytest.mark.unit
+def test_discover_defaults_missing_display_name_i18n_to_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An extension that does not declare ``display_name_i18n`` — i.e. every
+    extension shipped before this feature existed — must continue to load."""
+    from mureo.web.extensions import discover_web_extensions
+
+    _patch_entry_points(monkeypatch, [_FakeEP("demo", _DemoExtension)])
+    entries = discover_web_extensions()
+    assert len(entries) == 1
+    assert entries[0].display_name_i18n == {}
+
+
+@pytest.mark.unit
+def test_discover_skips_extension_with_non_mapping_display_name_i18n(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from mureo.web.extensions import WebExtensionWarning, discover_web_extensions
+
+    _patch_entry_points(
+        monkeypatch,
+        [
+            _FakeEP("bad-i18n-type", _BadI18nMappingType),
+            _FakeEP("demo", _DemoExtension),
+        ],
+    )
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        entries = discover_web_extensions()
+    assert [e.name for e in entries] == ["demo"]
+    assert any(
+        issubclass(w.category, WebExtensionWarning)
+        and "bad-i18n-type" in str(w.message)
+        for w in caught
+    )
+
+
+@pytest.mark.unit
+def test_discover_skips_extension_with_non_str_i18n_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from mureo.web.extensions import WebExtensionWarning, discover_web_extensions
+
+    _patch_entry_points(
+        monkeypatch,
+        [
+            _FakeEP("bad-i18n-value", _BadI18nValueType),
+            _FakeEP("demo", _DemoExtension),
+        ],
+    )
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        entries = discover_web_extensions()
+    assert [e.name for e in entries] == ["demo"]
+    assert any(
+        issubclass(w.category, WebExtensionWarning)
+        and "bad-i18n-value" in str(w.message)
+        for w in caught
+    )
+
+
+@pytest.mark.unit
+def test_discover_skips_extension_with_non_str_i18n_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from mureo.web.extensions import WebExtensionWarning, discover_web_extensions
+
+    _patch_entry_points(
+        monkeypatch,
+        [
+            _FakeEP("bad-i18n-key", _BadI18nKeyType),
+            _FakeEP("demo", _DemoExtension),
+        ],
+    )
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        entries = discover_web_extensions()
+    assert [e.name for e in entries] == ["demo"]
+    assert any(
+        issubclass(w.category, WebExtensionWarning) and "bad-i18n-key" in str(w.message)
+        for w in caught
+    )
+
+
+class _NoneI18n:
+    name = "none-i18n"
+    display_name = "None i18n"
+    display_name_i18n = None  # explicit None — not a Mapping
+
+    def routes(self) -> tuple[Any, ...]:
+        return ()
+
+    def view(self) -> Any:
+        return None
+
+
+@pytest.mark.unit
+def test_discover_skips_extension_with_none_display_name_i18n(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicit ``None`` value is distinct from the attribute being
+    absent (which defaults to ``{}`` via ``getattr``). ``None`` is not a
+    ``Mapping`` so discovery must skip the entry."""
+    from mureo.web.extensions import WebExtensionWarning, discover_web_extensions
+
+    _patch_entry_points(
+        monkeypatch,
+        [_FakeEP("none-i18n", _NoneI18n), _FakeEP("demo", _DemoExtension)],
+    )
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        entries = discover_web_extensions()
+    assert [e.name for e in entries] == ["demo"]
+    assert any(
+        issubclass(w.category, WebExtensionWarning) and "none-i18n" in str(w.message)
+        for w in caught
+    )
+
+
 @pytest.fixture(autouse=True)
 def _reset_extensions_cache() -> Iterator[None]:
     """Every test starts with a clean discovery cache."""


### PR DESCRIPTION
## Summary

Built-in nav tabs (Setup / Demo / BYOD / Danger Zone) are already translated via `data-i18n` keys in `i18n.json`, but third-party web-extension tabs were stuck on a single English string. Operators toggling `日本語` saw the rest of the UI flip while extension tabs stayed put. This PR closes that consistency gap by letting an extension declare an optional `display_name_i18n: Mapping[str, str]` class attribute that the renderer prefers per-locale, falling back to `display_name` for any locale (or extension) that has not opted in.

```python
class MyExtension:
    name = "acme-vault"
    display_name = "Acme Vault setup"            # fallback
    display_name_i18n = {"en": "Vault", "ja": "Vault 設定"}
    # ...routes() / view() unchanged
```

Lookup priority: `display_name_i18n[active_locale]` → `display_name_i18n["en"]` → `display_name`. The renderer listens for the existing `mureo:locale_changed` event (fired by `app.js#setLocale`) so the nav label flips the moment the operator toggles locale.

## Public surface

- `mureo.web.extensions.WebExtensionEntry` gains a `display_name_i18n: Mapping[str, str]` field with `field(default_factory=dict)`. Existing 5-field constructors keep working unchanged.
- The `WebExtension` Protocol is **unchanged** — the new attribute is read via `getattr` inside the discovery layer. Adding it to a `@runtime_checkable` Protocol would have broken `isinstance(...)` for every pre-feature extension.
- `GET /api/extensions` gains a `display_name_i18n` key per entry (empty `{}` for extensions that did not declare any).
- `mureo/_data/web/extensions.js` gains `_resolveDisplayName(extension, locale)` + a `mureo:locale_changed` listener.

## Validation

Discovery treats the value as `Mapping[str, str]` and skips the entry with a `WebExtensionWarning` if anything else turns up: explicit `None`, list of pairs, `int` keys, `int` values. The JSON serialiser never sees a malformed shape.

## Security

Labels are injected via `textContent` (never `innerHTML`), so an i18n value containing `<script>` is harmless DOM text. The configure-UI CSP (`script-src 'self'; style-src 'self'`) is unchanged.

## Backward compatibility

- Extensions that do not declare `display_name_i18n` get an empty `dict` in their `WebExtensionEntry`. The renderer's fallback chain resolves to `display_name`, so the nav tab looks byte-identical to v0.9.5.
- The new `/api/extensions` field is additive JSON; existing consumers ignore unknown keys.
- No change to `i18n.json` — extension authors ship their own labels without touching the OSS catalog.

## Docs

`docs/plugin-authoring.md` §13 gains a *Localising the nav-tab label* subsection with the example class attribute, the documented lookup priority, the empty-string fallthrough note, and the "no need to touch OSS `i18n.json`" guarantee.

## Test plan

- [ ] CI lint (`ruff check mureo/`, `black --check mureo/`) — clean locally
- [ ] CI tests (Python 3.10 / 3.11 / 3.12 + Windows) — 9 new unit tests + 1 new integration test + 2 existing assertions updated; 80 tests pass in the two extension test files, 252 pass across `tests/test_web_*`
- [ ] CodeQL — no new findings expected; net additions are pure-Python + plain JS, no `eval` / `Function(...)` / subprocess / shell
- [ ] Manual: launch `mureo configure` with an extension that declares `display_name_i18n` → toggle `English ⇄ 日本語` → confirm the extension nav tab updates without a page reload
- [ ] Manual: an extension that does NOT declare `display_name_i18n` continues to render its English `display_name` in both locales (byte-identical to v0.9.5)
