### PR TITLE
chore(release): v0.9.26 — BM ad-account dropdown shows every account

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mureo",
-  "version": "0.9.25",
+  "version": "0.9.26",
   "description": "Your local-first AI ad ops crew for Google Ads, Meta Ads, Search Console & GA4. mureo sits on top of the official ad-platform MCPs, gates every change against your strategy, correlates outcomes locally, and keeps an auditable decision log — credentials never leave your machine.",
   "author": {
     "name": "Logly Inc.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.26] - 2026-06-09
+
+### Fixed — `mureo configure` Meta ad-account dropdown now lists every account under a Business Manager (#181)
+
+The configure UI's Meta ad-account picker silently truncated to the
+first 25 accounts under any Business Manager because
+`list_meta_ad_accounts` in `mureo/meta_ads/accounts.py` called
+`GET /me/adaccounts` once and returned the first page verbatim.
+Operators with mid-sized BM portfolios (26+ accounts) could not select
+the account they actually wanted to connect — it never appeared in the
+dropdown.
+
+This release walks `paging.next` until exhausted (with `limit=100` on
+the first request to minimise round-trips) and concatenates every page
+in cursor order. A 50-page hard cap stops a buggy Graph response from
+spinning the configure UI forever; the cap path logs a warning so the
+gap is visible to operators.
+
+Two defence-in-depth additions land alongside the pagination fix:
+
+- **Host pinning on `paging.next`.** Refuse to follow any URL whose
+  host is not `graph.facebook.com` or whose scheme is not `https`.
+  From page 2 onward the access token lives inside the cursor URL
+  itself, so a tampered response (broken TLS pinning, proxy mis-route)
+  could otherwise exfiltrate it.
+- **Token redaction in `RuntimeError`.** Scrub the access token out
+  of the wrapped exception message and break the exception chain with
+  `raise ... from None`, so `httpx.HTTPStatusError` (whose `__str__`
+  embeds the full request URL) cannot leak the token into operator
+  logs or UI error surfaces on a mid-walk failure.
+
+No public surface change — `list_meta_ad_accounts(access_token)
+-> list[dict[str, Any]]` is unchanged. Operators see the fix
+immediately after upgrading to 0.9.26 the next time they run
+`mureo configure`.
+
 ## [0.9.25] - 2026-06-06
 
 ### Added — `mureo upgrade [--all]` for pipx venv-aware plugin upgrades (#177, #178)

--- a/mureo/__init__.py
+++ b/mureo/__init__.py
@@ -1,3 +1,3 @@
 """mureo — your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."""
 
-__version__ = "0.9.25"
+__version__ = "0.9.26"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mureo"
-version = "0.9.25"
+version = "0.9.26"
 description = "Your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."
 requires-python = ">=3.10"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Release v0.9.26 — ships the BM ad-account dropdown fix from #181.

PyPI users will go 0.9.25 → 0.9.26 and `mureo configure` will list every Meta ad account under a Business Manager (no longer truncated at the Graph API default of 25 per page).

## Files touched

- `pyproject.toml` — version 0.9.25 → 0.9.26
- `mureo/__init__.py` — `__version__` bump
- `.claude-plugin/plugin.json` — `version` field bump
- `CHANGELOG.md` — adds 0.9.26 entry headlining the BM pagination fix; keeps 0.9.25 entry intact

## Test plan

- [x] `tests/test_plugin_manifests.py` (version-parity guard) — 9 / 9 pass
- [ ] Post-merge: tag `v0.9.26` on `main`
- [ ] Create GitHub Release with the 0.9.26 CHANGELOG section as notes → auto-triggers `.github/workflows/release.yml` PyPI publish
