### PR TITLE
feat(providers): add optional secret flag to AccountCredentialField

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mureo",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "description": "Your local-first AI ad ops crew for Google Ads, Meta Ads, Search Console & GA4. mureo sits on top of the official ad-platform MCPs, gates every change against your strategy, correlates outcomes locally, and keeps an auditable decision log — credentials never leave your machine.",
   "author": {
     "name": "Logly Inc.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.12] - 2026-05-26
+
+### Added — `AccountCredentialField` gains optional `secret: bool` flag
+
+`AccountCredentialField` (introduced in v0.9.7 to let providers declare per-account credential fields) gains an optional `secret: bool = False` attribute. It lets a provider mark a per-account field as a secret value (API key, per-account OAuth token, etc.) rather than a public identifier.
+
+Consumers — configure wizards, third-party setup UIs — read the flag to render a masked input, avoid pre-populating the value on edit, and choose tighter storage permissions (typically `0o600`) when the value lands in a file. The flag defaults to `False`, so existing plugin and built-in declarations continue to work unchanged.
+
+The OSS-shipped `GoogleAdsAdapter` and `MetaAdsAdapter` do not declare any field with `secret=True` — their per-account fields are public identifiers and the sensitive material lives in the operator-shared `SecretStore` layer. The flag exists for plugins whose authentication model places the secret inside the per-account slice (e.g. ad platforms with one API key per account).
+
+`docs/plugin-authoring.md` documents the new flag under "Secret per-account fields".
+
 ## [0.9.11] - 2026-05-26
 
 ### Fixed — `list_accessible_accounts` resolves name + manager flag for customers outside the operator-default MCC

--- a/docs/plugin-authoring.md
+++ b/docs/plugin-authoring.md
@@ -311,6 +311,7 @@ class MyAdsProvider:
 | `placeholder` | `""` | Example value shown in form inputs (never used as a default — auto-applying would surprise operators). |
 | `required` | `False` | When `True`, tooling may warn or block on a missing value. |
 | `description` | `""` | One-line operator-facing hint pointing at where the value comes from. |
+| `secret` | `False` | When `True`, consumers render a masked input and may pick tighter storage permissions. Use only when the per-account slice itself is sensitive (e.g. a per-account API key). See "Secret per-account fields" below. |
 
 The accessor `mureo.core.providers.get_account_credential_fields(provider)`
 reads the attribute defensively (returns `()` when absent) and
@@ -371,6 +372,43 @@ Two patterns worth noting in the example:
   `mureo.google_ads.list_accessible_accounts` for child accounts
   reached via MCC traversal. Surfacing this in the description lets
   tooling auto-populate the field from a discovery call.
+
+#### Secret per-account fields
+
+When a per-account field carries a secret value (API key, per-account
+OAuth token, etc.) rather than a public identifier, set
+`secret=True`. Consumers — configure wizards, third-party setup UIs —
+use the flag to:
+
+- Render the value as a masked / password-style input.
+- Avoid pre-populating the value on edit / re-display (a blank input
+  conventionally means "keep the existing value").
+- Choose tighter storage permissions, typically `0o600`, when the
+  value lands in a file rather than an injected `SecretStore`.
+
+```python
+account_credential_fields = (
+    AccountCredentialField(
+        key="api_key",
+        display_name="API Key",
+        placeholder="advertiser_api_key_xxxx",
+        required=True,
+        secret=True,
+        description=(
+            "Per-account API key sent in the X-API-Key header on "
+            "every request. Each account has its own key."
+        ),
+    ),
+)
+```
+
+The OSS-shipped `GoogleAdsAdapter` and `MetaAdsAdapter` do **not**
+use `secret=True` — their per-account fields are public identifiers
+(`customer_id`, `ad_account_id`, `login_customer_id`); the sensitive
+material (refresh tokens, system user tokens) is operator-shared and
+lives in the `SecretStore` base layer, not in
+`account_credential_fields`. Use `secret=True` when the per-account
+slice itself is the secret.
 
 ### Domain Protocols (implement at least one)
 

--- a/mureo/__init__.py
+++ b/mureo/__init__.py
@@ -1,3 +1,3 @@
 """mureo — your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."""
 
-__version__ = "0.9.11"
+__version__ = "0.9.12"

--- a/mureo/core/providers/credentials.py
+++ b/mureo/core/providers/credentials.py
@@ -47,6 +47,20 @@ class AccountCredentialField:
             the value comes from (e.g., ``"From Google Ads UI >
             Settings > Account details > Customer ID"``).
             Default: ``""``.
+        secret: ``True`` when the field carries a secret value (API
+            key, per-account OAuth token, etc.) rather than a public
+            identifier (``customer_id``, ``ad_account_id``, …). Like
+            the other attributes this flag is declarative metadata
+            only — mureo itself does not redact or remask the value.
+            Consumers — configure wizards, third-party setup UIs —
+            can use this flag to render a masked input, redact the
+            value in logs, and choose tighter storage permissions
+            (typically ``0o600``). Default: ``False`` — most
+            per-account fields are non-secret identifiers, and the
+            OSS-shipped ``GoogleAdsAdapter`` / ``MetaAdsAdapter``
+            leave secret material (refresh tokens, system user
+            tokens) in the operator-shared ``SecretStore`` layer
+            rather than declaring it here.
 
     The dataclass is JSON-friendly: ``dataclasses.asdict(field)``
     returns a plain ``dict`` of primitive ``str`` / ``bool`` values
@@ -58,6 +72,7 @@ class AccountCredentialField:
     placeholder: str = ""
     required: bool = False
     description: str = ""
+    secret: bool = False
 
 
 __all__ = ["AccountCredentialField"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mureo"
-version = "0.9.11"
+version = "0.9.12"
 description = "Your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/tests/core/providers/test_account_credential_field.py
+++ b/tests/core/providers/test_account_credential_field.py
@@ -32,12 +32,50 @@ def test_construct_with_required_and_optional_fields() -> None:
 
 @pytest.mark.unit
 def test_optional_fields_default_to_documented_values() -> None:
-    """``placeholder``, ``required``, ``description`` are optional with
-    well-defined defaults so a provider can declare a single line."""
+    """``placeholder``, ``required``, ``description``, ``secret`` are
+    optional with well-defined defaults so a provider can declare a
+    single line."""
     field = AccountCredentialField(key="account_id", display_name="Account ID")
     assert field.placeholder == ""
     assert field.required is False
     assert field.description == ""
+    assert field.secret is False
+
+
+@pytest.mark.unit
+def test_secret_flag_can_be_set_to_true() -> None:
+    """``secret=True`` lets a provider declare an API-key-shaped field
+    so consumers (configure wizards, third-party setup UIs) can render
+    a masked input and choose tighter storage permissions."""
+    field = AccountCredentialField(
+        key="api_key",
+        display_name="API Key",
+        placeholder="advertiser_api_key_xxxx",
+        required=True,
+        secret=True,
+        description="Per-account API key sent in the X-API-Key header.",
+    )
+    assert field.secret is True
+    assert field.required is True
+
+
+@pytest.mark.unit
+def test_secret_flag_serialises_in_asdict() -> None:
+    """``secret`` must round-trip through ``dataclasses.asdict`` so
+    consumers receiving the field over an HTTP / JSON boundary can
+    react to the flag without reflection."""
+    field = AccountCredentialField(
+        key="api_key",
+        display_name="API Key",
+        required=True,
+        secret=True,
+    )
+    payload = asdict(field)
+    assert payload["secret"] is True
+    # Public identifiers default to ``secret=False`` so existing
+    # built-in declarations stay non-secret without a code change.
+    other = AccountCredentialField(key="customer_id", display_name="Customer ID")
+    assert asdict(other)["secret"] is False
 
 
 @pytest.mark.unit
@@ -66,6 +104,7 @@ def test_asdict_is_json_friendly() -> None:
         "placeholder": "act_123",
         "required": True,
         "description": "hint",
+        "secret": False,
     }
     # Verify no exotic types slipped in.
     for value in payload.values():


### PR DESCRIPTION
## Summary

- Adds an optional `secret: bool = False` attribute to `AccountCredentialField` so a provider can mark a per-account credential field as a secret value (API key, per-account OAuth token, etc.) rather than a public identifier.
- Consumers — configure wizards, third-party setup UIs — read the flag to render a masked input, avoid pre-populating the value on edit, and choose tighter storage permissions (typically `0o600`) when the value lands in a file.
- Backward compatible: default `False` keeps every existing built-in / plugin declaration working unchanged.
- Bumps version 0.9.11 → 0.9.12.

## Why

`AccountCredentialField` (introduced in v0.9.7) currently has no way to declare that a per-account field is sensitive. The OSS-shipped `GoogleAdsAdapter` and `MetaAdsAdapter` never need this — their per-account fields are public identifiers (`customer_id`, `ad_account_id`, `login_customer_id`) and the sensitive material (refresh tokens, system user tokens) is operator-shared and lives in the `SecretStore` layer. But that pattern doesn't match every plugin's authentication model: some ad platforms use one API key per account, and the per-account slice itself is the secret. Without a `secret` flag, consumers cannot tell the difference between a public identifier and an API key, so they render every input the same way — visible, pre-populated on edit, stored at the same permissions.

This PR adds the flag without changing any existing behaviour. The dataclass remains declarative metadata only — mureo itself does not redact or remask the value; consumers act on the flag.

## Changes

- `mureo/core/providers/credentials.py` — add `secret: bool = False` to the dataclass + docstring entry explicitly noting the field is declarative metadata only and listing the three things consumers typically do with it.
- `tests/core/providers/test_account_credential_field.py` — three new tests (default `False`, `secret=True` construction, `asdict` round-trip including both true/false cases). The existing `asdict` literal-payload test was updated to include `"secret": False` in the expected dict.
- `docs/plugin-authoring.md` — new row in the attribute reference table + new "Secret per-account fields" subsection under "Multiple account-level fields", with the canonical `api_key` example and a note that the OSS-shipped Google Ads / Meta Ads adapters do not use the flag.
- `CHANGELOG.md` — 0.9.12 entry.
- `pyproject.toml`, `mureo/__init__.py`, `.claude-plugin/plugin.json` — version bump.

## Backward compatibility

- `secret` defaults to `False`. New attribute appended to the end of the dataclass — existing positional / keyword construction is unaffected.
- `dataclasses.asdict(field)` gains a new `"secret"` key. The only place in the codebase that asserted on a literal `asdict` payload was the canonical test in `tests/core/providers/test_account_credential_field.py` (now updated). Other tests assert on individual attributes, which still work.
- No built-in adapter declarations change.

## Test plan

- [x] Three new tests in `tests/core/providers/test_account_credential_field.py` (default `False`, `secret=True`, asdict serialisation) pass.
- [x] Existing `tests/core/providers/test_account_credential_field.py` literal-payload test updated and passes.
- [x] `tests/core/providers/` 218 tests pass.
- [x] `tests/test_plugin_manifests.py` version-parity test passes.
- [x] `ruff check` clean on modified files.
- [x] Full suite passes (3605 tests, excluding the 3 pre-existing dev-env entry-point pollution failures that also fail on `main`).
- [ ] CI green.
