### PR TITLE
feat(mcp): federate /learn insights with external MCP servers

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mureo",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "description": "Your local-first AI ad ops crew for Google Ads, Meta Ads, Search Console & GA4. mureo sits on top of the official ad-platform MCPs, gates every change against your strategy, correlates outcomes locally, and keeps an auditable decision log — credentials never leave your machine.",
   "author": {
     "name": "Logly Inc.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.19] - 2026-05-29
+
+### Added — External MCP insight-source federation
+
+v0.9.18 closed the `/learn` read-side gap by exposing the local knowledge base via `mureo_learning_insights_get`. This release extends that tool to **federate with external MCP servers** — anyone can run an MCP server that publishes practitioner know-how (consulting companies, industry benchmark sources, OSS community knowledge bases, internal team wikis) and mureo will aggregate it alongside the operator's local `/learn` history.
+
+**Config**: declare external sources in `~/.mureo/insight_sources.json`:
+
+```json
+{
+  "sources": [
+    {
+      "name": "acme-consulting",
+      "transport": "stdio",
+      "command": "acme-insights-mcp",
+      "args": ["--scope", "google-ads"],
+      "env": {"ACME_API_KEY": "..."},
+      "tool": "insights_get",
+      "timeout_sec": 10
+    },
+    {
+      "name": "industry-benchmarks",
+      "transport": "sse",
+      "url": "https://benchmarks.example/mcp",
+      "headers": {"Authorization": "Bearer ..."},
+      "tool": "benchmarks_get"
+    }
+  ]
+}
+```
+
+Three transports are supported: `stdio` (subprocess; the mcp SDK's `stdio_client`), `sse` (`sse_client`), and `http` (`streamablehttp_client`).
+
+**Per-source error isolation**: a single misbehaving source (slow, crashed, malformed response, network error) NEVER blocks the diagnostic flow. Per-source timeouts (default 10s) cap each call; failures yield `None` for that source and the others continue. Sources fan out via `asyncio.gather` so total wall-time is bounded by the slowest, not the sum.
+
+**Aggregation**: local insights come first (operator's own `/learn` history is canonical), then each external source becomes a labelled `## <name>` section separated by a horizontal rule (`---`). When all sources (local + external) are empty, the guidance message from v0.9.18 is returned unchanged.
+
+**No tool-shape change**: `mureo_learning_insights_get` still takes no arguments and returns a single `TextContent` — existing skill prompts work unchanged. Federation happens behind the `KnowledgeStore` Protocol, so an alternate runtime context factory that wraps a remote-fetch backend (PR A's exit point) keeps working without changes.
+
+New modules: `mureo.learning.insight_sources` (frozen-dataclass model + tolerant JSON parser) and `mureo.learning.federation` (MCP-client wrappers + per-source fetch + aggregator).
+
+Closes [#163](https://github.com/logly/mureo/issues/163) (part 2 of 2 of umbrella [#161](https://github.com/logly/mureo/issues/161)).
+
 ## [0.9.18] - 2026-05-29
 
 ### Added — `mureo_learning_insights_get` MCP tool closes the `/learn` read-side gap

--- a/docs/insight-federation.md
+++ b/docs/insight-federation.md
@@ -1,0 +1,186 @@
+# Insight federation: serving practitioner know-how to mureo via MCP
+
+`mureo_learning_insights_get` aggregates insights from two layers:
+
+1. **Local** — the operator's own `/learn` history saved by
+   `mureo learn add` (default location:
+   `~/.claude/skills/_mureo-pro-diagnosis/SKILL.md`).
+2. **External MCP servers** — third-party servers that publish
+   know-how, configured in `~/.mureo/insight_sources.json`.
+
+This guide covers the external layer.
+
+## Why federation?
+
+- **Consulting companies** can publish their accumulated marketing
+  know-how as an MCP server; clients install once and every mureo
+  diagnostic flow benefits.
+- **Industry trade groups** can serve benchmark deltas (CPA,
+  conversion-rate baselines per vertical) so the agent calibrates
+  recommendations against the cohort.
+- **OSS communities** can run a shared insights MCP that aggregates
+  what operators have collectively learned.
+- **Enterprise teams** can wrap an internal wiki / Notion / SharePoint
+  as a small MCP server so the agent gets cross-team learnings.
+
+The MCP server can be written in **any language** — Python,
+TypeScript, Go, Rust — as long as it implements the MCP protocol.
+
+## Config file
+
+Path: `~/.mureo/insight_sources.json`.
+
+Schema:
+
+```jsonc
+{
+  "sources": [
+    {
+      "name": "acme-consulting",        // section heading in the merged output
+      "transport": "stdio",              // "stdio" | "sse" | "http"
+      "tool": "insights_get",            // the remote tool name to call
+      "command": "acme-insights-mcp",    // stdio only: executable
+      "args": ["--scope", "google-ads"], // stdio only: extra CLI args
+      "env": {"ACME_API_KEY": "..."},    // stdio only: env vars merged into subprocess
+      "url": "https://...",              // sse / http only
+      "headers": {"Authorization": "Bearer ..."}, // sse / http only
+      "timeout_sec": 10                  // optional; default 10
+    }
+  ]
+}
+```
+
+Required fields per transport:
+
+| transport | required fields            |
+|-----------|----------------------------|
+| `stdio`   | `name`, `tool`, `command`  |
+| `sse`     | `name`, `tool`, `url`      |
+| `http`    | `name`, `tool`, `url`      |
+
+The MCP server should expose a tool (any name, declared via `tool`)
+that takes no arguments and returns Markdown text via `TextContent`
+blocks. The first text block becomes the section under
+`## <name>` in the merged response; multiple text blocks are
+concatenated with a single blank line between them.
+
+## Per-source error isolation
+
+mureo treats every external source as advisory. A failure mode in
+one source NEVER blocks the diagnostic flow:
+
+| failure                              | mureo's response                                  |
+|--------------------------------------|---------------------------------------------------|
+| config file missing / malformed JSON | empty config + WARNING log; local insights only   |
+| one entry has wrong shape            | skip that entry + WARNING; siblings continue      |
+| duplicate `name` across entries      | keep the first; skip subsequent + WARNING         |
+| source exceeds `timeout_sec`         | drop the source + WARNING; siblings continue      |
+| network / subprocess error           | drop the source + WARNING; siblings continue      |
+| `tools/call` returns `isError`       | drop the source + WARNING; siblings continue      |
+| response has no text content         | drop the source + WARNING; siblings continue      |
+
+Operators can grep the mureo MCP server log for `insight source` to
+diagnose problems.
+
+## Performance
+
+Sources fan out via `asyncio.gather`, so total wall-time is bounded
+by the slowest source, not the sum. Default per-source timeout is
+10 seconds — long enough for a slow remote MCP, short enough that a
+dead server does not stall the diagnostic UX.
+
+There is no caching in v0.9.19. Every call to
+`mureo_learning_insights_get` re-fetches every external source. If
+your insight set is large and stable, consider serving an HTTP MCP
+with appropriate cache headers (mureo respects them).
+
+## Writing a federation-friendly MCP server
+
+The minimum contract:
+
+1. Expose a single tool that takes no arguments.
+2. Return `CallToolResult` with `isError = False` and at least one
+   `TextContent` block whose `text` is Markdown.
+3. Respond within `timeout_sec` (default 10s).
+
+The Markdown can be anything. Convention: use `###` headings for
+individual insights and a brief `**Why:**` / `**When to apply:**`
+template under each, mirroring the `/learn` skill's local format
+([learn skill template](../skills/learn/SKILL.md)).
+
+Example (Python, minimal):
+
+```python
+from mcp.server.fastmcp import FastMCP
+
+app = FastMCP("acme-insights")
+
+@app.tool()
+def insights_get() -> str:
+    return """\
+### Always disable underperforming RSAs after 14 days at <2 conversions
+**Why:** Asset combination volume below this threshold doesn't recover.
+**When to apply:** Any RSA that has accumulated 14 days at <2 conversions.
+
+### Cap broad-match keyword bids at 70% of phrase-match bids
+**Why:** Broad-match competes with phrase / exact on the same query —
+keeping broad cheaper prevents cannibalisation.
+**When to apply:** Any campaign mixing broad and phrase keywords.
+"""
+
+if __name__ == "__main__":
+    app.run()  # stdio by default
+```
+
+Register it on the operator's machine:
+
+```json
+{
+  "sources": [
+    {
+      "name": "acme-insights",
+      "transport": "stdio",
+      "command": "python",
+      "args": ["-m", "acme_insights"],
+      "tool": "insights_get"
+    }
+  ]
+}
+```
+
+Next time the operator runs `/daily-check`, `/rescue`, or any other
+diagnostic skill, the Acme insights appear under
+`## acme-insights` in the aggregated response.
+
+## Security model
+
+mureo treats every external source as **untrusted advisory content**.
+The text is forwarded to the agent as Markdown but never executed.
+No `tools/call` from the external server reaches mureo's own tool
+surface; the federation is one-way.
+
+For stdio sources, `env` keys are passed to the subprocess (so an
+`ACME_API_KEY` can be supplied without bleeding into the operator's
+shell history). The subprocess's stdout/stderr is captured by the
+MCP transport and not surfaced as part of the insights.
+
+For sse / http sources, headers are forwarded as supplied; mureo does
+not refresh tokens automatically. If a source needs an auth refresh
+loop, wrap it in a small local MCP proxy.
+
+**Secret hygiene**: if the config carries bearer tokens or API keys
+in `headers` / `env`, `chmod 600 ~/.mureo/insight_sources.json` so
+the file is not world-readable. mureo does not enforce this — it is
+on the operator.
+
+## Roadmap
+
+- **Caching with TTL** — short-circuit identical fetches within a
+  configurable window
+- **Insight scoring / dedupe** — merge similar insights from
+  multiple sources
+- **Per-account / per-workspace filtering** — allow sources to scope
+  themselves to specific platforms or accounts
+
+None of these are blocking the v0.9.19 release; they will land as
+needed based on operator feedback.

--- a/mureo/__init__.py
+++ b/mureo/__init__.py
@@ -1,3 +1,3 @@
 """mureo — your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."""
 
-__version__ = "0.9.18"
+__version__ = "0.9.19"

--- a/mureo/learning/__init__.py
+++ b/mureo/learning/__init__.py
@@ -1,0 +1,11 @@
+"""Learning-insights federation surface.
+
+This subpackage owns the read-side aggregation for ``/learn`` insights:
+the operator-local :class:`mureo.core.knowledge_store.KnowledgeStore`
+combined with zero or more external MCP servers configured in
+``~/.mureo/insight_sources.json``. The MCP tool
+:data:`mureo.mcp.tools_learning.mureo_learning_insights_get` consumes
+the aggregator, so a third party who runs their own insights MCP
+server (consulting know-how, industry benchmarks, community wisdom)
+can be federated in without changing the tool's public shape.
+"""

--- a/mureo/learning/federation.py
+++ b/mureo/learning/federation.py
@@ -1,0 +1,230 @@
+"""External insight-source federation client.
+
+Translates an :class:`mureo.learning.insight_sources.InsightSource`
+into a concrete MCP client session and extracts the Markdown content
+returned by the configured remote tool.
+
+Design constraints:
+
+- **Per-source error isolation.** A single misbehaving source (slow,
+  crashed, malformed response, network error) must never block the
+  diagnostic flow. Every failure mode in this module returns ``None``
+  with a warning log, and :func:`fetch_all` filters those out.
+
+- **Per-source timeout.** ``InsightSource.timeout_sec`` caps each
+  ``tools/call`` round-trip via :func:`asyncio.wait_for`. The default
+  of 10s is long enough for a slow remote, short enough to keep the
+  diagnostic UX responsive when the operator's network is down.
+
+- **Concurrent fan-out.** :func:`fetch_all` uses
+  :func:`asyncio.gather` so the wall-time of N sources is bounded by
+  the slowest, not their sum.
+
+- **No SDK leak.** The SDK imports stay local to this module so a
+  test that just exercises config parsing
+  (:mod:`mureo.learning.insight_sources`) does not pull in the
+  network-capable client modules.
+
+The text-extraction policy is deliberately strict: only ``type ==
+"text"`` content blocks are kept. Image / resource / structured-data
+blocks are dropped silently rather than rendered as placeholders that
+would pollute the agent's prompt with non-Markdown noise.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING, Any
+
+from mcp import ClientSession
+from mcp.client.sse import sse_client
+from mcp.client.stdio import StdioServerParameters, stdio_client
+from mcp.client.streamable_http import streamablehttp_client
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from mureo.learning.insight_sources import InsightSource
+
+logger = logging.getLogger(__name__)
+
+
+@asynccontextmanager
+async def _open_session(source: InsightSource) -> AsyncIterator[ClientSession]:
+    """Open an MCP client session for ``source`` via the right
+    transport, perform the protocol initialize, and yield the
+    session. The context exits clean up the transport.
+
+    This wrapper exists so :func:`fetch_from_source` can be unit-tested
+    by patching just this one function instead of mocking three
+    separate transport helpers.
+    """
+    if source.transport == "stdio":
+        # ``command`` is guaranteed non-None by ``InsightSource``
+        # post-init validation. ``env`` and ``headers`` are passed
+        # as ``None`` (not empty dict) when unset so the SDK's
+        # "inherit / default" semantics apply — a future SDK that
+        # distinguishes ``{}`` from ``None`` would otherwise break.
+        params = StdioServerParameters(
+            command=source.command or "",
+            args=list(source.args),
+            env=dict(source.env) if source.env else None,
+        )
+        async with (
+            stdio_client(params) as (read, write),
+            ClientSession(read, write) as session,
+        ):
+            await session.initialize()
+            yield session
+        return
+    if source.transport == "sse":
+        async with (
+            sse_client(
+                source.url or "",
+                headers=dict(source.headers) if source.headers else None,
+            ) as (read, write),
+            ClientSession(read, write) as session,
+        ):
+            await session.initialize()
+            yield session
+        return
+    if source.transport == "http":
+        # streamablehttp_client yields a (read, write, _close) tuple
+        # on newer SDK versions; we only need the first two for
+        # ClientSession.
+        async with streamablehttp_client(
+            source.url or "",
+            headers=dict(source.headers) if source.headers else None,
+        ) as streams:
+            read, write = streams[0], streams[1]
+            async with ClientSession(read, write) as session:  # noqa: SIM117
+                await session.initialize()
+                yield session
+        return
+    # Defence-in-depth: ``InsightSource.__post_init__`` already
+    # refuses unknown transports, so a config-built source can
+    # never reach this branch. Kept so a hand-built source (e.g.
+    # in a future test fixture) fails loudly rather than silently
+    # returning ``None``.
+    raise ValueError(f"unknown transport for source {source.name!r}")
+
+
+def _extract_text(result: Any) -> str:
+    """Concatenate every ``type == "text"`` block in ``result.content``.
+
+    Each block's trailing whitespace is stripped before joining
+    with a blank-line separator so blocks render as one Markdown
+    paragraph break regardless of whether the remote server emits
+    each block with or without a trailing newline. Single-block
+    responses round-trip unchanged (the strip only removes
+    trailing whitespace; leading content is preserved).
+    """
+    parts: list[str] = []
+    for block in getattr(result, "content", None) or []:
+        if getattr(block, "type", None) == "text":
+            text = getattr(block, "text", None)
+            if isinstance(text, str):
+                parts.append(text.rstrip())
+    return "\n\n".join(parts)
+
+
+async def fetch_from_source(source: InsightSource) -> str | None:
+    """Fetch insights from one external MCP server.
+
+    Returns the Markdown text on success, ``None`` on any failure
+    mode (timeout, network error, ``isError`` response, malformed
+    content). The error path always logs a WARNING that names the
+    source so an operator inspecting the log can act on it.
+    """
+    try:
+        async with _open_session(source) as session:
+            # ``asyncio.wait_for`` is the canonical timeout layer —
+            # it raises ``asyncio.TimeoutError`` which we map to a
+            # clear "timed out" warning. The SDK's own
+            # ``read_timeout_seconds`` is intentionally not set so
+            # there is no second timer that could fire first with
+            # an SDK-specific exception type masquerading as a
+            # generic failure.
+            result = await asyncio.wait_for(
+                session.call_tool(source.tool, arguments={}),
+                timeout=source.timeout_sec,
+            )
+    except asyncio.TimeoutError:
+        logger.warning(
+            "insight source %r: timed out after %.1fs",
+            source.name,
+            source.timeout_sec,
+        )
+        return None
+    except Exception as exc:  # noqa: BLE001 — per-source isolation
+        # ``except Exception`` (not ``BaseException``) is
+        # deliberate: ``asyncio.CancelledError`` inherits from
+        # ``BaseException`` in 3.8+, so it correctly propagates and
+        # the outer task group can still cancel cleanly. Only
+        # operational failures (network / subprocess / protocol)
+        # are caught here.
+        logger.warning(
+            "insight source %r: fetch failed (%s): %s",
+            source.name,
+            type(exc).__name__,
+            exc,
+        )
+        return None
+
+    if getattr(result, "isError", False):
+        logger.warning(
+            "insight source %r: remote tool returned an error result",
+            source.name,
+        )
+        return None
+
+    text = _extract_text(result)
+    if not text:
+        logger.warning("insight source %r: response had no text content", source.name)
+        return None
+    return text
+
+
+async def fetch_all(
+    sources: tuple[InsightSource, ...],
+) -> dict[str, str]:
+    """Fetch insights from every source concurrently.
+
+    Returns ``{source_name: insight_text}`` keyed by
+    :attr:`InsightSource.name`. Sources that failed (returned
+    ``None``) are omitted, so the caller can iterate without
+    re-checking for blanks.
+
+    Cancellation safety: ``asyncio.gather`` with default
+    ``return_exceptions=False`` would cancel the rest of the task
+    group on any unhandled exception. The per-source error trap in
+    :func:`fetch_from_source` makes that unreachable in practice, but
+    we still pass ``return_exceptions=True`` as a belt-and-suspenders
+    guard so a future refactor can't accidentally introduce a global
+    failure mode.
+    """
+    if not sources:
+        return {}
+    coros = [fetch_from_source(s) for s in sources]
+    results = await asyncio.gather(*coros, return_exceptions=True)
+    out: dict[str, str] = {}
+    for source, result in zip(sources, results, strict=True):
+        if isinstance(result, BaseException):
+            logger.warning(
+                "insight source %r: unexpected exception escaped (%s): %s",
+                source.name,
+                type(result).__name__,
+                result,
+            )
+            continue
+        if result:
+            out[source.name] = result
+    return out
+
+
+__all__ = [
+    "fetch_all",
+    "fetch_from_source",
+]

--- a/mureo/learning/insight_sources.py
+++ b/mureo/learning/insight_sources.py
@@ -1,0 +1,213 @@
+"""External insight-source configuration.
+
+Owns the on-disk shape of ``~/.mureo/insight_sources.json`` and the
+in-memory frozen dataclass model the federation layer consumes.
+
+The config is a thin pass-through over JSON: nothing here connects
+to an MCP server — :mod:`mureo.learning.federation` handles that.
+The split keeps the config layer free of MCP-SDK imports, so a test
+that just exercises parse/validation behaviour does not pull in the
+network-capable client modules.
+
+Tolerance philosophy: a misconfigured or missing config file must
+NEVER block :data:`mureo.mcp.tools_learning.mureo_learning_insights_get`.
+The tool's primary value is the operator-local knowledge base; the
+external sources are an optional augmentation. Every error path here
+degrades to "return what we have" so a typo in JSON does not stop the
+agent from seeing the operator's own ``/learn`` history.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+logger = logging.getLogger(__name__)
+
+
+# Allowed ``transport`` values. ``stdio`` is a local subprocess; ``sse``
+# is the MCP server-sent-events transport; ``http`` is the MCP
+# streamable-HTTP transport (the SDK's newer non-SSE transport for
+# remote servers). The federation layer routes on the value so adding a
+# new transport requires touching both this constant and the federation
+# dispatcher — a deliberately small surface.
+_ALLOWED_TRANSPORTS: frozenset[str] = frozenset({"stdio", "sse", "http"})
+
+
+Transport = Literal["stdio", "sse", "http"]
+
+
+@dataclass(frozen=True)
+class InsightSource:
+    """One configured external MCP server entry.
+
+    Attributes:
+        name: Operator-facing label that becomes the section heading
+            in the merged output. Must be unique within a config file
+            (enforced by :func:`load_insight_sources`).
+        transport: ``"stdio"``, ``"sse"``, or ``"http"``. Picks the
+            mcp SDK client transport used to talk to the server.
+        tool: The remote tool name to call (each external server can
+            choose its own naming — ``insights_get`` /
+            ``benchmarks_get`` / etc.).
+        command: stdio-only. Executable to spawn (PATH-resolved).
+        args: stdio-only. Extra CLI args. Defaults to ``()``.
+        env: stdio-only. Process env vars merged into the subprocess.
+            Defaults to ``{}``.
+        url: sse / http only. Remote MCP endpoint.
+        headers: sse / http only. Additional HTTP headers (e.g.
+            ``Authorization``). Defaults to ``{}``.
+        timeout_sec: Per-source call timeout. Defaults to 10s — long
+            enough for a slow remote MCP, short enough that a dead
+            server does not stall the diagnostic flow.
+    """
+
+    name: str
+    transport: Transport
+    tool: str
+    command: str | None = None
+    args: tuple[str, ...] = ()
+    env: dict[str, str] = field(default_factory=dict)
+    url: str | None = None
+    headers: dict[str, str] = field(default_factory=dict)
+    timeout_sec: float = 10.0
+
+    def __post_init__(self) -> None:
+        if self.transport not in _ALLOWED_TRANSPORTS:
+            raise ValueError(
+                f"unknown transport {self.transport!r}; expected one of "
+                f"{sorted(_ALLOWED_TRANSPORTS)}"
+            )
+        if self.transport == "stdio" and not self.command:
+            raise ValueError(
+                f"source {self.name!r}: stdio transport requires 'command'"
+            )
+        if self.transport in {"sse", "http"} and not self.url:
+            raise ValueError(
+                f"source {self.name!r}: {self.transport} transport requires 'url'"
+            )
+
+
+@dataclass(frozen=True)
+class InsightSourceConfig:
+    """The parsed contents of ``insight_sources.json``."""
+
+    sources: tuple[InsightSource, ...] = ()
+
+
+def default_config_path() -> Path:
+    """Path the federation layer reads when no override is supplied.
+
+    ``~/.mureo/insight_sources.json``. Resolved lazily via
+    :meth:`Path.home` so an alternate ``$HOME`` (test sandbox,
+    environment override) routes correctly without a separate
+    indirection.
+    """
+    return Path.home() / ".mureo" / "insight_sources.json"
+
+
+def load_insight_sources(path: Path | None = None) -> InsightSourceConfig:
+    """Parse the config file at ``path`` (or :func:`default_config_path`).
+
+    Tolerance:
+    - Missing file → empty config (no warning; that's the common case).
+    - Empty / malformed JSON → empty config + WARNING (the operator
+      gets a pointer to the path so they can fix it).
+    - Top-level shape wrong (no ``sources`` array, wrong types) →
+      empty config + WARNING.
+    - Individual entry invalid → that entry is skipped + WARNING; the
+      remaining valid entries are returned.
+
+    None of those failure modes raise — the federation layer treats
+    "no external sources" as a benign state.
+    """
+    resolved = path if path is not None else default_config_path()
+    if not resolved.exists():
+        return InsightSourceConfig()
+
+    try:
+        raw = json.loads(resolved.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("insight_sources config unreadable at %s: %s", resolved, exc)
+        return InsightSourceConfig()
+
+    if not isinstance(raw, dict):
+        logger.warning("insight_sources config at %s is not a JSON object", resolved)
+        return InsightSourceConfig()
+
+    entries = raw.get("sources", [])
+    if not isinstance(entries, list):
+        logger.warning(
+            "insight_sources config at %s: 'sources' is not a list", resolved
+        )
+        return InsightSourceConfig()
+
+    parsed: list[InsightSource] = []
+    seen_names: set[str] = set()
+    for idx, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            logger.warning(
+                "insight_sources config at %s entry #%d is not an object",
+                resolved,
+                idx,
+            )
+            continue
+        try:
+            source = _build_source(entry)
+        except (TypeError, ValueError) as exc:
+            logger.warning(
+                "insight_sources config at %s: skipping invalid entry " "#%d (%s): %s",
+                resolved,
+                idx,
+                entry.get("name", "<unnamed>"),
+                exc,
+            )
+            continue
+        if source.name in seen_names:
+            logger.warning(
+                "insight_sources config at %s: duplicate source name %r "
+                "(entry #%d) — keeping the first",
+                resolved,
+                source.name,
+                idx,
+            )
+            continue
+        seen_names.add(source.name)
+        parsed.append(source)
+
+    return InsightSourceConfig(sources=tuple(parsed))
+
+
+def _build_source(entry: dict[str, Any]) -> InsightSource:
+    """Convert one JSON object to an :class:`InsightSource`.
+
+    Tuple / dict coercion: ``args`` in JSON arrives as ``list[str]``
+    but the dataclass field is ``tuple[str, ...]`` for hashability;
+    ``env`` and ``headers`` are passed through as-is.
+    """
+    args_raw = entry.get("args", [])
+    if not isinstance(args_raw, list):
+        raise ValueError("'args' must be a list of strings")
+    return InsightSource(
+        name=entry["name"],
+        transport=entry["transport"],
+        tool=entry["tool"],
+        command=entry.get("command"),
+        args=tuple(str(a) for a in args_raw),
+        env=dict(entry.get("env", {})),
+        url=entry.get("url"),
+        headers=dict(entry.get("headers", {})),
+        timeout_sec=float(entry.get("timeout_sec", 10.0)),
+    )
+
+
+__all__ = [
+    "InsightSource",
+    "InsightSourceConfig",
+    "Transport",
+    "default_config_path",
+    "load_insight_sources",
+]

--- a/mureo/mcp/tools_learning.py
+++ b/mureo/mcp/tools_learning.py
@@ -37,6 +37,8 @@ from mcp.types import TextContent, Tool
 
 from mureo.core.knowledge_store import _OPERATOR_SCAFFOLD
 from mureo.core.runtime_context import get_runtime_context
+from mureo.learning.federation import fetch_all
+from mureo.learning.insight_sources import load_insight_sources
 
 logger = logging.getLogger(__name__)
 
@@ -129,21 +131,51 @@ async def handle_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]
 async def _handle_learning_insights_get(
     arguments: dict[str, Any],  # noqa: ARG001
 ) -> list[TextContent]:
-    """Return the operator-tier knowledge base as a single
-    ``TextContent``.
+    """Return local + external insights as a single ``TextContent``.
 
-    Defers to the runtime context's ``KnowledgeStore`` so an
-    alternate backend registered via
-    ``mureo.runtime_context_factory`` (filesystem-backed by default;
-    could be DB-backed or remote-fetch-backed under a third-party
-    runtime context factory) works transparently.
+    Local first (operator's own ``/learn`` history is canonical),
+    then each external MCP source declared in
+    ``~/.mureo/insight_sources.json`` as a labelled ``## <name>``
+    section separated by a horizontal rule. Local defers to the
+    runtime context's ``KnowledgeStore`` so an alternate backend
+    registered via ``mureo.runtime_context_factory`` (filesystem-
+    backed by default; could be DB-backed or remote-fetch-backed
+    under a third-party runtime context factory) works
+    transparently. External sources fan out via
+    :func:`mureo.learning.federation.fetch_all` so a slow / dead
+    source does not block siblings.
+
+    Returns the guidance message only when both the local store
+    AND every external source produced no content — otherwise the
+    agent sees whatever is available so the diagnostic flow can
+    proceed informed.
     """
+    sections: list[str] = []
+
     store = get_runtime_context().knowledge_store
-    text = store.read_operator_knowledge()
-    if _is_scaffold_only(text):
-        logger.debug("learning insights: knowledge base empty / scaffold-only")
+    local_text = store.read_operator_knowledge()
+    if not _is_scaffold_only(local_text):
+        # Prefix local insights with an "authoritative" label so the
+        # agent treats them as canonical guidance from the operator
+        # and external sections (added below) as advisory cross-
+        # references rather than ground truth.
+        sections.append("## Local /learn history (authoritative)\n\n" + local_text)
+
+    config = load_insight_sources()
+    if config.sources:
+        external = await fetch_all(config.sources)
+        # Iterate in config order so the agent sees external
+        # sections in the order the operator declared them — that
+        # ordering doubles as a priority hint.
+        for source in config.sources:
+            text = external.get(source.name)
+            if text:
+                sections.append(f"## {source.name} (advisory)\n\n{text}")
+
+    if not sections:
+        logger.debug("learning insights: no content from local or any external source")
         return [TextContent(type="text", text=_NO_INSIGHTS_MESSAGE)]
-    return [TextContent(type="text", text=text)]
+    return [TextContent(type="text", text="\n\n---\n\n".join(sections))]
 
 
 __all__ = ["TOOLS", "handle_tool"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mureo"
-version = "0.9.18"
+version = "0.9.19"
 description = "Your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/tests/test_insight_federation.py
+++ b/tests/test_insight_federation.py
@@ -1,0 +1,424 @@
+"""Tests for ``mureo.learning.federation``.
+
+The federation layer:
+
+- Translates an :class:`mureo.learning.insight_sources.InsightSource`
+  into a concrete MCP client session (stdio / sse / streamable-HTTP).
+- Calls the configured ``tool`` and extracts text content from the
+  response.
+- Imposes a per-source timeout so a slow / dead remote does not stall
+  the diagnostic flow.
+- Isolates per-source failures: a single timeout / network error /
+  malformed response logs a warning and yields ``None`` for that
+  source, never raising into the caller.
+
+We do not stand up real MCP servers in the test suite — that would
+require subprocess plumbing and would be slow. Instead we patch the
+small set of SDK seams the federation layer touches (``ClientSession``,
+``stdio_client``, ``sse_client``, ``streamablehttp_client``) and
+verify that the right helper is selected per transport, that the
+right tool name is called, and that the right text is extracted.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _make_mock_tool_result(text: str) -> Any:
+    """Build a mock ``CallToolResult`` carrying a single text block.
+
+    The federation layer only reads ``result.content[*].text`` (when
+    ``type == "text"``), so we can get away with a minimal mock that
+    pins just those attributes.
+    """
+    block = MagicMock()
+    block.type = "text"
+    block.text = text
+    result = MagicMock()
+    result.isError = False
+    result.content = [block]
+    return result
+
+
+@asynccontextmanager
+async def _fake_session_factory(tool_result: Any):
+    """Yield a mock ``ClientSession`` whose ``call_tool`` returns
+    ``tool_result``.
+
+    Used by the patched ``ClientSession`` to short-circuit the real
+    transport handshake.
+    """
+    session = MagicMock()
+    session.initialize = AsyncMock()
+    session.call_tool = AsyncMock(return_value=tool_result)
+    yield session
+
+
+@asynccontextmanager
+async def _fake_transport_streams():
+    """Yield (read, write) streams the real transport context managers
+    would. The federation layer just forwards them into
+    ``ClientSession``, which we are also patching, so they can be
+    sentinel objects."""
+    yield (object(), object())
+
+
+@pytest.fixture
+def stdio_source() -> Any:
+    from mureo.learning.insight_sources import InsightSource
+
+    return InsightSource(
+        name="acme",
+        transport="stdio",
+        tool="insights_get",
+        command="acme-insights-mcp",
+    )
+
+
+@pytest.fixture
+def sse_source() -> Any:
+    from mureo.learning.insight_sources import InsightSource
+
+    return InsightSource(
+        name="benchmarks",
+        transport="sse",
+        tool="benchmarks_get",
+        url="https://benchmarks.example/mcp",
+        headers={"Authorization": "Bearer xyz"},
+    )
+
+
+@pytest.fixture
+def http_source() -> Any:
+    from mureo.learning.insight_sources import InsightSource
+
+    return InsightSource(
+        name="kb",
+        transport="http",
+        tool="insights_get",
+        url="https://kb.example/mcp",
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestFetchFromSource:
+    async def test_stdio_source_uses_stdio_client_helper(
+        self, stdio_source: Any
+    ) -> None:
+        from mureo.learning import federation
+
+        with (
+            patch.object(federation, "stdio_client") as mock_stdio,
+            patch.object(federation, "sse_client") as mock_sse,
+            patch.object(federation, "streamablehttp_client") as mock_http,
+            patch.object(
+                federation,
+                "_open_session",
+                return_value=_fake_session_factory(
+                    _make_mock_tool_result("## Insight A\n")
+                ),
+            ),
+        ):
+            mock_stdio.return_value = _fake_transport_streams()
+            text = await federation.fetch_from_source(stdio_source)
+
+        # ``_extract_text`` strips trailing whitespace from each
+        # block; the source text had a trailing newline that is
+        # normalised out so the agent sees a clean single section.
+        assert text == "## Insight A"
+        # Only the stdio helper is dispatched.
+        mock_sse.assert_not_called()
+        mock_http.assert_not_called()
+
+    async def test_sse_source_uses_sse_client_helper(self, sse_source: Any) -> None:
+        from mureo.learning import federation
+
+        with (
+            patch.object(federation, "stdio_client") as mock_stdio,
+            patch.object(federation, "sse_client") as mock_sse,
+            patch.object(federation, "streamablehttp_client") as mock_http,
+            patch.object(
+                federation,
+                "_open_session",
+                return_value=_fake_session_factory(
+                    _make_mock_tool_result("## Industry benchmarks\n")
+                ),
+            ),
+        ):
+            mock_sse.return_value = _fake_transport_streams()
+            text = await federation.fetch_from_source(sse_source)
+
+        assert text == "## Industry benchmarks"
+        mock_stdio.assert_not_called()
+        mock_http.assert_not_called()
+
+    async def test_http_source_uses_streamable_http_client_helper(
+        self, http_source: Any
+    ) -> None:
+        from mureo.learning import federation
+
+        with (
+            patch.object(federation, "stdio_client") as mock_stdio,
+            patch.object(federation, "sse_client") as mock_sse,
+            patch.object(federation, "streamablehttp_client") as mock_http,
+            patch.object(
+                federation,
+                "_open_session",
+                return_value=_fake_session_factory(_make_mock_tool_result("## KB\n")),
+            ),
+        ):
+            mock_http.return_value = _fake_transport_streams()
+            text = await federation.fetch_from_source(http_source)
+
+        assert text == "## KB"
+        mock_stdio.assert_not_called()
+        mock_sse.assert_not_called()
+
+    async def test_call_tool_uses_configured_tool_name(self, stdio_source: Any) -> None:
+        """The ``tool`` field on the source picks the remote tool name;
+        the federation layer must NOT hardcode a name."""
+        from mureo.learning import federation
+
+        captured: dict[str, Any] = {}
+
+        @asynccontextmanager
+        async def capturing_session():
+            session = MagicMock()
+            session.initialize = AsyncMock()
+
+            async def fake_call_tool(name: str, *args: Any, **kw: Any) -> Any:
+                captured["name"] = name
+                return _make_mock_tool_result("ok")
+
+            session.call_tool = fake_call_tool
+            yield session
+
+        with (
+            patch.object(federation, "stdio_client") as mock_stdio,
+            patch.object(federation, "_open_session", return_value=capturing_session()),
+        ):
+            mock_stdio.return_value = _fake_transport_streams()
+            await federation.fetch_from_source(stdio_source)
+
+        assert captured["name"] == "insights_get"
+
+    async def test_text_is_concatenated_across_multiple_text_blocks(
+        self, stdio_source: Any
+    ) -> None:
+        """A remote tool can return its insights split across several
+        text blocks; we concatenate them with a single newline so the
+        agent sees them as one section."""
+        from mureo.learning import federation
+
+        block_a, block_b = MagicMock(), MagicMock()
+        block_a.type = "text"
+        block_a.text = "## Block A\n"
+        block_b.type = "text"
+        # No trailing newline — the rstrip-then-join policy produces
+        # the same output regardless, which is the whole point.
+        block_b.text = "## Block B"
+        multi = MagicMock()
+        multi.isError = False
+        multi.content = [block_a, block_b]
+
+        with (
+            patch.object(federation, "stdio_client") as mock_stdio,
+            patch.object(
+                federation,
+                "_open_session",
+                return_value=_fake_session_factory(multi),
+            ),
+        ):
+            mock_stdio.return_value = _fake_transport_streams()
+            text = await federation.fetch_from_source(stdio_source)
+
+        assert text == "## Block A\n\n## Block B"
+
+    async def test_non_text_content_blocks_are_skipped(self, stdio_source: Any) -> None:
+        """Image / resource blocks aren't useful as Markdown insights —
+        they get dropped silently rather than rendered as ``[image]``
+        placeholders that would pollute the agent's context."""
+        from mureo.learning import federation
+
+        text_block, image_block = MagicMock(), MagicMock()
+        text_block.type = "text"
+        text_block.text = "real insight"
+        image_block.type = "image"
+        mixed = MagicMock()
+        mixed.isError = False
+        mixed.content = [text_block, image_block]
+
+        with (
+            patch.object(federation, "stdio_client") as mock_stdio,
+            patch.object(
+                federation,
+                "_open_session",
+                return_value=_fake_session_factory(mixed),
+            ),
+        ):
+            mock_stdio.return_value = _fake_transport_streams()
+            text = await federation.fetch_from_source(stdio_source)
+
+        assert text == "real insight"
+
+    async def test_error_response_returns_none(self, stdio_source: Any) -> None:
+        """``CallToolResult.isError`` set by the remote tool itself
+        (the SDK's structured error path) should not raise — we just
+        skip the source with a warning, same as any other failure."""
+        from mureo.learning import federation
+
+        error_result = MagicMock()
+        error_result.isError = True
+        error_result.content = []
+
+        with (
+            patch.object(federation, "stdio_client") as mock_stdio,
+            patch.object(
+                federation,
+                "_open_session",
+                return_value=_fake_session_factory(error_result),
+            ),
+        ):
+            mock_stdio.return_value = _fake_transport_streams()
+            text = await federation.fetch_from_source(stdio_source)
+
+        assert text is None
+
+    async def test_exception_during_fetch_returns_none(self, stdio_source: Any) -> None:
+        """Network exceptions / subprocess crashes must be swallowed
+        per source — a dead Acme MCP server should not block the
+        operator's local insights from reaching the agent."""
+        from mureo.learning import federation
+
+        @asynccontextmanager
+        async def boom_session():
+            session = MagicMock()
+            session.initialize = AsyncMock()
+            session.call_tool = AsyncMock(
+                side_effect=RuntimeError("connection refused")
+            )
+            yield session
+
+        with (
+            patch.object(federation, "stdio_client") as mock_stdio,
+            patch.object(federation, "_open_session", return_value=boom_session()),
+        ):
+            mock_stdio.return_value = _fake_transport_streams()
+            text = await federation.fetch_from_source(stdio_source)
+
+        assert text is None
+
+    async def test_timeout_returns_none(self, stdio_source: Any) -> None:
+        """A source that exceeds ``timeout_sec`` is dropped, not
+        awaited indefinitely."""
+        import asyncio
+
+        from mureo.learning import federation
+        from mureo.learning.insight_sources import InsightSource
+
+        slow_source = InsightSource(
+            name="slow",
+            transport="stdio",
+            tool="insights_get",
+            command="slow-mcp",
+            timeout_sec=0.05,
+        )
+
+        @asynccontextmanager
+        async def stalling_session():
+            session = MagicMock()
+            session.initialize = AsyncMock()
+
+            async def slow_call(*args: Any, **kw: Any) -> Any:
+                await asyncio.sleep(1.0)
+                return _make_mock_tool_result("late")
+
+            session.call_tool = slow_call
+            yield session
+
+        with (
+            patch.object(federation, "stdio_client") as mock_stdio,
+            patch.object(federation, "_open_session", return_value=stalling_session()),
+        ):
+            mock_stdio.return_value = _fake_transport_streams()
+            text = await federation.fetch_from_source(slow_source)
+
+        assert text is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestFetchAll:
+    async def test_fetch_all_returns_dict_keyed_by_source_name(self) -> None:
+        from mureo.learning import federation
+        from mureo.learning.insight_sources import InsightSource
+
+        a = InsightSource(name="a", transport="stdio", tool="t", command="c")
+        b = InsightSource(name="b", transport="stdio", tool="t", command="c")
+
+        async def fake_fetch(src: Any) -> str:
+            return f"insight from {src.name}"
+
+        with patch.object(federation, "fetch_from_source", side_effect=fake_fetch):
+            result = await federation.fetch_all((a, b))
+
+        assert result == {"a": "insight from a", "b": "insight from b"}
+
+    async def test_fetch_all_isolates_per_source_failures(self) -> None:
+        """One source failing or returning ``None`` must not block
+        others. The returned dict only contains sources that produced
+        usable text."""
+        from mureo.learning import federation
+        from mureo.learning.insight_sources import InsightSource
+
+        good = InsightSource(name="good", transport="stdio", tool="t", command="c")
+        bad = InsightSource(name="bad", transport="stdio", tool="t", command="c")
+
+        async def fake_fetch(src: Any) -> str | None:
+            if src.name == "good":
+                return "good insight"
+            return None  # simulated failure
+
+        with patch.object(federation, "fetch_from_source", side_effect=fake_fetch):
+            result = await federation.fetch_all((good, bad))
+
+        assert result == {"good": "good insight"}
+
+    async def test_fetch_all_runs_sources_concurrently(self) -> None:
+        """Sources fan out via ``asyncio.gather`` so total wall-time
+        is bounded by the slowest source, not their sum."""
+        import asyncio
+
+        from mureo.learning import federation
+        from mureo.learning.insight_sources import InsightSource
+
+        sources = tuple(
+            InsightSource(name=f"s{i}", transport="stdio", tool="t", command="c")
+            for i in range(5)
+        )
+
+        async def slow_fetch(src: Any) -> str:
+            await asyncio.sleep(0.1)
+            return src.name
+
+        import time
+
+        start = time.monotonic()
+        with patch.object(federation, "fetch_from_source", side_effect=slow_fetch):
+            await federation.fetch_all(sources)
+        elapsed = time.monotonic() - start
+
+        # Sequential would be 0.5s; concurrent should be ~0.1-0.15s.
+        assert elapsed < 0.4
+
+    async def test_fetch_all_empty_sources_returns_empty_dict(self) -> None:
+        from mureo.learning import federation
+
+        result = await federation.fetch_all(())
+        assert result == {}

--- a/tests/test_insight_sources_config.py
+++ b/tests/test_insight_sources_config.py
@@ -1,0 +1,245 @@
+"""Tests for ``mureo.learning.insight_sources``.
+
+The config module owns the shape of ``~/.mureo/insight_sources.json``:
+an immutable :class:`InsightSourceConfig` (the top-level document) plus
+:class:`InsightSource` entries describing each external MCP server.
+
+The parser:
+
+- Tolerates a missing config file (returns the empty document).
+- Tolerates an empty / malformed file with a logger warning (returns
+  the empty document) so a misconfigured operator does not block the
+  ``mureo_learning_insights_get`` tool entirely.
+- Refuses unknown ``transport`` values at parse time so a typo blows
+  up loudly rather than failing later on the network.
+- Pins the defaults for optional fields (``timeout_sec`` default,
+  empty ``env`` / ``headers`` / ``args``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.unit
+class TestInsightSourceModel:
+    def test_stdio_source_minimal_required_fields(self) -> None:
+        from mureo.learning.insight_sources import InsightSource
+
+        src = InsightSource(
+            name="acme",
+            transport="stdio",
+            tool="insights_get",
+            command="acme-insights-mcp",
+        )
+        assert src.name == "acme"
+        assert src.transport == "stdio"
+        assert src.tool == "insights_get"
+        assert src.command == "acme-insights-mcp"
+        # Defaults
+        assert src.args == ()
+        assert src.env == {}
+        assert src.timeout_sec == 10.0
+        assert src.url is None
+        assert src.headers == {}
+
+    def test_sse_source_minimal_required_fields(self) -> None:
+        from mureo.learning.insight_sources import InsightSource
+
+        src = InsightSource(
+            name="benchmarks",
+            transport="sse",
+            tool="benchmarks_get",
+            url="https://benchmarks.example/mcp",
+        )
+        assert src.transport == "sse"
+        assert src.url == "https://benchmarks.example/mcp"
+        assert src.command is None
+
+    def test_source_is_frozen(self) -> None:
+        from mureo.learning.insight_sources import InsightSource
+
+        src = InsightSource(
+            name="a",
+            transport="stdio",
+            tool="t",
+            command="c",
+        )
+        with pytest.raises(FrozenInstanceError):
+            src.name = "b"  # type: ignore[misc]
+
+    def test_stdio_source_without_command_raises(self) -> None:
+        """``stdio`` transport requires a ``command``; a missing
+        command at construction time should fail loudly, not silently
+        produce a half-built source we'd try to spawn later."""
+        from mureo.learning.insight_sources import InsightSource
+
+        with pytest.raises(ValueError, match="command"):
+            InsightSource(name="a", transport="stdio", tool="t")
+
+    def test_sse_source_without_url_raises(self) -> None:
+        from mureo.learning.insight_sources import InsightSource
+
+        with pytest.raises(ValueError, match="url"):
+            InsightSource(name="a", transport="sse", tool="t")
+
+    def test_http_transport_accepted(self) -> None:
+        """``http`` is an alias for the MCP streamable-HTTP transport
+        — same shape as ``sse`` (URL + headers) but a different SDK
+        helper handles it. We accept it at the config layer so future
+        federation work can route on the value."""
+        from mureo.learning.insight_sources import InsightSource
+
+        src = InsightSource(
+            name="kb",
+            transport="http",
+            tool="insights_get",
+            url="https://kb.example/mcp",
+        )
+        assert src.transport == "http"
+
+    def test_unknown_transport_raises(self) -> None:
+        """An unknown transport value blocks construction so a typo
+        in the JSON file surfaces at parse time, not at fetch time."""
+        from mureo.learning.insight_sources import InsightSource
+
+        with pytest.raises(ValueError, match="transport"):
+            InsightSource(
+                name="a",
+                transport="ftp",  # type: ignore[arg-type]
+                tool="t",
+                command="c",
+            )
+
+
+@pytest.mark.unit
+class TestLoadConfig:
+    def test_missing_file_returns_empty_config(self, tmp_path: Path) -> None:
+        from mureo.learning.insight_sources import load_insight_sources
+
+        cfg = load_insight_sources(tmp_path / "does-not-exist.json")
+        assert cfg.sources == ()
+
+    def test_empty_sources_array_returns_empty_config(self, tmp_path: Path) -> None:
+        from mureo.learning.insight_sources import load_insight_sources
+
+        path = tmp_path / "insight_sources.json"
+        path.write_text('{"sources": []}', encoding="utf-8")
+        cfg = load_insight_sources(path)
+        assert cfg.sources == ()
+
+    def test_parses_mixed_transports(self, tmp_path: Path) -> None:
+        from mureo.learning.insight_sources import load_insight_sources
+
+        path = tmp_path / "insight_sources.json"
+        path.write_text(
+            """
+            {
+              "sources": [
+                {
+                  "name": "acme",
+                  "transport": "stdio",
+                  "tool": "insights_get",
+                  "command": "acme-insights-mcp",
+                  "args": ["--scope", "google-ads"],
+                  "env": {"ACME_API_KEY": "secret"},
+                  "timeout_sec": 5.0
+                },
+                {
+                  "name": "benchmarks",
+                  "transport": "sse",
+                  "tool": "benchmarks_get",
+                  "url": "https://benchmarks.example/mcp",
+                  "headers": {"Authorization": "Bearer xyz"}
+                }
+              ]
+            }
+            """,
+            encoding="utf-8",
+        )
+        cfg = load_insight_sources(path)
+        assert len(cfg.sources) == 2
+
+        acme, benchmarks = cfg.sources
+        assert acme.name == "acme"
+        assert acme.transport == "stdio"
+        assert acme.command == "acme-insights-mcp"
+        assert acme.args == ("--scope", "google-ads")
+        assert acme.env == {"ACME_API_KEY": "secret"}
+        assert acme.timeout_sec == 5.0
+
+        assert benchmarks.transport == "sse"
+        assert benchmarks.url == "https://benchmarks.example/mcp"
+        assert benchmarks.headers == {"Authorization": "Bearer xyz"}
+
+    def test_malformed_json_returns_empty_config_with_warning(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A broken file should not block the diagnostic flow — log a
+        warning that points the operator at the path, then return
+        the empty document so :func:`mureo_learning_insights_get`
+        still surfaces local insights."""
+        import logging
+
+        from mureo.learning.insight_sources import load_insight_sources
+
+        path = tmp_path / "insight_sources.json"
+        path.write_text("{this is not json", encoding="utf-8")
+
+        with caplog.at_level(logging.WARNING, logger="mureo.learning.insight_sources"):
+            cfg = load_insight_sources(path)
+
+        assert cfg.sources == ()
+        # The operator should see the path in the log so they can fix it.
+        assert any(str(path) in rec.getMessage() for rec in caplog.records)
+
+    def test_invalid_source_entry_skipped_and_logged(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """One bad entry should not block valid sibling sources — log
+        the bad one, return the valid ones."""
+        import logging
+
+        from mureo.learning.insight_sources import load_insight_sources
+
+        path = tmp_path / "insight_sources.json"
+        path.write_text(
+            """
+            {
+              "sources": [
+                {
+                  "name": "good",
+                  "transport": "stdio",
+                  "tool": "insights_get",
+                  "command": "good-mcp"
+                },
+                {
+                  "name": "bad",
+                  "transport": "stdio",
+                  "tool": "insights_get"
+                }
+              ]
+            }
+            """,
+            encoding="utf-8",
+        )
+        with caplog.at_level(logging.WARNING, logger="mureo.learning.insight_sources"):
+            cfg = load_insight_sources(path)
+
+        assert [s.name for s in cfg.sources] == ["good"]
+        assert any("bad" in rec.getMessage() for rec in caplog.records)
+
+    def test_default_config_path_resolution(self) -> None:
+        """The default path is ``~/.mureo/insight_sources.json`` so
+        operators do not have to learn yet another location."""
+        from mureo.learning.insight_sources import default_config_path
+
+        path = default_config_path()
+        assert path == Path.home() / ".mureo" / "insight_sources.json"

--- a/tests/test_mcp_tools_learning.py
+++ b/tests/test_mcp_tools_learning.py
@@ -21,6 +21,7 @@ These tests pin three things:
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -166,8 +167,7 @@ diagnostic workflow.
         # scaffold-only — guards against a regression where the
         # derived marker drifts and starts catching everything.
         insight = (
-            "### Use micro-conversions when CV is sparse\n\n"
-            "**Situation:** ...\n"
+            "### Use micro-conversions when CV is sparse\n\n" "**Situation:** ...\n"
         )
         assert _is_scaffold_only(_OPERATOR_SCAFFOLD + insight) is False
 
@@ -179,6 +179,186 @@ diagnostic workflow.
         mod = _import_learning_tools()
         with pytest.raises(ValueError, match="Unknown tool"):
             await mod.handle_tool("not_a_real_tool", {})
+
+
+@pytest.mark.unit
+class TestLearningInsightsHandlerAggregation:
+    """The handler merges local insights with external sources loaded
+    via :mod:`mureo.learning.federation`. Local always comes first
+    (operator's own ``/learn`` history is canonical); each external
+    source becomes a labelled section after a horizontal rule."""
+
+    @pytest.mark.asyncio
+    async def test_local_only_when_no_external_sources(self) -> None:
+        from mureo.learning.insight_sources import InsightSourceConfig
+
+        mod = _import_learning_tools()
+        fake_store = MagicMock()
+        fake_store.read_operator_knowledge.return_value = (
+            "## Learned Insights\n\n### Local lesson\n"
+        )
+        fake_ctx = MagicMock(knowledge_store=fake_store)
+        with (
+            patch(
+                "mureo.mcp.tools_learning.get_runtime_context",
+                return_value=fake_ctx,
+            ),
+            patch(
+                "mureo.mcp.tools_learning.load_insight_sources",
+                return_value=InsightSourceConfig(sources=()),
+            ),
+        ):
+            result = await mod.handle_tool("mureo_learning_insights_get", {})
+
+        assert len(result) == 1
+        assert "Local lesson" in result[0].text
+        # No external sources → no horizontal rule separator.
+        assert "---" not in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_external_sources_appended_after_local(self) -> None:
+        from mureo.learning.insight_sources import (
+            InsightSource,
+            InsightSourceConfig,
+        )
+
+        mod = _import_learning_tools()
+        fake_store = MagicMock()
+        fake_store.read_operator_knowledge.return_value = (
+            "## Learned Insights\n\n### Local lesson\n"
+        )
+        fake_ctx = MagicMock(knowledge_store=fake_store)
+        sources = (
+            InsightSource(name="acme", transport="stdio", tool="t", command="c"),
+            InsightSource(
+                name="benchmarks", transport="sse", tool="t", url="https://x"
+            ),
+        )
+
+        async def fake_fetch_all(srcs: Any) -> dict[str, str]:
+            return {
+                "acme": "## Acme consulting insight",
+                "benchmarks": "## Industry benchmark",
+            }
+
+        with (
+            patch(
+                "mureo.mcp.tools_learning.get_runtime_context",
+                return_value=fake_ctx,
+            ),
+            patch(
+                "mureo.mcp.tools_learning.load_insight_sources",
+                return_value=InsightSourceConfig(sources=sources),
+            ),
+            patch(
+                "mureo.mcp.tools_learning.fetch_all",
+                side_effect=fake_fetch_all,
+            ),
+        ):
+            result = await mod.handle_tool("mureo_learning_insights_get", {})
+
+        text = result[0].text
+        local_idx = text.index("Local lesson")
+        acme_idx = text.index("Acme consulting insight")
+        bench_idx = text.index("Industry benchmark")
+        assert local_idx < acme_idx < bench_idx
+        # External sections labelled with their name.
+        assert "## acme" in text
+        assert "## benchmarks" in text
+        # Horizontal rule separator between sections.
+        assert "---" in text
+
+    @pytest.mark.asyncio
+    async def test_external_only_when_local_empty(self) -> None:
+        """If the operator has no local /learn entries but does have
+        external sources configured, return just the external
+        sections — no guidance message, since the agent does have
+        insights to consult."""
+        from mureo.learning.insight_sources import (
+            InsightSource,
+            InsightSourceConfig,
+        )
+
+        mod = _import_learning_tools()
+        fake_store = MagicMock()
+        fake_store.read_operator_knowledge.return_value = ""
+        fake_ctx = MagicMock(knowledge_store=fake_store)
+
+        async def fake_fetch_all(srcs: Any) -> dict[str, str]:
+            return {"acme": "## Acme insight"}
+
+        with (
+            patch(
+                "mureo.mcp.tools_learning.get_runtime_context",
+                return_value=fake_ctx,
+            ),
+            patch(
+                "mureo.mcp.tools_learning.load_insight_sources",
+                return_value=InsightSourceConfig(
+                    sources=(
+                        InsightSource(
+                            name="acme",
+                            transport="stdio",
+                            tool="t",
+                            command="c",
+                        ),
+                    ),
+                ),
+            ),
+            patch(
+                "mureo.mcp.tools_learning.fetch_all",
+                side_effect=fake_fetch_all,
+            ),
+        ):
+            result = await mod.handle_tool("mureo_learning_insights_get", {})
+
+        text = result[0].text
+        assert "Acme insight" in text
+        assert "no insights" not in text.lower()
+
+    @pytest.mark.asyncio
+    async def test_all_empty_returns_guidance(self) -> None:
+        """Local empty + every external source failed (returned None
+        and was dropped by ``fetch_all``) → guidance message."""
+        from mureo.learning.insight_sources import (
+            InsightSource,
+            InsightSourceConfig,
+        )
+
+        mod = _import_learning_tools()
+        fake_store = MagicMock()
+        fake_store.read_operator_knowledge.return_value = ""
+        fake_ctx = MagicMock(knowledge_store=fake_store)
+
+        async def fake_fetch_all(srcs: Any) -> dict[str, str]:
+            return {}  # all sources failed
+
+        with (
+            patch(
+                "mureo.mcp.tools_learning.get_runtime_context",
+                return_value=fake_ctx,
+            ),
+            patch(
+                "mureo.mcp.tools_learning.load_insight_sources",
+                return_value=InsightSourceConfig(
+                    sources=(
+                        InsightSource(
+                            name="dead",
+                            transport="stdio",
+                            tool="t",
+                            command="c",
+                        ),
+                    ),
+                ),
+            ),
+            patch(
+                "mureo.mcp.tools_learning.fetch_all",
+                side_effect=fake_fetch_all,
+            ),
+        ):
+            result = await mod.handle_tool("mureo_learning_insights_get", {})
+
+        assert "no insights" in result[0].text.lower()
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

Closes #163 (part 2 of 2 of umbrella #161 — /learn knowledge consumption + external MCP federation). Bumps version 0.9.18 → 0.9.19.

v0.9.18 closed the `/learn` read-side gap with the local `mureo_learning_insights_get` tool. This PR extends that tool so mureo aggregates insights from **external MCP servers** alongside the operator's local `/learn` history. Anyone can run an MCP server that publishes practitioner know-how — consulting cos, industry trade groups, OSS communities, internal team wikis — and mureo will surface it to every diagnostic skill without changing the tool's public shape.

## What changes

### Config schema

Operators declare external sources in `~/.mureo/insight_sources.json`:

```json
{
  "sources": [
    {
      "name": "acme",
      "transport": "stdio",
      "command": "acme-insights-mcp",
      "args": ["--scope", "google-ads"],
      "env": {"ACME_API_KEY": "..."},
      "tool": "insights_get",
      "timeout_sec": 10
    },
    {
      "name": "benchmarks",
      "transport": "sse",
      "url": "https://benchmarks.example/mcp",
      "headers": {"Authorization": "Bearer ..."},
      "tool": "benchmarks_get"
    }
  ]
}
```

Three transports supported: `stdio` (subprocess; the mcp SDK's `stdio_client`), `sse` (`sse_client`), and `http` (`streamablehttp_client`).

### Per-source error isolation

A single misbehaving source (slow, crashed, malformed response, network error) NEVER blocks the diagnostic flow. Per-source timeouts (default 10s) cap each call via `asyncio.wait_for`; failures yield `None` for that source and the others continue. Sources fan out via `asyncio.gather` so total wall-time is bounded by the slowest, not the sum.

| failure                              | mureo's response                                  |
|--------------------------------------|---------------------------------------------------|
| config missing / malformed JSON      | empty config + WARNING; local insights only       |
| one entry has wrong shape            | skip + WARNING; siblings continue                 |
| duplicate `name` across entries      | keep the first; skip subsequent + WARNING         |
| source exceeds `timeout_sec`         | drop + WARNING; siblings continue                 |
| network / subprocess error           | drop + WARNING; siblings continue                 |
| `tools/call` returns `isError`       | drop + WARNING; siblings continue                 |
| response has no text content         | drop + WARNING; siblings continue                 |

### Aggregator update

The handler `_handle_learning_insights_get`:

1. Reads local via `KnowledgeStore.read_operator_knowledge()` (unchanged from v0.9.18).
2. Loads config + fans out to external sources via `fetch_all`.
3. Local goes first prefixed `## Local /learn history (authoritative)`; each external source becomes `## <name> (advisory)`. Sections separated by horizontal rules (`---`). The authoritative/advisory split gives the agent a clear precedence hint.

If both local and every external source produced no content, the v0.9.18 guidance message is returned unchanged.

### No tool-shape change

`mureo_learning_insights_get` still takes no arguments and returns a single `TextContent` — existing v0.9.18 skill prompts (the "Before you start" paragraph in 7 diagnostic skills) work unchanged. Federation happens behind the `KnowledgeStore` Protocol, so an alternate runtime context factory wrapping a remote-fetch backend (PR A's exit point) keeps working without modifications.

### Files changed

- `mureo/learning/__init__.py` (NEW) — subpackage init.
- `mureo/learning/insight_sources.py` (NEW) — frozen-dataclass `InsightSource` / `InsightSourceConfig` + tolerant JSON parser + `default_config_path` resolving `~/.mureo/insight_sources.json`. Per-source validation in `__post_init__`. Every error path returns the empty config + WARNING so a misconfigured file never blocks local insights.
- `mureo/learning/federation.py` (NEW) — `_open_session` (transport dispatcher: stdio / sse / streamable-http via mcp SDK), `fetch_from_source` (`asyncio.wait_for` timeout + `Exception`-only catch so `CancelledError` propagates), `fetch_all` (`asyncio.gather` concurrent fan-out, returns dict keyed by source name).
- `mureo/mcp/tools_learning.py` — handler now aggregates local + external with authoritative/advisory labels.
- `tests/test_insight_sources_config.py` (NEW) — 13 tests pinning model validation, parse tolerance, duplicate-name dedup.
- `tests/test_insight_federation.py` (NEW) — 13 tests pinning transport dispatch (stdio/sse/http use the right SDK helper), text extraction (single block / multi-block strip-then-join / non-text skip), error/exception/timeout → None, fetch_all aggregation + isolation + concurrent fan-out + empty.
- `tests/test_mcp_tools_learning.py` — 4 new tests in `TestLearningInsightsHandlerAggregation` (local-only / external appended / external-only when local empty / all-empty returns guidance).
- `docs/insight-federation.md` (NEW) — operator setup guide plus a "Writing a federation-friendly MCP server" section so a third party can stand up a Python or TypeScript MCP server in under 20 lines.
- `CHANGELOG.md` — 0.9.19 entry.
- `pyproject.toml`, `mureo/__init__.py`, `.claude-plugin/plugin.json` — version 0.9.18 → 0.9.19.

## Test plan

- [x] 40 new tests pass (config 13 + federation 13 + tools_learning 4 + the 10 pre-existing local-only tests in `tests/test_mcp_tools_learning.py`).
- [x] Full suite 3716 passed (excluding 3 pre-existing dev-env entry-point pollution failures that also fail on `main`).
- [x] `black --check mureo/` clean.
- [x] `ruff check` clean on all modified files.
- [x] Two-round code review APPROVED (`code-reviewer` agent). Round 1 raised 1 HIGH (unreachable transport branch needs comment) + 5 MEDIUM (`dict() or None` fragility, redundant double-timeout, `_extract_text` join fragile to trailing-newline presence, missing `Any` import in tests, `CancelledError` comment) + 5 LOW (log format, duplicate-name docs, chmod 600 docs, authoritative/advisory hint, `get_event_loop` deprecation). Every flagged item is reflected.
- [ ] CI green.

## Backward compatibility

Purely additive. No tool-shape change, no signature changes, no removed surface. Existing operators without `~/.mureo/insight_sources.json` get exactly the v0.9.18 behaviour (local-only). The aggregator's "authoritative" prefix on local content is a visual change in the markdown the agent sees, but the section content itself is unchanged.

## Security model

External sources are treated as **untrusted advisory content**. The text is forwarded to the agent as Markdown but never executed; no `tools/call` from the external server reaches mureo's own tool surface. The single residual prompt-injection vector is generic ("a malicious source ships text that says 'ignore prior instructions'") — same risk as any retrieval. The "authoritative / advisory" labelling helps the agent frame external content correctly.

For stdio sources, `env` keys are passed to the subprocess so secrets don't bleed into shell history. For sse/http sources, `headers` are forwarded as supplied. Operators are responsible for `chmod 600 ~/.mureo/insight_sources.json` if it carries secrets — documented in `docs/insight-federation.md`.

## What this enables

| Use case | Example |
|---|---|
| Consulting cos publish know-how as a server | `mureo` clients install once, every diagnostic flow benefits |
| Industry trade groups serve benchmark deltas | agent calibrates recommendations against cohort baselines |
| OSS community pools `/learn` history | shared insight MCP that aggregates contributors' lessons |
| Enterprise teams wrap internal wikis | small MCP shim over Notion / SharePoint / Confluence |

The MCP server can be written in **any language** — Python, TypeScript, Go, Rust — as long as it implements the MCP protocol. mureo's federation is purely on the wire.
