### PR TITLE
fix(meta-ads): paginate /me/adaccounts so BM dropdowns show every account

### DIFF
--- a/mureo/meta_ads/accounts.py
+++ b/mureo/meta_ads/accounts.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import logging
 from typing import Any
+from urllib.parse import urlparse
 
 import httpx
 
@@ -35,13 +36,53 @@ logger = logging.getLogger(__name__)
 _META_GRAPH_API_BASE = "https://graph.facebook.com/v21.0"
 _HTTP_TIMEOUT = 30.0
 
+# Largest page size Graph API will accept without truncation for the
+# ``adaccounts`` edge. Defaults to 25 when omitted — too small for any
+# Business Manager with more than a handful of accounts.
+_PAGE_SIZE = 100
+
+# Defensive upper bound on the cursor walk. 50 pages × 100 = 5000 ad
+# accounts — well past anything seen in practice. Caps a buggy Graph
+# response that keeps returning a ``paging.next`` cursor so the
+# configure UI never spins forever.
+_MAX_PAGES = 50
+
+# Host pinning for ``paging.next`` URLs. Graph echoes the URL back to
+# us in the response body — refusing to follow anything other than the
+# Graph API host stops a tampered response (broken TLS pinning, proxy
+# mis-route, etc.) from exfiltrating the access token (which travels in
+# the cursor URL's query string from page 2 onward).
+_GRAPH_HOST = "graph.facebook.com"
+
+
+def _is_safe_graph_url(url: str) -> bool:
+    """Return True iff ``url`` is an https URL pointing at the Graph host."""
+
+    parsed = urlparse(url)
+    return parsed.scheme == "https" and parsed.netloc == _GRAPH_HOST
+
+
+def _redact(message: str, secret: str) -> str:
+    """Replace ``secret`` in ``message`` with a fixed token marker.
+
+    Used to scrub access tokens out of error messages before they reach
+    operator logs or UI surfaces. The original exception chain is broken
+    with ``raise ... from None`` separately — see the raise site.
+    """
+
+    if not secret:
+        return message
+    return message.replace(secret, "***REDACTED***")
+
 
 async def list_meta_ad_accounts(access_token: str) -> list[dict[str, Any]]:
     """Retrieve the list of Meta ad accounts the access token can reach.
 
-    Calls ``GET /me/adaccounts`` on the Graph API. Returns the raw
-    ``data`` array as-is so callers can pick the fields they need
-    without an intermediate normalisation step.
+    Calls ``GET /me/adaccounts`` on the Graph API and walks the
+    ``paging.next`` cursor until exhausted so every account under a
+    Business Manager is returned, not just the first 25. Pages are
+    concatenated in cursor order (== Graph's natural order) so the
+    configure-UI dropdown ranks accounts consistently across runs.
 
     Args:
         access_token: Meta Ads access token (System User or User token).
@@ -53,22 +94,54 @@ async def list_meta_ad_accounts(access_token: str) -> list[dict[str, Any]]:
         RuntimeError: When the Graph API call fails (network error or
             non-2xx response).
     """
-    params = {
+    accounts: list[dict[str, Any]] = []
+    next_url: str | None = f"{_META_GRAPH_API_BASE}/me/adaccounts"
+    # ``params`` is only sent on the first request — subsequent
+    # ``paging.next`` URLs already carry every query parameter Graph
+    # needs (including ``access_token`` and ``after`` cursor), so
+    # resending them would corrupt the cursor.
+    first_request_params: dict[str, Any] | None = {
         "fields": "id,name,account_status",
+        "limit": _PAGE_SIZE,
         "access_token": access_token,
     }
 
     try:
         async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
-            response = await client.get(
-                f"{_META_GRAPH_API_BASE}/me/adaccounts",
-                params=params,
-            )
-            response.raise_for_status()
-            data = response.json()
-            return data.get("data", [])  # type: ignore[no-any-return]
+            for _ in range(_MAX_PAGES):
+                if not next_url:
+                    break
+                if not _is_safe_graph_url(next_url):
+                    logger.warning(
+                        "Refusing to follow non-Graph paging.next URL; "
+                        "truncating Meta ad-account list."
+                    )
+                    break
+                response = await client.get(next_url, params=first_request_params)
+                response.raise_for_status()
+                payload = response.json()
+                accounts.extend(payload.get("data", []) or [])
+                next_url = (payload.get("paging") or {}).get("next")
+                first_request_params = None
+            else:
+                # Loop exhausted the cap — log so the gap is visible in
+                # operator logs even though the UI sees a finite list.
+                logger.warning(
+                    "Meta ad-account pagination hit the %d-page cap; some "
+                    "accounts may be missing from the configure UI.",
+                    _MAX_PAGES,
+                )
+        return accounts
     except Exception as exc:
-        raise RuntimeError(f"Failed to retrieve ad account list: {exc}") from exc
+        # Scrub the access token before it lands in operator logs or UI.
+        # From page 2 onward the token lives in ``next_url`` itself, so
+        # an HTTPStatusError from httpx (which embeds the request URL in
+        # its ``__str__``) would otherwise leak it verbatim.
+        scrubbed = _redact(str(exc), access_token)
+        # ``from None`` breaks the exception chain so the original
+        # exception's ``__cause__`` (which still carries the unscrubbed
+        # URL) is not printed by default traceback formatting.
+        raise RuntimeError(f"Failed to retrieve ad account list: {scrubbed}") from None
 
 
 __all__ = ["list_meta_ad_accounts"]

--- a/tests/test_auth_setup_meta.py
+++ b/tests/test_auth_setup_meta.py
@@ -246,6 +246,242 @@ async def test_list_meta_ad_accounts_empty() -> None:
 
 
 @pytest.mark.unit
+async def test_list_meta_ad_accounts_follows_paging_next_until_exhausted() -> None:
+    """When the Graph API splits the response across multiple pages,
+    every page must be fetched and concatenated. Regression test for
+    the original "only 25 BM accounts ever showed up" bug.
+    """
+    page1 = MagicMock()
+    page1.status_code = 200
+    page1.json.return_value = {
+        "data": [
+            {"id": f"act_{i}", "name": f"A{i}", "account_status": 1} for i in range(100)
+        ],
+        "paging": {"next": "https://graph.facebook.com/v21.0/me/adaccounts?after=cur1"},
+    }
+    page1.raise_for_status = MagicMock()
+
+    page2 = MagicMock()
+    page2.status_code = 200
+    page2.json.return_value = {
+        "data": [
+            {"id": f"act_{i}", "name": f"A{i}", "account_status": 1}
+            for i in range(100, 175)
+        ],
+        "paging": {"next": "https://graph.facebook.com/v21.0/me/adaccounts?after=cur2"},
+    }
+    page2.raise_for_status = MagicMock()
+
+    # Terminal page: no ``paging.next`` cursor → walk stops.
+    page3 = MagicMock()
+    page3.status_code = 200
+    page3.json.return_value = {
+        "data": [
+            {"id": f"act_{i}", "name": f"A{i}", "account_status": 1}
+            for i in range(175, 230)
+        ],
+        "paging": {},
+    }
+    page3.raise_for_status = MagicMock()
+
+    with patch("mureo.meta_ads.accounts.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=[page1, page2, page3])
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        accounts = await list_meta_ad_accounts(access_token="bm-token")
+
+    assert len(accounts) == 230, "every page must be appended"
+    # Three calls: one per page.
+    assert mock_client.get.call_count == 3
+    # Order preserved (page1 → page2 → page3).
+    assert accounts[0]["id"] == "act_0"
+    assert accounts[100]["id"] == "act_100"
+    assert accounts[-1]["id"] == "act_229"
+
+    # Cursor-shape guarantees: the first call MUST send our params dict
+    # (with access_token + limit); subsequent calls MUST follow the
+    # Graph-supplied ``paging.next`` URL verbatim and pass ``params=None``
+    # so the cursor is not corrupted by re-encoding.
+    calls = mock_client.get.call_args_list
+    assert calls[0].args[0].endswith("/me/adaccounts")
+    assert calls[0].kwargs["params"]["access_token"] == "bm-token"
+    assert calls[0].kwargs["params"]["limit"] >= 100
+    assert calls[1].args[0] == (
+        "https://graph.facebook.com/v21.0/me/adaccounts?after=cur1"
+    )
+    assert calls[1].kwargs.get("params") is None
+    assert calls[2].args[0] == (
+        "https://graph.facebook.com/v21.0/me/adaccounts?after=cur2"
+    )
+    assert calls[2].kwargs.get("params") is None
+
+
+@pytest.mark.unit
+async def test_list_meta_ad_accounts_refuses_non_graph_paging_next() -> None:
+    """If the response body is tampered with and ``paging.next`` points
+    at a non-Graph host, the walker must refuse to follow it (otherwise
+    the access token — which lives in the cursor URL from page 2
+    onward — would be leaked to whoever supplied the URL).
+    """
+    import logging
+
+    page1 = MagicMock()
+    page1.status_code = 200
+    page1.json.return_value = {
+        "data": [{"id": "act_1", "name": "A1", "account_status": 1}],
+        "paging": {"next": "https://attacker.example/steal?access_token=tok"},
+    }
+    page1.raise_for_status = MagicMock()
+
+    with (
+        patch("mureo.meta_ads.accounts.httpx.AsyncClient") as mock_client_cls,
+        patch.object(logging.getLogger("mureo.meta_ads.accounts"), "warning") as warn,
+    ):
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=page1)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        accounts = await list_meta_ad_accounts(access_token="tok")
+
+    # Only the trusted first page is returned — the attacker URL is not
+    # followed, so the dropdown silently truncates rather than leaking.
+    assert accounts == [{"id": "act_1", "name": "A1", "account_status": 1}]
+    assert mock_client.get.call_count == 1
+    # The truncation must be visible in operator logs.
+    assert warn.called
+    assert "non-Graph" in warn.call_args.args[0]
+
+
+@pytest.mark.unit
+async def test_list_meta_ad_accounts_mid_walk_failure_discards_partial_and_redacts() -> (
+    None
+):
+    """If page 1 succeeds and page 2 returns non-2xx, the walker must
+    (a) raise ``RuntimeError`` (not return partial data) and
+    (b) scrub the access token from the error message — the token
+    lives inside the page-2 cursor URL and httpx's ``HTTPStatusError``
+    embeds the full URL in its ``str()``.
+    """
+    page1 = MagicMock()
+    page1.status_code = 200
+    page1.json.return_value = {
+        "data": [{"id": "act_1", "name": "A1", "account_status": 1}],
+        "paging": {
+            "next": (
+                "https://graph.facebook.com/v21.0/me/adaccounts"
+                "?after=cur&access_token=SECRET-TOKEN-XYZ"
+            )
+        },
+    }
+    page1.raise_for_status = MagicMock()
+
+    page2 = MagicMock()
+    page2.status_code = 401
+    page2.json.return_value = {"error": {"message": "Token expired"}}
+    page2.raise_for_status = MagicMock(
+        side_effect=Exception(
+            "Client error '401 Unauthorized' for url "
+            "'https://graph.facebook.com/v21.0/me/adaccounts"
+            "?after=cur&access_token=SECRET-TOKEN-XYZ'"
+        )
+    )
+
+    with patch("mureo.meta_ads.accounts.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=[page1, page2])
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        with pytest.raises(RuntimeError) as excinfo:
+            await list_meta_ad_accounts(access_token="SECRET-TOKEN-XYZ")
+
+    # Partial accounts MUST NOT be returned on mid-walk failure — caller
+    # gets the error, not a half-filled list.
+    msg = str(excinfo.value)
+    assert (
+        "SECRET-TOKEN-XYZ" not in msg
+    ), "access token must not leak into error message"
+    assert "***REDACTED***" in msg
+    # Chain is broken with ``from None`` so the original exception's
+    # ``__cause__`` (which carries the unscrubbed URL) is not surfaced.
+    assert excinfo.value.__cause__ is None
+
+
+@pytest.mark.unit
+async def test_list_meta_ad_accounts_requests_large_page_size() -> None:
+    """Default Graph API page size is 25 — we ask for the safe maximum
+    so a single page covers most BMs and pagination only kicks in for
+    truly large portfolios.
+    """
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"data": [], "paging": {}}
+    mock_response.raise_for_status = MagicMock()
+
+    with patch("mureo.meta_ads.accounts.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        await list_meta_ad_accounts(access_token="tok")
+
+    call_kwargs = mock_client.get.call_args.kwargs
+    params = call_kwargs.get("params") or {}
+    assert (
+        int(params.get("limit", 0)) >= 100
+    ), "first request must ask for at least 100 accounts per page"
+
+
+@pytest.mark.unit
+async def test_list_meta_ad_accounts_caps_page_walk() -> None:
+    """A buggy Graph API response that always returns a ``next``
+    cursor must NOT spin the configure UI forever; the walker stops
+    at the documented cap and warns so the gap is visible.
+    """
+    import logging
+
+    from mureo.meta_ads.accounts import _MAX_PAGES
+
+    looping_page = MagicMock()
+    looping_page.status_code = 200
+    looping_page.json.return_value = {
+        "data": [{"id": "act_x", "name": "X", "account_status": 1}],
+        "paging": {"next": "https://graph.facebook.com/v21.0/me/adaccounts?after=loop"},
+    }
+    looping_page.raise_for_status = MagicMock()
+
+    with (
+        patch("mureo.meta_ads.accounts.httpx.AsyncClient") as mock_client_cls,
+        patch.object(logging.getLogger("mureo.meta_ads.accounts"), "warning") as warn,
+    ):
+        mock_client = AsyncMock()
+        # Always return the same looping page — if the walker had no
+        # cap it would hang the configure UI thread.
+        mock_client.get = AsyncMock(return_value=looping_page)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        accounts = await list_meta_ad_accounts(access_token="tok")
+
+    # Exact equality locks in the documented contract — a future change
+    # that silently drops the cap to 1 would be caught here.
+    assert mock_client.get.call_count == _MAX_PAGES
+    assert len(accounts) == _MAX_PAGES
+    # Operators must see a warning when the cap truncated the list.
+    assert warn.called
+    assert "cap" in warn.call_args.args[0]
+
+
+@pytest.mark.unit
 async def test_list_meta_ad_accounts_error() -> None:
     """Raises RuntimeError when fetching the ad-account list fails."""
     mock_response = MagicMock()


### PR DESCRIPTION
## Summary

The `mureo configure` Meta ad-account picker only showed the first 25 ad accounts under a Business Manager because `list_meta_ad_accounts` in `mureo/meta_ads/accounts.py` called `GET /me/adaccounts` once and returned the first page verbatim. Beyond 25 accounts, the dropdown silently truncated.

This PR walks `paging.next` until exhausted, with `limit=100` on the first call to minimise round-trips and a 50-page hard cap so a buggy Graph response can never spin the UI forever.

## Defence-in-depth

- **Host pinning** on `paging.next`: refuse any URL whose host is not `graph.facebook.com` or whose scheme is not `https`. From page 2 onward the access token lives inside the cursor URL — a tampered response could otherwise exfiltrate it.
- **Token redaction** in `RuntimeError`: scrub the access token out of the wrapped exception message and break the exception chain with `raise ... from None`, so httpx's `HTTPStatusError` (which embeds the full request URL in its `str()`) cannot leak the token into operator logs or UI error surfaces.

## Test plan

- [x] 4 new tests + tightened existing cap test in `tests/test_auth_setup_meta.py`:
  - multi-page concat preserves order; per-call params shape pinned (first call sends params dict, page 2+ uses bare `paging.next` URL with `params=None`)
  - non-Graph `paging.next` refused with warning; only trusted page data returned
  - mid-walk 401 discards partial data, redacts the token, breaks `__cause__`
  - cap walk asserts exact `_MAX_PAGES` round-trips + warning fired
- [x] Existing test suite around this code path regression: **157 passed** (153 prior + 4 new)
- [x] `ruff check mureo/meta_ads/accounts.py` clean
- [x] `black --check` clean

## Signature / public surface

`list_meta_ad_accounts(access_token: str) -> list[dict[str, Any]]` — unchanged. No public surface change.
