### PR TITLE
chore(release): v0.9.8

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mureo",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "description": "Your local-first AI ad ops crew for Google Ads, Meta Ads, Search Console & GA4. mureo sits on top of the official ad-platform MCPs, gates every change against your strategy, correlates outcomes locally, and keeps an auditable decision log — credentials never leave your machine.",
   "author": {
     "name": "Logly Inc.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.8] - 2026-05-22
+
 ### Fixed — Meta Ads `period` argument no longer silently falls back to `last_7d` (#134)
 
 The Meta Ads MCP tools' `period` argument advertised `last_14d`, `last_90d`, and explicit `YYYY-MM-DD..YYYY-MM-DD` ranges, but the implementation accepted only six hard-coded preset names and silently returned `last_7d` data for anything else. Period-over-period analyses (`meta_ads_analysis_performance`, `meta_ads_analysis_cost`) doubled the bug: the "previous" window was likewise mapped via a tiny dict that, for `last_7d`, returned `last_30d` — a superset that overlaps the current window, making every delta meaningless.

--- a/mureo/__init__.py
+++ b/mureo/__init__.py
@@ -1,3 +1,3 @@
 """mureo — your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."""
 
-__version__ = "0.9.7"
+__version__ = "0.9.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mureo"
-version = "0.9.7"
+version = "0.9.8"
 description = "Your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."
 requires-python = ">=3.10"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Releases v0.9.8 covering the Meta Ads `period` silent-fallback fix in #135 (closes #134).

### Behaviour change

`mureo.meta_ads`-backed MCP tools now honour the full `period` surface their tool descriptions advertise:

- preset names: `today`, `yesterday`, `last_7d`, `last_14d`, `last_30d`, `last_90d`, `this_month`, `last_month`
- explicit custom ranges: `YYYY-MM-DD..YYYY-MM-DD` (both endpoints inclusive) — forwarded to Meta as `time_range`
- anything else: `ValueError`, surfaced at the MCP boundary

Period-over-period analyses (`meta_ads_analysis_performance`, `meta_ads_analysis_cost`) now compute the previous window as the same-length block immediately before the current — never the `last_30d` superset that overlapped `last_7d` pre-fix.

### Version bump

- `.claude-plugin/plugin.json`: 0.9.7 → 0.9.8
- `mureo/__init__.py`: 0.9.7 → 0.9.8
- `pyproject.toml`: 0.9.7 → 0.9.8

## Test plan

- [ ] CI green (lint, test 3.10/3.11/3.12, test-windows, CodeQL, Analyze)
- [ ] Version parity test (`tests/test_plugin_manifests.py`) passes
- [ ] Tag `v0.9.8` after merge → GitHub Release → `release.yml` publishes to PyPI
