### PR TITLE
fix(meta_ads): no silent fallback to last_7d for unknown `period` values (#134)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — Meta Ads `period` argument no longer silently falls back to `last_7d` (#134)
+
+The Meta Ads MCP tools' `period` argument advertised `last_14d`, `last_90d`, and explicit `YYYY-MM-DD..YYYY-MM-DD` ranges, but the implementation accepted only six hard-coded preset names and silently returned `last_7d` data for anything else. Period-over-period analyses (`meta_ads_analysis_performance`, `meta_ads_analysis_cost`) doubled the bug: the "previous" window was likewise mapped via a tiny dict that, for `last_7d`, returned `last_30d` — a superset that overlaps the current window, making every delta meaningless.
+
+This release wires the full advertised surface through to the Meta Graph API:
+
+- New `mureo/meta_ads/_period.py`: `resolve_period(period)` returns either `("date_preset", str)` or `("time_range", (since, until))`. Unknown values raise `ValueError` — there is no silent fallback. ISO date validation, ordering, and `..` separator counting all surface clear errors at the boundary.
+- `get_performance_report` and `get_breakdown_report` now build their request params via the resolver, so a `YYYY-MM-DD..YYYY-MM-DD` `period` is forwarded as Meta's `time_range`, and `last_14d` / `last_90d` are forwarded as `date_preset` (instead of being silently downgraded).
+- `previous_period(period, *, today=…)` returns a same-length window that sits immediately before the current window. For `last_7d` the previous block is the 7 days before that — never the `last_30d` superset. `this_month` round-trips to `last_month`; `last_month` returns an explicit calendar-month range so callers don't need to do calendar arithmetic themselves.
+- `AnalysisMixin.investigate_cost` uses the new helper, so its current/previous comparison is correct for every accepted `period` shape (including custom date ranges).
+
+Regression tests (`tests/test_meta_ads_period.py`, plus four additions to `tests/test_meta_ads_operations.py`) pin every preset name, the explicit-range path, and the "previous must not overlap current" invariant.
+
 ## [0.9.7] - 2026-05-22
 
 ### Added — Optional `account_credential_fields` for self-describing providers

--- a/mureo/mcp/_tools_meta_ads_insights.py
+++ b/mureo/mcp/_tools_meta_ads_insights.py
@@ -27,7 +27,8 @@ _PERIOD_PARAM = {
     "description": (
         "Analysis window. Accepts Meta predefined ranges ('today', "
         "'yesterday', 'last_7d', 'last_14d', 'last_30d' (default), "
-        "'last_90d') or explicit 'YYYY-MM-DD..YYYY-MM-DD'. Longer "
+        "'last_90d', 'this_month', 'last_month') or explicit "
+        "'YYYY-MM-DD..YYYY-MM-DD' (both endpoints inclusive). Longer "
         "windows cost more Graph API quota."
     ),
 }

--- a/mureo/meta_ads/_analysis.py
+++ b/mureo/meta_ads/_analysis.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from mureo.meta_ads._period import previous_period as _previous_period
+
 logger = logging.getLogger(__name__)
 
 
@@ -132,15 +134,20 @@ class AnalysisMixin:
         campaign_id: str,
         period: str = "last_7d",
     ) -> dict[str, Any]:
-        """Investigate causes of ad spend increase or CPA degradation."""
-        prev_map = {"last_7d": "last_30d", "last_30d": "last_month"}
-        prev_period = prev_map.get(period, "last_30d")
+        """Investigate causes of ad spend increase or CPA degradation.
+
+        The previous-period window is computed as the same-length
+        block immediately preceding ``period`` (fix for #134 — the
+        pre-fix code mapped ``last_7d`` to ``last_30d``, a superset
+        rather than a previous, which made every delta meaningless).
+        """
+        prev_period_str = _previous_period(period)
 
         current = await self.get_performance_report(
             campaign_id=campaign_id, period=period
         )
         previous = await self.get_performance_report(
-            campaign_id=campaign_id, period=prev_period
+            campaign_id=campaign_id, period=prev_period_str
         )
 
         if not current:

--- a/mureo/meta_ads/_insights.py
+++ b/mureo/meta_ads/_insights.py
@@ -4,17 +4,9 @@ import json
 import logging
 from typing import Any
 
-logger = logging.getLogger(__name__)
+from mureo.meta_ads._period import previous_period, resolve_period
 
-# Meta API date_preset mapping
-_PERIOD_TO_DATE_PRESET: dict[str, str] = {
-    "today": "today",
-    "yesterday": "yesterday",
-    "last_7d": "last_7d",
-    "last_30d": "last_30d",
-    "this_month": "this_month",
-    "last_month": "last_month",
-}
+logger = logging.getLogger(__name__)
 
 # Common Insights retrieval fields
 _INSIGHTS_FIELDS = (
@@ -29,6 +21,17 @@ _INSIGHTS_FIELDS = (
 # Protocol's ``DailyReportRow`` only needs date, volume, cost, and
 # action counts.
 _TIME_RANGE_INSIGHTS_FIELDS = "impressions,clicks,spend,actions,date_start,date_stop"
+
+
+def _period_params(period: str) -> dict[str, Any]:
+    """Build the Meta API date parameters from a ``period`` string.
+
+    Returns a fresh dict with exactly one of ``date_preset`` or
+    ``time_range`` populated. Unknown ``period`` values raise
+    :class:`ValueError` — fix for #134 (no silent fallback to
+    ``last_7d``).
+    """
+    return resolve_period(period).to_api_params()
 
 
 class InsightsMixin:
@@ -50,23 +53,24 @@ class InsightsMixin:
         period: str = "last_7d",
         level: str = "campaign",
     ) -> list[dict[str, Any]]:
-        """Get performance report
+        """Get performance report.
 
         Args:
             campaign_id: Campaign ID (limits to this campaign when specified)
-            period: Period (today, yesterday, last_7d, last_30d, this_month, last_month)
+            period: Either a documented Meta ``date_preset`` (``today``,
+                ``yesterday``, ``last_7d``, ``last_14d``, ``last_30d``,
+                ``last_90d``, ``this_month``, ``last_month``) or an
+                explicit ``YYYY-MM-DD..YYYY-MM-DD`` range. Unknown
+                values raise :class:`ValueError` (no silent fallback —
+                fix for #134).
             level: Aggregation level (campaign, adset, ad)
 
         Returns:
             List of insight data.
         """
-        date_preset = _PERIOD_TO_DATE_PRESET.get(period, "last_7d")
-
-        params: dict[str, Any] = {
-            "fields": _INSIGHTS_FIELDS,
-            "date_preset": date_preset,
-            "level": level,
-        }
+        params: dict[str, Any] = _period_params(period)
+        params["fields"] = _INSIGHTS_FIELDS
+        params["level"] = level
 
         if campaign_id:
             path = f"/{campaign_id}/insights"
@@ -123,20 +127,18 @@ class InsightsMixin:
     ) -> dict[str, Any]:
         """Comprehensively analyze campaign performance.
 
-        Compares current and previous period insights to identify issues.
+        Compares current and previous period insights to identify
+        issues. The previous-period window is computed as the
+        same-length block immediately before ``period`` (fix for
+        #134 — the pre-fix code mapped ``last_7d`` to ``last_30d``,
+        a superset that overlapped the current window and made every
+        delta meaningless).
         """
         current = await self.get_performance_report(
             campaign_id=campaign_id, period=period
         )
 
-        # Get previous period data
-        prev_period_map = {
-            "last_7d": "last_30d",
-            "last_30d": "last_month",
-            "today": "yesterday",
-            "yesterday": "last_7d",
-        }
-        prev_period = prev_period_map.get(period, "last_30d")
+        prev_period = previous_period(period)
         previous = await self.get_performance_report(
             campaign_id=campaign_id, period=prev_period
         )
@@ -297,13 +299,9 @@ class InsightsMixin:
         Returns:
             List of insight data with breakdowns.
         """
-        date_preset = _PERIOD_TO_DATE_PRESET.get(period, "last_7d")
-
-        params: dict[str, Any] = {
-            "fields": _INSIGHTS_FIELDS,
-            "date_preset": date_preset,
-            "breakdowns": breakdown,
-        }
+        params: dict[str, Any] = _period_params(period)
+        params["fields"] = _INSIGHTS_FIELDS
+        params["breakdowns"] = breakdown
 
         result = await self._get(f"/{campaign_id}/insights", params)
         return result.get("data", [])  # type: ignore[no-any-return]

--- a/mureo/meta_ads/_period.py
+++ b/mureo/meta_ads/_period.py
@@ -1,0 +1,259 @@
+"""Period argument resolution for Meta Ads insights requests.
+
+The Meta Graph API accepts either ``date_preset`` (a documented
+named window like ``last_7d``) or ``time_range`` (an explicit
+``{"since": …, "until": …}`` pair). The Meta Ads MCP tools expose a
+single ``period`` string that may be either shape — this module
+normalises it into one of those API shapes, and rejects unknown
+values with :class:`ValueError` rather than silently degrading the
+request to ``last_7d`` (Issue #134).
+
+A companion :func:`previous_period` builds the corresponding prior
+window so period-over-period analyses (``meta_ads_analysis_cost``,
+``meta_ads_analysis_performance``) can return a previous block that
+genuinely sits immediately before the current block — not the
+last_30d superset of last_7d that the pre-fix code produced.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import date, timedelta
+from typing import Any, Final
+
+# The Meta ``date_preset`` values advertised by the Meta Ads MCP tool
+# descriptions. Keep aligned with ``_PERIOD_PARAM`` in
+# ``mureo/mcp/_tools_meta_ads_insights.py`` so the surface and the
+# implementation never drift apart again.
+_DATE_PRESETS: Final[frozenset[str]] = frozenset(
+    {
+        "today",
+        "yesterday",
+        "last_7d",
+        "last_14d",
+        "last_30d",
+        "last_90d",
+        "this_month",
+        "last_month",
+    }
+)
+
+# Length-in-days for the presets that map to a fixed-length window.
+# Calendar-relative presets (``this_month`` / ``last_month``) are
+# absent on purpose — their length depends on the current month, so
+# consumers must treat them separately.
+_PRESET_DAYS: Final[dict[str, int]] = {
+    # ``today`` and ``yesterday`` share length 1 but anchor at
+    # different days — keep that in mind when reasoning about windows.
+    "today": 1,
+    "yesterday": 1,
+    "last_7d": 7,
+    "last_14d": 14,
+    "last_30d": 30,
+    "last_90d": 90,
+}
+
+
+@dataclass(frozen=True)
+class ResolvedPeriod:
+    """Result of resolving a ``period`` string.
+
+    Exactly one of ``date_preset`` / ``time_range`` is populated.
+    ``time_range`` is a ``(since, until)`` tuple of ``YYYY-MM-DD``
+    strings, both endpoints inclusive (Meta's documented convention).
+    """
+
+    date_preset: str | None = None
+    time_range: tuple[str, str] | None = None
+
+    @property
+    def is_preset(self) -> bool:
+        return self.date_preset is not None
+
+    @property
+    def days(self) -> int:
+        """Inclusive length of the window in days.
+
+        For an explicit ``time_range`` this is ``until - since + 1``.
+        For a fixed-length preset (``last_Nd`` / ``today`` /
+        ``yesterday``) this is the documented length. For a
+        calendar-relative preset (``this_month`` / ``last_month``)
+        the value is ``0`` — there is no fixed length, and callers
+        that need one must resolve to an explicit range first.
+        """
+        if self.time_range is not None:
+            since, until = self.time_range
+            return (date.fromisoformat(until) - date.fromisoformat(since)).days + 1
+        return _PRESET_DAYS.get(self.date_preset or "", 0)
+
+    def to_api_params(self) -> dict[str, Any]:
+        """Build the Meta API request parameters for this resolved
+        period.
+
+        Returns a fresh dict with exactly one key — ``date_preset`` or
+        ``time_range`` — depending on which form the resolver chose.
+        The ``time_range`` value is the JSON-encoded
+        ``{"since": …, "until": …}`` shape Meta expects.
+
+        Raises:
+            RuntimeError: The dataclass somehow has neither field
+                populated. ``resolve_period`` cannot construct such
+                an instance, so this only fires if an external caller
+                ignored the API and built a ``ResolvedPeriod()`` by
+                hand.
+        """
+        if self.date_preset is not None:
+            return {"date_preset": self.date_preset}
+        if self.time_range is not None:
+            since, until = self.time_range
+            return {"time_range": json.dumps({"since": since, "until": until})}
+        raise RuntimeError(
+            "ResolvedPeriod is empty: neither date_preset nor "
+            "time_range is set. Build via resolve_period(...)."
+        )
+
+
+def resolve_period(period: str) -> ResolvedPeriod:
+    """Resolve a ``period`` string to a Meta API request shape.
+
+    Args:
+        period: Either a documented Meta ``date_preset`` name
+            (``today``, ``yesterday``, ``last_7d``, ``last_14d``,
+            ``last_30d``, ``last_90d``, ``this_month``,
+            ``last_month``) or an explicit ``YYYY-MM-DD..YYYY-MM-DD``
+            range with both endpoints inclusive.
+
+    Returns:
+        A :class:`ResolvedPeriod` describing whether the caller should
+        send ``date_preset`` or ``time_range`` to Meta.
+
+    Raises:
+        ValueError: ``period`` is empty, not a string, not a
+            documented preset, contains the wrong number of ``..``
+            separators, has a malformed ISO date, or has
+            ``since`` > ``until``.
+    """
+    if not isinstance(period, str) or not period:
+        raise ValueError(f"period must be a non-empty string, got {period!r}")
+    if period in _DATE_PRESETS:
+        return ResolvedPeriod(date_preset=period)
+    if ".." in period:
+        return _resolve_range(period)
+    raise ValueError(
+        f"period {period!r} is not a Meta date_preset and not a valid "
+        f"YYYY-MM-DD..YYYY-MM-DD range. Accepted presets: "
+        f"{sorted(_DATE_PRESETS)}"
+    )
+
+
+def _resolve_range(period: str) -> ResolvedPeriod:
+    parts = period.split("..")
+    if len(parts) != 2:
+        raise ValueError(
+            f"period {period!r} contains multiple '..' separators; "
+            f"expected exactly one (YYYY-MM-DD..YYYY-MM-DD)"
+        )
+    since_str, until_str = parts[0], parts[1]
+    try:
+        since = date.fromisoformat(since_str)
+        until = date.fromisoformat(until_str)
+    except ValueError as exc:
+        raise ValueError(
+            f"period {period!r} contains a malformed date (expected "
+            f"YYYY-MM-DD..YYYY-MM-DD): {exc}"
+        ) from exc
+    if since > until:
+        raise ValueError(
+            f"period {period!r}: 'since' ({since_str}) is after 'until' "
+            f"({until_str})"
+        )
+    return ResolvedPeriod(time_range=(since_str, until_str))
+
+
+def previous_period(period: str, *, today: date | None = None) -> str:
+    """Return the previous-window for ``period`` in the same shape.
+
+    For an explicit ``YYYY-MM-DD..YYYY-MM-DD`` range, the previous
+    window is the same-length window immediately before ``since``.
+    For ``this_month``, the natural previous is the matching preset
+    name ``last_month``. For ``last_month``, return an explicit
+    ``YYYY-MM-DD..YYYY-MM-DD`` for the calendar month before that.
+    For fixed-length presets (``today`` / ``yesterday`` /
+    ``last_Nd``) the previous is an explicit range that does NOT
+    overlap the current window — this is the bug fix at the heart of
+    Issue #134, where the pre-fix code mapped ``last_7d`` to
+    ``last_30d`` (a superset, not a previous).
+
+    Args:
+        period: A value :func:`resolve_period` accepts.
+        today: The anchor date for converting presets to explicit
+            ranges. Defaults to :func:`date.today`. Injectable for
+            deterministic testing.
+
+    Returns:
+        A string suitable for round-tripping through
+        :func:`resolve_period` — either a preset name (``"yesterday"``
+        for ``"today"``; ``"last_month"`` for ``"this_month"``) or a
+        ``YYYY-MM-DD..YYYY-MM-DD`` range. The asymmetry is
+        deliberate: when a documented preset cleanly names the prior
+        window, we return the cheaper preset form so the Meta API
+        call doesn't carry an explicit range.
+
+        ``last_Nd`` is treated as "the N complete days ending
+        yesterday" — the most conservative interpretation of Meta's
+        own definition. The returned previous-window therefore ends
+        at ``anchor - N`` and never overlaps the current window, but
+        the operator should be aware that today's partial-day data
+        is in neither window when comparing.
+
+    Raises:
+        ValueError: Propagated from :func:`resolve_period` for any
+            invalid ``period``.
+    """
+    anchor = today if today is not None else date.today()
+
+    # ``this_month`` has a natural preset previous; round-tripping
+    # through preset names keeps the Meta API call cheap.
+    if period == "this_month":
+        return "last_month"
+
+    if period == "last_month":
+        first_of_this = anchor.replace(day=1)
+        last_of_last = first_of_this - timedelta(days=1)
+        first_of_last = last_of_last.replace(day=1)
+        last_of_prev = first_of_last - timedelta(days=1)
+        first_of_prev = last_of_prev.replace(day=1)
+        return f"{first_of_prev.isoformat()}..{last_of_prev.isoformat()}"
+
+    rp = resolve_period(period)
+
+    if rp.time_range is not None:
+        since = date.fromisoformat(rp.time_range[0])
+        length = rp.days
+        prev_until = since - timedelta(days=1)
+        prev_since = prev_until - timedelta(days=length - 1)
+        return f"{prev_since.isoformat()}..{prev_until.isoformat()}"
+
+    # Fixed-length presets. ``last_Nd`` ends at the most recent
+    # complete day (conventionally yesterday); ``today`` is itself;
+    # ``yesterday`` is the single day before today.
+    if rp.date_preset == "today":
+        return "yesterday"
+    if rp.date_preset == "yesterday":
+        d = anchor - timedelta(days=2)
+        return f"{d.isoformat()}..{d.isoformat()}"
+
+    days = _PRESET_DAYS[rp.date_preset or ""]
+    cur_until = anchor - timedelta(days=1)
+    cur_since = cur_until - timedelta(days=days - 1)
+    prev_until = cur_since - timedelta(days=1)
+    prev_since = prev_until - timedelta(days=days - 1)
+    return f"{prev_since.isoformat()}..{prev_until.isoformat()}"
+
+
+__all__ = [
+    "ResolvedPeriod",
+    "previous_period",
+    "resolve_period",
+]

--- a/tests/test_meta_ads_operations.py
+++ b/tests/test_meta_ads_operations.py
@@ -548,6 +548,46 @@ class TestInsightsMixin:
         assert "/camp1/insights" in client._get.call_args[0][0]
 
     @pytest.mark.asyncio
+    async def test_get_performance_report_forwards_custom_range_as_time_range(
+        self, client
+    ) -> None:
+        """Issue #134 regression: ``YYYY-MM-DD..YYYY-MM-DD`` must be
+        forwarded to Meta as ``time_range``, not silently degraded to
+        ``last_7d`` via ``date_preset``."""
+        client._get = AsyncMock(return_value={"data": []})
+        await client.get_performance_report(period="2026-05-01..2026-05-14")
+        params = client._get.call_args[0][1]
+        assert "date_preset" not in params, (
+            f"custom range must not be coerced into a date_preset; "
+            f"got params={params}"
+        )
+        assert params["time_range"] == json.dumps(
+            {"since": "2026-05-01", "until": "2026-05-14"}
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("preset", ["last_14d", "last_90d"])
+    async def test_get_performance_report_accepts_documented_presets(
+        self, client, preset
+    ) -> None:
+        """``last_14d`` and ``last_90d`` are advertised in the tool
+        description; #134 was that they silently fell back to
+        ``last_7d``. Now they must round-trip into ``date_preset``."""
+        client._get = AsyncMock(return_value={"data": []})
+        await client.get_performance_report(period=preset)
+        params = client._get.call_args[0][1]
+        assert params.get("date_preset") == preset
+
+    @pytest.mark.asyncio
+    async def test_get_performance_report_rejects_unknown_period(self, client) -> None:
+        """No silent fallback. The pre-fix code accepted any string and
+        returned last_7d data — silently misleading. Now an unknown
+        ``period`` must raise so the operator hears about it."""
+        client._get = AsyncMock(return_value={"data": []})
+        with pytest.raises(ValueError):
+            await client.get_performance_report(period="last_60d")
+
+    @pytest.mark.asyncio
     async def test_analyze_performance_no_data(self, client) -> None:
         client._get = AsyncMock(return_value={"data": []})
         result = await client.analyze_performance()
@@ -717,6 +757,44 @@ class TestAnalysisMixin:
         result = await client.investigate_cost("camp1")
         assert len(result["findings"]) > 0
         assert any("increased" in f.lower() for f in result["findings"])
+
+    @pytest.mark.asyncio
+    async def test_investigate_cost_previous_window_does_not_overlap_current(
+        self, client
+    ) -> None:
+        """Issue #134 regression: the pre-fix code mapped
+        ``last_7d``-as-current to ``last_30d``-as-previous, which is a
+        SUPERSET (it overlaps last_7d entirely). Now the previous
+        window must be a same-length block that does not overlap.
+
+        We capture the ``period`` strings passed to
+        ``get_performance_report`` and verify the previous one parses
+        to a 7-day range immediately before today's last 7 days."""
+        from datetime import date
+
+        from mureo.meta_ads._period import resolve_period
+
+        captured: list[str] = []
+
+        async def fake_report(**kwargs):
+            captured.append(kwargs.get("period", ""))
+            return [{"spend": "1", "cpc": "1", "clicks": "1"}]
+
+        client.get_performance_report = AsyncMock(side_effect=fake_report)
+        await client.investigate_cost("camp1", period="last_7d")
+        assert captured[0] == "last_7d"
+        prev_str = captured[1]
+        # Must NOT be the broken pre-fix value.
+        assert prev_str != "last_30d", (
+            "previous-window must not be the last_30d superset of "
+            "last_7d (pre-#134 bug)"
+        )
+        prev_rp = resolve_period(prev_str)
+        # And the parsed window must be 7 days long and end before today.
+        assert prev_rp.days == 7
+        assert prev_rp.time_range is not None
+        prev_until_str = prev_rp.time_range[1]
+        assert date.fromisoformat(prev_until_str) < date.today()
 
     @pytest.mark.asyncio
     async def test_compare_ads_no_data(self, client) -> None:

--- a/tests/test_meta_ads_period.py
+++ b/tests/test_meta_ads_period.py
@@ -1,0 +1,201 @@
+"""Tests for ``mureo.meta_ads._period`` — period argument resolution.
+
+Covers the contract that fixes #134:
+
+* Known Meta ``date_preset`` names resolve to themselves.
+* ``YYYY-MM-DD..YYYY-MM-DD`` resolves to an explicit ``time_range``.
+* Anything else raises ``ValueError`` (no silent fallback to
+  ``last_7d``).
+* ``previous_period`` returns the prior same-length window, with
+  every result either a preset name the API accepts or an explicit
+  range — never overlapping the current window.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from mureo.meta_ads._period import ResolvedPeriod, previous_period, resolve_period
+
+# ---------------------------------------------------------------------------
+# resolve_period
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "name",
+    [
+        "today",
+        "yesterday",
+        "last_7d",
+        "last_14d",
+        "last_30d",
+        "last_90d",
+        "this_month",
+        "last_month",
+    ],
+)
+def test_resolve_known_preset_returns_preset(name: str) -> None:
+    rp = resolve_period(name)
+    assert isinstance(rp, ResolvedPeriod)
+    assert rp.is_preset is True
+    assert rp.date_preset == name
+    assert rp.time_range is None
+
+
+@pytest.mark.unit
+def test_resolve_custom_range_returns_time_range() -> None:
+    rp = resolve_period("2026-05-01..2026-05-14")
+    assert rp.is_preset is False
+    assert rp.date_preset is None
+    assert rp.time_range == ("2026-05-01", "2026-05-14")
+
+
+@pytest.mark.unit
+def test_resolve_single_day_range_is_supported() -> None:
+    """An explicit ``since==until`` is the canonical way to query one
+    day from the past — Meta accepts it; the resolver must too."""
+    rp = resolve_period("2026-05-01..2026-05-01")
+    assert rp.time_range == ("2026-05-01", "2026-05-01")
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "",
+        "last_7days",  # the user said days, not d
+        "last_60d",  # not in the documented preset surface
+        "May 1-14",  # human-readable shorthand
+        "2026/05/01..2026/05/14",  # slash, not iso
+        "2026-05-01..2026-05-14..2026-05-21",  # too many separators
+        "2026-13-01..2026-05-14",  # bogus month
+        "2026-05-14..2026-05-01",  # since > until
+        "2026-05-01..",  # missing until — looks like a range but isn't
+        "..2026-05-14",  # missing since
+        " last_7d ",  # whitespace-padded preset name; no implicit strip
+        "2026-05-01 .. 2026-05-14",  # whitespace around separator
+    ],
+)
+def test_resolve_unknown_value_raises_value_error(bad: str) -> None:
+    """No silent fallback. An operator who typed a nonsense period
+    must hear about it instead of receiving last_7d data labelled
+    with their period (Issue #134)."""
+    with pytest.raises(ValueError):
+        resolve_period(bad)
+
+
+@pytest.mark.unit
+def test_resolve_non_string_raises_value_error() -> None:
+    with pytest.raises(ValueError):
+        resolve_period(None)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# ResolvedPeriod.days
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("today", 1),
+        ("yesterday", 1),
+        ("last_7d", 7),
+        ("last_14d", 14),
+        ("last_30d", 30),
+        ("last_90d", 90),
+    ],
+)
+def test_preset_days(name: str, expected: int) -> None:
+    assert resolve_period(name).days == expected
+
+
+@pytest.mark.unit
+def test_custom_range_days_is_inclusive() -> None:
+    """Meta treats both endpoints of a time_range as inclusive, so a
+    14-day window from May 1 through May 14 reports 14 days, not 13.
+    Off-by-one here propagates straight into previous_period."""
+    rp = resolve_period("2026-05-01..2026-05-14")
+    assert rp.days == 14
+
+
+# ---------------------------------------------------------------------------
+# previous_period
+# ---------------------------------------------------------------------------
+
+
+_FIXED_TODAY = date(2026, 5, 22)
+
+
+@pytest.mark.unit
+def test_previous_for_custom_range_is_same_length_immediately_before() -> None:
+    """May 1–14 (14 days) → prior 14 days ending Apr 30."""
+    prev = previous_period("2026-05-01..2026-05-14", today=_FIXED_TODAY)
+    assert prev == "2026-04-17..2026-04-30"
+
+
+@pytest.mark.unit
+def test_previous_for_last_7d_is_prior_7_days_ending_8_days_ago() -> None:
+    """Today = May 22. last_7d = May 15..May 21 (the 7 complete days
+    ending yesterday). previous = May 8..May 14."""
+    prev = previous_period("last_7d", today=_FIXED_TODAY)
+    assert prev == "2026-05-08..2026-05-14"
+
+
+@pytest.mark.unit
+def test_previous_for_last_14d_does_not_overlap_current() -> None:
+    """The fix's whole point: previous must NOT overlap current. The
+    pre-fix code mapped last_7d → last_30d which DID overlap (a
+    superset). This regression test pins that to never recur."""
+    rp_cur = resolve_period("last_14d")
+    cur_days = rp_cur.days
+    cur_until = _FIXED_TODAY  # last_14d ends "today" inclusive in this
+    # impl; we don't depend on the exact convention, only that the
+    # previous string parses to a window that does NOT overlap.
+    prev_str = previous_period("last_14d", today=_FIXED_TODAY)
+    prev_rp = resolve_period(prev_str)
+    assert prev_rp.time_range is not None
+    prev_since, prev_until = prev_rp.time_range
+    assert prev_rp.days == cur_days
+    # The previous-window's ``until`` must be strictly before today
+    # minus (cur_days - 1) days — anything else means overlap.
+    assert date.fromisoformat(prev_until) < cur_until
+
+
+@pytest.mark.unit
+def test_previous_for_today_is_yesterday() -> None:
+    assert previous_period("today", today=_FIXED_TODAY) == "yesterday"
+
+
+@pytest.mark.unit
+def test_previous_for_yesterday_is_day_before_yesterday() -> None:
+    assert previous_period("yesterday", today=_FIXED_TODAY) == "2026-05-20..2026-05-20"
+
+
+@pytest.mark.unit
+def test_previous_for_this_month_is_last_month() -> None:
+    """``this_month`` has a natural calendar-relative previous: the
+    matching preset name. Honour that — round-tripping through preset
+    names preserves Meta's intent."""
+    assert previous_period("this_month", today=_FIXED_TODAY) == "last_month"
+
+
+@pytest.mark.unit
+def test_previous_for_last_month_is_month_before_last() -> None:
+    """Today = May 22 → last_month = April → month-before-last =
+    March. Returned as an explicit range so the caller doesn't have
+    to do calendar arithmetic itself."""
+    assert previous_period("last_month", today=_FIXED_TODAY) == "2026-03-01..2026-03-31"
+
+
+@pytest.mark.unit
+def test_previous_rejects_bad_period() -> None:
+    """previous_period should validate via the same path resolve_period
+    uses — no silent acceptance of an unknown current period."""
+    with pytest.raises(ValueError):
+        previous_period("last_60d", today=_FIXED_TODAY)


### PR DESCRIPTION
Closes #134.

## Problem

The Meta Ads MCP tools' `period` argument advertised `last_14d`, `last_90d`, and explicit `YYYY-MM-DD..YYYY-MM-DD` ranges, but the implementation accepted only six hard-coded preset names and **silently returned `last_7d` data for anything else.** Period-over-period analyses (`meta_ads_analysis_performance`, `meta_ads_analysis_cost`) doubled the bug: the "previous" window was likewise mapped via a tiny dict that, for `last_7d`, returned `last_30d` — a superset that overlaps the current window, making every delta meaningless.

Severity: **silent data corruption.** Operators acting on the returned numbers (budget reallocations, pause/enable decisions, A/B winner picks) were acting on the wrong window with no exception, log line, or warning string in the response.

## Fix

| Tool / function | Before | After |
|---|---|---|
| `meta_ads_insights_report` / `meta_ads_insights_breakdown` | Unknown `period` → silent `last_7d` | Unknown `period` → `ValueError` surfaced at MCP boundary. `YYYY-MM-DD..YYYY-MM-DD` → forwarded as `time_range`. `last_14d` / `last_90d` → forwarded as `date_preset`. |
| `meta_ads_analysis_cost` (`investigate_cost`) | `prev_map.get(period, "last_30d")` → previous overlapped current | `previous_period(period)` → same-length window immediately before current |
| `meta_ads_analysis_performance` (`analyze_performance`) | 4-key `prev_period_map` with same superset bug | Same `previous_period(period)` helper |
| Tool description `_PERIOD_PARAM` | Listed `last_14d` / `last_90d` / custom range without `this_month` / `last_month` | Lists every preset the resolver accepts |

### Public behaviour

- `period` accepts `today`, `yesterday`, `last_7d`, `last_14d`, `last_30d`, `last_90d`, `this_month`, `last_month`, or `YYYY-MM-DD..YYYY-MM-DD` (both endpoints inclusive).
- Anything else raises `ValueError` (no silent fallback).
- The previous-period for any current `period` is the same-length window immediately before it.

### Implementation

- **New `mureo/meta_ads/_period.py`** — `ResolvedPeriod` dataclass + `resolve_period()` parser + `previous_period()` builder. The dataclass owns `.to_api_params()` so the `date_preset | time_range` narrowing lives next to the invariant.
- **`_insights.py`** — `get_performance_report`, `get_breakdown_report`, and `analyze_performance` funnel through the resolver. `_PERIOD_TO_DATE_PRESET` deleted.
- **`_analysis.py`** — `investigate_cost` uses `previous_period(period)`.
- **`_tools_meta_ads_insights.py`** — `_PERIOD_PARAM` description aligned with the resolver's accepted surface.

## Test plan

- [x] Targeted unit tests pass: **107 / 107** across `tests/test_meta_ads_period.py` (38 new) + `tests/test_meta_ads_operations.py` (+4 new in `TestInsightsMixin` / `TestAnalysisMixin`).
- [x] Coverage includes: every preset round-trip, custom-range round-trip, single-day range, twelve bad-input rejection cases (trailing/leading `..`, slash-style, since > until, whitespace, non-string, etc.), `.days` inclusive arithmetic, all `previous_period` branches, the no-overlap invariant.
- [x] Regression: `meta_ads` test suite as a whole shows **407 passed** on this branch vs 364 on `main` (+43 expected — entirely from new tests). 67 pre-existing failures in `test_meta_ads_leads.py` / `test_meta_ads_media.py` are unchanged and unrelated (handler-mock setup issues; same count and same names on `main`). **Zero new regressions.**
- [x] Lint: `ruff check` and `black --check` clean on every file this PR touches.
- [x] `mureo/mcp/_helpers.py` `api_error_handler` re-raises `ValueError` unchanged, so the new error surfaces to the operator with the full message (preset list included).
- [ ] CI green (3.10 / 3.11 / 3.12 / Windows, Analyze, CodeQL).

## Backwards compatibility

- Callers relying on the silent `last_7d` fallback now see a `ValueError`. This is the bug being fixed — they were always getting the wrong window.
- BYOD (`mureo/byod/clients.py`) uses its own `_period_to_range` (`LAST_30_DAYS` shape) — unaffected.
- Google Ads has its own comparison logic — unaffected.
- Every previously-working preset (`today` / `yesterday` / `last_7d` / `last_30d` / `this_month` / `last_month`) keeps working, plus the previously-advertised-but-broken `last_14d`, `last_90d`, and custom range shapes.
