### PR TITLE
chore(release): v0.9.7

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mureo",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Your local-first AI ad ops crew for Google Ads, Meta Ads, Search Console & GA4. mureo sits on top of the official ad-platform MCPs, gates every change against your strategy, correlates outcomes locally, and keeps an auditable decision log — credentials never leave your machine.",
   "author": {
     "name": "Logly Inc.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.7] - 2026-05-22
+
 ### Added — Optional `account_credential_fields` for self-describing providers
 
 Provider plugins (built-in `google_ads` / `meta_ads`, and third-party plugins discovered via the `mureo.providers` entry-point group) can now declare an optional `account_credential_fields: tuple[AccountCredentialField, ...]` class attribute so introspection tooling — the `mureo providers …` CLI, configuration wizards, plugin authoring guides — can render setup prompts, validate config, and document plugins without hardcoding per-provider knowledge.

--- a/mureo/__init__.py
+++ b/mureo/__init__.py
@@ -1,3 +1,3 @@
 """mureo — your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."""
 
-__version__ = "0.9.6"
+__version__ = "0.9.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mureo"
-version = "0.9.6"
+version = "0.9.7"
 description = "Your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."
 requires-python = ">=3.10"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Releases v0.9.7 covering the self-describing-providers work in #131.

### Public addition

Provider plugins can now declare an optional `account_credential_fields: tuple[AccountCredentialField, ...]` class attribute so introspection tooling renders setup prompts, validates config, and documents plugins without hardcoding per-provider knowledge.

```python
from mureo.core.providers import AccountCredentialField

class MyAdsProvider:
    name = "my_ads"
    display_name = "My Ads"
    capabilities = frozenset({...})
    account_credential_fields = (
        AccountCredentialField(
            key="advertiser_id",
            display_name="Advertiser ID",
            placeholder="adv-12345",
            required=True,
            description="From the MyAds dashboard.",
        ),
    )
```

### Built-in adapter updates

- `GoogleAdsAdapter` declares `customer_id` (placeholder `"123-456-7890"`, required).
- `MetaAdsAdapter` declares `ad_account_id` (placeholder `"act_1234567890"`, required).

Operator-shared OAuth-level credentials (developer token, app secret, refresh token, MCC `login_customer_id`) intentionally remain outside this layer.

### Backward compatibility

- `BaseProvider` Protocol body is unchanged — the new attribute is read via `getattr`, so every pre-feature plugin keeps loading without modification.
- `get_account_credential_fields()` returns `()` for plugins that do not declare the attribute; consumers treat that as "no per-account configuration needed."

### Version bump

- `.claude-plugin/plugin.json`: 0.9.6 → 0.9.7
- `mureo/__init__.py`: 0.9.6 → 0.9.7
- `pyproject.toml`: 0.9.6 → 0.9.7

## Test plan

- [ ] All CI jobs green (lint, test 3.10/3.11/3.12, test-windows, CodeQL, Analyze)
- [ ] Version parity test (`tests/test_plugin_manifests.py::test_plugin_version_matches_pyproject`) passes
- [ ] Tag `v0.9.7` after merge → GitHub Release published → `release.yml` workflow pushes to PyPI
