### PR TITLE
feat(meta-ads): Instant Form CSV export + advanced form authoring

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mureo",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "description": "Your local-first AI ad ops crew for Google Ads, Meta Ads, Search Console & GA4. mureo sits on top of the official ad-platform MCPs, gates every change against your strategy, correlates outcomes locally, and keeps an auditable decision log — credentials never leave your machine.",
   "author": {
     "name": "Logly Inc.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.16] - 2026-05-28
+
+### Added — Meta Instant Form: CSV export + advanced form authoring
+
+Two additions on `LeadsMixin`:
+
+- `export_leads_to_csv(form_id, output_path, *, limit=1000, field_order=None) -> int` — pulls the form's leads and writes them to a local CSV file. Header is `[id, created_time, *question_keys]`; the question_keys column order comes from the form's declared questions (or from caller-supplied `field_order` for a stable CRM-import schema). PII is never surfaced in mureo's log output — only the row count. Returns the number of rows written.
+- `create_lead_form` gains four optional advanced kwargs that pass through to Meta as-is (all default to "no-op" so existing callers are unaffected):
+  - `context_card` — intro / welcome screen. Lifts conversion rate measurably; recommended for any campaign past a one-week test.
+  - `thank_you_page` — custom completion screen with a CTA; supersedes the simpler `follow_up_action_url` redirect when both are supplied.
+  - `is_higher_intent=False` — flip to `True` for a 3-step input → review → submit form. Trims junk submissions at the cost of total leads volume; pick when CV quality matters more than CV volume.
+  - `conditional_questions_choices` — branching logic, so a follow-up question only shows when a prior answer matches.
+
+Two new MCP-tool entries expose the additions: `meta_ads_leads_export_csv` (new tool) and an extended `meta_ads_lead_forms_create` (signature only — tool name unchanged). The `_mureo-meta-ads` skill documents both in the tool table and the lead_forms / leads reference sections, with usage guidance on when each advanced flag is worth the friction.
+
+This is part 3 of 3 closing [#151](https://github.com/logly/mureo/issues/151) (Meta Instant Form full coverage). Part 1 ([#152](https://github.com/logly/mureo/issues/152)) and part 2 ([#153](https://github.com/logly/mureo/issues/153)) shipped in 0.9.14 and 0.9.15. Closes [#154](https://github.com/logly/mureo/issues/154).
+
 ## [0.9.15] - 2026-05-28
 
 ### Added — Meta Instant Form: lifecycle (status update + duplicate)

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -377,6 +377,7 @@ Or use `uv` to run it:
 | `meta_ads_lead_forms_create` | Create a lead form | `account_id`, `page_id`, `name`, `questions`, `privacy_policy_url` |
 | `meta_ads_lead_forms_update` | Update lead form status (ACTIVE / ARCHIVED) | `account_id`, `form_id`, `status` |
 | `meta_ads_lead_forms_duplicate` | Duplicate a lead form under a Page with a new name | `account_id`, `form_id`, `page_id`, `new_name` |
+| `meta_ads_leads_export_csv` | Export form leads to a local CSV file | `account_id`, `form_id`, `output_path` |
 | `meta_ads_leads_get` | Get lead data (per form) | `account_id`, `form_id` |
 | `meta_ads_leads_get_by_ad` | Get lead data (per ad) | `account_id`, `ad_id` |
 

--- a/mureo/__init__.py
+++ b/mureo/__init__.py
@@ -1,3 +1,3 @@
 """mureo — your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."""
 
-__version__ = "0.9.15"
+__version__ = "0.9.16"

--- a/mureo/_data/skills/_mureo-meta-ads/SKILL.md
+++ b/mureo/_data/skills/_mureo-meta-ads/SKILL.md
@@ -98,6 +98,7 @@ metadata:
 | 78 | `meta_ads_creatives_create_lead` | Lead / Creative | Write | Create a Lead Ad AdCreative attached to an Instant Form |
 | 79 | `meta_ads_lead_forms_update` | Lead | Write | Change a lead form status (ACTIVE / ARCHIVED) |
 | 80 | `meta_ads_lead_forms_duplicate` | Lead | Write | Duplicate a lead form under a Page with a new name |
+| 81 | `meta_ads_leads_export_csv` | Lead | Write (local) | Export form leads to a local CSV file |
 
 ## Key Differences from Google Ads
 
@@ -467,7 +468,25 @@ metadata:
 - `create` -- Create a lead form. **Requires user confirmation.**
   ```
   Required: account_id, page_id, name, questions (array), privacy_policy_url
+  Optional advanced: locale, context_card (intro screen),
+    thank_you_page (custom completion screen), is_higher_intent
+    (3-step input→review→submit form), conditional_questions_choices
+    (branching logic), follow_up_action_url (simple redirect; superseded
+    by thank_you_page when both present)
   ```
+
+  When to use `is_higher_intent=true`: trims junk submissions, lowers
+  total volume — pick when CV quality matters more than CV volume
+  (e.g. B2B / enterprise lead capture).
+
+  When to use `context_card`: lifts conversion rate measurably. Always
+  worth a `{title, content, style=PARAGRAPH_STYLE}` minimum for any
+  campaign that survives past a 1-week test.
+
+  When to use `conditional_questions_choices`: when a follow-up
+  question is only relevant given a prior answer (e.g. "How many
+  employees?" only if "Decision-maker?" was YES). Reduces form length
+  for users who don't need the branch.
 
 - `update` -- Change a lead form status (ACTIVE / ARCHIVED only — other
   fields are immutable post-creation). **Requires user confirmation.**
@@ -483,6 +502,17 @@ metadata:
   ```
 
 ### leads
+
+- `export_csv` -- Export form leads to a local CSV file. Header row
+  is ``[id, created_time, *question_keys]`` (question_keys come from
+  the form's declared questions in declared order, or from caller-
+  supplied ``field_order`` to lock a custom schema). PII does NOT
+  appear in mureo's log output — only the row count.
+  ```
+  Required: account_id, form_id, output_path
+  Optional: limit (default 1000, max 1000), field_order (list of
+    question keys to override column order)
+  ```
 
 - `get` -- Get lead data (per form).
   ```

--- a/mureo/mcp/_handlers_meta_ads.py
+++ b/mureo/mcp/_handlers_meta_ads.py
@@ -564,11 +564,43 @@ async def handle_lead_forms_create(args: dict[str, Any]) -> list[TextContent]:
         "questions": _require(args, "questions"),
         "privacy_policy_url": _require(args, "privacy_policy_url"),
     }
-    follow_up = _opt(args, "follow_up_action_url")
-    if follow_up is not None:
-        kwargs["follow_up_action_url"] = follow_up
+    for key in (
+        "follow_up_action_url",
+        "locale",
+        "context_card",
+        "thank_you_page",
+        "conditional_questions_choices",
+    ):
+        val = _opt(args, key)
+        if val is not None:
+            kwargs[key] = val
+    if _opt(args, "is_higher_intent"):
+        kwargs["is_higher_intent"] = True
     result = await client.create_lead_form(**kwargs)
     return _json_result(result)
+
+
+@api_error_handler
+async def handle_leads_export_csv(args: dict[str, Any]) -> list[TextContent]:
+    """Export form leads to a local CSV file."""
+    from pathlib import Path as _Path
+
+    client = await _get_client(args)
+    if client is None:
+        return _no_meta_creds()
+    kwargs: dict[str, Any] = {}
+    limit = _opt(args, "limit")
+    if limit is not None:
+        kwargs["limit"] = limit
+    field_order = _opt(args, "field_order")
+    if field_order is not None:
+        kwargs["field_order"] = field_order
+    count = await client.export_leads_to_csv(
+        _require(args, "form_id"),
+        _Path(_require(args, "output_path")),
+        **kwargs,
+    )
+    return _json_result({"rows": count})
 
 
 @api_error_handler

--- a/mureo/mcp/_tools_meta_ads_leads.py
+++ b/mureo/mcp/_tools_meta_ads_leads.py
@@ -174,8 +174,56 @@ TOOLS: list[Tool] = [
                     "description": (
                         "Optional URL the user is redirected to after "
                         "submission (e.g. thank-you page). Omit to show "
-                        "Meta's default confirmation only."
+                        "Meta's default confirmation only. Superseded by "
+                        "thank_you_page when both are supplied."
                     ),
+                },
+                "locale": {
+                    "type": "string",
+                    "description": (
+                        "Optional form locale (e.g. ``ja_JP``). Defaults "
+                        "to the Page's primary locale."
+                    ),
+                },
+                "context_card": {
+                    "type": "object",
+                    "description": (
+                        "Optional intro / welcome screen shown before "
+                        "the form. Lifts conversion rate measurably when "
+                        "supplied. Expected keys: title, content, style "
+                        "(PARAGRAPH_STYLE or LIST_STYLE), cover_photo_id."
+                    ),
+                },
+                "thank_you_page": {
+                    "type": "object",
+                    "description": (
+                        "Optional custom completion screen with a CTA. "
+                        "Replaces follow_up_action_url's simple "
+                        "redirect when supplied. Expected keys: title, "
+                        "body, button_type (VIEW_WEBSITE / "
+                        "CALL_BUSINESS / MESSAGE_BUSINESS / DOWNLOAD / "
+                        "DOWNLOAD_APP), website_url, button_text."
+                    ),
+                },
+                "is_higher_intent": {
+                    "type": "boolean",
+                    "description": (
+                        "When true, Meta renders a 3-step form "
+                        "(input → review → submit) which trims junk "
+                        "submissions at the cost of total leads "
+                        "volume. Default false (single-step)."
+                    ),
+                },
+                "conditional_questions_choices": {
+                    "type": "array",
+                    "description": (
+                        "Branching logic — given a prior question's "
+                        "value, choose which question to ask next. "
+                        "Each entry: {question: <key>, value: "
+                        "<choice>, next_question_key: <key>}. Meta "
+                        "validates the keys refer to real questions."
+                    ),
+                    "items": {"type": "object"},
                 },
             },
             "required": [
@@ -263,6 +311,58 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["form_id", "page_id", "new_name"],
+        },
+    ),
+    Tool(
+        name="meta_ads_leads_export_csv",
+        description=(
+            "Fetches all leads for a lead form and writes them to a "
+            "local CSV file. Returns the number of rows written. "
+            'Header row is ``["id", "created_time", *question_keys]``; '
+            "question_keys come from the form's declared questions "
+            "(in declared order) so column order stays stable across "
+            "exports. Pass field_order to lock a different column "
+            "order (useful for stable CRM-import schemas). PII never "
+            "appears in mureo's log output — only the row count. "
+            "Read-only with respect to Meta, but writes locally. "
+            "Meta retains lead data for 90 days; export regularly."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "form_id": {
+                    "type": "string",
+                    "description": "Lead form ID whose leads to export.",
+                },
+                "output_path": {
+                    "type": "string",
+                    "description": (
+                        "Absolute local path for the CSV file. Parent "
+                        "directory is auto-created if missing; "
+                        "existing file is overwritten. UTF-8 encoded."
+                    ),
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 1000,
+                    "description": (
+                        "Max leads per API call. Default 1000, "
+                        "Meta's per-call ceiling."
+                    ),
+                },
+                "field_order": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": (
+                        "Optional list of question keys to lock the "
+                        "column order. Overrides the form's declared "
+                        "question order."
+                    ),
+                },
+            },
+            "required": ["form_id", "output_path"],
         },
     ),
     Tool(

--- a/mureo/mcp/tools_meta_ads.py
+++ b/mureo/mcp/tools_meta_ads.py
@@ -55,6 +55,7 @@ from mureo.mcp._handlers_meta_ads import (
     handle_lead_forms_get,
     handle_lead_forms_list,
     handle_lead_forms_update,
+    handle_leads_export_csv,
     handle_leads_get,
     handle_leads_get_by_ad,
     handle_products_add,
@@ -221,6 +222,7 @@ _HANDLERS: dict[str, Any] = {
     "meta_ads_lead_forms_create": handle_lead_forms_create,
     "meta_ads_lead_forms_update": handle_lead_forms_update,
     "meta_ads_lead_forms_duplicate": handle_lead_forms_duplicate,
+    "meta_ads_leads_export_csv": handle_leads_export_csv,
     "meta_ads_leads_get": handle_leads_get,
     "meta_ads_leads_get_by_ad": handle_leads_get_by_ad,
     # Image upload

--- a/mureo/meta_ads/_leads.py
+++ b/mureo/meta_ads/_leads.py
@@ -7,9 +7,14 @@ Lead data contains PII and is not logged.
 
 from __future__ import annotations
 
+import csv
 import json
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
+from urllib.parse import parse_qs, urlparse
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -28,6 +33,21 @@ _LEAD_FIELDS = "id,created_time,field_data,ad_id,ad_name,form_id"
 # values (``DRAFT``, ``DELETED``, ``DELETION_PENDING``) appear in
 # read paths but cannot be set by an operator.
 _VALID_FORM_STATUSES: frozenset[str] = frozenset({"ACTIVE", "ARCHIVED"})
+
+# Characters that turn a CSV cell into a live formula in
+# Excel / Sheets / Numbers. Prepending a single-quote disarms the
+# injection without breaking the visible value for spreadsheet users.
+_CSV_INJECTION_PREFIXES: tuple[str, ...] = ("=", "+", "-", "@", "\t", "\r")
+
+
+def _csv_safe(value: str) -> str:
+    """Escape leading characters that would otherwise be interpreted
+    as a spreadsheet formula. Idempotent — re-escaping the result is
+    a no-op because the leading single quote is itself benign.
+    """
+    if value and value[0] in _CSV_INJECTION_PREFIXES:
+        return "'" + value
+    return value
 
 
 class LeadsMixin:
@@ -94,19 +114,54 @@ class LeadsMixin:
         *,
         follow_up_action_url: str | None = None,
         locale: str | None = None,
+        context_card: dict[str, Any] | None = None,
+        thank_you_page: dict[str, Any] | None = None,
+        is_higher_intent: bool = False,
+        conditional_questions_choices: list[dict[str, Any]] | None = None,
     ) -> dict[str, Any]:
-        """Create a lead form
+        """Create a lead form.
 
         Args:
-            page_id: Facebook page ID
-            name: Form name
-            questions: List of questions (FULL_NAME, EMAIL, PHONE_NUMBER, COMPANY_NAME, CUSTOM, etc.)
-            privacy_policy_url: Privacy policy URL
-            follow_up_action_url: Redirect URL after form submission
-            locale: Locale
+            page_id: Facebook page ID.
+            name: Form name shown in Ads Manager and Lead Center.
+            questions: Ordered list of question dicts. Standard
+                types (``FULL_NAME``, ``EMAIL``, ``PHONE_NUMBER``,
+                ``COMPANY_NAME``, ``JOB_TITLE``, ``CITY``, ``STATE``,
+                ``ZIP_CODE``, ``COUNTRY``, ``DATE_OF_BIRTH``) only
+                need ``type``; ``CUSTOM`` questions require ``key``,
+                ``label``, and (for dropdowns) ``options``.
+            privacy_policy_url: HTTPS URL of the advertiser's
+                privacy policy. Required by Meta policy.
+            follow_up_action_url: Optional redirect URL shown after
+                submission. Omit for Meta's default confirmation.
+            locale: Optional form locale (e.g. ``"ja_JP"``).
+            context_card: Optional intro / welcome screen shown
+                before the form. Expected shape:
+                ``{"title": "...", "content": "...",
+                "style": "PARAGRAPH_STYLE" | "LIST_STYLE",
+                "cover_photo_id": "..."}``. Meta lifts conversion
+                rates measurably when an intro is supplied.
+            thank_you_page: Optional custom completion screen with
+                a CTA. Expected shape (subset):
+                ``{"title": "...", "body": "...",
+                "button_type": "VIEW_WEBSITE" | "CALL_BUSINESS" |
+                "MESSAGE_BUSINESS" | "DOWNLOAD" | "DOWNLOAD_APP",
+                "website_url": "...", "button_text": "..."}``.
+                Replaces ``follow_up_action_url``'s simple redirect.
+            is_higher_intent: When ``True``, Meta renders a 3-step
+                form (input → review → submit) which trims junk
+                submissions at the cost of total leads volume.
+                Default ``False`` (single-step standard form).
+            conditional_questions_choices: Branching logic — list of
+                entries that, given a prior question's value, choose
+                which question to ask next. Each entry's expected
+                shape: ``{"question": "<key>", "value": "<choice>",
+                "next_question_key": "<key>"}``. Mureo passes the
+                value through unchanged; Meta validates the keys
+                refer to real questions.
 
         Returns:
-            Created lead form information.
+            Created lead form info dict.
         """
         data: dict[str, Any] = {
             "name": name,
@@ -118,6 +173,16 @@ class LeadsMixin:
             data["follow_up_action_url"] = follow_up_action_url
         if locale is not None:
             data["locale"] = locale
+        if context_card is not None:
+            data["context_card"] = json.dumps(context_card)
+        if thank_you_page is not None:
+            data["thank_you_page"] = json.dumps(thank_you_page)
+        if is_higher_intent:
+            data["is_higher_intent"] = True
+        if conditional_questions_choices is not None:
+            data["conditional_questions_choices"] = json.dumps(
+                conditional_questions_choices
+            )
 
         logger.info(
             "Lead form creation: page_id=%s, name=%s",
@@ -288,3 +353,121 @@ class LeadsMixin:
         leads = result.get("data", [])
         logger.info("Lead data by ad: ad_id=%s, count=%d", ad_id, len(leads))
         return leads  # type: ignore[no-any-return]
+
+    async def export_leads_to_csv(
+        self,
+        form_id: str,
+        output_path: Path,
+        *,
+        limit: int = 1000,
+        field_order: list[str] | None = None,
+    ) -> int:
+        """Fetch all leads for a form and write them to a CSV file.
+
+        The header row is ``["id", "created_time", *field_keys]``.
+        ``field_keys`` is derived from the form's declared questions
+        in declared order — for standard questions without an
+        explicit ``key`` (the common case) Meta's wire format uses
+        the lowercased ``type`` (``"EMAIL"`` → ``"email"``), so the
+        helper aligns column names with ``field_data[].name``. Pass
+        ``field_order`` to lock a different column order — useful
+        when the operator wants a stable CRM-import schema
+        regardless of future form edits.
+
+        Pagination is followed automatically: the helper calls
+        ``/{form_id}/leads?fields=…&limit=<limit>`` and keeps
+        traversing ``paging.next`` cursors until no more pages
+        remain, so a form with arbitrarily many leads completes in
+        one call.
+
+        CSV-injection defense: values starting with ``= + - @ \\t
+        \\r`` are prefixed with a single quote before they reach the
+        ``csv.writer``. Lead values are operator-controlled
+        downstream (the operator opens the export in Excel /
+        Sheets / Numbers), so the prefix prevents user-supplied
+        text becoming a live formula. Multi-value answers are
+        joined with ``" | "`` so a comma inside one value does not
+        get confused with a value separator (``csv.writer`` quotes
+        the whole cell, but the prior format collapsed multi-values
+        into a single comma-joined string which was ambiguous).
+
+        Lead values are sensitive (PII): nothing from the lead's
+        ``field_data`` is ever surfaced in mureo's log output. Only
+        the row count, form_id, and path make it to the info log.
+
+        Args:
+            form_id: Lead form ID.
+            output_path: File path for the CSV. Parent directory is
+                auto-created. UTF-8 encoded; existing files are
+                overwritten.
+            limit: Max leads to fetch per Graph API call. Default
+                1000 (Meta's per-call ceiling). The helper still
+                fetches every lead via pagination — this only
+                controls page size.
+            field_order: Optional explicit list of question keys to
+                drive the column order. Overrides the form's
+                declared question order.
+
+        Returns:
+            Number of lead rows written (excluding the header).
+        """
+        form = await self.get_lead_form(form_id)
+        if field_order is None:
+            field_order = []
+            for q in form.get("questions", []):
+                # Meta's wire format for ``field_data[].name`` uses
+                # the lowercased standard type (e.g. ``"EMAIL"`` →
+                # ``"email"``) when the form question has no explicit
+                # ``key``. CUSTOM questions always have a ``key``.
+                key = q.get("key") or q.get("type", "").lower()
+                if key:
+                    field_order.append(key)
+
+        # Page through /{form_id}/leads until paging.next is absent.
+        # Meta returns a fully-qualified ``paging.next`` URL, but
+        # ``_get`` always prepends ``BASE_URL`` so an absolute URL
+        # would double-prefix. Extract the ``after`` cursor instead
+        # and re-issue with the same relative path.
+        all_leads: list[dict[str, Any]] = []
+        path: str = f"/{form_id}/leads"
+        params: dict[str, Any] = {"fields": _LEAD_FIELDS, "limit": limit}
+        while True:
+            result = await self._get(path, params)
+            all_leads.extend(result.get("data", []) or [])
+            next_url = (result.get("paging", {}) or {}).get("next")
+            if not next_url:
+                break
+            after_values = parse_qs(urlparse(next_url).query).get("after")
+            if not after_values:
+                # Paging cursor missing in a non-standard ``next`` —
+                # bail out rather than loop forever.
+                break
+            params = {**params, "after": after_values[0]}
+
+        header = ["id", "created_time", *field_order]
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(output_path, "w", encoding="utf-8", newline="") as fh:
+            writer = csv.writer(fh)
+            writer.writerow(header)
+            for lead in all_leads:
+                field_lookup = {
+                    fd.get("name", ""): _csv_safe(
+                        " | ".join(fd.get("values", []) or [])
+                    )
+                    for fd in lead.get("field_data", [])
+                }
+                row = [
+                    _csv_safe(lead.get("id", "")),
+                    _csv_safe(lead.get("created_time", "")),
+                    *[field_lookup.get(key, "") for key in field_order],
+                ]
+                writer.writerow(row)
+
+        # PII intentionally not logged — only the count.
+        logger.info(
+            "Lead CSV export: form_id=%s, rows=%d, path=%s",
+            form_id,
+            len(all_leads),
+            output_path,
+        )
+        return len(all_leads)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mureo"
-version = "0.9.15"
+version = "0.9.16"
 description = "Your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/skills/_mureo-meta-ads/SKILL.md
+++ b/skills/_mureo-meta-ads/SKILL.md
@@ -98,6 +98,7 @@ metadata:
 | 78 | `meta_ads_creatives_create_lead` | Lead / Creative | Write | Create a Lead Ad AdCreative attached to an Instant Form |
 | 79 | `meta_ads_lead_forms_update` | Lead | Write | Change a lead form status (ACTIVE / ARCHIVED) |
 | 80 | `meta_ads_lead_forms_duplicate` | Lead | Write | Duplicate a lead form under a Page with a new name |
+| 81 | `meta_ads_leads_export_csv` | Lead | Write (local) | Export form leads to a local CSV file |
 
 ## Key Differences from Google Ads
 
@@ -467,7 +468,25 @@ metadata:
 - `create` -- Create a lead form. **Requires user confirmation.**
   ```
   Required: account_id, page_id, name, questions (array), privacy_policy_url
+  Optional advanced: locale, context_card (intro screen),
+    thank_you_page (custom completion screen), is_higher_intent
+    (3-step input→review→submit form), conditional_questions_choices
+    (branching logic), follow_up_action_url (simple redirect; superseded
+    by thank_you_page when both present)
   ```
+
+  When to use `is_higher_intent=true`: trims junk submissions, lowers
+  total volume — pick when CV quality matters more than CV volume
+  (e.g. B2B / enterprise lead capture).
+
+  When to use `context_card`: lifts conversion rate measurably. Always
+  worth a `{title, content, style=PARAGRAPH_STYLE}` minimum for any
+  campaign that survives past a 1-week test.
+
+  When to use `conditional_questions_choices`: when a follow-up
+  question is only relevant given a prior answer (e.g. "How many
+  employees?" only if "Decision-maker?" was YES). Reduces form length
+  for users who don't need the branch.
 
 - `update` -- Change a lead form status (ACTIVE / ARCHIVED only — other
   fields are immutable post-creation). **Requires user confirmation.**
@@ -483,6 +502,17 @@ metadata:
   ```
 
 ### leads
+
+- `export_csv` -- Export form leads to a local CSV file. Header row
+  is ``[id, created_time, *question_keys]`` (question_keys come from
+  the form's declared questions in declared order, or from caller-
+  supplied ``field_order`` to lock a custom schema). PII does NOT
+  appear in mureo's log output — only the row count.
+  ```
+  Required: account_id, form_id, output_path
+  Optional: limit (default 1000, max 1000), field_order (list of
+    question keys to override column order)
+  ```
 
 - `get` -- Get lead data (per form).
   ```

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -41,12 +41,12 @@ class TestListTools:
     """list_tools が正しいツール定義を返すことを検証する"""
 
     async def test_list_tools_returns_all_tools(self) -> None:
-        """list_tools は全ツール（Google Ads 83 + Meta Ads 80 + Search Console 10
+        """list_tools は全ツール（Google Ads 83 + Meta Ads 81 + Search Console 10
         + Rollback 2 + Analysis 1 + Mureo Context 5 + Analytics Registry 1
-        = 182）を返す"""
+        = 183）を返す"""
         mod = _import_server_module()
         tools = await mod.handle_list_tools()
-        assert len(tools) == 182
+        assert len(tools) == 183
 
     async def test_list_tools_contains_google_and_meta(self) -> None:
         """Google Ads と Meta Ads のツールが含まれること"""

--- a/tests/test_mcp_tools_meta_ads.py
+++ b/tests/test_mcp_tools_meta_ads.py
@@ -34,9 +34,9 @@ class TestMetaAdsToolDefinitions:
     """Meta Adsツール一覧が正しく定義されていることを検証する"""
 
     def test_tool_count(self) -> None:
-        """全80ツールが定義されていること"""
+        """全81ツールが定義されていること"""
         mod = _import_meta_ads_tools()
-        assert len(mod.TOOLS) == 80
+        assert len(mod.TOOLS) == 81
 
     def test_all_tool_names(self) -> None:
         """全ツール名が meta_ads_ で始まること（MCP仕様準拠の underscore 区切り）"""

--- a/tests/test_meta_ads_leads.py
+++ b/tests/test_meta_ads_leads.py
@@ -574,7 +574,7 @@ class TestLeadAdsToolDefinitions:
         assert set(tool.inputSchema["required"]) == set(expected_required)
 
     def test_all_lead_tools_exist(self) -> None:
-        """7つのLead Adsツールがすべて登録されていること"""
+        """8つのLead Adsツールがすべて登録されていること"""
         mod = _import_meta_ads_tools()
         tool_names = {t.name for t in mod.TOOLS}
         expected = {
@@ -585,6 +585,7 @@ class TestLeadAdsToolDefinitions:
             "meta_ads_lead_forms_duplicate",
             "meta_ads_leads_get",
             "meta_ads_leads_get_by_ad",
+            "meta_ads_leads_export_csv",
         }
         assert expected.issubset(tool_names)
 
@@ -822,3 +823,583 @@ class TestDuplicateLeadForm:
             await client.duplicate_lead_form(
                 "form_1", page_id="page_123", new_name="Copy"
             )
+
+
+# ===========================================================================
+# Advanced lead form creation (PR 3) — context_card / thank_you_page /
+# is_higher_intent / conditional_questions_choices
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestCreateLeadFormAdvanced:
+    @pytest.fixture()
+    def client(self) -> LeadsMixin:
+        return _make_mock_client()
+
+    @pytest.mark.asyncio
+    async def test_advanced_kwargs_all_omitted_keeps_backcompat_shape(
+        self, client: LeadsMixin
+    ) -> None:
+        """新しい optional kwargs を全て省略しても従来の payload と一致
+        — 既存 caller を破壊しないことを ABI レベルで pin する"""
+        await client.create_lead_form(
+            page_id="page_123",
+            name="basic",
+            questions=[{"type": "EMAIL"}],
+            privacy_policy_url="https://example.com/policy",
+        )
+        data = client._post.call_args[0][1]
+        # 新フィールドは送られない
+        assert "context_card" not in data
+        assert "thank_you_page" not in data
+        assert "is_higher_intent" not in data
+        assert "conditional_questions_choices" not in data
+
+    @pytest.mark.asyncio
+    async def test_context_card_serialised_into_payload(
+        self, client: LeadsMixin
+    ) -> None:
+        """intro 画面の構成情報が JSON エンコードされて context_card に入る"""
+        card = {
+            "title": "資料請求はこちら",
+            "content": "60秒で完了します。",
+            "style": "PARAGRAPH_STYLE",
+            "cover_photo_id": "img_123",
+        }
+        await client.create_lead_form(
+            page_id="page_123",
+            name="intro form",
+            questions=[{"type": "EMAIL"}],
+            privacy_policy_url="https://example.com/policy",
+            context_card=card,
+        )
+        data = client._post.call_args[0][1]
+        assert json.loads(data["context_card"]) == card
+
+    @pytest.mark.asyncio
+    async def test_thank_you_page_serialised_into_payload(
+        self, client: LeadsMixin
+    ) -> None:
+        """完了画面の構成情報が JSON エンコードされて thank_you_page に入る"""
+        page = {
+            "title": "ありがとうございます",
+            "body": "担当者から連絡します。",
+            "button_type": "VIEW_WEBSITE",
+            "website_url": "https://example.com/landing",
+            "button_text": "サイトを見る",
+        }
+        await client.create_lead_form(
+            page_id="page_123",
+            name="ty form",
+            questions=[{"type": "EMAIL"}],
+            privacy_policy_url="https://example.com/policy",
+            thank_you_page=page,
+        )
+        data = client._post.call_args[0][1]
+        assert json.loads(data["thank_you_page"]) == page
+
+    @pytest.mark.asyncio
+    async def test_is_higher_intent_true_added_as_boolean(
+        self, client: LeadsMixin
+    ) -> None:
+        """higher-intent は 3-step (入力→確認→送信) に切り替える bool flag
+
+        Meta API は文字列ではなく真偽値を期待する。
+        """
+        await client.create_lead_form(
+            page_id="page_123",
+            name="HI form",
+            questions=[{"type": "EMAIL"}],
+            privacy_policy_url="https://example.com/policy",
+            is_higher_intent=True,
+        )
+        data = client._post.call_args[0][1]
+        assert data["is_higher_intent"] is True
+
+    @pytest.mark.asyncio
+    async def test_is_higher_intent_false_default_not_sent(
+        self, client: LeadsMixin
+    ) -> None:
+        """デフォルト (False) は payload に出ない — Meta の標準 = False と
+        一致するので、明示的に送る必要はない"""
+        await client.create_lead_form(
+            page_id="page_123",
+            name="standard form",
+            questions=[{"type": "EMAIL"}],
+            privacy_policy_url="https://example.com/policy",
+        )
+        data = client._post.call_args[0][1]
+        assert "is_higher_intent" not in data
+
+    @pytest.mark.asyncio
+    async def test_conditional_questions_choices_serialised(
+        self, client: LeadsMixin
+    ) -> None:
+        """conditional question 分岐情報は JSON エンコードされて送られる"""
+        choices = [
+            {
+                "question": "predefined",
+                "value": "INTERESTED_IN_DEMO",
+                "next_question_key": "company_size",
+            },
+        ]
+        await client.create_lead_form(
+            page_id="page_123",
+            name="branching form",
+            questions=[{"type": "EMAIL"}],
+            privacy_policy_url="https://example.com/policy",
+            conditional_questions_choices=choices,
+        )
+        data = client._post.call_args[0][1]
+        assert json.loads(data["conditional_questions_choices"]) == choices
+
+
+# ===========================================================================
+# export_leads_to_csv (PR 3)
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestExportLeadsToCsv:
+    @pytest.fixture()
+    def client(self) -> LeadsMixin:
+        return _make_mock_client()
+
+    @pytest.mark.asyncio
+    async def test_writes_csv_header_from_form_questions(
+        self, client: LeadsMixin, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        """CSV 1 行目は form の questions の順序に従う — operator が
+        export を何度走らせても列順が安定する"""
+        from pathlib import Path
+
+        form = {
+            "id": "form_1",
+            "name": "Test",
+            "questions": [
+                {"type": "FULL_NAME", "key": "full_name"},
+                {"type": "EMAIL", "key": "email"},
+                {"type": "PHONE_NUMBER", "key": "phone_number"},
+            ],
+            "privacy_policy": {"url": "https://example.com/p"},
+        }
+        leads = [
+            {
+                "id": "lead_1",
+                "created_time": "2026-01-01T00:00:00+0000",
+                "field_data": [
+                    {"name": "full_name", "values": ["田中 太郎"]},
+                    {"name": "email", "values": ["taro@example.com"]},
+                    {"name": "phone_number", "values": ["0901234567"]},
+                ],
+            },
+        ]
+        client._get = AsyncMock(side_effect=[form, {"data": leads}])
+
+        out: Path = tmp_path / "out.csv"  # type: ignore[assignment]
+        count = await client.export_leads_to_csv("form_1", out)
+        assert count == 1
+
+        rows = out.read_text(encoding="utf-8").splitlines()
+        header = rows[0].split(",")
+        # id / created_time + 質問キー
+        assert header[:2] == ["id", "created_time"]
+        assert set(header[2:]) == {"full_name", "email", "phone_number"}
+        # 列順は form の question 順
+        assert header[2:] == ["full_name", "email", "phone_number"]
+
+    @pytest.mark.asyncio
+    async def test_csv_one_row_per_lead(
+        self, client: LeadsMixin, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        from pathlib import Path
+
+        form = {
+            "id": "form_1",
+            "questions": [{"type": "EMAIL", "key": "email"}],
+            "privacy_policy": {"url": "https://example.com/p"},
+        }
+        leads = [
+            {
+                "id": "lead_1",
+                "created_time": "2026-01-01T00:00:00+0000",
+                "field_data": [{"name": "email", "values": ["a@example.com"]}],
+            },
+            {
+                "id": "lead_2",
+                "created_time": "2026-01-02T00:00:00+0000",
+                "field_data": [{"name": "email", "values": ["b@example.com"]}],
+            },
+        ]
+        client._get = AsyncMock(side_effect=[form, {"data": leads}])
+
+        out: Path = tmp_path / "out.csv"  # type: ignore[assignment]
+        count = await client.export_leads_to_csv("form_1", out)
+        assert count == 2
+
+        rows = out.read_text(encoding="utf-8").splitlines()
+        # header + 2 leads
+        assert len(rows) == 3
+
+    @pytest.mark.asyncio
+    async def test_csv_zero_leads_writes_header_only(
+        self, client: LeadsMixin, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        from pathlib import Path
+
+        form = {
+            "id": "form_1",
+            "questions": [{"type": "EMAIL", "key": "email"}],
+            "privacy_policy": {"url": "https://example.com/p"},
+        }
+        client._get = AsyncMock(side_effect=[form, {"data": []}])
+
+        out: Path = tmp_path / "out.csv"  # type: ignore[assignment]
+        count = await client.export_leads_to_csv("form_1", out)
+        assert count == 0
+
+        rows = out.read_text(encoding="utf-8").splitlines()
+        assert len(rows) == 1  # header only
+
+    @pytest.mark.asyncio
+    async def test_csv_does_not_log_pii(
+        self,
+        client: LeadsMixin,
+        tmp_path: pytest.TempPathFactory,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """lead の field_data の値は log 出力に絶対現れない"""
+        from pathlib import Path
+        import logging
+
+        form = {
+            "id": "form_1",
+            "questions": [{"type": "EMAIL", "key": "email"}],
+            "privacy_policy": {"url": "https://example.com/p"},
+        }
+        sentinel = "ultra-secret-email-address@example.com"
+        leads = [
+            {
+                "id": "lead_1",
+                "created_time": "2026-01-01T00:00:00+0000",
+                "field_data": [{"name": "email", "values": [sentinel]}],
+            },
+        ]
+        client._get = AsyncMock(side_effect=[form, {"data": leads}])
+
+        out: Path = tmp_path / "out.csv"  # type: ignore[assignment]
+        with caplog.at_level(logging.DEBUG, logger="mureo.meta_ads._leads"):
+            await client.export_leads_to_csv("form_1", out)
+
+        log_text = "\n".join(rec.getMessage() for rec in caplog.records)
+        assert sentinel not in log_text
+
+    @pytest.mark.asyncio
+    async def test_csv_field_order_override(
+        self, client: LeadsMixin, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        """caller が field_order を明示したら form の question 順より優先する"""
+        from pathlib import Path
+
+        form = {
+            "id": "form_1",
+            "questions": [
+                {"type": "FULL_NAME", "key": "full_name"},
+                {"type": "EMAIL", "key": "email"},
+            ],
+            "privacy_policy": {"url": "https://example.com/p"},
+        }
+        leads = [
+            {
+                "id": "lead_1",
+                "created_time": "2026-01-01T00:00:00+0000",
+                "field_data": [
+                    {"name": "full_name", "values": ["A"]},
+                    {"name": "email", "values": ["a@example.com"]},
+                ],
+            },
+        ]
+        client._get = AsyncMock(side_effect=[form, {"data": leads}])
+
+        out: Path = tmp_path / "out.csv"  # type: ignore[assignment]
+        await client.export_leads_to_csv(
+            "form_1", out, field_order=["email", "full_name"]
+        )
+        header = out.read_text(encoding="utf-8").splitlines()[0].split(",")
+        assert header[2:] == ["email", "full_name"]
+
+    @pytest.mark.asyncio
+    async def test_csv_handles_missing_field_data(
+        self, client: LeadsMixin, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        """lead が一部 field を持たない場合は空セルにする (raise しない)"""
+        from pathlib import Path
+
+        form = {
+            "id": "form_1",
+            "questions": [
+                {"type": "FULL_NAME", "key": "full_name"},
+                {"type": "EMAIL", "key": "email"},
+            ],
+            "privacy_policy": {"url": "https://example.com/p"},
+        }
+        leads = [
+            {
+                "id": "lead_1",
+                "created_time": "2026-01-01T00:00:00+0000",
+                "field_data": [
+                    # full_name 欠落
+                    {"name": "email", "values": ["a@example.com"]},
+                ],
+            },
+        ]
+        client._get = AsyncMock(side_effect=[form, {"data": leads}])
+
+        out: Path = tmp_path / "out.csv"  # type: ignore[assignment]
+        count = await client.export_leads_to_csv("form_1", out)
+        assert count == 1
+        rows = out.read_text(encoding="utf-8").splitlines()
+        # 欠落セルは空 — 値そのものを assert するため csv パーサで読む
+        import csv
+
+        with open(out, encoding="utf-8") as f:
+            parsed = list(csv.DictReader(f))
+        assert parsed[0]["full_name"] == ""
+        assert parsed[0]["email"] == "a@example.com"
+
+    @pytest.mark.asyncio
+    async def test_csv_standard_question_without_key_uses_lowercase_type(
+        self,
+        client: LeadsMixin,
+        tmp_path: pytest.TempPathFactory,
+    ) -> None:
+        """Standard questions usually omit ``key``. Meta's
+        ``field_data[].name`` returns the lowercased type
+        (``EMAIL`` → ``email``); the header must match that wire
+        format so the value lookup actually hits the cell."""
+        from pathlib import Path
+
+        form = {
+            "id": "form_1",
+            "questions": [
+                {"type": "FULL_NAME"},  # no key
+                {"type": "EMAIL"},  # no key
+            ],
+            "privacy_policy": {"url": "https://example.com/p"},
+        }
+        leads = [
+            {
+                "id": "lead_1",
+                "created_time": "2026-01-01T00:00:00+0000",
+                "field_data": [
+                    {"name": "full_name", "values": ["山田 太郎"]},
+                    {"name": "email", "values": ["t@example.com"]},
+                ],
+            },
+        ]
+        client._get = AsyncMock(side_effect=[form, {"data": leads}])
+
+        out: Path = tmp_path / "out.csv"  # type: ignore[assignment]
+        await client.export_leads_to_csv("form_1", out)
+
+        import csv
+
+        with open(out, encoding="utf-8") as f:
+            parsed = list(csv.DictReader(f))
+        assert parsed[0]["full_name"] == "山田 太郎"
+        assert parsed[0]["email"] == "t@example.com"
+
+    @pytest.mark.asyncio
+    async def test_csv_injection_values_are_escaped(
+        self,
+        client: LeadsMixin,
+        tmp_path: pytest.TempPathFactory,
+    ) -> None:
+        """値が ``=``, ``+``, ``-``, ``@``, タブ, CR で始まると
+        spreadsheet で formula として実行される (CSV injection)。
+        helper は単一引用符を先頭に付けて無害化する。"""
+        from pathlib import Path
+
+        form = {
+            "id": "form_1",
+            "questions": [{"type": "CUSTOM", "key": "free_text"}],
+            "privacy_policy": {"url": "https://example.com/p"},
+        }
+        leads = [
+            {
+                "id": "lead_1",
+                "created_time": "2026-01-01T00:00:00+0000",
+                "field_data": [
+                    {"name": "free_text", "values": ['=cmd|"/c calc"!A1']},
+                ],
+            },
+            {
+                "id": "lead_2",
+                "created_time": "2026-01-02T00:00:00+0000",
+                "field_data": [
+                    {"name": "free_text", "values": ["@SUM(A1:A10)"]},
+                ],
+            },
+        ]
+        client._get = AsyncMock(side_effect=[form, {"data": leads}])
+
+        out: Path = tmp_path / "out.csv"  # type: ignore[assignment]
+        await client.export_leads_to_csv("form_1", out)
+
+        import csv
+
+        with open(out, encoding="utf-8") as f:
+            parsed = list(csv.DictReader(f))
+        assert parsed[0]["free_text"].startswith("'=")
+        assert parsed[1]["free_text"].startswith("'@")
+
+    @pytest.mark.asyncio
+    async def test_csv_multi_value_uses_pipe_separator(
+        self,
+        client: LeadsMixin,
+        tmp_path: pytest.TempPathFactory,
+    ) -> None:
+        """multi-select の値は ``" | "`` で結合 — 値自体に comma が
+        含まれても spreadsheet 上で意味が壊れない"""
+        from pathlib import Path
+
+        form = {
+            "id": "form_1",
+            "questions": [{"type": "CUSTOM", "key": "interests"}],
+            "privacy_policy": {"url": "https://example.com/p"},
+        }
+        leads = [
+            {
+                "id": "lead_1",
+                "created_time": "2026-01-01T00:00:00+0000",
+                "field_data": [
+                    {
+                        "name": "interests",
+                        "values": ["AI, ML", "infra", "DX"],
+                    },
+                ],
+            },
+        ]
+        client._get = AsyncMock(side_effect=[form, {"data": leads}])
+
+        out: Path = tmp_path / "out.csv"  # type: ignore[assignment]
+        await client.export_leads_to_csv("form_1", out)
+
+        import csv
+
+        with open(out, encoding="utf-8") as f:
+            parsed = list(csv.DictReader(f))
+        assert parsed[0]["interests"] == "AI, ML | infra | DX"
+
+    @pytest.mark.asyncio
+    async def test_csv_pagination_follows_next_cursor(
+        self,
+        client: LeadsMixin,
+        tmp_path: pytest.TempPathFactory,
+    ) -> None:
+        """1 ページに収まらない件数の lead も全件取得する"""
+        from pathlib import Path
+
+        form = {
+            "id": "form_1",
+            "questions": [{"type": "EMAIL", "key": "email"}],
+            "privacy_policy": {"url": "https://example.com/p"},
+        }
+        page_1 = {
+            "data": [
+                {
+                    "id": f"lead_{i}",
+                    "created_time": "2026-01-01T00:00:00+0000",
+                    "field_data": [
+                        {"name": "email", "values": [f"u{i}@example.com"]}
+                    ],
+                }
+                for i in range(2)
+            ],
+            "paging": {
+                "next": "https://graph.facebook.com/v23.0/form_1/leads?after=cursor1"
+            },
+        }
+        page_2 = {
+            "data": [
+                {
+                    "id": "lead_2",
+                    "created_time": "2026-01-01T00:00:00+0000",
+                    "field_data": [
+                        {"name": "email", "values": ["u2@example.com"]}
+                    ],
+                },
+            ],
+            # No paging.next → loop terminates.
+        }
+        client._get = AsyncMock(side_effect=[form, page_1, page_2])
+
+        out: Path = tmp_path / "out.csv"  # type: ignore[assignment]
+        count = await client.export_leads_to_csv("form_1", out)
+        assert count == 3
+
+        import csv
+
+        with open(out, encoding="utf-8") as f:
+            parsed = list(csv.DictReader(f))
+        assert {row["email"] for row in parsed} == {
+            "u0@example.com",
+            "u1@example.com",
+            "u2@example.com",
+        }
+        # 2nd & 3rd call は paging.next の URL を path にして呼ぶ —
+        # 4 回目以降は呼ばれない (= ループ終了が正常)
+        assert client._get.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_csv_pagination_uses_relative_path_with_after_cursor(
+        self,
+        client: LeadsMixin,
+        tmp_path: pytest.TempPathFactory,
+    ) -> None:
+        """``paging.next`` は絶対 URL だが ``_get`` は BASE_URL を必ず
+        前置するため、絶対 URL を path に渡すと URL が二重連結されて
+        404 になる。helper は ``after`` cursor だけ抜き出して相対 path
+        で再呼び出しすべきこと。
+        """
+        from pathlib import Path
+
+        form = {
+            "id": "form_1",
+            "questions": [{"type": "EMAIL", "key": "email"}],
+            "privacy_policy": {"url": "https://example.com/p"},
+        }
+        page_1 = {
+            "data": [
+                {
+                    "id": "lead_0",
+                    "created_time": "2026-01-01T00:00:00+0000",
+                    "field_data": [
+                        {"name": "email", "values": ["u0@example.com"]}
+                    ],
+                }
+            ],
+            "paging": {
+                "next": (
+                    "https://graph.facebook.com/v23.0/form_1/leads"
+                    "?fields=id,created_time,field_data&limit=1000"
+                    "&after=CURSOR_ABC"
+                )
+            },
+        }
+        page_2 = {"data": [], "paging": {}}
+        client._get = AsyncMock(side_effect=[form, page_1, page_2])
+
+        out: Path = tmp_path / "out.csv"  # type: ignore[assignment]
+        await client.export_leads_to_csv("form_1", out)
+
+        # 2 回目の lead fetch (= 3 番目の _get 呼び出し) は
+        # 相対 path を維持し、after cursor だけ params に渡す。
+        third_call = client._get.await_args_list[2]
+        third_path, third_params = third_call.args[0], third_call.args[1]
+        assert third_path == "/form_1/leads"
+        assert third_params.get("after") == "CURSOR_ABC"
+        # 既存の fields / limit も保持される
+        assert "fields" in third_params
+        assert third_params.get("limit") == 1000


### PR DESCRIPTION
## Summary

Closes #154 (part 3 of 3 of umbrella #151, Meta Instant Form full coverage). Stacked on top of #156 (PR 2) — base branch is `feat/meta-instant-form-lifecycle`. GitHub will retarget the base as the stack merges: PR 1 → main retargets PR 2 → main, then PR 2 → main retargets PR 3 → main.

Two additions: lead CSV export with pagination + injection defense, and advanced form authoring (intro card, custom thank-you, higher-intent 3-step, conditional branching). Bumps version 0.9.15 → 0.9.16. Two-round code review APPROVED.

## What changes

### `mureo/meta_ads/_leads.py`

- **`export_leads_to_csv(form_id, output_path, *, limit=1000, field_order=None) -> int`** — new helper. Pulls **every** lead for a form by following `paging.next` cursors (extracts `after` via `urllib.parse` and re-issues on the relative path, so we don't trip Meta client's `BASE_URL`-always-prepend behaviour). Writes a CSV at `output_path` with header `[id, created_time, *question_keys]`. Column-order logic:
  - Standard questions without explicit `key` map to Meta's lowercased `field_data[].name` (`EMAIL` → `email`) — the wire format Meta actually emits.
  - Custom questions use their declared `key`.
  - Caller can lock a different order via `field_order` for stable CRM import schemas.

  **CSV-injection defense**: values starting with `= + - @ \t \r` are prefixed with `'` via the new private `_csv_safe` helper. Lead exports get opened in Excel / Sheets / Numbers; user-supplied form text starting with `=` would otherwise become a live formula (OWASP CSV injection).

  **Multi-value handling**: joined with `" | "` (not `,`) so a comma inside one value doesn't get confused with a value separator.

  **PII handling**: only `form_id`, `path`, `rows` reach the log line. The lead `field_data` never gets stringified into any log or exception.

- **`create_lead_form` extension**: four new kwarg-only optional fields, all default to no-op so existing callers keep working unchanged:
  - `context_card: dict | None` — intro / welcome screen. Lifts conversion rate measurably.
  - `thank_you_page: dict | None` — custom completion screen with CTA. Supersedes the simpler `follow_up_action_url` redirect when both present.
  - `is_higher_intent: bool = False` — when `True`, Meta renders a 3-step (input → review → submit) form. Trims junk submissions at the cost of total volume; recommended when CV quality matters more than CV volume.
  - `conditional_questions_choices: list[dict] | None` — branching: only show question B if a prior answer matches.

### MCP layer

- New tool `meta_ads_leads_export_csv` with required `form_id`, `output_path`; optional `limit`, `field_order`.
- Existing `meta_ads_lead_forms_create` schema gains 5 optional entries (the 4 advanced fields above + `locale`, which pre-existed in the helper but wasn't surfaced in the schema). Tool name unchanged.

### Docs

- `mureo/_data/skills/_mureo-meta-ads/SKILL.md` + `skills/_mureo-meta-ads/SKILL.md` (synced) — tool row 81 + lead_forms.create advanced kwargs reference with usage guidance for each flag + leads.export_csv section.
- `docs/mcp-server.md` — tool table row.

### Tests (16 new)

- `TestCreateLeadFormAdvanced` (6): back-compat shape pin, context_card serialisation, thank_you_page serialisation, is_higher_intent true / false-default, conditional_questions_choices.
- `TestExportLeadsToCsv` (10): header from form questions, row-per-lead, zero leads, no PII in logs, field_order override, missing field_data, **standard-question-without-key uses lowercase type, CSV injection escaped, multi-value pipe-join, pagination follows next cursor (3-page test), pagination passes after cursor via relative path with merged params**.
- Tool count assertions bumped (80 → 81; total 182 → 183); `test_all_lead_tools_exist` 7 → 8.

### Version bump

`pyproject.toml`, `mureo/__init__.py`, `.claude-plugin/plugin.json`: 0.9.15 → 0.9.16. `CHANGELOG.md` 0.9.16 entry.

## Code review

**Two rounds**:

Round 1 flagged 2 HIGH + 4 MEDIUM:
- HIGH-1: pagination silent-truncation past `limit`. **Fixed**: follow `paging.next`.
- HIGH-2: CSV-injection (`=cmd|"/c calc"!A1` becomes a live formula in Excel). **Fixed**: `_csv_safe` prefix.
- MED-1: standard-question key heuristic missed `field_data[].name` lowercase. **Fixed**.
- MED-2: multi-value `","` join was ambiguous. **Fixed**: `" | "` separator.
- MED-3: `is_higher_intent` payload omission verify against Meta — **deferred** (matches current docs; documented in CHANGELOG).
- MED-4: `conditional_questions_choices` singular naming — **deferred** (correct per Graph v18+; documented).

Round 2 caught a regression in HIGH-1's fix: I'd been passing the absolute `next_url` directly through `_get`, but `Meta API client` always prepends `BASE_URL` → would produce `https://graph.facebook.com/v23.0https://graph.facebook.com/...` and 404. **Fixed**: extract `after` cursor via `urllib.parse.parse_qs(urlparse(next_url).query).get("after")` and re-issue on the relative path with merged params. New test `test_csv_pagination_uses_relative_path_with_after_cursor` pins it.

LOW items (test fixture annotation, redundant Path imports) deferred as cosmetic.

## Backward compatibility

Purely additive. `create_lead_form` gains keyword-only optional args (no positional shift). New `export_leads_to_csv` is a new method. No renamed / removed surface.

## Test plan

- [x] 16 new tests pass; pre-existing leads tests untouched
- [x] `tests/test_mcp_tools_meta_ads.py` and `tests/test_mcp_server.py` count assertions updated
- [x] `tests/test_plugin_manifests.py::test_packaged_skills_match_canonical_byte_for_byte` passes
- [x] `black --check mureo/` clean
- [x] `ruff check` clean on all modified `mureo/` files
- [x] Full suite 3667 passed (excluding 3 pre-existing dev-env entry-point pollution failures that also fail on `main`)
- [x] Code review APPROVED across both rounds; all HIGH/MEDIUM resolved
- [ ] CI green (CI only triggers on PRs to `main`; will run after PR 2 → PR 1 → main retargets cascade)

## Out of scope (handled separately)

- Webhook subscription for real-time lead delivery — local-first design constraint; would need its own architecture
- External CRM sync (Salesforce / HubSpot push) — belongs in dedicated plugin packages
- DRY refactor of `_build_link_data` shared between `create_ad_creative` and `create_lead_ad_creative` (raised in PR 1's review; tracked as follow-up)
