### PR TITLE
feat(providers): add optional AccountCredentialField for self-describing plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — Optional `account_credential_fields` for self-describing providers
+
+Provider plugins (built-in `google_ads` / `meta_ads`, and third-party plugins discovered via the `mureo.providers` entry-point group) can now declare an optional `account_credential_fields: tuple[AccountCredentialField, ...]` class attribute so introspection tooling — the `mureo providers …` CLI, configuration wizards, plugin authoring guides — can render setup prompts, validate config, and document plugins without hardcoding per-provider knowledge.
+
+```python
+from mureo.core.providers import AccountCredentialField
+
+class MyAdsProvider:
+    name = "my_ads"
+    display_name = "My Ads"
+    capabilities = frozenset({...})
+    account_credential_fields = (
+        AccountCredentialField(
+            key="advertiser_id",
+            display_name="Advertiser ID",
+            placeholder="adv-12345",
+            required=True,
+            description="From the MyAds dashboard.",
+        ),
+    )
+```
+
+- **New public surface in `mureo.core.providers`**: `AccountCredentialField` (frozen dataclass — `key`, `display_name`, `placeholder=""`, `required=False`, `description=""`) and `get_account_credential_fields(provider) -> tuple[AccountCredentialField, ...]` accessor. The accessor reads the optional attribute defensively (returns `()` when absent) and validates the shape (`tuple` of `AccountCredentialField` only) — malformed declarations raise `TypeError` at introspection time, not deep inside the consuming UI.
+- **`BaseProvider` Protocol is unchanged**. The new attribute is documented as optional in the `BaseProvider` docstring; the Protocol body itself stays stable so every pre-feature plugin keeps loading without modification.
+- **Built-in adapters updated**: `mureo.adapters.google_ads.GoogleAdsAdapter` declares `customer_id`; `mureo.adapters.meta_ads.MetaAdsAdapter` declares `ad_account_id`. Operator-shared credentials (developer token, app secret, refresh token, MCC `login_customer_id`) intentionally do NOT appear — those belong to a separate operator-level layer.
+- **Plugin author guide**: `docs/plugin-authoring.md` §3 (`BaseProvider`) gains a *Declaring per-account credential fields (optional)* subsection covering the dataclass shape, defaults, and the accessor's defensive-read / strict-validation semantics.
+
+Backward compatibility: providers that do not declare `account_credential_fields` continue to load unchanged; `get_account_credential_fields()` returns `()`, which downstream tooling treats as "no per-account configuration needed."
+
 ## [0.9.6] - 2026-05-22
 
 ### Added — Optional per-locale labels for web-extension nav tabs

--- a/docs/plugin-authoring.md
+++ b/docs/plugin-authoring.md
@@ -271,6 +271,59 @@ both look them up on the class via `getattr`.
 adding required methods later cannot break installed plugins — new
 behaviour goes into secondary Protocols.
 
+### Declaring per-account credential fields (optional)
+
+Providers often need identifiers that vary per platform account —
+Google Ads `customer_id`, Meta Ads `ad_account_id`, an analytics
+product's `advertiser_id`. These are distinct from operator-shared
+OAuth credentials (developer tokens, refresh tokens) which typically
+apply to every account on the same platform.
+
+Declare them via the optional `account_credential_fields` class
+attribute so introspection tooling — the `mureo providers …` CLI,
+configuration wizards, plugin authoring guides — can render setup
+prompts, validate config, and document your provider without
+hardcoding per-provider knowledge:
+
+```python
+from mureo.core.providers import AccountCredentialField
+
+class MyAdsProvider:
+    name = "my_ads"
+    display_name = "My Ads"
+    capabilities = frozenset({...})
+    account_credential_fields = (
+        AccountCredentialField(
+            key="advertiser_id",
+            display_name="Advertiser ID",
+            placeholder="adv-12345",
+            required=True,
+            description="Advertiser ID from the MyAds dashboard.",
+        ),
+    )
+```
+
+| Field | Default | Notes |
+|---|---|---|
+| `key` | (required) | Stable snake_case identifier used in credential storage. Treat as part of your public ABI — renaming after release breaks operator config. |
+| `display_name` | (required) | Human-readable label for CLI prompts / wizard forms. |
+| `placeholder` | `""` | Example value shown in form inputs (never used as a default — auto-applying would surprise operators). |
+| `required` | `False` | When `True`, tooling may warn or block on a missing value. |
+| `description` | `""` | One-line operator-facing hint pointing at where the value comes from. |
+
+The accessor `mureo.core.providers.get_account_credential_fields(provider)`
+reads the attribute defensively (returns `()` when absent) and
+validates the shape — providers shipped before this feature existed
+keep loading without modification, but a malformed declaration
+(non-tuple, wrong element type) raises `TypeError` at introspection
+time so the failure surfaces near the plugin, not deep inside the
+consuming UI.
+
+OAuth-level / operator-shared credentials (developer token, app
+secret, refresh token, MCC `login_customer_id`) intentionally do
+NOT live here — `account_credential_fields` is for the per-account
+slice only.
+
 ### Domain Protocols (implement at least one)
 
 | Protocol | Purpose | Methods |

--- a/mureo/adapters/google_ads/adapter.py
+++ b/mureo/adapters/google_ads/adapter.py
@@ -45,6 +45,7 @@ from mureo.adapters.google_ads.mappers import (
     to_search_term,
 )
 from mureo.core.providers.capabilities import Capability
+from mureo.core.providers.credentials import AccountCredentialField
 from mureo.core.providers.models import (
     Ad,
     AdStatus,
@@ -106,6 +107,23 @@ class GoogleAdsAdapter:
             Capability.WRITE_EXTENSIONS,
             Capability.WRITE_CAMPAIGN_STATUS,
         }
+    )
+    # Per-account credential the operator must supply for Google Ads.
+    # The MCC ``login_customer_id`` is intentionally NOT listed here —
+    # it identifies the operator's manager account and is typically
+    # shared across every Google Ads account the operator manages
+    # (operator-shared OAuth-level credential, not per-account).
+    account_credential_fields: tuple[AccountCredentialField, ...] = (
+        AccountCredentialField(
+            key="customer_id",
+            display_name="Customer ID",
+            placeholder="123-456-7890",
+            required=True,
+            description=(
+                "10-digit Google Ads customer ID (with or without dashes). "
+                "Find it in the Google Ads UI top-right corner."
+            ),
+        ),
     )
 
     def __init__(self, client: GoogleAdsApiClient) -> None:

--- a/mureo/adapters/meta_ads/adapter.py
+++ b/mureo/adapters/meta_ads/adapter.py
@@ -54,6 +54,7 @@ from mureo.adapters.meta_ads.mappers import (
     to_daily_report_row,
 )
 from mureo.core.providers.capabilities import Capability
+from mureo.core.providers.credentials import AccountCredentialField
 from mureo.core.providers.models import (
     Ad,
     AdStatus,
@@ -134,6 +135,23 @@ class MetaAdsAdapter:
             Capability.WRITE_CAMPAIGN_STATUS,
             Capability.WRITE_AUDIENCES,
         }
+    )
+    # Per-account credential the operator must supply for Meta Ads.
+    # Token-level material (the System User access token / app id /
+    # app secret) is operator-shared in the common Business Manager
+    # setup and lives outside this declaration; ``ad_account_id`` is
+    # the only field that varies per account.
+    account_credential_fields: tuple[AccountCredentialField, ...] = (
+        AccountCredentialField(
+            key="ad_account_id",
+            display_name="Ad Account ID",
+            placeholder="act_1234567890",
+            required=True,
+            description=(
+                "Meta ad account ID prefixed with ``act_``. "
+                "Find it in Meta Ads Manager > Account Settings."
+            ),
+        ),
     )
 
     def __init__(self, client: MetaAdsApiClient) -> None:

--- a/mureo/core/providers/__init__.py
+++ b/mureo/core/providers/__init__.py
@@ -23,6 +23,7 @@ from mureo.core.providers.capabilities import (
     parse_capabilities,
     parse_capability,
 )
+from mureo.core.providers.credentials import AccountCredentialField
 from mureo.core.providers.extension import ExtensionProvider
 from mureo.core.providers.keyword import KeywordProvider
 from mureo.core.providers.models import (
@@ -59,6 +60,7 @@ from mureo.core.providers.registry import (
     clear_registry,
     default_registry,
     discover_providers,
+    get_account_credential_fields,
     get_provider,
     list_providers_by_capability,
     register_provider_class,
@@ -68,6 +70,7 @@ __all__ = [
     "CAPABILITY_NAMES",
     "PROVIDERS_ENTRY_POINT_GROUP",
     "SKILLS_ENTRY_POINT_GROUP",
+    "AccountCredentialField",
     "Ad",
     "AdStatus",
     "Audience",
@@ -103,6 +106,7 @@ __all__ = [
     "clear_registry",
     "default_registry",
     "discover_providers",
+    "get_account_credential_fields",
     "get_provider",
     "list_providers_by_capability",
     "parse_capabilities",

--- a/mureo/core/providers/base.py
+++ b/mureo/core/providers/base.py
@@ -84,6 +84,21 @@ class BaseProvider(Protocol):
     would be a breaking change for installed plugins; new behaviour
     should be added via secondary Protocols rather than expanding this
     one.
+
+    Optional class attributes (read defensively via :func:`getattr`
+    so the Protocol body itself stays stable across releases):
+
+    * ``account_credential_fields: tuple[AccountCredentialField, ...]``
+      — declares the per-account credential fields the provider needs
+      (e.g., Google Ads ``customer_id``, Meta Ads ``ad_account_id``).
+      Tooling that introspects providers (the ``mureo providers …``
+      CLI, configuration wizards, plugin authoring docs) reads this
+      via :func:`mureo.core.providers.get_account_credential_fields`
+      to render setup prompts, validate config, and document plugins
+      without hardcoding per-provider knowledge. Providers that omit
+      the attribute behave as before — tooling assumes "no
+      per-account fields" (operator-shared credentials are the entire
+      credential set).
     """
 
     name: str

--- a/mureo/core/providers/credentials.py
+++ b/mureo/core/providers/credentials.py
@@ -1,0 +1,63 @@
+"""Declarative metadata for a provider's per-account credential fields.
+
+A provider (built-in or third-party) often needs identifiers that
+vary per platform account — Google Ads ``customer_id``, Meta Ads
+``ad_account_id``, an analytics product's ``advertiser_id``. These
+are distinct from operator-shared OAuth credentials (developer
+tokens, refresh tokens) which typically apply to every account on
+the same platform.
+
+:class:`AccountCredentialField` lets a provider declare these
+per-account fields so introspection tooling — the ``mureo
+providers …`` CLI, configuration wizards, plugin authoring guides,
+third-party setup UIs — can render prompts, validate config, and
+document the provider's needs without hardcoding per-provider
+knowledge.
+
+The dataclass is **declarative metadata only**: it carries no
+behaviour and never reads or writes a value. Storage policy
+(env vars, ``~/.mureo/credentials.json``, an injected
+:class:`SecretStore`, etc.) is the consumer's concern.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class AccountCredentialField:
+    """One per-account credential field declared by a provider.
+
+    Attributes:
+        key: Stable snake_case identifier used in credential storage
+            and config (e.g., ``"customer_id"``). Treat as part of
+            the provider's public ABI — renaming the key after
+            release breaks any operator config that referenced it.
+        display_name: Human-readable label for CLI prompts and
+            wizard forms (e.g., ``"Customer ID"``).
+        placeholder: Example value shown as a form-input placeholder
+            (e.g., ``"123-456-7890"``). Never used as a default —
+            tooling that auto-applies the placeholder would surprise
+            operators. Default: ``""``.
+        required: ``True`` when the provider cannot function without
+            the field populated; tooling may then warn or block on a
+            missing value. Default: ``False``.
+        description: One-line operator-facing hint pointing at where
+            the value comes from (e.g., ``"From Google Ads UI >
+            Settings > Account details > Customer ID"``).
+            Default: ``""``.
+
+    The dataclass is JSON-friendly: ``dataclasses.asdict(field)``
+    returns a plain ``dict`` of primitive ``str`` / ``bool`` values
+    suitable for serialising over HTTP / writing to a config file.
+    """
+
+    key: str
+    display_name: str
+    placeholder: str = ""
+    required: bool = False
+    description: str = ""
+
+
+__all__ = ["AccountCredentialField"]

--- a/mureo/core/providers/registry.py
+++ b/mureo/core/providers/registry.py
@@ -86,6 +86,7 @@ from mureo.core.providers.base import (
     validate_provider_name,
 )
 from mureo.core.providers.capabilities import Capability
+from mureo.core.providers.credentials import AccountCredentialField
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -544,6 +545,59 @@ def clear_registry() -> None:
     default_registry.clear()
 
 
+def get_account_credential_fields(
+    provider: object,
+) -> tuple[AccountCredentialField, ...]:
+    """Return ``provider.account_credential_fields`` defensively.
+
+    The attribute is **optional** — providers shipped before this
+    helper existed (and providers that genuinely have no per-account
+    fields) do not declare it. Returning ``()`` for the missing case
+    lets introspection tooling render "no per-account configuration
+    needed" without raising :class:`AttributeError` at every call
+    site.
+
+    Shape validation is strict: if the provider declared the attribute
+    but the value is not a ``tuple``, or any element is not an
+    :class:`AccountCredentialField`, the helper raises
+    :class:`TypeError`. The error surfaces here rather than at the
+    consumer (the CLI / wizard rendering loop) so a malformed plugin
+    fails loudly at the boundary instead of silently degrading the UX.
+
+    Args:
+        provider: The provider instance to introspect. Any object
+            exposing the optional class attribute works — the helper
+            uses :func:`getattr` and never instantiates anything.
+
+    Returns:
+        The declared tuple of :class:`AccountCredentialField`s, or
+        the empty tuple when the attribute is absent.
+
+    Raises:
+        TypeError: The attribute is present but not a ``tuple``, or
+            it contains a non-:class:`AccountCredentialField` element.
+    """
+    # Mirror ``base._identity_hint`` semantics inline so the helper
+    # stays in the foundation layer above ``base`` without exporting
+    # additional private surface — a non-``str`` / empty ``name`` falls
+    # back to ``repr`` so the offending provider is locatable in logs.
+    raw_name = getattr(provider, "name", None)
+    identity = raw_name if isinstance(raw_name, str) and raw_name else repr(provider)
+    fields = getattr(provider, "account_credential_fields", ())
+    if not isinstance(fields, tuple):
+        raise TypeError(
+            f"{identity}.account_credential_fields must be a tuple, "
+            f"got {type(fields).__name__}"
+        )
+    for f in fields:
+        if not isinstance(f, AccountCredentialField):
+            raise TypeError(
+                f"{identity}.account_credential_fields entries must be "
+                f"AccountCredentialField, got {type(f).__name__}"
+            )
+    return cast("tuple[AccountCredentialField, ...]", fields)
+
+
 __all__ = [
     "PROVIDERS_ENTRY_POINT_GROUP",
     "SKILLS_ENTRY_POINT_GROUP",
@@ -553,6 +607,7 @@ __all__ = [
     "clear_registry",
     "default_registry",
     "discover_providers",
+    "get_account_credential_fields",
     "get_provider",
     "list_providers_by_capability",
     "register_provider_class",

--- a/tests/adapters/google_ads/test_adapter.py
+++ b/tests/adapters/google_ads/test_adapter.py
@@ -201,6 +201,26 @@ def test_capabilities_match_exact_expected_set() -> None:
 
 
 @pytest.mark.unit
+def test_account_credential_fields_declared_for_customer_id() -> None:
+    """Google Ads is per-account-identified by ``customer_id`` (10 digit,
+    optionally dash-separated). The declarative field lets generic
+    introspection tooling render setup prompts without hardcoding
+    per-provider knowledge."""
+    from mureo.core.providers.credentials import AccountCredentialField
+
+    fields = GoogleAdsAdapter.account_credential_fields  # type: ignore[attr-defined]
+    assert isinstance(fields, tuple)
+    assert len(fields) == 1
+    field = fields[0]
+    assert isinstance(field, AccountCredentialField)
+    assert field.key == "customer_id"
+    assert field.required is True
+    # Placeholder shape is a hint, not a regex contract — assert it
+    # carries the canonical Google Ads dashed form.
+    assert "123-456-7890" in field.placeholder
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize("forbidden", sorted(_FORBIDDEN_CAPABILITIES, key=str))
 def test_forbidden_capabilities_not_declared(forbidden: Capability) -> None:
     """Audience and bid capabilities are explicitly NOT declared in

--- a/tests/adapters/google_ads/test_imports.py
+++ b/tests/adapters/google_ads/test_imports.py
@@ -41,6 +41,7 @@ _ADAPTER_ALLOWED: frozenset[str] = frozenset(
         "mureo.core.providers",
         "mureo.core.providers.base",
         "mureo.core.providers.capabilities",
+        "mureo.core.providers.credentials",
         "mureo.core.providers.models",
         "mureo.core.providers.registry",
         "mureo.core.providers.campaign",

--- a/tests/adapters/meta_ads/test_adapter.py
+++ b/tests/adapters/meta_ads/test_adapter.py
@@ -254,6 +254,25 @@ def test_capabilities_match_exact_expected_set() -> None:
 
 
 @pytest.mark.unit
+def test_account_credential_fields_declared_for_ad_account_id() -> None:
+    """Meta Ads is per-account-identified by ``ad_account_id`` (the
+    ``act_*`` form Meta Ads Manager exposes). The declarative field
+    lets generic introspection tooling render setup prompts without
+    hardcoding per-provider knowledge."""
+    from mureo.core.providers.credentials import AccountCredentialField
+
+    fields = MetaAdsAdapter.account_credential_fields  # type: ignore[attr-defined]
+    assert isinstance(fields, tuple)
+    assert len(fields) == 1
+    field = fields[0]
+    assert isinstance(field, AccountCredentialField)
+    assert field.key == "ad_account_id"
+    assert field.required is True
+    # Placeholder hint carries the canonical ``act_`` prefix.
+    assert field.placeholder.startswith("act_")
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize("forbidden", sorted(_FORBIDDEN_CAPABILITIES, key=str))
 def test_forbidden_capabilities_not_declared(forbidden: Capability) -> None:
     """Keyword / extension / bid capabilities are explicitly NOT declared

--- a/tests/adapters/meta_ads/test_imports.py
+++ b/tests/adapters/meta_ads/test_imports.py
@@ -41,6 +41,7 @@ _ADAPTER_ALLOWED: frozenset[str] = frozenset(
         "mureo.core.providers",
         "mureo.core.providers.base",
         "mureo.core.providers.capabilities",
+        "mureo.core.providers.credentials",
         "mureo.core.providers.models",
         "mureo.core.providers.registry",
         "mureo.core.providers.campaign",

--- a/tests/core/providers/test_account_credential_field.py
+++ b/tests/core/providers/test_account_credential_field.py
@@ -1,0 +1,72 @@
+"""Tests for ``mureo.core.providers.credentials.AccountCredentialField``.
+
+The dataclass is declarative metadata only: it carries no behaviour,
+so the test surface is small — construction, immutability, defaults,
+and JSON-friendliness via ``dataclasses.asdict``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError, asdict
+
+import pytest
+
+from mureo.core.providers.credentials import AccountCredentialField
+
+
+@pytest.mark.unit
+def test_construct_with_required_and_optional_fields() -> None:
+    field = AccountCredentialField(
+        key="customer_id",
+        display_name="Customer ID",
+        placeholder="123-456-7890",
+        required=True,
+        description="10-digit Google Ads customer ID",
+    )
+    assert field.key == "customer_id"
+    assert field.display_name == "Customer ID"
+    assert field.placeholder == "123-456-7890"
+    assert field.required is True
+    assert field.description == "10-digit Google Ads customer ID"
+
+
+@pytest.mark.unit
+def test_optional_fields_default_to_documented_values() -> None:
+    """``placeholder``, ``required``, ``description`` are optional with
+    well-defined defaults so a provider can declare a single line."""
+    field = AccountCredentialField(key="account_id", display_name="Account ID")
+    assert field.placeholder == ""
+    assert field.required is False
+    assert field.description == ""
+
+
+@pytest.mark.unit
+def test_is_frozen() -> None:
+    field = AccountCredentialField(key="x", display_name="X")
+    with pytest.raises(FrozenInstanceError):
+        field.key = "y"  # type: ignore[misc]
+
+
+@pytest.mark.unit
+def test_asdict_is_json_friendly() -> None:
+    """Tooling that surfaces fields over an HTTP / JSON boundary uses
+    ``dataclasses.asdict``; the result must be a plain ``dict`` with
+    primitive values only (no nested dataclasses, no enums)."""
+    field = AccountCredentialField(
+        key="account_id",
+        display_name="Account ID",
+        placeholder="act_123",
+        required=True,
+        description="hint",
+    )
+    payload = asdict(field)
+    assert payload == {
+        "key": "account_id",
+        "display_name": "Account ID",
+        "placeholder": "act_123",
+        "required": True,
+        "description": "hint",
+    }
+    # Verify no exotic types slipped in.
+    for value in payload.values():
+        assert isinstance(value, (str, bool))

--- a/tests/core/providers/test_registry.py
+++ b/tests/core/providers/test_registry.py
@@ -28,6 +28,7 @@ import pytest
 # module ``mureo.core.providers.registry`` does not exist yet. That is
 # correct. The implementer (GREEN phase) will create it.
 from mureo.core.providers.capabilities import Capability
+from mureo.core.providers.credentials import AccountCredentialField
 from mureo.core.providers.registry import (  # noqa: E402
     ProviderEntry,
     RegistryWarning,
@@ -509,3 +510,105 @@ def test_clear_registry_resets_state(monkeypatch: pytest.MonkeyPatch) -> None:
         "clear_registry() must also invalidate the discovery cache so "
         "the next discover_providers() re-iterates entry_points."
     )
+
+
+# ---------------------------------------------------------------------------
+# get_account_credential_fields — defensive read of the optional
+# ``account_credential_fields`` class attribute (PR description: declarative
+# introspection so tooling can render setup prompts without per-provider
+# hardcoding).
+# ---------------------------------------------------------------------------
+
+
+class _ProviderWithoutAccountFields:
+    """Provider that does not declare ``account_credential_fields``.
+
+    Returning ``()`` from the accessor lets tooling render "no
+    per-account configuration needed" without raising ``AttributeError``.
+    """
+
+    name = "no_fields_provider"
+    display_name = "No fields"
+    capabilities = frozenset({Capability.READ_CAMPAIGNS})
+
+
+class _ProviderWithAccountFields:
+    name = "fields_provider"
+    display_name = "Fields"
+    capabilities = frozenset({Capability.READ_CAMPAIGNS})
+    account_credential_fields = (
+        AccountCredentialField(
+            key="account_id",
+            display_name="Account ID",
+            placeholder="acct-1",
+            required=True,
+            description="hint",
+        ),
+    )
+
+
+class _BadAccountFieldsNotTuple:
+    name = "bad_not_tuple"
+    display_name = "Bad not tuple"
+    capabilities = frozenset({Capability.READ_CAMPAIGNS})
+    account_credential_fields = ["should be tuple"]  # list, not tuple
+
+
+class _BadAccountFieldsWrongElement:
+    name = "bad_wrong_element"
+    display_name = "Bad wrong element"
+    capabilities = frozenset({Capability.READ_CAMPAIGNS})
+    account_credential_fields = ("not a dataclass instance",)  # str, not field
+
+
+@pytest.mark.unit
+def test_account_fields_returns_empty_when_attr_absent() -> None:
+    from mureo.core.providers.registry import get_account_credential_fields
+
+    assert get_account_credential_fields(_ProviderWithoutAccountFields()) == ()
+
+
+@pytest.mark.unit
+def test_account_fields_returns_declared_tuple() -> None:
+    from mureo.core.providers.registry import get_account_credential_fields
+
+    fields = get_account_credential_fields(_ProviderWithAccountFields())
+    assert isinstance(fields, tuple)
+    assert len(fields) == 1
+    field = fields[0]
+    assert isinstance(field, AccountCredentialField)
+    assert field.key == "account_id"
+    assert field.required is True
+
+
+@pytest.mark.unit
+def test_account_fields_raises_for_non_tuple() -> None:
+    from mureo.core.providers.registry import get_account_credential_fields
+
+    with pytest.raises(TypeError, match="must be a tuple"):
+        get_account_credential_fields(_BadAccountFieldsNotTuple())
+
+
+@pytest.mark.unit
+def test_account_fields_raises_for_wrong_element_type() -> None:
+    from mureo.core.providers.registry import get_account_credential_fields
+
+    with pytest.raises(TypeError, match="must be AccountCredentialField"):
+        get_account_credential_fields(_BadAccountFieldsWrongElement())
+
+
+@pytest.mark.unit
+def test_account_fields_helper_is_exported_from_package() -> None:
+    """Public surface — consumers should reach the helper via
+    ``mureo.core.providers`` without knowing the registry submodule."""
+    from mureo.core.providers import (
+        AccountCredentialField as ReexportedField,
+    )
+    from mureo.core.providers import (
+        get_account_credential_fields,
+    )
+
+    assert callable(get_account_credential_fields)
+    # Sanity: the dataclass is also re-exported from the package root.
+    field = ReexportedField(key="x", display_name="X")
+    assert field.key == "x"


### PR DESCRIPTION
## Summary

Provider plugins (built-in `google_ads` / `meta_ads`, and third-party plugins discovered via the `mureo.providers` entry-point group) can now declare an optional `account_credential_fields: tuple[AccountCredentialField, ...]` class attribute so introspection tooling — the `mureo providers …` CLI, configuration wizards, plugin authoring guides — can render setup prompts, validate config, and document plugins without hardcoding per-provider knowledge.

> Plugins declare their per-account credential needs so tooling can render setup prompts, validate config, and document plugins without hardcoding per-provider knowledge. Existing providers without this declaration behave unchanged.

```python
from mureo.core.providers import AccountCredentialField

class MyAdsProvider:
    name = "my_ads"
    display_name = "My Ads"
    capabilities = frozenset({...})
    account_credential_fields = (
        AccountCredentialField(
            key="advertiser_id",
            display_name="Advertiser ID",
            placeholder="adv-12345",
            required=True,
            description="From the MyAds dashboard.",
        ),
    )
```

## Public surface added to `mureo.core.providers`

| Name | Kind | Purpose |
|---|---|---|
| `AccountCredentialField` | frozen dataclass | One per-account credential descriptor: `key`, `display_name`, `placeholder=""`, `required=False`, `description=""`. Primitive `str` / `bool` only so `dataclasses.asdict` is JSON-serialisable. |
| `get_account_credential_fields(provider)` | function | Defensive accessor — returns `()` for providers that do not declare the attribute, raises `TypeError` when the declaration is malformed (non-tuple or wrong element type). |

`BaseProvider` Protocol body is **unchanged**. The new attribute is documented as optional in the `BaseProvider` docstring and is read via `getattr` so `@runtime_checkable` `isinstance()` results do not flip for any existing plugin.

## Built-in adapter updates

- `mureo.adapters.google_ads.GoogleAdsAdapter` declares `customer_id` (placeholder `"123-456-7890"`, required). MCC `login_customer_id` is intentionally excluded — it identifies the operator's manager account and is shared across every Google Ads account the operator manages (operator-shared OAuth-level credential, not per-account).
- `mureo.adapters.meta_ads.MetaAdsAdapter` declares `ad_account_id` (placeholder `"act_1234567890"`, required). Token / app id / app secret are operator-shared in the common Business Manager setup and live outside this declaration.

## Backward compatibility

- Plugins that do not declare `account_credential_fields` continue to register and discover unchanged; `get_account_credential_fields()` returns `()`, which downstream tooling treats as "no per-account configuration needed."
- The `BaseProvider` Protocol body is unchanged so `@runtime_checkable` `isinstance(obj, BaseProvider)` keeps returning the same value for every existing plugin.
- `get_account_credential_fields` validation raises `TypeError` only when a plugin actively declares a malformed attribute — pure additive footprint for everyone else.

## Plugin author docs

`docs/plugin-authoring.md` §3 (`BaseProvider`) gains a *Declaring per-account credential fields (optional)* subsection covering the dataclass shape, default values, and the accessor's defensive-read / strict-validation semantics — plus the operator-shared / per-account credential split shown above.

## Test plan

- [ ] CI lint (`ruff check mureo/`, `black --check mureo/`) — clean locally
- [ ] CI tests (Python 3.10 / 3.11 / 3.12 + Windows) — 11 new unit tests + 2 import-allowlist updates; 394 tests pass across `tests/core/providers/` + `tests/adapters/`
- [ ] CodeQL — no new findings expected; net additions are pure-Python `@dataclass(frozen=True)` + a defensive `getattr`-based accessor. No `eval` / subprocess / shell / network.
- [ ] Manual: drop into a Python shell, import `from mureo.core.providers import get_account_credential_fields, AccountCredentialField`, run `get_account_credential_fields(GoogleAdsAdapter)` and confirm it returns the declared tuple.
- [ ] Manual: install a pre-feature third-party plugin (anything that does not declare `account_credential_fields`); confirm discovery still loads it and `get_account_credential_fields(...)` returns `()`.
