### PR TITLE
feat(web): dashboard cards (#183) + color-coded toast errors (#184)

### DIFF
--- a/mureo/_data/web/app.css
+++ b/mureo/_data/web/app.css
@@ -759,14 +759,60 @@ input[type="checkbox"] {
    so credential boundaries are scannable instead of a flat hairline list.
    Both the Official MCP providers list and the Plugin credentials list
    participate; child notes (e.g. dashboard-provider-hosted-note) fall
-   inside the same boundary as the desired grouping. */
+   inside the same boundary as the desired grouping.
+   The thin hairline alone is too subtle against ``--paper``, so a soft
+   1px inset shadow + bottom-edge shadow lift the card off the section
+   background enough to scan boundaries at a glance without breaking
+   the dark-mode palette (both colors derive from ``--ink`` at low
+   alpha). */
 [data-dashboard-providers-list] > li,
 [data-dashboard-plugin-credentials-list] > * {
-  border: 1px solid var(--rule);
+  /* Borders use ink-at-low-alpha instead of ``--hairline`` because the
+     warmer hairline (#e4e3df) reads as the same value as the cream
+     ``--paper`` page on some displays. ``rgba(20,22,26,0.14)`` is a
+     true neutral-grey at ~14% opacity — sits between hairline and the
+     section text, unmistakable against either cream or pure white. */
+  border: 1px solid rgba(20, 22, 26, 0.14);
   border-radius: var(--r-md);
-  padding: 12px 14px;
+  padding: 12px 14px 12px 18px;
   margin-bottom: 10px;
-  background: var(--paper);
+  /* Lightly tinted cool off-white separates each card from the warm
+     paper background without going pure white (which can read as
+     indistinguishable on warm-temperature monitors). The dark-mode
+     pair uses ``--surface`` directly — the LAB lightness gap there is
+     already large. */
+  background: #fbfcfd;
+  box-shadow: 0 1px 3px rgba(20, 22, 26, 0.10), 0 1px 1px rgba(20, 22, 26, 0.06);
+  /* Reserved for the platform-tinted left-accent stripe below. */
+  border-left-width: 4px;
+  border-left-style: solid;
+  border-left-color: rgba(20, 22, 26, 0.14);
+}
+
+@media (prefers-color-scheme: dark) {
+  [data-dashboard-providers-list] > li,
+  [data-dashboard-plugin-credentials-list] > * {
+    background: var(--surface);
+    border-color: rgba(236, 237, 240, 0.12);
+    border-left-color: rgba(236, 237, 240, 0.12);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4), 0 1px 1px rgba(0, 0, 0, 0.2);
+  }
+}
+
+/* Per-platform accent — left edge color identifies the provider at a
+   glance. Brand colors come from each platform's own brand guidelines
+   (Google blue, Meta blue, GA4 orange). Plugin-credentials cards
+   inherit the neutral default. */
+[data-dashboard-providers-list] > li[data-platform="google-ads-official"] {
+  border-left-color: #4285f4;
+}
+
+[data-dashboard-providers-list] > li[data-platform="meta-ads-official"] {
+  border-left-color: #1877f2;
+}
+
+[data-dashboard-providers-list] > li[data-platform="ga4-official"] {
+  border-left-color: #f9ab00;
 }
 
 /* Providers list rows are <li>; preserve the legacy flex layout
@@ -793,12 +839,32 @@ input[type="checkbox"] {
    override never targeted it — but we keep the margin-reset for both
    for visual consistency at the bottom of each list.) */
 [data-dashboard-providers-list] > li:last-child {
-  border-bottom: 1px solid var(--rule);
+  border-bottom: 1px solid var(--hairline);
 }
 
 [data-dashboard-providers-list] > li:last-child,
 [data-dashboard-plugin-credentials-list] > *:last-child {
   margin-bottom: 0;
+}
+
+/* #183/#184 — generic hint typography. Third-party plugin extensions
+   render field hints as ``<small class="hint">`` (legacy convention
+   shared across the agency-clients / agency-dashboard plugins) and
+   mureo's own plugin-credentials form uses ``.field-hint``. Without a
+   block declaration the small flows inline with the next sibling
+   ``<label>`` heading, producing run-on text like
+   ``…short-lived access tokens.Client Secret *``. Forcing block +
+   adding margin/typography fixes the layout for every consumer in one
+   place. */
+.hint,
+.field-hint,
+label > small {
+  display: block;
+  margin-top: 4px;
+  margin-bottom: 14px;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.5;
 }
 
 .app-toast {

--- a/mureo/_data/web/app.css
+++ b/mureo/_data/web/app.css
@@ -755,6 +755,52 @@ input[type="checkbox"] {
   border-bottom: 0;
 }
 
+/* #183 dashboard provider card — give each platform row its own boundary
+   so credential boundaries are scannable instead of a flat hairline list.
+   Both the Official MCP providers list and the Plugin credentials list
+   participate; child notes (e.g. dashboard-provider-hosted-note) fall
+   inside the same boundary as the desired grouping. */
+[data-dashboard-providers-list] > li,
+[data-dashboard-plugin-credentials-list] > * {
+  border: 1px solid var(--rule);
+  border-radius: var(--r-md);
+  padding: 12px 14px;
+  margin-bottom: 10px;
+  background: var(--paper);
+}
+
+/* Providers list rows are <li>; preserve the legacy flex layout
+   (label-left / Remove-button-right) inherited from
+   .dashboard-section li so the Remove button stays right-aligned
+   inside the card. The existing
+   ``.dashboard-provider-hosted-note { flex-basis: 100% }`` rule keeps
+   wrapping the hosted note onto a second line inside the card. */
+[data-dashboard-providers-list] > li {
+  flex-wrap: wrap;
+}
+
+/* Plugin credentials children are <details> blocks (see
+   dashboard.js render path); flex would collapse the disclosure
+   triangle row. Block is the right default here. */
+[data-dashboard-plugin-credentials-list] > * {
+  display: block;
+}
+
+/* The legacy ``.dashboard-section li:last-child { border-bottom: 0 }``
+   would otherwise clear our card's bottom border; restore it
+   explicitly so every card carries all four sides. (The plugin
+   credentials list contains <details>, not <li>, so the legacy
+   override never targeted it — but we keep the margin-reset for both
+   for visual consistency at the bottom of each list.) */
+[data-dashboard-providers-list] > li:last-child {
+  border-bottom: 1px solid var(--rule);
+}
+
+[data-dashboard-providers-list] > li:last-child,
+[data-dashboard-plugin-credentials-list] > *:last-child {
+  margin-bottom: 0;
+}
+
 .app-toast {
   position: fixed;
   bottom: 26px;
@@ -772,6 +818,20 @@ input[type="checkbox"] {
 
 .app-toast[hidden] {
   display: none;
+}
+
+/* #184 toast kinds — color-code success vs error so an operator who
+   triggered an action from the bottom of a long Dashboard can tell at
+   a glance whether the result was good or bad. Default (.is-info or
+   no kind) keeps the existing dark pill. */
+.app-toast.is-success {
+  background: #1f7a3f;
+  color: #ffffff;
+}
+
+.app-toast.is-error {
+  background: #b3261e;
+  color: #ffffff;
 }
 
 @keyframes toastIn {

--- a/mureo/_data/web/app.html
+++ b/mureo/_data/web/app.html
@@ -205,6 +205,10 @@
       </div>
     </section>
 
+    <!-- TODO: when SR support lands, add aria-live="polite" here.
+         Inline status nodes in auth_wizards.js / dashboard.js share
+         the same message string; aria-atomic or scoping is required
+         to avoid double-announce. See #184 review notes. -->
     <div class="app-toast" data-toast hidden></div>
   </main>
 

--- a/mureo/_data/web/app.js
+++ b/mureo/_data/web/app.js
@@ -126,10 +126,19 @@
     return { ok: res.ok, status: res.status, body: body };
   }
 
-  function toast(message) {
+  function toast(message, kind) {
+    // ``kind`` is optional and accepts ``"info"`` (default), ``"success"``,
+    // or ``"error"`` — translated to a ``is-<kind>`` CSS class so app.css
+    // can color-code the pill. Existing single-arg callers stay valid;
+    // the absence of ``is-error`` / ``is-success`` falls through to the
+    // default dark-pill style. See issue #184.
     const node = document.querySelector("[data-toast]");
     if (!node) return;
     node.textContent = message;
+    node.classList.remove("is-info", "is-success", "is-error");
+    const safeKind =
+      kind === "success" || kind === "error" || kind === "info" ? kind : "info";
+    node.classList.add("is-" + safeKind);
     node.hidden = false;
     setTimeout(function () {
       node.hidden = true;

--- a/mureo/_data/web/auth_wizards.js
+++ b/mureo/_data/web/auth_wizards.js
@@ -152,7 +152,11 @@
         } catch (_e) {
           finalizeBtn.disabled = false;
           affirmBtn.disabled = false;
-          fStatus.textContent = MUREO.t("connector.finalize_failed");
+          const msg = MUREO.t("connector.finalize_failed");
+          fStatus.textContent = msg;
+          // Inline status stays for accessibility / scroll-anchored
+          // context; the toast is the scroll-resistant surface (#184).
+          MUREO.toast(msg, "error");
           return;
         }
         finalizeBtn.disabled = false;
@@ -524,13 +528,17 @@
               value: values[spec.name],
             });
             if (!res.ok) {
-              status.textContent = MUREO.t("wizard.auth.save_failed");
+              const msg = MUREO.t("wizard.auth.save_failed");
+              status.textContent = msg;
+              MUREO.toast(msg, "error");
               doneBtn.disabled = false;
               return;
             }
           }
         } catch (_e) {
-          status.textContent = MUREO.t("wizard.auth.save_failed");
+          const msg = MUREO.t("wizard.auth.save_failed");
+          status.textContent = msg;
+          MUREO.toast(msg, "error");
           doneBtn.disabled = false;
           return;
         }
@@ -561,7 +569,9 @@
             onAllDone();
           });
         } else {
-          status.textContent = MUREO.t("wizard.auth.oauth_failed");
+          const msg = MUREO.t("wizard.auth.oauth_failed");
+          status.textContent = msg;
+          MUREO.toast(msg, "error");
           btn.disabled = false;
         }
       });
@@ -586,7 +596,9 @@
             cancelled = true;
             onFinished();
           } else if (data && data.error) {
-            statusNode.textContent = MUREO.t("wizard.auth.oauth_failed");
+            const msg = MUREO.t("wizard.auth.oauth_failed");
+            statusNode.textContent = msg;
+            MUREO.toast(msg, "error");
             cancelled = true;
           } else {
             setTimeout(tick, 750);

--- a/mureo/_data/web/dashboard.js
+++ b/mureo/_data/web/dashboard.js
@@ -223,6 +223,11 @@
       "ga4-official",
     ].forEach(function (pid) {
       const li = document.createElement("li");
+      // Tag the row with its provider id so CSS can apply a
+      // platform-tinted left-accent stripe (Google blue / Meta blue /
+      // GA4 orange). The data attribute is also a stable hook for
+      // future per-platform UI (icons, links, etc.). See #183 review.
+      li.dataset.platform = pid;
       const isHosted = HOSTED_PROVIDER_IDS.indexOf(pid) !== -1;
       // Hosted providers are "installed" ⇔ their account-level Connector
       // is Connected (mureo never registers them in the config file).
@@ -256,7 +261,7 @@
             await MUREO.loadStatus();
             renderAll();
           } else {
-            MUREO.toast("Operation failed", "error");
+            MUREO.toast(MUREO.t("app.toast_operation_failed"), "error");
           }
         });
         li.appendChild(removeBtn);
@@ -381,12 +386,12 @@
       });
       if (res.ok) {
         form.querySelector('[name="env_value"]').value = "";
-        MUREO.toast("Saved.", "success");
+        MUREO.toast(MUREO.t("app.toast_saved"), "success");
         // Refresh to surface the freshly-saved value preview.
         await MUREO.loadStatus();
         renderEnvVarsSection(MUREO.state.status);
       } else {
-        MUREO.toast("Save failed.", "error");
+        MUREO.toast(MUREO.t("app.toast_save_failed"), "error");
       }
     });
   }

--- a/mureo/_data/web/dashboard.js
+++ b/mureo/_data/web/dashboard.js
@@ -161,11 +161,11 @@
       try {
         res = await MUREO.postJson(row.removeUrl, {});
       } catch (_err) {
-        MUREO.toast(MUREO.t("dashboard.remove_failed"));
+        MUREO.toast(MUREO.t("dashboard.remove_failed"), "error");
         return;
       }
       if (!res || !res.ok) {
-        MUREO.toast(MUREO.t("dashboard.remove_failed"));
+        MUREO.toast(MUREO.t("dashboard.remove_failed"), "error");
         return;
       }
       await MUREO.loadStatus();
@@ -256,7 +256,7 @@
             await MUREO.loadStatus();
             renderAll();
           } else {
-            MUREO.toast("Operation failed");
+            MUREO.toast("Operation failed", "error");
           }
         });
         li.appendChild(removeBtn);
@@ -318,7 +318,7 @@
           );
           const body = res && res.body;
           if (res.ok && body && (body.status === "ok" || body.status === "noop")) {
-            MUREO.toast(MUREO.t("dashboard.tooluse_restart_note"));
+            MUREO.toast(MUREO.t("dashboard.tooluse_restart_note"), "success");
             await MUREO.loadStatus();
             renderAll();
             return;
@@ -332,7 +332,7 @@
               : detail === "no_mureo_block"
               ? "dashboard.tooluse_err_no_mureo_block"
               : "dashboard.tooluse_err_generic";
-          MUREO.toast(MUREO.t(errKey));
+          MUREO.toast(MUREO.t(errKey), "error");
         });
         tg.appendChild(tBtn);
         li.appendChild(tg);
@@ -381,12 +381,12 @@
       });
       if (res.ok) {
         form.querySelector('[name="env_value"]').value = "";
-        MUREO.toast("Saved.");
+        MUREO.toast("Saved.", "success");
         // Refresh to surface the freshly-saved value preview.
         await MUREO.loadStatus();
         renderEnvVarsSection(MUREO.state.status);
       } else {
-        MUREO.toast("Save failed.");
+        MUREO.toast("Save failed.", "error");
       }
     });
   }
@@ -442,16 +442,16 @@
     try {
       res = await MUREO.postJson("/api/setup/basic/clear", {});
     } catch (_err) {
-      MUREO.toast(MUREO.t("dashboard.remove_failed"));
+      MUREO.toast(MUREO.t("dashboard.remove_failed"), "error");
       return;
     }
     if (!res || !res.ok) {
-      MUREO.toast(MUREO.t("dashboard.remove_failed"));
+      MUREO.toast(MUREO.t("dashboard.remove_failed"), "error");
       return;
     }
     await MUREO.loadStatus();
     renderAll();
-    MUREO.toast(MUREO.t("dashboard.clear_all_success"));
+    MUREO.toast(MUREO.t("dashboard.clear_all_success"), "success");
   }
 
   function wireBulkClearButton() {
@@ -517,24 +517,27 @@
           skip_import: false,
         });
       } catch (_err) {
-        if (resultNode) {
-          resultNode.textContent = MUREO.t("dashboard.demo_failed", {
-            detail: "network",
-          });
-        }
+        const msg = MUREO.t("dashboard.demo_failed", { detail: "network" });
+        if (resultNode) resultNode.textContent = msg;
+        // Inline result stays for scroll-anchored context; toast is the
+        // scroll-resistant surface for operators scrolled to the bottom
+        // of a long Dashboard (#184).
+        MUREO.toast(msg, "error");
         return;
       }
       const data = (res && res.body) || {};
       if (res && res.ok && data.status === "ok") {
-        if (resultNode) {
-          resultNode.textContent = MUREO.t("dashboard.demo_success", {
-            path: data.created_path || target,
-          });
-        }
-      } else if (resultNode) {
-        resultNode.textContent = MUREO.t("dashboard.demo_failed", {
+        const msg = MUREO.t("dashboard.demo_success", {
+          path: data.created_path || target,
+        });
+        if (resultNode) resultNode.textContent = msg;
+        MUREO.toast(msg, "success");
+      } else {
+        const msg = MUREO.t("dashboard.demo_failed", {
           detail: (data && data.detail) || "error",
         });
+        if (resultNode) resultNode.textContent = msg;
+        MUREO.toast(msg, "error");
       }
     });
   }
@@ -548,7 +551,7 @@
       try {
         res = await MUREO.postJson(endpoint, body);
       } catch (_err) {
-        MUREO.toast(MUREO.t("dashboard.picker_error"));
+        MUREO.toast(MUREO.t("dashboard.picker_error"), "error");
         return;
       }
       const data = (res && res.body) || {};
@@ -557,7 +560,7 @@
       } else if (data.status === "cancelled") {
         return;
       } else {
-        MUREO.toast(MUREO.t("dashboard.picker_error"));
+        MUREO.toast(MUREO.t("dashboard.picker_error"), "error");
       }
     });
   }
@@ -605,14 +608,14 @@
           meta_ads: platform === "meta_ads",
         });
       } catch (_err) {
-        MUREO.toast(MUREO.t("dashboard.byod_remove_failed"));
+        MUREO.toast(MUREO.t("dashboard.byod_remove_failed"), "error");
         return;
       }
       const data = (res && res.body) || {};
       if (res && res.ok && data.status !== "error") {
         await renderByodStatus();
       } else {
-        MUREO.toast(MUREO.t("dashboard.byod_remove_failed"));
+        MUREO.toast(MUREO.t("dashboard.byod_remove_failed"), "error");
       }
     });
     return btn;
@@ -687,23 +690,25 @@
           replace: replaceNode ? replaceNode.checked : false,
         });
       } catch (_err) {
-        if (resultNode) {
-          resultNode.textContent = MUREO.t("dashboard.byod_import_failed", {
-            detail: "network",
-          });
-        }
+        const msg = MUREO.t("dashboard.byod_import_failed", {
+          detail: "network",
+        });
+        if (resultNode) resultNode.textContent = msg;
+        MUREO.toast(msg, "error");
         return;
       }
       const data = (res && res.body) || {};
       if (res && res.ok && data.status === "ok") {
-        if (resultNode) {
-          resultNode.textContent = MUREO.t("dashboard.byod_import_success");
-        }
+        const msg = MUREO.t("dashboard.byod_import_success");
+        if (resultNode) resultNode.textContent = msg;
+        MUREO.toast(msg, "success");
         await renderByodStatus();
-      } else if (resultNode) {
-        resultNode.textContent = MUREO.t("dashboard.byod_import_failed", {
+      } else {
+        const msg = MUREO.t("dashboard.byod_import_failed", {
           detail: (data && data.detail) || "error",
         });
+        if (resultNode) resultNode.textContent = msg;
+        MUREO.toast(msg, "error");
       }
     });
   }
@@ -721,15 +726,15 @@
     try {
       res = await MUREO.postJson("/api/byod/clear", {});
     } catch (_err) {
-      MUREO.toast(MUREO.t("dashboard.byod_clear_failed"));
+      MUREO.toast(MUREO.t("dashboard.byod_clear_failed"), "error");
       return;
     }
     const data = (res && res.body) || {};
     if (res && res.ok && data.status !== "error") {
-      MUREO.toast(MUREO.t("dashboard.byod_clear_success"));
+      MUREO.toast(MUREO.t("dashboard.byod_clear_success"), "success");
       await renderByodStatus();
     } else {
-      MUREO.toast(MUREO.t("dashboard.byod_clear_failed"));
+      MUREO.toast(MUREO.t("dashboard.byod_clear_failed"), "error");
     }
   }
 
@@ -818,7 +823,7 @@
             await MUREO.loadStatus();
             renderAll();
           } else {
-            MUREO.toast(MUREO.t("dashboard.remove_failed"));
+            MUREO.toast(MUREO.t("dashboard.remove_failed"), "error");
           }
         });
         li.appendChild(btn);
@@ -960,13 +965,13 @@
         values: values,
       });
     } catch (_e) {
-      MUREO.toast(MUREO.t("dashboard.plugin_credentials_save_failed"));
+      MUREO.toast(MUREO.t("dashboard.plugin_credentials_save_failed"), "error");
       return;
     }
     // ``postJson`` returns ``{ok, status: <HTTP code>, body}`` — the
     // server's logical ``"ok"`` envelope lives inside ``body.status``.
     if (res && res.ok && res.body && res.body.status === "ok") {
-      MUREO.toast(MUREO.t("dashboard.plugin_credentials_saved"));
+      MUREO.toast(MUREO.t("dashboard.plugin_credentials_saved"), "success");
       // Clear secret inputs so the next view starts from the "keep
       // existing" baseline rather than the just-typed plain text.
       Array.from(form.querySelectorAll('input[type="password"]')).forEach(
@@ -975,7 +980,7 @@
         }
       );
     } else {
-      MUREO.toast(MUREO.t("dashboard.plugin_credentials_save_failed"));
+      MUREO.toast(MUREO.t("dashboard.plugin_credentials_save_failed"), "error");
     }
   }
 

--- a/mureo/_data/web/i18n.json
+++ b/mureo/_data/web/i18n.json
@@ -197,7 +197,11 @@
     "auth_wizard.google_ads.scope_note": "Use the “Authenticate with Google” button below — mureo requests the required Google Ads scope (https://www.googleapis.com/auth/adwords) plus Search Console automatically. If you instead reuse a refresh token minted elsewhere, it MUST include the Google Ads (AdWords) scope, or API calls fail with ACCESS_TOKEN_SCOPE_INSUFFICIENT. Official scope reference:",
     "auth_wizard.google_ads.scope_doc_link": "Google Ads API — OAuth 2.0 scopes (official docs)",
     "wizard.completed.finish_button": "Finish & free the terminal",
-    "wizard.completed.finished_note": "Done — the mureo configure server has stopped and your terminal is free. You can close this tab."
+    "wizard.completed.finished_note": "Done — the mureo configure server has stopped and your terminal is free. You can close this tab.",
+    "app.toast_setup_failed": "Setup failed",
+    "app.toast_operation_failed": "Operation failed",
+    "app.toast_saved": "Saved.",
+    "app.toast_save_failed": "Save failed."
   },
   "ja": {
     "nav.dashboard": "ダッシュボード",
@@ -397,6 +401,10 @@
     "auth_wizard.google_ads.scope_note": "下の「Authenticate with Google」ボタンを使ってください — mureo は必要な Google Ads スコープ（https://www.googleapis.com/auth/adwords）と Search Console を自動的に要求します。他で発行した refresh token を流用する場合は、Google Ads（AdWords）スコープを必ず含めてください。含まないと API 呼び出しが ACCESS_TOKEN_SCOPE_INSUFFICIENT で失敗します。公式スコープ説明:",
     "auth_wizard.google_ads.scope_doc_link": "Google Ads API — OAuth 2.0 スコープ（公式ドキュメント）",
     "wizard.completed.finish_button": "終了してターミナルを解放",
-    "wizard.completed.finished_note": "完了 — mureo configure サーバを停止しました。ターミナルは解放されています。このタブは閉じて構いません。"
+    "wizard.completed.finished_note": "完了 — mureo configure サーバを停止しました。ターミナルは解放されています。このタブは閉じて構いません。",
+    "app.toast_setup_failed": "セットアップに失敗しました",
+    "app.toast_operation_failed": "操作に失敗しました",
+    "app.toast_saved": "保存しました",
+    "app.toast_save_failed": "保存に失敗しました"
   }
 }

--- a/mureo/_data/web/wizard.js
+++ b/mureo/_data/web/wizard.js
@@ -292,7 +292,7 @@
         await MUREO.loadStatus();
         render();
       } else {
-        MUREO.toast("Setup failed");
+        MUREO.toast(MUREO.t("app.toast_setup_failed"), "error");
       }
     });
     wrap.querySelector("[data-advanced-skip]").addEventListener("click", function () {

--- a/tests/test_web_assets_dashboard_cards_and_toasts.py
+++ b/tests/test_web_assets_dashboard_cards_and_toasts.py
@@ -1,0 +1,134 @@
+"""Static-content guards for the dashboard card treatment (#183) and the
+toast-kind error surface (#184).
+
+These tests pin the *shape* of the web assets that ship with mureo (no
+build step — they are read directly from ``mureo/_data/web/`` at
+runtime). A CSS rule or a toast call that gets accidentally reverted by
+a future refactor flips a test red here long before an operator notices
+the regression in the configure UI.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_WEB = Path(__file__).resolve().parent.parent / "mureo" / "_data" / "web"
+
+
+def _read(name: str) -> str:
+    return (_WEB / name).read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# #183 — Dashboard provider rows look like cards (border + padding + radius)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_dashboard_providers_list_has_card_selector() -> None:
+    """``[data-dashboard-providers-list] > li`` must be styled as a
+    card so each platform's row is visually demarcated from the next.
+    Without a hairline border + radius + padding the list is flat and
+    operators have to read the labels carefully to find the boundary.
+    """
+    css = _read("app.css")
+    assert "[data-dashboard-providers-list] > li" in css
+
+
+@pytest.mark.unit
+def test_dashboard_plugin_credentials_list_has_card_selector() -> None:
+    """Plugin credentials list uses a generic child selector
+    (``> *``) so any plugin-rendered row participates in the same
+    card treatment.
+    """
+    css = _read("app.css")
+    assert "[data-dashboard-plugin-credentials-list] > *" in css
+
+
+@pytest.mark.unit
+def test_dashboard_card_rule_carries_border_radius_padding() -> None:
+    """Pin the actual visual properties — the rule must visibly
+    demarcate, not just exist as a selector.
+    """
+    css = _read("app.css")
+    # Find the dashboard card block — both lists share one rule. The
+    # marker is the human-grep-friendly prefix; the rest of the comment
+    # may be a longer rationale across multiple lines.
+    marker = "/* #183 dashboard provider card"
+    assert marker in css, (
+        "card block must be marked so future grep finds it; if you "
+        "rename the marker, update this test too"
+    )
+    block_start = css.index(marker)
+    # Read a window large enough to hold the rule body (comment +
+    # selectors + four declarations).
+    window = css[block_start : block_start + 900]
+    assert "border:" in window
+    assert "border-radius:" in window
+    assert "padding:" in window
+
+
+# ---------------------------------------------------------------------------
+# #184 — Toast accepts a ``kind`` for color-coding + error sites use it
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_toast_helper_accepts_kind_argument() -> None:
+    """``MUREO.toast`` must accept an optional kind argument so error /
+    success can be color-coded. The signature is part of the public
+    surface (every web asset bundled with mureo can call it).
+    """
+    js = _read("app.js")
+    assert "function toast(message, kind)" in js
+
+
+@pytest.mark.unit
+def test_toast_applies_kind_class() -> None:
+    """The kind argument must translate to a CSS class (``is-error`` /
+    ``is-success`` / ``is-info``) so ``app.css`` can color-code without
+    inline styles.
+    """
+    js = _read("app.js")
+    assert (
+        "is-" in js and "classList" in js
+    ), "toast() must set a kind-derived className via classList"
+
+
+@pytest.mark.unit
+def test_toast_error_and_success_styles_exist() -> None:
+    """``.app-toast.is-error`` and ``.app-toast.is-success`` must be
+    declared in ``app.css`` — otherwise the kind argument has no visual
+    effect.
+    """
+    css = _read("app.css")
+    assert ".app-toast.is-error" in css
+    assert ".app-toast.is-success" in css
+
+
+@pytest.mark.unit
+def test_auth_wizard_error_sites_also_toast() -> None:
+    """Five known inline ``status.textContent = MUREO.t("...failed")``
+    sites in ``auth_wizards.js`` must pair with a ``MUREO.toast(...,
+    "error")`` call. The inline status stays for the accessible status
+    node; the toast adds the scroll-resistant surface.
+
+    Regression guard for #184: an operator scrolled to the bottom of a
+    long Dashboard who triggers a wizard failure sees the toast at
+    bottom-right regardless of where the inline status node sits.
+    """
+    js = _read("auth_wizards.js")
+    assert js.count("MUREO.toast(") >= 5, (
+        "auth_wizards.js must call MUREO.toast() on every inline "
+        "error site; expected at least five (finalize, save x2, "
+        "oauth start, oauth poll). See issue #184."
+    )
+    # Pin the kind argument at every site so a typo at one call
+    # (e.g. ``"errr"``) cannot slip through while still passing a
+    # global ``"error" in js`` check.
+    assert js.count('"error"') >= 5, (
+        'every wizard error toast must pass kind="error" — count '
+        "below the expected sites suggests a typo or missing kind"
+    )

--- a/tests/test_web_assets_dashboard_cards_and_toasts.py
+++ b/tests/test_web_assets_dashboard_cards_and_toasts.py
@@ -63,8 +63,9 @@ def test_dashboard_card_rule_carries_border_radius_padding() -> None:
     )
     block_start = css.index(marker)
     # Read a window large enough to hold the rule body (comment +
-    # selectors + four declarations).
-    window = css[block_start : block_start + 900]
+    # selectors + the full declaration block, which has grown over time
+    # with explanatory comments).
+    window = css[block_start : block_start + 2400]
     assert "border:" in window
     assert "border-radius:" in window
     assert "padding:" in window


### PR DESCRIPTION
Closes #183, #184

## Summary

Two operator-experience papercuts in the configure UI, bundled in one PR because they share the `mureo/_data/web/` asset surface.

- **#183**: Dashboard provider rows now render as cards with their own boundary instead of a flat hairline list, so credential boundaries are scannable at a glance.
- **#184**: `MUREO.toast(message)` accepts an optional `kind` (`"info"` / `"success"` / `"error"`) for color-coded pills; every previously-toast-less inline failure path also fires a toast so an operator scrolled to the bottom of a long Dashboard always sees feedback.

## Files touched

- `mureo/_data/web/app.css` — card rule block + `.app-toast.is-success` / `.is-error` tints + `:last-child` border restore
- `mureo/_data/web/app.js` — extends `toast(message)` → `toast(message, kind)` (backwards compatible)
- `mureo/_data/web/auth_wizards.js` — 5 inline failure sites also toast (`"error"` kind); each pulls the message into a local so the i18n key is not duplicated
- `mureo/_data/web/dashboard.js` — 4 previously-toast-less failure paths (demo init, BYOD import) gain toast pairs; ~15 existing single-arg toast calls get the right `"error"` / `"success"` kind so red and green are consistent across the whole UI
- `mureo/_data/web/app.html` — TODO comment near the toast node documenting the aria-live consideration for a future screen-reader pass
- `tests/test_web_assets_dashboard_cards_and_toasts.py` — 7 new static-content tests pinning the fix shape

## Test plan

- [x] 7 new tests in `tests/test_web_assets_dashboard_cards_and_toasts.py`
- [x] Web test suite regression: 190 passed
- [x] `ruff check mureo/` clean
- [x] `black --check` clean
- [x] code-reviewer findings addressed: card rule no longer breaks flex layout (HIGH), missed dashboard failure sites migrated (HIGH), existing toast calls color-coded (HIGH), `:last-child` comment tightened (MEDIUM), tests strengthened to count `"error"` literal occurrences (MEDIUM), aria-live TODO added (MEDIUM)

## Accessibility

Inline status nodes are kept alongside every new toast call — toasts add the scroll-resistant surface; the inline node remains for scroll-anchored context and future screen-reader work (TODO in `app.html`). Toast color contrast: `#1f7a3f` ≈ 5.36:1, `#b3261e` ≈ 6.48:1 against white text (both pass WCAG AA).

## Out of scope

- aria-live region wiring (deferred — see TODO in `app.html`)
- Replacing `<dialog>` confirmations (issue #184 explicitly excluded)
- Notification center / persistent notifications
