### PR TITLE
feat(core): add PolicyGate extension point for third-party pre-dispatch policy hooks (0.9.23)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mureo",
-  "version": "0.9.22",
+  "version": "0.9.23",
   "description": "Your local-first AI ad ops crew for Google Ads, Meta Ads, Search Console & GA4. mureo sits on top of the official ad-platform MCPs, gates every change against your strategy, correlates outcomes locally, and keeps an auditable decision log — credentials never leave your machine.",
   "author": {
     "name": "Logly Inc.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,63 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.23] - 2026-05-31
+
+### Added — `mureo.core.policy.PolicyGate` extension point + `mureo.policy_gates` entry-point group
+
+mureo OSS gains a small generic policy-gate extension point. Third-party packages (for example `mureo-agency`, which is building a paid read-only mode that blocks ad-platform mutations) can register a `PolicyGate` implementation against the new `mureo.policy_gates` entry-point group, and mureo's MCP server consults every registered gate before dispatching each tool call. mureo OSS itself ships **zero gates**, so the default behaviour is byte-identical to v0.9.22 — every call dispatches normally with zero policy overhead.
+
+The OSS surface is intentionally tiny: a `PolicyGate` Protocol, a `PolicyDecision` frozen dataclass, and the dispatcher integration. The policy logic — what to allow, what to block, how to detect read-only-safe tools on external MCPs, the bundled catalog of safe tools per provider, the CLI surface, the `~/.mureo/config.json` schema — all lives outside OSS, in the third-party package. This keeps mureo focused on being the orchestration layer and lets commercial / agency extensions differentiate without forking.
+
+**New module `mureo/core/policy.py`**
+
+```python
+from typing import Any, Protocol, runtime_checkable
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class PolicyDecision:
+    allowed: bool
+    reason: str = ""  # surfaced verbatim to the agent when allowed=False
+
+@runtime_checkable
+class PolicyGate(Protocol):
+    def evaluate(
+        self, tool_name: str, arguments: dict[str, Any]
+    ) -> PolicyDecision: ...
+```
+
+**Registration via the entry-point group `mureo.policy_gates`**
+
+```toml
+[project.entry-points."mureo.policy_gates"]
+read_only = "mureo_agency.policy:ReadOnlyGate"
+```
+
+**Dispatcher integration in `mureo/mcp/server.py`**
+
+`handle_call_tool` calls `_evaluate_policy_gates(name, arguments)` before any per-family dispatch. The helper iterates every registered gate; if any returns `allowed=False`, the dispatcher returns a `TextContent` refusal that surfaces the gate's `reason` verbatim to the agent and the per-family handler is never invoked. If a gate raises any `Exception`, the dispatcher treats it as **abstain** (allow this gate; consult the next one) and logs a WARNING — a broken third-party gate cannot take mureo offline. Subsequent gates are still consulted, so a deny from a later gate still blocks the call.
+
+`_load_policy_gates` is called per dispatch rather than cached at module-import time so a (rare) at-runtime install/uninstall of a third-party gate is picked up without a server restart. `importlib.metadata.entry_points` is itself cached internally, so the per-call cost is microseconds. Per-entry-point exception isolation: a broken third-party package (partial install, import error) drops with a WARNING and the rest still load.
+
+**ABI stability**
+
+`docs/ABI-stability.md` §6 adds the fourth entry-point group (`mureo.policy_gates`) alongside the existing `mureo.providers` / `mureo.skills` / `mureo.analytics` groups. mureo MAY add fields to `PolicyDecision` over time but MUST NOT remove or rename existing ones; third-party gates SHOULD construct `PolicyDecision` with keyword arguments only.
+
+**Tests (13 new in `tests/test_policy_gate.py`)**
+
+- Protocol + dataclass shape pins (`PolicyDecision` frozen, default `reason` empty, `PolicyGate` runtime-checkable, non-gate objects fail the protocol check).
+- Dispatcher integration: no gates → dispatched as today; single allowing gate → dispatched; single denying gate → refused with reason surfaced; two gates any deny → refused; gate exception isolated and logged; subsequent gate after one raises still consulted.
+- Entry-point discovery: no entry points → empty tuple; entry point returning a gate class → instantiated and isinstance-checked against the Protocol; entry-point load failure isolated with WARNING.
+
+**What this enables**
+
+The matching `mureo-agency` issue ([logly/mureo-agency#6](https://github.com/logly/mureo-agency/issues/6)) builds the actual read-only mode on top of this hook: a `ReadOnlyGate` for mureo's own MCP tool surface (using the existing `mureo.mcp.plugin_semantics.derive_semantics` to identify mutating calls, with `rollback_apply` / `rollback_plan_get` exempted), a bundled catalog of read-only tools for four initial providers (Google Ads / Meta Ads / GA4 / Amazon Ads official MCPs), a `PreToolUse` Claude Code hook that screens calls to *external* MCPs (since mureo cannot intercept those from its own dispatcher), and the `mureo-agency readonly enable/disable/status` CLI. Detection on external MCPs prefers the MCP `annotations.readOnlyHint` standard field over name heuristics, falling back to the bundled catalog and then to a user override file; unknown tools are refused fail-closed.
+
+OSS users who do not install `mureo-agency` see no behaviour change.
+
+Closes [#174](https://github.com/logly/mureo/issues/174).
+
 ## [0.9.22] - 2026-05-30
 
 ### Docs — drift fixes after v0.9.18–v0.9.21 (no code path or schema changes)

--- a/docs/ABI-stability.md
+++ b/docs/ABI-stability.md
@@ -318,19 +318,57 @@ boundary. This is permanent.
 
 ## 6. Entry-point group names
 
-Three group names are part of the ABI:
+Four group names are part of the ABI:
 
 | Constant | Value | Iterated by |
 |---|---|---|
 | `PROVIDERS_ENTRY_POINT_GROUP` | `"mureo.providers"` | `Registry.discover` |
 | `SKILLS_ENTRY_POINT_GROUP` | `"mureo.skills"` | `discover_skills` |
 | `ANALYTICS_ENTRY_POINT_GROUP` | `"mureo.analytics"` | `AnalyticsRegistry.discover` |
+| (literal) | `"mureo.policy_gates"` | `mureo.mcp.server._load_policy_gates` |
 
 `PROVIDERS_…` / `SKILLS_…` are exported from
 `mureo.core.providers.registry` (re-exported from
 `mureo.core.skills`); `ANALYTICS_…` is exported from
-`mureo.analytics`. Renaming any of these groups is a breaking
-change — every plugin's `pyproject.toml` would have to change.
+`mureo.analytics`. The `mureo.policy_gates` literal is documented
+here (no exported constant) because policy gates are loaded by the
+MCP server itself rather than by a third-party-facing registry.
+Renaming any of these groups is a breaking change — every plugin's
+`pyproject.toml` would have to change.
+
+### `mureo.policy_gates` (added in v0.9.23)
+
+Third-party packages register a `PolicyGate` implementation against
+this group to participate in mureo's pre-dispatch policy chain. The
+contract:
+
+- `mureo.core.policy.PolicyGate` Protocol (`runtime_checkable`,
+  single method `evaluate(tool_name, arguments) -> PolicyDecision`).
+- `mureo.core.policy.PolicyDecision` frozen dataclass
+  (`allowed: bool`, `reason: str = ""`).
+- The MCP server consults every registered gate before dispatching
+  each tool call. If any gate returns `allowed=False`, the call is
+  refused and the reason surfaces verbatim to the agent. A gate
+  that raises any `Exception` is treated as **abstain** (allow this
+  gate; consult the next) and logged at WARNING — a broken
+  third-party gate cannot take mureo offline.
+- mureo MAY add fields to `PolicyDecision` over time but MUST NOT
+  remove or rename existing ones. Implementations SHOULD construct
+  it with keyword arguments only.
+- Gate evaluation order is **unspecified**; gates MUST NOT depend
+  on each other or on a particular ordering — any single deny
+  blocks the call regardless of position in the chain.
+- A buggy gate that returns any type other than `PolicyDecision`
+  (e.g. `None`, `True`, a tuple) is treated as **abstain** + logged
+  WARNING, identical to the per-call exception isolation. This
+  keeps a buggy third-party gate from taking mureo offline.
+- The dispatcher's refusal payload deliberately echoes the tool
+  name and the gate's `reason` but **not** the `arguments` dict —
+  arguments routinely contain account IDs, budget figures, or
+  credentials, and the agent already has them. Do not put secrets
+  in `reason`; that is the only field surfaced.
+- The default behaviour with zero gates registered is byte-
+  identical to v0.9.22: every call dispatches normally.
 
 The three groups are independent: a package may register against any
 subset (provider only, analytics only, both, etc.) — the discovery

--- a/mureo/__init__.py
+++ b/mureo/__init__.py
@@ -1,3 +1,3 @@
 """mureo — your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."""
 
-__version__ = "0.9.22"
+__version__ = "0.9.23"

--- a/mureo/core/policy.py
+++ b/mureo/core/policy.py
@@ -1,0 +1,141 @@
+"""Policy-gate extension point for mureo's MCP tool dispatch.
+
+Constants exported:
+- :data:`POLICY_GATES_ENTRY_POINT_GROUP` — the entry-point group name
+  (``"mureo.policy_gates"``). Exposed for symmetry with the existing
+  ``PROVIDERS_ENTRY_POINT_GROUP`` etc.
+
+
+
+mureo OSS itself ships zero gates — the dispatcher consults gates
+registered by third-party packages via the ``mureo.policy_gates``
+entry-point group. The default behaviour (no gates installed) is
+byte-identical to v0.9.22: every tool call dispatches normally with
+zero policy overhead.
+
+This module exists so that third-party packages (for example
+``mureo-agency``, which builds a read-only mode for ad-platform
+mutations) can plug their policy logic into mureo without forking
+the dispatcher. mureo's job is to define the contract and call the
+gates; the policy itself stays out of OSS.
+
+Stable ABI (1.x):
+- :class:`PolicyGate` Protocol — the contract a third-party gate
+  must satisfy.
+- :class:`PolicyDecision` frozen dataclass — the return shape.
+- ``mureo.policy_gates`` entry-point group — registration mechanism.
+
+mureo MAY add fields to :class:`PolicyDecision` over time but MUST
+NOT remove or rename existing ones. Third-party gates SHOULD
+construct ``PolicyDecision`` with keyword arguments only.
+
+Per-gate evaluation rules enforced by the dispatcher (in
+:func:`mureo.mcp.server.handle_call_tool`):
+
+- Every registered gate is evaluated on every tool call, in
+  entry-point discovery order.
+- If any gate returns ``allowed=False``, the tool call is refused
+  and the gate's ``reason`` surfaces verbatim to the agent as a
+  TextContent error.
+- If a gate raises any ``Exception``, the dispatcher treats the
+  gate as **abstain** (i.e. allow this gate; consult the next one)
+  and logs a WARNING. A broken third-party gate MUST NOT take
+  mureo offline. Subsequent gates are still consulted, so a deny
+  from a later gate still blocks the call.
+
+Implementations MUST be pure and fast — ``evaluate`` runs on every
+tool call. Cache any expensive lookup (file reads, network calls)
+behind a TTL inside the implementation itself; the dispatcher does
+no caching.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol, runtime_checkable
+
+#: The entry-point group name third-party packages register against.
+#: Renaming this string is a breaking change — every plugin's
+#: ``pyproject.toml`` would have to change. See
+#: ``docs/ABI-stability.md`` §6.
+POLICY_GATES_ENTRY_POINT_GROUP = "mureo.policy_gates"
+
+
+@dataclass(frozen=True)
+class PolicyDecision:
+    """Outcome of a single :meth:`PolicyGate.evaluate` call.
+
+    Attributes:
+        allowed: ``True`` to let the call proceed (this gate
+            abstains from blocking it); ``False`` to refuse.
+        reason: Human-readable explanation surfaced to the agent
+            verbatim when ``allowed`` is ``False``. Required to be
+            meaningful when denying — an empty reason makes the
+            refusal opaque to the operator-side LLM.
+    """
+
+    allowed: bool
+    reason: str = ""
+
+
+@runtime_checkable
+class PolicyGate(Protocol):
+    """Pre-dispatch policy hook for mureo's MCP tool surface.
+
+    A third-party package registers an implementation via the
+    ``mureo.policy_gates`` entry-point group::
+
+        [project.entry-points."mureo.policy_gates"]
+        read_only = "mureo_agency.policy:ReadOnlyGate"
+
+    mureo's dispatcher consults all registered gates before
+    dispatching each tool call. See the module docstring for the
+    evaluation rules.
+
+    **Lifecycle**: the dispatcher instantiates the gate class fresh
+    on every dispatch (one ``cls()`` call per tool call). Instance
+    attributes therefore do NOT persist across calls. If you need
+    cross-call caching (e.g. a TTL'd re-read of
+    ``~/.mureo/config.json``), put the cache on a class attribute
+    or a module-level singleton — instance state is ephemeral.
+
+    **Async**: the v1 contract is synchronous by design. A future
+    Protocol for asynchronous gates may be added under a separate
+    name; gates that need to await network I/O are out of scope for
+    ``mureo.policy_gates`` in 0.9.x.
+
+    **Evaluation order**: the order in which gates are consulted is
+    *unspecified* — gates MUST NOT depend on each other or on a
+    particular ordering. Any single deny blocks the call regardless
+    of position.
+    """
+
+    def evaluate(self, tool_name: str, arguments: dict[str, Any]) -> PolicyDecision:
+        """Decide whether ``tool_name`` (called with ``arguments``)
+        should be allowed.
+
+        MUST return a :class:`PolicyDecision` instance. Returning any
+        other type (``None``, ``True``, a tuple, etc.) is treated by
+        the dispatcher as a buggy gate and the gate is **abstained
+        with a WARNING** — the call proceeds as if the gate had
+        returned ``PolicyDecision(allowed=True)``.
+
+        MUST NOT have side effects beyond local caching. MUST NOT
+        raise — if the gate cannot decide, return
+        ``PolicyDecision(allowed=True)`` to abstain rather than
+        raising, so the dispatcher does not log it as a broken gate.
+
+        ``reason`` (when denying) is surfaced to the operator-side
+        agent verbatim. Do NOT include credentials, account IDs, or
+        anything else sensitive in ``reason``; the dispatcher itself
+        deliberately does NOT echo the ``arguments`` dict in the
+        refusal payload to avoid the same leak.
+        """
+        ...
+
+
+__all__ = [
+    "POLICY_GATES_ENTRY_POINT_GROUP",
+    "PolicyDecision",
+    "PolicyGate",
+]

--- a/mureo/mcp/server.py
+++ b/mureo/mcp/server.py
@@ -38,6 +38,7 @@ from mcp.server.stdio import stdio_server
 if TYPE_CHECKING:
     from mcp.types import Tool
 
+    from mureo.core.policy import PolicyDecision, PolicyGate
     from mureo.mcp.tool_provider import MCPToolProvider
 
 from mureo.mcp.plugin_audit import record_plugin_call
@@ -267,12 +268,132 @@ async def handle_list_tools() -> list[Any]:
     return list(_ALL_TOOLS)
 
 
+def _policy_gate_entry_points() -> tuple[Any, ...]:
+    """Return the entry points registered under
+    ``mureo.policy_gates``. Isolated so the unit tests can patch this
+    without monkeypatching ``importlib.metadata``."""
+    from importlib.metadata import entry_points
+
+    from mureo.core.policy import POLICY_GATES_ENTRY_POINT_GROUP
+
+    try:
+        eps = entry_points(group=POLICY_GATES_ENTRY_POINT_GROUP)
+    except Exception as exc:  # noqa: BLE001
+        # importlib.metadata blowing up is rare but possible on weird
+        # environments (unusual install layout, corrupted metadata).
+        # Log so operators have a signal rather than silently treating
+        # the situation as "no gates registered".
+        logger.warning(
+            "policy gates: importlib.metadata.entry_points failed (%s); "
+            "treating as zero gates registered",
+            exc,
+        )
+        return ()
+    return tuple(eps)
+
+
+def _load_policy_gates() -> tuple[PolicyGate, ...]:
+    """Load and instantiate every gate declared under the
+    ``mureo.policy_gates`` entry-point group.
+
+    Per-entry-point exception isolation: a broken third-party
+    package (partial install, import error) MUST NOT take mureo
+    offline. The failing entry is dropped with a WARNING and the
+    rest still load.
+    """
+    gates: list[PolicyGate] = []
+    for ep in _policy_gate_entry_points():
+        try:
+            cls = ep.load()
+            instance = cls()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "policy gate '%s' failed to load (%s); skipping",
+                getattr(ep, "name", "?"),
+                exc,
+            )
+            continue
+        gates.append(instance)
+    return tuple(gates)
+
+
+def _evaluate_policy_gates(
+    name: str, arguments: dict[str, Any]
+) -> PolicyDecision | None:
+    """Run every registered gate. Returns the first deny decision, or
+    ``None`` if every gate allowed (or abstained on exception).
+
+    Calls :func:`_load_policy_gates` on every dispatch rather than
+    caching at module-import time so a (rare) at-runtime
+    install/uninstall of a third-party gate is picked up without a
+    server restart. ``importlib.metadata.entry_points`` is itself
+    cached internally, so the per-call cost is microseconds.
+    """
+    # Lazy-imported so the type is available for the isinstance guard
+    # without re-introducing the runtime import at module top (it lives
+    # under TYPE_CHECKING for the rest of this module).
+    from mureo.core.policy import PolicyDecision as _PolicyDecision
+
+    for gate in _load_policy_gates():
+        try:
+            decision = gate.evaluate(name, arguments)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "policy gate %r raised on '%s' (%s); abstain",
+                type(gate).__name__,
+                name,
+                exc,
+            )
+            continue
+        # Protocol violation guard: a buggy gate that returns None /
+        # True / a tuple / dict / etc. would crash the dispatcher
+        # downstream (AttributeError on `.allowed` or `.reason`).
+        # Treat any non-PolicyDecision return as a buggy abstain so
+        # one broken gate cannot take mureo offline — the exact same
+        # discipline as the per-call exception isolation above.
+        if not isinstance(decision, _PolicyDecision):
+            logger.warning(
+                "policy gate %r returned %r (not PolicyDecision) on '%s'; " "abstain",
+                type(gate).__name__,
+                type(decision).__name__,
+                name,
+            )
+            continue
+        if not decision.allowed:
+            return decision
+    return None
+
+
+def _refuse_text_content(name: str, decision: PolicyDecision) -> list[Any]:
+    """Build the TextContent payload returned to the agent when a
+    policy gate refuses a tool call. Kept here so the message format
+    has one source of truth.
+    """
+    from mcp.types import TextContent
+
+    reason = decision.reason.strip() or "(no reason provided by the policy gate)"
+    body = (
+        f"Tool call refused by policy gate.\n"
+        f"  Tool: {name}\n"
+        f"  Reason: {reason}\n"
+    )
+    return [TextContent(type="text", text=body)]
+
+
 async def handle_call_tool(name: str, arguments: dict[str, Any]) -> list[Any]:
     """Execute a tool and return the result.
+
+    Before dispatch, every gate registered under the
+    ``mureo.policy_gates`` entry-point group is consulted. If any
+    gate denies the call, a TextContent refusal is returned and the
+    handler is never invoked. See :mod:`mureo.core.policy`.
 
     Raises:
         ValueError: Unknown tool name or missing required parameter
     """
+    decision = _evaluate_policy_gates(name, arguments)
+    if decision is not None:
+        return _refuse_text_content(name, decision)
     if name in _GOOGLE_ADS_NAMES:
         return await handle_google_ads_tool(name, arguments)
     if name in _META_ADS_NAMES:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mureo"
-version = "0.9.22"
+version = "0.9.23"
 description = "Your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/tests/test_policy_gate.py
+++ b/tests/test_policy_gate.py
@@ -1,0 +1,319 @@
+"""Tests for the ``mureo.core.policy`` extension point (v0.9.23).
+
+The OSS surface is intentionally tiny: a PolicyGate Protocol, a
+PolicyDecision dataclass, and the dispatcher integration that
+consults gates registered via the ``mureo.policy_gates`` entry-point
+group. mureo OSS itself ships zero gates — third-party packages
+(e.g. mureo-agency) supply the policy logic. These tests pin:
+
+1. The Protocol + dataclass shape are stable.
+2. The dispatcher consults gates AFTER name resolution but BEFORE
+   dispatching to the handler.
+3. Per-gate exception isolation — a broken gate must not break
+   mureo; the gate is treated as "abstain" (allow) and the call
+   continues.
+4. Refuse messages surface the gate's ``reason`` to the agent.
+5. Default behaviour (no gates registered) is byte-identical to
+   v0.9.22 — zero overhead, every call dispatches.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mureo.core.policy import PolicyDecision, PolicyGate
+
+# ---------------------------------------------------------------------------
+# Type-level pins
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestPolicyGateProtocol:
+    def test_policy_decision_is_frozen(self) -> None:
+        from dataclasses import FrozenInstanceError
+
+        decision = PolicyDecision(allowed=True)
+        with pytest.raises(FrozenInstanceError):
+            decision.allowed = False  # type: ignore[misc]
+
+    def test_policy_decision_default_reason_is_empty(self) -> None:
+        assert PolicyDecision(allowed=True).reason == ""
+
+    def test_policy_gate_is_runtime_checkable(self) -> None:
+        class _MyGate:
+            def evaluate(
+                self, tool_name: str, arguments: dict[str, Any]
+            ) -> PolicyDecision:
+                return PolicyDecision(allowed=True)
+
+        assert isinstance(_MyGate(), PolicyGate)
+
+    def test_non_gate_object_fails_protocol_check(self) -> None:
+        class _NotAGate:
+            pass
+
+        assert not isinstance(_NotAGate(), PolicyGate)
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher integration — uses mureo.mcp.server.handle_call_tool
+# ---------------------------------------------------------------------------
+
+
+def _make_gate(decision: PolicyDecision) -> MagicMock:
+    gate = MagicMock(spec=PolicyGate)
+    gate.evaluate.return_value = decision
+    return gate
+
+
+def _make_raising_gate(exc: Exception) -> MagicMock:
+    gate = MagicMock(spec=PolicyGate)
+    gate.evaluate.side_effect = exc
+    return gate
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestDispatcherGateIntegration:
+    """Pin that ``mureo.mcp.server.handle_call_tool`` consults gates
+    before dispatching, with the right ordering and isolation
+    semantics."""
+
+    async def test_no_gates_registered_dispatches_as_today(self) -> None:
+        from mureo.mcp.server import handle_call_tool
+
+        fake_handler = AsyncMock(return_value=[MagicMock(text="result")])
+        with (
+            patch("mureo.mcp.server._load_policy_gates", return_value=()),
+            patch("mureo.mcp.server.handle_rollback_tool", new=fake_handler),
+        ):
+            result = await handle_call_tool("rollback_plan_get", {})
+        fake_handler.assert_awaited_once()
+        assert result[0].text == "result"
+
+    async def test_single_allowing_gate_dispatches(self) -> None:
+        from mureo.mcp.server import handle_call_tool
+
+        gate = _make_gate(PolicyDecision(allowed=True))
+        fake_handler = AsyncMock(return_value=[MagicMock(text="result")])
+        with (
+            patch("mureo.mcp.server._load_policy_gates", return_value=(gate,)),
+            patch("mureo.mcp.server.handle_rollback_tool", new=fake_handler),
+        ):
+            result = await handle_call_tool("rollback_plan_get", {"k": "v"})
+        gate.evaluate.assert_called_once_with("rollback_plan_get", {"k": "v"})
+        fake_handler.assert_awaited_once()
+        assert result[0].text == "result"
+
+    async def test_denying_gate_refuses_and_surfaces_reason(self) -> None:
+        from mureo.mcp.server import handle_call_tool
+
+        gate = _make_gate(
+            PolicyDecision(allowed=False, reason="read-only mode is active")
+        )
+        fake_handler = AsyncMock()
+        with (
+            patch("mureo.mcp.server._load_policy_gates", return_value=(gate,)),
+            patch("mureo.mcp.server.handle_rollback_tool", new=fake_handler),
+        ):
+            result = await handle_call_tool("rollback_plan_get", {})
+        fake_handler.assert_not_awaited()
+        text = result[0].text
+        assert "rollback_plan_get" in text
+        assert "read-only mode is active" in text
+        assert "refused" in text.lower() or "denied" in text.lower()
+
+    async def test_two_gates_any_deny_blocks(self) -> None:
+        from mureo.mcp.server import handle_call_tool
+
+        gate_allow = _make_gate(PolicyDecision(allowed=True))
+        gate_deny = _make_gate(PolicyDecision(allowed=False, reason="nope"))
+        fake_handler = AsyncMock()
+        with (
+            patch(
+                "mureo.mcp.server._load_policy_gates",
+                return_value=(gate_allow, gate_deny),
+            ),
+            patch("mureo.mcp.server.handle_rollback_tool", new=fake_handler),
+        ):
+            result = await handle_call_tool("rollback_plan_get", {})
+        fake_handler.assert_not_awaited()
+        assert "nope" in result[0].text
+
+    async def test_gate_exception_is_isolated_and_logged(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A broken third-party gate MUST NOT break mureo. The gate
+        is treated as 'abstain' (allow) and the failure is logged so
+        an operator can diagnose it."""
+        from mureo.mcp.server import handle_call_tool
+
+        broken = _make_raising_gate(RuntimeError("gate import explode"))
+        fake_handler = AsyncMock(return_value=[MagicMock(text="result")])
+        with (
+            patch("mureo.mcp.server._load_policy_gates", return_value=(broken,)),
+            patch("mureo.mcp.server.handle_rollback_tool", new=fake_handler),
+            caplog.at_level(logging.WARNING, logger="mureo.mcp.server"),
+        ):
+            result = await handle_call_tool("rollback_plan_get", {})
+        fake_handler.assert_awaited_once()
+        assert result[0].text == "result"
+        assert any(
+            "gate" in r.message.lower() and "abstain" in r.message.lower()
+            for r in caplog.records
+        )
+
+    @pytest.mark.parametrize(
+        "bad_return",
+        [None, True, False, "deny", ("deny", "x"), {"allowed": False}, 42],
+        ids=["none", "true", "false", "string", "tuple", "dict", "int"],
+    )
+    async def test_non_policy_decision_return_is_abstain(
+        self,
+        bad_return: Any,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A buggy gate that returns something other than
+        :class:`PolicyDecision` MUST be treated as abstain (allow) +
+        WARNING, not crash the dispatcher. Critical because a returned
+        ``False`` would otherwise propagate to ``_refuse_text_content``
+        and AttributeError there with no surrounding try/except."""
+        from mureo.mcp.server import handle_call_tool
+
+        gate = MagicMock(spec=PolicyGate)
+        gate.evaluate.return_value = bad_return
+        fake_handler = AsyncMock(return_value=[MagicMock(text="result")])
+        with (
+            patch("mureo.mcp.server._load_policy_gates", return_value=(gate,)),
+            patch("mureo.mcp.server.handle_rollback_tool", new=fake_handler),
+            caplog.at_level(logging.WARNING, logger="mureo.mcp.server"),
+        ):
+            result = await handle_call_tool("rollback_plan_get", {})
+        fake_handler.assert_awaited_once()
+        assert result[0].text == "result"
+        assert any(
+            "not PolicyDecision" in r.message or "abstain" in r.message.lower()
+            for r in caplog.records
+        )
+
+    async def test_refusal_does_not_echo_arguments(self) -> None:
+        """The refusal payload sent to the agent MUST NOT echo the
+        ``arguments`` dict. Arguments routinely contain account IDs,
+        budget figures, and (for some plugin tools) credentials or
+        tokens. The gate author controls ``reason``; the dispatcher
+        controls what surrounds it. Pin that the surrounding text
+        carries name + reason only."""
+        from mureo.mcp.server import handle_call_tool
+
+        sentinel_key = "sentinel_arg_key"
+        sentinel_value = "sentinel_arg_value_must_not_leak"
+        gate = _make_gate(PolicyDecision(allowed=False, reason="denied"))
+        fake_handler = AsyncMock()
+        with (
+            patch("mureo.mcp.server._load_policy_gates", return_value=(gate,)),
+            patch("mureo.mcp.server.handle_rollback_tool", new=fake_handler),
+        ):
+            result = await handle_call_tool(
+                "rollback_plan_get",
+                {sentinel_key: sentinel_value},
+            )
+        text = result[0].text
+        assert sentinel_key not in text
+        assert sentinel_value not in text
+
+    async def test_other_gate_still_consulted_after_one_raises(self) -> None:
+        """After one gate raises, the dispatcher must continue to the
+        next gate rather than short-circuiting. A subsequent gate's
+        deny still blocks."""
+        from mureo.mcp.server import handle_call_tool
+
+        broken = _make_raising_gate(RuntimeError("boom"))
+        denier = _make_gate(PolicyDecision(allowed=False, reason="still denied"))
+        fake_handler = AsyncMock()
+        with (
+            patch(
+                "mureo.mcp.server._load_policy_gates",
+                return_value=(broken, denier),
+            ),
+            patch("mureo.mcp.server.handle_rollback_tool", new=fake_handler),
+        ):
+            result = await handle_call_tool("rollback_plan_get", {})
+        fake_handler.assert_not_awaited()
+        assert "still denied" in result[0].text
+
+
+# ---------------------------------------------------------------------------
+# Entry-point discovery
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestPolicyGateEntryPointDiscovery:
+    def test_no_entry_points_returns_empty_tuple(self) -> None:
+        """With no third-party packages installed, the discovery
+        helper returns an empty tuple (zero overhead in the
+        dispatcher)."""
+        from mureo.mcp.server import _load_policy_gates
+
+        with patch(
+            "mureo.mcp.server._policy_gate_entry_points",
+            return_value=(),
+        ):
+            assert _load_policy_gates() == ()
+
+    def test_entry_point_returning_gate_instance_is_collected(self) -> None:
+        from mureo.mcp.server import _load_policy_gates
+
+        class _Gate:
+            def evaluate(
+                self, tool_name: str, arguments: dict[str, Any]
+            ) -> PolicyDecision:
+                return PolicyDecision(allowed=True)
+
+        fake_ep = MagicMock()
+        fake_ep.name = "test_gate"
+        fake_ep.load.return_value = _Gate
+        with patch(
+            "mureo.mcp.server._policy_gate_entry_points",
+            return_value=(fake_ep,),
+        ):
+            gates = _load_policy_gates()
+        assert len(gates) == 1
+        assert isinstance(gates[0], PolicyGate)
+
+    def test_entry_point_load_failure_is_isolated(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """If a third-party entry point fails to load (e.g. import
+        error from a partial install), other gates must still load."""
+        from mureo.mcp.server import _load_policy_gates
+
+        class _Gate:
+            def evaluate(
+                self, tool_name: str, arguments: dict[str, Any]
+            ) -> PolicyDecision:
+                return PolicyDecision(allowed=True)
+
+        broken_ep = MagicMock()
+        broken_ep.name = "broken"
+        broken_ep.load.side_effect = ImportError("partial install")
+        good_ep = MagicMock()
+        good_ep.name = "good"
+        good_ep.load.return_value = _Gate
+        with (
+            patch(
+                "mureo.mcp.server._policy_gate_entry_points",
+                return_value=(broken_ep, good_ep),
+            ),
+            caplog.at_level(logging.WARNING, logger="mureo.mcp.server"),
+        ):
+            gates = _load_policy_gates()
+        assert len(gates) == 1
+        assert any("broken" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

Closes #174. Bumps version 0.9.22 → 0.9.23.

mureo OSS gains a small generic policy-gate extension point. Third-party packages (for example `mureo-agency`, which is building a paid read-only mode that blocks ad-platform mutations — see [logly/mureo-agency#6](https://github.com/logly/mureo-agency/issues/6)) can register a `PolicyGate` implementation against the new `mureo.policy_gates` entry-point group, and mureo's MCP server consults every registered gate before dispatching each tool call. **mureo OSS itself ships zero gates**, so the default behaviour is byte-identical to v0.9.22 — every call dispatches normally with zero policy overhead.

The OSS surface is intentionally tiny: a Protocol, a frozen dataclass, an entry-point group, and the dispatcher integration. The actual policy logic (what to allow / block, bundled catalog, CLI surface, config-file schema) lives outside OSS so commercial / agency extensions differentiate without forking.

## What changes

### New module `mureo/core/policy.py`

```python
@dataclass(frozen=True)
class PolicyDecision:
    allowed: bool
    reason: str = ""  # surfaced verbatim to the agent when allowed=False

@runtime_checkable
class PolicyGate(Protocol):
    def evaluate(
        self, tool_name: str, arguments: dict[str, Any]
    ) -> PolicyDecision: ...

POLICY_GATES_ENTRY_POINT_GROUP = "mureo.policy_gates"
```

### Registration via entry-point group `mureo.policy_gates`

```toml
[project.entry-points."mureo.policy_gates"]
read_only = "mureo_agency.policy:ReadOnlyGate"
```

### Dispatcher integration (`mureo/mcp/server.py`)

`handle_call_tool` calls `_evaluate_policy_gates(name, arguments)` before any per-family dispatch. If any gate returns `allowed=False`, a `TextContent` refusal is returned and the per-family handler is never invoked.

### Three layers of fault isolation

| Layer | Failure mode | Behaviour |
|---|---|---|
| `_policy_gate_entry_points` | `importlib.metadata.entry_points` raises | logs WARNING, returns empty tuple |
| `_load_policy_gates` | `ep.load()` or `cls()` raises | logs WARNING, skips that gate, continues |
| `_evaluate_policy_gates` | `gate.evaluate(...)` raises **OR** returns non-`PolicyDecision` | logs WARNING, abstains (allow this gate), continues to next gate |

The non-`PolicyDecision` `isinstance` guard was added in round 2 to address a HIGH from round-1 code review: a buggy gate returning `False` would have crashed `_refuse_text_content` downstream with no surrounding try/except.

### Per-call cost

`_load_policy_gates` is called per dispatch rather than cached at module-import time so a (rare) at-runtime install / uninstall of a third-party gate is picked up without a server restart. `importlib.metadata.entry_points` is itself cached internally, so the per-call cost is microseconds. Each gate is instantiated fresh per call — implementors needing TTL caches should put state on class or module level (documented explicitly in `PolicyGate` docstring).

### Refusal payload security

The dispatcher's refusal payload deliberately echoes the tool name and the gate's `reason` but **not** the `arguments` dict — arguments routinely contain account IDs, budget figures, or credentials, and the agent already has them. Pinned by `test_refusal_does_not_echo_arguments` with sentinel key/value.

### ABI stability declaration

`docs/ABI-stability.md` §6 expanded from 3 to 4 entry-point groups; the full contract for `mureo.policy_gates` documented: stability promise (MAY add fields to `PolicyDecision`, MUST NOT remove or rename existing ones; SHOULD use kwargs); evaluation order unspecified; buggy-return discipline; refusal-payload boundary; zero-gates byte-identical default.

### Files changed

- `mureo/core/policy.py` (NEW, ~70 lines)
- `mureo/mcp/server.py` — added 4 helpers (`_policy_gate_entry_points`, `_load_policy_gates`, `_evaluate_policy_gates`, `_refuse_text_content`) + 1 line at the top of `handle_call_tool`. TYPE_CHECKING imports for the Protocol/dataclass.
- `tests/test_policy_gate.py` (NEW, 21 tests)
- `docs/ABI-stability.md` — §6 expansion
- `CHANGELOG.md` — 0.9.23 entry
- `pyproject.toml`, `mureo/__init__.py`, `.claude-plugin/plugin.json` — version 0.9.22 → 0.9.23

## What this enables (cross-repo)

The matching `mureo-agency` issue ([logly/mureo-agency#6](https://github.com/logly/mureo-agency/issues/6)) builds the actual read-only mode on top of this hook:

- A `ReadOnlyGate` for mureo's own MCP tool surface (using existing `mureo.mcp.plugin_semantics.derive_semantics` to identify mutating calls, with `rollback_apply` / `rollback_plan_get` exempted).
- A bundled catalog of read-only tools for four initial providers (Google Ads / Meta Ads / GA4 / Amazon Ads official MCPs).
- A `PreToolUse` Claude Code hook that screens calls to external MCPs (since mureo cannot intercept those from its own dispatcher).
- The `mureo-agency readonly enable / disable / status` CLI.

OSS users who do not install `mureo-agency` see no behaviour change.

## Test plan

- [x] 21 new tests in `tests/test_policy_gate.py` pass.
- [x] Full suite 3815 passed (excluding the 3 pre-existing dev-env entry-point pollution failures that also fail on `main`).
- [x] `black --check` clean.
- [x] `ruff check` clean.
- [x] Two-round code review APPROVED (`code-reviewer` agent). Round 1 raised 1 HIGH (non-`PolicyDecision` return values crashing dispatcher) + 5 MEDIUM + LOW. All seven addressed in round 2 (some as code, some as docstring strengthening for contract-defining items). Round 2 APPROVED with no new blockers.
- [ ] CI green.

## Backward compatibility

Purely additive. OSS ships zero gates; with no third-party `mureo.policy_gates` entries the dispatcher's added code path is `_load_policy_gates()` returning `()` and the for-loop short-circuiting. Microsecond-level overhead. Existing tool dispatch flows unchanged.
