### PR TITLE
feat(meta-ads): end-to-end Instant Form deployability via create_lead_ad_creative

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mureo",
-  "version": "0.9.13",
+  "version": "0.9.14",
   "description": "Your local-first AI ad ops crew for Google Ads, Meta Ads, Search Console & GA4. mureo sits on top of the official ad-platform MCPs, gates every change against your strategy, correlates outcomes locally, and keeps an auditable decision log — credentials never leave your machine.",
   "author": {
     "name": "Logly Inc.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.14] - 2026-05-28
+
+### Added — Meta Instant Form: end-to-end Lead Ad deployability
+
+`mureo.meta_ads` gains `create_lead_ad_creative(name, page_id, form_id, link_url, ...)`, the missing link that lets mureo deploy ads attached to a Meta Instant Form (Lead Form). Previously the wizard could create the form and fetch the leads, but had no way to produce the `object_story_spec.link_data.lead_gen_form_id` wiring required to attach the form to a creative — so the form-to-running-ad path required hand-crafting the spec elsewhere.
+
+The helper builds the correct payload (lead_gen_form_id + link + call_to_action) and auto-uploads `image_url` to an `image_hash` the same way the existing `create_ad_creative` does. The default CTA is `SIGN_UP` (the canonical Lead Ad CTA); `LEARN_MORE`, `APPLY_NOW`, `GET_QUOTE`, `SUBSCRIBE`, `CONTACT_US`, `DOWNLOAD`, and `BOOK_TRAVEL` are also valid.
+
+The new MCP tool `meta_ads_creatives_create_lead` exposes the operation; the `_mureo-meta-ads` skill now documents the end-to-end Lead Generation workflow (form → creative → campaign with `OUTCOME_LEADS` objective → ad set with `LEAD_GENERATION` optimisation goal → ad → leads polling).
+
+This is part 1 of 3 closing [#151](https://github.com/logly/mureo/issues/151) (Meta Instant Form full coverage). Parts 2 ([#153](https://github.com/logly/mureo/issues/153) — form lifecycle) and 3 ([#154](https://github.com/logly/mureo/issues/154) — CSV export + conditional questions + multi-step) follow in subsequent releases.
+
 ## [0.9.13] - 2026-05-27
 
 ### Added — `mureo configure` UI registers plugin per-account credentials

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -298,6 +298,7 @@ Or use `uv` to run it:
 | `meta_ads_creatives_create_carousel` | Create a carousel creative (2-10 cards) | `account_id`, `page_id`, `cards`, `link` |
 | `meta_ads_creatives_create_collection` | Create a collection creative | `account_id`, `page_id`, `product_ids`, `link` |
 | `meta_ads_creatives_create_dynamic` | Create a dynamic product ad creative | `account_id`, `catalog_id` |
+| `meta_ads_creatives_create_lead` | Create a Lead Ad creative attached to an Instant Form | `account_id`, `name`, `page_id`, `form_id`, `link_url` |
 | `meta_ads_creatives_upload_image` | Upload an image for use in creatives | `account_id`, `file_path` |
 
 #### Images

--- a/mureo/__init__.py
+++ b/mureo/__init__.py
@@ -1,3 +1,3 @@
 """mureo — your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."""
 
-__version__ = "0.9.13"
+__version__ = "0.9.14"

--- a/mureo/_data/skills/_mureo-meta-ads/SKILL.md
+++ b/mureo/_data/skills/_mureo-meta-ads/SKILL.md
@@ -95,6 +95,7 @@ metadata:
 | 75 | `meta_ads_instagram_accounts` | Instagram | Read | List connected Instagram accounts |
 | 76 | `meta_ads_instagram_media` | Instagram | Read | List Instagram posts |
 | 77 | `meta_ads_instagram_boost` | Instagram | Write | Boost an Instagram post |
+| 78 | `meta_ads_creatives_create_lead` | Lead / Creative | Write | Create a Lead Ad AdCreative attached to an Instant Form |
 
 ## Key Differences from Google Ads
 
@@ -653,18 +654,48 @@ Step 3: Create a dynamic product ad creative (CONFIRM WITH USER)
   -> meta_ads_creatives_create_dynamic {account_id, catalog_id}
 ```
 
-### 6. Lead Generation
+### 6. Lead Generation (Instant Form, end-to-end)
 
 ```
-Step 1: Create a lead form (CONFIRM WITH USER)
+Step 1: Create the Instant Form (CONFIRM WITH USER)
   -> meta_ads_lead_forms_create {account_id, page_id, name, questions, privacy_policy_url}
+  Returns: { id: "<form_id>", ... }
 
-Step 2: Set up campaign with LEAD_GENERATION objective
-  -> meta_ads_campaigns_create {account_id, name, objective: "LEAD_GENERATION"}
+Step 2: Create a Lead Ad creative attached to the form
+  -> meta_ads_creatives_create_lead {
+       account_id, name, page_id, form_id: "<form_id>",
+       link_url: "<https-domain-verified-url>",
+       image_hash (or image_url), message, headline,
+       call_to_action: "SIGN_UP"   # default; APPLY_NOW / LEARN_MORE / etc. also valid
+     }
+  Returns: { id: "<creative_id>", ... }
 
-Step 3: Download leads
+Step 3: Set up the campaign + ad set
+  -> meta_ads_campaigns_create {account_id, name, objective: "OUTCOME_LEADS"}
+  -> meta_ads_ad_sets_create {
+       account_id, campaign_id, name, daily_budget,
+       optimization_goal: "LEAD_GENERATION",
+       targeting: { ... }
+     }
+
+Step 4: Attach the creative to a new ad
+  -> meta_ads_ads_create {account_id, ad_set_id, name, creative_id: "<creative_id>"}
+
+Step 5: Download leads as they come in (poll)
   -> meta_ads_leads_get {account_id, form_id}
+  Or by ad: meta_ads_leads_get_by_ad {account_id, ad_id}
 ```
+
+The legacy `LEAD_GENERATION` campaign objective is still accepted by
+the API but `OUTCOME_LEADS` is the current (ODAX) canonical name.
+
+Pre-requisites the API will enforce (catch them before campaign
+launch, not after):
+- the Page that owns the form must have its lead-form Terms of
+  Service accepted (or the form must be created with
+  `leadgen_tos_accepted=true`);
+- the Page must be linked to a CRM destination or have lead access
+  configured, otherwise the lead data sits unread in Meta's UI.
 
 ### 7. Pause / Enable Entities
 

--- a/mureo/mcp/_handlers_meta_ads_extended.py
+++ b/mureo/mcp/_handlers_meta_ads_extended.py
@@ -173,7 +173,7 @@ async def handle_audiences_create_lookalike(
 
 
 # ---------------------------------------------------------------------------
-# Creative list / create / dynamic / upload_image
+# Creative list / create / create_lead / dynamic / upload_image
 # ---------------------------------------------------------------------------
 
 
@@ -210,6 +210,33 @@ async def handle_creatives_create(args: dict[str, Any]) -> list[TextContent]:
         if val is not None:
             kwargs[key] = val
     result = await client.create_ad_creative(**kwargs)
+    return _json_result(result)
+
+
+@api_error_handler
+async def handle_creatives_create_lead(args: dict[str, Any]) -> list[TextContent]:
+    """Create a Lead Ad creative wired to a Meta Instant Form."""
+    client = await _get_client(args)
+    if client is None:
+        return _no_meta_creds()
+    kwargs: dict[str, Any] = {
+        "name": _require(args, "name"),
+        "page_id": _require(args, "page_id"),
+        "form_id": _require(args, "form_id"),
+        "link_url": _require(args, "link_url"),
+    }
+    for key in (
+        "image_url",
+        "image_hash",
+        "message",
+        "headline",
+        "description",
+        "call_to_action",
+    ):
+        val = _opt(args, key)
+        if val is not None:
+            kwargs[key] = val
+    result = await client.create_lead_ad_creative(**kwargs)
     return _json_result(result)
 
 

--- a/mureo/mcp/_tools_meta_ads_creatives.py
+++ b/mureo/mcp/_tools_meta_ads_creatives.py
@@ -162,6 +162,110 @@ TOOLS: list[Tool] = [
         },
     ),
     Tool(
+        name="meta_ads_creatives_create_lead",
+        description=(
+            "Creates a Lead Ad AdCreative attached to a Meta Instant "
+            "Form. Returns the new creative's id and object_story_id. "
+            "Mutating, reversible via rollback_apply. Use under a "
+            "campaign with objective=OUTCOME_LEADS and an ad set with "
+            "optimization_goal=LEAD_GENERATION. Pre-requisite: the "
+            "lead form must exist (create via "
+            "meta_ads_lead_forms_create) and belong to the same "
+            "Facebook Page. link_url is the fallback landing page for "
+            "placements where the in-app form cannot render; it must "
+            "be HTTPS and domain-verified on the ad account."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "name": {
+                    "type": "string",
+                    "description": (
+                        "Creative name shown in Ads Manager. Internal "
+                        "label — not visible to end users."
+                    ),
+                },
+                "page_id": _PAGE_ID_PARAM,
+                "form_id": {
+                    "type": "string",
+                    "description": (
+                        "Lead Form ID returned by "
+                        "meta_ads_lead_forms_create or listed via "
+                        "meta_ads_lead_forms_list. The form must belong "
+                        "to the supplied page_id."
+                    ),
+                },
+                "link_url": {
+                    "type": "string",
+                    "description": (
+                        "Fallback destination URL for placements where "
+                        "the in-app form cannot render. Must be HTTPS "
+                        "and domain-verified on the ad account."
+                    ),
+                },
+                "image_url": {
+                    "type": "string",
+                    "description": (
+                        "Public HTTPS image URL. Auto-uploaded to "
+                        "image_hash. Mutually exclusive with "
+                        "image_hash."
+                    ),
+                },
+                "image_hash": {
+                    "type": "string",
+                    "description": (
+                        "Pre-uploaded image hash from "
+                        "meta_ads_creatives_upload_image / "
+                        "meta_ads_images_upload_file. Mutually "
+                        "exclusive with image_url."
+                    ),
+                },
+                "message": {
+                    "type": "string",
+                    "description": (
+                        "Primary ad body text shown above the image. "
+                        "Plain text, emoji allowed. ≤125 characters "
+                        "fits most placements without truncation."
+                    ),
+                },
+                "headline": {
+                    "type": "string",
+                    "description": (
+                        "Headline shown below the image. ~40 "
+                        "characters fits most placements."
+                    ),
+                },
+                "description": {
+                    "type": "string",
+                    "description": (
+                        "Link-caption text shown below the headline. "
+                        "Optional; not all placements render it."
+                    ),
+                },
+                "call_to_action": {
+                    "type": "string",
+                    "enum": [
+                        "SIGN_UP",
+                        "LEARN_MORE",
+                        "APPLY_NOW",
+                        "GET_QUOTE",
+                        "SUBSCRIBE",
+                        "CONTACT_US",
+                        "DOWNLOAD",
+                        "BOOK_TRAVEL",
+                    ],
+                    "description": (
+                        "CTA button label. SIGN_UP is the canonical "
+                        "Lead Ad CTA and the default. Choose the one "
+                        "that matches the form's purpose."
+                    ),
+                },
+            },
+            "required": ["name", "page_id", "form_id", "link_url"],
+        },
+    ),
+    Tool(
         name="meta_ads_creatives_create_dynamic",
         description=(
             "Creates a Dynamic Creative — Meta auto-generates and "

--- a/mureo/mcp/tools_meta_ads.py
+++ b/mureo/mcp/tools_meta_ads.py
@@ -83,6 +83,7 @@ from mureo.mcp._handlers_meta_ads_extended import (
     handle_campaigns_pause,
     handle_creatives_create,
     handle_creatives_create_dynamic,
+    handle_creatives_create_lead,
     handle_creatives_list,
     handle_creatives_upload_image,
     handle_pixels_events,
@@ -226,6 +227,7 @@ _HANDLERS: dict[str, Any] = {
     # Creatives
     "meta_ads_creatives_list": handle_creatives_list,
     "meta_ads_creatives_create": handle_creatives_create,
+    "meta_ads_creatives_create_lead": handle_creatives_create_lead,
     "meta_ads_creatives_create_dynamic": handle_creatives_create_dynamic,
     "meta_ads_creatives_upload_image": handle_creatives_upload_image,
     "meta_ads_creatives_create_carousel": handle_creatives_create_carousel,

--- a/mureo/meta_ads/_creatives.py
+++ b/mureo/meta_ads/_creatives.py
@@ -137,6 +137,97 @@ class CreativesMixin:
 
         return await self._post(f"/{self._ad_account_id}/adcreatives", data)
 
+    async def create_lead_ad_creative(
+        self,
+        name: str,
+        page_id: str,
+        form_id: str,
+        link_url: str,
+        *,
+        image_url: str | None = None,
+        image_hash: str | None = None,
+        message: str | None = None,
+        headline: str | None = None,
+        description: str | None = None,
+        call_to_action: str = "SIGN_UP",
+    ) -> dict[str, Any]:
+        """Create an AdCreative wired to a Meta Instant Form (Lead Ad).
+
+        Builds the ``object_story_spec.link_data.lead_gen_form_id``
+        contract that turns a normal link creative into a Lead Ad so
+        the resulting creative can be attached to an Ad whose Ad Set
+        uses ``optimization_goal=LEAD_GENERATION`` under a campaign
+        with ``objective=OUTCOME_LEADS``.
+
+        Args:
+            name: Internal creative label shown in Ads Manager.
+            page_id: Facebook Page that owns the Lead Form (the form
+                must belong to this Page).
+            form_id: Lead Form ID to attach. Get it from
+                ``list_lead_forms`` / ``create_lead_form``.
+            link_url: Destination URL used as the fallback landing
+                page on placements where the in-app form cannot
+                render. Required by the API even for pure Lead Ads.
+            image_url: Optional public HTTPS image URL — triggers
+                auto-upload to ``image_hash``. Mutually exclusive
+                with ``image_hash``.
+            image_hash: Optional pre-uploaded image hash from
+                ``upload_ad_image`` / ``upload_ad_image_file``.
+            message: Primary body text shown above the image.
+            headline: Headline text shown below the image
+                (mapped to ``link_data.name``).
+            description: Link-caption shown below the headline.
+            call_to_action: CTA button label. Defaults to
+                ``"SIGN_UP"`` (canonical Lead Ad CTA). Other commonly
+                supported values: ``LEARN_MORE``, ``APPLY_NOW``,
+                ``GET_QUOTE``, ``SUBSCRIBE``, ``CONTACT_US``,
+                ``DOWNLOAD``, ``BOOK_TRAVEL``. Meta's published list
+                also includes ``GET_OFFER`` / ``ORDER_NOW`` /
+                ``REGISTER``; mureo passes the value through
+                untouched, and Meta validates server-side. Note that
+                ``SHOP_NOW`` (valid for normal link creatives) is
+                explicitly **not** allowed on Lead Ads — Meta rejects
+                it with a 400.
+
+        Returns:
+            Created AdCreative info dict (id, ...).
+        """
+        link_data: dict[str, Any] = {
+            "link": link_url,
+            "lead_gen_form_id": form_id,
+            "call_to_action": {"type": call_to_action},
+        }
+
+        if image_url and not image_hash:
+            upload_result = await self.upload_ad_image(image_url)
+            if "hash" in upload_result:
+                image_hash = upload_result["hash"]
+            else:
+                logger.warning(
+                    "Auto-upload failed for %s: %s", image_url, upload_result
+                )
+
+        if image_hash:
+            link_data["image_hash"] = image_hash
+        if message:
+            link_data["message"] = message
+        if headline:
+            link_data["name"] = headline
+        if description:
+            link_data["description"] = description
+
+        object_story_spec = {
+            "page_id": page_id,
+            "link_data": link_data,
+        }
+
+        data: dict[str, Any] = {
+            "name": name,
+            "object_story_spec": json.dumps(object_story_spec),
+        }
+
+        return await self._post(f"/{self._ad_account_id}/adcreatives", data)
+
     async def upload_ad_image(
         self,
         image_url: str,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mureo"
-version = "0.9.13"
+version = "0.9.14"
 description = "Your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/skills/_mureo-meta-ads/SKILL.md
+++ b/skills/_mureo-meta-ads/SKILL.md
@@ -95,6 +95,7 @@ metadata:
 | 75 | `meta_ads_instagram_accounts` | Instagram | Read | List connected Instagram accounts |
 | 76 | `meta_ads_instagram_media` | Instagram | Read | List Instagram posts |
 | 77 | `meta_ads_instagram_boost` | Instagram | Write | Boost an Instagram post |
+| 78 | `meta_ads_creatives_create_lead` | Lead / Creative | Write | Create a Lead Ad AdCreative attached to an Instant Form |
 
 ## Key Differences from Google Ads
 
@@ -653,18 +654,48 @@ Step 3: Create a dynamic product ad creative (CONFIRM WITH USER)
   -> meta_ads_creatives_create_dynamic {account_id, catalog_id}
 ```
 
-### 6. Lead Generation
+### 6. Lead Generation (Instant Form, end-to-end)
 
 ```
-Step 1: Create a lead form (CONFIRM WITH USER)
+Step 1: Create the Instant Form (CONFIRM WITH USER)
   -> meta_ads_lead_forms_create {account_id, page_id, name, questions, privacy_policy_url}
+  Returns: { id: "<form_id>", ... }
 
-Step 2: Set up campaign with LEAD_GENERATION objective
-  -> meta_ads_campaigns_create {account_id, name, objective: "LEAD_GENERATION"}
+Step 2: Create a Lead Ad creative attached to the form
+  -> meta_ads_creatives_create_lead {
+       account_id, name, page_id, form_id: "<form_id>",
+       link_url: "<https-domain-verified-url>",
+       image_hash (or image_url), message, headline,
+       call_to_action: "SIGN_UP"   # default; APPLY_NOW / LEARN_MORE / etc. also valid
+     }
+  Returns: { id: "<creative_id>", ... }
 
-Step 3: Download leads
+Step 3: Set up the campaign + ad set
+  -> meta_ads_campaigns_create {account_id, name, objective: "OUTCOME_LEADS"}
+  -> meta_ads_ad_sets_create {
+       account_id, campaign_id, name, daily_budget,
+       optimization_goal: "LEAD_GENERATION",
+       targeting: { ... }
+     }
+
+Step 4: Attach the creative to a new ad
+  -> meta_ads_ads_create {account_id, ad_set_id, name, creative_id: "<creative_id>"}
+
+Step 5: Download leads as they come in (poll)
   -> meta_ads_leads_get {account_id, form_id}
+  Or by ad: meta_ads_leads_get_by_ad {account_id, ad_id}
 ```
+
+The legacy `LEAD_GENERATION` campaign objective is still accepted by
+the API but `OUTCOME_LEADS` is the current (ODAX) canonical name.
+
+Pre-requisites the API will enforce (catch them before campaign
+launch, not after):
+- the Page that owns the form must have its lead-form Terms of
+  Service accepted (or the form must be created with
+  `leadgen_tos_accepted=true`);
+- the Page must be linked to a CRM destination or have lead access
+  configured, otherwise the lead data sits unread in Meta's UI.
 
 ### 7. Pause / Enable Entities
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -41,12 +41,12 @@ class TestListTools:
     """list_tools が正しいツール定義を返すことを検証する"""
 
     async def test_list_tools_returns_all_tools(self) -> None:
-        """list_tools は全ツール（Google Ads 83 + Meta Ads 77 + Search Console 10
+        """list_tools は全ツール（Google Ads 83 + Meta Ads 78 + Search Console 10
         + Rollback 2 + Analysis 1 + Mureo Context 5 + Analytics Registry 1
-        = 179）を返す"""
+        = 180）を返す"""
         mod = _import_server_module()
         tools = await mod.handle_list_tools()
-        assert len(tools) == 179
+        assert len(tools) == 180
 
     async def test_list_tools_contains_google_and_meta(self) -> None:
         """Google Ads と Meta Ads のツールが含まれること"""

--- a/tests/test_mcp_tools_meta_ads.py
+++ b/tests/test_mcp_tools_meta_ads.py
@@ -34,9 +34,9 @@ class TestMetaAdsToolDefinitions:
     """Meta Adsツール一覧が正しく定義されていることを検証する"""
 
     def test_tool_count(self) -> None:
-        """全77ツールが定義されていること"""
+        """全78ツールが定義されていること"""
         mod = _import_meta_ads_tools()
-        assert len(mod.TOOLS) == 77
+        assert len(mod.TOOLS) == 78
 
     def test_all_tool_names(self) -> None:
         """全ツール名が meta_ads_ で始まること（MCP仕様準拠の underscore 区切り）"""

--- a/tests/test_mcp_tools_meta_ads_extended.py
+++ b/tests/test_mcp_tools_meta_ads_extended.py
@@ -343,6 +343,59 @@ class TestCreativeHandlers:
         parsed = json.loads(result[0].text)
         assert parsed["id"] == "cr_2"
 
+    async def test_creatives_create_lead(self) -> None:
+        mod = _import_meta_ads_tools()
+        handlers = _import_handlers()
+        creds, client = _mock_meta_ads_context()
+        client.create_lead_ad_creative.return_value = {"id": "cr_lead_1"}
+
+        with (
+            patch.object(handlers, "load_meta_ads_credentials", return_value=creds),
+            patch.object(handlers, "create_meta_ads_client", return_value=client),
+        ):
+            result = await mod.handle_tool(
+                "meta_ads_creatives_create_lead",
+                {
+                    "account_id": "act_123",
+                    "name": "LeadCreative",
+                    "page_id": "pg_1",
+                    "form_id": "form_42",
+                    "link_url": "https://example.com",
+                    "call_to_action": "APPLY_NOW",
+                },
+            )
+
+        client.create_lead_ad_creative.assert_awaited_once()
+        kwargs = client.create_lead_ad_creative.call_args.kwargs
+        assert kwargs["form_id"] == "form_42"
+        assert kwargs["call_to_action"] == "APPLY_NOW"
+        parsed = json.loads(result[0].text)
+        assert parsed["id"] == "cr_lead_1"
+
+    async def test_creatives_create_lead_requires_form_id(self) -> None:
+        """form_id is a hard requirement of the Lead Ad spec — omit it
+        and the handler must raise rather than POST a malformed
+        payload."""
+        mod = _import_meta_ads_tools()
+        handlers = _import_handlers()
+        creds, client = _mock_meta_ads_context()
+
+        with (
+            patch.object(handlers, "load_meta_ads_credentials", return_value=creds),
+            patch.object(handlers, "create_meta_ads_client", return_value=client),
+        ):
+            with pytest.raises(Exception):  # noqa: B017, PT011
+                await mod.handle_tool(
+                    "meta_ads_creatives_create_lead",
+                    {
+                        "account_id": "act_123",
+                        "name": "LeadCreative",
+                        "page_id": "pg_1",
+                        # form_id missing
+                        "link_url": "https://example.com",
+                    },
+                )
+
     async def test_creatives_create_dynamic(self) -> None:
         mod = _import_meta_ads_tools()
         handlers = _import_handlers()

--- a/tests/test_meta_ads_operations.py
+++ b/tests/test_meta_ads_operations.py
@@ -376,6 +376,131 @@ class TestCreativesMixin:
         assert "error" in result
 
     @pytest.mark.asyncio
+    async def test_create_lead_ad_creative_attaches_form_id(self, client) -> None:
+        """Lead Ad creative must surface ``lead_gen_form_id`` inside
+        ``link_data`` — this is the API contract that turns a normal
+        link creative into a Lead Ad."""
+        await client.create_lead_ad_creative(
+            "LeadCreative1",
+            "page1",
+            "form_99",
+            "https://example.com/landing",
+        )
+        data = client._post.call_args[0][1]
+        spec = json.loads(data["object_story_spec"])
+        assert spec["page_id"] == "page1"
+        assert spec["link_data"]["lead_gen_form_id"] == "form_99"
+        assert spec["link_data"]["link"] == "https://example.com/landing"
+
+    @pytest.mark.asyncio
+    async def test_create_lead_ad_creative_defaults_cta_to_sign_up(
+        self, client
+    ) -> None:
+        """``SIGN_UP`` is the canonical CTA for Lead Ads — must be the
+        default so the operator does not have to remember it."""
+        await client.create_lead_ad_creative(
+            "LeadCreative2",
+            "page1",
+            "form_42",
+            "https://example.com",
+        )
+        spec = json.loads(client._post.call_args[0][1]["object_story_spec"])
+        assert spec["link_data"]["call_to_action"] == {"type": "SIGN_UP"}
+
+    @pytest.mark.asyncio
+    async def test_create_lead_ad_creative_accepts_alternate_cta(
+        self, client
+    ) -> None:
+        """Lead Ads support several CTAs (LEARN_MORE, APPLY_NOW,
+        GET_QUOTE, SUBSCRIBE, ...) — the helper must pass through
+        whatever the caller chooses without validation."""
+        await client.create_lead_ad_creative(
+            "LeadCreative3",
+            "page1",
+            "form_42",
+            "https://example.com",
+            call_to_action="APPLY_NOW",
+        )
+        spec = json.loads(client._post.call_args[0][1]["object_story_spec"])
+        assert spec["link_data"]["call_to_action"] == {"type": "APPLY_NOW"}
+
+    @pytest.mark.asyncio
+    async def test_create_lead_ad_creative_with_image_hash(self, client) -> None:
+        """image_hash flows into link_data unchanged — no auto-upload."""
+        await client.create_lead_ad_creative(
+            "LeadCreative4",
+            "page1",
+            "form_42",
+            "https://example.com",
+            image_hash="hash_abc",
+            message="本文",
+            headline="見出し",
+            description="説明",
+        )
+        spec = json.loads(client._post.call_args[0][1]["object_story_spec"])
+        assert spec["link_data"]["image_hash"] == "hash_abc"
+        assert spec["link_data"]["message"] == "本文"
+        assert spec["link_data"]["name"] == "見出し"
+        assert spec["link_data"]["description"] == "説明"
+
+    @pytest.mark.asyncio
+    async def test_create_lead_ad_creative_with_image_url_auto_uploads(
+        self, client
+    ) -> None:
+        """An image_url triggers auto-upload (same convention as
+        ``create_ad_creative``) so the operator does not need a
+        separate step."""
+        client.upload_ad_image = AsyncMock(
+            return_value={"hash": "uploaded_hash", "url": "https://cdn/x.jpg"}
+        )
+        await client.create_lead_ad_creative(
+            "LeadCreative5",
+            "page1",
+            "form_42",
+            "https://example.com",
+            image_url="https://img.example.com/x.jpg",
+        )
+        client.upload_ad_image.assert_awaited_once_with(
+            "https://img.example.com/x.jpg"
+        )
+        spec = json.loads(client._post.call_args[0][1]["object_story_spec"])
+        assert spec["link_data"]["image_hash"] == "uploaded_hash"
+
+    @pytest.mark.asyncio
+    async def test_create_lead_ad_creative_link_url_present_without_image(
+        self, client
+    ) -> None:
+        """Meta requires ``link_data.link`` even on pure Lead Ads
+        (used as fallback landing page on placements that cannot
+        render the in-app form). The helper must surface it
+        regardless of whether an image is supplied."""
+        await client.create_lead_ad_creative(
+            "LeadCreativeNoImage",
+            "page1",
+            "form_42",
+            "https://example.com/fallback",
+        )
+        spec = json.loads(client._post.call_args[0][1]["object_story_spec"])
+        assert spec["link_data"]["link"] == "https://example.com/fallback"
+        # No image fields when neither image_hash nor image_url supplied.
+        assert "image_hash" not in spec["link_data"]
+
+    @pytest.mark.asyncio
+    async def test_create_lead_ad_creative_calls_correct_endpoint(
+        self, client
+    ) -> None:
+        """The POST goes to ``/<ad_account_id>/adcreatives`` — same
+        endpoint as ``create_ad_creative``, only the payload differs."""
+        await client.create_lead_ad_creative(
+            "LeadCreative6",
+            "page1",
+            "form_42",
+            "https://example.com",
+        )
+        path = client._post.call_args[0][0]
+        assert path == "/act_123/adcreatives"
+
+    @pytest.mark.asyncio
     async def test_create_dynamic_creative(self, client) -> None:
         await client.create_dynamic_creative(
             "DC1",


### PR DESCRIPTION
## Summary

Closes #152 (part 1 of 3 of umbrella #151, Meta Instant Form full coverage).

`mureo.meta_ads` could already create lead forms and fetch the resulting leads, but had **no way to attach a form to an Ad Creative**. The `object_story_spec.link_data.lead_gen_form_id` wiring had to be hand-rolled outside mureo, which broke the end-to-end "form → running ad" path. This PR adds that missing middle step.

Adds `create_lead_ad_creative(name, page_id, form_id, link_url, ...)` on `CreativesMixin` plus the MCP tool `meta_ads_creatives_create_lead`. Bumps version 0.9.13 → 0.9.14.

## What changes

- **`mureo/meta_ads/_creatives.py`** — new `create_lead_ad_creative` helper. Builds the correct `object_story_spec` payload (`page_id` + `link_data.lead_gen_form_id` + `link_data.link` + `link_data.call_to_action`). Default CTA is `SIGN_UP` (canonical Lead Ad CTA); `LEARN_MORE`, `APPLY_NOW`, `GET_QUOTE`, `SUBSCRIBE`, `CONTACT_US`, `DOWNLOAD`, `BOOK_TRAVEL` all pass through. Meta validates server-side, so the enum is non-exhaustive but documented. `image_url` auto-uploads to `image_hash` matching the existing `create_ad_creative` convention.

- **`mureo/mcp/_tools_meta_ads_creatives.py`** — new `Tool` definition. Hard-required: `account_id`, `name`, `page_id`, `form_id`, `link_url`.

- **`mureo/mcp/_handlers_meta_ads_extended.py`** — `handle_creatives_create_lead`. Passes all kwargs through to the helper.

- **`mureo/mcp/tools_meta_ads.py`** — imports the new handler and registers it in the dispatch map.

- **`mureo/_data/skills/_mureo-meta-ads/SKILL.md`** + **`skills/_mureo-meta-ads/SKILL.md`** (synced byte-for-byte) — rewrote Section 6 "Lead Generation (Instant Form, end-to-end)" with the full 5-step workflow:
  1. `meta_ads_lead_forms_create` → returns `form_id`
  2. `meta_ads_creatives_create_lead` → returns `creative_id`
  3. `meta_ads_campaigns_create` with `objective="OUTCOME_LEADS"` + `meta_ads_ad_sets_create` with `optimization_goal="LEAD_GENERATION"`
  4. `meta_ads_ads_create` with the `creative_id`
  5. `meta_ads_leads_get` to poll leads

  Also notes Meta's pre-launch enforcement: Page must have lead-form Terms accepted (or form created with `leadgen_tos_accepted=true`); Page must be CRM-linked or have lead-access configured.

- **`docs/mcp-server.md`** — tool table entry.

- **`CHANGELOG.md`** — 0.9.14 entry framing this as part 1/3 of the Instant Form umbrella.

- **`pyproject.toml`, `mureo/__init__.py`, `.claude-plugin/plugin.json`** — version bump.

- **Tests** — 7 new tests in `tests/test_meta_ads_operations.py::TestCreativesMixin` (form_id attachment, default CTA, alternate CTA, image_hash, image_url auto-upload, link-without-image, endpoint path); 2 new in `tests/test_mcp_tools_meta_ads_extended.py::TestCreativeHandlers` (handler success + missing `form_id` rejection); bumped expected tool count 77 → 78 in `tests/test_mcp_tools_meta_ads.py`.

## Backward compatibility

Purely additive. New helper + new MCP tool + new skill workflow lines. No signature changes to existing surface; no storage shape change; no removal.

## Test plan

- [x] All 9 new tests pass; full suite 3637 passed (excluding 3 pre-existing dev-env entry-point pollution failures that also fail on `main`)
- [x] `ruff check` clean on all new files
- [x] `black --check mureo/` clean
- [x] `tests/test_plugin_manifests.py::test_packaged_skills_match_canonical_byte_for_byte` passes (skills/ and mureo/_data/skills/ in sync)
- [x] Code review APPROVED (`code-reviewer` agent). MEDIUM/LOW follow-ups reflected: CTA enum comment, Page TOS/CRM workflow note, table row renumbering, handler docstring, link-without-image test. Deferred to follow-up PRs: DRY `_build_link_data` refactor, `image_url`/`image_hash` mutual-exclusion validation (both inherited from existing `create_ad_creative`).
- [ ] CI green

## Out of scope (handled in subsequent PRs of #151)

- Lead form lifecycle (status update, duplicate) → #153
- CSV export + conditional questions + multi-step layout → #154
