### PR TITLE
feat(meta-ads): Instant Form HIGH gap closures (video creative + pagination + duplicate widening)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mureo",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "description": "Your local-first AI ad ops crew for Google Ads, Meta Ads, Search Console & GA4. mureo sits on top of the official ad-platform MCPs, gates every change against your strategy, correlates outcomes locally, and keeps an auditable decision log — credentials never leave your machine.",
   "author": {
     "name": "Logly Inc.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.17] - 2026-05-29
+
+### Added — Meta Instant Form: gap-closure patch
+
+Pre-release patch addressing three HIGH-priority gaps in the v0.9.14-v0.9.16 Instant Form rollout (umbrella [#151](https://github.com/logly/mureo/issues/151)):
+
+- **`create_lead_ad_creative` video support**: adds optional `video_id` kwarg. When supplied, the payload uses `object_story_spec.video_data` (instead of `link_data`) with `lead_gen_form_id` nested under `call_to_action.value` — Meta's contract for video Lead Ads. `image_hash` becomes the video thumbnail. Image and video modes are mutually exclusive (`video_id` + `image_url` raises `ValueError` at the helper layer). The MCP tool `meta_ads_creatives_create_lead` gains a matching `video_id` schema entry.
+
+- **`get_leads` / `get_ad_leads` pagination**: both helpers previously truncated at the per-call `limit` (default 100) and silently dropped any leads past that. They now follow `paging.next` cursors automatically (extracting the `after` query parameter via `urllib.parse` and re-issuing on the relative path) until no more pages remain — matching the behaviour `export_leads_to_csv` already had. `limit` now controls per-page size, not the total cap. Pagination logic is consolidated into a shared `_paginate_leads` helper so future read paths inherit it; `export_leads_to_csv` was refactored to use it too.
+
+- **`duplicate_lead_form` widening**: the duplicate helper now copies the PR 3 advanced fields (`context_card`, `thank_you_page`, `is_higher_intent`, `conditional_questions_choices`) from the source form to the new form, fulfilling the "PR 3 will widen the copied surface" promise that the v0.9.15 docstring left outstanding. `_LEAD_FORM_FIELDS` was extended to fetch the four fields so `get_lead_form` surfaces them. `is_higher_intent=False` is still elided from the payload to match Meta's default.
+
+This is a follow-up to PRs [#155](https://github.com/logly/mureo/pull/155) / [#156](https://github.com/logly/mureo/pull/156) / [#158](https://github.com/logly/mureo/pull/158); the umbrella issue closes with v0.9.17.
+
 ## [0.9.16] - 2026-05-28
 
 ### Added — Meta Instant Form: CSV export + advanced form authoring

--- a/mureo/__init__.py
+++ b/mureo/__init__.py
@@ -1,3 +1,3 @@
 """mureo — your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."""
 
-__version__ = "0.9.16"
+__version__ = "0.9.17"

--- a/mureo/mcp/_handlers_meta_ads_extended.py
+++ b/mureo/mcp/_handlers_meta_ads_extended.py
@@ -228,6 +228,7 @@ async def handle_creatives_create_lead(args: dict[str, Any]) -> list[TextContent
     for key in (
         "image_url",
         "image_hash",
+        "video_id",
         "message",
         "headline",
         "description",

--- a/mureo/mcp/_tools_meta_ads_creatives.py
+++ b/mureo/mcp/_tools_meta_ads_creatives.py
@@ -218,13 +218,29 @@ TOOLS: list[Tool] = [
                         "Pre-uploaded image hash from "
                         "meta_ads_creatives_upload_image / "
                         "meta_ads_images_upload_file. Mutually "
-                        "exclusive with image_url."
+                        "exclusive with image_url. In video mode "
+                        "(when video_id is set), used as the video "
+                        "thumbnail."
+                    ),
+                },
+                "video_id": {
+                    "type": "string",
+                    "description": (
+                        "Pre-uploaded video ID from "
+                        "meta_ads_videos_upload / "
+                        "meta_ads_videos_upload_file. When supplied, "
+                        "the creative becomes a video Lead Ad — "
+                        "object_story_spec.video_data is used (not "
+                        "link_data) and lead_gen_form_id is nested "
+                        "under call_to_action.value. image_url is "
+                        "rejected in video mode; supply image_hash "
+                        "directly as the thumbnail."
                     ),
                 },
                 "message": {
                     "type": "string",
                     "description": (
-                        "Primary ad body text shown above the image. "
+                        "Primary ad body text shown above the creative. "
                         "Plain text, emoji allowed. ≤125 characters "
                         "fits most placements without truncation."
                     ),
@@ -232,8 +248,10 @@ TOOLS: list[Tool] = [
                 "headline": {
                     "type": "string",
                     "description": (
-                        "Headline shown below the image. ~40 "
-                        "characters fits most placements."
+                        "Headline shown with the creative. ~40 "
+                        "characters fits most placements. Mapped to "
+                        "link_data.name in image mode and "
+                        "video_data.title in video mode."
                     ),
                 },
                 "description": {

--- a/mureo/meta_ads/_creatives.py
+++ b/mureo/meta_ads/_creatives.py
@@ -279,7 +279,7 @@ class CreativesMixin:
             "link_data": link_data,
         }
 
-        data: dict[str, Any] = {
+        data = {
             "name": name,
             "object_story_spec": json.dumps(object_story_spec),
         }

--- a/mureo/meta_ads/_creatives.py
+++ b/mureo/meta_ads/_creatives.py
@@ -146,6 +146,7 @@ class CreativesMixin:
         *,
         image_url: str | None = None,
         image_hash: str | None = None,
+        video_id: str | None = None,
         message: str | None = None,
         headline: str | None = None,
         description: str | None = None,
@@ -153,11 +154,17 @@ class CreativesMixin:
     ) -> dict[str, Any]:
         """Create an AdCreative wired to a Meta Instant Form (Lead Ad).
 
-        Builds the ``object_story_spec.link_data.lead_gen_form_id``
-        contract that turns a normal link creative into a Lead Ad so
-        the resulting creative can be attached to an Ad whose Ad Set
-        uses ``optimization_goal=LEAD_GENERATION`` under a campaign
-        with ``objective=OUTCOME_LEADS``.
+        Image mode (default): builds
+        ``object_story_spec.link_data.lead_gen_form_id`` so the
+        creative can be attached to an Ad whose Ad Set uses
+        ``optimization_goal=LEAD_GENERATION`` under a campaign with
+        ``objective=OUTCOME_LEADS``.
+
+        Video mode (``video_id`` supplied): builds
+        ``object_story_spec.video_data`` with ``lead_gen_form_id``
+        nested under ``call_to_action.value`` — Meta routes Instant
+        Form attachments for video creatives through that path, not
+        ``link_data``.
 
         Args:
             name: Internal creative label shown in Ads Manager.
@@ -169,14 +176,20 @@ class CreativesMixin:
                 page on placements where the in-app form cannot
                 render. Required by the API even for pure Lead Ads.
             image_url: Optional public HTTPS image URL — triggers
-                auto-upload to ``image_hash``. Mutually exclusive
-                with ``image_hash``.
+                auto-upload to ``image_hash``. Image mode only;
+                supplying both ``image_url`` and ``video_id`` raises
+                ``ValueError`` (caller intent ambiguous).
             image_hash: Optional pre-uploaded image hash from
-                ``upload_ad_image`` / ``upload_ad_image_file``.
-            message: Primary body text shown above the image.
-            headline: Headline text shown below the image
-                (mapped to ``link_data.name``).
-            description: Link-caption shown below the headline.
+                ``upload_ad_image`` / ``upload_ad_image_file``. In
+                video mode, used as the video thumbnail.
+            video_id: Optional pre-uploaded video ID from
+                ``upload_ad_video`` / ``upload_ad_video_file``.
+                When supplied, the creative becomes a video Lead Ad.
+            message: Primary body text shown above the creative.
+            headline: Headline text. In image mode mapped to
+                ``link_data.name``; in video mode mapped to
+                ``video_data.title``.
+            description: Link-caption / description.
             call_to_action: CTA button label. Defaults to
                 ``"SIGN_UP"`` (canonical Lead Ad CTA). Other commonly
                 supported values: ``LEARN_MORE``, ``APPLY_NOW``,
@@ -191,7 +204,52 @@ class CreativesMixin:
 
         Returns:
             Created AdCreative info dict (id, ...).
+
+        Raises:
+            ValueError: ``video_id`` and ``image_url`` are both set.
+                Supply ``image_hash`` directly for the video
+                thumbnail instead.
         """
+        if video_id and image_url:
+            raise ValueError(
+                "video_id and image_url cannot be combined — supply "
+                "image_hash directly for the video thumbnail"
+            )
+
+        if video_id:
+            video_data: dict[str, Any] = {
+                "video_id": video_id,
+                "call_to_action": {
+                    "type": call_to_action,
+                    "value": {
+                        "lead_gen_form_id": form_id,
+                        "link": link_url,
+                    },
+                },
+            }
+            if image_hash:
+                # Meta's video_data thumbnail accepts either
+                # ``image_url`` or ``image_hash`` (per Marketing API
+                # docs, exactly one). We use ``image_hash`` for
+                # consistency with link_data and the upload helpers
+                # (``upload_ad_image`` returns ``{"hash": ..., "url": ...}``).
+                video_data["image_hash"] = image_hash
+            if message:
+                video_data["message"] = message
+            if headline:
+                video_data["title"] = headline
+            if description:
+                video_data["description"] = description
+            object_story_spec = {
+                "page_id": page_id,
+                "video_data": video_data,
+            }
+            data: dict[str, Any] = {
+                "name": name,
+                "object_story_spec": json.dumps(object_story_spec),
+            }
+            return await self._post(f"/{self._ad_account_id}/adcreatives", data)
+
         link_data: dict[str, Any] = {
             "link": link_url,
             "lead_gen_form_id": form_id,

--- a/mureo/meta_ads/_leads.py
+++ b/mureo/meta_ads/_leads.py
@@ -22,7 +22,10 @@ logger = logging.getLogger(__name__)
 _LEAD_FORM_FIELDS = (
     "id,name,status,locale,questions,privacy_policy,"
     "follow_up_action_url,created_time,expired_leads_count,"
-    "leads_count,organic_leads_count"
+    "leads_count,organic_leads_count,"
+    # PR 4 — surfaced so duplicate_lead_form can copy them.
+    "context_card,thank_you_page,is_higher_intent,"
+    "conditional_questions_choices"
 )
 
 # Lead data retrieval fields
@@ -38,6 +41,12 @@ _VALID_FORM_STATUSES: frozenset[str] = frozenset({"ACTIVE", "ARCHIVED"})
 # Excel / Sheets / Numbers. Prepending a single-quote disarms the
 # injection without breaking the visible value for spreadsheet users.
 _CSV_INJECTION_PREFIXES: tuple[str, ...] = ("=", "+", "-", "@", "\t", "\r")
+
+# Safety cap on ``paging.next`` traversal to defeat a hypothetical
+# misbehaving Meta cursor loop. Even at the default per-call limit
+# (100 leads), 10_000 pages = 1M leads — well past any real form's
+# lifetime; the per-page max of 1000 lifts that to 10M.
+_MAX_LEAD_PAGES = 10_000
 
 
 def _csv_safe(value: str) -> str:
@@ -236,19 +245,21 @@ class LeadsMixin:
         """Duplicate a lead form under the same (or another) Page.
 
         Meta has no native "copy" endpoint, so the helper fetches the
-        source form's core configuration (questions, privacy policy,
-        optional follow-up URL, locale) and creates a fresh form
-        with the supplied ``new_name``. The returned dict carries
-        the new form's ID; the source form is untouched.
+        source form's configuration and creates a fresh form with
+        the supplied ``new_name``. The returned dict carries the
+        new form's ID; the source form is untouched.
 
-        **Lossy duplication.** Only the four fields above round-trip.
-        Advanced features that may exist on the source —
-        ``legal_content_id``, ``gdpr_required`` /
+        **Copied fields**: ``questions``, ``privacy_policy``,
+        ``follow_up_action_url``, ``locale``, ``context_card``,
+        ``thank_you_page``, ``is_higher_intent``,
+        ``conditional_questions_choices``.
+
+        **NOT copied** (lossy by design — Meta either makes them
+        immutable post-creation or they require separate setup on
+        the new Page): ``legal_content_id``, ``gdpr_required`` /
         ``custom_disclaimer``, ``question_page_custom_headline``,
-        intro / thank-you screens, conditional question branches —
-        are **not** copied. If you need those, re-create them on the
-        new form manually after duplication. PR 3 (advanced form
-        features) will widen the copied surface.
+        and any other future advanced fields not in the list
+        above. Re-apply manually on the new form if needed.
 
         Args:
             form_id: Source lead form ID to copy from.
@@ -290,6 +301,22 @@ class LeadsMixin:
         if source.get("locale"):
             data["locale"] = source["locale"]
 
+        # PR 4 — copy the advanced fields PR 3 added support for, so
+        # an operator who built a form with intro / thank-you /
+        # higher-intent / conditional logic gets all of it on the
+        # duplicate. JSON-encode dict / list fields the same way
+        # create_lead_form does.
+        if source.get("context_card"):
+            data["context_card"] = json.dumps(source["context_card"])
+        if source.get("thank_you_page"):
+            data["thank_you_page"] = json.dumps(source["thank_you_page"])
+        if source.get("is_higher_intent"):
+            data["is_higher_intent"] = True
+        if source.get("conditional_questions_choices"):
+            data["conditional_questions_choices"] = json.dumps(
+                source["conditional_questions_choices"]
+            )
+
         logger.info(
             "Lead form duplicate: source=%s, page_id=%s, new_name=%s",
             form_id,
@@ -304,27 +331,29 @@ class LeadsMixin:
         *,
         limit: int = 100,
     ) -> list[dict[str, Any]]:
-        """Get lead data submitted to a form
+        """Get every lead submitted to a form.
+
+        Pagination is automatic: the helper follows ``paging.next``
+        cursors (extracting the ``after`` query parameter and
+        re-issuing on the relative path, to avoid the
+        ``BASE_URL``-prepend behaviour) until no more pages remain.
+        ``limit`` controls per-page size, not the total cap.
 
         Lead data contains PII (name, email, phone, etc.) and
         is not logged.
 
         Args:
-            form_id: Lead form ID
-            limit: Maximum number of items to retrieve
+            form_id: Lead form ID.
+            limit: Maximum number of items per Graph API call.
+                Default 100; the helper still returns every lead
+                via pagination.
 
         Returns:
-            List of lead data.
+            All leads (list-of-dict).
         """
-        params: dict[str, Any] = {
-            "fields": _LEAD_FIELDS,
-            "limit": limit,
-        }
-        result = await self._get(f"/{form_id}/leads", params)
-        # Not logged because it contains PII
-        leads = result.get("data", [])
+        leads = await self._paginate_leads(f"/{form_id}/leads", limit)
         logger.info("Lead data retrieval: form_id=%s, count=%d", form_id, len(leads))
-        return leads  # type: ignore[no-any-return]
+        return leads
 
     async def get_ad_leads(
         self,
@@ -332,27 +361,54 @@ class LeadsMixin:
         *,
         limit: int = 100,
     ) -> list[dict[str, Any]]:
-        """Get lead data via ads
+        """Get every lead attributed to a single ad.
+
+        Pagination is automatic, mirroring :meth:`get_leads`.
 
         Lead data contains PII (name, email, phone, etc.) and
         is not logged.
 
         Args:
-            ad_id: Ad ID
-            limit: Maximum number of items to retrieve
+            ad_id: Ad ID.
+            limit: Maximum number of items per Graph API call.
+                Default 100; the helper still returns every lead
+                via pagination.
 
         Returns:
-            List of lead data.
+            All leads (list-of-dict).
         """
-        params: dict[str, Any] = {
-            "fields": _LEAD_FIELDS,
-            "limit": limit,
-        }
-        result = await self._get(f"/{ad_id}/leads", params)
-        # Not logged because it contains PII
-        leads = result.get("data", [])
+        leads = await self._paginate_leads(f"/{ad_id}/leads", limit)
         logger.info("Lead data by ad: ad_id=%s, count=%d", ad_id, len(leads))
-        return leads  # type: ignore[no-any-return]
+        return leads
+
+    async def _paginate_leads(self, path: str, limit: int) -> list[dict[str, Any]]:
+        """Follow ``paging.next`` cursors and return the concatenated
+        ``data`` arrays. Shared by :meth:`get_leads`,
+        :meth:`get_ad_leads`, and :meth:`export_leads_to_csv` so the
+        cursor-extraction trick (avoid passing absolute URL through
+        ``_get``) lives in one place. A hard cap of
+        :data:`_MAX_LEAD_PAGES` iterations guards against a
+        misbehaving Meta cursor loop.
+        """
+        all_leads: list[dict[str, Any]] = []
+        params: dict[str, Any] = {"fields": _LEAD_FIELDS, "limit": limit}
+        for _ in range(_MAX_LEAD_PAGES):
+            result = await self._get(path, params)
+            all_leads.extend(result.get("data", []) or [])
+            next_url = (result.get("paging", {}) or {}).get("next")
+            if not next_url:
+                return all_leads
+            after_values = parse_qs(urlparse(next_url).query).get("after")
+            if not after_values:
+                return all_leads
+            params = {**params, "after": after_values[0]}
+        logger.warning(
+            "Lead pagination hit safety cap (%d pages) on path=%s — "
+            "returning what we have; investigate the cursor loop",
+            _MAX_LEAD_PAGES,
+            path,
+        )
+        return all_leads
 
     async def export_leads_to_csv(
         self,
@@ -423,26 +479,10 @@ class LeadsMixin:
                 if key:
                     field_order.append(key)
 
-        # Page through /{form_id}/leads until paging.next is absent.
-        # Meta returns a fully-qualified ``paging.next`` URL, but
-        # ``_get`` always prepends ``BASE_URL`` so an absolute URL
-        # would double-prefix. Extract the ``after`` cursor instead
-        # and re-issue with the same relative path.
-        all_leads: list[dict[str, Any]] = []
-        path: str = f"/{form_id}/leads"
-        params: dict[str, Any] = {"fields": _LEAD_FIELDS, "limit": limit}
-        while True:
-            result = await self._get(path, params)
-            all_leads.extend(result.get("data", []) or [])
-            next_url = (result.get("paging", {}) or {}).get("next")
-            if not next_url:
-                break
-            after_values = parse_qs(urlparse(next_url).query).get("after")
-            if not after_values:
-                # Paging cursor missing in a non-standard ``next`` —
-                # bail out rather than loop forever.
-                break
-            params = {**params, "after": after_values[0]}
+        # Pagination is delegated to the shared :meth:`_paginate_leads`
+        # so the cursor-extraction trick (avoid passing absolute URL
+        # through ``_get``) lives in one place.
+        all_leads = await self._paginate_leads(f"/{form_id}/leads", limit)
 
         header = ["id", "created_time", *field_order]
         output_path.parent.mkdir(parents=True, exist_ok=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mureo"
-version = "0.9.16"
+version = "0.9.17"
 description = "Your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/tests/test_meta_ads_leads.py
+++ b/tests/test_meta_ads_leads.py
@@ -272,9 +272,11 @@ class TestGetLeads:
     async def test_get_leads_paginates_through_next_cursor(
         self, client: LeadsMixin
     ) -> None:
-        """``paging.next`` がある間は ``after`` cursor で繰り返し取得し、
-        全件を結合して返す。limit=100 を超える form でも silently
-        truncate しないこと (export_leads_to_csv と挙動を揃える)。"""
+        """Follow ``paging.next`` cursors via the ``after`` token,
+        concatenate the results, and return them all. Forms with
+        more than ``limit`` leads must NOT be silently truncated —
+        ``get_leads`` should match ``export_leads_to_csv``'s
+        pagination behaviour."""
         page_1 = {
             "data": [{"id": f"lead_{i}", "field_data": []} for i in range(2)],
             "paging": {
@@ -294,7 +296,8 @@ class TestGetLeads:
         result = await client.get_leads("form_1")
         assert [r["id"] for r in result] == ["lead_0", "lead_1", "lead_2"]
         assert client._get.await_count == 2
-        # 2 回目は after cursor だけ更新して同じ相対 path に
+        # Second call keeps the same relative path; only ``after``
+        # is updated.
         second_call = client._get.await_args_list[1]
         assert second_call.args[0] == "/form_1/leads"
         assert second_call.args[1].get("after") == "CUR_A"
@@ -348,7 +351,7 @@ class TestGetAdLeads:
     async def test_get_ad_leads_paginates_through_next_cursor(
         self, client: LeadsMixin
     ) -> None:
-        """get_leads と同じ paging.next 追跡を行うこと"""
+        """Identical ``paging.next`` traversal to :func:`get_leads`."""
         page_1 = {
             "data": [{"id": "lead_a", "field_data": []}],
             "paging": {
@@ -884,12 +887,13 @@ class TestDuplicateLeadForm:
     async def test_duplicate_lead_form_copies_advanced_fields(
         self, client: LeadsMixin
     ) -> None:
-        """PR 3 で追加した advanced fields (context_card / thank_you_page
-        / is_higher_intent / conditional_questions_choices) を持つ source
-        form を duplicate すると、それらも新 form に引き継がれること。
+        """A source form carrying the PR 3 advanced fields
+        (``context_card`` / ``thank_you_page`` / ``is_higher_intent`` /
+        ``conditional_questions_choices``) must round-trip those
+        fields onto the new form when duplicated.
 
-        PR 2 の docstring で『PR 3 で widen する』と書いた約束を、
-        PR 4 で履行する。
+        This fulfils the v0.9.15 docstring promise that "PR 3 will
+        widen the copied surface", which was deferred at the time.
         """
         source = {
             "id": "form_1",
@@ -938,9 +942,9 @@ class TestDuplicateLeadForm:
     async def test_duplicate_lead_form_skips_absent_advanced_fields(
         self, client: LeadsMixin
     ) -> None:
-        """advanced fields を持たない source form の duplicate では、
-        payload に余計な空 field を増やさない (=既存の backcompat shape
-        を維持)。
+        """A source form without the advanced fields produces a
+        payload that does not gain extra empty keys — preserves the
+        backward-compatible shape pinned by earlier tests.
         """
         source = {
             "id": "form_1",
@@ -965,8 +969,9 @@ class TestDuplicateLeadForm:
     async def test_duplicate_lead_form_higher_intent_false_not_sent(
         self, client: LeadsMixin
     ) -> None:
-        """is_higher_intent=False の source は payload に True を立て
-        ない (= Meta デフォルトと一致するので omit)。"""
+        """``is_higher_intent=False`` on the source is elided from
+        the payload — it matches Meta's default, so omitting it
+        keeps the request body minimal."""
         source = {
             "id": "form_1",
             "name": "原本",
@@ -1518,8 +1523,10 @@ class TestExportLeadsToCsv:
         client: LeadsMixin,
         tmp_path: pytest.TempPathFactory,
     ) -> None:
-        """非標準形 (after= が欠落した paging.next) では即終了 — 無限
-        ループに陥らないことを pin。"""
+        """A non-standard ``paging.next`` URL missing the ``after``
+        query parameter must terminate the loop immediately — pins
+        the defensive break path so we never infinite-loop on a
+        malformed cursor."""
         from pathlib import Path
 
         form = {
@@ -1535,7 +1542,7 @@ class TestExportLeadsToCsv:
                     "field_data": [{"name": "email", "values": ["a@x.io"]}],
                 }
             ],
-            # next 自体は存在するが after クエリ無し
+            # ``next`` is present but has no ``after=`` query.
             "paging": {
                 "next": "https://graph.facebook.com/v23.0/form_1/leads?foo=bar"
             },
@@ -1545,7 +1552,7 @@ class TestExportLeadsToCsv:
         out: Path = tmp_path / "out.csv"  # type: ignore[assignment]
         count = await client.export_leads_to_csv("form_1", out)
         assert count == 1
-        # form fetch + 1 page fetch = 2 calls (3 回目以降は呼ばれない)
+        # form fetch + 1 page fetch = 2 calls; no third call.
         assert client._get.await_count == 2
 
     @pytest.mark.asyncio

--- a/tests/test_meta_ads_leads.py
+++ b/tests/test_meta_ads_leads.py
@@ -268,6 +268,37 @@ class TestGetLeads:
 
         assert result == []
 
+    @pytest.mark.asyncio
+    async def test_get_leads_paginates_through_next_cursor(
+        self, client: LeadsMixin
+    ) -> None:
+        """``paging.next`` がある間は ``after`` cursor で繰り返し取得し、
+        全件を結合して返す。limit=100 を超える form でも silently
+        truncate しないこと (export_leads_to_csv と挙動を揃える)。"""
+        page_1 = {
+            "data": [{"id": f"lead_{i}", "field_data": []} for i in range(2)],
+            "paging": {
+                "next": (
+                    "https://graph.facebook.com/v23.0/form_1/leads"
+                    "?fields=id,created_time,field_data,ad_id,ad_name,form_id"
+                    "&limit=100&after=CUR_A"
+                )
+            },
+        }
+        page_2 = {
+            "data": [{"id": "lead_2", "field_data": []}],
+            "paging": {},
+        }
+        client._get = AsyncMock(side_effect=[page_1, page_2])
+
+        result = await client.get_leads("form_1")
+        assert [r["id"] for r in result] == ["lead_0", "lead_1", "lead_2"]
+        assert client._get.await_count == 2
+        # 2 回目は after cursor だけ更新して同じ相対 path に
+        second_call = client._get.await_args_list[1]
+        assert second_call.args[0] == "/form_1/leads"
+        assert second_call.args[1].get("after") == "CUR_A"
+
 
 # ===========================================================================
 # test_get_ad_leads — 広告別リードデータ取得
@@ -312,6 +343,31 @@ class TestGetAdLeads:
 
         params = client._get.call_args[0][1]
         assert params["limit"] == 50
+
+    @pytest.mark.asyncio
+    async def test_get_ad_leads_paginates_through_next_cursor(
+        self, client: LeadsMixin
+    ) -> None:
+        """get_leads と同じ paging.next 追跡を行うこと"""
+        page_1 = {
+            "data": [{"id": "lead_a", "field_data": []}],
+            "paging": {
+                "next": (
+                    "https://graph.facebook.com/v23.0/ad_456/leads"
+                    "?limit=100&after=AD_CUR_A"
+                )
+            },
+        }
+        page_2 = {
+            "data": [{"id": "lead_b", "field_data": []}],
+            "paging": {},
+        }
+        client._get = AsyncMock(side_effect=[page_1, page_2])
+
+        result = await client.get_ad_leads("ad_456")
+        assert [r["id"] for r in result] == ["lead_a", "lead_b"]
+        assert client._get.await_count == 2
+        assert client._get.await_args_list[1].args[1].get("after") == "AD_CUR_A"
 
 
 # ===========================================================================
@@ -823,6 +879,110 @@ class TestDuplicateLeadForm:
             await client.duplicate_lead_form(
                 "form_1", page_id="page_123", new_name="Copy"
             )
+
+    @pytest.mark.asyncio
+    async def test_duplicate_lead_form_copies_advanced_fields(
+        self, client: LeadsMixin
+    ) -> None:
+        """PR 3 で追加した advanced fields (context_card / thank_you_page
+        / is_higher_intent / conditional_questions_choices) を持つ source
+        form を duplicate すると、それらも新 form に引き継がれること。
+
+        PR 2 の docstring で『PR 3 で widen する』と書いた約束を、
+        PR 4 で履行する。
+        """
+        source = {
+            "id": "form_1",
+            "name": "原本",
+            "questions": [{"type": "EMAIL"}],
+            "privacy_policy": {"url": "https://example.com/policy"},
+            "context_card": {
+                "title": "資料請求",
+                "content": "60秒で完了",
+                "style": "PARAGRAPH_STYLE",
+            },
+            "thank_you_page": {
+                "title": "ありがとうございます",
+                "body": "担当者から連絡します",
+                "button_type": "VIEW_WEBSITE",
+                "website_url": "https://example.com/thanks",
+            },
+            "is_higher_intent": True,
+            "conditional_questions_choices": [
+                {
+                    "question": "predefined",
+                    "value": "INTERESTED",
+                    "next_question_key": "company_size",
+                },
+            ],
+        }
+        client._get = AsyncMock(return_value=source)
+        client._post = AsyncMock(return_value={"id": "form_2"})
+
+        await client.duplicate_lead_form(
+            "form_1", page_id="page_123", new_name="Copy"
+        )
+
+        post_data = client._post.call_args[0][1]
+        assert json.loads(post_data["context_card"]) == source["context_card"]
+        assert (
+            json.loads(post_data["thank_you_page"]) == source["thank_you_page"]
+        )
+        assert post_data["is_higher_intent"] is True
+        assert (
+            json.loads(post_data["conditional_questions_choices"])
+            == source["conditional_questions_choices"]
+        )
+
+    @pytest.mark.asyncio
+    async def test_duplicate_lead_form_skips_absent_advanced_fields(
+        self, client: LeadsMixin
+    ) -> None:
+        """advanced fields を持たない source form の duplicate では、
+        payload に余計な空 field を増やさない (=既存の backcompat shape
+        を維持)。
+        """
+        source = {
+            "id": "form_1",
+            "name": "原本",
+            "questions": [{"type": "EMAIL"}],
+            "privacy_policy": {"url": "https://example.com/policy"},
+        }
+        client._get = AsyncMock(return_value=source)
+        client._post = AsyncMock(return_value={"id": "form_2"})
+
+        await client.duplicate_lead_form(
+            "form_1", page_id="page_123", new_name="Copy"
+        )
+
+        post_data = client._post.call_args[0][1]
+        assert "context_card" not in post_data
+        assert "thank_you_page" not in post_data
+        assert "is_higher_intent" not in post_data
+        assert "conditional_questions_choices" not in post_data
+
+    @pytest.mark.asyncio
+    async def test_duplicate_lead_form_higher_intent_false_not_sent(
+        self, client: LeadsMixin
+    ) -> None:
+        """is_higher_intent=False の source は payload に True を立て
+        ない (= Meta デフォルトと一致するので omit)。"""
+        source = {
+            "id": "form_1",
+            "name": "原本",
+            "questions": [{"type": "EMAIL"}],
+            "privacy_policy": {"url": "https://example.com/policy"},
+            "is_higher_intent": False,
+        }
+        client._get = AsyncMock(return_value=source)
+        client._post = AsyncMock(return_value={"id": "form_2"})
+
+        await client.duplicate_lead_form(
+            "form_1", page_id="page_123", new_name="Copy"
+        )
+
+        post_data = client._post.call_args[0][1]
+        assert "is_higher_intent" not in post_data
 
 
 # ===========================================================================
@@ -1351,6 +1511,42 @@ class TestExportLeadsToCsv:
         # 2nd & 3rd call は paging.next の URL を path にして呼ぶ —
         # 4 回目以降は呼ばれない (= ループ終了が正常)
         assert client._get.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_csv_pagination_bails_when_next_has_no_after_cursor(
+        self,
+        client: LeadsMixin,
+        tmp_path: pytest.TempPathFactory,
+    ) -> None:
+        """非標準形 (after= が欠落した paging.next) では即終了 — 無限
+        ループに陥らないことを pin。"""
+        from pathlib import Path
+
+        form = {
+            "id": "form_1",
+            "questions": [{"type": "EMAIL", "key": "email"}],
+            "privacy_policy": {"url": "https://example.com/p"},
+        }
+        page = {
+            "data": [
+                {
+                    "id": "lead_only",
+                    "created_time": "2026-01-01T00:00:00+0000",
+                    "field_data": [{"name": "email", "values": ["a@x.io"]}],
+                }
+            ],
+            # next 自体は存在するが after クエリ無し
+            "paging": {
+                "next": "https://graph.facebook.com/v23.0/form_1/leads?foo=bar"
+            },
+        }
+        client._get = AsyncMock(side_effect=[form, page])
+
+        out: Path = tmp_path / "out.csv"  # type: ignore[assignment]
+        count = await client.export_leads_to_csv("form_1", out)
+        assert count == 1
+        # form fetch + 1 page fetch = 2 calls (3 回目以降は呼ばれない)
+        assert client._get.await_count == 2
 
     @pytest.mark.asyncio
     async def test_csv_pagination_uses_relative_path_with_after_cursor(

--- a/tests/test_meta_ads_operations.py
+++ b/tests/test_meta_ads_operations.py
@@ -501,6 +501,59 @@ class TestCreativesMixin:
         assert path == "/act_123/adcreatives"
 
     @pytest.mark.asyncio
+    async def test_create_lead_ad_creative_with_video_uses_video_data(
+        self, client
+    ) -> None:
+        """Lead Ad with video_id uses ``video_data`` payload with the
+        lead_gen_form_id nested under ``call_to_action.value`` — that's
+        how Meta routes the Instant Form attachment for video creatives
+        (not under ``link_data`` like image creatives)."""
+        await client.create_lead_ad_creative(
+            "LeadCreativeVideo",
+            "page1",
+            "form_99",
+            "https://example.com/landing",
+            video_id="video_abc",
+            image_hash="thumb_hash",
+            message="本文",
+            headline="見出し",
+        )
+        spec = json.loads(client._post.call_args[0][1]["object_story_spec"])
+        assert "video_data" in spec
+        assert "link_data" not in spec
+        vd = spec["video_data"]
+        assert vd["video_id"] == "video_abc"
+        # thumbnail
+        assert vd["image_hash"] == "thumb_hash"
+        # message / title
+        assert vd["message"] == "本文"
+        assert vd["title"] == "見出し"
+        # CTA value carries lead_gen_form_id + link
+        assert vd["call_to_action"]["type"] == "SIGN_UP"
+        assert vd["call_to_action"]["value"]["lead_gen_form_id"] == "form_99"
+        assert vd["call_to_action"]["value"]["link"] == "https://example.com/landing"
+
+    @pytest.mark.asyncio
+    async def test_create_lead_ad_creative_rejects_video_and_image_together(
+        self, client
+    ) -> None:
+        """video_id と (image_url が指定されていて image_hash が未設定) の
+        組み合わせは曖昧。Meta は video_data.image_hash を thumbnail として
+        受けるので image_hash 単独は OK だが、image_url の auto-upload は
+        video モードでは適用しない (caller の意図が読めない)。
+        """
+        with pytest.raises(ValueError) as excinfo:
+            await client.create_lead_ad_creative(
+                "LeadCreativeBoth",
+                "page1",
+                "form_99",
+                "https://example.com",
+                video_id="video_abc",
+                image_url="https://img.example.com/x.jpg",
+            )
+        assert "image_url" in str(excinfo.value) and "video_id" in str(excinfo.value)
+
+    @pytest.mark.asyncio
     async def test_create_dynamic_creative(self, client) -> None:
         await client.create_dynamic_creative(
             "DC1",

--- a/tests/test_meta_ads_operations.py
+++ b/tests/test_meta_ads_operations.py
@@ -537,11 +537,11 @@ class TestCreativesMixin:
     async def test_create_lead_ad_creative_rejects_video_and_image_together(
         self, client
     ) -> None:
-        """video_id と (image_url が指定されていて image_hash が未設定) の
-        組み合わせは曖昧。Meta は video_data.image_hash を thumbnail として
-        受けるので image_hash 単独は OK だが、image_url の auto-upload は
-        video モードでは適用しない (caller の意図が読めない)。
-        """
+        """``video_id`` plus ``image_url`` is ambiguous. ``image_url``'s
+        auto-upload semantics belong to image mode; video mode wants
+        an explicit thumbnail ``image_hash``. The helper rejects
+        the combination at the call site rather than silently
+        picking one branch."""
         with pytest.raises(ValueError) as excinfo:
             await client.create_lead_ad_creative(
                 "LeadCreativeBoth",


### PR DESCRIPTION
## Summary

Pre-release patch closing the three HIGH-priority gaps surfaced in the v0.9.16 audit of the Instant Form rollout (umbrella #151). Bumps version 0.9.16 → 0.9.17. **Closes umbrella #151**.

Two-round code-review APPROVED.

## What changes

### 1. `create_lead_ad_creative` video support

`mureo/meta_ads/_creatives.py` + matching MCP tool schema (`_tools_meta_ads_creatives.py`) + handler pass-through (`_handlers_meta_ads_extended.py`).

- New optional `video_id` kwarg. When supplied, the payload uses `object_story_spec.video_data` (not `link_data`) with `lead_gen_form_id` nested under `call_to_action.value` — Meta's contract for video Lead Ads.
- `image_hash` becomes the video thumbnail. Meta's `video_data` accepts either `image_hash` or `image_url` (mutually exclusive); mureo uses `image_hash` for consistency with `link_data` and with the existing `upload_ad_image` return shape — documented inline.
- Image and video modes are mutually exclusive at the helper layer: `video_id` + `image_url` raises `ValueError` before any API call (caller intent ambiguous; image_url's auto-upload semantics don't combine with video mode).
- `headline` is mapped to `link_data.name` in image mode and `video_data.title` in video mode — Meta's per-format conventions.

### 2. `get_leads` / `get_ad_leads` pagination

`mureo/meta_ads/_leads.py`.

- Both helpers previously made one `_get` call and silently truncated at the per-call `limit` (default 100). This was inconsistent with `export_leads_to_csv` which already paginated.
- They now follow `paging.next` cursors automatically (extracting the `after` query parameter via `urllib.parse.parse_qs(urlparse(next_url).query)` and re-issuing on the relative path, to avoid Meta API client's `BASE_URL`-always-prepend trap).
- Logic consolidated into a new private `_paginate_leads(path, limit)` helper. `export_leads_to_csv` was refactored to use it too, eliminating the duplicated cursor loop.
- Safety cap `_MAX_LEAD_PAGES = 10_000` guards against a misbehaving Meta cursor — even at the default 100-leads-per-page that's 1M leads, well past any real form's lifetime. Cap-hit emits a `logger.warning` and returns the partial result.
- `limit` now controls per-page size, not the total cap.

### 3. `duplicate_lead_form` widening

`mureo/meta_ads/_leads.py`.

- `_LEAD_FORM_FIELDS` extended to fetch `context_card`, `thank_you_page`, `is_higher_intent`, `conditional_questions_choices` from the source form.
- `duplicate_lead_form` now JSON-encodes those fields (when present in source) into the new form's payload — fulfilling the v0.9.15 docstring promise that "PR 3 will widen the copied surface".
- `is_higher_intent=False` is still elided to match Meta's default (no need to send the explicit `false`).
- Docstring rewritten to explicitly list **Copied** fields (`questions`, `privacy_policy`, `follow_up_action_url`, `locale`, `context_card`, `thank_you_page`, `is_higher_intent`, `conditional_questions_choices`) and **NOT copied** fields (`legal_content_id`, `gdpr_required` / `custom_disclaimer`, `question_page_custom_headline`, and any future advanced fields). The "PR 3 will widen" line is gone.

## Tests (10 new)

- **Video Lead Ad creative** (2): `test_create_lead_ad_creative_with_video_uses_video_data`, `test_create_lead_ad_creative_rejects_video_and_image_together`.
- **Pagination** (2): `test_get_leads_paginates_through_next_cursor`, `test_get_ad_leads_paginates_through_next_cursor`.
- **Duplicate widening** (3): `test_duplicate_lead_form_copies_advanced_fields`, `test_duplicate_lead_form_skips_absent_advanced_fields`, `test_duplicate_lead_form_higher_intent_false_not_sent`.
- **CSV bail-out edge case** (1): `test_csv_pagination_bails_when_next_has_no_after_cursor` — pins the defensive break path when `paging.next` lacks an `after` query parameter.
- **Pre-existing CSV-pagination tests** unchanged (they exercise the same `_paginate_leads` now via the refactored `export_leads_to_csv`).

Full suite passes (3675 tests excluding the 3 pre-existing dev-env entry-point pollution failures that also fail on `main`).

## Code review

**Round 1**: 1 HIGH (`video_data` thumbnail field name claimed wrong) + 3 MEDIUM (pagination cap, `_LEAD_FORM_FIELDS` 400 risk, BASE_URL version mismatch) + 4 LOW.

Resolved:
- HIGH-1 → **Disagreement, verified by Meta docs**. `video_data` accepts both `image_hash` and `image_url` (mutually exclusive); mureo keeps `image_hash` for consistency. Inline comment added.
- MED-1 (cap) → Added `_MAX_LEAD_PAGES` + warning.
- LOW-2 (test) → Added `test_csv_pagination_bails_when_next_has_no_after_cursor`.
- LOW-4 (docstring) → Rewrote duplicate_lead_form docstring.

Deferred (justified):
- MED-2 (`_LEAD_FORM_FIELDS` 400) → Meta returns null for absent scalar fields, not 400.
- MED-3 (BASE_URL version) → Cosmetic; mock URLs in tests use a separate version that the helper ignores.
- LOW-1 (`_FIELDS` constant) → Low value.
- LOW-3 (`context_card == {}`) → Truthy check handles it.

**Round 2**: APPROVED, ship it. Verified the H1 disagreement, the cap implementation, and the new test pin both defensive branches.

## Test plan

- [x] 10 new tests pass
- [x] Full suite green (3675 passed, excluding pre-existing dev-env entry-point pollution failures)
- [x] `black --check mureo/` clean
- [x] `ruff check` clean on all modified files
- [x] Two-round code-review APPROVED
- [ ] CI green

## Backward compatibility

Purely additive. New optional `video_id` kwarg + new `_paginate_leads` private helper + extended `_LEAD_FORM_FIELDS` (wire-format expansion only — existing callers reading the old fields keep getting them). No signature removal; no behaviour change for callers not opting in.

## Closes umbrella

#151 (Meta Instant Form full coverage) — all four PRs (#155, #156, #158, this one) land the umbrella's acceptance criteria + the audit-surfaced HIGH gaps. Open issues / future work tracked in CHANGELOG and individual PR descriptions:
- MEDIUM-level advanced form fields (`gdpr_required` / `custom_disclaimer`, `question_page_custom_headline`, `tracking_parameters`, `legal_content_id`, `block_display_for_non_targeted_viewer`) — not blocking this release; can land in 0.9.18+ as needed.
- DRY refactor of `_build_link_data` shared between `create_ad_creative` and `create_lead_ad_creative` — PR 1 review follow-up.
- `image_url`/`image_hash` mutual-exclusion validation in image mode — PR 1 review follow-up.
