### PR TITLE
fix(cli): restore terminal state around TerminalMenu.show() (#190)

### DIFF
--- a/mureo/auth_setup.py
+++ b/mureo/auth_setup.py
@@ -7,6 +7,7 @@ Meta Ads: App ID/Secret input -> Browser OAuth -> Long-Lived Token retrieval -> 
 
 from __future__ import annotations
 
+import contextlib
 import html
 import http.server
 import json
@@ -18,6 +19,11 @@ import sys
 import threading
 import urllib.parse
 import webbrowser
+
+try:
+    import termios
+except ImportError:  # pragma: no cover - Windows (Unix-only stdlib)
+    termios = None  # type: ignore[assignment]
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -53,6 +59,67 @@ _SEARCH_CONSOLE_SCOPE = "https://www.googleapis.com/auth/webmasters"
 _GOOGLE_SCOPES = [_GOOGLE_ADS_SCOPE, _SEARCH_CONSOLE_SCOPE]
 
 
+def _terminal_fd() -> int | None:
+    """Resolve the controlling-terminal fd, or ``None`` for non-TTY.
+
+    Wraps ``sys.stdin.fileno()`` so the lookup itself does not raise
+    under pytest (the test harness replaces stdin with a pseudo-file
+    whose ``fileno()`` raises ``UnsupportedOperation``) or in any
+    other context where stdin is not a real file descriptor.
+    """
+    try:
+        return sys.stdin.fileno()
+    except (OSError, ValueError, AttributeError):
+        return None
+
+
+def _capture_terminal_state(fd: int | None) -> Any | None:
+    """Snapshot the current terminal attributes for later restore.
+
+    Returns the result of ``termios.tcgetattr(fd)`` on success, or
+    ``None`` when stdin is not a TTY (pipe / redirect / CI / Windows /
+    pytest's stdin replacement). The ``None`` return signals the
+    matching ``_restore_terminal_state`` call to skip the restore —
+    the snapshot would not have been meaningful, and ``tcsetattr`` on
+    a non-TTY would itself raise.
+
+    See #190 — ``simple_term_menu.TerminalMenu.show()`` flips the
+    terminal into cbreak (no ``ICANON`` / ``ECHO`` / ``ISIG``) and on
+    any non-normal exit can leave it that way. mureo wraps every
+    ``show()`` call in a ``try/finally`` that pairs this helper with
+    ``_restore_terminal_state`` so the shell session always recovers,
+    even when the operator cancels the menu or ``show()`` raises.
+    """
+    if termios is None or fd is None:
+        return None
+    try:
+        return termios.tcgetattr(fd)
+    except (termios.error, OSError, ValueError):
+        return None
+
+
+def _restore_terminal_state(fd: int | None, state: Any | None) -> None:
+    """Re-apply a snapshot captured by ``_capture_terminal_state``.
+
+    No-op when ``state`` is ``None`` (matches the
+    ``_capture_terminal_state`` contract for non-TTY input). Errors
+    from ``tcsetattr`` are swallowed — the restore is best-effort,
+    not a hard requirement, and a failure here should not crash the
+    surrounding CLI flow.
+
+    Uses ``TCSADRAIN`` so any pending output drains before the mode
+    flip; this avoids the cosmetic glitch where a trailing menu
+    redraw can race the restore and leave stray escape codes visible
+    in the next prompt.
+    """
+    if state is None or termios is None or fd is None:
+        return
+    # Best-effort restore — a ``tcsetattr`` failure here should not
+    # crash the surrounding CLI flow. See #190.
+    with contextlib.suppress(termios.error, OSError, ValueError, AttributeError):
+        termios.tcsetattr(fd, termios.TCSADRAIN, state)
+
+
 def _select_account(
     accounts: list[dict[str, Any]],
     *,
@@ -74,8 +141,22 @@ def _select_account(
     try:
         from simple_term_menu import TerminalMenu
 
-        menu = TerminalMenu(labels, title="Select with ↑↓ and press Enter to confirm:")
-        idx = menu.show()
+        # #190 — wrap ``TerminalMenu.show()`` in try/finally with an
+        # explicit terminal-state save/restore. ``show()`` puts the
+        # terminal into cbreak (no ICANON / ECHO / ISIG) and on any
+        # non-normal exit (operator Esc, internal exception,
+        # KeyboardInterrupt) the restore may silently fail — every
+        # subsequent program in the same shell session would then drop
+        # echo and SIGINT.
+        fd = _terminal_fd()
+        old_attrs = _capture_terminal_state(fd)
+        try:
+            menu = TerminalMenu(
+                labels, title="Select with ↑↓ and press Enter to confirm:"
+            )
+            idx = menu.show()
+        finally:
+            _restore_terminal_state(fd, old_attrs)
         if idx is None:
             print("Selection cancelled. You can configure it later.")
             return None
@@ -558,10 +639,16 @@ def setup_mcp_config() -> None:
             "This directory (.mcp.json) — This project only",
             "Skip (configure manually)",
         ]
-        menu = TerminalMenu(
-            options, title="Where should the MCP configuration be placed?"
-        )
-        idx = menu.show()
+        # See _select_account for the rationale — same #190 fix.
+        fd = _terminal_fd()
+        old_attrs = _capture_terminal_state(fd)
+        try:
+            menu = TerminalMenu(
+                options, title="Where should the MCP configuration be placed?"
+            )
+            idx = menu.show()
+        finally:
+            _restore_terminal_state(fd, old_attrs)
         if idx is None or idx == 2:
             print("MCP configuration skipped.")
             return

--- a/tests/test_auth_setup_terminal_restore.py
+++ b/tests/test_auth_setup_terminal_restore.py
@@ -1,0 +1,329 @@
+"""Regression tests for #190 — TerminalMenu must not leak cbreak mode
+into the surrounding shell session.
+
+``simple_term_menu.TerminalMenu.show()`` flips the terminal into cbreak
+(no ``ICANON``, no ``ECHO``, no ``ISIG``) and on a normal happy-path
+exit it restores the original mode. On *any* non-normal exit path the
+restore can silently fail and the terminal stays in cbreak — every
+subsequent program in the same shell stops echoing keystrokes and
+stops receiving SIGINT from Ctrl+C.
+
+The fix is a small ``try/finally`` in mureo around every
+``TerminalMenu.show()`` call that takes a snapshot of the terminal
+attributes via ``termios.tcgetattr`` and restores them via
+``termios.tcsetattr(fd, TCSADRAIN, ...)`` regardless of how
+``show()`` exits. These tests pin that contract for both call sites
+(``_select_account`` and ``setup_mcp_config``) and the non-TTY
+degradation path.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Windows test shim mirrors test_auth_setup.py: ``simple_term_menu``
+# itself fails to import on Windows, so the module-level fallback path
+# is what runs there in production. Stub the package so the
+# ``patch("simple_term_menu.TerminalMenu", ...)`` calls below can
+# resolve.
+if sys.platform == "win32":  # pragma: no cover - Windows CI only
+    import types as _types
+
+    try:
+        import simple_term_menu as _stm_real  # noqa: F401
+    except Exception:
+        _stm_stub = _types.ModuleType("simple_term_menu")
+
+        class _StubTerminalMenu:
+            def __init__(self, *a: object, **k: object) -> None: ...
+
+            def show(self) -> None:
+                return None
+
+        _stm_stub.TerminalMenu = _StubTerminalMenu  # type: ignore[attr-defined]
+        sys.modules["simple_term_menu"] = _stm_stub
+
+
+_SENTINEL_OLD_ATTRS = ["iflag", "oflag", "cflag", "lflag", 0, 0, [b"\x00"] * 32]
+
+
+def _patch_termios(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    tty: bool = True,
+) -> tuple[MagicMock, MagicMock]:
+    """Install spy mocks for ``termios.tcgetattr`` / ``tcsetattr`` on the
+    auth_setup module's view of ``termios``.
+
+    Also patches ``_terminal_fd`` so the production code sees a real
+    ``int`` fd (under pytest, ``sys.stdin.fileno()`` raises
+    ``UnsupportedOperation`` because the harness replaces stdin with a
+    pseudo-file — the helper would otherwise short-circuit before
+    reaching ``tcgetattr``).
+
+    Returns ``(tcgetattr_mock, tcsetattr_mock)`` so individual tests can
+    assert call counts / args.
+
+    When ``tty=False``, ``tcgetattr`` raises ``termios.error`` to
+    simulate stdin being a pipe / closed / Windows — the production
+    code must degrade to "do nothing" without crashing.
+    """
+    import termios
+
+    import mureo.auth_setup as auth_setup_mod
+
+    if tty:
+        tcgetattr = MagicMock(return_value=list(_SENTINEL_OLD_ATTRS))
+    else:
+        tcgetattr = MagicMock(side_effect=termios.error("not a tty"))
+    tcsetattr = MagicMock()
+
+    monkeypatch.setattr(auth_setup_mod.termios, "tcgetattr", tcgetattr)
+    monkeypatch.setattr(auth_setup_mod.termios, "tcsetattr", tcsetattr)
+    monkeypatch.setattr(auth_setup_mod, "_terminal_fd", lambda: 0)
+    return tcgetattr, tcsetattr
+
+
+# ---------------------------------------------------------------------------
+# _select_account
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_select_account_restores_terminal_on_normal_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A successful menu pick must still restore terminal attributes —
+    we cannot rely on ``simple_term_menu`` doing it on the happy path.
+    """
+    from mureo.auth_setup import _select_account
+
+    tcgetattr, tcsetattr = _patch_termios(monkeypatch)
+    accounts = [{"id": "111", "name": "A"}, {"id": "222", "name": "B"}]
+
+    fake_menu = MagicMock()
+    fake_menu.show.return_value = 1
+    with patch("simple_term_menu.TerminalMenu", return_value=fake_menu) as menu_cls:
+        result = _select_account(accounts)
+
+    assert result == "222"
+    menu_cls.assert_called_once()
+    assert (
+        tcgetattr.call_count == 1
+    ), "must snapshot terminal attrs before TerminalMenu.show()"
+    assert (
+        tcsetattr.call_count == 1
+    ), "must restore terminal attrs after TerminalMenu.show()"
+    # tcsetattr is called with the snapshot from tcgetattr.
+    args, _kwargs = tcsetattr.call_args
+    assert args[2] == _SENTINEL_OLD_ATTRS
+
+
+@pytest.mark.unit
+def test_select_account_restores_terminal_on_cancelled_menu(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``TerminalMenu.show()`` returning ``None`` (operator pressed Esc /
+    cancelled) is the most common non-happy-path. The terminal must
+    still be restored — this is the primary failure mode reported in
+    #190 (cancel a menu, run ``mureo configure``, Ctrl+C dead).
+    """
+    from mureo.auth_setup import _select_account
+
+    tcgetattr, tcsetattr = _patch_termios(monkeypatch)
+    accounts = [{"id": "111", "name": "A"}]
+
+    fake_menu = MagicMock()
+    fake_menu.show.return_value = None  # cancelled
+    with patch("simple_term_menu.TerminalMenu", return_value=fake_menu):
+        result = _select_account(accounts)
+
+    assert result is None
+    assert (
+        tcsetattr.call_count == 1
+    ), "restore must run even when the menu was cancelled"
+    args, _kwargs = tcsetattr.call_args
+    assert args[2] == _SENTINEL_OLD_ATTRS
+
+
+@pytest.mark.unit
+def test_select_account_restores_terminal_when_show_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An exception from ``TerminalMenu.show()`` (e.g. KeyboardInterrupt,
+    internal cbreak failure) must still trigger the restore — that is
+    the whole point of the ``try/finally`` introduced by #190.
+    """
+    from mureo.auth_setup import _select_account
+
+    tcgetattr, tcsetattr = _patch_termios(monkeypatch)
+    accounts = [{"id": "111", "name": "A"}]
+
+    fake_menu = MagicMock()
+    fake_menu.show.side_effect = KeyboardInterrupt
+    with (
+        patch("simple_term_menu.TerminalMenu", return_value=fake_menu),
+        pytest.raises(KeyboardInterrupt),
+    ):
+        _select_account(accounts)
+
+    assert tcsetattr.call_count == 1, "restore must run before re-raising the exception"
+
+
+@pytest.mark.unit
+def test_select_account_no_crash_when_stdin_is_not_a_tty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When ``termios.tcgetattr`` raises (pipe, closed stdin, Windows),
+    the snapshot is skipped, restore is skipped, and the function
+    still returns normally.
+    """
+    from mureo.auth_setup import _select_account
+
+    tcgetattr, tcsetattr = _patch_termios(monkeypatch, tty=False)
+    accounts = [{"id": "111", "name": "A"}]
+
+    fake_menu = MagicMock()
+    fake_menu.show.return_value = 0
+    with patch("simple_term_menu.TerminalMenu", return_value=fake_menu):
+        result = _select_account(accounts)
+
+    assert result == "111"
+    assert tcgetattr.call_count == 1
+    # No snapshot → no restore. The function must not raise from the
+    # finally block in this state.
+    assert tcsetattr.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# setup_mcp_config
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_setup_mcp_config_restores_terminal_on_normal_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``setup_mcp_config()`` carries the second ``TerminalMenu`` site
+    (placement scope choice). Same restore contract as
+    ``_select_account``.
+    """
+    from mureo.auth_setup import setup_mcp_config
+
+    tcgetattr, tcsetattr = _patch_termios(monkeypatch)
+
+    fake_menu = MagicMock()
+    fake_menu.show.return_value = 2  # "Skip" — fastest happy-path exit
+    with patch("simple_term_menu.TerminalMenu", return_value=fake_menu):
+        setup_mcp_config()
+
+    assert tcgetattr.call_count == 1
+    assert tcsetattr.call_count == 1
+    args, _kwargs = tcsetattr.call_args
+    assert args[2] == _SENTINEL_OLD_ATTRS
+
+
+@pytest.mark.unit
+def test_setup_mcp_config_restores_terminal_on_cancelled_menu(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``setup_mcp_config()`` second-call-site mirror of the cancelled
+    case — the operator picking nothing must still trigger restore.
+    """
+    from mureo.auth_setup import setup_mcp_config
+
+    tcgetattr, tcsetattr = _patch_termios(monkeypatch)
+
+    fake_menu = MagicMock()
+    fake_menu.show.return_value = None  # cancelled
+    with patch("simple_term_menu.TerminalMenu", return_value=fake_menu):
+        setup_mcp_config()
+
+    assert (
+        tcsetattr.call_count == 1
+    ), "restore must run even when the operator cancelled the menu"
+
+
+@pytest.mark.unit
+def test_setup_mcp_config_no_crash_when_stdin_is_not_a_tty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``setup_mcp_config()`` non-TTY mirror — snapshot fails, restore
+    is skipped, function still completes normally."""
+    from mureo.auth_setup import setup_mcp_config
+
+    tcgetattr, tcsetattr = _patch_termios(monkeypatch, tty=False)
+
+    fake_menu = MagicMock()
+    fake_menu.show.return_value = 2  # "Skip"
+    with patch("simple_term_menu.TerminalMenu", return_value=fake_menu):
+        setup_mcp_config()
+
+    assert tcgetattr.call_count == 1
+    assert tcsetattr.call_count == 0
+
+
+@pytest.mark.unit
+def test_setup_mcp_config_restores_terminal_when_show_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from mureo.auth_setup import setup_mcp_config
+
+    tcgetattr, tcsetattr = _patch_termios(monkeypatch)
+
+    fake_menu = MagicMock()
+    fake_menu.show.side_effect = KeyboardInterrupt
+    with (
+        patch("simple_term_menu.TerminalMenu", return_value=fake_menu),
+        pytest.raises(KeyboardInterrupt),
+    ):
+        setup_mcp_config()
+
+    assert tcsetattr.call_count == 1, "restore must run before re-raising the exception"
+
+
+# ---------------------------------------------------------------------------
+# Order pin — snapshot before show(), restore after, regardless of exit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_select_account_call_order_is_get_then_show_then_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Guard against a future refactor that flips the order — the snapshot
+    must precede ``show()`` and the restore must follow it (otherwise we
+    capture a *broken* state and "restore" to it, which is worse than
+    not running the fix at all).
+    """
+    import mureo.auth_setup as auth_setup_mod
+    from mureo.auth_setup import _select_account
+
+    events: list[str] = []
+
+    def _spy_tcgetattr(_fd: int) -> list[Any]:
+        events.append("tcgetattr")
+        return list(_SENTINEL_OLD_ATTRS)
+
+    def _spy_tcsetattr(*_args: Any, **_kwargs: Any) -> None:
+        events.append("tcsetattr")
+
+    monkeypatch.setattr(auth_setup_mod.termios, "tcgetattr", _spy_tcgetattr)
+    monkeypatch.setattr(auth_setup_mod.termios, "tcsetattr", _spy_tcsetattr)
+    monkeypatch.setattr(auth_setup_mod, "_terminal_fd", lambda: 0)
+
+    fake_menu = MagicMock()
+
+    def _spy_show() -> int:
+        events.append("show")
+        return 0
+
+    fake_menu.show.side_effect = _spy_show
+    with patch("simple_term_menu.TerminalMenu", return_value=fake_menu):
+        _select_account([{"id": "111", "name": "A"}])
+
+    assert events == ["tcgetattr", "show", "tcsetattr"]

--- a/tests/test_auth_setup_terminal_restore.py
+++ b/tests/test_auth_setup_terminal_restore.py
@@ -25,27 +25,15 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-# Windows test shim mirrors test_auth_setup.py: ``simple_term_menu``
-# itself fails to import on Windows, so the module-level fallback path
-# is what runs there in production. Stub the package so the
-# ``patch("simple_term_menu.TerminalMenu", ...)`` calls below can
-# resolve.
-if sys.platform == "win32":  # pragma: no cover - Windows CI only
-    import types as _types
-
-    try:
-        import simple_term_menu as _stm_real  # noqa: F401
-    except Exception:
-        _stm_stub = _types.ModuleType("simple_term_menu")
-
-        class _StubTerminalMenu:
-            def __init__(self, *a: object, **k: object) -> None: ...
-
-            def show(self) -> None:
-                return None
-
-        _stm_stub.TerminalMenu = _StubTerminalMenu  # type: ignore[attr-defined]
-        sys.modules["simple_term_menu"] = _stm_stub
+# ``termios`` is Unix-only and the entire restore mechanism this module
+# exercises does not apply on Windows — mureo's production code on
+# Windows takes the ``(ImportError, NotImplementedError)`` fallback
+# path through ``simple_term_menu`` (its own ``termios`` import fails
+# first), so there is nothing to restore and nothing to test.
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="termios save/restore is Unix-only — Windows takes the no-menu fallback path",
+)
 
 
 _SENTINEL_OLD_ATTRS = ["iflag", "oflag", "cflag", "lflag", 0, 0, [b"\x00"] * 32]


### PR DESCRIPTION
Closes #190

## Summary

`simple_term_menu.TerminalMenu.show()` switches the terminal into cbreak mode (no `ICANON` / `ECHO` / `ISIG`). On any non-normal exit path — operator pressed Esc, internal exception, `KeyboardInterrupt` — the library's restore can silently fail and the terminal stays in cbreak. Every subsequent program in the same shell session then drops echo and swallows `SIGINT`.

In the wild this surfaces as: *"`mureo configure` ignores Ctrl+C and shows no keystroke echo"* after the operator interrupted an earlier `mureo setup` / `mureo auth …` menu in the same shell.

The bug reproduces **only** when one or more provider plugins are installed: with no plugins, `select_account()` / `setup_mcp_config()` are never invoked → terminal is never touched. Plugin packages themselves were independently audited and confirmed clean (no `termios` / `tty` / `prompt_toolkit` / `getch` / etc.).

## Fix

Wrap every `TerminalMenu(...).show()` call in a `try/finally` that snapshots `termios.tcgetattr` before `show()` and restores with `termios.tcsetattr(fd, TCSADRAIN, ...)` on **any** exit path.

Three small private helpers in `mureo/auth_setup.py` handle the cross-platform / non-TTY edge cases:

- `_terminal_fd()` — `sys.stdin.fileno()` guarded against `OSError`/`ValueError`/`AttributeError` (pytest's pseudo-stdin, pipes, redirects).
- `_capture_terminal_state(fd)` — returns the snapshot or `None` on non-TTY / Windows.
- `_restore_terminal_state(fd, state)` — best-effort `tcsetattr` with `contextlib.suppress`. A restore failure must never crash the surrounding CLI flow.

`TCSADRAIN` (not `TCSANOW`) so pending output drains before the mode flip — avoids the cosmetic stray-escape-code glitch.

## Scope

`mureo/auth_setup.py` only — both known `TerminalMenu` call sites (`_select_account` at line 77, `setup_mcp_config` at line 561). Defense-in-depth in `run_configure_wizard()` (proposed as layer 2 in the issue) is intentionally deferred to a follow-up; the root cause is now patched at the source.

## Test plan

- [x] 9 new regression tests in `tests/test_auth_setup_terminal_restore.py`:
  - normal exit, cancelled menu, raised exception → each must trigger restore on both call sites
  - non-TTY (`tcgetattr` raises `termios.error`): snapshot is skipped, restore is skipped, function returns normally — both call sites
  - call ordering: snapshot → `show` → restore (guard against a future refactor that flips the order and "restores" a broken state)
- [x] Full `auth_setup` test suite: 102 / 102 pass
- [x] `ruff check mureo/` clean
- [x] `black --check` clean
- [x] code-reviewer findings addressed:
  - MEDIUM (test gaps): `setup_mcp_config` non-TTY + cancelled-menu mirror tests added
  - LOW (symmetry): `_restore_terminal_state` suppress set now includes `AttributeError` to match `_terminal_fd`

## Manual reproduction guide (for reviewers)

1. `pipx install mureo==0.9.27` and add a provider plugin (`mureo-lineyahoo-bridge` or similar).
2. Run `mureo setup` and let the placement menu draw — then press Ctrl+C while it's open.
3. In the same shell, type any other command — observe no echo. Run `stty -a` and see `-echo -icanon -isig`.
4. Run `mureo configure` — Ctrl+C is silently swallowed.

With the fix:
- After step 2, `stty -a` shows `echo icanon isig` (restored).
- `mureo configure` honours Ctrl+C immediately.

## Out of scope

- Belt-and-braces terminal-state assertion at `run_configure_wizard()` entry — deferred to a follow-up issue.
- A full audit of every CLI subcommand for terminal-state hygiene — only the two known offenders are addressed here.
