### PR TITLE
feat(analytics): per-campaign drilldown for audit_creative (#120)

### DIFF
--- a/docs/ABI-stability.md
+++ b/docs/ABI-stability.md
@@ -222,6 +222,17 @@ platforms. Renaming or removing a member is breaking, same rule as
 mutation rules in §5 apply to them identically — adding a field with
 a default is non-breaking; adding one without a default is breaking.
 
+Stable additions so far (each was added with a default, so existing
+plugin code keeps constructing without changes):
+
+- `CreativeFinding.campaign_id: str = ""` — owning campaign for the
+  finding, empty when the platform's `list_ads` response omits the
+  join.
+- `CreativeAudit.per_campaign_summary: tuple[tuple[str, int], ...] = ()`
+  — `(campaign_id, finding_count)` pairs sorted by campaign_id,
+  letting workflow skills drill down without re-walking the findings
+  tuple.
+
 The four analytics methods follow the same Protocol-evolution rules
 as §4: adding a new method is breaking, adding a new method
 parameter as a keyword with a default is non-breaking. Adding an

--- a/mureo/analytics/builtin/_creative_audit.py
+++ b/mureo/analytics/builtin/_creative_audit.py
@@ -19,9 +19,12 @@ the finding rather than guess at the missing strings.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from mureo.analytics.models import AnomalySeverity, CreativeFinding
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 # Google RSA policy thresholds — match the values shown in the Google
 # Ads UI's "Ad strength" panel.
@@ -63,6 +66,36 @@ def _non_empty_strings(values: Any) -> list[str]:
     return out
 
 
+def _extract_campaign_id(ad: dict[str, Any]) -> str:
+    """Return the owning campaign_id from an ad row.
+
+    Both Google and Meta — live and BYOD — expose ``campaign_id`` at
+    the top level of the ``list_ads`` row, but Google's live response
+    also nests campaign info under ``ad["campaign"]`` (the mapper
+    flattens this on its own). We accept either, falling back to
+    ``ad["campaign"]["id"]`` for forward compat in case the mapper
+    ever stops flattening.
+
+    Coerces non-string values (e.g. an ``int`` campaign id from a
+    loose BYOD adapter) the same way :func:`audit_*` coerces
+    ``ad_id`` — keeps the result a usable string instead of silently
+    dropping the join.
+    """
+    direct = ad.get("campaign_id")
+    if direct is not None:
+        text = str(direct).strip()
+        if text:
+            return text
+    campaign = ad.get("campaign")
+    if isinstance(campaign, dict):
+        nested = campaign.get("id")
+        if nested is not None:
+            text = str(nested).strip()
+            if text:
+                return text
+    return ""
+
+
 def audit_google_ads_creatives(
     ads: list[dict[str, Any]],
 ) -> list[CreativeFinding]:
@@ -72,21 +105,28 @@ def audit_google_ads_creatives(
     silently. The function is pure — no network, no I/O — so the
     adapter can call it on whatever shape the live or BYOD client
     returns without further plumbing.
+
+    Each finding carries the owning ``campaign_id`` (when the row
+    includes it) so the adapter can build a per-campaign drilldown
+    summary without re-walking ``ads``.
     """
     findings: list[CreativeFinding] = []
     for ad in ads:
         ad_id = str(ad.get("id") or ad.get("ad_id") or "").strip()
         if not ad_id:
             continue
+        campaign_id = _extract_campaign_id(ad)
 
         if _is_rsa(ad):
-            findings.extend(_audit_rsa(ad, ad_id))
+            findings.extend(_audit_rsa(ad, ad_id, campaign_id))
         elif _is_rda(ad):
-            findings.extend(_audit_rda(ad, ad_id))
+            findings.extend(_audit_rda(ad, ad_id, campaign_id))
     return findings
 
 
-def _audit_rsa(ad: dict[str, Any], ad_id: str) -> list[CreativeFinding]:
+def _audit_rsa(
+    ad: dict[str, Any], ad_id: str, campaign_id: str
+) -> list[CreativeFinding]:
     findings: list[CreativeFinding] = []
     headlines = _non_empty_strings(ad.get("headlines"))
     descriptions = _non_empty_strings(ad.get("descriptions"))
@@ -106,6 +146,7 @@ def _audit_rsa(ad: dict[str, Any], ad_id: str) -> list[CreativeFinding]:
                     "Google recommends filling all 15 slots for full "
                     "Ad-Strength evaluation."
                 ),
+                campaign_id=campaign_id,
             )
         )
     elif len(headlines) < _RSA_RECOMMENDED_HEADLINES:
@@ -119,6 +160,7 @@ def _audit_rsa(ad: dict[str, Any], ad_id: str) -> list[CreativeFinding]:
                     f"Google recommends {_RSA_RECOMMENDED_HEADLINES}"
                 ),
                 recommended_action=("Add headline variants to improve Ad Strength."),
+                campaign_id=campaign_id,
             )
         )
 
@@ -133,13 +175,16 @@ def _audit_rsa(ad: dict[str, Any], ad_id: str) -> list[CreativeFinding]:
                     f"minimum is {_RSA_MIN_DESCRIPTIONS}"
                 ),
                 recommended_action="Add at least 2 descriptions.",
+                campaign_id=campaign_id,
             )
         )
 
     return findings
 
 
-def _audit_rda(ad: dict[str, Any], ad_id: str) -> list[CreativeFinding]:
+def _audit_rda(
+    ad: dict[str, Any], ad_id: str, campaign_id: str
+) -> list[CreativeFinding]:
     findings: list[CreativeFinding] = []
     headlines = _non_empty_strings(ad.get("headlines"))
     long_headline = str(ad.get("long_headline") or "").strip()
@@ -154,6 +199,7 @@ def _audit_rda(ad: dict[str, Any], ad_id: str) -> list[CreativeFinding]:
                 severity=AnomalySeverity.CRITICAL,
                 message="RDA has no short headlines",
                 recommended_action="Add at least one short headline (≤30 chars).",
+                campaign_id=campaign_id,
             )
         )
     if not long_headline:
@@ -164,6 +210,7 @@ def _audit_rda(ad: dict[str, Any], ad_id: str) -> list[CreativeFinding]:
                 severity=AnomalySeverity.HIGH,
                 message="RDA missing long headline",
                 recommended_action="Add a long headline (≤90 chars).",
+                campaign_id=campaign_id,
             )
         )
     if not descriptions:
@@ -174,6 +221,7 @@ def _audit_rda(ad: dict[str, Any], ad_id: str) -> list[CreativeFinding]:
                 severity=AnomalySeverity.CRITICAL,
                 message="RDA has no descriptions",
                 recommended_action="Add at least one description.",
+                campaign_id=campaign_id,
             )
         )
     if not isinstance(images, list) or not images:
@@ -184,6 +232,7 @@ def _audit_rda(ad: dict[str, Any], ad_id: str) -> list[CreativeFinding]:
                 severity=AnomalySeverity.HIGH,
                 message="RDA has no marketing images",
                 recommended_action="Add at least one landscape image.",
+                campaign_id=campaign_id,
             )
         )
     return findings
@@ -203,6 +252,7 @@ def audit_meta_ads_creatives(
         ad_id = str(ad.get("id") or ad.get("ad_id") or "").strip()
         if not ad_id:
             continue
+        campaign_id = _extract_campaign_id(ad)
 
         creative = ad.get("creative")
         if not isinstance(creative, dict):
@@ -231,6 +281,7 @@ def audit_meta_ads_creatives(
                     severity=AnomalySeverity.CRITICAL,
                     message="Ad has no primary text",
                     recommended_action="Add a primary text variant.",
+                    campaign_id=campaign_id,
                 )
             )
         if not title:
@@ -241,6 +292,7 @@ def audit_meta_ads_creatives(
                     severity=AnomalySeverity.HIGH,
                     message="Ad has no headline",
                     recommended_action="Add a headline.",
+                    campaign_id=campaign_id,
                 )
             )
         if not image_url:
@@ -251,6 +303,7 @@ def audit_meta_ads_creatives(
                     severity=AnomalySeverity.CRITICAL,
                     message="Ad has no image",
                     recommended_action="Attach an image or thumbnail.",
+                    campaign_id=campaign_id,
                 )
             )
         if not cta:
@@ -263,12 +316,33 @@ def audit_meta_ads_creatives(
                     recommended_action=(
                         "Set a call_to_action.type (e.g. LEARN_MORE, SIGN_UP)."
                     ),
+                    campaign_id=campaign_id,
                 )
             )
     return findings
 
 
+def summarise_findings_by_campaign(
+    findings: Iterable[CreativeFinding],
+) -> tuple[tuple[str, int], ...]:
+    """Group findings by ``campaign_id`` and return ``(campaign_id, count)``.
+
+    Findings whose ``campaign_id`` is empty are dropped — there is no
+    meaningful "ungrouped" bucket to report. The result is sorted by
+    campaign_id so the workflow renders deterministically regardless
+    of dict-insertion order.
+    """
+    counts: dict[str, int] = {}
+    for finding in findings:
+        cid = finding.campaign_id.strip()
+        if not cid:
+            continue
+        counts[cid] = counts.get(cid, 0) + 1
+    return tuple(sorted(counts.items()))
+
+
 __all__ = [
     "audit_google_ads_creatives",
     "audit_meta_ads_creatives",
+    "summarise_findings_by_campaign",
 ]

--- a/mureo/analytics/builtin/google_ads.py
+++ b/mureo/analytics/builtin/google_ads.py
@@ -40,7 +40,10 @@ from mureo.analytics.builtin._common import (
 
 if TYPE_CHECKING:
     from mureo.analysis.anomaly_detector import CampaignMetrics
-from mureo.analytics.builtin._creative_audit import audit_google_ads_creatives
+from mureo.analytics.builtin._creative_audit import (
+    audit_google_ads_creatives,
+    summarise_findings_by_campaign,
+)
 from mureo.analytics.builtin._live_clients import (
     NoCredentialsError,
     fetch_google_ads_list,
@@ -229,11 +232,12 @@ class GoogleAdsAnalyticsModule(AnalyticsModule):
                     account_id=account_id,
                     findings=(),
                 )
-        findings = audit_google_ads_creatives(ads)
+        findings = tuple(audit_google_ads_creatives(ads))
         return CreativeAudit(
             platform=self.platform,
             account_id=account_id,
-            findings=tuple(findings),
+            findings=findings,
+            per_campaign_summary=summarise_findings_by_campaign(findings),
         )
 
     async def analyze_budget_efficiency(self, account_id: str) -> BudgetEfficiency:

--- a/mureo/analytics/builtin/meta_ads.py
+++ b/mureo/analytics/builtin/meta_ads.py
@@ -35,7 +35,10 @@ from mureo.analytics.builtin._common import (
 
 if TYPE_CHECKING:
     from mureo.analysis.anomaly_detector import CampaignMetrics
-from mureo.analytics.builtin._creative_audit import audit_meta_ads_creatives
+from mureo.analytics.builtin._creative_audit import (
+    audit_meta_ads_creatives,
+    summarise_findings_by_campaign,
+)
 from mureo.analytics.builtin._live_clients import (
     NoCredentialsError,
     fetch_meta_ads_list,
@@ -192,11 +195,12 @@ class MetaAdsAnalyticsModule(AnalyticsModule):
                     account_id=account_id,
                     findings=(),
                 )
-        findings = audit_meta_ads_creatives(ads)
+        findings = tuple(audit_meta_ads_creatives(ads))
         return CreativeAudit(
             platform=self.platform,
             account_id=account_id,
-            findings=tuple(findings),
+            findings=findings,
+            per_campaign_summary=summarise_findings_by_campaign(findings),
         )
 
     async def analyze_budget_efficiency(self, account_id: str) -> BudgetEfficiency:

--- a/mureo/analytics/models.py
+++ b/mureo/analytics/models.py
@@ -74,22 +74,39 @@ class PerformanceDiagnosis:
 
 @dataclass(frozen=True)
 class CreativeFinding:
-    """One issue or insight from :meth:`AnalyticsModule.audit_creative`."""
+    """One issue or insight from :meth:`AnalyticsModule.audit_creative`.
+
+    ``campaign_id`` is the owning campaign when the platform's
+    ``list_ads`` response includes it (it does on both Google and
+    Meta, live and BYOD). Defaults to the empty string so an adapter
+    that genuinely cannot resolve the campaign keeps the field stable
+    and the workflow can branch on ``finding.campaign_id != ""``
+    rather than catching ``AttributeError``.
+    """
 
     asset_id: str
     asset_type: str
     severity: AnomalySeverity
     message: str
     recommended_action: str
+    campaign_id: str = ""
 
 
 @dataclass(frozen=True)
 class CreativeAudit:
-    """Result of :meth:`AnalyticsModule.audit_creative`."""
+    """Result of :meth:`AnalyticsModule.audit_creative`.
+
+    ``per_campaign_summary`` is a deterministically-sorted list of
+    ``(campaign_id, finding_count)`` pairs that lets a workflow skill
+    say "campaign X has 3 RSA issues" without walking every finding
+    twice. Empty when no findings carry a campaign_id (rare today;
+    expected when a platform's ``list_ads`` omits the campaign join).
+    """
 
     platform: str
     account_id: str
     findings: tuple[CreativeFinding, ...] = ()
+    per_campaign_summary: tuple[tuple[str, int], ...] = ()
 
 
 @dataclass(frozen=True)

--- a/tests/analytics/builtin/test_creative_audit.py
+++ b/tests/analytics/builtin/test_creative_audit.py
@@ -9,6 +9,7 @@ import pytest
 from mureo.analytics.builtin._creative_audit import (
     audit_google_ads_creatives,
     audit_meta_ads_creatives,
+    summarise_findings_by_campaign,
 )
 from mureo.analytics.builtin.google_ads import GoogleAdsAnalyticsModule
 from mureo.analytics.builtin.meta_ads import MetaAdsAnalyticsModule
@@ -244,3 +245,174 @@ def test_capabilities_advertise_audit_creative() -> None:
     m_caps = MetaAdsAnalyticsModule().capabilities()
     assert AnalyticsCapability.AUDIT_CREATIVE in g_caps
     assert AnalyticsCapability.AUDIT_CREATIVE in m_caps
+
+
+# ---------------------------------------------------------------------------
+# Per-campaign drilldown
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_google_audit_stamps_campaign_id_on_findings() -> None:
+    """RSAs with the same defect across two campaigns must keep their
+    owning ``campaign_id`` on each finding — that's the foundation
+    the per-campaign summary builds on.
+    """
+    ads: list[dict[str, Any]] = [
+        {
+            "id": "ad_A",
+            "campaign_id": "camp_1",
+            "type": "RESPONSIVE_SEARCH_AD",
+            "headlines": ["only one"],
+            "descriptions": ["only one"],
+        },
+        {
+            "id": "ad_B",
+            "campaign_id": "camp_2",
+            "type": "RESPONSIVE_SEARCH_AD",
+            "headlines": ["only one"],
+            "descriptions": ["only one"],
+        },
+    ]
+    findings = audit_google_ads_creatives(ads)
+    by_ad = {f.asset_id: f.campaign_id for f in findings}
+    assert by_ad["ad_A"] == "camp_1"
+    assert by_ad["ad_B"] == "camp_2"
+
+
+@pytest.mark.unit
+def test_google_audit_falls_back_to_nested_campaign_dict() -> None:
+    """Forward-compat: if the live mapper ever stops flattening, we
+    still find ``ad["campaign"]["id"]``.
+    """
+    ads: list[dict[str, Any]] = [
+        {
+            "id": "ad1",
+            "campaign": {"id": "camp_99"},
+            "type": "RESPONSIVE_SEARCH_AD",
+            "headlines": ["one"],
+            "descriptions": ["one"],
+        }
+    ]
+    findings = audit_google_ads_creatives(ads)
+    assert findings[0].campaign_id == "camp_99"
+
+
+@pytest.mark.unit
+def test_meta_audit_stamps_campaign_id() -> None:
+    ads: list[dict[str, Any]] = [{"id": "ad1", "campaign_id": "camp_meta_1"}]
+    findings = audit_meta_ads_creatives(ads)
+    assert findings
+    assert all(f.campaign_id == "camp_meta_1" for f in findings)
+
+
+@pytest.mark.unit
+def test_summarise_findings_by_campaign_groups_and_sorts() -> None:
+    from mureo.analytics.models import AnomalySeverity, CreativeFinding
+
+    findings = [
+        CreativeFinding(
+            asset_id="a",
+            asset_type="RSA",
+            severity=AnomalySeverity.HIGH,
+            message="m",
+            recommended_action="r",
+            campaign_id="camp_zebra",
+        ),
+        CreativeFinding(
+            asset_id="b",
+            asset_type="RSA",
+            severity=AnomalySeverity.HIGH,
+            message="m",
+            recommended_action="r",
+            campaign_id="camp_alpha",
+        ),
+        CreativeFinding(
+            asset_id="c",
+            asset_type="RSA",
+            severity=AnomalySeverity.HIGH,
+            message="m",
+            recommended_action="r",
+            campaign_id="camp_alpha",
+        ),
+    ]
+    summary = summarise_findings_by_campaign(findings)
+    # Sorted alphabetically, counts aggregated.
+    assert summary == (("camp_alpha", 2), ("camp_zebra", 1))
+
+
+@pytest.mark.unit
+def test_summarise_findings_drops_empty_campaign_id() -> None:
+    from mureo.analytics.models import AnomalySeverity, CreativeFinding
+
+    findings = [
+        CreativeFinding(
+            asset_id="a",
+            asset_type="META_AD",
+            severity=AnomalySeverity.HIGH,
+            message="m",
+            recommended_action="r",
+            campaign_id="",
+        ),
+    ]
+    assert summarise_findings_by_campaign(findings) == ()
+
+
+@pytest.mark.asyncio
+async def test_google_adapter_audit_populates_per_campaign_summary() -> None:
+    """End-to-end: the adapter must populate
+    :attr:`CreativeAudit.per_campaign_summary` from the findings it
+    produces — that's the per-campaign drilldown contract.
+    """
+
+    async def fetcher(account_id: str) -> list[dict[str, Any]]:
+        return [
+            {
+                "id": "ad1",
+                "campaign_id": "camp_X",
+                "type": "RESPONSIVE_SEARCH_AD",
+                "headlines": ["h1"],
+                "descriptions": ["d1"],
+            },
+            {
+                "id": "ad2",
+                "campaign_id": "camp_X",
+                "type": "RESPONSIVE_SEARCH_AD",
+                "headlines": ["h1"],
+                "descriptions": ["d1"],
+            },
+            {
+                "id": "ad3",
+                "campaign_id": "camp_Y",
+                "type": "RESPONSIVE_SEARCH_AD",
+                "headlines": ["h1", "h2", "h3"],
+                "descriptions": ["d1"],  # only 1 description → 1 finding
+            },
+        ]
+
+    module = GoogleAdsAnalyticsModule(ads_list_fetcher=fetcher)
+    audit = await module.audit_creative("acct-1")
+    summary = dict(audit.per_campaign_summary)
+    # camp_X: 2 RSAs × (CRITICAL <3 headlines + CRITICAL <2 descriptions)
+    #       = 4 findings
+    # camp_Y: 1 RSA × (HIGH below-recommended-15 headlines
+    #                  + CRITICAL <2 descriptions) = 2 findings
+    assert summary["camp_X"] == 4
+    assert summary["camp_Y"] == 2
+
+
+@pytest.mark.asyncio
+async def test_meta_adapter_audit_populates_per_campaign_summary() -> None:
+    async def fetcher(account_id: str) -> list[dict[str, Any]]:
+        return [
+            {"id": "a", "campaign_id": "c1"},
+            {"id": "b", "campaign_id": "c1"},
+            {"id": "c", "campaign_id": "c2"},
+        ]
+
+    module = MetaAdsAnalyticsModule(ads_list_fetcher=fetcher)
+    audit = await module.audit_creative("act_1")
+    summary = dict(audit.per_campaign_summary)
+    # Each ad has 4 findings (no body, no title, no image, no cta).
+    assert summary["c1"] == 8
+    assert summary["c2"] == 4


### PR DESCRIPTION
## Summary

Adds per-campaign drilldown to `audit_creative`. `CreativeFinding` now carries the owning `campaign_id` (defaults to `""` — ABI non-breaking) and `CreativeAudit` exposes a sorted `per_campaign_summary: tuple[(campaign_id, finding_count), ...]` that lets workflow skills drill down without re-walking the findings tuple.

The pure `summarise_findings_by_campaign` helper aggregates findings, dropping any with an empty campaign_id (no meaningful "ungrouped" bucket). Both built-in adapters populate the summary; `_extract_campaign_id` accepts both the flat top-level shape (all four mureo paths today) and the nested `ad["campaign"]["id"]` shape (forward-compat for a Google live mapper change). Non-string ids are coerced to match how `ad_id` is handled.

## Test plan

- [x] +7 tests (123 → 130 cumulative on analytics package); 93.9% coverage
- [x] Code-review approved (3 LOW items addressed: `Iterable` arg type, non-string id coercion, single-pass findings tuple)
- [x] End-to-end validation: 15/15 checks PASS, including the drilldown invariant (`{camp_A: 4, camp_B: 2}` correctly aggregated from 3 ads with shared/distinct campaigns)
- [x] `docs/ABI-stability.md` §4a explicitly lists both additions under "Stable additions so far"
- [x] Zero regressions vs `main`

Stacked on #PR3 (`feat/analytics-fanout-creative-budget`). Closes the implementation work for #120 (Phase 3 reference-platform modules are explicitly out of scope per the issue).

Refs #120
