### PR TITLE
chore(release): v0.9.6

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mureo",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "Your local-first AI ad ops crew for Google Ads, Meta Ads, Search Console & GA4. mureo sits on top of the official ad-platform MCPs, gates every change against your strategy, correlates outcomes locally, and keeps an auditable decision log — credentials never leave your machine.",
   "author": {
     "name": "Logly Inc.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.6] - 2026-05-22
+
 ### Added — Optional per-locale labels for web-extension nav tabs
 
 Web extensions can now ship an optional `display_name_i18n: Mapping[str, str]` class attribute alongside `display_name` so the configure-UI nav tab follows the active locale. Built-in nav tabs (Setup / Demo / BYOD / Danger Zone) are already translated via `data-i18n` keys in `i18n.json`; extension tabs now follow the same convention without extension authors having to touch the OSS `i18n.json` catalog.

--- a/mureo/__init__.py
+++ b/mureo/__init__.py
@@ -1,3 +1,3 @@
 """mureo — your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."""
 
-__version__ = "0.9.5"
+__version__ = "0.9.6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mureo"
-version = "0.9.5"
+version = "0.9.6"
 description = "Your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."
 requires-python = ">=3.10"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Releases v0.9.6 covering the i18n nav-label work in #129.

### Public addition

Web extensions can now ship an optional `display_name_i18n: Mapping[str, str]` class attribute so the configure-UI nav tab follows the active locale:

```python
class MyExtension:
    name = "acme-vault"
    display_name = "Acme Vault setup"            # fallback
    display_name_i18n = {"en": "Vault", "ja": "Vault 設定"}
```

Lookup priority: `display_name_i18n[active_locale]` → `display_name_i18n["en"]` → `display_name`. The renderer listens for the existing `mureo:locale_changed` event so labels flip without a page reload.

### Backward compatibility

- `WebExtension` Protocol unchanged — the new attribute is read defensively via `getattr`, so every pre-feature extension keeps loading without modification.
- `WebExtensionEntry` defaults the new field to `{}` so existing 5-field constructors continue to work.
- Extensions that do not declare `display_name_i18n` render byte-identical to v0.9.5.
- `GET /api/extensions` adds a `display_name_i18n` key (empty `{}` when not declared). JSON-only addition.

### Version bump

- `.claude-plugin/plugin.json`: 0.9.5 → 0.9.6
- `mureo/__init__.py`: 0.9.5 → 0.9.6
- `pyproject.toml`: 0.9.5 → 0.9.6

## Test plan

- [ ] All CI jobs green (lint, test 3.10/3.11/3.12, test-windows, CodeQL, Analyze)
- [ ] Version parity test (`tests/test_plugin_manifests.py::test_plugin_version_matches_pyproject`) passes
- [ ] Tag `v0.9.6` after merge → GitHub Release published → `release.yml` workflow pushes to PyPI
