### PR TITLE
feat(mcp): mureo_learning_insights_get closes the /learn read-side gap

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mureo",
-  "version": "0.9.17",
+  "version": "0.9.18",
   "description": "Your local-first AI ad ops crew for Google Ads, Meta Ads, Search Console & GA4. mureo sits on top of the official ad-platform MCPs, gates every change against your strategy, correlates outcomes locally, and keeps an auditable decision log — credentials never leave your machine.",
   "author": {
     "name": "Logly Inc.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.18] - 2026-05-29
+
+### Added — `mureo_learning_insights_get` MCP tool closes the `/learn` read-side gap
+
+`/learn` (in v0.8.0) has been writing insights to `~/.claude/skills/_mureo-pro-diagnosis/SKILL.md` via the `FilesystemKnowledgeStore`, but the diagnostic workflows that the docstring claimed would consume those insights (`/daily-check`, `/rescue`, `/budget-rebalance`, etc.) had no read path. The saved Markdown sat on disk, available to Claude Code's general skill discovery but never explicitly consulted by the workflows. This release closes that read-side gap.
+
+A new MCP tool, `mureo_learning_insights_get`, returns the operator-tier knowledge base verbatim by calling `KnowledgeStore.read_operator_knowledge()`. The tool takes no arguments — its job is to surface every saved insight so the agent treats them as authoritative practitioner know-how. An empty knowledge base (no file, or only the YAML-frontmatter scaffold) returns a guidance string rather than a blank payload, so the agent neither quotes an empty section into its analysis nor mistakes the scaffold header for content.
+
+Seven diagnostic skills (`daily-check`, `rescue`, `budget-rebalance`, `creative-refresh`, `goal-review`, `competitive-scan`, `search-term-cleanup`) gain a "Before you start" paragraph at the top of their Steps section instructing the agent to call `mureo_learning_insights_get` first and treat the returned Markdown as authoritative context.
+
+The tool defers entirely to the runtime context's `KnowledgeStore`, so an alternate backend registered via the `mureo.runtime_context_factory` entry-point group works transparently. This sets up the federation work in v0.9.19 (umbrella [#161](https://github.com/logly/mureo/issues/161), PR B [#163](https://github.com/logly/mureo/issues/163)), which will let mureo aggregate insights from external MCP servers alongside the local file.
+
+Closes [#162](https://github.com/logly/mureo/issues/162) (part 1 of 2 of umbrella [#161](https://github.com/logly/mureo/issues/161)).
+
 ## [0.9.17] - 2026-05-29
 
 ### Added — Meta Instant Form: gap-closure patch

--- a/mureo/__init__.py
+++ b/mureo/__init__.py
@@ -1,3 +1,3 @@
 """mureo — your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."""
 
-__version__ = "0.9.17"
+__version__ = "0.9.18"

--- a/mureo/_data/skills/budget-rebalance/SKILL.md
+++ b/mureo/_data/skills/budget-rebalance/SKILL.md
@@ -16,6 +16,9 @@ Analyze budget allocation and suggest rebalancing across all campaigns.
 
 ## Steps
 
+**Before you start**: Call `mureo_learning_insights_get` (no arguments) and treat the returned Markdown as authoritative practitioner know-how. Those insights were recorded by the operator via `/learn` precisely because they're worth applying — let them inform every conclusion you draw below. When the response is the "no insights saved yet" guidance, proceed without it.
+
+
 1. **Load context**: Read STRATEGY.md (Operation Mode, Market Context, Goal sections, Data Sources) and STATE.json.
 
 2. **Discover platforms**: Identify all configured ad platforms from STATE.json `platforms`.

--- a/mureo/_data/skills/competitive-scan/SKILL.md
+++ b/mureo/_data/skills/competitive-scan/SKILL.md
@@ -16,6 +16,9 @@ Scan the competitive landscape and suggest strategic responses across all channe
 
 ## Steps
 
+**Before you start**: Call `mureo_learning_insights_get` (no arguments) and treat the returned Markdown as authoritative practitioner know-how. Those insights were recorded by the operator via `/learn` precisely because they're worth applying — let them inform every conclusion you draw below. When the response is the "no insights saved yet" guidance, proceed without it.
+
+
 1. **Load context**: Read STRATEGY.md (Market Context, USP, Data Sources) and STATE.json.
 
 2. **Discover platforms**: Identify all configured platforms from STATE.json `platforms`.

--- a/mureo/_data/skills/creative-refresh/SKILL.md
+++ b/mureo/_data/skills/creative-refresh/SKILL.md
@@ -16,6 +16,9 @@ Refresh ad creatives based on strategy context and performance data across all p
 
 ## Steps
 
+**Before you start**: Call `mureo_learning_insights_get` (no arguments) and treat the returned Markdown as authoritative practitioner know-how. Those insights were recorded by the operator via `/learn` precisely because they're worth applying — let them inform every conclusion you draw below. When the response is the "no insights saved yet" guidance, proceed without it.
+
+
 1. **Load context**: Read STRATEGY.md (Persona, USP, Brand Voice, Data Sources) and STATE.json.
 
 2. **Discover platforms**: Identify all configured ad platforms from STATE.json `platforms`.

--- a/mureo/_data/skills/daily-check/SKILL.md
+++ b/mureo/_data/skills/daily-check/SKILL.md
@@ -16,6 +16,9 @@ Run a daily health check on all marketing accounts using the strategy context.
 
 ## Steps
 
+**Before you start**: Call `mureo_learning_insights_get` (no arguments) and treat the returned Markdown as authoritative practitioner know-how. Those insights were recorded by the operator via `/learn` precisely because they're worth applying — let them inform every conclusion you draw below. When the response is the "no insights saved yet" guidance, proceed without it.
+
+
 1. **Load context**: Read STRATEGY.md (especially Operation Mode, Data Sources, and all Goal sections) and STATE.json.
 
 2. **Discover available platforms**: Identify all configured platforms from STATE.json `platforms` and check which data sources (Search Console, GA4) are accessible. Also enumerate installed **plugin** platforms (`mcp__mureo__<plugin>_*` tools) and include them best-effort — see `_mureo-shared` → *Plugin platforms*.

--- a/mureo/_data/skills/goal-review/SKILL.md
+++ b/mureo/_data/skills/goal-review/SKILL.md
@@ -17,6 +17,9 @@ Review progress toward all marketing goals across all platforms.
 
 ## Steps
 
+**Before you start**: Call `mureo_learning_insights_get` (no arguments) and treat the returned Markdown as authoritative practitioner know-how. Those insights were recorded by the operator via `/learn` precisely because they're worth applying — let them inform every conclusion you draw below. When the response is the "no insights saved yet" guidance, proceed without it.
+
+
 1. **Load context**: Read STRATEGY.md (all Goal sections, Data Sources) and STATE.json.
 
 2. **Discover platforms**: Identify all configured platforms and available data sources.

--- a/mureo/_data/skills/rescue/SKILL.md
+++ b/mureo/_data/skills/rescue/SKILL.md
@@ -16,6 +16,9 @@ Run an emergency performance rescue workflow for underperforming campaigns.
 
 ## Steps
 
+**Before you start**: Call `mureo_learning_insights_get` (no arguments) and treat the returned Markdown as authoritative practitioner know-how. Those insights were recorded by the operator via `/learn` precisely because they're worth applying — let them inform every conclusion you draw below. When the response is the "no insights saved yet" guidance, proceed without it.
+
+
 1. **Load context**: Read STRATEGY.md (including Goal sections and Data Sources) and STATE.json. Set Operation Mode to `TURNAROUND_RESCUE` in STRATEGY.md.
 
 2. **Discover platforms**: Identify all configured ad platforms from STATE.json `platforms`.

--- a/mureo/_data/skills/search-term-cleanup/SKILL.md
+++ b/mureo/_data/skills/search-term-cleanup/SKILL.md
@@ -16,6 +16,9 @@ Review and clean up search terms and keywords across all platforms.
 
 ## Steps
 
+**Before you start**: Call `mureo_learning_insights_get` (no arguments) and treat the returned Markdown as authoritative practitioner know-how. Those insights were recorded by the operator via `/learn` precisely because they're worth applying — let them inform every conclusion you draw below. When the response is the "no insights saved yet" guidance, proceed without it.
+
+
 1. **Load context**: Read STRATEGY.md (Persona, USP, Target Audience, Data Sources) and STATE.json.
 
 2. **Discover platforms**: Identify all configured platforms that support search term data from STATE.json `platforms`.

--- a/mureo/mcp/server.py
+++ b/mureo/mcp/server.py
@@ -57,6 +57,8 @@ from mureo.mcp.tools_analytics_registry import (
 )
 from mureo.mcp.tools_google_ads import TOOLS as GOOGLE_ADS_TOOLS
 from mureo.mcp.tools_google_ads import handle_tool as handle_google_ads_tool
+from mureo.mcp.tools_learning import TOOLS as LEARNING_TOOLS
+from mureo.mcp.tools_learning import handle_tool as handle_learning_tool
 from mureo.mcp.tools_meta_ads import TOOLS as META_ADS_TOOLS
 from mureo.mcp.tools_meta_ads import handle_tool as handle_meta_ads_tool
 from mureo.mcp.tools_mureo_context import TOOLS as MUREO_CONTEXT_TOOLS
@@ -108,6 +110,7 @@ _ALL_TOOLS: list[Tool] = [
     *ANALYSIS_TOOLS,
     *MUREO_CONTEXT_TOOLS,
     *ANALYTICS_REGISTRY_TOOLS,
+    *LEARNING_TOOLS,
 ]
 _GOOGLE_ADS_NAMES: frozenset[str] = (
     frozenset(t.name for t in GOOGLE_ADS_TOOLS) if _GOOGLE_ADS_ENABLED else frozenset()
@@ -122,6 +125,7 @@ _MUREO_CONTEXT_NAMES: frozenset[str] = frozenset(t.name for t in MUREO_CONTEXT_T
 _ANALYTICS_REGISTRY_NAMES: frozenset[str] = frozenset(
     t.name for t in ANALYTICS_REGISTRY_TOOLS
 )
+_LEARNING_NAMES: frozenset[str] = frozenset(t.name for t in LEARNING_TOOLS)
 
 # ---------------------------------------------------------------------------
 # Third-party plugin tools (entry-point–discovered providers implementing
@@ -142,6 +146,7 @@ _PLUGIN_TOOLS, _PLUGIN_DISPATCH = collect_plugin_tools(
         | _ANALYSIS_NAMES
         | _MUREO_CONTEXT_NAMES
         | _ANALYTICS_REGISTRY_NAMES
+        | _LEARNING_NAMES
     ),
 )
 _ALL_TOOLS.extend(_PLUGIN_TOOLS)
@@ -282,6 +287,8 @@ async def handle_call_tool(name: str, arguments: dict[str, Any]) -> list[Any]:
         return await handle_mureo_context_tool(name, arguments)
     if name in _ANALYTICS_REGISTRY_NAMES:
         return await handle_analytics_registry_tool(name, arguments)
+    if name in _LEARNING_NAMES:
+        return await handle_learning_tool(name, arguments)
     if name in _PLUGIN_NAMES:
         provider = _PLUGIN_DISPATCH[name]
         source = plugin_source(provider)

--- a/mureo/mcp/tools_learning.py
+++ b/mureo/mcp/tools_learning.py
@@ -1,0 +1,152 @@
+"""mureo's learned-insights MCP tool surface.
+
+A single tool — :data:`TOOLS` exposes ``mureo_learning_insights_get``
+— that returns the operator-tier knowledge base for diagnostic
+workflows to consult. The data flow is the read-side counterpart to
+``mureo learn add``:
+
+    /learn skill (markdown)
+      → mureo learn add "<insight>"  (mureo/cli/learn_cmd.py)
+      → KnowledgeStore.append_operator_knowledge()
+      ↑ write side already shipped
+      ↓ this module — read side
+      → KnowledgeStore.read_operator_knowledge()
+      → mureo_learning_insights_get  (this tool)
+      → /daily-check / /rescue / /budget-rebalance / …
+
+The tool deliberately takes no arguments: its job is to surface
+every saved insight so the agent treats them as authoritative
+context. A future, separate tool could expose a filtered / scoped
+view if scoping turns out to be necessary; the current design
+errs on the side of "give the agent everything it should know".
+
+An empty knowledge base (no file, or only the YAML-frontmatter
+scaffold) returns a guidance string rather than a blank or
+scaffold-only payload — otherwise the agent would either quote an
+empty section into its analysis or treat the scaffold header as
+real content. The guidance also encourages the operator to start
+using ``/learn``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from mcp.types import TextContent, Tool
+
+from mureo.core.knowledge_store import _OPERATOR_SCAFFOLD
+from mureo.core.runtime_context import get_runtime_context
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+logger = logging.getLogger(__name__)
+
+
+# Sentinel returned when the knowledge base is effectively empty. The
+# explicit "no insights" wording is also what
+# ``test_handler_returns_guidance_when_no_insights_saved`` pins.
+_NO_INSIGHTS_MESSAGE = (
+    "(No insights saved yet — the operator hasn't run /learn yet. "
+    "Continue with the workflow using only STRATEGY.md / STATE.json "
+    "as context, and consider suggesting /learn at the end if you "
+    "uncover a reusable lesson.)"
+)
+
+
+# Derive the scaffold's terminal heading from the single source of
+# truth in ``knowledge_store._OPERATOR_SCAFFOLD`` so a future edit
+# to the scaffold heading does not silently break this check. A
+# parity test pins the derivation.
+_SCAFFOLD_TERMINAL_HEADING = "## " + _OPERATOR_SCAFFOLD.rsplit("## ", 1)[1].strip()
+
+
+def _is_scaffold_only(text: str) -> bool:
+    """Return ``True`` when ``text`` is empty or contains only the
+    frontmatter scaffold seeded by
+    :func:`mureo.core.knowledge_store.FilesystemKnowledgeStore.append_operator_knowledge`
+    on first write.
+
+    The check has to tolerate trailing whitespace because the
+    scaffold ends with a newline and the file may or may not have
+    content appended after it. We treat "scaffold + only whitespace"
+    as scaffold-only.
+    """
+    if not text or not text.strip():
+        return True
+    # ``rfind`` over ``find`` is deliberate: if an operator pastes a
+    # transcript whose body happens to contain the literal scaffold
+    # heading, the last occurrence is the true scaffold boundary and
+    # everything after it is the real content. This keeps the
+    # "agent sees every saved insight" contract while staying robust
+    # against transcripts that re-use the heading.
+    idx = text.rfind(_SCAFFOLD_TERMINAL_HEADING)
+    if idx == -1:
+        return False
+    tail = text[idx + len(_SCAFFOLD_TERMINAL_HEADING) :]
+    return not tail.strip()
+
+
+TOOLS: list[Tool] = [
+    Tool(
+        name="mureo_learning_insights_get",
+        description=(
+            "Load every insight previously saved via /learn from the "
+            "operator-tier knowledge base. Returns the raw Markdown so "
+            "the agent can apply the lessons when forming a "
+            "diagnostic answer. Read-only. Call this near the start "
+            "of every diagnostic workflow (/daily-check, /rescue, "
+            "/budget-rebalance, /creative-refresh, /goal-review, "
+            "/competitive-scan, /search-term-cleanup) BEFORE drawing "
+            "conclusions, so accumulated practitioner know-how "
+            "informs the analysis instead of being ignored. Returns "
+            "a guidance string when no insights have been saved yet."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {},
+            "required": [],
+        },
+    ),
+]
+
+
+_TOOL_NAMES: frozenset[str] = frozenset(t.name for t in TOOLS)
+
+
+async def handle_tool(name: str, arguments: dict[str, Any]) -> Sequence[TextContent]:
+    """Dispatch entry point used by ``mureo.mcp.server``.
+
+    Mirrors the shape of every other ``tools_*`` module's
+    ``handle_tool`` so the server can dispatch uniformly.
+
+    Raises:
+        ValueError: ``name`` is not a tool exported by this module.
+    """
+    if name == "mureo_learning_insights_get":
+        return await _handle_learning_insights_get(arguments)
+    raise ValueError(f"Unknown tool: {name}")
+
+
+async def _handle_learning_insights_get(
+    arguments: dict[str, Any],  # noqa: ARG001
+) -> Sequence[TextContent]:
+    """Return the operator-tier knowledge base as a single
+    ``TextContent``.
+
+    Defers to the runtime context's ``KnowledgeStore`` so an
+    alternate backend registered via
+    ``mureo.runtime_context_factory`` (filesystem-backed by default;
+    could be DB-backed or remote-fetch-backed under a third-party
+    runtime context factory) works transparently.
+    """
+    store = get_runtime_context().knowledge_store
+    text = store.read_operator_knowledge()
+    if _is_scaffold_only(text):
+        logger.debug("learning insights: knowledge base empty / scaffold-only")
+        return [TextContent(type="text", text=_NO_INSIGHTS_MESSAGE)]
+    return [TextContent(type="text", text=text)]
+
+
+__all__ = ["TOOLS", "handle_tool"]

--- a/mureo/mcp/tools_learning.py
+++ b/mureo/mcp/tools_learning.py
@@ -31,15 +31,12 @@ using ``/learn``.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from mcp.types import TextContent, Tool
 
 from mureo.core.knowledge_store import _OPERATOR_SCAFFOLD
 from mureo.core.runtime_context import get_runtime_context
-
-if TYPE_CHECKING:
-    from collections.abc import Sequence
 
 logger = logging.getLogger(__name__)
 
@@ -115,7 +112,7 @@ TOOLS: list[Tool] = [
 _TOOL_NAMES: frozenset[str] = frozenset(t.name for t in TOOLS)
 
 
-async def handle_tool(name: str, arguments: dict[str, Any]) -> Sequence[TextContent]:
+async def handle_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
     """Dispatch entry point used by ``mureo.mcp.server``.
 
     Mirrors the shape of every other ``tools_*`` module's
@@ -131,7 +128,7 @@ async def handle_tool(name: str, arguments: dict[str, Any]) -> Sequence[TextCont
 
 async def _handle_learning_insights_get(
     arguments: dict[str, Any],  # noqa: ARG001
-) -> Sequence[TextContent]:
+) -> list[TextContent]:
     """Return the operator-tier knowledge base as a single
     ``TextContent``.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mureo"
-version = "0.9.17"
+version = "0.9.18"
 description = "Your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/skills/budget-rebalance/SKILL.md
+++ b/skills/budget-rebalance/SKILL.md
@@ -16,6 +16,9 @@ Analyze budget allocation and suggest rebalancing across all campaigns.
 
 ## Steps
 
+**Before you start**: Call `mureo_learning_insights_get` (no arguments) and treat the returned Markdown as authoritative practitioner know-how. Those insights were recorded by the operator via `/learn` precisely because they're worth applying — let them inform every conclusion you draw below. When the response is the "no insights saved yet" guidance, proceed without it.
+
+
 1. **Load context**: Read STRATEGY.md (Operation Mode, Market Context, Goal sections, Data Sources) and STATE.json.
 
 2. **Discover platforms**: Identify all configured ad platforms from STATE.json `platforms`.

--- a/skills/competitive-scan/SKILL.md
+++ b/skills/competitive-scan/SKILL.md
@@ -16,6 +16,9 @@ Scan the competitive landscape and suggest strategic responses across all channe
 
 ## Steps
 
+**Before you start**: Call `mureo_learning_insights_get` (no arguments) and treat the returned Markdown as authoritative practitioner know-how. Those insights were recorded by the operator via `/learn` precisely because they're worth applying — let them inform every conclusion you draw below. When the response is the "no insights saved yet" guidance, proceed without it.
+
+
 1. **Load context**: Read STRATEGY.md (Market Context, USP, Data Sources) and STATE.json.
 
 2. **Discover platforms**: Identify all configured platforms from STATE.json `platforms`.

--- a/skills/creative-refresh/SKILL.md
+++ b/skills/creative-refresh/SKILL.md
@@ -16,6 +16,9 @@ Refresh ad creatives based on strategy context and performance data across all p
 
 ## Steps
 
+**Before you start**: Call `mureo_learning_insights_get` (no arguments) and treat the returned Markdown as authoritative practitioner know-how. Those insights were recorded by the operator via `/learn` precisely because they're worth applying — let them inform every conclusion you draw below. When the response is the "no insights saved yet" guidance, proceed without it.
+
+
 1. **Load context**: Read STRATEGY.md (Persona, USP, Brand Voice, Data Sources) and STATE.json.
 
 2. **Discover platforms**: Identify all configured ad platforms from STATE.json `platforms`.

--- a/skills/daily-check/SKILL.md
+++ b/skills/daily-check/SKILL.md
@@ -16,6 +16,9 @@ Run a daily health check on all marketing accounts using the strategy context.
 
 ## Steps
 
+**Before you start**: Call `mureo_learning_insights_get` (no arguments) and treat the returned Markdown as authoritative practitioner know-how. Those insights were recorded by the operator via `/learn` precisely because they're worth applying — let them inform every conclusion you draw below. When the response is the "no insights saved yet" guidance, proceed without it.
+
+
 1. **Load context**: Read STRATEGY.md (especially Operation Mode, Data Sources, and all Goal sections) and STATE.json.
 
 2. **Discover available platforms**: Identify all configured platforms from STATE.json `platforms` and check which data sources (Search Console, GA4) are accessible. Also enumerate installed **plugin** platforms (`mcp__mureo__<plugin>_*` tools) and include them best-effort — see `_mureo-shared` → *Plugin platforms*.

--- a/skills/goal-review/SKILL.md
+++ b/skills/goal-review/SKILL.md
@@ -17,6 +17,9 @@ Review progress toward all marketing goals across all platforms.
 
 ## Steps
 
+**Before you start**: Call `mureo_learning_insights_get` (no arguments) and treat the returned Markdown as authoritative practitioner know-how. Those insights were recorded by the operator via `/learn` precisely because they're worth applying — let them inform every conclusion you draw below. When the response is the "no insights saved yet" guidance, proceed without it.
+
+
 1. **Load context**: Read STRATEGY.md (all Goal sections, Data Sources) and STATE.json.
 
 2. **Discover platforms**: Identify all configured platforms and available data sources.

--- a/skills/rescue/SKILL.md
+++ b/skills/rescue/SKILL.md
@@ -16,6 +16,9 @@ Run an emergency performance rescue workflow for underperforming campaigns.
 
 ## Steps
 
+**Before you start**: Call `mureo_learning_insights_get` (no arguments) and treat the returned Markdown as authoritative practitioner know-how. Those insights were recorded by the operator via `/learn` precisely because they're worth applying — let them inform every conclusion you draw below. When the response is the "no insights saved yet" guidance, proceed without it.
+
+
 1. **Load context**: Read STRATEGY.md (including Goal sections and Data Sources) and STATE.json. Set Operation Mode to `TURNAROUND_RESCUE` in STRATEGY.md.
 
 2. **Discover platforms**: Identify all configured ad platforms from STATE.json `platforms`.

--- a/skills/search-term-cleanup/SKILL.md
+++ b/skills/search-term-cleanup/SKILL.md
@@ -16,6 +16,9 @@ Review and clean up search terms and keywords across all platforms.
 
 ## Steps
 
+**Before you start**: Call `mureo_learning_insights_get` (no arguments) and treat the returned Markdown as authoritative practitioner know-how. Those insights were recorded by the operator via `/learn` precisely because they're worth applying — let them inform every conclusion you draw below. When the response is the "no insights saved yet" guidance, proceed without it.
+
+
 1. **Load context**: Read STRATEGY.md (Persona, USP, Target Audience, Data Sources) and STATE.json.
 
 2. **Discover platforms**: Identify all configured platforms that support search term data from STATE.json `platforms`.

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -44,10 +44,10 @@ class TestListTools:
     async def test_list_tools_returns_all_tools(self) -> None:
         """list_tools returns all tools (Google Ads 83 + Meta Ads 81 + Search Console 10
         + Rollback 2 + Analysis 1 + Mureo Context 5 + Analytics Registry 1
-        = 183)."""
+        + Learning 1 = 184)."""
         mod = _import_server_module()
         tools = await mod.handle_list_tools()
-        assert len(tools) == 183
+        assert len(tools) == 184
 
     async def test_list_tools_contains_google_and_meta(self) -> None:
         """Google Ads and Meta Ads tools are included."""

--- a/tests/test_mcp_tools_learning.py
+++ b/tests/test_mcp_tools_learning.py
@@ -1,0 +1,207 @@
+"""Tests for the ``mureo_learning_insights_get`` MCP tool.
+
+The tool is the read-side counterpart to the ``/learn`` skill's
+``mureo learn add`` CLI: it returns the operator-tier knowledge base
+(by default the contents of
+``~/.claude/skills/_mureo-pro-diagnosis/SKILL.md``) so diagnostic
+workflows like ``/daily-check``, ``/rescue``, and ``/budget-rebalance``
+can consult accumulated practitioner know-how before drawing
+conclusions.
+
+These tests pin three things:
+
+1. The tool is registered in ``mureo.mcp.tools_learning.TOOLS`` with
+   the expected name and an empty ``inputSchema`` (no arguments).
+2. The handler routes through the runtime context's KnowledgeStore
+   (so an alternate backend registered via the
+   ``mureo.runtime_context_factory`` entry-point group still works).
+3. The handler returns a non-empty guidance string when no insights
+   have been saved yet, instead of an empty / confusing payload.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _import_learning_tools() -> object:
+    """Import :mod:`mureo.mcp.tools_learning` fresh per test.
+
+    Mirrors the convention used by other ``test_mcp_tools_*`` files
+    so module-level state (TOOLS list construction) is observed in a
+    clean state.
+    """
+    import importlib
+
+    import mureo.mcp.tools_learning
+
+    return importlib.reload(mureo.mcp.tools_learning)
+
+
+@pytest.mark.unit
+class TestLearningInsightsToolDefinition:
+    def test_tool_registered_with_correct_name(self) -> None:
+        mod = _import_learning_tools()
+        names = {t.name for t in mod.TOOLS}
+        assert "mureo_learning_insights_get" in names
+
+    def test_tool_has_empty_input_schema(self) -> None:
+        """The tool takes no arguments — its job is to surface every
+        insight in the operator-tier knowledge base. Callers must not
+        be tempted to pass a filter / scope hint that we silently
+        ignore."""
+        mod = _import_learning_tools()
+        tool = next(t for t in mod.TOOLS if t.name == "mureo_learning_insights_get")
+        assert tool.inputSchema == {
+            "type": "object",
+            "properties": {},
+            "required": [],
+        }
+
+    def test_tool_description_references_learn_skill(self) -> None:
+        """A reader inspecting the tool description should understand
+        where the data comes from and why they should call it."""
+        mod = _import_learning_tools()
+        tool = next(t for t in mod.TOOLS if t.name == "mureo_learning_insights_get")
+        assert "/learn" in tool.description
+        assert "diagnostic" in tool.description.lower()
+
+
+@pytest.mark.unit
+class TestLearningInsightsHandler:
+    @pytest.mark.asyncio
+    async def test_handler_returns_insights_from_knowledge_store(self) -> None:
+        """The handler must defer to the runtime context's
+        KnowledgeStore — an alternate backend swapped in via the
+        ``mureo.runtime_context_factory`` entry-point group should
+        take effect transparently."""
+        mod = _import_learning_tools()
+        fake_store = MagicMock()
+        fake_store.read_operator_knowledge.return_value = (
+            "## Learned Insights\n\n### Use micro-conversions when CV is sparse\n"
+        )
+        fake_ctx = MagicMock(knowledge_store=fake_store)
+        with patch(
+            "mureo.mcp.tools_learning.get_runtime_context", return_value=fake_ctx
+        ):
+            result = await mod.handle_tool("mureo_learning_insights_get", {})
+
+        fake_store.read_operator_knowledge.assert_called_once()
+        assert len(result) == 1
+        assert "Use micro-conversions when CV is sparse" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_handler_returns_guidance_when_no_insights_saved(self) -> None:
+        """An empty knowledge base is the common first-time case, not
+        an error. Return a guidance string so the agent understands
+        nothing has been saved yet and the operator should be
+        encouraged to run ``/learn``."""
+        mod = _import_learning_tools()
+        fake_store = MagicMock()
+        fake_store.read_operator_knowledge.return_value = ""
+        fake_ctx = MagicMock(knowledge_store=fake_store)
+        with patch(
+            "mureo.mcp.tools_learning.get_runtime_context", return_value=fake_ctx
+        ):
+            result = await mod.handle_tool("mureo_learning_insights_get", {})
+
+        assert len(result) == 1
+        assert "/learn" in result[0].text
+        # Should explicitly note absence rather than returning a
+        # blank string the agent might quote into its analysis.
+        assert "no insights" in result[0].text.lower()
+
+    @pytest.mark.asyncio
+    async def test_handler_treats_scaffold_only_as_empty(self) -> None:
+        """A freshly-created file with only the YAML frontmatter
+        scaffold (no actual insights) should count as 'no insights
+        saved yet' — otherwise the agent would treat the empty
+        ``## Learned Insights`` header as authoritative content."""
+        mod = _import_learning_tools()
+        scaffold_only = """\
+---
+name: _mureo-pro-diagnosis
+description: "Professional marketing diagnostic frameworks: expert-level campaign analysis that grows with your experience."
+metadata:
+  version: 0.1.0
+---
+
+# Pro Diagnosis — Account Knowledge Base
+
+Insights learned from operating this account, applied by every mureo
+diagnostic workflow.
+
+## Learned Insights
+"""
+        fake_store = MagicMock()
+        fake_store.read_operator_knowledge.return_value = scaffold_only
+        fake_ctx = MagicMock(knowledge_store=fake_store)
+        with patch(
+            "mureo.mcp.tools_learning.get_runtime_context", return_value=fake_ctx
+        ):
+            result = await mod.handle_tool("mureo_learning_insights_get", {})
+
+        # Treated as empty — guidance, not the raw scaffold.
+        assert "no insights" in result[0].text.lower()
+
+    def test_scaffold_only_check_matches_canonical_scaffold(self) -> None:
+        """Pin the parity between
+        :func:`mureo.mcp.tools_learning._is_scaffold_only` and the
+        canonical scaffold constant in
+        :mod:`mureo.core.knowledge_store`.
+
+        Without this test, a future edit to ``_OPERATOR_SCAFFOLD``
+        (renaming the heading, localising it, restructuring it)
+        would silently break the empty-state detection and the
+        agent would start seeing the raw YAML frontmatter dumped
+        into its context.
+        """
+        from mureo.core.knowledge_store import _OPERATOR_SCAFFOLD
+        from mureo.mcp.tools_learning import _is_scaffold_only
+
+        assert _is_scaffold_only(_OPERATOR_SCAFFOLD) is True
+        # The same scaffold with one trailing insight is NOT
+        # scaffold-only — guards against a regression where the
+        # derived marker drifts and starts catching everything.
+        insight = (
+            "### Use micro-conversions when CV is sparse\n\n"
+            "**Situation:** ...\n"
+        )
+        assert _is_scaffold_only(_OPERATOR_SCAFFOLD + insight) is False
+
+    @pytest.mark.asyncio
+    async def test_handler_unknown_tool_raises(self) -> None:
+        """Same dispatch contract as every other ``tools_*`` module
+        — unknown names raise ``ValueError`` so the server can return
+        a clear MCP error."""
+        mod = _import_learning_tools()
+        with pytest.raises(ValueError, match="Unknown tool"):
+            await mod.handle_tool("not_a_real_tool", {})
+
+
+@pytest.mark.unit
+class TestLearningInsightsServerWiring:
+    """The tool surface is empty unless ``tools_learning`` is wired
+    into the top-level server module — pin that wiring so a future
+    refactor cannot accidentally drop it."""
+
+    def test_server_module_includes_learning_tool(self) -> None:
+        import importlib
+
+        import mureo.mcp.server as server_mod
+
+        importlib.reload(server_mod)
+        names = {t.name for t in server_mod._ALL_TOOLS}
+        assert "mureo_learning_insights_get" in names
+
+    def test_server_reserves_learning_tool_name_against_plugins(self) -> None:
+        """The plugin discovery layer must refuse a third-party tool
+        that tries to shadow this name."""
+        import importlib
+
+        import mureo.mcp.server as server_mod
+
+        importlib.reload(server_mod)
+        assert "mureo_learning_insights_get" in server_mod._LEARNING_NAMES


### PR DESCRIPTION
## Summary

Closes #162 (part 1 of 2 of umbrella #161 — /learn knowledge consumption + external MCP federation).

Since v0.8.0 the `/learn` skill has been writing insights to `~/.claude/skills/_mureo-pro-diagnosis/SKILL.md` via the `FilesystemKnowledgeStore`, but **no diagnostic workflow ever read them back**. The learn skill's docstring claim that "Saved insights are loaded at the start of future sessions and applied across /daily-check, /rescue, /budget-rebalance" was unimplemented on the read side. The saved Markdown sat on disk — discoverable by Claude Code's general skill loading but never explicitly consulted by `daily-check`, `rescue`, `budget-rebalance`, or any other diagnostic skill.

This PR closes that gap with a single new MCP tool and the skill prompts that drive it. Bumps version 0.9.17 → 0.9.18.

## What changes

### New tool `mureo_learning_insights_get`

`mureo/mcp/tools_learning.py` (NEW). Single tool, no arguments, returns the operator-tier knowledge base verbatim by calling `KnowledgeStore.read_operator_knowledge()` through `get_runtime_context()`. An alternate backend registered via the `mureo.runtime_context_factory` entry-point group works transparently — the tool only knows about the Protocol, not the implementation.

An empty knowledge base (no file, or only the YAML-frontmatter scaffold) returns a guidance string instead of a blank payload so the agent neither quotes an empty section into its analysis nor mistakes the scaffold header for content:

```
(No insights saved yet — the operator hasn't run /learn yet.
Continue with the workflow using only STRATEGY.md / STATE.json
as context, and consider suggesting /learn at the end if you
uncover a reusable lesson.)
```

### Scaffold-only detection

The "is this just the scaffold?" heuristic derives its terminal heading from the canonical `_OPERATOR_SCAFFOLD` constant in `mureo.core.knowledge_store` rather than hardcoding it (round-1 review caught this as a drift risk). A parity test pins the derivation against future scaffold edits.

`rfind` (over `find`) is used deliberately so an operator who pastes a transcript containing the literal scaffold heading into a `/learn` entry still degrades safely to "everything past the last occurrence is real content".

### Server wiring

`mureo/mcp/server.py` gains the standard pattern (matching `tools_mureo_context`, `tools_analytics_registry`, etc.):
- `LEARNING_TOOLS` / `_LEARNING_NAMES` added to the tool list and reserved-name set (plugins can't shadow `mureo_learning_insights_get`).
- One new dispatch branch in the call-tool handler.

### Skill updates (7 diagnostic skills × 2 locations = 14 files)

Each of `daily-check`, `rescue`, `budget-rebalance`, `creative-refresh`, `goal-review`, `competitive-scan`, `search-term-cleanup` gains a "Before you start" paragraph at the top of `## Steps`:

> **Before you start**: Call `mureo_learning_insights_get` (no arguments) and treat the returned Markdown as authoritative practitioner know-how. Those insights were recorded by the operator via `/learn` precisely because they're worth applying — let them inform every conclusion you draw below. When the response is the "no insights saved yet" guidance, proceed without it.

Both `mureo/_data/skills/` (packaged) and `skills/` (canonical) updated; `test_packaged_skills_match_canonical_byte_for_byte` confirms parity.

### Tests (10 new)

`tests/test_mcp_tools_learning.py`:
- `TestLearningInsightsToolDefinition` (3): tool registered, empty input schema, description references `/learn`.
- `TestLearningInsightsHandler` (5): defers to `KnowledgeStore`, returns guidance on empty / scaffold-only, scaffold-marker parity with canonical `_OPERATOR_SCAFFOLD`, unknown tool name raises `ValueError`.
- `TestLearningInsightsServerWiring` (2): tool surfaces in `_ALL_TOOLS`, reserved against plugin shadowing.

`tests/test_mcp_server.py` total tool count bumped 183 → 184.

## Test plan

- [x] 10 new tests pass; full suite 3685 passed (excluding 3 pre-existing dev-env entry-point pollution failures that also fail on `main`).
- [x] `black --check mureo/` clean.
- [x] `ruff check` clean on all modified files.
- [x] `test_packaged_skills_match_canonical_byte_for_byte` passes — `mureo/_data/skills/` and `skills/` in sync.
- [x] Code review APPROVED (`code-reviewer` agent). 2 MEDIUMs reflected (scaffold marker derivation + `rfind` rationale comment); 2 LOWs deferred as cosmetic / pre-existing.
- [ ] CI green.

## Backward compatibility

Purely additive. New module, new tool, new lines in 7 skills. No signature changes, no removed surface, no version-pin changes.

## What's next (PR B, target 0.9.19)

External MCP server federation — see issue #163. mureo learns to spawn / connect to external MCP servers (via the `mcp` SDK's `ClientSession`, stdio + HTTP/SSE) configured in `~/.mureo/insight_sources.json` and merges their `tools/call`-returned Markdown alongside the local file. Because `mureo_learning_insights_get` already routes through the `KnowledgeStore` Protocol, the federation work can land without touching this tool's public shape — the aggregation happens behind the Protocol.
