### PR TITLE
feat(core): locale-aware AccountCredentialField via OSS-side locale-selection hook (#186)

### DIFF
--- a/docs/plugin-authoring.md
+++ b/docs/plugin-authoring.md
@@ -307,11 +307,40 @@ class MyAdsProvider:
 | Field | Default | Notes |
 |---|---|---|
 | `key` | (required) | Stable snake_case identifier used in credential storage. Treat as part of your public ABI — renaming after release breaks operator config. |
-| `display_name` | (required) | Human-readable label for CLI prompts / wizard forms. |
+| `display_name` | (required) | Human-readable label for CLI prompts / wizard forms. Used as the fallback when no `display_name_i18n` entry resolves for the active locale. |
 | `placeholder` | `""` | Example value shown in form inputs (never used as a default — auto-applying would surprise operators). |
 | `required` | `False` | When `True`, tooling may warn or block on a missing value. |
-| `description` | `""` | One-line operator-facing hint pointing at where the value comes from. |
+| `description` | `""` | One-line operator-facing hint pointing at where the value comes from. Used as the fallback when no `description_i18n` entry resolves. |
 | `secret` | `False` | When `True`, consumers render a masked input and may pick tighter storage permissions. Use only when the per-account slice itself is sensitive (e.g. a per-account API key). See "Secret per-account fields" below. |
+| `display_name_i18n` | `{}` | Optional `{locale: label}` map (BCP-47 codes). Resolved via `i18n[locale] → i18n["en"] → display_name`. Empty-string entries fall through to the next layer. Ship only the locales you have translated. See "Localised labels" below. |
+| `description_i18n` | `{}` | Same shape and fallback chain as `display_name_i18n`, applied to the hint text. |
+
+#### Localised labels (`*_i18n`)
+
+The configure UI carries an active locale per session (`en` / `ja`
+today; the lookup is BCP-47 so future locales drop in). Each plugin
+ships its own translation strings — mureo's OSS never ships
+non-English copy for plugin-declared fields. The resolution chain is
+`i18n[locale] → i18n["en"] → display_name` (and the equivalent for
+description); an empty-string entry is treated as "not declared" so a
+mistakenly-empty translation cannot blank the label.
+
+```python
+account_credential_fields = (
+    AccountCredentialField(
+        key="business_id",
+        display_name="Business ID",                          # universal fallback
+        description="Yahoo! JAPAN Business ID.",
+        required=True,
+        display_name_i18n={"ja": "ビジネス ID"},               # per-locale label
+        description_i18n={"ja": "Yahoo! JAPAN ビジネス ID。"},  # per-locale hint
+    ),
+)
+```
+
+A plugin that ships only English (no `*_i18n` declared) keeps working
+unchanged — both maps default to `{}` and every locale falls through
+to the bare `display_name` / `description` strings.
 
 The accessor `mureo.core.providers.get_account_credential_fields(provider)`
 reads the attribute defensively (returns `()` when absent) and

--- a/mureo/core/providers/credentials.py
+++ b/mureo/core/providers/credentials.py
@@ -22,7 +22,11 @@ behaviour and never reads or writes a value. Storage policy
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 
 @dataclass(frozen=True)
@@ -35,7 +39,9 @@ class AccountCredentialField:
             the provider's public ABI — renaming the key after
             release breaks any operator config that referenced it.
         display_name: Human-readable label for CLI prompts and
-            wizard forms (e.g., ``"Customer ID"``).
+            wizard forms (e.g., ``"Customer ID"``). Used as the
+            fallback when no ``display_name_i18n`` entry resolves
+            for the active locale — see the ``*_i18n`` attributes.
         placeholder: Example value shown as a form-input placeholder
             (e.g., ``"123-456-7890"``). Never used as a default —
             tooling that auto-applies the placeholder would surprise
@@ -45,8 +51,9 @@ class AccountCredentialField:
             missing value. Default: ``False``.
         description: One-line operator-facing hint pointing at where
             the value comes from (e.g., ``"From Google Ads UI >
-            Settings > Account details > Customer ID"``).
-            Default: ``""``.
+            Settings > Account details > Customer ID"``). Used as
+            the fallback when no ``description_i18n`` entry resolves
+            for the active locale. Default: ``""``.
         secret: ``True`` when the field carries a secret value (API
             key, per-account OAuth token, etc.) rather than a public
             identifier (``customer_id``, ``ad_account_id``, …). Like
@@ -61,10 +68,26 @@ class AccountCredentialField:
             leave secret material (refresh tokens, system user
             tokens) in the operator-shared ``SecretStore`` layer
             rather than declaring it here.
+        display_name_i18n: Optional locale → label mapping (BCP-47
+            language codes; mureo's configure UI currently switches
+            between ``"en"`` and ``"ja"``). The consumer resolves the
+            label via ``i18n[locale] → i18n["en"] → display_name`` so
+            a plugin can supply only the locales it has translated.
+            Default: empty ``dict`` (pre-#186 behaviour — the bare
+            ``display_name`` is used in every locale).
+        description_i18n: Same shape and fallback chain as
+            ``display_name_i18n``, applied to the hint text.
 
     The dataclass is JSON-friendly: ``dataclasses.asdict(field)``
-    returns a plain ``dict`` of primitive ``str`` / ``bool`` values
-    suitable for serialising over HTTP / writing to a config file.
+    returns a plain ``dict`` of primitive ``str`` / ``bool`` / dict
+    values suitable for serialising over HTTP / writing to a config
+    file.
+
+    The ``*_i18n`` attributes were added in #186 so plugins shipping
+    to non-English audiences (Yahoo! JAPAN Ads, LINE Ads, ...) can
+    keep their translation strings in their own package without
+    forking mureo. The translation tables are plugin-owned by design
+    — mureo itself never ships strings for plugin-declared fields.
     """
 
     key: str
@@ -73,6 +96,8 @@ class AccountCredentialField:
     required: bool = False
     description: str = ""
     secret: bool = False
+    display_name_i18n: Mapping[str, str] = field(default_factory=dict)
+    description_i18n: Mapping[str, str] = field(default_factory=dict)
 
 
 __all__ = ["AccountCredentialField"]

--- a/mureo/web/handlers.py
+++ b/mureo/web/handlers.py
@@ -284,7 +284,17 @@ class ConfigureHandler(BaseHTTPRequestHandler):
             send_json(self, byod_status().as_dict())
             return
         if path == "/api/credentials/plugins":
-            send_json(self, {"plugins": list_plugin_credential_fields()})
+            # Forward the session locale so plugin-declared
+            # ``display_name_i18n`` / ``description_i18n`` entries are
+            # resolved against the operator's active locale (#186).
+            send_json(
+                self,
+                {
+                    "plugins": list_plugin_credential_fields(
+                        locale=self.wizard.session.locale,
+                    )
+                },
+            )
             return
         match = _OAUTH_PROVIDER_RE.match(path)
         if match is not None and match.group("verb") == "status":

--- a/mureo/web/plugin_credentials.py
+++ b/mureo/web/plugin_credentials.py
@@ -33,6 +33,8 @@ from mureo.core.providers import default_registry, get_account_credential_fields
 from mureo.core.secret_store import FilesystemSecretStore, SecretStore
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from mureo.core.providers.credentials import AccountCredentialField
 
 logger = logging.getLogger(__name__)
@@ -62,8 +64,20 @@ class RequiredFieldMissingError(PluginCredentialsError):
     """
 
 
-def list_plugin_credential_fields() -> list[dict[str, Any]]:
+def list_plugin_credential_fields(
+    locale: str = "en",
+) -> list[dict[str, Any]]:
     """Enumerate providers that declare per-account credential fields.
+
+    Args:
+        locale: BCP-47 language code used to resolve plugin-supplied
+            ``display_name_i18n`` / ``description_i18n`` entries on
+            each field. The fallback chain is
+            ``i18n[locale] → i18n["en"] → display_name`` (and the
+            equivalent for description), so a plugin may ship only
+            the locales it has translated. Defaults to ``"en"`` —
+            matches pre-#186 behaviour for callers that don't yet
+            pass a locale.
 
     Returns:
         A list of provider descriptors sorted alphabetically by
@@ -85,6 +99,8 @@ def list_plugin_credential_fields() -> list[dict[str, Any]]:
                 ],
             }
 
+        ``display_name`` and ``description`` on each field are the
+        locale-resolved strings; the ``key`` is locale-independent.
         Providers without declared fields are skipped — they have
         nothing for the operator to fill in.
     """
@@ -97,7 +113,7 @@ def list_plugin_credential_fields() -> list[dict[str, Any]]:
             {
                 "provider_name": entry.name,
                 "display_name": entry.display_name,
-                "fields": [_field_to_dict(f) for f in fields],
+                "fields": [_field_to_dict(f, locale) for f in fields],
             }
         )
     return result
@@ -204,22 +220,56 @@ def save_plugin_credentials(
     return {"merged": merged, "accepted_keys": accepted_keys}
 
 
-def _field_to_dict(field: AccountCredentialField) -> dict[str, Any]:
+def _field_to_dict(field: AccountCredentialField, locale: str) -> dict[str, Any]:
     """Convert one ``AccountCredentialField`` to its JSON payload shape.
+
+    Args:
+        field: The plugin-declared field.
+        locale: BCP-47 language code used for the ``display_name`` /
+            ``description`` lookup chain. Resolution order:
+            ``i18n[locale]`` → ``i18n["en"]`` → the bare
+            ``field.display_name`` / ``field.description``. A plugin
+            that ships only English keeps working unchanged because
+            both ``*_i18n`` mappings default to ``{}`` so the chain
+            collapses to the bare attribute on every locale.
 
     We do not use :func:`dataclasses.asdict` here so the wire-level
     shape is pinned by this module — a future ``AccountCredentialField``
-    field gets a deliberate decision about whether the UI should see
-    it.
+    attribute gets a deliberate decision about whether the UI should
+    see it.
     """
     return {
         "key": field.key,
-        "display_name": field.display_name,
+        "display_name": _resolve_localized(
+            field.display_name_i18n, field.display_name, locale
+        ),
         "placeholder": field.placeholder,
         "required": field.required,
         "secret": field.secret,
-        "description": field.description,
+        "description": _resolve_localized(
+            field.description_i18n, field.description, locale
+        ),
     }
+
+
+def _resolve_localized(i18n: Mapping[str, str], fallback: str, locale: str) -> str:
+    """Return ``i18n[locale]`` if present, else ``i18n["en"]``, else fallback.
+
+    Empty-string entries are treated as "not declared" so a plugin
+    cannot accidentally erase a label by shipping an empty JA entry —
+    the chain falls through to the next layer instead. ``en`` is
+    privileged as the universal fallback because the configure UI
+    defaults to it and every existing in-tree provider already ships
+    English copy as ``display_name`` / ``description``.
+    """
+    candidate = i18n.get(locale)
+    if candidate:
+        return candidate
+    if locale != "en":
+        en_candidate = i18n.get("en")
+        if en_candidate:
+            return en_candidate
+    return fallback
 
 
 __all__ = [

--- a/tests/core/providers/test_account_credential_field.py
+++ b/tests/core/providers/test_account_credential_field.py
@@ -105,7 +105,14 @@ def test_asdict_is_json_friendly() -> None:
         "required": True,
         "description": "hint",
         "secret": False,
+        # #186: the optional i18n maps default to empty dicts so a
+        # plugin that does not ship translations stays
+        # forwards-compatible with the locale-aware list payload.
+        "display_name_i18n": {},
+        "description_i18n": {},
     }
-    # Verify no exotic types slipped in.
+    # Verify no exotic types slipped in. The i18n maps are plain
+    # ``dict[str, str]`` so a JSON serialiser handles them without
+    # a custom encoder.
     for value in payload.values():
-        assert isinstance(value, (str, bool))
+        assert isinstance(value, (str, bool, dict))

--- a/tests/test_web_handlers_plugin_credentials.py
+++ b/tests/test_web_handlers_plugin_credentials.py
@@ -182,6 +182,43 @@ def test_get_lists_plugins_with_declared_fields(
 
 
 @pytest.mark.unit
+def test_get_uses_session_locale_for_field_labels(
+    wizard: ConfigureWizard, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The handler must forward ``session.locale`` into the registry
+    walk so plugin-declared ``display_name_i18n`` / ``description_i18n``
+    entries are resolved against the active operator locale (#186).
+    """
+    monkeypatch.setattr(
+        default_registry,
+        "_entries",
+        {
+            "lineyahoo_ads": _entry(
+                "lineyahoo_ads",
+                display_name="LINE/Yahoo! Ads",
+                fields=(
+                    AccountCredentialField(
+                        key="business_id",
+                        display_name="Business ID",
+                        description="Yahoo! JAPAN Business ID.",
+                        display_name_i18n={"ja": "ビジネス ID"},
+                        description_i18n={"ja": "Yahoo! JAPAN ビジネス ID。"},
+                    ),
+                ),
+            )
+        },
+    )
+    wizard.session.set_locale("ja")
+
+    resp = _get(wizard, "/api/credentials/plugins")
+    body = json.loads(resp.read())
+    [plugin] = body["plugins"]
+    [field] = plugin["fields"]
+    assert field["display_name"] == "ビジネス ID"
+    assert field["description"] == "Yahoo! JAPAN ビジネス ID。"
+
+
+@pytest.mark.unit
 def test_get_returns_empty_list_when_no_plugins(
     wizard: ConfigureWizard, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_web_plugin_credentials.py
+++ b/tests/test_web_plugin_credentials.py
@@ -186,6 +186,219 @@ def test_list_includes_full_field_metadata(
 
 
 @pytest.mark.unit
+def test_account_credential_field_has_empty_i18n_dicts_by_default() -> None:
+    """Backwards compatibility for plugins that don't declare i18n.
+
+    Plugins that predate locale support keep working unchanged — the
+    new ``display_name_i18n`` / ``description_i18n`` attributes default
+    to empty mappings, so the fallback chain (i18n[locale] →
+    i18n["en"] → display_name) lands on the legacy single-string
+    value when no translation is declared.
+    """
+    f = AccountCredentialField(key="api_key", display_name="API Key")
+    assert f.display_name_i18n == {}
+    assert f.description_i18n == {}
+
+
+@pytest.mark.unit
+def test_list_uses_locale_when_field_declares_i18n(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``locale="ja"`` resolves to the JA entry declared by the plugin."""
+    from mureo.web.plugin_credentials import list_plugin_credential_fields
+
+    _register(
+        monkeypatch,
+        [
+            _entry(
+                "lineyahoo_ads",
+                display_name="LINE/Yahoo! Ads",
+                fields=(
+                    AccountCredentialField(
+                        key="business_id",
+                        display_name="Business ID",
+                        description="Yahoo! JAPAN Business ID.",
+                        display_name_i18n={"ja": "ビジネス ID"},
+                        description_i18n={"ja": "Yahoo! JAPAN ビジネス ID。"},
+                    ),
+                ),
+            )
+        ],
+    )
+
+    [entry] = list_plugin_credential_fields(locale="ja")
+    [field] = entry["fields"]
+    assert field["display_name"] == "ビジネス ID"
+    assert field["description"] == "Yahoo! JAPAN ビジネス ID。"
+
+
+@pytest.mark.unit
+def test_list_falls_back_to_en_when_requested_locale_not_declared(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unknown locale falls back to ``en`` if declared, then ``display_name``."""
+    from mureo.web.plugin_credentials import list_plugin_credential_fields
+
+    _register(
+        monkeypatch,
+        [
+            _entry(
+                "demo_ads",
+                fields=(
+                    AccountCredentialField(
+                        key="api_key",
+                        display_name="API Key",
+                        description="Per-account API key.",
+                        # JA omitted; EN declared explicitly.
+                        display_name_i18n={"en": "API Key (EN)"},
+                        description_i18n={"en": "Per-account API key. (EN)"},
+                    ),
+                ),
+            )
+        ],
+    )
+
+    [entry] = list_plugin_credential_fields(locale="ja")
+    [field] = entry["fields"]
+    assert field["display_name"] == "API Key (EN)"
+    assert field["description"] == "Per-account API key. (EN)"
+
+
+@pytest.mark.unit
+def test_list_falls_back_to_display_name_when_no_i18n_declared(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When neither locale nor ``en`` i18n is declared, the bare
+    ``display_name`` / ``description`` strings come through."""
+    from mureo.web.plugin_credentials import list_plugin_credential_fields
+
+    _register(
+        monkeypatch,
+        [
+            _entry(
+                "demo_ads",
+                fields=(
+                    AccountCredentialField(
+                        key="api_key",
+                        display_name="API Key",
+                        description="Per-account API key.",
+                    ),
+                ),
+            )
+        ],
+    )
+
+    [entry] = list_plugin_credential_fields(locale="ja")
+    [field] = entry["fields"]
+    assert field["display_name"] == "API Key"
+    assert field["description"] == "Per-account API key."
+
+
+@pytest.mark.unit
+def test_list_locale_en_with_only_ja_declared_returns_display_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``locale="en"`` + only ``display_name_i18n={"ja": "..."}`` must
+    NOT leak the JA entry into the EN locale. The chain is
+    ``i18n[locale] → i18n["en"] → display_name`` — with no ``"en"``
+    declared either, the bare ``display_name`` wins.
+    """
+    from mureo.web.plugin_credentials import list_plugin_credential_fields
+
+    _register(
+        monkeypatch,
+        [
+            _entry(
+                "demo_ads",
+                fields=(
+                    AccountCredentialField(
+                        key="api_key",
+                        display_name="API Key",
+                        description="Per-account API key.",
+                        display_name_i18n={"ja": "API キー"},
+                        description_i18n={"ja": "アカウント単位の API キー。"},
+                    ),
+                ),
+            )
+        ],
+    )
+
+    [entry] = list_plugin_credential_fields(locale="en")
+    [field] = entry["fields"]
+    assert field["display_name"] == "API Key"
+    assert field["description"] == "Per-account API key."
+
+
+@pytest.mark.unit
+def test_list_empty_string_i18n_entry_falls_through(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An empty-string i18n entry must be treated as "not declared",
+    not "render an empty label". A mistakenly-empty translation should
+    fall through to the next layer (``en`` → ``display_name``) rather
+    than blank the form. Regression guard against a refactor that
+    flips the truthiness check to ``is not None``.
+    """
+    from mureo.web.plugin_credentials import list_plugin_credential_fields
+
+    _register(
+        monkeypatch,
+        [
+            _entry(
+                "demo_ads",
+                fields=(
+                    AccountCredentialField(
+                        key="api_key",
+                        display_name="API Key",
+                        description="Per-account API key.",
+                        display_name_i18n={"ja": "", "en": "API Key (EN)"},
+                        description_i18n={"ja": ""},
+                    ),
+                ),
+            )
+        ],
+    )
+
+    [entry] = list_plugin_credential_fields(locale="ja")
+    [field] = entry["fields"]
+    # Empty JA → falls through to EN-declared entry.
+    assert field["display_name"] == "API Key (EN)"
+    # Empty JA + no EN declared → falls through to bare description.
+    assert field["description"] == "Per-account API key."
+
+
+@pytest.mark.unit
+def test_list_default_locale_is_en(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Calling without a locale keeps the pre-#186 behaviour: EN."""
+    from mureo.web.plugin_credentials import list_plugin_credential_fields
+
+    _register(
+        monkeypatch,
+        [
+            _entry(
+                "demo_ads",
+                fields=(
+                    AccountCredentialField(
+                        key="api_key",
+                        display_name="API Key",
+                        display_name_i18n={
+                            "en": "API Key (EN)",
+                            "ja": "API キー",
+                        },
+                    ),
+                ),
+            )
+        ],
+    )
+
+    [entry] = list_plugin_credential_fields()
+    [field] = entry["fields"]
+    assert field["display_name"] == "API Key (EN)"
+
+
+@pytest.mark.unit
 def test_list_sorts_providers_alphabetically_by_name(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Closes #186

## Summary

Plugin-declared per-account credential field labels and descriptions were locale-independent strings, so operators using `mureo configure` in Japanese saw English labels even for plugins that wanted to ship JA copy. This PR adds an **OSS-side locale-selection hook**; plugins keep their translation strings in their own package — mureo only picks the right one for the active session locale.

Mirrors the pattern already used for web-extension menu names (`display_name_i18n` in `mureo/web/extensions.py`) — same fallback chain, same backwards-compat default.

## Wire format

- `AccountCredentialField` gains two optional dataclass attributes (`display_name_i18n`, `description_i18n`, both `Mapping[str, str]` defaulting to `{}` via `field(default_factory=dict)`).
- `list_plugin_credential_fields(locale: str = "en")` resolves each label via the chain `i18n[locale] → i18n["en"] → display_name` (and the equivalent for description). Empty-string entries fall through to the next layer.
- `GET /api/credentials/plugins` forwards `self.wizard.session.locale` (the existing allow-listed `{"en", "ja"}` session attribute).
- `dashboard.js` is unchanged — it already renders the JSON-supplied strings verbatim.

## Backwards compatibility

- Plugins declaring only `display_name` keep working in every locale (both maps default to `{}`).
- Wire shape of `_field_to_dict` adds no new top-level keys — i18n resolution happens in-place on `display_name` / `description`.
- `dataclasses.asdict(field)` gains the two new dict-typed keys; the asdict test now asserts `(str, bool, dict)` value types.
- Frozen dataclass + mutable default handled via `field(default_factory=dict)` — no shared-default bug.

## Test plan

- [x] 7 new unit/handler tests:
  - empty i18n dict default (regression guard for `default_factory` contract)
  - `locale="ja"` resolves to JA entry
  - fallback to EN when requested locale not declared
  - fallback to bare `display_name` when neither i18n declared
  - default locale (`"en"`) picks the EN entry
  - `locale="en"` + only JA declared → bare `display_name` (regression guard for the EN-fallback guard)
  - empty-string i18n entry falls through (regression guard against an `is not None` refactor)
  - handler integration: `GET /api/credentials/plugins` picks up `session.locale`
- [x] Existing regression: 426 passed (plugin-credentials + handlers + providers + adapters)
- [x] `ruff check mureo/` clean
- [x] `black --check` clean
- [x] code-reviewer findings addressed:
  - MEDIUM (docs): `docs/plugin-authoring.md` updated — two table rows + new "Localised labels" subsection mirroring the extension-tab i18n example
  - LOW (test coverage): two edge-case tests added (`locale=en` + only JA, empty-string entry)

## Out of scope

- Provider group heading `entry.display_name` locale support — explicitly deferred in the issue body (separate issue).
- Per-plugin JA translation strings — owned by each plugin's package (mureo never ships strings for plugin-declared fields).
