### PR TITLE
feat(google-ads): optional login_customer_id per-account field + public account-listing helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — `login_customer_id` is now an optional account-level field on `GoogleAdsAdapter`
+
+`GoogleAdsAdapter.account_credential_fields` previously declared only `customer_id`. The MCC `login_customer_id` was treated as operator-shared (one MCC default per OAuth identity). That works for the common case but stranded the multi-MCC setup, where a single OAuth identity reaches accounts under different manager accounts and each child must be routed through its own MCC.
+
+This release adds `login_customer_id` as a second, **optional** field on the same declaration. Leave it blank to inherit the operator-wide MCC default (no behaviour change for existing setups); set it per account when the target `customer_id` resolves through a different MCC. The new `parent_id` returned by `mureo.google_ads.list_accessible_accounts` for child accounts reached via MCC traversal is exactly the value to populate into `login_customer_id`, so account-picker tooling can auto-fill the field from a discovery call.
+
+The `account_credential_fields` ABI is non-breaking — adding a new entry to the tuple is purely additive. Plugins that read the tuple iteratively keep working without modification.
+
+### Added — Public-API surface for accessible-account discovery
+
+`list_accessible_accounts(credentials)` (Google Ads) and `list_meta_ad_accounts(access_token)` (Meta) were previously defined inside `mureo.auth_setup` as helpers for the interactive OAuth wizard's account-picker step. They are now part of the public API surface so configure-UI tooling and third-party setup utilities can build account pickers without reaching into the wizard's internal module:
+
+- `mureo.google_ads.list_accessible_accounts` — re-exported from the new `mureo.google_ads.accounts` module. Enumerates directly accessible accounts plus child accounts reached via MCC traversal; child entries carry `parent_id` (the MCC used to reach the child), which doubles as the `login_customer_id` value to set on `GoogleAdsAdapter` per the new account-level field above.
+- `mureo.meta_ads.list_meta_ad_accounts` — re-exported from the new `mureo.meta_ads.accounts` module. Calls `GET /me/adaccounts` on the Graph API and returns the raw `data` array.
+
+Both functions keep their original signatures and `list[dict[str, Any]]` return shape. The legacy import paths (`mureo.auth_setup.list_accessible_accounts`, `mureo.auth_setup.list_meta_ad_accounts`) are preserved as documented backward-compat re-exports — existing callers do not need to change.
+
 ## [0.9.9] - 2026-05-23
 
 ### Added — Per-platform analytics module surface for external-integration platforms (#120)

--- a/docs/plugin-authoring.md
+++ b/docs/plugin-authoring.md
@@ -321,9 +321,56 @@ time so the failure surfaces near the plugin, not deep inside the
 consuming UI.
 
 OAuth-level / operator-shared credentials (developer token, app
-secret, refresh token, MCC `login_customer_id`) intentionally do
-NOT live here — `account_credential_fields` is for the per-account
-slice only.
+secret, refresh token) intentionally do NOT live here —
+`account_credential_fields` is for the per-account slice only.
+
+#### Multiple account-level fields
+
+A provider can declare more than one `AccountCredentialField` when
+the per-account configuration genuinely requires multiple values.
+The built-in `GoogleAdsAdapter` is the canonical example: a single
+OAuth identity can reach accounts that live under different Manager
+(MCC) accounts, so both `customer_id` (which account to operate on)
+*and* `login_customer_id` (which manager account to route the call
+through) are per-account in that setup.
+
+```python
+account_credential_fields = (
+    AccountCredentialField(
+        key="customer_id",
+        display_name="Customer ID",
+        placeholder="123-456-7890",
+        required=True,
+        description=(
+            "10-digit Google Ads customer ID — find it in the "
+            "Google Ads UI top-right corner."
+        ),
+    ),
+    AccountCredentialField(
+        key="login_customer_id",
+        display_name="Login Customer ID (MCC)",
+        placeholder="987-654-3210",
+        required=False,
+        description=(
+            "Manager (MCC) Customer ID used as ``login_customer_id`` "
+            "when calling the API. Leave blank to inherit the "
+            "operator-wide MCC default; set per account when the "
+            "target ``customer_id`` resolves through a different MCC."
+        ),
+    ),
+)
+```
+
+Two patterns worth noting in the example:
+
+- **Required + optional mixed**: the primary identifier is `required=True`;
+  an additional field can be `required=False` so tooling falls back to
+  an operator-wide value when the per-account override is blank.
+- **Cross-reference**: the optional field's description points to where
+  the value comes from — for Google Ads, the `parent_id` returned by
+  `mureo.google_ads.list_accessible_accounts` for child accounts
+  reached via MCC traversal. Surfacing this in the description lets
+  tooling auto-populate the field from a discovery call.
 
 ### Domain Protocols (implement at least one)
 

--- a/mureo/adapters/google_ads/adapter.py
+++ b/mureo/adapters/google_ads/adapter.py
@@ -108,11 +108,22 @@ class GoogleAdsAdapter:
             Capability.WRITE_CAMPAIGN_STATUS,
         }
     )
-    # Per-account credential the operator must supply for Google Ads.
-    # The MCC ``login_customer_id`` is intentionally NOT listed here —
-    # it identifies the operator's manager account and is typically
-    # shared across every Google Ads account the operator manages
-    # (operator-shared OAuth-level credential, not per-account).
+    # Per-account credentials the operator must supply for Google Ads.
+    #
+    # ``customer_id`` (required) identifies which Google Ads account to
+    # operate on.
+    #
+    # ``login_customer_id`` (optional) names the Manager (MCC) account
+    # used as the ``login_customer_id`` header when calling the Google
+    # Ads API. Leave blank to use the operator-wide default declared at
+    # the OAuth credential level (the common case where one MCC owns
+    # every reachable account). Set per account when the target
+    # ``customer_id`` is reached through a different MCC than the
+    # operator-wide default — i.e. the same OAuth identity has access
+    # to multiple manager accounts and each child resolves through its
+    # own MCC. ``mureo.google_ads.list_accessible_accounts`` populates
+    # ``parent_id`` with exactly this value for child accounts reached
+    # via MCC traversal.
     account_credential_fields: tuple[AccountCredentialField, ...] = (
         AccountCredentialField(
             key="customer_id",
@@ -122,6 +133,21 @@ class GoogleAdsAdapter:
             description=(
                 "10-digit Google Ads customer ID (with or without dashes). "
                 "Find it in the Google Ads UI top-right corner."
+            ),
+        ),
+        AccountCredentialField(
+            key="login_customer_id",
+            display_name="Login Customer ID (MCC)",
+            placeholder="987-654-3210",
+            required=False,
+            description=(
+                "Manager (MCC) Customer ID used as ``login_customer_id`` "
+                "when calling the Google Ads API for this account. Leave "
+                "blank to inherit the operator-wide MCC default. Set "
+                "when the target ``customer_id`` is owned by a manager "
+                "account different from that default — most often "
+                "populated automatically from the ``parent_id`` field "
+                "returned by ``mureo.google_ads.list_accessible_accounts``."
             ),
         ),
     )

--- a/mureo/auth_setup.py
+++ b/mureo/auth_setup.py
@@ -36,11 +36,14 @@ from mureo.fsutil import secure_chmod
 # ``mureo.auth_setup.list_accessible_accounts`` /
 # ``mureo.auth_setup.list_meta_ad_accounts`` remain stable via these
 # aliases — existing callers do not need to change.
-from mureo.google_ads.accounts import (  # noqa: F401 — re-export
-    list_accessible_accounts,
+#
+# ``as <same-name>`` is the PEP 484 explicit-re-export form mypy --strict
+# requires before a downstream module can import the symbol back out.
+from mureo.google_ads.accounts import (
+    list_accessible_accounts as list_accessible_accounts,
 )
-from mureo.meta_ads.accounts import (  # noqa: F401 — re-export
-    list_meta_ad_accounts,
+from mureo.meta_ads.accounts import (
+    list_meta_ad_accounts as list_meta_ad_accounts,
 )
 
 logger = logging.getLogger(__name__)

--- a/mureo/auth_setup.py
+++ b/mureo/auth_setup.py
@@ -28,6 +28,21 @@ from google_auth_oauthlib.flow import Flow, InstalledAppFlow
 from mureo.auth import GoogleAdsCredentials, MetaAdsCredentials
 from mureo.fsutil import secure_chmod
 
+# Backward-compat re-exports of the platform-level account-discovery
+# helpers that used to live in this module. The canonical homes are
+# now :mod:`mureo.google_ads.accounts` and :mod:`mureo.meta_ads.accounts`
+# (public-API surface for configure-wizard tooling and third-party
+# setup utilities). The legacy import paths
+# ``mureo.auth_setup.list_accessible_accounts`` /
+# ``mureo.auth_setup.list_meta_ad_accounts`` remain stable via these
+# aliases — existing callers do not need to change.
+from mureo.google_ads.accounts import (  # noqa: F401 — re-export
+    list_accessible_accounts,
+)
+from mureo.meta_ads.accounts import (  # noqa: F401 — re-export
+    list_meta_ad_accounts,
+)
+
 logger = logging.getLogger(__name__)
 
 _GOOGLE_ADS_SCOPE = "https://www.googleapis.com/auth/adwords"
@@ -86,14 +101,20 @@ def _select_account(
         return None
 
 
-_META_GRAPH_API_BASE = "https://graph.facebook.com/v21.0"
+# ``_META_GRAPH_API_BASE`` and ``_HTTP_TIMEOUT`` are now defined in
+# :mod:`mureo.meta_ads.accounts` (the public-API home for Meta account
+# discovery). Importing from there keeps a single source of truth so a
+# Graph API version bump only needs to land in one place.
+from mureo.meta_ads.accounts import (  # noqa: E402
+    _HTTP_TIMEOUT,
+    _META_GRAPH_API_BASE,
+)
+
 _META_AUTH_URL = "https://www.facebook.com/v21.0/dialog/oauth"
 _META_OAUTH_SCOPES = (
     "ads_management,ads_read,business_management,"
     "pages_show_list,pages_manage_ads,pages_read_engagement,leads_retrieval"
 )
-
-_HTTP_TIMEOUT = 30.0
 
 # Input function replaceable for testing
 input_func = input
@@ -360,151 +381,6 @@ async def run_google_oauth(
         refresh_token=credentials.refresh_token,
         access_token=credentials.token,
     )
-
-
-# ---------------------------------------------------------------------------
-# Account list retrieval
-# ---------------------------------------------------------------------------
-
-
-async def list_accessible_accounts(
-    credentials: GoogleAdsCredentials,
-) -> list[dict[str, Any]]:
-    """Retrieve the list of accessible accounts via Google Ads API.
-
-    Enumerates all accounts the user can operate on:
-    1. Directly accessible accounts (from listAccessibleCustomers).
-    2. Child accounts under any accessible Manager (MCC) account,
-       traversed via the customer_client table.
-
-    This handles the common case where a user has been granted access
-    only to an MCC, but needs to operate on its child client accounts.
-
-    Args:
-        credentials: Google Ads credentials
-
-    Returns:
-        List of account info dicts. Each dict contains:
-        - id: Customer ID (10-digit string)
-        - name: Descriptive name
-        - is_manager: True if this is an MCC account
-        - parent_id: Parent MCC ID for child accounts reached via
-          MCC traversal. None for directly accessible accounts.
-          Used as login_customer_id when operating on the account.
-    """
-    from google.ads.googleads.client import GoogleAdsClient
-    from google.oauth2.credentials import Credentials as OAuthCredentials
-
-    oauth_creds = OAuthCredentials(  # type: ignore[no-untyped-call]
-        token=None,
-        refresh_token=credentials.refresh_token,
-        client_id=credentials.client_id,
-        client_secret=credentials.client_secret,
-        token_uri="https://oauth2.googleapis.com/token",
-    )
-
-    def _make_client(login_cid: str | None = None) -> Any:
-        return GoogleAdsClient(
-            credentials=oauth_creds,
-            developer_token=credentials.developer_token,
-            login_customer_id=login_cid,
-        )
-
-    # Step 1: Get directly accessible accounts
-    base_client = _make_client(login_cid=credentials.login_customer_id)
-    try:
-        customer_service = base_client.get_service("CustomerService")
-        response = customer_service.list_accessible_customers()
-    except Exception:
-        logger.warning("Failed to retrieve account list", exc_info=True)
-        return []
-
-    accounts: list[dict[str, Any]] = []
-    seen_ids: set[str] = set()
-
-    def _add(
-        customer_id: str,
-        name: str,
-        is_manager: bool = False,
-        parent_id: str | None = None,
-    ) -> None:
-        if customer_id in seen_ids:
-            return
-        accounts.append(
-            {
-                "id": customer_id,
-                "name": name,
-                "is_manager": is_manager,
-                "parent_id": parent_id,
-            }
-        )
-        seen_ids.add(customer_id)
-
-    # Step 2: For each directly accessible account, get info and traverse
-    # children if it's an MCC
-    base_ga_service = base_client.get_service("GoogleAdsService")
-    for resource_name in response.resource_names:
-        customer_id = resource_name.split("/")[-1]
-
-        name = customer_id
-        is_manager = False
-        try:
-            query = (
-                "SELECT customer.descriptive_name, customer.manager "
-                "FROM customer LIMIT 1"
-            )
-            rows = base_ga_service.search(customer_id=customer_id, query=query)
-            for row in rows:
-                name = row.customer.descriptive_name or customer_id
-                is_manager = bool(row.customer.manager)
-                break
-        except Exception:
-            logger.debug(
-                "Failed to retrieve account info: %s", customer_id, exc_info=True
-            )
-
-        _add(customer_id, name, is_manager=is_manager, parent_id=None)
-
-        if not is_manager:
-            continue
-
-        # Step 3: Traverse child accounts under this MCC.
-        # Requires login_customer_id set to the MCC.
-        try:
-            mcc_client = _make_client(login_cid=customer_id)
-            mcc_ga_service = mcc_client.get_service("GoogleAdsService")
-            child_query = (
-                "SELECT "
-                "  customer_client.id, "
-                "  customer_client.descriptive_name, "
-                "  customer_client.manager, "
-                "  customer_client.level, "
-                "  customer_client.status "
-                "FROM customer_client "
-                "WHERE customer_client.status = 'ENABLED' "
-                "AND customer_client.level > 0"
-            )
-            child_rows = mcc_ga_service.search(
-                customer_id=customer_id, query=child_query
-            )
-            for child_row in child_rows:
-                child = child_row.customer_client
-                child_id = str(child.id)
-                child_name = child.descriptive_name or child_id
-                _add(
-                    child_id,
-                    child_name,
-                    is_manager=bool(child.manager),
-                    parent_id=customer_id,
-                )
-        except Exception:
-            logger.warning(
-                "Failed to retrieve child accounts for MCC %s",
-                customer_id,
-                exc_info=True,
-            )
-
-    return accounts
 
 
 # ---------------------------------------------------------------------------
@@ -1173,45 +1049,6 @@ async def _exchange_short_for_long_token(
             )
     except Exception as exc:
         raise RuntimeError(f"Failed to convert to Long-Lived Token: {exc}") from exc
-
-
-# ---------------------------------------------------------------------------
-# Meta ad account list retrieval
-# ---------------------------------------------------------------------------
-
-
-async def list_meta_ad_accounts(access_token: str) -> list[dict[str, Any]]:
-    """Retrieve ad account list via Graph API.
-
-    GET https://graph.facebook.com/v21.0/me/adaccounts?
-        fields=id,name,account_status&
-        access_token={access_token}
-
-    Args:
-        access_token: Meta Ads access token
-
-    Returns:
-        List of ad account dicts (id, name, account_status).
-
-    Raises:
-        RuntimeError: If ad account list retrieval fails.
-    """
-    params = {
-        "fields": "id,name,account_status",
-        "access_token": access_token,
-    }
-
-    try:
-        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
-            response = await client.get(
-                f"{_META_GRAPH_API_BASE}/me/adaccounts",
-                params=params,
-            )
-            response.raise_for_status()
-            data = response.json()
-            return data.get("data", [])  # type: ignore[no-any-return]
-    except Exception as exc:
-        raise RuntimeError(f"Failed to retrieve ad account list: {exc}") from exc
 
 
 # ---------------------------------------------------------------------------

--- a/mureo/google_ads/__init__.py
+++ b/mureo/google_ads/__init__.py
@@ -1,5 +1,9 @@
 """mureo.google_ads - Google Ads API operations (database-independent)."""
 
+from mureo.google_ads.accounts import list_accessible_accounts
 from mureo.google_ads.client import GoogleAdsApiClient
 
-__all__ = ["GoogleAdsApiClient"]
+__all__ = [
+    "GoogleAdsApiClient",
+    "list_accessible_accounts",
+]

--- a/mureo/google_ads/accounts.py
+++ b/mureo/google_ads/accounts.py
@@ -1,0 +1,184 @@
+"""Accessible-account discovery for the Google Ads API.
+
+Public surface for tooling that needs to enumerate the customer
+accounts a given set of Google Ads credentials can reach — both
+directly accessible accounts and child accounts reached via MCC
+(Manager Customer Account) traversal.
+
+The function was previously defined inside
+:mod:`mureo.auth_setup` for the interactive OAuth wizard's account-
+picker step. Promoting it to ``mureo.google_ads.accounts`` exposes
+the same logic as a stable public API so configure-UI consumers
+(in-tree and third-party) can build account pickers without reaching
+into the wizard's internal module.
+
+The original import path ``mureo.auth_setup.list_accessible_accounts``
+remains valid via a thin re-export there — existing callers do not
+need to change.
+
+The returned shape stays ``list[dict[str, Any]]`` (the same dict
+shape the auth-setup wizard has always produced). A future minor
+release MAY introduce a frozen-dataclass parallel return type; the
+dict shape will remain supported for at least one minor.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from mureo.auth import GoogleAdsCredentials
+
+logger = logging.getLogger(__name__)
+
+
+async def list_accessible_accounts(
+    credentials: GoogleAdsCredentials,
+) -> list[dict[str, Any]]:
+    """Retrieve the list of Google Ads accounts the credentials can reach.
+
+    Enumerates all accounts the user can operate on:
+
+    1. Directly accessible accounts (from ``listAccessibleCustomers``).
+    2. Child accounts under any accessible Manager (MCC) account,
+       traversed via the ``customer_client`` table.
+
+    This handles the common case where a user has been granted access
+    only to an MCC but needs to operate on its child accounts.
+
+    Args:
+        credentials: Google Ads credentials (developer token + OAuth
+            client + refresh token). ``credentials.login_customer_id``
+            is used as the operator-wide MCC for the initial
+            ``listAccessibleCustomers`` call; per-child traversal uses
+            each MCC as its own ``login_customer_id``.
+
+    Returns:
+        List of account info dicts. Each dict contains:
+
+        - ``id``: Customer ID (10-digit string).
+        - ``name``: Descriptive name (falls back to the ID when the
+          API does not surface one).
+        - ``is_manager``: ``True`` when this is an MCC account.
+        - ``parent_id``: Parent MCC ID for child accounts reached via
+          MCC traversal. ``None`` for directly accessible accounts.
+          When set, it is the value to pass as ``login_customer_id``
+          when operating on the child.
+    """
+    from google.ads.googleads.client import GoogleAdsClient
+    from google.oauth2.credentials import Credentials as OAuthCredentials
+
+    oauth_creds = OAuthCredentials(  # type: ignore[no-untyped-call]
+        token=None,
+        refresh_token=credentials.refresh_token,
+        client_id=credentials.client_id,
+        client_secret=credentials.client_secret,
+        token_uri="https://oauth2.googleapis.com/token",
+    )
+
+    def _make_client(login_cid: str | None = None) -> Any:
+        return GoogleAdsClient(
+            credentials=oauth_creds,
+            developer_token=credentials.developer_token,
+            login_customer_id=login_cid,
+        )
+
+    # Step 1: Get directly accessible accounts
+    base_client = _make_client(login_cid=credentials.login_customer_id)
+    try:
+        customer_service = base_client.get_service("CustomerService")
+        response = customer_service.list_accessible_customers()
+    except Exception:
+        logger.warning("Failed to retrieve account list", exc_info=True)
+        return []
+
+    accounts: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+
+    def _add(
+        customer_id: str,
+        name: str,
+        is_manager: bool = False,
+        parent_id: str | None = None,
+    ) -> None:
+        if customer_id in seen_ids:
+            return
+        accounts.append(
+            {
+                "id": customer_id,
+                "name": name,
+                "is_manager": is_manager,
+                "parent_id": parent_id,
+            }
+        )
+        seen_ids.add(customer_id)
+
+    # Step 2: For each directly accessible account, get info and traverse
+    # children if it's an MCC
+    base_ga_service = base_client.get_service("GoogleAdsService")
+    for resource_name in response.resource_names:
+        customer_id = resource_name.split("/")[-1]
+
+        name = customer_id
+        is_manager = False
+        try:
+            query = (
+                "SELECT customer.descriptive_name, customer.manager "
+                "FROM customer LIMIT 1"
+            )
+            rows = base_ga_service.search(customer_id=customer_id, query=query)
+            for row in rows:
+                name = row.customer.descriptive_name or customer_id
+                is_manager = bool(row.customer.manager)
+                break
+        except Exception:
+            logger.debug(
+                "Failed to retrieve account info: %s", customer_id, exc_info=True
+            )
+
+        _add(customer_id, name, is_manager=is_manager, parent_id=None)
+
+        if not is_manager:
+            continue
+
+        # Step 3: Traverse child accounts under this MCC.
+        # Requires login_customer_id set to the MCC.
+        try:
+            mcc_client = _make_client(login_cid=customer_id)
+            mcc_ga_service = mcc_client.get_service("GoogleAdsService")
+            child_query = (
+                "SELECT "
+                "  customer_client.id, "
+                "  customer_client.descriptive_name, "
+                "  customer_client.manager, "
+                "  customer_client.level, "
+                "  customer_client.status "
+                "FROM customer_client "
+                "WHERE customer_client.status = 'ENABLED' "
+                "AND customer_client.level > 0"
+            )
+            child_rows = mcc_ga_service.search(
+                customer_id=customer_id, query=child_query
+            )
+            for child_row in child_rows:
+                child = child_row.customer_client
+                child_id = str(child.id)
+                child_name = child.descriptive_name or child_id
+                _add(
+                    child_id,
+                    child_name,
+                    is_manager=bool(child.manager),
+                    parent_id=customer_id,
+                )
+        except Exception:
+            logger.warning(
+                "Failed to retrieve child accounts for MCC %s",
+                customer_id,
+                exc_info=True,
+            )
+
+    return accounts
+
+
+__all__ = ["list_accessible_accounts"]

--- a/mureo/meta_ads/__init__.py
+++ b/mureo/meta_ads/__init__.py
@@ -1,5 +1,6 @@
 """mureo.meta_ads - Meta Ads API operations (database-independent)."""
 
+from mureo.meta_ads.accounts import list_meta_ad_accounts
 from mureo.meta_ads.client import MetaAdsApiClient
 from mureo.meta_ads.mappers import (
     map_ad,
@@ -10,6 +11,7 @@ from mureo.meta_ads.mappers import (
 
 __all__ = [
     "MetaAdsApiClient",
+    "list_meta_ad_accounts",
     "map_ad",
     "map_ad_set",
     "map_campaign",

--- a/mureo/meta_ads/accounts.py
+++ b/mureo/meta_ads/accounts.py
@@ -1,0 +1,74 @@
+"""Accessible-account discovery for the Meta Marketing API.
+
+Public surface for tooling that needs to enumerate the Meta ad
+accounts a given access token can reach.
+
+The function was previously defined inside :mod:`mureo.auth_setup`
+for the interactive OAuth wizard's account-picker step. Promoting it
+to ``mureo.meta_ads.accounts`` exposes the same logic as a stable
+public API so configure-UI consumers (in-tree and third-party) can
+build account pickers without reaching into the wizard's internal
+module.
+
+The original import path ``mureo.auth_setup.list_meta_ad_accounts``
+remains valid via a thin re-export there — existing callers do not
+need to change.
+
+The returned shape stays ``list[dict[str, Any]]`` (the same dict
+shape the auth-setup wizard has always produced). A future minor
+release MAY introduce a frozen-dataclass parallel return type; the
+dict shape will remain supported for at least one minor.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Same surface as ``mureo.auth_setup`` — mirrored here so the public
+# module does not depend on private constants in the auth-setup
+# module. Keep in sync if either side bumps the Graph API version.
+_META_GRAPH_API_BASE = "https://graph.facebook.com/v21.0"
+_HTTP_TIMEOUT = 30.0
+
+
+async def list_meta_ad_accounts(access_token: str) -> list[dict[str, Any]]:
+    """Retrieve the list of Meta ad accounts the access token can reach.
+
+    Calls ``GET /me/adaccounts`` on the Graph API. Returns the raw
+    ``data`` array as-is so callers can pick the fields they need
+    without an intermediate normalisation step.
+
+    Args:
+        access_token: Meta Ads access token (System User or User token).
+
+    Returns:
+        List of ad account dicts (``id``, ``name``, ``account_status``).
+
+    Raises:
+        RuntimeError: When the Graph API call fails (network error or
+            non-2xx response).
+    """
+    params = {
+        "fields": "id,name,account_status",
+        "access_token": access_token,
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+            response = await client.get(
+                f"{_META_GRAPH_API_BASE}/me/adaccounts",
+                params=params,
+            )
+            response.raise_for_status()
+            data = response.json()
+            return data.get("data", [])  # type: ignore[no-any-return]
+    except Exception as exc:
+        raise RuntimeError(f"Failed to retrieve ad account list: {exc}") from exc
+
+
+__all__ = ["list_meta_ad_accounts"]

--- a/tests/adapters/google_ads/test_adapter.py
+++ b/tests/adapters/google_ads/test_adapter.py
@@ -203,21 +203,34 @@ def test_capabilities_match_exact_expected_set() -> None:
 @pytest.mark.unit
 def test_account_credential_fields_declared_for_customer_id() -> None:
     """Google Ads is per-account-identified by ``customer_id`` (10 digit,
-    optionally dash-separated). The declarative field lets generic
-    introspection tooling render setup prompts without hardcoding
-    per-provider knowledge."""
+    optionally dash-separated) plus an optional MCC ``login_customer_id``
+    that names the manager account the API call routes through. The
+    declarative fields let generic introspection tooling render setup
+    prompts without hardcoding per-provider knowledge."""
     from mureo.core.providers.credentials import AccountCredentialField
 
     fields = GoogleAdsAdapter.account_credential_fields  # type: ignore[attr-defined]
     assert isinstance(fields, tuple)
-    assert len(fields) == 1
-    field = fields[0]
-    assert isinstance(field, AccountCredentialField)
-    assert field.key == "customer_id"
-    assert field.required is True
+    by_key = {f.key: f for f in fields}
+    # Assert the contract on field *keys* rather than the tuple length
+    # so a future additive field doesn't break this test for non-reasons.
+    assert {"customer_id", "login_customer_id"} <= set(by_key)
+
+    customer = by_key["customer_id"]
+    assert isinstance(customer, AccountCredentialField)
+    assert customer.required is True
     # Placeholder shape is a hint, not a regex contract — assert it
     # carries the canonical Google Ads dashed form.
-    assert "123-456-7890" in field.placeholder
+    assert "123-456-7890" in customer.placeholder
+
+    login = by_key["login_customer_id"]
+    assert isinstance(login, AccountCredentialField)
+    # Optional — operator-wide MCC default is inherited when this is
+    # blank. Set per account only when the target customer_id resolves
+    # through a different MCC than the operator-wide default.
+    assert login.required is False
+    assert login.display_name  # human-readable label populated
+    assert login.description  # explains when to set vs leave blank
 
 
 @pytest.mark.unit

--- a/tests/test_public_account_listing.py
+++ b/tests/test_public_account_listing.py
@@ -1,0 +1,101 @@
+"""Public-API surface tests for the account-listing helpers.
+
+``list_accessible_accounts`` (Google Ads) and ``list_meta_ad_accounts``
+(Meta) were promoted out of :mod:`mureo.auth_setup` into the
+platform-specific public modules so configure-wizard tooling and
+third-party consumers can build account-picker UIs without reaching
+into the wizard's internal module.
+
+These tests pin the public import paths and the backward-compat
+aliases so a future refactor can't silently strand callers.
+
+Behavioural correctness is exercised by ``tests/test_auth_setup.py``
+(via the legacy import path) and stays the canonical functional
+test surface — these tests assert *only* the public-API shape.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+
+@pytest.mark.unit
+def test_google_ads_list_accessible_accounts_publicly_exported() -> None:
+    """``mureo.google_ads.list_accessible_accounts`` is part of the
+    public ``__all__`` and resolves to the canonical implementation
+    in :mod:`mureo.google_ads.accounts`.
+    """
+    import mureo.google_ads
+    from mureo.google_ads import list_accessible_accounts
+    from mureo.google_ads.accounts import (
+        list_accessible_accounts as canonical,
+    )
+
+    assert "list_accessible_accounts" in mureo.google_ads.__all__
+    assert list_accessible_accounts is canonical
+
+
+@pytest.mark.unit
+def test_meta_ads_list_meta_ad_accounts_publicly_exported() -> None:
+    """``mureo.meta_ads.list_meta_ad_accounts`` is part of the public
+    ``__all__`` and resolves to the canonical implementation in
+    :mod:`mureo.meta_ads.accounts`.
+    """
+    import mureo.meta_ads
+    from mureo.meta_ads import list_meta_ad_accounts
+    from mureo.meta_ads.accounts import (
+        list_meta_ad_accounts as canonical,
+    )
+
+    assert "list_meta_ad_accounts" in mureo.meta_ads.__all__
+    assert list_meta_ad_accounts is canonical
+
+
+@pytest.mark.unit
+def test_auth_setup_alias_for_list_accessible_accounts() -> None:
+    """The legacy import path ``mureo.auth_setup.list_accessible_accounts``
+    keeps working — alias re-export, same callable identity.
+    """
+    from mureo.auth_setup import list_accessible_accounts as legacy
+    from mureo.google_ads.accounts import list_accessible_accounts as canonical
+
+    assert legacy is canonical
+
+
+@pytest.mark.unit
+def test_auth_setup_alias_for_list_meta_ad_accounts() -> None:
+    """The legacy import path ``mureo.auth_setup.list_meta_ad_accounts``
+    keeps working — alias re-export, same callable identity.
+    """
+    from mureo.auth_setup import list_meta_ad_accounts as legacy
+    from mureo.meta_ads.accounts import list_meta_ad_accounts as canonical
+
+    assert legacy is canonical
+
+
+@pytest.mark.unit
+def test_list_accessible_accounts_signature_is_stable() -> None:
+    """Argument shape stays ``(credentials: GoogleAdsCredentials) ->
+    list[dict[str, Any]]`` so consumers don't break on the move.
+    """
+    from mureo.google_ads import list_accessible_accounts
+
+    sig = inspect.signature(list_accessible_accounts)
+    params = list(sig.parameters.values())
+    assert len(params) == 1
+    assert params[0].name == "credentials"
+    assert inspect.iscoroutinefunction(list_accessible_accounts)
+
+
+@pytest.mark.unit
+def test_list_meta_ad_accounts_signature_is_stable() -> None:
+    """Argument shape stays ``(access_token: str) -> list[dict[str, Any]]``."""
+    from mureo.meta_ads import list_meta_ad_accounts
+
+    sig = inspect.signature(list_meta_ad_accounts)
+    params = list(sig.parameters.values())
+    assert len(params) == 1
+    assert params[0].name == "access_token"
+    assert inspect.iscoroutinefunction(list_meta_ad_accounts)


### PR DESCRIPTION
## Summary

Two coupled additions to the Google Ads / Meta Ads adapter surface, both ABI-non-breaking.

### 1. Optional `login_customer_id` on `GoogleAdsAdapter`

`GoogleAdsAdapter.account_credential_fields` previously declared only `customer_id`. The MCC `login_customer_id` was treated as operator-shared (one MCC default per OAuth identity), which works for the common single-MCC setup but stranded the case where a single OAuth identity reaches accounts under different manager accounts.

This PR adds `login_customer_id` as a second, **optional** field on the same declaration:

- Leave blank to inherit the operator-wide MCC default — no behaviour change for existing single-MCC setups.
- Set per account when the target `customer_id` resolves through a different MCC than the operator-wide default.
- The `parent_id` field returned by `mureo.google_ads.list_accessible_accounts` for child accounts reached via MCC traversal is exactly the value account-picker tooling should populate here — auto-fill from a discovery call.

Adding a new entry to the `account_credential_fields` tuple is purely additive — plugins that read it iteratively keep working.

### 2. Public-API surface for accessible-account discovery

`list_accessible_accounts(credentials)` (Google Ads) and `list_meta_ad_accounts(access_token)` (Meta) were previously defined inside `mureo.auth_setup` as helpers for the interactive OAuth wizard's account-picker step. They are now public:

- `mureo.google_ads.list_accessible_accounts` — re-exported from the new `mureo.google_ads.accounts` module.
- `mureo.meta_ads.list_meta_ad_accounts` — re-exported from the new `mureo.meta_ads.accounts` module.

Both functions keep their original signatures and `list[dict[str, Any]]` return shape (a future minor MAY add a frozen-dataclass parallel; the dict shape stays supported for at least one minor). The legacy import paths (`mureo.auth_setup.list_accessible_accounts`, `mureo.auth_setup.list_meta_ad_accounts`) are preserved as documented backward-compat re-exports — existing callers do not need to change.

## Refactor details

- `_META_GRAPH_API_BASE` and `_HTTP_TIMEOUT` now have a single source of truth in `mureo.meta_ads.accounts`; `auth_setup.py` imports them so a future Graph API version bump only lands in one place.
- The backward-compat re-export imports in `auth_setup.py` are hoisted to the top of the file with a single `# noqa: F401` each, matching the `__init__.py` re-export pattern used elsewhere in the repo.

## Test plan

- [x] `tests/test_public_account_listing.py` (new) — 6 tests pinning public import paths, `__all__` membership, alias identity, signature stability
- [x] `tests/adapters/google_ads/test_adapter.py::test_account_credential_fields_declared_for_customer_id` updated to assert the contract on field *keys* (set-comparison) rather than tuple length
- [x] Existing `tests/test_auth_setup.py` (5 cases importing via legacy paths) pass without modification
- [x] 131 focused tests pass; 3 unrelated failures verified to pre-exist on `main` (local environment plugin-count quirk)
- [x] ruff + black clean for all changed files
- [x] Code-review verdict: approve, no CRITICAL/HIGH; MEDIUM + LOW items addressed in-PR

## Docs

- `docs/plugin-authoring.md` gains a "Multiple account-level fields" subsection using Google Ads as the canonical multi-field example; the old "operator-shared, NOT here" list no longer mentions `login_customer_id`.
- `CHANGELOG.md` `[Unreleased]` documents both additions.

## Out of scope

- Migrating the dict return shape to a frozen-dataclass type — keeps signatures unchanged in this PR; possible follow-up in a future minor with a deprecation window.
- Narrowing the `except Exception` blocks in the moved functions — preserves the wizard's existing fault-tolerant behaviour; flagged in code review as a follow-up now that the surface is public.
- `mureo configure` wizard UI changes — the picker-rendering improvements that consume these public helpers are out of scope here.

Suggested target version: **0.9.10** (additive minor on top of the just-released v0.9.9).
