### PR TITLE
chore(release): v0.9.10 — optional login_customer_id + public account-listing helpers

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mureo",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "description": "Your local-first AI ad ops crew for Google Ads, Meta Ads, Search Console & GA4. mureo sits on top of the official ad-platform MCPs, gates every change against your strategy, correlates outcomes locally, and keeps an auditable decision log — credentials never leave your machine.",
   "author": {
     "name": "Logly Inc.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.10] - 2026-05-25
+
 ### Added — `login_customer_id` is now an optional account-level field on `GoogleAdsAdapter`
 
 `GoogleAdsAdapter.account_credential_fields` previously declared only `customer_id`. The MCC `login_customer_id` was treated as operator-shared (one MCC default per OAuth identity). That works for the common case but stranded the multi-MCC setup, where a single OAuth identity reaches accounts under different manager accounts and each child must be routed through its own MCC.

--- a/mureo/__init__.py
+++ b/mureo/__init__.py
@@ -1,3 +1,3 @@
 """mureo — your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."""
 
-__version__ = "0.9.9"
+__version__ = "0.9.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mureo"
-version = "0.9.9"
+version = "0.9.10"
 description = "Your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."
 requires-python = ">=3.10"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Bump version to **0.9.10** + move `[Unreleased]` CHANGELOG entries under `[0.9.10]`.

Shipped via #145 (`feat(google-ads): optional login_customer_id per-account field + public account-listing helpers`).

## Highlights

- `GoogleAdsAdapter.account_credential_fields` gains optional `login_customer_id` alongside the existing required `customer_id`. Leave blank to inherit the operator-wide MCC default (no behaviour change for the common single-MCC setup); set per account when the target `customer_id` resolves through a different MCC.
- `list_accessible_accounts` (Google Ads) and `list_meta_ad_accounts` (Meta) are now public — `mureo.google_ads.accounts` and `mureo.meta_ads.accounts`. The legacy `mureo.auth_setup.*` import paths remain stable via backward-compat re-exports.

## Test plan

- [x] Version parity test (`test_plugin_version_matches_pyproject`) passes
- [x] No code changes beyond version bump + CHANGELOG header — all functional changes already landed via #145 and passed CI on that PR

## Release flow

After merge:
1. Tag `v0.9.10` on the merge commit
2. Create GitHub Release — triggers `release.yml` → PyPI publish
