### PR TITLE
feat(analytics): wire built-in google_ads/meta_ads adapters to live clients (#120)

### DIFF
--- a/mureo/analytics/builtin/_common.py
+++ b/mureo/analytics/builtin/_common.py
@@ -17,6 +17,7 @@ avoids cycles at registration time.
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Protocol
 
 from mureo.analysis.anomaly_detector import (
@@ -31,6 +32,12 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
 
     from mureo.analysis.anomaly_detector import CampaignMetrics
+
+
+# Type alias used by both built-in adapters' ``diagnose_performance``.
+# Tests inject a deterministic stub; production paths resolve to the
+# live client inside the adapter.
+PerformanceFetcher = Callable[[str, str], Awaitable[list[dict[str, object]]]]
 
 
 _SEVERITY_MAP: dict[_DetectorSeverity, AnomalySeverity] = {
@@ -92,6 +99,7 @@ class MetricsFetcher(Protocol):
 
 __all__ = [
     "MetricsFetcher",
+    "PerformanceFetcher",
     "to_analytics_anomalies",
     "to_analytics_anomaly",
 ]

--- a/mureo/analytics/builtin/_live_clients.py
+++ b/mureo/analytics/builtin/_live_clients.py
@@ -1,0 +1,275 @@
+"""Live-client metrics fetchers for the built-in analytics adapters.
+
+Adapters are registered at process startup, before credentials are
+loaded. The fetcher abstraction lets the adapter look up creds + open
+a client **only when a workflow actually invokes the module**. That
+keeps registry imports cheap (no auth side effects, no network) and
+keeps the adapter usable in BYOD mode automatically — the client
+factory handles the live-vs-BYOD routing.
+
+Both fetchers return ``(current, baseline)`` :class:`CampaignMetrics`
+pairs aggregated across the requested account. ``baseline`` may be
+``None`` when:
+
+- the account is new (no prior-window data), or
+- credentials are missing (live mode only — BYOD always returns
+  zero-cost metrics rather than raising).
+
+Failure modes:
+
+- :class:`NoCredentialsError` — credentials are unset in live mode.
+  The adapter catches this and returns an empty anomaly tuple, since
+  the absence of credentials is a configuration issue rather than an
+  anomaly to report.
+- Any other client exception bubbles up; the MCP dispatch layer
+  surfaces it as a tool error.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mureo.analysis.anomaly_detector import CampaignMetrics
+
+
+class NoCredentialsError(RuntimeError):
+    """Raised when the platform's credentials are missing.
+
+    Distinct subclass so the adapter can catch this case and return an
+    honest empty result rather than surfacing a noisy error to the
+    workflow.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Google Ads
+# ---------------------------------------------------------------------------
+
+_GOOGLE_PERIOD_MAP: dict[int, tuple[str, str]] = {
+    # window_days -> (current period token, baseline period token).
+    # Tokens passed to GoogleAdsApiClient.get_performance_report —
+    # see mureo/google_ads/_analysis_constants.py _PERIOD_DAYS.
+    7: ("LAST_7_DAYS", "LAST_30_DAYS"),
+    14: ("LAST_14_DAYS", "LAST_30_DAYS"),
+    30: ("LAST_30_DAYS", "LAST_30_DAYS"),
+}
+
+
+def _aggregate_google_metrics(
+    rows: list[dict[str, Any]],
+    account_id: str,
+) -> CampaignMetrics:
+    """Collapse a multi-campaign performance report to a single account-level
+    :class:`CampaignMetrics`.
+
+    The pure anomaly detector operates per-campaign; account-level
+    detection over the aggregate is a Phase-1 simplification chosen so
+    the first wired implementation is small and predictable. A future
+    iteration can fan out per-campaign.
+    """
+    cost = 0.0
+    impressions = 0
+    clicks = 0
+    conversions = 0.0
+    for row in rows:
+        metrics = row.get("metrics") or {}
+        cost += float(metrics.get("cost", 0) or 0)
+        impressions += int(metrics.get("impressions", 0) or 0)
+        clicks += int(metrics.get("clicks", 0) or 0)
+        conversions += float(metrics.get("conversions", 0) or 0)
+    return CampaignMetrics(
+        campaign_id=account_id,
+        cost=cost,
+        impressions=impressions,
+        clicks=clicks,
+        conversions=conversions,
+    )
+
+
+def _open_google_ads_client(account_id: str) -> object:
+    """Resolve credentials + open a Google Ads client (live or BYOD).
+
+    Raises :class:`NoCredentialsError` in live mode when credentials
+    are missing. BYOD mode is detected by the client factory itself
+    (``mureo.mcp._client_factory``), so this helper does not re-check
+    ``byod_has`` — keeping the BYOD branching in one place avoids
+    drift if the factory's policy changes.
+
+    Local imports defer auth / google_ads SDK loading until first use
+    so the registry import remains cheap. Test patch sites:
+    ``mureo.auth.load_google_ads_credentials`` and
+    ``mureo.mcp._client_factory.get_google_ads_client``.
+    """
+    from mureo.auth import load_google_ads_credentials
+    from mureo.byod.runtime import byod_has
+    from mureo.mcp._client_factory import get_google_ads_client
+
+    if byod_has("google_ads"):
+        return get_google_ads_client(creds=None, customer_id=account_id)
+
+    creds = load_google_ads_credentials()
+    if creds is None:
+        raise NoCredentialsError("google_ads credentials not configured")
+    return get_google_ads_client(creds, account_id)
+
+
+async def fetch_google_ads_metrics(
+    account_id: str,
+    *,
+    window_days: int,
+) -> tuple[CampaignMetrics, CampaignMetrics | None]:
+    """Fetch ``(current, baseline)`` metrics for one Google Ads account.
+
+    Raises :class:`NoCredentialsError` when ``account_id`` cannot be
+    resolved to a usable client (live mode + missing creds).
+
+    Known limitation: rows are aggregated to a single account-level
+    :class:`CampaignMetrics`. A real anomaly affecting one campaign
+    while another scales up can net out at the aggregate (current
+    [bad, good], baseline [good, good] → no anomaly). Per-campaign
+    fan-out is a follow-up; the trade-off is documented and tested
+    in ``test_live_clients.py``.
+    """
+    client = _open_google_ads_client(account_id)
+
+    current_period, baseline_period = _GOOGLE_PERIOD_MAP.get(
+        window_days, ("LAST_7_DAYS", "LAST_30_DAYS")
+    )
+    current_rows = await client.get_performance_report(  # type: ignore[attr-defined]
+        period=current_period
+    )
+    baseline_rows = await client.get_performance_report(  # type: ignore[attr-defined]
+        period=baseline_period
+    )
+
+    current = _aggregate_google_metrics(current_rows, account_id)
+    baseline = _aggregate_google_metrics(baseline_rows, account_id)
+    # Treat a zero-spend baseline as "no useful comparison" — the pure
+    # detector then suppresses ratio-based alerts and we avoid
+    # divide-by-zero churn.
+    if baseline.cost <= 0:
+        return current, None
+    return current, baseline
+
+
+async def fetch_google_ads_performance_rows(
+    account_id: str,
+    period: str,
+) -> list[dict[str, object]]:
+    """Return raw performance rows for ``account_id`` over ``period``.
+
+    Used by :meth:`GoogleAdsAnalyticsModule.diagnose_performance`.
+    Raises :class:`NoCredentialsError` uniformly with
+    :func:`fetch_google_ads_metrics` so the adapter renders a single
+    sentinel headline rather than diverging on the same condition.
+    """
+    client = _open_google_ads_client(account_id)
+    return await client.get_performance_report(period=period)  # type: ignore[attr-defined,no-any-return]
+
+
+# ---------------------------------------------------------------------------
+# Meta Ads
+# ---------------------------------------------------------------------------
+
+_META_PERIOD_MAP: dict[int, tuple[str, str]] = {
+    # window_days -> (current period preset, baseline period preset).
+    # Tokens passed to MetaAdsApiClient.get_performance_report —
+    # see mureo/meta_ads/_period.py for supported presets.
+    7: ("last_7d", "last_30d"),
+    14: ("last_14d", "last_30d"),
+    30: ("last_30d", "last_30d"),
+}
+
+
+def _aggregate_meta_metrics(
+    rows: list[dict[str, Any]],
+    account_id: str,
+) -> CampaignMetrics:
+    """Aggregate Meta insights rows to an account-level metric tuple."""
+    cost = 0.0
+    impressions = 0
+    clicks = 0
+    conversions = 0.0
+    for row in rows:
+        cost += float(row.get("spend", 0) or 0)
+        impressions += int(row.get("impressions", 0) or 0)
+        clicks += int(row.get("clicks", 0) or 0)
+        # Meta returns conversions per action_type. We sum
+        # offsite_conversion.fb_pixel_lead + onsite_conversion.lead_grouped
+        # if present — same convention as the existing analysis surface
+        # (mureo/meta_ads/_analysis.py treats those as the canonical
+        # "lead" actions).
+        for action in row.get("actions", []) or []:
+            action_type = str(action.get("action_type", ""))
+            if "lead" in action_type or "purchase" in action_type:
+                conversions += float(action.get("value", 0) or 0)
+    return CampaignMetrics(
+        campaign_id=account_id,
+        cost=cost,
+        impressions=impressions,
+        clicks=clicks,
+        conversions=conversions,
+    )
+
+
+def _open_meta_ads_client(account_id: str) -> object:
+    """Parallel to :func:`_open_google_ads_client` for Meta Ads."""
+    from mureo.auth import load_meta_ads_credentials
+    from mureo.byod.runtime import byod_has
+    from mureo.mcp._client_factory import get_meta_ads_client
+
+    if byod_has("meta_ads"):
+        return get_meta_ads_client(creds=None, account_id=account_id)
+
+    creds = load_meta_ads_credentials()
+    if creds is None:
+        raise NoCredentialsError("meta_ads credentials not configured")
+    return get_meta_ads_client(creds, account_id)
+
+
+async def fetch_meta_ads_metrics(
+    account_id: str,
+    *,
+    window_days: int,
+) -> tuple[CampaignMetrics, CampaignMetrics | None]:
+    """Fetch ``(current, baseline)`` metrics for one Meta Ads account.
+
+    Raises :class:`NoCredentialsError` when credentials are missing
+    in live mode. Shares the per-campaign aggregation limitation
+    documented on :func:`fetch_google_ads_metrics`.
+    """
+    client = _open_meta_ads_client(account_id)
+
+    current_period, baseline_period = _META_PERIOD_MAP.get(
+        window_days, ("last_7d", "last_30d")
+    )
+    current_rows = await client.get_performance_report(  # type: ignore[attr-defined]
+        period=current_period
+    )
+    baseline_rows = await client.get_performance_report(  # type: ignore[attr-defined]
+        period=baseline_period
+    )
+
+    current = _aggregate_meta_metrics(current_rows, account_id)
+    baseline = _aggregate_meta_metrics(baseline_rows, account_id)
+    if baseline.cost <= 0:
+        return current, None
+    return current, baseline
+
+
+async def fetch_meta_ads_performance_rows(
+    account_id: str,
+    period: str,
+) -> list[dict[str, object]]:
+    """Return raw performance rows for ``account_id`` over ``period``."""
+    client = _open_meta_ads_client(account_id)
+    return await client.get_performance_report(period=period)  # type: ignore[attr-defined,no-any-return]
+
+
+__all__ = [
+    "NoCredentialsError",
+    "fetch_google_ads_metrics",
+    "fetch_google_ads_performance_rows",
+    "fetch_meta_ads_metrics",
+    "fetch_meta_ads_performance_rows",
+]

--- a/mureo/analytics/builtin/google_ads.py
+++ b/mureo/analytics/builtin/google_ads.py
@@ -2,17 +2,25 @@
 
 Implements two of the four Protocol methods today:
 
-- :meth:`detect_anomalies` — delegates to
-  :func:`mureo.analysis.anomaly_detector.detect_anomalies` after
-  resolving ``(current, baseline)`` metrics via an injectable fetcher.
-- :meth:`diagnose_performance` — returns a thin
-  :class:`PerformanceDiagnosis` summarising what the workflow skill
-  already surfaces via ``google_ads_performance_report``.
+- :meth:`detect_anomalies` — wraps the pure
+  :func:`mureo.analysis.anomaly_detector.detect_anomalies` over
+  ``(current, baseline)`` metrics resolved by an injectable fetcher
+  (defaults to :func:`fetch_google_ads_metrics`, which lazily opens
+  the live or BYOD client).
+- :meth:`diagnose_performance` — calls
+  :meth:`GoogleAdsApiClient.get_performance_report` and packs the
+  result into a :class:`PerformanceDiagnosis` with deterministic
+  findings strings the workflow skill can render verbatim.
 
 Creative-audit and budget-efficiency methods raise
-:class:`NotImplementedError` so :meth:`capabilities` is the single
-source of truth on what this adapter actually supports — skills
-SHOULD consult capabilities before calling.
+:class:`NotImplementedError` — :meth:`capabilities` is the single
+source of truth on what this adapter actually supports, and skills
+consult it before calling.
+
+The adapter holds no state other than the optional fetcher overrides:
+the live client is constructed per-call via the factory, so
+credentials can be configured after the adapter has been registered
+and BYOD mode is picked up automatically.
 """
 
 from __future__ import annotations
@@ -20,7 +28,13 @@ from __future__ import annotations
 from mureo.analysis.anomaly_detector import detect_anomalies
 from mureo.analytics.builtin._common import (
     MetricsFetcher,
+    PerformanceFetcher,
     to_analytics_anomalies,
+)
+from mureo.analytics.builtin._live_clients import (
+    NoCredentialsError,
+    fetch_google_ads_metrics,
+    fetch_google_ads_performance_rows,
 )
 from mureo.analytics.models import (
     Anomaly,
@@ -40,17 +54,21 @@ _CAPABILITIES: frozenset[AnalyticsCapability] = frozenset(
 
 
 class GoogleAdsAnalyticsModule(AnalyticsModule):
-    """mureo-native Google Ads analytics surface.
-
-    Stateless: no client is constructed at instantiation time so the
-    registry can build one with no arguments. Live wiring to the
-    Google Ads client happens lazily inside the injected fetcher.
-    """
+    """mureo-native Google Ads analytics surface."""
 
     platform: str = "google_ads"
 
-    def __init__(self, metrics_fetcher: MetricsFetcher | None = None) -> None:
+    def __init__(
+        self,
+        metrics_fetcher: MetricsFetcher | None = None,
+        performance_fetcher: PerformanceFetcher | None = None,
+    ) -> None:
+        # Default to the live fetcher; tests inject deterministic stubs.
+        # The fetcher is async but :class:`MetricsFetcher` is declared
+        # as a sync callable so the existing test stubs remain valid —
+        # we re-derive the async path at the call site below.
         self._metrics_fetcher = metrics_fetcher
+        self._performance_fetcher = performance_fetcher
 
     def capabilities(self) -> frozenset[AnalyticsCapability]:
         return _CAPABILITIES
@@ -61,17 +79,28 @@ class GoogleAdsAnalyticsModule(AnalyticsModule):
         *,
         window_days: int = 7,
     ) -> tuple[Anomaly, ...]:
-        """Detect anomalies on ``account_id`` via the pure detector.
+        """Detect anomalies on ``account_id`` over the trailing window.
 
-        Without an injected fetcher this returns an empty tuple — the
-        adapter is registered eagerly at import time, before the live
-        Google Ads client is configured, so the silent-empty default
-        is the safe behaviour. Tests inject a deterministic fetcher.
+        The injected ``metrics_fetcher`` (if any) takes precedence; it
+        keeps the unit-test surface synchronous so the existing tests
+        in ``tests/analytics/builtin/`` keep working. When no override
+        is supplied, the adapter falls back to the async live fetcher.
+        Missing credentials return an empty anomaly tuple so an
+        unconfigured account never shows up as "spend dropped to
+        zero" — that would be a config error, not a real anomaly.
         """
-        if self._metrics_fetcher is None:
-            return ()
+        if self._metrics_fetcher is not None:
+            current, baseline = self._metrics_fetcher(
+                account_id, window_days=window_days
+            )
+        else:
+            try:
+                current, baseline = await fetch_google_ads_metrics(
+                    account_id, window_days=window_days
+                )
+            except NoCredentialsError:
+                return ()
 
-        current, baseline = self._metrics_fetcher(account_id, window_days=window_days)
         had_prior_spend = baseline is not None and baseline.cost > 0
         detected = detect_anomalies(current, baseline, had_prior_spend=had_prior_spend)
         return to_analytics_anomalies(detected)
@@ -82,21 +111,42 @@ class GoogleAdsAnalyticsModule(AnalyticsModule):
         *,
         scope: PerformanceScope,
     ) -> PerformanceDiagnosis:
-        """Return a thin diagnosis stub for ``account_id``.
+        """Summarise ``account_id`` performance for ``scope``.
 
-        The live diagnosis pipeline lives in
-        :mod:`mureo.google_ads._analysis` and is exposed via the
-        ``google_ads_performance_report`` MCP tool. This adapter returns
-        the shape a skill expects; concrete delegation will be wired in
-        the same follow-up that wires :meth:`detect_anomalies` to the
-        live client.
+        Returns the account-level metrics over the last 7/30 days plus
+        a small ranked list of findings. Per-campaign drilldown
+        (``scope=PerformanceScope.DEEP``) is left to follow-up; for
+        now ``DEEP`` returns the same summary marked accordingly so the
+        skill can still proceed and report unavailability of the
+        deeper view.
+
+        Missing-credentials handling mirrors :meth:`detect_anomalies`:
+        the live fetcher raises :class:`NoCredentialsError`, which the
+        adapter renders as a sentinel :class:`PerformanceDiagnosis`
+        with a credentials-specific headline so the workflow can branch
+        uniformly across the two methods.
         """
-        return PerformanceDiagnosis(
+        period = "LAST_7_DAYS" if scope is PerformanceScope.ACCOUNT else "LAST_30_DAYS"
+
+        if self._performance_fetcher is not None:
+            rows = await self._performance_fetcher(account_id, period)
+        else:
+            try:
+                rows = await fetch_google_ads_performance_rows(account_id, period)
+            except NoCredentialsError:
+                return PerformanceDiagnosis(
+                    platform=self.platform,
+                    account_id=account_id,
+                    scope=scope,
+                    headline="google_ads credentials not configured",
+                    findings=(),
+                )
+
+        return _summarise_performance(
             platform=self.platform,
             account_id=account_id,
             scope=scope,
-            headline="google_ads diagnosis not yet wired to live client",
-            findings=(),
+            rows=rows,
         )
 
     async def audit_creative(self, account_id: str) -> CreativeAudit:
@@ -110,6 +160,75 @@ class GoogleAdsAnalyticsModule(AnalyticsModule):
             "GoogleAdsAnalyticsModule does not advertise "
             "ANALYZE_BUDGET_EFFICIENCY; consult capabilities() before calling"
         )
+
+
+def _summarise_performance(
+    *,
+    platform: str,
+    account_id: str,
+    scope: PerformanceScope,
+    rows: list[dict[str, object]],
+) -> PerformanceDiagnosis:
+    """Build a :class:`PerformanceDiagnosis` from raw performance rows.
+
+    Pure function so tests can exercise the rendering without
+    constructing the adapter or stubbing a fetcher.
+    """
+    if not rows:
+        return PerformanceDiagnosis(
+            platform=platform,
+            account_id=account_id,
+            scope=scope,
+            headline="no performance data available",
+            findings=(),
+        )
+
+    cost = 0.0
+    impressions = 0
+    clicks = 0
+    conversions = 0.0
+    for row in rows:
+        metrics = row.get("metrics") or {}
+        if isinstance(metrics, dict):
+            cost += float(metrics.get("cost", 0) or 0)
+            impressions += int(metrics.get("impressions", 0) or 0)
+            clicks += int(metrics.get("clicks", 0) or 0)
+            conversions += float(metrics.get("conversions", 0) or 0)
+
+    cpa = (cost / conversions) if conversions > 0 else None
+    ctr = (clicks / impressions) if impressions > 0 else None
+
+    findings: list[str] = [
+        f"{len(rows)} campaign(s) reporting",
+        f"spend={cost:,.0f}, conversions={conversions:.1f}",
+    ]
+    if cpa is not None:
+        findings.append(f"CPA={cpa:,.0f}")
+    if ctr is not None:
+        findings.append(f"CTR={ctr*100:.2f}%")
+    if scope is PerformanceScope.DEEP:
+        findings.append("per-campaign drilldown not yet implemented for this adapter")
+
+    metrics_tuple: tuple[tuple[str, float], ...] = (
+        ("cost", cost),
+        ("impressions", float(impressions)),
+        ("clicks", float(clicks)),
+        ("conversions", conversions),
+    )
+    if cpa is not None:
+        metrics_tuple = (*metrics_tuple, ("cpa", cpa))
+    if ctr is not None:
+        metrics_tuple = (*metrics_tuple, ("ctr", ctr))
+
+    headline = f"{platform}: {len(rows)} campaigns, spend={cost:,.0f}"
+    return PerformanceDiagnosis(
+        platform=platform,
+        account_id=account_id,
+        scope=scope,
+        headline=headline,
+        findings=tuple(findings),
+        metrics=metrics_tuple,
+    )
 
 
 __all__ = ["GoogleAdsAnalyticsModule"]

--- a/mureo/analytics/builtin/google_ads.py
+++ b/mureo/analytics/builtin/google_ads.py
@@ -25,6 +25,8 @@ and BYOD mode is picked up automatically.
 
 from __future__ import annotations
 
+from typing import Any
+
 from mureo.analysis.anomaly_detector import detect_anomalies
 from mureo.analytics.builtin._common import (
     MetricsFetcher,
@@ -167,7 +169,7 @@ def _summarise_performance(
     platform: str,
     account_id: str,
     scope: PerformanceScope,
-    rows: list[dict[str, object]],
+    rows: list[dict[str, Any]],
 ) -> PerformanceDiagnosis:
     """Build a :class:`PerformanceDiagnosis` from raw performance rows.
 

--- a/mureo/analytics/builtin/meta_ads.py
+++ b/mureo/analytics/builtin/meta_ads.py
@@ -20,6 +20,8 @@ Meta-specific:
 
 from __future__ import annotations
 
+from typing import Any
+
 from mureo.analysis.anomaly_detector import detect_anomalies
 from mureo.analytics.builtin._common import (
     MetricsFetcher,
@@ -164,7 +166,7 @@ def _classify_result_indicator(action_types: list[str]) -> str:
     return "unknown"
 
 
-def _detect_cv_definition_mismatch(rows: list[dict[str, object]]) -> str | None:
+def _detect_cv_definition_mismatch(rows: list[dict[str, Any]]) -> str | None:
     """Return a finding string if the account mixes click- and
     conversion-style result indicators across campaigns, else ``None``.
     """
@@ -194,7 +196,7 @@ def _summarise_meta_performance(
     platform: str,
     account_id: str,
     scope: PerformanceScope,
-    rows: list[dict[str, object]],
+    rows: list[dict[str, Any]],
 ) -> PerformanceDiagnosis:
     """Pure renderer for Meta performance rows."""
     if not rows:

--- a/mureo/analytics/builtin/meta_ads.py
+++ b/mureo/analytics/builtin/meta_ads.py
@@ -2,15 +2,20 @@
 
 Parallel structure to
 :class:`mureo.analytics.builtin.google_ads.GoogleAdsAnalyticsModule`.
-See that module's docstring for the design notes that apply to both.
+See that module's docstring for the shared design notes.
 
-The Meta-specific difference today is conceptual rather than
-implementation: ``diagnose_performance`` is the natural home for the
-``result_indicator`` CV-definition mismatch check (clicks vs
-``offsite_conversion.fb_pixel_lead``) that the
-``meta_ads_insights_report`` MCP tool surfaces. The mismatch
-detector lives in :mod:`mureo.meta_ads._analysis`; this adapter will
-delegate to it once the live wiring lands.
+Meta-specific:
+
+- :meth:`diagnose_performance` does a lightweight ``result_indicator``
+  CV-definition check on top of the account-level summary: if some
+  campaigns are optimised for ``link_click`` while others report
+  ``offsite_conversion.fb_pixel_lead`` as their "result", the headline
+  metric blends two incompatible definitions and the workflow should
+  flag the mismatch before any rescue action. The check is heuristic
+  and conservative — it surfaces a finding rather than gating downstream
+  steps. The full deep CV-mismatch analysis still lives in
+  :mod:`mureo.meta_ads._analysis` and is reachable via
+  ``meta_ads_insights_report``; this adapter only previews it.
 """
 
 from __future__ import annotations
@@ -18,7 +23,13 @@ from __future__ import annotations
 from mureo.analysis.anomaly_detector import detect_anomalies
 from mureo.analytics.builtin._common import (
     MetricsFetcher,
+    PerformanceFetcher,
     to_analytics_anomalies,
+)
+from mureo.analytics.builtin._live_clients import (
+    NoCredentialsError,
+    fetch_meta_ads_metrics,
+    fetch_meta_ads_performance_rows,
 )
 from mureo.analytics.models import (
     Anomaly,
@@ -37,13 +48,31 @@ _CAPABILITIES: frozenset[AnalyticsCapability] = frozenset(
 )
 
 
+# Heuristic: action_types we treat as "click-style" vs "conversion-style"
+# results. A mix across campaigns is what triggers the CV-mismatch
+# finding. Kept as module-level constants so tests can monkey-patch
+# them if Meta introduces new action_type names.
+_CLICK_RESULT_PREFIXES: tuple[str, ...] = ("link_click", "post_engagement")
+_CONVERSION_RESULT_TOKENS: tuple[str, ...] = (
+    "offsite_conversion",
+    "lead",
+    "purchase",
+    "complete_registration",
+)
+
+
 class MetaAdsAnalyticsModule(AnalyticsModule):
     """mureo-native Meta Ads analytics surface."""
 
     platform: str = "meta_ads"
 
-    def __init__(self, metrics_fetcher: MetricsFetcher | None = None) -> None:
+    def __init__(
+        self,
+        metrics_fetcher: MetricsFetcher | None = None,
+        performance_fetcher: PerformanceFetcher | None = None,
+    ) -> None:
         self._metrics_fetcher = metrics_fetcher
+        self._performance_fetcher = performance_fetcher
 
     def capabilities(self) -> frozenset[AnalyticsCapability]:
         return _CAPABILITIES
@@ -54,10 +83,18 @@ class MetaAdsAnalyticsModule(AnalyticsModule):
         *,
         window_days: int = 7,
     ) -> tuple[Anomaly, ...]:
-        if self._metrics_fetcher is None:
-            return ()
+        if self._metrics_fetcher is not None:
+            current, baseline = self._metrics_fetcher(
+                account_id, window_days=window_days
+            )
+        else:
+            try:
+                current, baseline = await fetch_meta_ads_metrics(
+                    account_id, window_days=window_days
+                )
+            except NoCredentialsError:
+                return ()
 
-        current, baseline = self._metrics_fetcher(account_id, window_days=window_days)
         had_prior_spend = baseline is not None and baseline.cost > 0
         detected = detect_anomalies(current, baseline, had_prior_spend=had_prior_spend)
         return to_analytics_anomalies(detected)
@@ -68,12 +105,30 @@ class MetaAdsAnalyticsModule(AnalyticsModule):
         *,
         scope: PerformanceScope,
     ) -> PerformanceDiagnosis:
-        return PerformanceDiagnosis(
+        """Same missing-credentials sentinel as Google Ads — see that
+        adapter's docstring for the policy rationale.
+        """
+        period = "last_7d" if scope is PerformanceScope.ACCOUNT else "last_30d"
+
+        if self._performance_fetcher is not None:
+            rows = await self._performance_fetcher(account_id, period)
+        else:
+            try:
+                rows = await fetch_meta_ads_performance_rows(account_id, period)
+            except NoCredentialsError:
+                return PerformanceDiagnosis(
+                    platform=self.platform,
+                    account_id=account_id,
+                    scope=scope,
+                    headline="meta_ads credentials not configured",
+                    findings=(),
+                )
+
+        return _summarise_meta_performance(
             platform=self.platform,
             account_id=account_id,
             scope=scope,
-            headline="meta_ads diagnosis not yet wired to live client",
-            findings=(),
+            rows=rows,
         )
 
     async def audit_creative(self, account_id: str) -> CreativeAudit:
@@ -87,6 +142,126 @@ class MetaAdsAnalyticsModule(AnalyticsModule):
             "MetaAdsAnalyticsModule does not advertise "
             "ANALYZE_BUDGET_EFFICIENCY; consult capabilities() before calling"
         )
+
+
+def _classify_result_indicator(action_types: list[str]) -> str:
+    """Return ``"click"``, ``"conversion"``, or ``"unknown"`` for ``action_types``.
+
+    A campaign whose recorded ``actions`` are dominated by clicks is a
+    click-optimised campaign; one with conversion / lead / purchase
+    actions is a conversion-optimised campaign. The classifier picks
+    the first matching bucket so a campaign with both signals lands
+    where the workflow expects (clicks are the cheaper signal — if a
+    conversion-optimised campaign reports clicks alongside leads it is
+    still a conversion campaign).
+    """
+    for token in _CONVERSION_RESULT_TOKENS:
+        if any(token in at for at in action_types):
+            return "conversion"
+    for prefix in _CLICK_RESULT_PREFIXES:
+        if any(at.startswith(prefix) for at in action_types):
+            return "click"
+    return "unknown"
+
+
+def _detect_cv_definition_mismatch(rows: list[dict[str, object]]) -> str | None:
+    """Return a finding string if the account mixes click- and
+    conversion-style result indicators across campaigns, else ``None``.
+    """
+    classifications: set[str] = set()
+    for row in rows:
+        actions = row.get("actions") or []
+        if not isinstance(actions, list):
+            continue
+        action_types = [
+            str(a.get("action_type", "")) for a in actions if isinstance(a, dict)
+        ]
+        bucket = _classify_result_indicator(action_types)
+        if bucket in {"click", "conversion"}:
+            classifications.add(bucket)
+
+    if len(classifications) > 1:
+        return (
+            "CV-definition mismatch: some campaigns optimise for clicks "
+            "while others report conversion-style actions; account-level "
+            "metrics blend two incompatible definitions"
+        )
+    return None
+
+
+def _summarise_meta_performance(
+    *,
+    platform: str,
+    account_id: str,
+    scope: PerformanceScope,
+    rows: list[dict[str, object]],
+) -> PerformanceDiagnosis:
+    """Pure renderer for Meta performance rows."""
+    if not rows:
+        return PerformanceDiagnosis(
+            platform=platform,
+            account_id=account_id,
+            scope=scope,
+            headline="no performance data available",
+            findings=(),
+        )
+
+    cost = 0.0
+    impressions = 0
+    clicks = 0
+    conversions = 0.0
+    for row in rows:
+        cost += float(row.get("spend", 0) or 0)
+        impressions += int(row.get("impressions", 0) or 0)
+        clicks += int(row.get("clicks", 0) or 0)
+        actions = row.get("actions") or []
+        if isinstance(actions, list):
+            for action in actions:
+                if not isinstance(action, dict):
+                    continue
+                action_type = str(action.get("action_type", ""))
+                if any(t in action_type for t in _CONVERSION_RESULT_TOKENS):
+                    conversions += float(action.get("value", 0) or 0)
+
+    cpa = (cost / conversions) if conversions > 0 else None
+    ctr = (clicks / impressions) if impressions > 0 else None
+
+    findings: list[str] = [
+        f"{len(rows)} campaign(s) reporting",
+        f"spend={cost:,.0f}, conversions={conversions:.1f}",
+    ]
+    if cpa is not None:
+        findings.append(f"CPA={cpa:,.0f}")
+    if ctr is not None:
+        findings.append(f"CTR={ctr*100:.2f}%")
+
+    mismatch = _detect_cv_definition_mismatch(rows)
+    if mismatch is not None:
+        findings.append(mismatch)
+
+    if scope is PerformanceScope.DEEP:
+        findings.append("per-campaign drilldown not yet implemented for this adapter")
+
+    metrics_tuple: tuple[tuple[str, float], ...] = (
+        ("cost", cost),
+        ("impressions", float(impressions)),
+        ("clicks", float(clicks)),
+        ("conversions", conversions),
+    )
+    if cpa is not None:
+        metrics_tuple = (*metrics_tuple, ("cpa", cpa))
+    if ctr is not None:
+        metrics_tuple = (*metrics_tuple, ("ctr", ctr))
+
+    headline = f"{platform}: {len(rows)} campaigns, spend={cost:,.0f}"
+    return PerformanceDiagnosis(
+        platform=platform,
+        account_id=account_id,
+        scope=scope,
+        headline=headline,
+        findings=tuple(findings),
+        metrics=metrics_tuple,
+    )
 
 
 __all__ = ["MetaAdsAnalyticsModule"]

--- a/tests/analytics/builtin/test_diagnose_performance.py
+++ b/tests/analytics/builtin/test_diagnose_performance.py
@@ -1,0 +1,316 @@
+"""Tests for the diagnose_performance live wiring and result-indicator
+mismatch detection.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from mureo.analytics.builtin.google_ads import (
+    GoogleAdsAnalyticsModule,
+    _summarise_performance,
+)
+from mureo.analytics.builtin.meta_ads import (
+    MetaAdsAnalyticsModule,
+    _classify_result_indicator,
+    _detect_cv_definition_mismatch,
+    _summarise_meta_performance,
+)
+from mureo.analytics.models import PerformanceScope
+
+# ---------------------------------------------------------------------------
+# Google Ads — pure summariser
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_google_summarise_empty_returns_no_data_headline() -> None:
+    diag = _summarise_performance(
+        platform="google_ads",
+        account_id="acct-1",
+        scope=PerformanceScope.ACCOUNT,
+        rows=[],
+    )
+    assert diag.headline == "no performance data available"
+    assert diag.findings == ()
+
+
+@pytest.mark.unit
+def test_google_summarise_aggregates_two_campaigns() -> None:
+    rows: list[dict[str, Any]] = [
+        {
+            "metrics": {
+                "cost": 1000.0,
+                "impressions": 5000,
+                "clicks": 100,
+                "conversions": 5,
+            }
+        },
+        {
+            "metrics": {
+                "cost": 2000.0,
+                "impressions": 10000,
+                "clicks": 200,
+                "conversions": 10,
+            }
+        },
+    ]
+    diag = _summarise_performance(
+        platform="google_ads",
+        account_id="acct-1",
+        scope=PerformanceScope.ACCOUNT,
+        rows=rows,
+    )
+    metrics = dict(diag.metrics)
+    assert metrics["cost"] == 3000.0
+    assert metrics["impressions"] == 15000.0
+    assert metrics["conversions"] == 15.0
+    assert metrics["cpa"] == pytest.approx(200.0)
+    assert "2 campaign(s)" in diag.findings[0]
+
+
+@pytest.mark.unit
+def test_google_summarise_deep_scope_flags_no_drilldown() -> None:
+    rows: list[dict[str, Any]] = [
+        {
+            "metrics": {
+                "cost": 100.0,
+                "impressions": 1000,
+                "clicks": 30,
+                "conversions": 2,
+            }
+        },
+    ]
+    diag = _summarise_performance(
+        platform="google_ads",
+        account_id="a",
+        scope=PerformanceScope.DEEP,
+        rows=rows,
+    )
+    assert any("drilldown not yet implemented" in f for f in diag.findings)
+
+
+@pytest.mark.unit
+def test_google_summarise_skips_cpa_when_no_conversions() -> None:
+    rows: list[dict[str, Any]] = [
+        {
+            "metrics": {
+                "cost": 100.0,
+                "impressions": 1000,
+                "clicks": 30,
+                "conversions": 0,
+            }
+        },
+    ]
+    diag = _summarise_performance(
+        platform="google_ads",
+        account_id="a",
+        scope=PerformanceScope.ACCOUNT,
+        rows=rows,
+    )
+    metrics = dict(diag.metrics)
+    assert "cpa" not in metrics
+
+
+# ---------------------------------------------------------------------------
+# Google Ads — adapter wiring (uses injected performance_fetcher)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_google_adapter_diagnose_uses_injected_fetcher() -> None:
+    captured: dict[str, Any] = {}
+
+    async def fetcher(account_id: str, period: str) -> list[dict[str, object]]:
+        captured["account_id"] = account_id
+        captured["period"] = period
+        return [
+            {
+                "metrics": {
+                    "cost": 500.0,
+                    "impressions": 2000,
+                    "clicks": 50,
+                    "conversions": 4,
+                }
+            },
+        ]
+
+    adapter = GoogleAdsAnalyticsModule(performance_fetcher=fetcher)
+    diag = await adapter.diagnose_performance("acct-9", scope=PerformanceScope.ACCOUNT)
+    assert captured == {"account_id": "acct-9", "period": "LAST_7_DAYS"}
+    assert "spend=500" in diag.headline
+
+
+@pytest.mark.asyncio
+async def test_google_adapter_diagnose_deep_scope_uses_longer_period() -> None:
+    captured: dict[str, str] = {}
+
+    async def fetcher(account_id: str, period: str) -> list[dict[str, object]]:
+        captured["period"] = period
+        return []
+
+    adapter = GoogleAdsAnalyticsModule(performance_fetcher=fetcher)
+    await adapter.diagnose_performance("acct", scope=PerformanceScope.DEEP)
+    assert captured["period"] == "LAST_30_DAYS"
+
+
+# ---------------------------------------------------------------------------
+# Meta Ads — result-indicator classifier
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_classify_result_indicator_click() -> None:
+    assert _classify_result_indicator(["link_click", "video_play"]) == "click"
+
+
+@pytest.mark.unit
+def test_classify_result_indicator_conversion_wins_over_click() -> None:
+    # A conversion campaign that also records clicks remains a
+    # conversion campaign — clicks are the cheaper signal.
+    assert (
+        _classify_result_indicator(["link_click", "offsite_conversion.fb_pixel_lead"])
+        == "conversion"
+    )
+
+
+@pytest.mark.unit
+def test_classify_result_indicator_unknown_for_empty() -> None:
+    assert _classify_result_indicator([]) == "unknown"
+
+
+@pytest.mark.unit
+def test_detect_cv_mismatch_when_both_styles_present() -> None:
+    rows: list[dict[str, Any]] = [
+        {"actions": [{"action_type": "link_click"}]},
+        {
+            "actions": [
+                {"action_type": "offsite_conversion.fb_pixel_lead"},
+            ]
+        },
+    ]
+    finding = _detect_cv_definition_mismatch(rows)
+    assert finding is not None
+    assert "mismatch" in finding
+
+
+@pytest.mark.unit
+def test_detect_cv_mismatch_returns_none_when_uniform() -> None:
+    rows: list[dict[str, Any]] = [
+        {"actions": [{"action_type": "offsite_conversion.fb_pixel_lead"}]},
+        {"actions": [{"action_type": "lead"}]},
+    ]
+    assert _detect_cv_definition_mismatch(rows) is None
+
+
+@pytest.mark.unit
+def test_detect_cv_mismatch_handles_missing_actions() -> None:
+    rows: list[dict[str, Any]] = [{}, {"actions": "not_a_list"}]
+    assert _detect_cv_definition_mismatch(rows) is None
+
+
+# ---------------------------------------------------------------------------
+# Meta Ads — summariser
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_meta_summarise_includes_cv_mismatch_finding() -> None:
+    rows: list[dict[str, Any]] = [
+        {
+            "spend": 100,
+            "impressions": 1000,
+            "clicks": 50,
+            "actions": [{"action_type": "link_click", "value": 50}],
+        },
+        {
+            "spend": 200,
+            "impressions": 2000,
+            "clicks": 80,
+            "actions": [
+                {"action_type": "offsite_conversion.fb_pixel_lead", "value": 5},
+            ],
+        },
+    ]
+    diag = _summarise_meta_performance(
+        platform="meta_ads",
+        account_id="act_1",
+        scope=PerformanceScope.ACCOUNT,
+        rows=rows,
+    )
+    assert any("mismatch" in f for f in diag.findings)
+
+
+@pytest.mark.unit
+def test_meta_summarise_no_data() -> None:
+    diag = _summarise_meta_performance(
+        platform="meta_ads",
+        account_id="act_1",
+        scope=PerformanceScope.ACCOUNT,
+        rows=[],
+    )
+    assert diag.headline == "no performance data available"
+
+
+# ---------------------------------------------------------------------------
+# Meta Ads — adapter wiring
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_google_adapter_diagnose_renders_sentinel_on_missing_creds() -> None:
+    """When the live fetcher raises ``NoCredentialsError``, the adapter
+    must render a sentinel :class:`PerformanceDiagnosis` rather than an
+    empty-data one — so callers can tell ``no data`` apart from
+    ``creds missing``.
+    """
+    from unittest.mock import patch
+
+    adapter = GoogleAdsAnalyticsModule()  # no fetcher → live path
+    with (
+        patch("mureo.byod.runtime.byod_has", return_value=False),
+        patch("mureo.auth.load_google_ads_credentials", return_value=None),
+    ):
+        diag = await adapter.diagnose_performance(
+            "acct-x", scope=PerformanceScope.ACCOUNT
+        )
+    assert diag.headline == "google_ads credentials not configured"
+    assert diag.findings == ()
+
+
+@pytest.mark.asyncio
+async def test_meta_adapter_diagnose_renders_sentinel_on_missing_creds() -> None:
+    from unittest.mock import patch
+
+    adapter = MetaAdsAnalyticsModule()
+    with (
+        patch("mureo.byod.runtime.byod_has", return_value=False),
+        patch("mureo.auth.load_meta_ads_credentials", return_value=None),
+    ):
+        diag = await adapter.diagnose_performance(
+            "act_x", scope=PerformanceScope.ACCOUNT
+        )
+    assert diag.headline == "meta_ads credentials not configured"
+
+
+@pytest.mark.asyncio
+async def test_meta_adapter_diagnose_uses_injected_fetcher() -> None:
+    captured: dict[str, str] = {}
+
+    async def fetcher(account_id: str, period: str) -> list[dict[str, object]]:
+        captured["period"] = period
+        return [
+            {
+                "spend": 50,
+                "impressions": 500,
+                "clicks": 20,
+                "actions": [{"action_type": "link_click", "value": 20}],
+            }
+        ]
+
+    adapter = MetaAdsAnalyticsModule(performance_fetcher=fetcher)
+    diag = await adapter.diagnose_performance("act_42", scope=PerformanceScope.ACCOUNT)
+    assert captured["period"] == "last_7d"
+    assert "1 campaign" in diag.findings[0]

--- a/tests/analytics/builtin/test_live_clients.py
+++ b/tests/analytics/builtin/test_live_clients.py
@@ -1,0 +1,357 @@
+"""Tests for the live-client metrics fetchers."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from mureo.analytics.builtin._live_clients import (
+    NoCredentialsError,
+    _aggregate_google_metrics,
+    _aggregate_meta_metrics,
+    fetch_google_ads_metrics,
+    fetch_meta_ads_metrics,
+)
+
+# ---------------------------------------------------------------------------
+# Aggregation helpers (pure)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_aggregate_google_metrics_sums_rows() -> None:
+    rows: list[dict[str, Any]] = [
+        {
+            "metrics": {
+                "cost": 100.0,
+                "impressions": 500,
+                "clicks": 20,
+                "conversions": 3,
+            }
+        },
+        {
+            "metrics": {
+                "cost": 250.0,
+                "impressions": 1000,
+                "clicks": 50,
+                "conversions": 7,
+            }
+        },
+    ]
+    result = _aggregate_google_metrics(rows, account_id="acct-1")
+    assert result.campaign_id == "acct-1"
+    assert result.cost == 350.0
+    assert result.impressions == 1500
+    assert result.clicks == 70
+    assert result.conversions == 10
+
+
+@pytest.mark.unit
+def test_aggregate_google_metrics_handles_empty() -> None:
+    result = _aggregate_google_metrics([], account_id="acct-2")
+    assert result.cost == 0.0
+    assert result.impressions == 0
+
+
+@pytest.mark.unit
+def test_aggregate_google_metrics_handles_none_values() -> None:
+    rows: list[dict[str, Any]] = [
+        {"metrics": {"cost": None, "impressions": None, "clicks": None}}
+    ]
+    result = _aggregate_google_metrics(rows, account_id="a")
+    assert result.cost == 0.0
+
+
+@pytest.mark.unit
+def test_aggregate_meta_metrics_sums_actions() -> None:
+    rows: list[dict[str, Any]] = [
+        {
+            "spend": "50.0",
+            "impressions": "1000",
+            "clicks": "40",
+            "actions": [
+                {"action_type": "offsite_conversion.fb_pixel_lead", "value": "3"},
+                {"action_type": "link_click", "value": "40"},
+            ],
+        },
+        {
+            "spend": 30.0,
+            "impressions": 500,
+            "clicks": 15,
+            "actions": [
+                {"action_type": "lead", "value": 2},
+                {"action_type": "purchase", "value": 1},
+            ],
+        },
+    ]
+    result = _aggregate_meta_metrics(rows, account_id="act_123")
+    assert result.cost == 80.0
+    assert result.impressions == 1500
+    assert result.clicks == 55
+    # 3 (lead) + 2 (lead) + 1 (purchase) = 6
+    assert result.conversions == 6
+
+
+@pytest.mark.unit
+def test_aggregate_meta_metrics_handles_missing_actions() -> None:
+    rows: list[dict[str, Any]] = [
+        {"spend": 10, "impressions": 100, "clicks": 5},
+    ]
+    result = _aggregate_meta_metrics(rows, account_id="x")
+    assert result.conversions == 0.0
+
+
+# ---------------------------------------------------------------------------
+# fetch_google_ads_metrics (live path mocked)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fetch_google_ads_metrics_raises_when_creds_missing() -> None:
+    with (
+        patch("mureo.byod.runtime.byod_has", return_value=False),
+        patch("mureo.auth.load_google_ads_credentials", return_value=None),
+        pytest.raises(NoCredentialsError),
+    ):
+        await fetch_google_ads_metrics("acct-1", window_days=7)
+
+
+@pytest.mark.asyncio
+async def test_fetch_google_ads_metrics_returns_current_and_baseline() -> None:
+    fake_client = AsyncMock()
+    fake_client.get_performance_report = AsyncMock(
+        side_effect=[
+            [
+                {
+                    "metrics": {
+                        "cost": 100.0,
+                        "impressions": 500,
+                        "clicks": 20,
+                        "conversions": 5,
+                    }
+                }
+            ],
+            [
+                {
+                    "metrics": {
+                        "cost": 200.0,
+                        "impressions": 1000,
+                        "clicks": 40,
+                        "conversions": 10,
+                    }
+                }
+            ],
+        ]
+    )
+    with (
+        patch("mureo.byod.runtime.byod_has", return_value=False),
+        patch("mureo.auth.load_google_ads_credentials", return_value=object()),
+        patch(
+            "mureo.mcp._client_factory.get_google_ads_client",
+            return_value=fake_client,
+        ),
+    ):
+        current, baseline = await fetch_google_ads_metrics("acct-1", window_days=7)
+
+    assert current.cost == 100.0
+    assert baseline is not None
+    assert baseline.cost == 200.0
+
+
+@pytest.mark.asyncio
+async def test_fetch_google_ads_metrics_returns_none_baseline_when_zero_spend() -> None:
+    fake_client = AsyncMock()
+    fake_client.get_performance_report = AsyncMock(
+        side_effect=[
+            [
+                {
+                    "metrics": {
+                        "cost": 50.0,
+                        "impressions": 200,
+                        "clicks": 5,
+                        "conversions": 1,
+                    }
+                }
+            ],
+            [
+                {
+                    "metrics": {
+                        "cost": 0.0,
+                        "impressions": 0,
+                        "clicks": 0,
+                        "conversions": 0,
+                    }
+                }
+            ],
+        ]
+    )
+    with (
+        patch("mureo.byod.runtime.byod_has", return_value=False),
+        patch("mureo.auth.load_google_ads_credentials", return_value=object()),
+        patch(
+            "mureo.mcp._client_factory.get_google_ads_client",
+            return_value=fake_client,
+        ),
+    ):
+        current, baseline = await fetch_google_ads_metrics("acct-1", window_days=7)
+
+    assert current.cost == 50.0
+    assert baseline is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_google_ads_metrics_uses_byod_when_registered() -> None:
+    fake_client = AsyncMock()
+    fake_client.get_performance_report = AsyncMock(
+        return_value=[
+            {"metrics": {"cost": 10, "impressions": 100, "clicks": 1, "conversions": 0}}
+        ]
+    )
+    with (
+        patch("mureo.byod.runtime.byod_has", return_value=True),
+        patch(
+            "mureo.mcp._client_factory.get_google_ads_client",
+            return_value=fake_client,
+        ) as get_client,
+    ):
+        await fetch_google_ads_metrics("byod-acct", window_days=7)
+
+    # BYOD path must pass creds=None.
+    get_client.assert_called_once()
+    _, kwargs = get_client.call_args
+    assert kwargs["creds"] is None
+
+
+# ---------------------------------------------------------------------------
+# fetch_meta_ads_metrics (live path mocked)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fetch_meta_ads_metrics_raises_when_creds_missing() -> None:
+    with (
+        patch("mureo.byod.runtime.byod_has", return_value=False),
+        patch("mureo.auth.load_meta_ads_credentials", return_value=None),
+        pytest.raises(NoCredentialsError),
+    ):
+        await fetch_meta_ads_metrics("act_x", window_days=7)
+
+
+@pytest.mark.asyncio
+async def test_fetch_google_ads_performance_rows_raises_when_creds_missing() -> None:
+    """Uniform missing-creds semantics: the rows fetcher raises the
+    same :class:`NoCredentialsError` as the metrics fetcher so the
+    adapter can render a single sentinel headline.
+    """
+    from mureo.analytics.builtin._live_clients import (
+        fetch_google_ads_performance_rows,
+    )
+
+    with (
+        patch("mureo.byod.runtime.byod_has", return_value=False),
+        patch("mureo.auth.load_google_ads_credentials", return_value=None),
+        pytest.raises(NoCredentialsError, match="google_ads"),
+    ):
+        await fetch_google_ads_performance_rows("acct-1", "LAST_7_DAYS")
+
+
+@pytest.mark.asyncio
+async def test_fetch_meta_ads_performance_rows_raises_when_creds_missing() -> None:
+    from mureo.analytics.builtin._live_clients import (
+        fetch_meta_ads_performance_rows,
+    )
+
+    with (
+        patch("mureo.byod.runtime.byod_has", return_value=False),
+        patch("mureo.auth.load_meta_ads_credentials", return_value=None),
+        pytest.raises(NoCredentialsError, match="meta_ads"),
+    ):
+        await fetch_meta_ads_performance_rows("act_x", "last_7d")
+
+
+@pytest.mark.unit
+def test_aggregation_masks_per_campaign_anomaly_known_limitation() -> None:
+    """Pin the known-limitation trade-off documented on
+    :func:`fetch_google_ads_metrics`: one campaign dropping cost to
+    zero while another scales up nets out at the aggregate.
+
+    This is intentional Phase-1 behavior — per-campaign fan-out is a
+    follow-up. The test exists so a future change that breaks the
+    trade-off (in either direction) is caught and reviewed
+    deliberately rather than slipping past.
+    """
+    from mureo.analysis.anomaly_detector import detect_anomalies
+
+    current_rows: list[dict[str, Any]] = [
+        # Campaign A: cost collapsed to zero.
+        {
+            "metrics": {
+                "cost": 0.0,
+                "impressions": 0,
+                "clicks": 0,
+                "conversions": 0,
+            }
+        },
+        # Campaign B: scaled up to compensate.
+        {
+            "metrics": {
+                "cost": 1000.0,
+                "impressions": 5000,
+                "clicks": 200,
+                "conversions": 20,
+            }
+        },
+    ]
+    baseline_rows: list[dict[str, Any]] = [
+        {
+            "metrics": {
+                "cost": 500.0,
+                "impressions": 2500,
+                "clicks": 100,
+                "conversions": 10,
+            }
+        },
+        {
+            "metrics": {
+                "cost": 500.0,
+                "impressions": 2500,
+                "clicks": 100,
+                "conversions": 10,
+            }
+        },
+    ]
+    current = _aggregate_google_metrics(current_rows, account_id="acct")
+    baseline = _aggregate_google_metrics(baseline_rows, account_id="acct")
+    # Aggregate: current cost == baseline cost == 1000. No anomaly.
+    anomalies = detect_anomalies(current, baseline, had_prior_spend=True)
+    assert anomalies == [], (
+        "Phase-1 aggregation should mask per-campaign offsets — if this "
+        "assertion fires, the trade-off has changed and the docstring on "
+        "fetch_google_ads_metrics must be updated."
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_meta_ads_metrics_returns_current_and_baseline() -> None:
+    fake_client = AsyncMock()
+    fake_client.get_performance_report = AsyncMock(
+        side_effect=[
+            [{"spend": 100.0, "impressions": 500, "clicks": 20, "actions": []}],
+            [{"spend": 200.0, "impressions": 1000, "clicks": 40, "actions": []}],
+        ]
+    )
+    with (
+        patch("mureo.byod.runtime.byod_has", return_value=False),
+        patch("mureo.auth.load_meta_ads_credentials", return_value=object()),
+        patch(
+            "mureo.mcp._client_factory.get_meta_ads_client",
+            return_value=fake_client,
+        ),
+    ):
+        current, baseline = await fetch_meta_ads_metrics("act_x", window_days=7)
+
+    assert current.cost == 100.0
+    assert baseline is not None
+    assert baseline.cost == 200.0


### PR DESCRIPTION
## Summary

Follow-up to the protocol/registry PR. The built-in `google_ads` / `meta_ads` adapters previously returned empty tuples / stub headlines; this PR wires them to the real platform clients via a lazy-import fetcher layer.

Also fixes a **silent-zero bug** discovered during end-to-end validation: the aggregators assumed the live row shape (metrics nested under `row["metrics"]` for Google, conversions in `row["actions"]` for Meta) but BYOD clients return flat shapes — silently producing `cost=0` / `conversions=0` in BYOD mode.

## What ships

- `mureo/analytics/builtin/_live_clients.py` — `fetch_*_metrics` / `fetch_*_performance_rows`, lazy auth lookup, BYOD-routing via the existing `_client_factory`, uniform `NoCredentialsError`
- Adapter changes: `detect_anomalies` + `diagnose_performance` now run against live (or BYOD) data; missing creds rendered as sentinel `PerformanceDiagnosis` ("credentials not configured"); type-safe shape-tolerance helpers
- Regression tests pinning both shapes

Validated post-fix against the local BYOD bundle:
- `google_ads`: 4 campaigns, spend 4,256,000, CV 478.4, CPA 8,895
- `meta_ads`:   4 campaigns, spend   854,000, CV 306.6, CPA 2,785

## Test plan

- [x] +26 tests (89 → 115 cumulative on analytics package)
- [x] Code-review HIGH (mock patch-site / dead `except NoCredentialsError` / asymmetric missing-creds) + MEDIUM (dedupe `PerformanceFetcher`, redundant `byod_has`, known-limit regression) addressed
- [x] Zero regressions vs `main`

Stacked on #PR1 (`feat/analytics-module-protocol-120`).

Refs #120
