### PR TITLE
fix(google-ads): resolve name + manager flag for customers outside operator-default MCC

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mureo",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "description": "Your local-first AI ad ops crew for Google Ads, Meta Ads, Search Console & GA4. mureo sits on top of the official ad-platform MCPs, gates every change against your strategy, correlates outcomes locally, and keeps an auditable decision log — credentials never leave your machine.",
   "author": {
     "name": "Logly Inc.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.11] - 2026-05-26
+
+### Fixed — `list_accessible_accounts` resolves name + manager flag for customers outside the operator-default MCC
+
+`mureo.google_ads.list_accessible_accounts` queried every customer returned by `listAccessibleCustomers` through the operator-wide `credentials.login_customer_id`. Customers reachable only via a manager-link to a different MCC could not be queried with that header — the Google Ads API rejects the request — so they silently fell back to the raw customer ID for `name` and `False` for `is_manager`, and their child accounts were never traversed.
+
+The fix builds a fresh client per customer with the customer's own ID as `login_customer_id` for both the info query and the child traversal. The operator-default `base_client` is now used only for `listAccessibleCustomers` itself. The function's signature and return shape are unchanged.
+
 ## [0.9.10] - 2026-05-25
 
 ### Added — `login_customer_id` is now an optional account-level field on `GoogleAdsAdapter`

--- a/mureo/__init__.py
+++ b/mureo/__init__.py
@@ -1,3 +1,3 @@
 """mureo — your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."""
 
-__version__ = "0.9.10"
+__version__ = "0.9.11"

--- a/mureo/google_ads/accounts.py
+++ b/mureo/google_ads/accounts.py
@@ -115,10 +115,21 @@ async def list_accessible_accounts(
         seen_ids.add(customer_id)
 
     # Step 2: For each directly accessible account, get info and traverse
-    # children if it's an MCC
-    base_ga_service = base_client.get_service("GoogleAdsService")
+    # children if it's an MCC.
+    #
+    # ``listAccessibleCustomers`` can return customers reachable via a
+    # manager-link to an MCC other than ``credentials.login_customer_id``
+    # — direct access to those customers requires the request's
+    # ``login_customer_id`` header to match their own MCC context, not
+    # the operator-wide default. Build a fresh client per customer so
+    # both the info query and the child traversal run against the
+    # right context; the operator-default ``base_client`` is reserved
+    # for the ``listAccessibleCustomers`` call itself.
     for resource_name in response.resource_names:
         customer_id = resource_name.split("/")[-1]
+
+        own_client = _make_client(login_cid=customer_id)
+        own_ga_service = own_client.get_service("GoogleAdsService")
 
         name = customer_id
         is_manager = False
@@ -127,7 +138,7 @@ async def list_accessible_accounts(
                 "SELECT customer.descriptive_name, customer.manager "
                 "FROM customer LIMIT 1"
             )
-            rows = base_ga_service.search(customer_id=customer_id, query=query)
+            rows = own_ga_service.search(customer_id=customer_id, query=query)
             for row in rows:
                 name = row.customer.descriptive_name or customer_id
                 is_manager = bool(row.customer.manager)
@@ -142,11 +153,9 @@ async def list_accessible_accounts(
         if not is_manager:
             continue
 
-        # Step 3: Traverse child accounts under this MCC.
-        # Requires login_customer_id set to the MCC.
+        # Step 3: Traverse child accounts under this MCC. Same client
+        # already has ``login_customer_id`` set to the MCC.
         try:
-            mcc_client = _make_client(login_cid=customer_id)
-            mcc_ga_service = mcc_client.get_service("GoogleAdsService")
             child_query = (
                 "SELECT "
                 "  customer_client.id, "
@@ -158,7 +167,7 @@ async def list_accessible_accounts(
                 "WHERE customer_client.status = 'ENABLED' "
                 "AND customer_client.level > 0"
             )
-            child_rows = mcc_ga_service.search(
+            child_rows = own_ga_service.search(
                 customer_id=customer_id, query=child_query
             )
             for child_row in child_rows:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mureo"
-version = "0.9.10"
+version = "0.9.11"
 description = "Your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/tests/test_public_account_listing.py
+++ b/tests/test_public_account_listing.py
@@ -11,12 +11,15 @@ aliases so a future refactor can't silently strand callers.
 
 Behavioural correctness is exercised by ``tests/test_auth_setup.py``
 (via the legacy import path) and stays the canonical functional
-test surface — these tests assert *only* the public-API shape.
+test surface — these tests assert *only* the public-API shape, plus
+one regression test for separately-linked-MCC name resolution.
 """
 
 from __future__ import annotations
 
 import inspect
+from typing import Any
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -99,3 +102,119 @@ def test_list_meta_ad_accounts_signature_is_stable() -> None:
     assert len(params) == 1
     assert params[0].name == "access_token"
     assert inspect.iscoroutinefunction(list_meta_ad_accounts)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_resolves_name_for_account_under_separate_mcc() -> None:
+    """Each customer's info query uses its own ID as ``login_customer_id``.
+
+    ``listAccessibleCustomers`` can return customers that live outside
+    the hierarchy of ``credentials.login_customer_id`` (e.g. another
+    MCC the operator has been manager-linked to). Querying those with
+    the operator-wide default ``login_customer_id`` returns
+    ``PERMISSION_DENIED``, which previously caused them to fall back
+    to the raw ID for ``name`` and ``False`` for ``is_manager`` — and
+    skipped child traversal entirely.
+
+    The fix builds a fresh client per customer so the info query and
+    the child traversal both run against the customer's own MCC
+    context.
+    """
+    from mureo.auth import GoogleAdsCredentials
+    from mureo.google_ads import list_accessible_accounts
+
+    mcc_a = "1111111111"
+    mcc_b = "2222222222"
+    child_of_b = "3333333333"
+
+    creds = GoogleAdsCredentials(
+        developer_token="dev-tok",
+        client_id="cid",
+        client_secret="csec",
+        refresh_token="rtok",
+        login_customer_id=mcc_a,
+    )
+
+    list_customers_response = MagicMock()
+    list_customers_response.resource_names = [
+        f"customers/{mcc_a}",
+        f"customers/{mcc_b}",
+    ]
+
+    info_names = {mcc_a: "MCC-A", mcc_b: "MCC-B"}
+
+    def _info_row(customer_id: str) -> MagicMock:
+        row = MagicMock()
+        row.customer.descriptive_name = info_names[customer_id]
+        row.customer.manager = True
+        return row
+
+    def _child_row(cid: str, name: str) -> MagicMock:
+        row = MagicMock()
+        row.customer_client.id = int(cid)
+        row.customer_client.descriptive_name = name
+        row.customer_client.manager = False
+        return row
+
+    constructed_login_cids: list[str | None] = []
+
+    def _build_mock_client(login_cid: str | None) -> MagicMock:
+        client = MagicMock()
+        customer_service = MagicMock()
+        customer_service.list_accessible_customers.return_value = (
+            list_customers_response
+        )
+        ga_service = MagicMock()
+
+        def _search(*, customer_id: str, query: str) -> list[MagicMock]:
+            # Real Google Ads API rejects a query when ``customer_id``
+            # is not reachable via the request's ``login_customer_id``.
+            if customer_id != login_cid:
+                raise RuntimeError(
+                    f"PERMISSION_DENIED: customer {customer_id} not "
+                    f"reachable via login_customer_id={login_cid}"
+                )
+            if "customer_client" in query:
+                if customer_id == mcc_b:
+                    return [_child_row(child_of_b, "child-of-B")]
+                return []
+            return [_info_row(customer_id)]
+
+        ga_service.search.side_effect = _search
+
+        def _get_service(name: str) -> MagicMock:
+            if name == "CustomerService":
+                return customer_service
+            return ga_service
+
+        client.get_service.side_effect = _get_service
+        return client
+
+    def _client_factory(**kwargs: Any) -> MagicMock:
+        login_cid = kwargs.get("login_customer_id")
+        constructed_login_cids.append(login_cid)
+        return _build_mock_client(login_cid)
+
+    with patch(
+        "google.ads.googleads.client.GoogleAdsClient",
+        side_effect=_client_factory,
+    ):
+        accounts = await list_accessible_accounts(creds)
+
+    by_id = {a["id"]: a for a in accounts}
+
+    assert by_id[mcc_a]["name"] == "MCC-A"
+    assert by_id[mcc_a]["is_manager"] is True
+    assert by_id[mcc_b]["name"] == "MCC-B"
+    assert by_id[mcc_b]["is_manager"] is True
+    assert child_of_b in by_id, (
+        "child traversal must run for an MCC reached outside the "
+        "operator's default login_customer_id hierarchy"
+    )
+    assert by_id[child_of_b]["parent_id"] == mcc_b
+
+    assert mcc_b in constructed_login_cids, (
+        "a client must be constructed with the separately-linked MCC "
+        "as its own login_customer_id"
+    )


### PR DESCRIPTION
## Summary

- `mureo.google_ads.list_accessible_accounts` queried every customer returned by `listAccessibleCustomers` through the operator-wide `credentials.login_customer_id`. Customers reachable only via a manager-link to a different MCC are rejected by the Google Ads API under that header (`PERMISSION_DENIED`), so they silently fell back to the raw customer ID for `name` and `False` for `is_manager` — and child traversal was skipped.
- Fix: build a fresh client per customer with the customer's own ID as `login_customer_id` for **both** the info query and the child traversal. `base_client` is now used only for `listAccessibleCustomers` itself. The function's signature and `list[dict[str, Any]]` return shape are unchanged.
- Bumps version 0.9.10 → 0.9.11.

## Why

`listAccessibleCustomers` returns every customer the OAuth identity can reach, including ones that live outside the hierarchy of the operator's default `login_customer_id`. The Google Ads API requires the request's `login_customer_id` header to match a manager context that actually reaches the target customer — there is no operator-wide bypass. The previous code shared a single `base_client` (constructed with `credentials.login_customer_id`) for every per-customer info query, so any customer outside that hierarchy was silently dropped to ID-only output. The child-traversal code path already used the per-MCC pattern correctly; this PR applies the same pattern to the info query.

## Changes

- `mureo/google_ads/accounts.py` — replace `base_ga_service.search(...)` with `own_ga_service = _make_client(login_cid=customer_id).get_service("GoogleAdsService")`, reused for the subsequent child-traversal query (no duplicate client construction per customer).
- `tests/test_public_account_listing.py` — add `test_resolves_name_for_account_under_separate_mcc`. Mocks `GoogleAdsClient` per `login_customer_id` so each client's `search()` only succeeds when `customer_id == login_customer_id` (matching real API rejection semantics). Asserts both MCC names resolve, the separately-linked MCC is flagged `is_manager=True`, and its child accounts are traversed.
- `CHANGELOG.md` — 0.9.11 entry.
- `pyproject.toml`, `mureo/__init__.py`, `.claude-plugin/plugin.json` — version bump.

## Backward compatibility

- Signature unchanged: `list_accessible_accounts(credentials: GoogleAdsCredentials) -> list[dict[str, Any]]`.
- Dict shape unchanged: `id`, `name`, `is_manager`, `parent_id`.
- Existing behavioural tests in `tests/test_auth_setup.py` continue to pass (they use a single mock client returned for every constructor call, which still satisfies the new per-customer construction).

## Test plan

- [x] New regression test `test_resolves_name_for_account_under_separate_mcc` fails on `main` and passes on this branch.
- [x] Existing `tests/test_public_account_listing.py` and `tests/test_auth_setup.py` continue to pass (69/69).
- [x] `tests/test_plugin_manifests.py` version-parity test passes (8/8).
- [x] `ruff check mureo/google_ads/accounts.py tests/test_public_account_listing.py` clean.
- [ ] CI green.
