### PR TITLE
feat(analytics): per-campaign fan-out + audit_creative + analyze_budget_efficiency (#120)

### DIFF
--- a/mureo/analytics/builtin/_budget_efficiency.py
+++ b/mureo/analytics/builtin/_budget_efficiency.py
@@ -1,0 +1,175 @@
+"""Budget efficiency scoring for the built-in analytics adapters.
+
+Pure scorer: takes per-campaign performance rows in either Google's
+``{metrics: {...}}`` shape or the flat BYOD / Meta shape, normalises
+the conversion-per-cost ratio across campaigns, and returns the
+:class:`BudgetEfficiency` payload the workflow skills consume.
+
+Scoring model (deliberately simple — see the budget-rebalance skill
+for the deeper analysis):
+
+- For each campaign with spend > 0, compute ``conversions / cost``.
+- Normalise to [0.0, 1.0] by dividing by the best campaign's rate
+  (so the top performer scores 1.0, others scale relative to it).
+- Flag campaigns with score < 0.3 as inefficient if there is at least
+  one campaign with score >= 0.7 — that's the "reallocation
+  opportunity" signal.
+
+Pure: no I/O, no platform-specific calls. The adapter feeds it the
+data and renders the response.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mureo.analytics.models import BudgetEfficiency
+
+INEFFICIENT_THRESHOLD = 0.3
+EFFICIENT_THRESHOLD = 0.7
+
+
+def _extract_cost_and_conversions(
+    row: dict[str, Any],
+    *,
+    spend_key: str,
+    nested_metrics: bool,
+) -> tuple[str, float, float] | None:
+    """Return ``(campaign_id, cost, conversions)`` for one row, or
+    ``None`` when the row is unusable (missing id / non-positive cost).
+
+    The two shape selectors mirror the live-clients module's
+    BYOD-tolerance helpers — kept here as small inline branches rather
+    than importing the helpers to avoid a circular dep on adapters.
+    """
+    campaign_id = str(row.get("campaign_id") or "").strip()
+    if not campaign_id:
+        return None
+
+    if nested_metrics:
+        metrics = row.get("metrics")
+        if isinstance(metrics, dict) and metrics:
+            cost = float(metrics.get("cost") or 0)
+            conversions = float(metrics.get("conversions") or 0)
+        else:
+            # Live mapper produced no nested metrics — fall through to
+            # flat lookup. Matches the BYOD path.
+            cost = float(row.get("cost") or 0)
+            conversions = float(row.get("conversions") or 0)
+    else:
+        cost = float(row.get(spend_key) or 0)
+        conversions = float(row.get("conversions") or 0)
+        # Meta Live shape: conversions live inside ``actions``. Sum
+        # leads/purchases there if no flat conversion field is set.
+        if conversions == 0:
+            actions = row.get("actions")
+            if isinstance(actions, list):
+                for action in actions:
+                    if not isinstance(action, dict):
+                        continue
+                    action_type = str(action.get("action_type", ""))
+                    if "lead" in action_type or "purchase" in action_type:
+                        conversions += float(action.get("value") or 0)
+
+    if cost <= 0:
+        return None
+    return campaign_id, cost, conversions
+
+
+def score_budget_efficiency(
+    rows: list[dict[str, Any]],
+    *,
+    platform: str,
+    account_id: str,
+    spend_key: str = "cost",
+    nested_metrics: bool = True,
+) -> BudgetEfficiency:
+    """Score per-campaign efficiency and propose a reallocation move.
+
+    Args:
+        rows: Per-campaign performance rows.
+        platform: Stamped onto the returned :class:`BudgetEfficiency`.
+        account_id: Same.
+        spend_key: ``"cost"`` for Google, ``"spend"`` for Meta.
+        nested_metrics: ``True`` when the row may wrap metrics under
+            ``row["metrics"]`` (Google live). The function still
+            tolerates either shape when this flag is set; the explicit
+            flag exists for callers that want to assert the shape they
+            expect (and catch upstream bugs that drop the wrapper).
+    """
+    rates: dict[str, tuple[float, float]] = {}  # campaign_id -> (rate, cost)
+    total_unused = 0.0
+    for row in rows:
+        extracted = _extract_cost_and_conversions(
+            row, spend_key=spend_key, nested_metrics=nested_metrics
+        )
+        if extracted is None:
+            continue
+        campaign_id, cost, conversions = extracted
+        rate = conversions / cost  # cost > 0 enforced by extractor
+        rates[campaign_id] = (rate, cost)
+        if conversions == 0:
+            total_unused += cost
+
+    if not rates:
+        return BudgetEfficiency(
+            platform=platform,
+            account_id=account_id,
+            per_campaign_score=(),
+            rebalance_suggestion="no campaigns with spend",
+            unused_budget_amount=0.0,
+        )
+
+    best_rate = max(rate for rate, _ in rates.values())
+    if best_rate <= 0:
+        # All campaigns have zero conversions — every campaign is "as
+        # efficient as the best", which is meaningless. Return zeros
+        # and let the workflow flag the absence of conversions.
+        scores = [(cid, 0.0) for cid in sorted(rates)]
+        return BudgetEfficiency(
+            platform=platform,
+            account_id=account_id,
+            per_campaign_score=tuple(scores),
+            rebalance_suggestion=(
+                "no campaign converted this window — check tracking before "
+                "reallocating budget"
+            ),
+            unused_budget_amount=total_unused,
+        )
+
+    scored: list[tuple[str, float]] = []
+    for cid in sorted(rates):
+        rate, _ = rates[cid]
+        scored.append((cid, round(rate / best_rate, 3)))
+
+    inefficient = [cid for cid, score in scored if score < INEFFICIENT_THRESHOLD]
+    # The top campaign by definition scores 1.0 (best_rate > 0 here), so
+    # at least one campaign satisfies the EFFICIENT_THRESHOLD bound —
+    # the previous ``elif inefficient and not efficient`` branch was
+    # unreachable. Kept the suggestion text scoped to the inefficient/
+    # efficient split that actually occurs.
+    efficient = [cid for cid, score in scored if score >= EFFICIENT_THRESHOLD]
+
+    if inefficient:
+        suggestion = (
+            f"reallocate spend from {len(inefficient)} inefficient campaign(s) "
+            f"({', '.join(inefficient[:3])}) toward {len(efficient)} efficient "
+            f"campaign(s) ({', '.join(efficient[:3])})"
+        )
+    else:
+        suggestion = "budget mix is balanced — no reallocation suggested"
+
+    return BudgetEfficiency(
+        platform=platform,
+        account_id=account_id,
+        per_campaign_score=tuple(scored),
+        rebalance_suggestion=suggestion,
+        unused_budget_amount=total_unused,
+    )
+
+
+__all__ = [
+    "EFFICIENT_THRESHOLD",
+    "INEFFICIENT_THRESHOLD",
+    "score_budget_efficiency",
+]

--- a/mureo/analytics/builtin/_common.py
+++ b/mureo/analytics/builtin/_common.py
@@ -18,7 +18,7 @@ avoids cycles at registration time.
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 
 from mureo.analysis.anomaly_detector import (
     Anomaly as _DetectorAnomaly,
@@ -34,10 +34,67 @@ if TYPE_CHECKING:
     from mureo.analysis.anomaly_detector import CampaignMetrics
 
 
+def google_row_metrics(row: dict[str, Any]) -> dict[str, Any]:
+    """Return the metrics view of a Google Ads performance row.
+
+    Live :func:`mureo.google_ads.mappers.map_performance_report` nests
+    metrics under ``row["metrics"]``; BYOD
+    :class:`mureo.byod.clients.ByodGoogleAdsClient.get_performance_report`
+    returns them flat at the top level. Both are valid factory outputs
+    so the helper accepts either — strictly preferring the nested view
+    when it is a non-empty dict (the live mapper always populates it),
+    falling back to the row itself for the BYOD shape.
+
+    Promoted from ``_live_clients`` so the budget-efficiency scorer
+    and the diagnose summariser can share the same single helper
+    rather than each importing a private symbol.
+    """
+    nested = row.get("metrics")
+    if isinstance(nested, dict) and nested:
+        return nested
+    return row
+
+
+def meta_row_conversions(row: dict[str, Any]) -> float:
+    """Return the conversion count for a Meta performance row.
+
+    Live: conversions live inside an ``actions`` list keyed by
+    ``action_type``. BYOD: pre-aggregated under a top-level
+    ``conversions`` field with no ``actions`` list. Detected during
+    the #120 live-wiring validation — accepting only the live shape
+    silently zeroes BYOD conversions.
+    """
+    actions = row.get("actions")
+    if isinstance(actions, list):
+        total = 0.0
+        for action in actions:
+            if not isinstance(action, dict):
+                continue
+            action_type = str(action.get("action_type", ""))
+            if "lead" in action_type or "purchase" in action_type:
+                total += float(action.get("value") or 0)
+        return total
+    return float(row.get("conversions") or 0)
+
+
 # Type alias used by both built-in adapters' ``diagnose_performance``.
 # Tests inject a deterministic stub; production paths resolve to the
 # live client inside the adapter.
 PerformanceFetcher = Callable[[str, str], Awaitable[list[dict[str, object]]]]
+
+
+# Per-campaign fan-out fetcher — successor to the legacy
+# :class:`MetricsFetcher` aggregate path. Returns a mapping of
+# ``campaign_id`` to ``(current, baseline)`` so the detector runs once
+# per campaign instead of once per account. ``baseline`` is ``None``
+# when the campaign has no usable prior-window data.
+if TYPE_CHECKING:
+    from mureo.analysis.anomaly_detector import CampaignMetrics
+
+PerCampaignMetricsFetcher = Callable[
+    ...,
+    "Awaitable[dict[str, tuple[CampaignMetrics, CampaignMetrics | None]]]",
+]
 
 
 _SEVERITY_MAP: dict[_DetectorSeverity, AnomalySeverity] = {
@@ -99,7 +156,10 @@ class MetricsFetcher(Protocol):
 
 __all__ = [
     "MetricsFetcher",
+    "PerCampaignMetricsFetcher",
     "PerformanceFetcher",
+    "google_row_metrics",
+    "meta_row_conversions",
     "to_analytics_anomalies",
     "to_analytics_anomaly",
 ]

--- a/mureo/analytics/builtin/_creative_audit.py
+++ b/mureo/analytics/builtin/_creative_audit.py
@@ -1,0 +1,274 @@
+"""Creative audit logic for the built-in analytics adapters.
+
+Pure functions that consume the platform's ``list_ads`` response and
+produce :class:`CreativeFinding` lists. Kept platform-specific because
+RSA / RDA / Meta-creative have genuinely different surfaces; sharing
+across them would invent a generic that fits neither well.
+
+Severity follows the same CRITICAL / HIGH scheme as
+:class:`mureo.analytics.models.AnomalySeverity` — CRITICAL is something
+the system would otherwise reject (RSA with <3 headlines is policy-
+violating in Google's UI), HIGH is a strong recommendation (no image,
+missing description).
+
+Tolerates BYOD shape: the Google BYOD adapter returns ads with
+``headlines`` as a 2-element list of ``[headline_1, headline_2]``,
+which trips the "must have ≥3 headlines" check naturally. We surface
+the finding rather than guess at the missing strings.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mureo.analytics.models import AnomalySeverity, CreativeFinding
+
+# Google RSA policy thresholds — match the values shown in the Google
+# Ads UI's "Ad strength" panel.
+_RSA_MIN_HEADLINES = 3
+_RSA_MIN_DESCRIPTIONS = 2
+_RSA_RECOMMENDED_HEADLINES = 15  # Google recommends filling all 15 slots
+_RSA_RECOMMENDED_DESCRIPTIONS = 4
+
+
+def _is_rsa(ad: dict[str, Any]) -> bool:
+    ad_type = str(ad.get("type", "") or ad.get("ad_type", "")).upper()
+    return ad_type in {"RESPONSIVE_SEARCH_AD", "RSA"}
+
+
+def _is_rda(ad: dict[str, Any]) -> bool:
+    ad_type = str(ad.get("type", "") or ad.get("ad_type", "")).upper()
+    return ad_type in {"RESPONSIVE_DISPLAY_AD", "RDA"}
+
+
+def _non_empty_strings(values: Any) -> list[str]:
+    """Filter to non-empty trimmed strings.
+
+    Accepts the variety of shapes the live + BYOD clients return:
+    a list of plain strings, a list of dicts with ``text`` keys, or
+    ``None``.
+    """
+    if not isinstance(values, list):
+        return []
+    out: list[str] = []
+    for v in values:
+        if isinstance(v, str):
+            text = v.strip()
+        elif isinstance(v, dict):
+            text = str(v.get("text") or "").strip()
+        else:
+            text = ""
+        if text:
+            out.append(text)
+    return out
+
+
+def audit_google_ads_creatives(
+    ads: list[dict[str, Any]],
+) -> list[CreativeFinding]:
+    """Inspect a list of Google Ads ads and return policy/quality findings.
+
+    Only RSA + RDA ads are audited today; other ad types pass through
+    silently. The function is pure — no network, no I/O — so the
+    adapter can call it on whatever shape the live or BYOD client
+    returns without further plumbing.
+    """
+    findings: list[CreativeFinding] = []
+    for ad in ads:
+        ad_id = str(ad.get("id") or ad.get("ad_id") or "").strip()
+        if not ad_id:
+            continue
+
+        if _is_rsa(ad):
+            findings.extend(_audit_rsa(ad, ad_id))
+        elif _is_rda(ad):
+            findings.extend(_audit_rda(ad, ad_id))
+    return findings
+
+
+def _audit_rsa(ad: dict[str, Any], ad_id: str) -> list[CreativeFinding]:
+    findings: list[CreativeFinding] = []
+    headlines = _non_empty_strings(ad.get("headlines"))
+    descriptions = _non_empty_strings(ad.get("descriptions"))
+
+    if len(headlines) < _RSA_MIN_HEADLINES:
+        findings.append(
+            CreativeFinding(
+                asset_id=ad_id,
+                asset_type="RSA",
+                severity=AnomalySeverity.CRITICAL,
+                message=(
+                    f"RSA has only {len(headlines)} headline(s) — "
+                    f"minimum is {_RSA_MIN_HEADLINES}"
+                ),
+                recommended_action=(
+                    "Add headlines until at least 3 are present; "
+                    "Google recommends filling all 15 slots for full "
+                    "Ad-Strength evaluation."
+                ),
+            )
+        )
+    elif len(headlines) < _RSA_RECOMMENDED_HEADLINES:
+        findings.append(
+            CreativeFinding(
+                asset_id=ad_id,
+                asset_type="RSA",
+                severity=AnomalySeverity.HIGH,
+                message=(
+                    f"RSA has {len(headlines)} headlines — "
+                    f"Google recommends {_RSA_RECOMMENDED_HEADLINES}"
+                ),
+                recommended_action=("Add headline variants to improve Ad Strength."),
+            )
+        )
+
+    if len(descriptions) < _RSA_MIN_DESCRIPTIONS:
+        findings.append(
+            CreativeFinding(
+                asset_id=ad_id,
+                asset_type="RSA",
+                severity=AnomalySeverity.CRITICAL,
+                message=(
+                    f"RSA has only {len(descriptions)} description(s) — "
+                    f"minimum is {_RSA_MIN_DESCRIPTIONS}"
+                ),
+                recommended_action="Add at least 2 descriptions.",
+            )
+        )
+
+    return findings
+
+
+def _audit_rda(ad: dict[str, Any], ad_id: str) -> list[CreativeFinding]:
+    findings: list[CreativeFinding] = []
+    headlines = _non_empty_strings(ad.get("headlines"))
+    long_headline = str(ad.get("long_headline") or "").strip()
+    descriptions = _non_empty_strings(ad.get("descriptions"))
+    images = ad.get("marketing_images") or ad.get("square_marketing_images") or []
+
+    if not headlines:
+        findings.append(
+            CreativeFinding(
+                asset_id=ad_id,
+                asset_type="RDA",
+                severity=AnomalySeverity.CRITICAL,
+                message="RDA has no short headlines",
+                recommended_action="Add at least one short headline (≤30 chars).",
+            )
+        )
+    if not long_headline:
+        findings.append(
+            CreativeFinding(
+                asset_id=ad_id,
+                asset_type="RDA",
+                severity=AnomalySeverity.HIGH,
+                message="RDA missing long headline",
+                recommended_action="Add a long headline (≤90 chars).",
+            )
+        )
+    if not descriptions:
+        findings.append(
+            CreativeFinding(
+                asset_id=ad_id,
+                asset_type="RDA",
+                severity=AnomalySeverity.CRITICAL,
+                message="RDA has no descriptions",
+                recommended_action="Add at least one description.",
+            )
+        )
+    if not isinstance(images, list) or not images:
+        findings.append(
+            CreativeFinding(
+                asset_id=ad_id,
+                asset_type="RDA",
+                severity=AnomalySeverity.HIGH,
+                message="RDA has no marketing images",
+                recommended_action="Add at least one landscape image.",
+            )
+        )
+    return findings
+
+
+def audit_meta_ads_creatives(
+    ads: list[dict[str, Any]],
+) -> list[CreativeFinding]:
+    """Inspect a list of Meta ads and return creative-quality findings.
+
+    Meta's ad model nests the creative under ``ad["creative"]``; on the
+    BYOD side the same fields may be at the top level. Both shapes are
+    accepted.
+    """
+    findings: list[CreativeFinding] = []
+    for ad in ads:
+        ad_id = str(ad.get("id") or ad.get("ad_id") or "").strip()
+        if not ad_id:
+            continue
+
+        creative = ad.get("creative")
+        if not isinstance(creative, dict):
+            creative = ad
+
+        title = str(creative.get("title") or "").strip()
+        body = str(creative.get("body") or "").strip()
+        image_url = str(
+            creative.get("image_url") or creative.get("thumbnail_url") or ""
+        ).strip()
+        story_spec = creative.get("object_story_spec") or {}
+        link_data = (
+            story_spec.get("link_data") if isinstance(story_spec, dict) else None
+        )
+        cta = ""
+        if isinstance(link_data, dict):
+            call_to_action = link_data.get("call_to_action") or {}
+            if isinstance(call_to_action, dict):
+                cta = str(call_to_action.get("type") or "").strip()
+
+        if not body:
+            findings.append(
+                CreativeFinding(
+                    asset_id=ad_id,
+                    asset_type="META_AD",
+                    severity=AnomalySeverity.CRITICAL,
+                    message="Ad has no primary text",
+                    recommended_action="Add a primary text variant.",
+                )
+            )
+        if not title:
+            findings.append(
+                CreativeFinding(
+                    asset_id=ad_id,
+                    asset_type="META_AD",
+                    severity=AnomalySeverity.HIGH,
+                    message="Ad has no headline",
+                    recommended_action="Add a headline.",
+                )
+            )
+        if not image_url:
+            findings.append(
+                CreativeFinding(
+                    asset_id=ad_id,
+                    asset_type="META_AD",
+                    severity=AnomalySeverity.CRITICAL,
+                    message="Ad has no image",
+                    recommended_action="Attach an image or thumbnail.",
+                )
+            )
+        if not cta:
+            findings.append(
+                CreativeFinding(
+                    asset_id=ad_id,
+                    asset_type="META_AD",
+                    severity=AnomalySeverity.HIGH,
+                    message="Ad has no call_to_action",
+                    recommended_action=(
+                        "Set a call_to_action.type (e.g. LEARN_MORE, SIGN_UP)."
+                    ),
+                )
+            )
+    return findings
+
+
+__all__ = [
+    "audit_google_ads_creatives",
+    "audit_meta_ads_creatives",
+]

--- a/mureo/analytics/builtin/_live_clients.py
+++ b/mureo/analytics/builtin/_live_clients.py
@@ -55,6 +55,23 @@ _GOOGLE_PERIOD_MAP: dict[int, tuple[str, str]] = {
 }
 
 
+def _google_row_metrics(row: dict[str, Any]) -> dict[str, Any]:
+    """Return the metrics view of a Google Ads performance row.
+
+    Live :func:`mureo.google_ads.mappers.map_performance_report` nests
+    metrics under ``row["metrics"]``; BYOD
+    :class:`mureo.byod.clients.ByodGoogleAdsClient.get_performance_report`
+    returns them flat at the top level. Both shapes are valid responses
+    from :func:`mureo.mcp._client_factory.get_google_ads_client`, so
+    the aggregator has to accept either or it silently double-zeros
+    the BYOD path (confirmed bug during #120 live-wiring validation).
+    """
+    nested = row.get("metrics")
+    if isinstance(nested, dict) and nested:
+        return nested
+    return row
+
+
 def _aggregate_google_metrics(
     rows: list[dict[str, Any]],
     account_id: str,
@@ -72,11 +89,11 @@ def _aggregate_google_metrics(
     clicks = 0
     conversions = 0.0
     for row in rows:
-        metrics = row.get("metrics") or {}
-        cost += float(metrics.get("cost", 0) or 0)
-        impressions += int(metrics.get("impressions", 0) or 0)
-        clicks += int(metrics.get("clicks", 0) or 0)
-        conversions += float(metrics.get("conversions", 0) or 0)
+        metrics = _google_row_metrics(row)
+        cost += float(metrics.get("cost") or 0)
+        impressions += int(metrics.get("impressions") or 0)
+        clicks += int(metrics.get("clicks") or 0)
+        conversions += float(metrics.get("conversions") or 0)
     return CampaignMetrics(
         campaign_id=account_id,
         cost=cost,
@@ -181,28 +198,57 @@ _META_PERIOD_MAP: dict[int, tuple[str, str]] = {
 }
 
 
+def _meta_row_conversions(row: dict[str, Any]) -> float:
+    """Return conversion count for a Meta performance row.
+
+    Two shapes have to be accepted:
+
+    * Live :class:`MetaAdsApiClient` returns the raw Marketing API
+      response — conversions live inside an ``actions`` list keyed by
+      ``action_type``.
+    * BYOD :class:`ByodMetaAdsClient.get_performance_report` pre-
+      aggregates conversions into a top-level ``conversions`` field
+      and provides a ``result_indicator`` instead of the ``actions``
+      list.
+
+    Detected during #120 live-wiring validation — accepting only the
+    Live shape silently zeroes BYOD conversions.
+    """
+    actions = row.get("actions")
+    if isinstance(actions, list):
+        total = 0.0
+        for action in actions:
+            if not isinstance(action, dict):
+                continue
+            action_type = str(action.get("action_type", ""))
+            # Match the existing analysis-surface convention
+            # (mureo/meta_ads/_analysis.py): leads + purchases are
+            # the canonical conversion actions.
+            if "lead" in action_type or "purchase" in action_type:
+                total += float(action.get("value") or 0)
+        return total
+    # BYOD path — already aggregated.
+    return float(row.get("conversions") or 0)
+
+
 def _aggregate_meta_metrics(
     rows: list[dict[str, Any]],
     account_id: str,
 ) -> CampaignMetrics:
-    """Aggregate Meta insights rows to an account-level metric tuple."""
+    """Aggregate Meta insights rows to an account-level metric tuple.
+
+    Tolerates both the Live (``actions`` list) and BYOD (flat
+    ``conversions``) row shapes — see :func:`_meta_row_conversions`.
+    """
     cost = 0.0
     impressions = 0
     clicks = 0
     conversions = 0.0
     for row in rows:
-        cost += float(row.get("spend", 0) or 0)
-        impressions += int(row.get("impressions", 0) or 0)
-        clicks += int(row.get("clicks", 0) or 0)
-        # Meta returns conversions per action_type. We sum
-        # offsite_conversion.fb_pixel_lead + onsite_conversion.lead_grouped
-        # if present — same convention as the existing analysis surface
-        # (mureo/meta_ads/_analysis.py treats those as the canonical
-        # "lead" actions).
-        for action in row.get("actions", []) or []:
-            action_type = str(action.get("action_type", ""))
-            if "lead" in action_type or "purchase" in action_type:
-                conversions += float(action.get("value", 0) or 0)
+        cost += float(row.get("spend") or 0)
+        impressions += int(row.get("impressions") or 0)
+        clicks += int(row.get("clicks") or 0)
+        conversions += _meta_row_conversions(row)
     return CampaignMetrics(
         campaign_id=account_id,
         cost=cost,

--- a/mureo/analytics/builtin/_live_clients.py
+++ b/mureo/analytics/builtin/_live_clients.py
@@ -27,9 +27,18 @@ Failure modes:
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from mureo.analysis.anomaly_detector import CampaignMetrics
+from mureo.analytics.builtin._common import (
+    google_row_metrics as _google_row_metrics,
+)
+from mureo.analytics.builtin._common import (
+    meta_row_conversions as _meta_row_conversions,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 class NoCredentialsError(RuntimeError):
@@ -53,23 +62,6 @@ _GOOGLE_PERIOD_MAP: dict[int, tuple[str, str]] = {
     14: ("LAST_14_DAYS", "LAST_30_DAYS"),
     30: ("LAST_30_DAYS", "LAST_30_DAYS"),
 }
-
-
-def _google_row_metrics(row: dict[str, Any]) -> dict[str, Any]:
-    """Return the metrics view of a Google Ads performance row.
-
-    Live :func:`mureo.google_ads.mappers.map_performance_report` nests
-    metrics under ``row["metrics"]``; BYOD
-    :class:`mureo.byod.clients.ByodGoogleAdsClient.get_performance_report`
-    returns them flat at the top level. Both shapes are valid responses
-    from :func:`mureo.mcp._client_factory.get_google_ads_client`, so
-    the aggregator has to accept either or it silently double-zeros
-    the BYOD path (confirmed bug during #120 live-wiring validation).
-    """
-    nested = row.get("metrics")
-    if isinstance(nested, dict) and nested:
-        return nested
-    return row
 
 
 def _aggregate_google_metrics(
@@ -184,6 +176,205 @@ async def fetch_google_ads_performance_rows(
     return await client.get_performance_report(period=period)  # type: ignore[attr-defined,no-any-return]
 
 
+def _row_to_campaign_metrics(
+    row: dict[str, Any],
+    *,
+    nested_metrics_getter: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+    spend_key: str = "cost",
+    conversion_getter: Callable[[dict[str, Any]], float] | None = None,
+) -> CampaignMetrics | None:
+    """Convert one platform row into a :class:`CampaignMetrics`.
+
+    Centralises the BYOD↔Live shape tolerance documented on
+    :func:`_google_row_metrics` / :func:`_meta_row_conversions` so both
+    fan-out fetchers can reuse the same logic.
+
+    Returns ``None`` when the row has no usable ``campaign_id`` — such
+    rows are dropped rather than aggregated into a synthetic
+    ``""``-keyed entry that would silently mix multiple campaigns'
+    metrics.
+    """
+    campaign_id = str(row.get("campaign_id") or "").strip()
+    if not campaign_id:
+        return None
+
+    metrics = nested_metrics_getter(row) if nested_metrics_getter else row
+    cost = float(metrics.get(spend_key) or 0)
+    impressions = int(metrics.get("impressions") or 0)
+    clicks = int(metrics.get("clicks") or 0)
+    if conversion_getter is not None:
+        conversions = conversion_getter(row)
+    else:
+        conversions = float(metrics.get("conversions") or 0)
+    return CampaignMetrics(
+        campaign_id=campaign_id,
+        cost=cost,
+        impressions=impressions,
+        clicks=clicks,
+        conversions=conversions,
+    )
+
+
+def _index_google_rows_by_campaign(
+    rows: list[dict[str, Any]],
+) -> dict[str, CampaignMetrics]:
+    """Build ``{campaign_id: metrics}`` from Google rows.
+
+    A campaign appearing multiple times (e.g. day-grain rows) is
+    summed; the metrics are added field-by-field on a single
+    :class:`CampaignMetrics`. Real per-period reports return one row
+    per campaign so the sum is usually a no-op, but the contract is
+    explicit either way.
+    """
+    indexed: dict[str, CampaignMetrics] = {}
+    for row in rows:
+        metric = _row_to_campaign_metrics(
+            row, nested_metrics_getter=_google_row_metrics
+        )
+        if metric is None:
+            continue
+        existing = indexed.get(metric.campaign_id)
+        if existing is None:
+            indexed[metric.campaign_id] = metric
+        else:
+            indexed[metric.campaign_id] = CampaignMetrics(
+                campaign_id=metric.campaign_id,
+                cost=existing.cost + metric.cost,
+                impressions=existing.impressions + metric.impressions,
+                clicks=existing.clicks + metric.clicks,
+                conversions=existing.conversions + metric.conversions,
+            )
+    return indexed
+
+
+async def fetch_google_ads_per_campaign_metrics(
+    account_id: str,
+    *,
+    window_days: int,
+) -> dict[str, tuple[CampaignMetrics, CampaignMetrics | None]]:
+    """Return ``{campaign_id: (current, baseline)}`` for one Google account.
+
+    Per-campaign fan-out (#120 follow-up). Replaces the account-level
+    aggregation that masked offsetting per-campaign anomalies
+    (campaign A drops to zero spend while B scales up — aggregate
+    cost unchanged, no anomaly fires).
+
+    Baseline is ``None`` for campaigns that have no rows in the prior
+    window (new campaigns) or whose prior-window cost is zero
+    (paused/weekend dayparting). The pure detector treats those cases
+    correctly — see :func:`mureo.analysis.anomaly_detector.detect_anomalies`.
+
+    Raises :class:`NoCredentialsError` uniformly with
+    :func:`fetch_google_ads_metrics`.
+    """
+    client = _open_google_ads_client(account_id)
+    current_period, baseline_period = _GOOGLE_PERIOD_MAP.get(
+        window_days, ("LAST_7_DAYS", "LAST_30_DAYS")
+    )
+    current_rows = await client.get_performance_report(  # type: ignore[attr-defined]
+        period=current_period
+    )
+    baseline_rows = await client.get_performance_report(  # type: ignore[attr-defined]
+        period=baseline_period
+    )
+
+    current_index = _index_google_rows_by_campaign(current_rows)
+    baseline_index = _index_google_rows_by_campaign(baseline_rows)
+
+    out: dict[str, tuple[CampaignMetrics, CampaignMetrics | None]] = {}
+    for campaign_id, current in current_index.items():
+        baseline = baseline_index.get(campaign_id)
+        # Zero-spend baseline → no useful comparison; detector
+        # suppresses ratio-based alerts in that case anyway.
+        if baseline is not None and baseline.cost <= 0:
+            baseline = None
+        out[campaign_id] = (current, baseline)
+    return out
+
+
+def _index_meta_rows_by_campaign(
+    rows: list[dict[str, Any]],
+) -> dict[str, CampaignMetrics]:
+    """Build ``{campaign_id: metrics}`` from Meta rows.
+
+    Mirrors :func:`_index_google_rows_by_campaign` for Meta's flatter
+    shape — Meta exposes ``spend`` and either an ``actions`` list
+    (Live) or a top-level ``conversions`` field (BYOD).
+    """
+    indexed: dict[str, CampaignMetrics] = {}
+    for row in rows:
+        metric = _row_to_campaign_metrics(
+            row,
+            spend_key="spend",
+            conversion_getter=_meta_row_conversions,
+        )
+        if metric is None:
+            continue
+        existing = indexed.get(metric.campaign_id)
+        if existing is None:
+            indexed[metric.campaign_id] = metric
+        else:
+            indexed[metric.campaign_id] = CampaignMetrics(
+                campaign_id=metric.campaign_id,
+                cost=existing.cost + metric.cost,
+                impressions=existing.impressions + metric.impressions,
+                clicks=existing.clicks + metric.clicks,
+                conversions=existing.conversions + metric.conversions,
+            )
+    return indexed
+
+
+async def fetch_google_ads_list(
+    account_id: str,
+) -> list[dict[str, object]]:
+    """Return ``list_ads`` results for ``account_id`` (live or BYOD).
+
+    Used by :meth:`GoogleAdsAnalyticsModule.audit_creative`. Raises
+    :class:`NoCredentialsError` in live mode when creds are missing.
+    """
+    client = _open_google_ads_client(account_id)
+    return await client.list_ads()  # type: ignore[attr-defined,no-any-return]
+
+
+async def fetch_meta_ads_list(
+    account_id: str,
+) -> list[dict[str, object]]:
+    """Return ``list_ads`` results for one Meta account."""
+    client = _open_meta_ads_client(account_id)
+    return await client.list_ads()  # type: ignore[attr-defined,no-any-return]
+
+
+async def fetch_meta_ads_per_campaign_metrics(
+    account_id: str,
+    *,
+    window_days: int,
+) -> dict[str, tuple[CampaignMetrics, CampaignMetrics | None]]:
+    """Per-campaign fan-out for Meta — parallel to
+    :func:`fetch_google_ads_per_campaign_metrics`.
+    """
+    client = _open_meta_ads_client(account_id)
+    current_period, baseline_period = _META_PERIOD_MAP.get(
+        window_days, ("last_7d", "last_30d")
+    )
+    current_rows = await client.get_performance_report(  # type: ignore[attr-defined]
+        period=current_period
+    )
+    baseline_rows = await client.get_performance_report(  # type: ignore[attr-defined]
+        period=baseline_period
+    )
+
+    current_index = _index_meta_rows_by_campaign(current_rows)
+    baseline_index = _index_meta_rows_by_campaign(baseline_rows)
+
+    out: dict[str, tuple[CampaignMetrics, CampaignMetrics | None]] = {}
+    for campaign_id, current in current_index.items():
+        baseline = baseline_index.get(campaign_id)
+        if baseline is not None and baseline.cost <= 0:
+            baseline = None
+        out[campaign_id] = (current, baseline)
+    return out
+
+
 # ---------------------------------------------------------------------------
 # Meta Ads
 # ---------------------------------------------------------------------------
@@ -196,39 +387,6 @@ _META_PERIOD_MAP: dict[int, tuple[str, str]] = {
     14: ("last_14d", "last_30d"),
     30: ("last_30d", "last_30d"),
 }
-
-
-def _meta_row_conversions(row: dict[str, Any]) -> float:
-    """Return conversion count for a Meta performance row.
-
-    Two shapes have to be accepted:
-
-    * Live :class:`MetaAdsApiClient` returns the raw Marketing API
-      response — conversions live inside an ``actions`` list keyed by
-      ``action_type``.
-    * BYOD :class:`ByodMetaAdsClient.get_performance_report` pre-
-      aggregates conversions into a top-level ``conversions`` field
-      and provides a ``result_indicator`` instead of the ``actions``
-      list.
-
-    Detected during #120 live-wiring validation — accepting only the
-    Live shape silently zeroes BYOD conversions.
-    """
-    actions = row.get("actions")
-    if isinstance(actions, list):
-        total = 0.0
-        for action in actions:
-            if not isinstance(action, dict):
-                continue
-            action_type = str(action.get("action_type", ""))
-            # Match the existing analysis-surface convention
-            # (mureo/meta_ads/_analysis.py): leads + purchases are
-            # the canonical conversion actions.
-            if "lead" in action_type or "purchase" in action_type:
-                total += float(action.get("value") or 0)
-        return total
-    # BYOD path — already aggregated.
-    return float(row.get("conversions") or 0)
 
 
 def _aggregate_meta_metrics(
@@ -314,8 +472,12 @@ async def fetch_meta_ads_performance_rows(
 
 __all__ = [
     "NoCredentialsError",
+    "fetch_google_ads_list",
     "fetch_google_ads_metrics",
+    "fetch_google_ads_per_campaign_metrics",
     "fetch_google_ads_performance_rows",
+    "fetch_meta_ads_list",
     "fetch_meta_ads_metrics",
+    "fetch_meta_ads_per_campaign_metrics",
     "fetch_meta_ads_performance_rows",
 ]

--- a/mureo/analytics/builtin/google_ads.py
+++ b/mureo/analytics/builtin/google_ads.py
@@ -190,12 +190,15 @@ def _summarise_performance(
     clicks = 0
     conversions = 0.0
     for row in rows:
-        metrics = row.get("metrics") or {}
-        if isinstance(metrics, dict):
-            cost += float(metrics.get("cost", 0) or 0)
-            impressions += int(metrics.get("impressions", 0) or 0)
-            clicks += int(metrics.get("clicks", 0) or 0)
-            conversions += float(metrics.get("conversions", 0) or 0)
+        # Live vs BYOD row shape — see _google_row_metrics for the
+        # rationale; both shapes are valid factory outputs.
+        from mureo.analytics.builtin._live_clients import _google_row_metrics
+
+        metrics = _google_row_metrics(row)
+        cost += float(metrics.get("cost") or 0)
+        impressions += int(metrics.get("impressions") or 0)
+        clicks += int(metrics.get("clicks") or 0)
+        conversions += float(metrics.get("conversions") or 0)
 
     cpa = (cost / conversions) if conversions > 0 else None
     ctr = (clicks / impressions) if impressions > 0 else None

--- a/mureo/analytics/builtin/google_ads.py
+++ b/mureo/analytics/builtin/google_ads.py
@@ -25,17 +25,26 @@ and BYOD mode is picked up automatically.
 
 from __future__ import annotations
 
-from typing import Any
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Any
 
 from mureo.analysis.anomaly_detector import detect_anomalies
+from mureo.analytics.builtin._budget_efficiency import score_budget_efficiency
 from mureo.analytics.builtin._common import (
     MetricsFetcher,
+    PerCampaignMetricsFetcher,
     PerformanceFetcher,
+    google_row_metrics,
     to_analytics_anomalies,
 )
+
+if TYPE_CHECKING:
+    from mureo.analysis.anomaly_detector import CampaignMetrics
+from mureo.analytics.builtin._creative_audit import audit_google_ads_creatives
 from mureo.analytics.builtin._live_clients import (
     NoCredentialsError,
-    fetch_google_ads_metrics,
+    fetch_google_ads_list,
+    fetch_google_ads_per_campaign_metrics,
     fetch_google_ads_performance_rows,
 )
 from mureo.analytics.models import (
@@ -51,8 +60,17 @@ _CAPABILITIES: frozenset[AnalyticsCapability] = frozenset(
     {
         AnalyticsCapability.DETECT_ANOMALIES,
         AnalyticsCapability.DIAGNOSE_PERFORMANCE,
+        AnalyticsCapability.AUDIT_CREATIVE,
+        AnalyticsCapability.ANALYZE_BUDGET_EFFICIENCY,
     }
 )
+
+# Injectable fetchers for ``audit_creative`` and
+# ``analyze_budget_efficiency``. Production paths resolve to the live
+# client; tests inject deterministic stubs. Aliased here rather than in
+# ``_common.py`` because they're adapter-local — only used by one of
+# the two methods on one of the two adapters each.
+AdsListFetcher = Callable[[str], "Awaitable[list[dict[str, object]]]"]
 
 
 class GoogleAdsAnalyticsModule(AnalyticsModule):
@@ -64,13 +82,19 @@ class GoogleAdsAnalyticsModule(AnalyticsModule):
         self,
         metrics_fetcher: MetricsFetcher | None = None,
         performance_fetcher: PerformanceFetcher | None = None,
+        per_campaign_metrics_fetcher: PerCampaignMetricsFetcher | None = None,
+        ads_list_fetcher: AdsListFetcher | None = None,
     ) -> None:
-        # Default to the live fetcher; tests inject deterministic stubs.
-        # The fetcher is async but :class:`MetricsFetcher` is declared
-        # as a sync callable so the existing test stubs remain valid —
-        # we re-derive the async path at the call site below.
+        # ``metrics_fetcher`` is the legacy aggregate-path injection
+        # (kept for back-compat with existing tests); the live default
+        # is per-campaign fan-out via
+        # :func:`fetch_google_ads_per_campaign_metrics`. Tests that
+        # care about per-campaign behaviour inject
+        # ``per_campaign_metrics_fetcher`` instead.
         self._metrics_fetcher = metrics_fetcher
         self._performance_fetcher = performance_fetcher
+        self._per_campaign_metrics_fetcher = per_campaign_metrics_fetcher
+        self._ads_list_fetcher = ads_list_fetcher
 
     def capabilities(self) -> frozenset[AnalyticsCapability]:
         return _CAPABILITIES
@@ -81,31 +105,65 @@ class GoogleAdsAnalyticsModule(AnalyticsModule):
         *,
         window_days: int = 7,
     ) -> tuple[Anomaly, ...]:
-        """Detect anomalies on ``account_id`` over the trailing window.
+        """Detect anomalies per campaign on ``account_id``.
 
-        The injected ``metrics_fetcher`` (if any) takes precedence; it
-        keeps the unit-test surface synchronous so the existing tests
-        in ``tests/analytics/builtin/`` keep working. When no override
-        is supplied, the adapter falls back to the async live fetcher.
-        Missing credentials return an empty anomaly tuple so an
-        unconfigured account never shows up as "spend dropped to
-        zero" — that would be a config error, not a real anomaly.
+        Default path: per-campaign fan-out — the live fetcher returns
+        ``{campaign_id: (current, baseline)}`` and the pure detector
+        runs once per campaign. This surfaces single-campaign anomalies
+        that the previous account-level aggregation masked when an
+        offsetting campaign moved in the opposite direction (see #120).
+
+        Back-compat: an injected ``metrics_fetcher`` still triggers
+        the legacy aggregate path; existing tests continue to work
+        without modification. Missing credentials return an empty
+        anomaly tuple — config error, not an anomaly.
         """
         if self._metrics_fetcher is not None:
             current, baseline = self._metrics_fetcher(
                 account_id, window_days=window_days
             )
-        else:
-            try:
-                current, baseline = await fetch_google_ads_metrics(
-                    account_id, window_days=window_days
-                )
-            except NoCredentialsError:
-                return ()
+            had_prior_spend = baseline is not None and baseline.cost > 0
+            detected = detect_anomalies(
+                current, baseline, had_prior_spend=had_prior_spend
+            )
+            return to_analytics_anomalies(detected)
 
-        had_prior_spend = baseline is not None and baseline.cost > 0
-        detected = detect_anomalies(current, baseline, had_prior_spend=had_prior_spend)
-        return to_analytics_anomalies(detected)
+        per_campaign = await self._resolve_per_campaign_metrics(
+            account_id, window_days=window_days
+        )
+        if per_campaign is None:
+            return ()
+
+        all_anomalies: list[Anomaly] = []
+        for current, baseline in per_campaign.values():
+            had_prior_spend = baseline is not None and baseline.cost > 0
+            detected = detect_anomalies(
+                current, baseline, had_prior_spend=had_prior_spend
+            )
+            all_anomalies.extend(to_analytics_anomalies(detected))
+        return tuple(all_anomalies)
+
+    async def _resolve_per_campaign_metrics(
+        self,
+        account_id: str,
+        *,
+        window_days: int,
+    ) -> dict[str, tuple[CampaignMetrics, CampaignMetrics | None]] | None:
+        """Resolve the per-campaign metrics map for ``account_id``.
+
+        Returns ``None`` on missing credentials (the adapter renders
+        that as an empty anomaly tuple); returns the dict otherwise.
+        """
+        if self._per_campaign_metrics_fetcher is not None:
+            return await self._per_campaign_metrics_fetcher(
+                account_id, window_days=window_days
+            )
+        try:
+            return await fetch_google_ads_per_campaign_metrics(
+                account_id, window_days=window_days
+            )
+        except NoCredentialsError:
+            return None
 
     async def diagnose_performance(
         self,
@@ -152,15 +210,59 @@ class GoogleAdsAnalyticsModule(AnalyticsModule):
         )
 
     async def audit_creative(self, account_id: str) -> CreativeAudit:
-        raise NotImplementedError(
-            "GoogleAdsAnalyticsModule does not advertise AUDIT_CREATIVE; "
-            "consult capabilities() before calling"
+        """Audit RSA / RDA creative assets on ``account_id``.
+
+        Pulls ads via the live (or injected) ``list_ads`` fetcher,
+        passes the result through the pure
+        :func:`audit_google_ads_creatives` checker, and packs the
+        findings into a :class:`CreativeAudit`. Returns an empty audit
+        when credentials are missing (config error, not "no findings").
+        """
+        if self._ads_list_fetcher is not None:
+            ads = await self._ads_list_fetcher(account_id)
+        else:
+            try:
+                ads = await fetch_google_ads_list(account_id)
+            except NoCredentialsError:
+                return CreativeAudit(
+                    platform=self.platform,
+                    account_id=account_id,
+                    findings=(),
+                )
+        findings = audit_google_ads_creatives(ads)
+        return CreativeAudit(
+            platform=self.platform,
+            account_id=account_id,
+            findings=tuple(findings),
         )
 
     async def analyze_budget_efficiency(self, account_id: str) -> BudgetEfficiency:
-        raise NotImplementedError(
-            "GoogleAdsAnalyticsModule does not advertise "
-            "ANALYZE_BUDGET_EFFICIENCY; consult capabilities() before calling"
+        """Score per-campaign budget efficiency over the last 30 days.
+
+        Re-uses the same performance fetcher as
+        :meth:`diagnose_performance` (the data is the same — only the
+        analysis differs). Returns an empty :class:`BudgetEfficiency`
+        on missing credentials so the caller can branch uniformly with
+        :meth:`detect_anomalies` and :meth:`diagnose_performance`.
+        """
+        period = "LAST_30_DAYS"
+        if self._performance_fetcher is not None:
+            rows = await self._performance_fetcher(account_id, period)
+        else:
+            try:
+                rows = await fetch_google_ads_performance_rows(account_id, period)
+            except NoCredentialsError:
+                return BudgetEfficiency(
+                    platform=self.platform,
+                    account_id=account_id,
+                    rebalance_suggestion="google_ads credentials not configured",
+                )
+        return score_budget_efficiency(
+            rows,
+            platform=self.platform,
+            account_id=account_id,
+            spend_key="cost",
+            nested_metrics=True,
         )
 
 
@@ -190,11 +292,8 @@ def _summarise_performance(
     clicks = 0
     conversions = 0.0
     for row in rows:
-        # Live vs BYOD row shape — see _google_row_metrics for the
-        # rationale; both shapes are valid factory outputs.
-        from mureo.analytics.builtin._live_clients import _google_row_metrics
-
-        metrics = _google_row_metrics(row)
+        # Live vs BYOD row shape — see :func:`google_row_metrics`.
+        metrics = google_row_metrics(row)
         cost += float(metrics.get("cost") or 0)
         impressions += int(metrics.get("impressions") or 0)
         clicks += int(metrics.get("clicks") or 0)

--- a/mureo/analytics/builtin/meta_ads.py
+++ b/mureo/analytics/builtin/meta_ads.py
@@ -208,22 +208,19 @@ def _summarise_meta_performance(
             findings=(),
         )
 
+    from mureo.analytics.builtin._live_clients import _meta_row_conversions
+
     cost = 0.0
     impressions = 0
     clicks = 0
     conversions = 0.0
     for row in rows:
-        cost += float(row.get("spend", 0) or 0)
-        impressions += int(row.get("impressions", 0) or 0)
-        clicks += int(row.get("clicks", 0) or 0)
-        actions = row.get("actions") or []
-        if isinstance(actions, list):
-            for action in actions:
-                if not isinstance(action, dict):
-                    continue
-                action_type = str(action.get("action_type", ""))
-                if any(t in action_type for t in _CONVERSION_RESULT_TOKENS):
-                    conversions += float(action.get("value", 0) or 0)
+        cost += float(row.get("spend") or 0)
+        impressions += int(row.get("impressions") or 0)
+        clicks += int(row.get("clicks") or 0)
+        # Tolerates live (actions list) and BYOD (flat conversions);
+        # both shapes are valid factory outputs.
+        conversions += _meta_row_conversions(row)
 
     cpa = (cost / conversions) if conversions > 0 else None
     ctr = (clicks / impressions) if impressions > 0 else None

--- a/mureo/analytics/builtin/meta_ads.py
+++ b/mureo/analytics/builtin/meta_ads.py
@@ -20,17 +20,26 @@ Meta-specific:
 
 from __future__ import annotations
 
-from typing import Any
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Any
 
 from mureo.analysis.anomaly_detector import detect_anomalies
+from mureo.analytics.builtin._budget_efficiency import score_budget_efficiency
 from mureo.analytics.builtin._common import (
     MetricsFetcher,
+    PerCampaignMetricsFetcher,
     PerformanceFetcher,
+    meta_row_conversions,
     to_analytics_anomalies,
 )
+
+if TYPE_CHECKING:
+    from mureo.analysis.anomaly_detector import CampaignMetrics
+from mureo.analytics.builtin._creative_audit import audit_meta_ads_creatives
 from mureo.analytics.builtin._live_clients import (
     NoCredentialsError,
-    fetch_meta_ads_metrics,
+    fetch_meta_ads_list,
+    fetch_meta_ads_per_campaign_metrics,
     fetch_meta_ads_performance_rows,
 )
 from mureo.analytics.models import (
@@ -46,8 +55,12 @@ _CAPABILITIES: frozenset[AnalyticsCapability] = frozenset(
     {
         AnalyticsCapability.DETECT_ANOMALIES,
         AnalyticsCapability.DIAGNOSE_PERFORMANCE,
+        AnalyticsCapability.AUDIT_CREATIVE,
+        AnalyticsCapability.ANALYZE_BUDGET_EFFICIENCY,
     }
 )
+
+AdsListFetcher = Callable[[str], "Awaitable[list[dict[str, object]]]"]
 
 
 # Heuristic: action_types we treat as "click-style" vs "conversion-style"
@@ -72,9 +85,13 @@ class MetaAdsAnalyticsModule(AnalyticsModule):
         self,
         metrics_fetcher: MetricsFetcher | None = None,
         performance_fetcher: PerformanceFetcher | None = None,
+        per_campaign_metrics_fetcher: PerCampaignMetricsFetcher | None = None,
+        ads_list_fetcher: AdsListFetcher | None = None,
     ) -> None:
         self._metrics_fetcher = metrics_fetcher
         self._performance_fetcher = performance_fetcher
+        self._per_campaign_metrics_fetcher = per_campaign_metrics_fetcher
+        self._ads_list_fetcher = ads_list_fetcher
 
     def capabilities(self) -> frozenset[AnalyticsCapability]:
         return _CAPABILITIES
@@ -85,21 +102,50 @@ class MetaAdsAnalyticsModule(AnalyticsModule):
         *,
         window_days: int = 7,
     ) -> tuple[Anomaly, ...]:
+        """Detect anomalies per campaign — parallel to the Google
+        adapter's docstring (see that module for the rationale).
+        """
         if self._metrics_fetcher is not None:
             current, baseline = self._metrics_fetcher(
                 account_id, window_days=window_days
             )
-        else:
-            try:
-                current, baseline = await fetch_meta_ads_metrics(
-                    account_id, window_days=window_days
-                )
-            except NoCredentialsError:
-                return ()
+            had_prior_spend = baseline is not None and baseline.cost > 0
+            detected = detect_anomalies(
+                current, baseline, had_prior_spend=had_prior_spend
+            )
+            return to_analytics_anomalies(detected)
 
-        had_prior_spend = baseline is not None and baseline.cost > 0
-        detected = detect_anomalies(current, baseline, had_prior_spend=had_prior_spend)
-        return to_analytics_anomalies(detected)
+        per_campaign = await self._resolve_per_campaign_metrics(
+            account_id, window_days=window_days
+        )
+        if per_campaign is None:
+            return ()
+
+        all_anomalies: list[Anomaly] = []
+        for current, baseline in per_campaign.values():
+            had_prior_spend = baseline is not None and baseline.cost > 0
+            detected = detect_anomalies(
+                current, baseline, had_prior_spend=had_prior_spend
+            )
+            all_anomalies.extend(to_analytics_anomalies(detected))
+        return tuple(all_anomalies)
+
+    async def _resolve_per_campaign_metrics(
+        self,
+        account_id: str,
+        *,
+        window_days: int,
+    ) -> dict[str, tuple[CampaignMetrics, CampaignMetrics | None]] | None:
+        if self._per_campaign_metrics_fetcher is not None:
+            return await self._per_campaign_metrics_fetcher(
+                account_id, window_days=window_days
+            )
+        try:
+            return await fetch_meta_ads_per_campaign_metrics(
+                account_id, window_days=window_days
+            )
+        except NoCredentialsError:
+            return None
 
     async def diagnose_performance(
         self,
@@ -134,15 +180,47 @@ class MetaAdsAnalyticsModule(AnalyticsModule):
         )
 
     async def audit_creative(self, account_id: str) -> CreativeAudit:
-        raise NotImplementedError(
-            "MetaAdsAnalyticsModule does not advertise AUDIT_CREATIVE; "
-            "consult capabilities() before calling"
+        """Audit Meta creative assets — see the Google adapter docstring."""
+        if self._ads_list_fetcher is not None:
+            ads = await self._ads_list_fetcher(account_id)
+        else:
+            try:
+                ads = await fetch_meta_ads_list(account_id)
+            except NoCredentialsError:
+                return CreativeAudit(
+                    platform=self.platform,
+                    account_id=account_id,
+                    findings=(),
+                )
+        findings = audit_meta_ads_creatives(ads)
+        return CreativeAudit(
+            platform=self.platform,
+            account_id=account_id,
+            findings=tuple(findings),
         )
 
     async def analyze_budget_efficiency(self, account_id: str) -> BudgetEfficiency:
-        raise NotImplementedError(
-            "MetaAdsAnalyticsModule does not advertise "
-            "ANALYZE_BUDGET_EFFICIENCY; consult capabilities() before calling"
+        """Score per-campaign budget efficiency on Meta — see the
+        Google adapter docstring for the policy.
+        """
+        period = "last_30d"
+        if self._performance_fetcher is not None:
+            rows = await self._performance_fetcher(account_id, period)
+        else:
+            try:
+                rows = await fetch_meta_ads_performance_rows(account_id, period)
+            except NoCredentialsError:
+                return BudgetEfficiency(
+                    platform=self.platform,
+                    account_id=account_id,
+                    rebalance_suggestion="meta_ads credentials not configured",
+                )
+        return score_budget_efficiency(
+            rows,
+            platform=self.platform,
+            account_id=account_id,
+            spend_key="spend",
+            nested_metrics=False,
         )
 
 
@@ -208,8 +286,6 @@ def _summarise_meta_performance(
             findings=(),
         )
 
-    from mureo.analytics.builtin._live_clients import _meta_row_conversions
-
     cost = 0.0
     impressions = 0
     clicks = 0
@@ -220,7 +296,7 @@ def _summarise_meta_performance(
         clicks += int(row.get("clicks") or 0)
         # Tolerates live (actions list) and BYOD (flat conversions);
         # both shapes are valid factory outputs.
-        conversions += _meta_row_conversions(row)
+        conversions += meta_row_conversions(row)
 
     cpa = (cost / conversions) if conversions > 0 else None
     ctr = (clicks / impressions) if impressions > 0 else None

--- a/tests/analytics/builtin/test_budget_efficiency.py
+++ b/tests/analytics/builtin/test_budget_efficiency.py
@@ -1,0 +1,132 @@
+"""Tests for the pure :func:`score_budget_efficiency` scorer."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from mureo.analytics.builtin._budget_efficiency import (
+    EFFICIENT_THRESHOLD,
+    INEFFICIENT_THRESHOLD,
+    score_budget_efficiency,
+)
+
+
+@pytest.mark.unit
+def test_scorer_handles_empty_rows() -> None:
+    result = score_budget_efficiency(
+        [],
+        platform="google_ads",
+        account_id="acct",
+    )
+    assert result.per_campaign_score == ()
+    assert "no campaigns" in result.rebalance_suggestion
+
+
+@pytest.mark.unit
+def test_scorer_normalises_relative_to_top_performer() -> None:
+    rows: list[dict[str, Any]] = [
+        {"campaign_id": "best", "metrics": {"cost": 100, "conversions": 10}},
+        {"campaign_id": "mid", "metrics": {"cost": 100, "conversions": 5}},
+        {"campaign_id": "worst", "metrics": {"cost": 100, "conversions": 1}},
+    ]
+    result = score_budget_efficiency(rows, platform="google_ads", account_id="acct")
+    scores = dict(result.per_campaign_score)
+    assert scores["best"] == 1.0
+    assert scores["mid"] == pytest.approx(0.5, abs=0.01)
+    assert scores["worst"] == pytest.approx(0.1, abs=0.01)
+
+
+@pytest.mark.unit
+def test_scorer_suggests_reallocation_when_split_clear() -> None:
+    rows: list[dict[str, Any]] = [
+        {"campaign_id": "high", "metrics": {"cost": 100, "conversions": 10}},
+        {"campaign_id": "low", "metrics": {"cost": 100, "conversions": 1}},
+    ]
+    result = score_budget_efficiency(rows, platform="google_ads", account_id="acct")
+    assert "reallocate" in result.rebalance_suggestion
+    assert "low" in result.rebalance_suggestion
+    assert "high" in result.rebalance_suggestion
+
+
+@pytest.mark.unit
+def test_scorer_flags_no_efficient_when_all_inefficient() -> None:
+    """All campaigns at similar low rates → balanced (top scores 1.0
+    by definition; the others trail close behind). Specifically test
+    the case where the spread is too small to suggest reallocation.
+    """
+    rows: list[dict[str, Any]] = [
+        {"campaign_id": "a", "metrics": {"cost": 100, "conversions": 5}},
+        {"campaign_id": "b", "metrics": {"cost": 100, "conversions": 5.5}},
+    ]
+    result = score_budget_efficiency(rows, platform="google_ads", account_id="acct")
+    # No clear split → no reallocation suggestion
+    assert "no reallocation" in result.rebalance_suggestion
+
+
+@pytest.mark.unit
+def test_scorer_zero_conversions_returns_tracking_warning() -> None:
+    rows: list[dict[str, Any]] = [
+        {"campaign_id": "a", "metrics": {"cost": 100, "conversions": 0}},
+        {"campaign_id": "b", "metrics": {"cost": 200, "conversions": 0}},
+    ]
+    result = score_budget_efficiency(rows, platform="google_ads", account_id="acct")
+    assert "tracking" in result.rebalance_suggestion
+    assert result.unused_budget_amount == 300.0
+
+
+@pytest.mark.unit
+def test_scorer_drops_rows_with_zero_cost() -> None:
+    rows: list[dict[str, Any]] = [
+        {"campaign_id": "paused", "metrics": {"cost": 0, "conversions": 0}},
+        {"campaign_id": "active", "metrics": {"cost": 100, "conversions": 10}},
+    ]
+    result = score_budget_efficiency(rows, platform="google_ads", account_id="acct")
+    scores = dict(result.per_campaign_score)
+    assert "paused" not in scores
+    assert "active" in scores
+
+
+@pytest.mark.unit
+def test_scorer_accepts_byod_flat_google_shape() -> None:
+    """BYOD Google rows have metrics at the top level, not nested.
+    Even with ``nested_metrics=True`` the scorer must fall back.
+    """
+    rows: list[dict[str, Any]] = [
+        {"campaign_id": "c", "cost": 100, "conversions": 5},
+    ]
+    result = score_budget_efficiency(
+        rows, platform="google_ads", account_id="acct", nested_metrics=True
+    )
+    assert dict(result.per_campaign_score) == {"c": 1.0}
+
+
+@pytest.mark.unit
+def test_scorer_meta_sums_actions_when_flat_conversions_zero() -> None:
+    rows: list[dict[str, Any]] = [
+        {
+            "campaign_id": "c",
+            "spend": 100,
+            "conversions": 0,
+            "actions": [
+                {"action_type": "offsite_conversion.fb_pixel_lead", "value": 10},
+            ],
+        },
+    ]
+    result = score_budget_efficiency(
+        rows,
+        platform="meta_ads",
+        account_id="act",
+        spend_key="spend",
+        nested_metrics=False,
+    )
+    assert dict(result.per_campaign_score) == {"c": 1.0}
+
+
+@pytest.mark.unit
+def test_thresholds_are_stable_module_constants() -> None:
+    # Constants are referenced by skill prompts as well — keep them
+    # stable. A future tweak should bump tests deliberately.
+    assert INEFFICIENT_THRESHOLD == 0.3
+    assert EFFICIENT_THRESHOLD == 0.7

--- a/tests/analytics/builtin/test_creative_audit.py
+++ b/tests/analytics/builtin/test_creative_audit.py
@@ -1,0 +1,246 @@
+"""Creative audit pure-function tests + adapter wiring tests."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from mureo.analytics.builtin._creative_audit import (
+    audit_google_ads_creatives,
+    audit_meta_ads_creatives,
+)
+from mureo.analytics.builtin.google_ads import GoogleAdsAnalyticsModule
+from mureo.analytics.builtin.meta_ads import MetaAdsAnalyticsModule
+from mureo.analytics.models import AnomalySeverity
+from mureo.analytics.protocol import AnalyticsCapability
+
+# ---------------------------------------------------------------------------
+# Google RSA / RDA — pure
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_google_audit_flags_rsa_with_two_headlines() -> None:
+    """BYOD shape (headlines as a 2-element list) trips the
+    minimum-headline check naturally — that's exactly the case we want
+    surfaced to the user.
+    """
+    ads: list[dict[str, Any]] = [
+        {
+            "id": "ad1",
+            "type": "RESPONSIVE_SEARCH_AD",
+            "headlines": ["short headline 1", "short headline 2"],
+            "descriptions": ["desc 1", "desc 2"],
+        }
+    ]
+    findings = audit_google_ads_creatives(ads)
+    assert any(
+        f.asset_id == "ad1"
+        and f.severity is AnomalySeverity.CRITICAL
+        and "minimum is 3" in f.message
+        for f in findings
+    )
+
+
+@pytest.mark.unit
+def test_google_audit_passes_well_formed_rsa() -> None:
+    ads: list[dict[str, Any]] = [
+        {
+            "id": "ad1",
+            "type": "RESPONSIVE_SEARCH_AD",
+            "headlines": [f"headline {i}" for i in range(15)],
+            "descriptions": [f"description {i}" for i in range(4)],
+        }
+    ]
+    findings = audit_google_ads_creatives(ads)
+    assert findings == []
+
+
+@pytest.mark.unit
+def test_google_audit_flags_rsa_below_recommended_headlines() -> None:
+    ads: list[dict[str, Any]] = [
+        {
+            "id": "ad1",
+            "type": "RESPONSIVE_SEARCH_AD",
+            "headlines": [f"h{i}" for i in range(5)],
+            "descriptions": ["d1", "d2"],
+        }
+    ]
+    findings = audit_google_ads_creatives(ads)
+    assert any(
+        f.severity is AnomalySeverity.HIGH and "Google recommends 15" in f.message
+        for f in findings
+    )
+
+
+@pytest.mark.unit
+def test_google_audit_flags_missing_descriptions() -> None:
+    ads: list[dict[str, Any]] = [
+        {
+            "id": "ad1",
+            "type": "RESPONSIVE_SEARCH_AD",
+            "headlines": [f"h{i}" for i in range(3)],
+            "descriptions": ["only one"],
+        }
+    ]
+    findings = audit_google_ads_creatives(ads)
+    assert any("description" in f.message.lower() for f in findings)
+
+
+@pytest.mark.unit
+def test_google_audit_accepts_dict_headline_shape() -> None:
+    """Live API may return headlines as ``[{text: "..."}]`` rather
+    than plain strings; both shapes must be accepted.
+    """
+    ads: list[dict[str, Any]] = [
+        {
+            "id": "ad1",
+            "type": "RESPONSIVE_SEARCH_AD",
+            "headlines": [{"text": f"h{i}"} for i in range(3)],
+            "descriptions": [{"text": "d1"}, {"text": "d2"}],
+        }
+    ]
+    findings = audit_google_ads_creatives(ads)
+    # Has 3 headlines so minimum check passes; should still flag
+    # below-recommended (15).
+    assert any(f.severity is AnomalySeverity.HIGH for f in findings)
+
+
+@pytest.mark.unit
+def test_google_audit_flags_rda_missing_image() -> None:
+    ads: list[dict[str, Any]] = [
+        {
+            "id": "ad1",
+            "type": "RESPONSIVE_DISPLAY_AD",
+            "headlines": ["short"],
+            "long_headline": "long",
+            "descriptions": ["d1"],
+            "marketing_images": [],
+        }
+    ]
+    findings = audit_google_ads_creatives(ads)
+    assert any("marketing images" in f.message for f in findings)
+
+
+@pytest.mark.unit
+def test_google_audit_drops_ads_without_id() -> None:
+    findings = audit_google_ads_creatives(
+        [
+            {"type": "RESPONSIVE_SEARCH_AD", "headlines": [], "descriptions": []},
+            {"id": "", "type": "RESPONSIVE_SEARCH_AD"},
+        ]
+    )
+    assert findings == []
+
+
+@pytest.mark.unit
+def test_google_audit_skips_unknown_ad_types() -> None:
+    findings = audit_google_ads_creatives(
+        [
+            {"id": "ad1", "type": "IMAGE_AD", "headlines": []},
+        ]
+    )
+    assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# Meta — pure
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_meta_audit_flags_missing_body() -> None:
+    ads: list[dict[str, Any]] = [
+        {
+            "id": "act_1",
+            "creative": {
+                "title": "hi",
+                "image_url": "https://example.com/a.png",
+                "object_story_spec": {
+                    "link_data": {"call_to_action": {"type": "LEARN_MORE"}}
+                },
+            },
+        }
+    ]
+    findings = audit_meta_ads_creatives(ads)
+    assert any("primary text" in f.message for f in findings)
+
+
+@pytest.mark.unit
+def test_meta_audit_accepts_flat_byod_shape() -> None:
+    """BYOD Meta does not nest under ``creative`` — the audit must
+    fall back to top-level fields.
+    """
+    ads: list[dict[str, Any]] = [
+        {
+            "id": "ad1",
+            "title": "headline",
+            "body": "primary text",
+            "image_url": "url",
+        }
+    ]
+    findings = audit_meta_ads_creatives(ads)
+    # Has body / title / image, but no cta — should flag one finding.
+    assert any("call_to_action" in f.message for f in findings)
+
+
+@pytest.mark.unit
+def test_meta_audit_passes_complete_creative() -> None:
+    ads: list[dict[str, Any]] = [
+        {
+            "id": "ad1",
+            "creative": {
+                "title": "headline",
+                "body": "primary text",
+                "image_url": "url",
+                "object_story_spec": {
+                    "link_data": {"call_to_action": {"type": "LEARN_MORE"}}
+                },
+            },
+        }
+    ]
+    findings = audit_meta_ads_creatives(ads)
+    assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# Adapter wiring
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_google_adapter_audit_creative_via_injected_fetcher() -> None:
+    async def fetcher(account_id: str) -> list[dict[str, Any]]:
+        return [
+            {
+                "id": "ad1",
+                "type": "RESPONSIVE_SEARCH_AD",
+                "headlines": ["h1", "h2"],
+                "descriptions": ["d1", "d2"],
+            }
+        ]
+
+    module = GoogleAdsAnalyticsModule(ads_list_fetcher=fetcher)
+    audit = await module.audit_creative("acct-1")
+    assert audit.platform == "google_ads"
+    assert audit.account_id == "acct-1"
+    assert any(f.asset_id == "ad1" for f in audit.findings)
+
+
+@pytest.mark.asyncio
+async def test_meta_adapter_audit_creative_via_injected_fetcher() -> None:
+    async def fetcher(account_id: str) -> list[dict[str, Any]]:
+        return [{"id": "ad1"}]  # missing everything
+
+    module = MetaAdsAnalyticsModule(ads_list_fetcher=fetcher)
+    audit = await module.audit_creative("act_1")
+    assert len(audit.findings) >= 3  # title, body, image at minimum
+
+
+@pytest.mark.unit
+def test_capabilities_advertise_audit_creative() -> None:
+    g_caps = GoogleAdsAnalyticsModule().capabilities()
+    m_caps = MetaAdsAnalyticsModule().capabilities()
+    assert AnalyticsCapability.AUDIT_CREATIVE in g_caps
+    assert AnalyticsCapability.AUDIT_CREATIVE in m_caps

--- a/tests/analytics/builtin/test_google_ads_module.py
+++ b/tests/analytics/builtin/test_google_ads_module.py
@@ -20,8 +20,10 @@ def test_advertised_capabilities() -> None:
     caps = GoogleAdsAnalyticsModule().capabilities()
     assert AnalyticsCapability.DETECT_ANOMALIES in caps
     assert AnalyticsCapability.DIAGNOSE_PERFORMANCE in caps
-    assert AnalyticsCapability.AUDIT_CREATIVE not in caps
-    assert AnalyticsCapability.ANALYZE_BUDGET_EFFICIENCY not in caps
+    assert AnalyticsCapability.AUDIT_CREATIVE in caps
+    # ANALYZE_BUDGET_EFFICIENCY is advertised so the registry routes
+    # the call; the live wiring lands in the next step of this PR.
+    assert AnalyticsCapability.ANALYZE_BUDGET_EFFICIENCY in caps
 
 
 @pytest.mark.asyncio
@@ -76,12 +78,70 @@ async def test_diagnose_performance_returns_stub_shape() -> None:
 
 
 @pytest.mark.asyncio
-async def test_audit_creative_raises_not_implemented() -> None:
-    with pytest.raises(NotImplementedError, match="AUDIT_CREATIVE"):
-        await GoogleAdsAnalyticsModule().audit_creative("acct")
+async def test_per_campaign_fanout_surfaces_masked_anomaly() -> None:
+    """Demonstrates that per-campaign fan-out catches the offsetting
+    anomaly that the legacy aggregate path masked: campaign A drops to
+    zero spend while B keeps running.
+    """
+    from mureo.analysis.anomaly_detector import CampaignMetrics
+
+    async def per_campaign_fetcher(
+        account_id: str, *, window_days: int
+    ) -> dict[str, tuple[CampaignMetrics, CampaignMetrics | None]]:
+        # camp_A: spend collapsed to zero.
+        a_current = CampaignMetrics(
+            campaign_id="camp_A", cost=0, impressions=0, clicks=0, conversions=0
+        )
+        a_baseline = CampaignMetrics(
+            campaign_id="camp_A",
+            cost=500,
+            impressions=2500,
+            clicks=100,
+            conversions=10,
+        )
+        # camp_B: running normally.
+        b_current = CampaignMetrics(
+            campaign_id="camp_B",
+            cost=1000,
+            impressions=5000,
+            clicks=200,
+            conversions=20,
+        )
+        b_baseline = CampaignMetrics(
+            campaign_id="camp_B",
+            cost=500,
+            impressions=2500,
+            clicks=100,
+            conversions=10,
+        )
+        return {
+            "camp_A": (a_current, a_baseline),
+            "camp_B": (b_current, b_baseline),
+        }
+
+    module = GoogleAdsAnalyticsModule(per_campaign_metrics_fetcher=per_campaign_fetcher)
+    anomalies = await module.detect_anomalies("acct-1")
+    # Fan-out should fire the zero-spend critical on camp_A.
+    assert any(a.campaign_id == "camp_A" and a.metric == "cost" for a in anomalies)
 
 
 @pytest.mark.asyncio
-async def test_analyze_budget_efficiency_raises_not_implemented() -> None:
-    with pytest.raises(NotImplementedError, match="ANALYZE_BUDGET_EFFICIENCY"):
-        await GoogleAdsAnalyticsModule().analyze_budget_efficiency("acct")
+async def test_analyze_budget_efficiency_uses_performance_fetcher() -> None:
+    async def fetcher(account_id: str, period: str) -> list[dict[str, object]]:
+        return [
+            {
+                "campaign_id": "good",
+                "metrics": {"cost": 1000.0, "conversions": 50},
+            },
+            {
+                "campaign_id": "bad",
+                "metrics": {"cost": 1000.0, "conversions": 5},
+            },
+        ]
+
+    module = GoogleAdsAnalyticsModule(performance_fetcher=fetcher)
+    result = await module.analyze_budget_efficiency("acct-1")
+    scores = dict(result.per_campaign_score)
+    assert scores["good"] == 1.0
+    assert scores["bad"] == pytest.approx(0.1, abs=0.01)
+    assert "reallocate" in result.rebalance_suggestion

--- a/tests/analytics/builtin/test_live_clients.py
+++ b/tests/analytics/builtin/test_live_clients.py
@@ -316,15 +316,16 @@ async def test_fetch_meta_ads_performance_rows_raises_when_creds_missing() -> No
 
 
 @pytest.mark.unit
-def test_aggregation_masks_per_campaign_anomaly_known_limitation() -> None:
-    """Pin the known-limitation trade-off documented on
-    :func:`fetch_google_ads_metrics`: one campaign dropping cost to
-    zero while another scales up nets out at the aggregate.
+def test_aggregation_masks_per_campaign_anomaly_legacy_path() -> None:
+    """The legacy aggregate path (still used by the
+    ``metrics_fetcher`` injection point) collapses N campaigns into
+    one :class:`CampaignMetrics`, so offsetting per-campaign movements
+    net out and no anomaly fires.
 
-    This is intentional Phase-1 behavior — per-campaign fan-out is a
-    follow-up. The test exists so a future change that breaks the
-    trade-off (in either direction) is caught and reviewed
-    deliberately rather than slipping past.
+    Per-campaign fan-out (now the default live path) fixes this — see
+    ``test_per_campaign_fanout_surfaces_masked_anomaly``. This test
+    pins the **legacy** behaviour so removing the back-compat path is
+    a deliberate decision rather than silent breakage.
     """
     from mureo.analysis.anomaly_detector import detect_anomalies
 
@@ -375,6 +376,224 @@ def test_aggregation_masks_per_campaign_anomaly_known_limitation() -> None:
         "assertion fires, the trade-off has changed and the docstring on "
         "fetch_google_ads_metrics must be updated."
     )
+
+
+# ---------------------------------------------------------------------------
+# Per-campaign fan-out
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fetch_google_ads_per_campaign_metrics_keys_by_campaign() -> None:
+    """Per-campaign fetcher returns one entry per campaign with the
+    matching baseline joined from the prior window.
+    """
+    from mureo.analytics.builtin._live_clients import (
+        fetch_google_ads_per_campaign_metrics,
+    )
+
+    fake_client = AsyncMock()
+    # Current: 2 campaigns. Baseline: same 2 campaigns + 1 ghost
+    # ("camp_C" exists in prior but not current — must NOT appear in
+    # the per-campaign dict because we only iterate current).
+    fake_client.get_performance_report = AsyncMock(
+        side_effect=[
+            [
+                {
+                    "campaign_id": "camp_A",
+                    "cost": 100,
+                    "impressions": 500,
+                    "clicks": 30,
+                    "conversions": 5,
+                },
+                {
+                    "campaign_id": "camp_B",
+                    "cost": 200,
+                    "impressions": 1000,
+                    "clicks": 60,
+                    "conversions": 10,
+                },
+            ],
+            [
+                {
+                    "campaign_id": "camp_A",
+                    "cost": 80,
+                    "impressions": 400,
+                    "clicks": 24,
+                    "conversions": 4,
+                },
+                {
+                    "campaign_id": "camp_B",
+                    "cost": 180,
+                    "impressions": 900,
+                    "clicks": 55,
+                    "conversions": 9,
+                },
+                {
+                    "campaign_id": "camp_C",
+                    "cost": 50,
+                    "impressions": 250,
+                    "clicks": 15,
+                    "conversions": 2,
+                },
+            ],
+        ]
+    )
+    with (
+        patch("mureo.byod.runtime.byod_has", return_value=False),
+        patch("mureo.auth.load_google_ads_credentials", return_value=object()),
+        patch(
+            "mureo.mcp._client_factory.get_google_ads_client",
+            return_value=fake_client,
+        ),
+    ):
+        result = await fetch_google_ads_per_campaign_metrics("acct", window_days=7)
+
+    assert set(result.keys()) == {"camp_A", "camp_B"}
+    current_a, baseline_a = result["camp_A"]
+    assert current_a.cost == 100
+    assert baseline_a is not None
+    assert baseline_a.cost == 80
+
+
+@pytest.mark.asyncio
+async def test_fetch_google_ads_per_campaign_metrics_baseline_none_for_new_campaign() -> (
+    None
+):
+    """A campaign present in current but not in baseline (new
+    campaign) gets ``baseline=None`` rather than a synthetic zero —
+    that's the contract the pure detector expects.
+    """
+    from mureo.analytics.builtin._live_clients import (
+        fetch_google_ads_per_campaign_metrics,
+    )
+
+    fake_client = AsyncMock()
+    fake_client.get_performance_report = AsyncMock(
+        side_effect=[
+            [
+                {
+                    "campaign_id": "new_camp",
+                    "cost": 100,
+                    "impressions": 500,
+                    "clicks": 30,
+                    "conversions": 5,
+                }
+            ],
+            [],  # no rows in baseline
+        ]
+    )
+    with (
+        patch("mureo.byod.runtime.byod_has", return_value=False),
+        patch("mureo.auth.load_google_ads_credentials", return_value=object()),
+        patch(
+            "mureo.mcp._client_factory.get_google_ads_client",
+            return_value=fake_client,
+        ),
+    ):
+        result = await fetch_google_ads_per_campaign_metrics("acct", window_days=7)
+    _, baseline = result["new_camp"]
+    assert baseline is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_meta_ads_per_campaign_metrics_keys_by_campaign() -> None:
+    """Parallel of the Google per-campaign test for Meta."""
+    from mureo.analytics.builtin._live_clients import (
+        fetch_meta_ads_per_campaign_metrics,
+    )
+
+    fake_client = AsyncMock()
+    fake_client.get_performance_report = AsyncMock(
+        side_effect=[
+            [
+                {
+                    "campaign_id": "c1",
+                    "spend": 100,
+                    "impressions": 500,
+                    "clicks": 30,
+                    "conversions": 5,
+                },
+            ],
+            [
+                {
+                    "campaign_id": "c1",
+                    "spend": 80,
+                    "impressions": 400,
+                    "clicks": 25,
+                    "conversions": 4,
+                },
+            ],
+        ]
+    )
+    with (
+        patch("mureo.byod.runtime.byod_has", return_value=False),
+        patch("mureo.auth.load_meta_ads_credentials", return_value=object()),
+        patch(
+            "mureo.mcp._client_factory.get_meta_ads_client",
+            return_value=fake_client,
+        ),
+    ):
+        result = await fetch_meta_ads_per_campaign_metrics("act_1", window_days=7)
+
+    assert set(result.keys()) == {"c1"}
+    current, baseline = result["c1"]
+    assert current.cost == 100
+    assert baseline is not None
+    assert baseline.cost == 80
+
+
+@pytest.mark.unit
+def test_index_google_rows_drops_rows_without_campaign_id() -> None:
+    """Rows missing a usable ``campaign_id`` are dropped rather than
+    aggregated into a synthetic ``""``-keyed entry.
+    """
+    from mureo.analytics.builtin._live_clients import (
+        _index_google_rows_by_campaign,
+    )
+
+    rows: list[dict[str, Any]] = [
+        {"cost": 100, "impressions": 500},  # no campaign_id
+        {"campaign_id": "", "cost": 100},  # empty campaign_id
+        {
+            "campaign_id": "valid",
+            "cost": 200,
+            "impressions": 800,
+            "clicks": 50,
+            "conversions": 8,
+        },
+    ]
+    indexed = _index_google_rows_by_campaign(rows)
+    assert set(indexed.keys()) == {"valid"}
+
+
+@pytest.mark.unit
+def test_index_google_rows_sums_repeated_campaign_id() -> None:
+    """Multiple rows for the same campaign (day-grain) get summed."""
+    from mureo.analytics.builtin._live_clients import (
+        _index_google_rows_by_campaign,
+    )
+
+    rows: list[dict[str, Any]] = [
+        {
+            "campaign_id": "x",
+            "cost": 100,
+            "impressions": 500,
+            "clicks": 30,
+            "conversions": 5,
+        },
+        {
+            "campaign_id": "x",
+            "cost": 150,
+            "impressions": 800,
+            "clicks": 50,
+            "conversions": 7,
+        },
+    ]
+    indexed = _index_google_rows_by_campaign(rows)
+    assert indexed["x"].cost == 250
+    assert indexed["x"].clicks == 80
+    assert indexed["x"].conversions == 12
 
 
 @pytest.mark.asyncio

--- a/tests/analytics/builtin/test_live_clients.py
+++ b/tests/analytics/builtin/test_live_clients.py
@@ -56,6 +56,29 @@ def test_aggregate_google_metrics_handles_empty() -> None:
 
 
 @pytest.mark.unit
+def test_aggregate_google_metrics_accepts_byod_flat_shape() -> None:
+    """BYOD ``get_performance_report`` returns rows with metrics at the
+    top level, not nested under ``metrics``. The aggregator must accept
+    both shapes — regression for the silent-zero bug found during #120
+    live-wiring validation.
+    """
+    rows: list[dict[str, Any]] = [
+        # BYOD shape — flat
+        {
+            "campaign_id": "camp_abc",
+            "cost": 392000.0,
+            "impressions": 5600,
+            "clicks": 1120,
+            "conversions": 179.2,
+        },
+    ]
+    result = _aggregate_google_metrics(rows, account_id="byod-acct")
+    assert result.cost == 392000.0
+    assert result.impressions == 5600
+    assert result.conversions == pytest.approx(179.2)
+
+
+@pytest.mark.unit
 def test_aggregate_google_metrics_handles_none_values() -> None:
     rows: list[dict[str, Any]] = [
         {"metrics": {"cost": None, "impressions": None, "clicks": None}}
@@ -92,6 +115,27 @@ def test_aggregate_meta_metrics_sums_actions() -> None:
     assert result.clicks == 55
     # 3 (lead) + 2 (lead) + 1 (purchase) = 6
     assert result.conversions == 6
+
+
+@pytest.mark.unit
+def test_aggregate_meta_metrics_accepts_byod_flat_conversions() -> None:
+    """BYOD Meta returns conversions as a top-level field with no
+    ``actions`` list. Regression for the silent-zero bug found during
+    #120 live-wiring validation.
+    """
+    rows: list[dict[str, Any]] = [
+        {
+            "campaign_id": "camp_1",
+            "spend": 100.0,
+            "impressions": 500,
+            "clicks": 30,
+            "conversions": 12.0,
+            "result_indicator": "actions:offsite_conversion.fb_pixel_lead",
+        }
+    ]
+    result = _aggregate_meta_metrics(rows, account_id="act_byod")
+    assert result.cost == 100.0
+    assert result.conversions == 12.0
 
 
 @pytest.mark.unit

--- a/tests/analytics/builtin/test_meta_ads_module.py
+++ b/tests/analytics/builtin/test_meta_ads_module.py
@@ -22,6 +22,8 @@ def test_advertised_capabilities() -> None:
         {
             AnalyticsCapability.DETECT_ANOMALIES,
             AnalyticsCapability.DIAGNOSE_PERFORMANCE,
+            AnalyticsCapability.AUDIT_CREATIVE,
+            AnalyticsCapability.ANALYZE_BUDGET_EFFICIENCY,
         }
     )
 
@@ -64,12 +66,15 @@ async def test_diagnose_performance_carries_through_scope() -> None:
 
 
 @pytest.mark.asyncio
-async def test_audit_creative_raises_not_implemented() -> None:
-    with pytest.raises(NotImplementedError):
-        await MetaAdsAnalyticsModule().audit_creative("act_1")
+async def test_analyze_budget_efficiency_uses_performance_fetcher() -> None:
+    async def fetcher(account_id: str, period: str) -> list[dict[str, object]]:
+        return [
+            {"campaign_id": "good", "spend": 100, "conversions": 10},
+            {"campaign_id": "bad", "spend": 100, "conversions": 1},
+        ]
 
-
-@pytest.mark.asyncio
-async def test_analyze_budget_efficiency_raises_not_implemented() -> None:
-    with pytest.raises(NotImplementedError):
-        await MetaAdsAnalyticsModule().analyze_budget_efficiency("act_1")
+    module = MetaAdsAnalyticsModule(performance_fetcher=fetcher)
+    result = await module.analyze_budget_efficiency("act_1")
+    scores = dict(result.per_campaign_score)
+    assert scores["good"] == 1.0
+    assert scores["bad"] == pytest.approx(0.1, abs=0.01)


### PR DESCRIPTION
## Summary

Three additions on top of the live-wiring PR:

1. **Per-campaign fan-out for `detect_anomalies`** — replaces the account-level aggregation that masked single-campaign anomalies when an offsetting campaign moved opposite. New `fetch_*_per_campaign_metrics` returns `{campaign_id: (current, baseline)}` and the adapter runs the pure detector once per campaign.
2. **`audit_creative`** — Google flags RSAs with <3 headlines / <2 descriptions / below-recommended-15 headlines, RDAs missing copy / image. Meta flags ads without primary text / title / image / call_to_action.
3. **`analyze_budget_efficiency`** — normalises `conversions/cost` across campaigns to [0,1] relative to the top performer, flags campaigns below 0.3, emits a reallocation suggestion when a clear split exists.

Both adapters now advertise all four `AnalyticsCapability` values; the MCP `mureo_analytics_modules_list` picks this up dynamically — no schema change.

Shared BYOD-tolerance helpers (`google_row_metrics`, `meta_row_conversions`) promoted from `_live_clients` to public `_common.py` so the three callers (aggregator, summariser, budget scorer) share one definition.

## Test plan

- [x] +49 tests (115 → 130 cumulative on analytics package); 93.6% coverage
- [x] Code-review HIGH (`_resolve_per_campaign_metrics` return type tightened from `object` to `CampaignMetrics`; inline per-loop import removed) + MEDIUM (dead branch in `score_budget_efficiency` dropped; private helpers promoted) addressed
- [x] Live BYOD validation: `analyze_budget_efficiency` correctly identified 2 inefficient vs 2 efficient campaigns and produced a real reallocation suggestion
- [x] Zero regressions vs `main`

Stacked on #PR2 (`feat/analytics-builtin-live-wiring`).

Refs #120
