### PR TITLE
feat(cli): mureo upgrade [--all] — bulk upgrade for pipx-installed mureo + plugins

### DIFF
--- a/mureo/cli/main.py
+++ b/mureo/cli/main.py
@@ -17,6 +17,7 @@ from mureo.cli.learn_cmd import learn_app
 from mureo.cli.providers_cmd import providers_app
 from mureo.cli.rollback_cmd import rollback_app
 from mureo.cli.setup_cmd import setup_app
+from mureo.cli.upgrade_cmd import upgrade_app
 
 app = typer.Typer(
     name="mureo",
@@ -33,6 +34,7 @@ app.add_typer(demo_app)
 app.add_typer(providers_app)
 app.add_typer(configure_app)
 app.add_typer(learn_app)
+app.add_typer(upgrade_app)
 
 if __name__ == "__main__":
     app()

--- a/mureo/cli/upgrade_cmd.py
+++ b/mureo/cli/upgrade_cmd.py
@@ -1,0 +1,266 @@
+"""`mureo upgrade` — pipx venv-aware bulk upgrade for mureo + its plugins.
+
+Solves the UX gap documented in issue #177: when mureo is installed via
+``pipx install mureo`` and third-party packages are added via
+``pipx inject`` / ``pip install`` into the same venv (typically through
+the ``mureo.providers`` / ``mureo.policy_gates`` entry-point groups),
+neither ``pipx upgrade mureo`` (only upgrades the primary) nor
+``pipx upgrade <plugin>`` (the plugin has no same-named venv) gives the
+operator a single, memorable command for keeping the whole stack fresh.
+
+Design contract
+---------------
+
+- The target venv is the one running this CLI, so ``sys.executable`` is
+  authoritative — independent of ``cwd``, ``PATH``, and ``PYTHONPATH``.
+- ``--all`` discovers same-venv packages via
+  ``importlib.metadata.distributions()``, PEP 503 normalises each name,
+  and accepts only ``mureo`` exact match or ``mureo-<rest>``. This
+  excludes prefix squatters such as ``mureology`` or ``mureoextras``.
+- Operator-supplied package specs are validated with a strict PEP 503
+  regex (optionally followed by a single ``==<version>`` pin) before
+  being passed to pip. ``--``  is then inserted as a sentinel so pip's
+  option parser cannot reinterpret a hostile target as a flag.
+- ``python -m pip --version`` is probed first. Only the specific failure
+  mode "No module named pip" triggers an ``ensurepip --upgrade``
+  bootstrap; every other pip failure is surfaced verbatim so we do not
+  silently bypass permission / network errors.
+- pip's stdout / stderr is streamed straight through to the terminal
+  (no capture) so progress and error context reach the operator.
+- pip's exit code is propagated as the CLI exit code, enabling
+  automation scripts to retry / branch on the result.
+"""
+
+from __future__ import annotations
+
+import re
+import shlex
+import subprocess
+import sys
+from importlib import metadata
+
+import typer
+
+upgrade_app = typer.Typer(
+    name="upgrade",
+    help=(
+        "Upgrade mureo and its plugins in the current pipx venv. "
+        "Use `--all` to upgrade every installed `mureo-*` together."
+    ),
+    invoke_without_command=True,
+)
+
+# PEP 503: lowercase, separators normalised to '-'.
+_NORMALIZE_RE = re.compile(r"[-_.]+")
+
+# Accept either ``name`` or ``name==version``. Names are PEP 503 canonical
+# form only (lowercase letters, digits, ``-``), and version uses the
+# minimum subset that pip will accept without further interpretation
+# (digits, dots, letters, ``+``, ``-``). Anything else — extras, markers,
+# URLs, options — is refused at the boundary.
+_PACKAGE_SPEC_RE = re.compile(
+    r"^[a-z0-9]+(?:-[a-z0-9]+)*(?:==[A-Za-z0-9][A-Za-z0-9.+\-]*)?$"
+)
+
+
+def _canonicalise(name: str) -> str:
+    """Return the PEP 503 canonical form of ``name``."""
+
+    return _NORMALIZE_RE.sub("-", name).lower()
+
+
+def _is_mureo_package(name: str) -> bool:
+    """Return True iff ``name`` is ``mureo`` or ``mureo-<rest>``."""
+
+    canonical = _canonicalise(name)
+    return canonical == "mureo" or canonical.startswith("mureo-")
+
+
+def _validate_spec(spec: str) -> str:
+    """Return the canonicalised spec, or raise ``typer.BadParameter``."""
+
+    canonical = spec
+    # Lowercase only the name portion; preserve version exactly.
+    if "==" in spec:
+        name_part, _, version_part = spec.partition("==")
+        canonical = f"{_canonicalise(name_part)}=={version_part}"
+    else:
+        canonical = _canonicalise(spec)
+    if not _PACKAGE_SPEC_RE.match(canonical):
+        msg = (
+            f"Refusing to upgrade {spec!r}: package spec must match "
+            "PEP 503 name (optionally `==version`). URLs, extras, markers, "
+            "and pip options are not accepted here."
+        )
+        raise typer.BadParameter(msg)
+    return canonical
+
+
+def _discover_all_mureo_packages() -> list[str]:
+    """Return canonical names of every ``mureo`` / ``mureo-*`` dist found.
+
+    Walks ``importlib.metadata.distributions()`` and dedupes after PEP 503
+    canonicalisation. The result is deterministic: ``mureo`` first (if
+    present), then the rest sorted alphabetically.
+    """
+
+    seen: set[str] = set()
+    for dist in metadata.distributions():
+        try:
+            # ``Distribution.name`` (3.10+) routes through ``metadata`` but
+            # tolerates a few of the more common dist-info quirks. We still
+            # wrap it because a single broken dist-info in the venv must
+            # not crash ``mureo upgrade --all``.
+            name = dist.name
+        except Exception:
+            continue
+        if not name or not _is_mureo_package(name):
+            continue
+        seen.add(_canonicalise(name))
+    ordered: list[str] = []
+    if "mureo" in seen:
+        ordered.append("mureo")
+        seen.discard("mureo")
+    ordered.extend(sorted(seen))
+    return ordered
+
+
+def _pip_is_available() -> tuple[bool, str]:
+    """Return ``(ok, stderr)`` for ``python -m pip --version`` on this venv."""
+
+    proc = subprocess.run(
+        [sys.executable, "-m", "pip", "--version"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return proc.returncode == 0, proc.stderr or ""
+
+
+def _bootstrap_pip() -> int:
+    """Run ``ensurepip --upgrade``; return its exit code."""
+
+    proc = subprocess.run(
+        [sys.executable, "-m", "ensurepip", "--upgrade"],
+        check=False,
+    )
+    return proc.returncode
+
+
+def _run_pip_install(targets: list[str]) -> int:
+    """Invoke ``pip install --upgrade -- <targets>``; return exit code."""
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "pip",
+        "install",
+        "--upgrade",
+        "--",
+        *targets,
+    ]
+    proc = subprocess.run(cmd, check=False)
+    return proc.returncode
+
+
+def _resolve_targets(packages: list[str], upgrade_all: bool) -> list[str]:
+    """Compute the target list from CLI inputs."""
+
+    if upgrade_all and packages:
+        msg = "`--all` cannot be combined with explicit package names."
+        raise typer.BadParameter(msg)
+    if upgrade_all:
+        targets = _discover_all_mureo_packages()
+        if "mureo" not in targets:
+            # mureo itself must always be upgraded under --all even if its
+            # dist metadata is hidden for some reason (e.g. editable installs
+            # without dist-info, or a corrupted METADATA file). Belt-and-
+            # braces — prepend without disturbing the sorted tail.
+            targets = ["mureo", *targets]
+        return targets
+    if not packages:
+        return ["mureo"]
+    return [_validate_spec(p) for p in packages]
+
+
+@upgrade_app.callback(invoke_without_command=True)
+def upgrade(
+    packages: list[str] | None = typer.Argument(  # noqa: B008
+        None,
+        metavar="[PACKAGE]...",
+        help=(
+            "Package(s) to upgrade in the mureo venv. Defaults to `mureo` "
+            "itself. Each entry may be a bare name (`mureo-foo`) or a "
+            "pinned spec (`mureo-foo==1.2.3`)."
+        ),
+    ),
+    all_: bool = typer.Option(
+        False,
+        "--all",
+        help=(
+            "Upgrade mureo and every installed `mureo-<name>` plugin found "
+            "in the current venv (sys.executable). Prefix squatters like "
+            "`mureology` are not matched."
+        ),
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Print the pip command that would run; do not invoke pip.",
+    ),
+) -> None:
+    """Upgrade mureo and/or its plugins in the active pipx venv."""
+
+    targets = _resolve_targets(packages or [], all_)
+
+    cmd_preview = [
+        sys.executable,
+        "-m",
+        "pip",
+        "install",
+        "--upgrade",
+        "--",
+        *targets,
+    ]
+    if dry_run:
+        # shlex.join keeps the preview shell-safe and copy-pasteable —
+        # ``sys.executable`` on macOS pipx installs typically contains
+        # spaces (e.g. ``Library/Application Support/pipx/...``).
+        typer.echo(shlex.join(cmd_preview))
+        return
+
+    ok, stderr = _pip_is_available()
+    if not ok:
+        if "No module named pip" in stderr:
+            typer.echo(
+                "pip is not available in this venv — bootstrapping with "
+                "ensurepip...",
+                err=True,
+            )
+            rc = _bootstrap_pip()
+            if rc != 0:
+                typer.echo(
+                    f"ensurepip failed with exit code {rc}; aborting upgrade.",
+                    err=True,
+                )
+                raise typer.Exit(code=rc)
+            # Verify the bootstrap actually wired pip in — broken
+            # site-packages / stale ``__pycache__`` can leave the venv in a
+            # state where ensurepip succeeds but ``import pip`` still fails.
+            ok_after, stderr_after = _pip_is_available()
+            if not ok_after:
+                typer.echo(
+                    "ensurepip succeeded but `python -m pip --version` is "
+                    f"still failing:\n{stderr_after}",
+                    err=True,
+                )
+                raise typer.Exit(code=1)
+        else:
+            typer.echo(
+                f"`python -m pip --version` failed:\n{stderr}", err=True
+            )
+            raise typer.Exit(code=1)
+
+    rc = _run_pip_install(targets)
+    if rc != 0:
+        raise typer.Exit(code=rc)

--- a/mureo/cli/upgrade_cmd.py
+++ b/mureo/cli/upgrade_cmd.py
@@ -256,9 +256,7 @@ def upgrade(
                 )
                 raise typer.Exit(code=1)
         else:
-            typer.echo(
-                f"`python -m pip --version` failed:\n{stderr}", err=True
-            )
+            typer.echo(f"`python -m pip --version` failed:\n{stderr}", err=True)
             raise typer.Exit(code=1)
 
     rc = _run_pip_install(targets)

--- a/tests/test_cli_upgrade.py
+++ b/tests/test_cli_upgrade.py
@@ -71,9 +71,7 @@ def fake_distributions(monkeypatch: pytest.MonkeyPatch) -> Any:
     def _distributions() -> list[_FakeDist]:
         return state["dists"]
 
-    monkeypatch.setattr(
-        "mureo.cli.upgrade_cmd.metadata.distributions", _distributions
-    )
+    monkeypatch.setattr("mureo.cli.upgrade_cmd.metadata.distributions", _distributions)
     return _set
 
 
@@ -85,7 +83,9 @@ def fake_pip(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
     Tests override ``return_value`` or ``side_effect`` to drive scenarios.
     """
 
-    def _default(cmd: list[str], *_: Any, **__: Any) -> subprocess.CompletedProcess[str]:
+    def _default(
+        cmd: list[str], *_: Any, **__: Any
+    ) -> subprocess.CompletedProcess[str]:
         return subprocess.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
 
     mock = MagicMock(side_effect=_default)
@@ -102,9 +102,7 @@ def test_upgrade_default_upgrades_mureo_self(fake_pip: MagicMock) -> None:
     result = _runner().invoke(_app(), ["upgrade"])
 
     assert result.exit_code == 0, result.stderr
-    install_calls = [
-        c for c in fake_pip.call_args_list if "install" in c.args[0]
-    ]
+    install_calls = [c for c in fake_pip.call_args_list if "install" in c.args[0]]
     assert len(install_calls) == 1
     cmd = install_calls[0].args[0]
     assert cmd[:3] == [sys.executable, "-m", "pip"]
@@ -173,10 +171,10 @@ def test_upgrade_all_invokes_pip_once_for_atomic_resolution(
 
     _runner().invoke(_app(), ["upgrade", "--all"])
 
-    install_calls = [
-        c for c in fake_pip.call_args_list if "install" in c.args[0]
-    ]
-    assert len(install_calls) == 1, "pip must be called once so resolver sees the full set"
+    install_calls = [c for c in fake_pip.call_args_list if "install" in c.args[0]]
+    assert (
+        len(install_calls) == 1
+    ), "pip must be called once so resolver sees the full set"
 
 
 # ---------------------------------------------------------------------------
@@ -203,9 +201,7 @@ def test_upgrade_rejects_hostile_package_specs(
     result = _runner().invoke(_app(), ["upgrade", hostile])
 
     assert result.exit_code != 0
-    install_calls = [
-        c for c in fake_pip.call_args_list if "install" in c.args[0]
-    ]
+    install_calls = [c for c in fake_pip.call_args_list if "install" in c.args[0]]
     assert install_calls == [], "pip must not be invoked for hostile input"
 
 
@@ -218,9 +214,7 @@ def test_upgrade_dry_run_does_not_invoke_pip_install(fake_pip: MagicMock) -> Non
     result = _runner().invoke(_app(), ["upgrade", "--dry-run"])
 
     assert result.exit_code == 0, result.stderr
-    install_calls = [
-        c for c in fake_pip.call_args_list if "install" in c.args[0]
-    ]
+    install_calls = [c for c in fake_pip.call_args_list if "install" in c.args[0]]
     assert install_calls == []
     assert "pip" in result.stdout
     assert "install" in result.stdout
@@ -237,7 +231,9 @@ def test_upgrade_bootstraps_pip_when_missing(fake_pip: MagicMock) -> None:
     calls: list[list[str]] = []
     state = {"bootstrapped": False}
 
-    def _side_effect(cmd: list[str], *_: Any, **__: Any) -> subprocess.CompletedProcess[str]:
+    def _side_effect(
+        cmd: list[str], *_: Any, **__: Any
+    ) -> subprocess.CompletedProcess[str]:
         calls.append(cmd)
         if cmd[-2:] == ["pip", "--version"]:
             if state["bootstrapped"]:
@@ -271,7 +267,9 @@ def test_upgrade_bootstraps_pip_when_missing(fake_pip: MagicMock) -> None:
 def test_upgrade_does_not_bootstrap_on_other_pip_errors(fake_pip: MagicMock) -> None:
     calls: list[list[str]] = []
 
-    def _side_effect(cmd: list[str], *_: Any, **__: Any) -> subprocess.CompletedProcess[str]:
+    def _side_effect(
+        cmd: list[str], *_: Any, **__: Any
+    ) -> subprocess.CompletedProcess[str]:
         calls.append(cmd)
         if cmd[-2:] == ["pip", "--version"]:
             return subprocess.CompletedProcess(
@@ -297,9 +295,13 @@ def test_upgrade_does_not_bootstrap_on_other_pip_errors(fake_pip: MagicMock) -> 
 
 
 def test_upgrade_propagates_pip_exit_code(fake_pip: MagicMock) -> None:
-    def _side_effect(cmd: list[str], *_: Any, **__: Any) -> subprocess.CompletedProcess[str]:
+    def _side_effect(
+        cmd: list[str], *_: Any, **__: Any
+    ) -> subprocess.CompletedProcess[str]:
         if "install" in cmd:
-            return subprocess.CompletedProcess(cmd, returncode=42, stdout="", stderr="boom")
+            return subprocess.CompletedProcess(
+                cmd, returncode=42, stdout="", stderr="boom"
+            )
         return subprocess.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
 
     fake_pip.side_effect = _side_effect
@@ -318,9 +320,7 @@ def test_upgrade_rejects_all_with_explicit_packages(fake_pip: MagicMock) -> None
     result = _runner().invoke(_app(), ["upgrade", "--all", "mureo-foo"])
 
     assert result.exit_code != 0
-    install_calls = [
-        c for c in fake_pip.call_args_list if "install" in c.args[0]
-    ]
+    install_calls = [c for c in fake_pip.call_args_list if "install" in c.args[0]]
     assert install_calls == []
 
 
@@ -379,9 +379,7 @@ def test_upgrade_rejects_double_equals(fake_pip: MagicMock) -> None:
     result = _runner().invoke(_app(), ["upgrade", "mureo==1.0==2.0"])
 
     assert result.exit_code != 0
-    install_calls = [
-        c for c in fake_pip.call_args_list if "install" in c.args[0]
-    ]
+    install_calls = [c for c in fake_pip.call_args_list if "install" in c.args[0]]
     assert install_calls == []
 
 
@@ -395,9 +393,9 @@ def test_upgrade_always_targets_sys_executable(fake_pip: MagicMock) -> None:
 
     for call in fake_pip.call_args_list:
         cmd = call.args[0]
-        assert cmd[0] == sys.executable, (
-            f"command must start with sys.executable, got {cmd!r}"
-        )
+        assert (
+            cmd[0] == sys.executable
+        ), f"command must start with sys.executable, got {cmd!r}"
 
 
 # ---------------------------------------------------------------------------
@@ -410,7 +408,9 @@ def test_upgrade_aborts_if_pip_still_missing_after_bootstrap(
 ) -> None:
     calls: list[list[str]] = []
 
-    def _side_effect(cmd: list[str], *_: Any, **__: Any) -> subprocess.CompletedProcess[str]:
+    def _side_effect(
+        cmd: list[str], *_: Any, **__: Any
+    ) -> subprocess.CompletedProcess[str]:
         calls.append(cmd)
         if cmd[-2:] == ["pip", "--version"]:
             return subprocess.CompletedProcess(
@@ -426,19 +426,23 @@ def test_upgrade_aborts_if_pip_still_missing_after_bootstrap(
 
     assert result.exit_code != 0
     install_calls = [c for c in calls if "install" in c and "ensurepip" not in c]
-    assert install_calls == [], (
-        "must not attempt `pip install` if pip is still broken post-bootstrap"
-    )
+    assert (
+        install_calls == []
+    ), "must not attempt `pip install` if pip is still broken post-bootstrap"
 
 
 def test_upgrade_propagates_ensurepip_failure(fake_pip: MagicMock) -> None:
-    def _side_effect(cmd: list[str], *_: Any, **__: Any) -> subprocess.CompletedProcess[str]:
+    def _side_effect(
+        cmd: list[str], *_: Any, **__: Any
+    ) -> subprocess.CompletedProcess[str]:
         if cmd[-2:] == ["pip", "--version"]:
             return subprocess.CompletedProcess(
                 cmd, returncode=1, stdout="", stderr="No module named pip\n"
             )
         if "ensurepip" in cmd:
-            return subprocess.CompletedProcess(cmd, returncode=7, stdout="", stderr="boom")
+            return subprocess.CompletedProcess(
+                cmd, returncode=7, stdout="", stderr="boom"
+            )
         return subprocess.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
 
     fake_pip.side_effect = _side_effect

--- a/tests/test_cli_upgrade.py
+++ b/tests/test_cli_upgrade.py
@@ -1,0 +1,448 @@
+"""Tests for ``mureo upgrade`` — pipx venv-aware bulk upgrade command.
+
+Implements the contract described in issue #177:
+
+- ``mureo upgrade``           → upgrade ``mureo`` itself
+- ``mureo upgrade <pkg>``     → upgrade a specific package in the same venv
+- ``mureo upgrade --all``     → upgrade ``mureo`` + every installed ``mureo-*``
+- ``mureo upgrade --dry-run`` → print the pip command without invoking it
+
+The unit-of-isolation is ``mureo.cli.upgrade_cmd``:
+
+* ``sys.executable`` is the source of truth for the target venv.
+* ``importlib.metadata.distributions()`` is used to discover ``mureo-*``
+  packages (PEP 503 canonicalised name match — exact ``mureo`` or
+  ``mureo-<rest>``; prefix squatters such as ``mureology`` must be
+  excluded).
+* Package names are validated with a PEP 503 regex and pip is always
+  invoked with a ``--`` sentinel so that operator-supplied input cannot
+  be parsed as a pip option / VCS URL / PEP 508 marker.
+* If ``python -m pip --version`` exits non-zero with ``No module named
+  pip`` on stderr we bootstrap with ``ensurepip`` once and retry; any
+  other failure is surfaced verbatim.
+* pip's exit code is propagated as the CLI exit code.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock
+
+import pytest
+from typer.testing import CliRunner
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+@dataclass(frozen=True)
+class _FakeDist:
+    """Stand-in for ``importlib.metadata.Distribution`` used by tests."""
+
+    name: str
+
+    @property
+    def metadata(self) -> dict[str, str]:
+        return {"Name": self.name}
+
+
+def _runner() -> CliRunner:
+    return CliRunner()
+
+
+def _app() -> Any:
+    from mureo.cli.main import app
+
+    return app
+
+
+@pytest.fixture
+def fake_distributions(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Patch ``importlib.metadata.distributions`` used by upgrade_cmd."""
+
+    state: dict[str, list[_FakeDist]] = {"dists": []}
+
+    def _set(names: Iterable[str]) -> None:
+        state["dists"] = [_FakeDist(name=n) for n in names]
+
+    def _distributions() -> list[_FakeDist]:
+        return state["dists"]
+
+    monkeypatch.setattr(
+        "mureo.cli.upgrade_cmd.metadata.distributions", _distributions
+    )
+    return _set
+
+
+@pytest.fixture
+def fake_pip(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    """Patch ``subprocess.run`` inside upgrade_cmd.
+
+    Default behaviour: ``pip --version`` is healthy, ``pip install`` exits 0.
+    Tests override ``return_value`` or ``side_effect`` to drive scenarios.
+    """
+
+    def _default(cmd: list[str], *_: Any, **__: Any) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
+
+    mock = MagicMock(side_effect=_default)
+    monkeypatch.setattr("mureo.cli.upgrade_cmd.subprocess.run", mock)
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# Default invocation — upgrade mureo itself
+# ---------------------------------------------------------------------------
+
+
+def test_upgrade_default_upgrades_mureo_self(fake_pip: MagicMock) -> None:
+    result = _runner().invoke(_app(), ["upgrade"])
+
+    assert result.exit_code == 0, result.stderr
+    install_calls = [
+        c for c in fake_pip.call_args_list if "install" in c.args[0]
+    ]
+    assert len(install_calls) == 1
+    cmd = install_calls[0].args[0]
+    assert cmd[:3] == [sys.executable, "-m", "pip"]
+    assert "install" in cmd
+    assert "--upgrade" in cmd
+    # Sentinel guard must precede every target.
+    assert "--" in cmd
+    assert cmd[-1] == "mureo"
+
+
+# ---------------------------------------------------------------------------
+# Explicit package + version pin
+# ---------------------------------------------------------------------------
+
+
+def test_upgrade_named_package_with_version(fake_pip: MagicMock) -> None:
+    result = _runner().invoke(_app(), ["upgrade", "mureo-logly-bridge==1.2.3"])
+
+    assert result.exit_code == 0, result.stderr
+    install_cmd = [
+        c.args[0] for c in fake_pip.call_args_list if "install" in c.args[0]
+    ][0]
+    assert install_cmd[-1] == "mureo-logly-bridge==1.2.3"
+    assert install_cmd[install_cmd.index("--") + 1 :] == ["mureo-logly-bridge==1.2.3"]
+
+
+# ---------------------------------------------------------------------------
+# --all discovery
+# ---------------------------------------------------------------------------
+
+
+def test_upgrade_all_discovers_mureo_and_mureo_prefixed(
+    fake_pip: MagicMock, fake_distributions: Any
+) -> None:
+    fake_distributions(
+        [
+            "mureo",
+            "Mureo-Logly-Bridge",  # case + separator variants must normalise
+            "mureo_lineyahoo_bridge",
+            "mureology",  # squatter — must NOT be picked up
+            "mureoextras",  # squatter — must NOT be picked up
+            "unrelated-pkg",
+        ]
+    )
+
+    result = _runner().invoke(_app(), ["upgrade", "--all"])
+
+    assert result.exit_code == 0, result.stderr
+    install_cmd = [
+        c.args[0] for c in fake_pip.call_args_list if "install" in c.args[0]
+    ][0]
+    targets = install_cmd[install_cmd.index("--") + 1 :]
+    assert set(targets) == {
+        "mureo",
+        "mureo-logly-bridge",
+        "mureo-lineyahoo-bridge",
+    }
+    # mureo itself must always be present and ideally first for readability.
+    assert "mureo" in targets
+
+
+def test_upgrade_all_invokes_pip_once_for_atomic_resolution(
+    fake_pip: MagicMock, fake_distributions: Any
+) -> None:
+    fake_distributions(["mureo", "mureo-a", "mureo-b", "mureo-c"])
+
+    _runner().invoke(_app(), ["upgrade", "--all"])
+
+    install_calls = [
+        c for c in fake_pip.call_args_list if "install" in c.args[0]
+    ]
+    assert len(install_calls) == 1, "pip must be called once so resolver sees the full set"
+
+
+# ---------------------------------------------------------------------------
+# Argument injection guards
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "hostile",
+    [
+        "-r/etc/passwd",
+        "--index-url=http://attacker/",
+        "pkg @ git+https://attacker/x.git",
+        "pkg; python_version<'3.0'",
+        "pkg[extras]",
+        "../mureo",
+        "",
+        "mureo plus space",
+    ],
+)
+def test_upgrade_rejects_hostile_package_specs(
+    fake_pip: MagicMock, hostile: str
+) -> None:
+    result = _runner().invoke(_app(), ["upgrade", hostile])
+
+    assert result.exit_code != 0
+    install_calls = [
+        c for c in fake_pip.call_args_list if "install" in c.args[0]
+    ]
+    assert install_calls == [], "pip must not be invoked for hostile input"
+
+
+# ---------------------------------------------------------------------------
+# --dry-run prints the command and does not invoke pip install
+# ---------------------------------------------------------------------------
+
+
+def test_upgrade_dry_run_does_not_invoke_pip_install(fake_pip: MagicMock) -> None:
+    result = _runner().invoke(_app(), ["upgrade", "--dry-run"])
+
+    assert result.exit_code == 0, result.stderr
+    install_calls = [
+        c for c in fake_pip.call_args_list if "install" in c.args[0]
+    ]
+    assert install_calls == []
+    assert "pip" in result.stdout
+    assert "install" in result.stdout
+    assert "--upgrade" in result.stdout
+    assert "mureo" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# ensurepip fallback — only when pip is missing
+# ---------------------------------------------------------------------------
+
+
+def test_upgrade_bootstraps_pip_when_missing(fake_pip: MagicMock) -> None:
+    calls: list[list[str]] = []
+    state = {"bootstrapped": False}
+
+    def _side_effect(cmd: list[str], *_: Any, **__: Any) -> subprocess.CompletedProcess[str]:
+        calls.append(cmd)
+        if cmd[-2:] == ["pip", "--version"]:
+            if state["bootstrapped"]:
+                return subprocess.CompletedProcess(
+                    cmd, returncode=0, stdout="pip 24.0", stderr=""
+                )
+            return subprocess.CompletedProcess(
+                cmd, returncode=1, stdout="", stderr="No module named pip\n"
+            )
+        if "ensurepip" in cmd:
+            state["bootstrapped"] = True
+            return subprocess.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
+        return subprocess.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
+
+    fake_pip.side_effect = _side_effect
+
+    result = _runner().invoke(_app(), ["upgrade"])
+
+    assert result.exit_code == 0, result.stderr
+    # ensurepip must be invoked exactly once before pip install proceeds.
+    ensurepip_calls = [c for c in calls if "ensurepip" in c]
+    assert len(ensurepip_calls) == 1
+    assert ensurepip_calls[0][:3] == [sys.executable, "-m", "ensurepip"]
+    # pip install must still run after the bootstrap, with the original target.
+    install_cmds = [c for c in calls if "install" in c and "ensurepip" not in c]
+    assert len(install_cmds) == 1
+    assert install_cmds[0][-1] == "mureo"
+    assert "--upgrade" in install_cmds[0]
+
+
+def test_upgrade_does_not_bootstrap_on_other_pip_errors(fake_pip: MagicMock) -> None:
+    calls: list[list[str]] = []
+
+    def _side_effect(cmd: list[str], *_: Any, **__: Any) -> subprocess.CompletedProcess[str]:
+        calls.append(cmd)
+        if cmd[-2:] == ["pip", "--version"]:
+            return subprocess.CompletedProcess(
+                cmd,
+                returncode=1,
+                stdout="",
+                stderr="PermissionError: [Errno 13] Permission denied\n",
+            )
+        return subprocess.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
+
+    fake_pip.side_effect = _side_effect
+
+    result = _runner().invoke(_app(), ["upgrade"])
+
+    assert result.exit_code != 0
+    ensurepip_calls = [c for c in calls if "ensurepip" in c]
+    assert ensurepip_calls == []
+
+
+# ---------------------------------------------------------------------------
+# pip exit code propagation
+# ---------------------------------------------------------------------------
+
+
+def test_upgrade_propagates_pip_exit_code(fake_pip: MagicMock) -> None:
+    def _side_effect(cmd: list[str], *_: Any, **__: Any) -> subprocess.CompletedProcess[str]:
+        if "install" in cmd:
+            return subprocess.CompletedProcess(cmd, returncode=42, stdout="", stderr="boom")
+        return subprocess.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
+
+    fake_pip.side_effect = _side_effect
+
+    result = _runner().invoke(_app(), ["upgrade"])
+
+    assert result.exit_code == 42
+
+
+# ---------------------------------------------------------------------------
+# Conflicting flags
+# ---------------------------------------------------------------------------
+
+
+def test_upgrade_rejects_all_with_explicit_packages(fake_pip: MagicMock) -> None:
+    result = _runner().invoke(_app(), ["upgrade", "--all", "mureo-foo"])
+
+    assert result.exit_code != 0
+    install_calls = [
+        c for c in fake_pip.call_args_list if "install" in c.args[0]
+    ]
+    assert install_calls == []
+
+
+# ---------------------------------------------------------------------------
+# Belt-and-braces: --all always includes mureo even if dist metadata hides it
+# ---------------------------------------------------------------------------
+
+
+def test_upgrade_all_always_includes_mureo_self(
+    fake_pip: MagicMock, fake_distributions: Any
+) -> None:
+    # Simulate an editable / source checkout where mureo's own dist-info
+    # is not visible to importlib.metadata.
+    fake_distributions(["mureo-foo"])
+
+    result = _runner().invoke(_app(), ["upgrade", "--all"])
+
+    assert result.exit_code == 0, result.stderr
+    install_cmd = [
+        c.args[0] for c in fake_pip.call_args_list if "install" in c.args[0]
+    ][0]
+    targets = install_cmd[install_cmd.index("--") + 1 :]
+    assert targets[0] == "mureo"
+    assert "mureo-foo" in targets
+
+
+def test_upgrade_all_dedups_case_and_separator_variants(
+    fake_pip: MagicMock, fake_distributions: Any
+) -> None:
+    fake_distributions(["mureo-foo", "mureo_foo", "Mureo.Foo"])
+
+    result = _runner().invoke(_app(), ["upgrade", "--all"])
+
+    assert result.exit_code == 0, result.stderr
+    install_cmd = [
+        c.args[0] for c in fake_pip.call_args_list if "install" in c.args[0]
+    ][0]
+    targets = install_cmd[install_cmd.index("--") + 1 :]
+    # mureo (belt-and-braces) + exactly one mureo-foo, no duplicates.
+    assert targets.count("mureo-foo") == 1
+    assert sorted(targets) == ["mureo", "mureo-foo"]
+
+
+# ---------------------------------------------------------------------------
+# Dry-run still validates hostile input
+# ---------------------------------------------------------------------------
+
+
+def test_upgrade_dry_run_still_rejects_hostile_input(fake_pip: MagicMock) -> None:
+    result = _runner().invoke(_app(), ["upgrade", "--dry-run", "-r/etc/passwd"])
+
+    assert result.exit_code != 0
+
+
+def test_upgrade_rejects_double_equals(fake_pip: MagicMock) -> None:
+    result = _runner().invoke(_app(), ["upgrade", "mureo==1.0==2.0"])
+
+    assert result.exit_code != 0
+    install_calls = [
+        c for c in fake_pip.call_args_list if "install" in c.args[0]
+    ]
+    assert install_calls == []
+
+
+# ---------------------------------------------------------------------------
+# sys.executable invariant: every captured cmd targets the running python
+# ---------------------------------------------------------------------------
+
+
+def test_upgrade_always_targets_sys_executable(fake_pip: MagicMock) -> None:
+    _runner().invoke(_app(), ["upgrade"])
+
+    for call in fake_pip.call_args_list:
+        cmd = call.args[0]
+        assert cmd[0] == sys.executable, (
+            f"command must start with sys.executable, got {cmd!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# ensurepip succeeds but pip is still broken → clean error, no install attempt
+# ---------------------------------------------------------------------------
+
+
+def test_upgrade_aborts_if_pip_still_missing_after_bootstrap(
+    fake_pip: MagicMock,
+) -> None:
+    calls: list[list[str]] = []
+
+    def _side_effect(cmd: list[str], *_: Any, **__: Any) -> subprocess.CompletedProcess[str]:
+        calls.append(cmd)
+        if cmd[-2:] == ["pip", "--version"]:
+            return subprocess.CompletedProcess(
+                cmd, returncode=1, stdout="", stderr="No module named pip\n"
+            )
+        if "ensurepip" in cmd:
+            return subprocess.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
+        return subprocess.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
+
+    fake_pip.side_effect = _side_effect
+
+    result = _runner().invoke(_app(), ["upgrade"])
+
+    assert result.exit_code != 0
+    install_calls = [c for c in calls if "install" in c and "ensurepip" not in c]
+    assert install_calls == [], (
+        "must not attempt `pip install` if pip is still broken post-bootstrap"
+    )
+
+
+def test_upgrade_propagates_ensurepip_failure(fake_pip: MagicMock) -> None:
+    def _side_effect(cmd: list[str], *_: Any, **__: Any) -> subprocess.CompletedProcess[str]:
+        if cmd[-2:] == ["pip", "--version"]:
+            return subprocess.CompletedProcess(
+                cmd, returncode=1, stdout="", stderr="No module named pip\n"
+            )
+        if "ensurepip" in cmd:
+            return subprocess.CompletedProcess(cmd, returncode=7, stdout="", stderr="boom")
+        return subprocess.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
+
+    fake_pip.side_effect = _side_effect
+
+    result = _runner().invoke(_app(), ["upgrade"])
+
+    assert result.exit_code == 7


### PR DESCRIPTION
Closes #177

## Summary

- Adds top-level `mureo upgrade` subcommand that targets `sys.executable` so pipx-installed mureo can upgrade itself **and** every `mureo.providers` / `mureo.policy_gates` / etc. plugin in the same venv with one memorable command.
- `mureo upgrade` (default = mureo itself) / `mureo upgrade <pkg>` (optional `==pin`) / `mureo upgrade --all` (mureo + every installed `mureo-*` in a single pip resolver call) / `mureo upgrade --dry-run` (print the pip command without invoking it).

## Why

`pipx upgrade mureo` upgrades only the primary venv package; injected / pip-installed plugins are left behind. `pipx upgrade <plugin>` fails because plugins have no same-named venv. `pipx inject mureo <pkg> --force` triggers a known pipx 1.11 "looks like a path" bug if cwd contains a `mureo` directory. This subcommand replaces those workarounds with a single venv-aware entry point that owns its own pip invocation.

## Safety

- Package specs validated via PEP 503 regex; pip is always invoked with a `--` sentinel so hostile input cannot be reinterpreted as flags, URLs, VCS refs, PEP 508 markers, or extras.
- `--all` discovery normalises dist names per PEP 503 and accepts only `mureo` exact or `mureo-<rest>` — prefix squatters like `mureology` / `mureoextras` are rejected.
- `ensurepip` bootstrap fires **only** for the literal `No module named pip` stderr; every other pip failure surfaces verbatim. After the bootstrap, pip availability is re-probed so a half-broken venv produces a clear diagnostic rather than a raw subprocess crash.
- pip exit code propagated as CLI exit code so automation can retry / branch.

## Test plan

- [x] 24 new unit tests in `tests/test_cli_upgrade.py` — default invocation, named + version pin, `--all` discovery with PEP 503 + squatter rejection, 8 injection-attack vectors, dry-run (happy + hostile), ensurepip bootstrap (positive + permission-denied negative + post-bootstrap pip-still-broken + ensurepip-failure code propagation), pip exit-code propagation, conflicting-flags rejection, `sys.executable` invariant, double-`==` rejection, case + separator dedup
- [x] Existing CLI test suite regression: 101 passed
- [x] `ruff check` clean
- [x] Real-environment smoke test in an isolated venv: `--help`, `--dry-run` variants, hostile inputs (all exit 2), real `pip` upgrade (no-op, exit 0)

## Out of scope / follow-up

- Optional PEP 440 version regex tightening (currently relies on the `--` sentinel as the primary defence — covered in review M1)
- Behaviour with editable / source-checkout mureo (belt-and-braces branch covered by test, but UX could grow a warning later)
