### PR TITLE
feat(web): WebExtension surface overrides — hidden_builtin_tabs + replaces_landing (#189)

### DIFF
--- a/docs/plugin-authoring.md
+++ b/docs/plugin-authoring.md
@@ -1568,6 +1568,55 @@ falsy entries and falls through to the next candidate. If you want
 to ship an intentionally blank label, render an explicit zero-width
 character (e.g. `"​"`) instead of `""`.
 
+### Taking over built-in surfaces (full-surface plugins)
+
+Most extensions *add* a tab next to the built-in ones. A plugin that
+supplies a complete alternative operator experience — its own setup
+flow, credential model, and dashboard — can additionally declare two
+optional class attributes (both read via `getattr`; pre-feature
+extensions keep loading unchanged):
+
+```python
+class MyExtension:
+    name = "acme-suite"
+    display_name = "Acme Suite"
+    # Hide the built-in tabs this plugin supersedes. Valid keys:
+    # "setup", "demo", "byod", "danger".
+    hidden_builtin_tabs = ("setup", "demo")
+    # Skip the built-in landing; the operator lands on this
+    # extension's view directly. Requires a non-None view().
+    replaces_landing = True
+    # ...routes() / view() unchanged
+```
+
+Validation discipline (mirrors `display_name_i18n`):
+
+- **Type-level problems are packaging bugs** — a non-tuple
+  `hidden_builtin_tabs`, a non-`str` element, or a non-`bool`
+  `replaces_landing` skips the whole extension at discovery with a
+  `WebExtensionWarning`.
+- **Value-level problems are soft** — an unknown tab key is dropped
+  with a warning (the extension survives); `replaces_landing=True`
+  without a `view()` is downgraded to `False` with a warning (there
+  would be nowhere for the operator to land).
+- **At most one landing owner** — when several installed extensions
+  set `replaces_landing=True`, the first-discovered one wins and the
+  rest are downgraded with a warning (mirrors the duplicate-name
+  discipline).
+
+Renderer behaviour: hidden tabs disappear from the dashboard nav and
+their panes are never shown; if a hidden tab would have been the
+default selection (Setup), the landing-owning extension's tab — or,
+absent one, the first extension tab — is selected instead. A headless
+extension that hides tabs without shipping any view falls back to the
+first still-visible built-in tab, so the pane is never orphaned; if
+you hide Setup you should normally ship a `view()` for the operator
+to land on. With `replaces_landing`, the built-in landing is skipped
+on first load and the operator is taken straight to the dashboard
+with your view active. Both attributes ride `/api/extensions` as
+`hidden_builtin_tabs` (list) and `replaces_landing` (bool) — always
+present, no existence check needed client-side.
+
 ### `pyproject.toml`
 
 ```toml

--- a/mureo/_data/web/extensions.js
+++ b/mureo/_data/web/extensions.js
@@ -16,8 +16,24 @@
 (function () {
   "use strict";
 
+  // Built-in dashboard tab keys an extension may hide via
+  // ``hidden_builtin_tabs`` (#189). Mirrors BUILTIN_DASHBOARD_TABS in
+  // ``mureo/web/extensions.py`` — the server already validates, but a
+  // client-side allowlist keeps a malformed payload from hiding an
+  // arbitrary node (e.g. another extension's tab).
+  const BUILTIN_TABS = ["setup", "demo", "byod", "danger"];
+
   const _populated = new Set();
+  // Every discovered extension (including headless / route-only ones —
+  // they may still hide built-in tabs); ``_extensions`` keeps the
+  // view-bearing subset that gets a nav tab rendered.
+  let _allExtensions = [];
   let _extensions = [];
+  // One-shot guard for the replaces_landing redirect — the jump to the
+  // dashboard must happen on first load only, never again on later
+  // init() calls (the operator may legitimately navigate back to the
+  // wizard route afterwards).
+  let _landingRedirected = false;
   // Single source of truth for "init() has already run". Set
   // synchronously at the top of init() so concurrent show() calls
   // collapse to one /api/extensions fetch even before the first
@@ -168,9 +184,102 @@
     pane.appendChild(group);
   }
 
+  function _hiddenTabKeys() {
+    // Union of every installed extension's hidden_builtin_tabs,
+    // filtered through the client-side allowlist. Includes headless
+    // extensions: hiding a tab does not require shipping a view.
+    const keys = new Set();
+    _allExtensions.forEach(function (extension) {
+      (extension.hidden_builtin_tabs || []).forEach(function (key) {
+        if (BUILTIN_TABS.indexOf(key) !== -1) keys.add(key);
+      });
+    });
+    return keys;
+  }
+
+  function _landingReplacer() {
+    // The server guarantees at most one entry carries the flag
+    // (first-discovered wins) and that it ships a view.
+    return _extensions.find(function (e) {
+      return e.replaces_landing === true;
+    });
+  }
+
+  function _applyOverrides() {
+    // #189 — hide built-in tabs superseded by full-surface plugins.
+    // Runs on every init() call (dashboard.js re-selects the built-in
+    // default on each show, so the override must be re-asserted).
+    const hidden = _hiddenTabKeys();
+    hidden.forEach(function (key) {
+      const navItem = document.querySelector(
+        '[data-dashboard-nav="' + key + '"]',
+      );
+      if (navItem && navItem.parentElement &&
+          navItem.parentElement.tagName === "LI") {
+        navItem.parentElement.hidden = true;
+      }
+      const group = document.querySelector(
+        '[data-dashboard-group="' + key + '"]',
+      );
+      if (group) group.hidden = true;
+    });
+
+    const replacer = _landingReplacer();
+    if (replacer) {
+      const landing = document.querySelector("[data-landing]");
+      if (landing) landing.hidden = true;
+    }
+
+    // Default-selection fallback: dashboard.js selects "setup" on every
+    // show. If the selected tab is one we just hid, hand the selection
+    // to the landing-owning extension (or the first extension tab) so
+    // the operator never faces a pane with no corresponding nav item.
+    const current = document.querySelector(
+      '[data-dashboard-nav][aria-current="page"]',
+    );
+    const currentKey = current && current.getAttribute("data-dashboard-nav");
+    if (currentKey && hidden.has(currentKey)) {
+      const target = replacer || _extensions[0];
+      if (target) {
+        _populate(target);
+        _selectGroup(_navItemId(target.name));
+      } else {
+        // Headless extension hid the default tab but shipped no view
+        // of its own — fall back to the first still-visible built-in
+        // tab so the pane is never orphaned. (All-hidden + no
+        // extension view is a degenerate config; nothing to select.)
+        const builtinFallback = BUILTIN_TABS.find(function (key) {
+          return !hidden.has(key);
+        });
+        if (builtinFallback) _selectGroup(builtinFallback);
+      }
+    }
+
+    // First-load handoff: when a plugin owns the landing and the page
+    // opened on the wizard route, jump straight to the dashboard so
+    // the plugin's view is what the operator lands on (#189). One-shot
+    // — later navigation back to the wizard route is respected.
+    if (
+      replacer &&
+      !_landingRedirected &&
+      window.MUREO &&
+      typeof MUREO.isDashboardRoute === "function" &&
+      !MUREO.isDashboardRoute()
+    ) {
+      _landingRedirected = true;
+      MUREO.navigateToDashboard();
+    }
+  }
+
   async function init() {
-    if (_initialised) return;
-    _initialised = true;
+    if (!_initialised) {
+      _initialised = true;
+      await _fetchAndRender();
+    }
+    _applyOverrides();
+  }
+
+  async function _fetchAndRender() {
     let res;
     try {
       res = await fetch("/api/extensions");
@@ -199,8 +308,9 @@
       );
       return;
     }
-    _extensions = payload.filter(function (item) {
-      return item && item.view; // skip headless / route-only extensions
+    _allExtensions = payload.filter(Boolean);
+    _extensions = _allExtensions.filter(function (item) {
+      return item.view; // tabs are only rendered for view-bearing extensions
     });
     _extensions.forEach(_renderNavItem);
   }
@@ -226,6 +336,16 @@
   // matching event — ``_extensions`` is simply empty until init()
   // populates it, so the listener is harmless until then.
   document.addEventListener("mureo:locale_changed", _onLocaleChanged);
+
+  // #189 — run discovery at app boot, not only on first dashboard
+  // show. Without this, replaces_landing could never take effect on
+  // first load: the landing route never calls dashboard.js#show(), so
+  // init() would never fetch and the built-in landing would win.
+  // init() is idempotent (one fetch per page load) so the later call
+  // from dashboard.js#show() stays cheap.
+  document.addEventListener("mureo:ready", function () {
+    init();
+  });
 
   window.MUREO = window.MUREO || {};
   window.MUREO.extensions = {

--- a/mureo/web/extensions.py
+++ b/mureo/web/extensions.py
@@ -48,6 +48,7 @@ deployments should opt into
 
 from __future__ import annotations
 
+import dataclasses
 import re
 import warnings
 from collections.abc import Mapping
@@ -94,6 +95,13 @@ SUBPATH_PATTERN: Final[str] = r"(?:/[A-Za-z0-9_-]+)+"
 _NAME_RE: Final[re.Pattern[str]] = re.compile(rf"^{NAME_PATTERN}$")
 _FILENAME_RE: Final[re.Pattern[str]] = re.compile(rf"^{FILENAME_PATTERN}$")
 _SUBPATH_RE: Final[re.Pattern[str]] = re.compile(rf"^{SUBPATH_PATTERN}$")
+
+#: Stable identifiers of the built-in dashboard tabs an extension may
+#: hide via ``hidden_builtin_tabs`` (#189). These are the
+#: ``data-dashboard-nav`` / ``data-dashboard-group`` attribute values
+#: hardcoded in ``mureo/_data/web/app.html`` — extending this tuple
+#: requires a matching markup change there.
+BUILTIN_DASHBOARD_TABS: Final[tuple[str, ...]] = ("setup", "demo", "byod", "danger")
 
 #: Inline-executable patterns banned in ``html_fragment``. The
 #: configure-UI CSP forbids ``unsafe-inline`` so these would not
@@ -238,7 +246,7 @@ class WebExtension(Protocol):
     skip the extension (with :class:`WebExtensionWarning`) without
     affecting other extensions or the configure server.
 
-    Optional class attribute (read via :func:`getattr` so the Protocol
+    Optional class attributes (read via :func:`getattr` so the Protocol
     itself stays backward-compatible):
 
     * ``display_name_i18n: Mapping[str, str]`` — per-locale labels
@@ -248,6 +256,20 @@ class WebExtension(Protocol):
       ``display_name_i18n["en"]``, then to ``display_name``.
       Extensions that do not declare it behave exactly as before —
       ``display_name`` is shown unchanged in every locale.
+    * ``hidden_builtin_tabs: tuple[str, ...]`` — built-in dashboard
+      tabs (subset of :data:`BUILTIN_DASHBOARD_TABS`) this extension
+      supersedes. The renderer hides the matching nav items + panes;
+      the extension's own tab becomes the default selection when a
+      hidden tab would have been the default. Unknown keys are
+      dropped with a :class:`WebExtensionWarning`; a non-tuple value
+      skips the extension. Added in #189 for full-surface plugins.
+    * ``replaces_landing: bool`` — when ``True`` and the extension
+      supplies a ``view()``, the renderer skips the built-in landing
+      and shows the extension's view directly on first load.
+      ``True`` without a view is downgraded to ``False`` with a
+      :class:`WebExtensionWarning`. When several installed
+      extensions claim the landing the first-discovered one wins
+      (later claims are downgraded with a warning). Added in #189.
     """
 
     @property
@@ -278,6 +300,12 @@ class WebExtensionEntry:
     view: ViewContribution | None
     source_distribution: str | None
     display_name_i18n: Mapping[str, str] = field(default_factory=dict)
+    # #189 — surface overrides for full-surface plugins. Both default
+    # to the no-op values so entries constructed before the feature
+    # existed (and every additive-only plugin) behave exactly as
+    # before.
+    hidden_builtin_tabs: tuple[str, ...] = ()
+    replaces_landing: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -318,6 +346,7 @@ def discover_web_extensions() -> tuple[WebExtensionEntry, ...]:
         return _cached_entries
 
     by_name: dict[str, WebExtensionEntry] = {}
+    landing_owner: str | None = None
     for ep in entry_points(group=WEB_EXTENSIONS_ENTRY_POINT_GROUP):
         entry = _load_entry_point(ep)
         if entry is None:
@@ -331,6 +360,21 @@ def discover_web_extensions() -> tuple[WebExtensionEntry, ...]:
                 stacklevel=2,
             )
             continue
+        # #189 — at most one installed extension may own the landing.
+        # First-discovered wins; later claims are downgraded with a
+        # warning (mirrors the duplicate-name discipline above).
+        if entry.replaces_landing:
+            if landing_owner is None:
+                landing_owner = entry.name
+            else:
+                warnings.warn(
+                    f"web extension {entry.name!r} sets "
+                    f"replaces_landing=True but {landing_owner!r} already "
+                    f"owns the landing (first discovered wins); downgraded",
+                    WebExtensionWarning,
+                    stacklevel=2,
+                )
+                entry = dataclasses.replace(entry, replaces_landing=False)
         by_name[entry.name] = entry
 
     _cached_entries = tuple(by_name.values())
@@ -419,6 +463,51 @@ def _load_entry_point(ep: Any) -> WebExtensionEntry | None:
                     f"got {type(value).__name__} for key {key!r}"
                 )
             i18n_normalised[key] = value
+        # #189 — surface overrides. Type-level problems (wrong container
+        # type, non-str element, non-bool flag) are packaging bugs and
+        # skip the whole extension via the surrounding try/except —
+        # mirroring the ``display_name_i18n`` discipline. Value-level
+        # problems (unknown tab key, landing claim without a view) are
+        # soft: warn + drop / downgrade, keep the extension.
+        hidden_raw = getattr(extension, "hidden_builtin_tabs", ())
+        if not isinstance(hidden_raw, tuple):
+            raise TypeError(
+                f"hidden_builtin_tabs must be tuple[str, ...], "
+                f"got {type(hidden_raw).__name__}"
+            )
+        hidden_tabs: list[str] = []
+        for tab in hidden_raw:
+            if not isinstance(tab, str):
+                raise TypeError(
+                    f"hidden_builtin_tabs elements must be str, "
+                    f"got {type(tab).__name__}"
+                )
+            if tab not in BUILTIN_DASHBOARD_TABS:
+                warnings.warn(
+                    f"web extension {name!r} lists unknown built-in tab "
+                    f"{tab!r} in hidden_builtin_tabs (known: "
+                    f"{BUILTIN_DASHBOARD_TABS}); key dropped",
+                    WebExtensionWarning,
+                    stacklevel=3,
+                )
+                continue
+            if tab not in hidden_tabs:
+                hidden_tabs.append(tab)
+        replaces_landing = getattr(extension, "replaces_landing", False)
+        if not isinstance(replaces_landing, bool):
+            raise TypeError(
+                f"replaces_landing must be bool, "
+                f"got {type(replaces_landing).__name__}"
+            )
+        if replaces_landing and view_value is None:
+            warnings.warn(
+                f"web extension {name!r} sets replaces_landing=True but "
+                f"supplies no view() — the operator would have nowhere "
+                f"to land; downgraded to False",
+                WebExtensionWarning,
+                stacklevel=3,
+            )
+            replaces_landing = False
     except Exception as exc:  # noqa: BLE001 — per-plugin fault isolation
         warnings.warn(
             f"failed to load web extension {ep_name!r}: {exc!r}",
@@ -434,6 +523,8 @@ def _load_entry_point(ep: Any) -> WebExtensionEntry | None:
         view=view_value,
         source_distribution=_resolve_source(ep),
         display_name_i18n=i18n_normalised,
+        hidden_builtin_tabs=tuple(hidden_tabs),
+        replaces_landing=replaces_landing,
     )
 
 
@@ -453,6 +544,7 @@ def _resolve_source(ep: Any) -> str | None:
 
 
 __all__ = [
+    "BUILTIN_DASHBOARD_TABS",
     "FILENAME_PATTERN",
     "NAME_PATTERN",
     "RouteContribution",

--- a/mureo/web/handlers.py
+++ b/mureo/web/handlers.py
@@ -693,6 +693,11 @@ class ConfigureHandler(BaseHTTPRequestHandler):
                 # extension may share the same mapping object across
                 # multiple discovery calls within a process.
                 "display_name_i18n": dict(entry.display_name_i18n),
+                # #189 — surface overrides. Always present (no-op
+                # defaults) so extensions.js never needs an existence
+                # check before reading them.
+                "hidden_builtin_tabs": list(entry.hidden_builtin_tabs),
+                "replaces_landing": entry.replaces_landing,
             }
             if entry.view is None:
                 item["view"] = None

--- a/tests/test_web_assets_extension_overrides.py
+++ b/tests/test_web_assets_extension_overrides.py
@@ -1,0 +1,62 @@
+"""Static-content guards for the #189 surface-override wiring in
+``extensions.js``.
+
+The renderer-side half of #189 lives in a bundled JS asset with no
+build step, so these tests pin the load-bearing strings the same way
+``test_web_assets_dashboard_cards_and_toasts.py`` pins the #183/#184
+fixes — a refactor that silently drops the override plumbing flips a
+test red here long before an operator notices built-in tabs
+reappearing next to a full-surface plugin.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_WEB = Path(__file__).resolve().parent.parent / "mureo" / "_data" / "web"
+
+
+def _js() -> str:
+    return (_WEB / "extensions.js").read_text(encoding="utf-8")
+
+
+@pytest.mark.unit
+def test_extensions_js_reads_hidden_builtin_tabs() -> None:
+    """The renderer must consume the ``hidden_builtin_tabs`` wire key."""
+    assert "hidden_builtin_tabs" in _js()
+
+
+@pytest.mark.unit
+def test_extensions_js_reads_replaces_landing() -> None:
+    """The renderer must consume the ``replaces_landing`` wire key and
+    target the built-in landing section."""
+    js = _js()
+    assert "replaces_landing" in js
+    assert "[data-landing]" in js
+
+
+@pytest.mark.unit
+def test_extensions_js_has_builtin_tab_allowlist() -> None:
+    """Client-side allowlist mirrors BUILTIN_DASHBOARD_TABS so a
+    malformed payload cannot hide arbitrary nodes."""
+    js = _js()
+    for key in ("setup", "demo", "byod", "danger"):
+        assert f'"{key}"' in js
+
+
+@pytest.mark.unit
+def test_extensions_js_inits_on_app_ready() -> None:
+    """Discovery must run at app boot (``mureo:ready``), not only on
+    first dashboard show — otherwise ``replaces_landing`` can never
+    take effect on first load."""
+    assert "mureo:ready" in _js()
+
+
+@pytest.mark.unit
+def test_extensions_js_prefers_landing_replacer_for_default_selection() -> None:
+    """When a hidden tab was the default selection, the landing-owning
+    extension must win over an arbitrary first-rendered extension —
+    review finding on #189: ``replacer || _extensions[0]``."""
+    assert "replacer || _extensions[0]" in _js()

--- a/tests/test_web_extension_routing.py
+++ b/tests/test_web_extension_routing.py
@@ -46,27 +46,21 @@ if TYPE_CHECKING:
 _recorded_calls: list[tuple[str, dict[str, Any]]] = []
 
 
-def _record_ping(
-    _req: BaseHTTPRequestHandler, payload: dict[str, Any]
-) -> None:
+def _record_ping(_req: BaseHTTPRequestHandler, payload: dict[str, Any]) -> None:
     from mureo.web._helpers import send_json
 
     _recorded_calls.append(("ping", dict(payload)))
     send_json(_req, {"echo": payload})
 
 
-def _record_save(
-    _req: BaseHTTPRequestHandler, payload: dict[str, Any]
-) -> None:
+def _record_save(_req: BaseHTTPRequestHandler, payload: dict[str, Any]) -> None:
     from mureo.web._helpers import send_json
 
     _recorded_calls.append(("save", dict(payload)))
     send_json(_req, {"saved": True, "received": payload})
 
 
-def _record_explode(
-    _req: BaseHTTPRequestHandler, _payload: dict[str, Any]
-) -> None:
+def _record_explode(_req: BaseHTTPRequestHandler, _payload: dict[str, Any]) -> None:
     raise RuntimeError("handler exploded")
 
 
@@ -82,7 +76,7 @@ def _make_entry() -> WebExtensionEntry:
             ),
         ),
         view=ViewContribution(
-            html_fragment='<section><h2 data-demo>Demo</h2></section>',
+            html_fragment="<section><h2 data-demo>Demo</h2></section>",
             scripts=(
                 StaticAsset(
                     filename="demo.js",
@@ -209,9 +203,49 @@ def test_extensions_index_lists_registered(
     assert item["name"] == "demo"
     assert item["display_name"] == "Demo extension"
     assert item["display_name_i18n"] == {}
+    # #189 — surface-override keys are always present (no-op defaults)
+    # so the renderer never needs an existence check.
+    assert item["hidden_builtin_tabs"] == []
+    assert item["replaces_landing"] is False
     assert item["view"]["html_fragment"].startswith("<section")
     assert item["view"]["scripts"] == ["demo.js"]
     assert item["view"]["styles"] == ["demo.css"]
+
+
+@pytest.mark.unit
+def test_extensions_index_includes_surface_overrides(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#189 — ``hidden_builtin_tabs`` / ``replaces_landing`` ride the
+    index payload so ``extensions.js`` can hide built-in tabs and skip
+    the landing for full-surface plugins."""
+    override_entry = WebExtensionEntry(
+        name="full-surface",
+        display_name="Full surface",
+        routes=(),
+        view=ViewContribution(html_fragment="<p>fs</p>"),
+        source_distribution=None,
+        hidden_builtin_tabs=("setup", "demo"),
+        replaces_landing=True,
+    )
+    monkeypatch.setattr("mureo.web.extensions._cached_entries", (override_entry,))
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".claude").mkdir()
+    (home / ".claude" / "commands").mkdir()
+    (home / ".mureo").mkdir()
+    wiz = ConfigureWizard(home=home)
+    t = threading.Thread(target=wiz.serve, daemon=True)
+    t.start()
+    wiz.wait_until_ready(timeout=5.0)
+    try:
+        resp = _get(wiz, "/api/extensions")
+        payload = json.loads(resp.read().decode())
+        assert payload[0]["hidden_builtin_tabs"] == ["setup", "demo"]
+        assert payload[0]["replaces_landing"] is True
+    finally:
+        wiz.shutdown()
+        t.join(timeout=2.0)
 
 
 @pytest.mark.unit
@@ -277,6 +311,8 @@ def test_extensions_index_view_null_when_extension_has_no_view(
                 "name": "nogui",
                 "display_name": "No GUI",
                 "display_name_i18n": {},
+                "hidden_builtin_tabs": [],
+                "replaces_landing": False,
                 "view": None,
             }
         ]
@@ -369,9 +405,7 @@ def test_get_extension_handler_exception_returns_500(
 def test_post_extension_route_dispatches_with_csrf(
     wizard_with_extensions: ConfigureWizard,
 ) -> None:
-    resp = _post(
-        wizard_with_extensions, "/api/ext/demo/save", {"key": "value"}
-    )
+    resp = _post(wizard_with_extensions, "/api/ext/demo/save", {"key": "value"})
     assert resp.status == 200
     body = json.loads(resp.read().decode())
     assert body == {"saved": True, "received": {"key": "value"}}
@@ -382,9 +416,7 @@ def test_post_extension_route_rejects_missing_csrf(
     wizard_with_extensions: ConfigureWizard,
 ) -> None:
     with pytest.raises(urllib.error.HTTPError) as exc:
-        _post(
-            wizard_with_extensions, "/api/ext/demo/save", {"key": "v"}, csrf=None
-        )
+        _post(wizard_with_extensions, "/api/ext/demo/save", {"key": "v"}, csrf=None)
     assert exc.value.code == 403
 
 

--- a/tests/test_web_extensions.py
+++ b/tests/test_web_extensions.py
@@ -19,12 +19,13 @@ Coverage:
 from __future__ import annotations
 
 import warnings
-from collections.abc import Iterator
 from dataclasses import FrozenInstanceError
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 # ---------------------------------------------------------------------------
 # Type-shape tests
@@ -231,9 +232,7 @@ class _FakeEP:
         return self._target
 
 
-def _patch_entry_points(
-    monkeypatch: pytest.MonkeyPatch, eps: list[_FakeEP]
-) -> None:
+def _patch_entry_points(monkeypatch: pytest.MonkeyPatch, eps: list[_FakeEP]) -> None:
     def fake_entry_points(*, group: str) -> list[_FakeEP]:
         assert group == "mureo.web_extensions"
         return eps
@@ -377,7 +376,7 @@ def test_discover_isolates_routes_call_failure(
 def test_discover_isolates_view_call_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from mureo.web.extensions import WebExtensionWarning, discover_web_extensions
+    from mureo.web.extensions import discover_web_extensions
 
     _patch_entry_points(
         monkeypatch,
@@ -683,6 +682,236 @@ def test_discover_skips_extension_with_none_display_name_i18n(
     assert [e.name for e in entries] == ["demo"]
     assert any(
         issubclass(w.category, WebExtensionWarning) and "none-i18n" in str(w.message)
+        for w in caught
+    )
+
+
+# ---------------------------------------------------------------------------
+# #189 — surface overrides: hidden_builtin_tabs / replaces_landing
+# ---------------------------------------------------------------------------
+
+
+def _make_view_extension(
+    ext_name: str,
+    *,
+    hidden_tabs: Any = None,
+    replaces: Any = None,
+    with_view: bool = True,
+) -> type:
+    """Build a synthetic extension class with optional override attrs."""
+    from mureo.web.extensions import ViewContribution
+
+    class _Ext:
+        name = ext_name
+        display_name = ext_name.title()
+
+        def routes(self) -> tuple[Any, ...]:
+            return ()
+
+        def view(self) -> Any:
+            if with_view:
+                return ViewContribution(html_fragment="<p>x</p>")
+            return None
+
+    if hidden_tabs is not None:
+        _Ext.hidden_builtin_tabs = hidden_tabs  # type: ignore[attr-defined]
+    if replaces is not None:
+        _Ext.replaces_landing = replaces  # type: ignore[attr-defined]
+    return _Ext
+
+
+@pytest.mark.unit
+def test_web_extension_entry_defaults_surface_overrides() -> None:
+    """Existing callers constructing ``WebExtensionEntry`` without the
+    new #189 fields must keep working — both attributes default to the
+    no-op values."""
+    from mureo.web.extensions import WebExtensionEntry
+
+    entry = WebExtensionEntry(
+        name="legacy",
+        display_name="Legacy",
+        routes=(),
+        view=None,
+        source_distribution=None,
+    )
+    assert entry.hidden_builtin_tabs == ()
+    assert entry.replaces_landing is False
+
+
+@pytest.mark.unit
+def test_discover_defaults_missing_surface_overrides(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pre-#189 extensions (no override attrs declared) load unchanged."""
+    from mureo.web.extensions import discover_web_extensions
+
+    _patch_entry_points(monkeypatch, [_FakeEP("demo", _DemoExtension)])
+    [entry] = discover_web_extensions()
+    assert entry.hidden_builtin_tabs == ()
+    assert entry.replaces_landing is False
+
+
+@pytest.mark.unit
+def test_discover_picks_up_hidden_builtin_tabs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from mureo.web.extensions import discover_web_extensions
+
+    ext = _make_view_extension("full-surface", hidden_tabs=("setup", "demo"))
+    _patch_entry_points(monkeypatch, [_FakeEP("full-surface", ext)])
+    [entry] = discover_web_extensions()
+    assert entry.hidden_builtin_tabs == ("setup", "demo")
+
+
+@pytest.mark.unit
+def test_discover_drops_unknown_hidden_tab_keys_with_warning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unknown keys are soft-dropped (extension survives) — matches the
+    issue's stated soft-fail discipline for value-level problems."""
+    from mureo.web.extensions import WebExtensionWarning, discover_web_extensions
+
+    ext = _make_view_extension("squatter", hidden_tabs=("setup", "bogus-tab"))
+    _patch_entry_points(monkeypatch, [_FakeEP("squatter", ext)])
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        [entry] = discover_web_extensions()
+    assert entry.hidden_builtin_tabs == ("setup",)
+    assert any(
+        issubclass(w.category, WebExtensionWarning) and "bogus-tab" in str(w.message)
+        for w in caught
+    )
+
+
+@pytest.mark.unit
+def test_discover_dedupes_hidden_tab_keys_preserving_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from mureo.web.extensions import discover_web_extensions
+
+    ext = _make_view_extension("dup", hidden_tabs=("danger", "setup", "danger"))
+    _patch_entry_points(monkeypatch, [_FakeEP("dup", ext)])
+    [entry] = discover_web_extensions()
+    assert entry.hidden_builtin_tabs == ("danger", "setup")
+
+
+@pytest.mark.unit
+def test_discover_skips_extension_with_non_tuple_hidden_tabs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Type-level problems are packaging bugs — the whole extension is
+    skipped, mirroring the ``display_name_i18n`` type discipline."""
+    from mureo.web.extensions import WebExtensionWarning, discover_web_extensions
+
+    ext = _make_view_extension("list-tabs", hidden_tabs=["setup"])  # list, not tuple
+    _patch_entry_points(
+        monkeypatch, [_FakeEP("list-tabs", ext), _FakeEP("demo", _DemoExtension)]
+    )
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        entries = discover_web_extensions()
+    assert [e.name for e in entries] == ["demo"]
+    assert any(
+        issubclass(w.category, WebExtensionWarning) and "list-tabs" in str(w.message)
+        for w in caught
+    )
+
+
+@pytest.mark.unit
+def test_discover_skips_extension_with_non_str_hidden_tab_element(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from mureo.web.extensions import WebExtensionWarning, discover_web_extensions
+
+    ext = _make_view_extension("int-tab", hidden_tabs=(1,))
+    _patch_entry_points(
+        monkeypatch, [_FakeEP("int-tab", ext), _FakeEP("demo", _DemoExtension)]
+    )
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        entries = discover_web_extensions()
+    assert [e.name for e in entries] == ["demo"]
+    assert any(
+        issubclass(w.category, WebExtensionWarning) and "int-tab" in str(w.message)
+        for w in caught
+    )
+
+
+@pytest.mark.unit
+def test_discover_picks_up_replaces_landing_with_view(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from mureo.web.extensions import discover_web_extensions
+
+    ext = _make_view_extension("landing-owner", replaces=True, with_view=True)
+    _patch_entry_points(monkeypatch, [_FakeEP("landing-owner", ext)])
+    [entry] = discover_web_extensions()
+    assert entry.replaces_landing is True
+
+
+@pytest.mark.unit
+def test_discover_downgrades_replaces_landing_without_view(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``replaces_landing=True`` with no ``view()`` leaves the operator
+    nowhere to land — the flag is downgraded (extension survives)."""
+    from mureo.web.extensions import WebExtensionWarning, discover_web_extensions
+
+    ext = _make_view_extension("headless", replaces=True, with_view=False)
+    _patch_entry_points(monkeypatch, [_FakeEP("headless", ext)])
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        [entry] = discover_web_extensions()
+    assert entry.replaces_landing is False
+    assert any(
+        issubclass(w.category, WebExtensionWarning) and "headless" in str(w.message)
+        for w in caught
+    )
+
+
+@pytest.mark.unit
+def test_discover_skips_extension_with_non_bool_replaces_landing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from mureo.web.extensions import WebExtensionWarning, discover_web_extensions
+
+    ext = _make_view_extension("stringy", replaces="yes")
+    _patch_entry_points(
+        monkeypatch, [_FakeEP("stringy", ext), _FakeEP("demo", _DemoExtension)]
+    )
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        entries = discover_web_extensions()
+    assert [e.name for e in entries] == ["demo"]
+    assert any(
+        issubclass(w.category, WebExtensionWarning) and "stringy" in str(w.message)
+        for w in caught
+    )
+
+
+@pytest.mark.unit
+def test_discover_first_replaces_landing_wins(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two installed extensions both claiming the landing: first
+    discovered keeps the flag; the second is downgraded with a warning
+    (mirrors the duplicate-name discipline)."""
+    from mureo.web.extensions import WebExtensionWarning, discover_web_extensions
+
+    first = _make_view_extension("first-owner", replaces=True, with_view=True)
+    second = _make_view_extension("second-owner", replaces=True, with_view=True)
+    _patch_entry_points(
+        monkeypatch,
+        [_FakeEP("first-owner", first), _FakeEP("second-owner", second)],
+    )
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        entries = discover_web_extensions()
+    by_name = {e.name: e for e in entries}
+    assert by_name["first-owner"].replaces_landing is True
+    assert by_name["second-owner"].replaces_landing is False
+    assert any(
+        issubclass(w.category, WebExtensionWarning) and "second-owner" in str(w.message)
         for w in caught
     )
 


### PR DESCRIPTION
Closes #189

## Summary

`WebExtension` plugins could only **add** a dashboard tab. Full-surface plugins — an alternative setup flow, credential model, and dashboard — had no way to **hide** the built-in tabs they supersede, so operators saw both surfaces side by side. This PR adds two optional, default-no-op Protocol attributes (read via `getattr`; pre-feature extensions load unchanged):

- **`hidden_builtin_tabs: tuple[str, ...]`** — declared subset of `{"setup", "demo", "byod", "danger"}` (new exported `BUILTIN_DASHBOARD_TABS` constant). The renderer hides the matching nav items + panes.
- **`replaces_landing: bool`** — when `True` and the extension ships a `view()`, the built-in landing is skipped on first load and the operator lands straight on the extension's view.

## Validation discipline (mirrors `display_name_i18n`)

- **Type-level problems** (non-tuple, non-str element, non-bool) skip the whole extension with `WebExtensionWarning`.
- **Value-level problems are soft**: unknown tab keys are dropped with a warning (dedup preserves order); `replaces_landing=True` without a `view()` is downgraded to `False` with a warning.
- **At most one landing owner**: first-discovered wins; later claims are downgraded via `dataclasses.replace` + warning **before** the result is cached.

## Wire change (additive only)

`/api/extensions` items always carry `hidden_builtin_tabs` (list) and `replaces_landing` (bool) — no existence check needed client-side.

## Renderer (`extensions.js`)

- Client-side `BUILTIN_TABS` allowlist mirrors the server constant — a malformed payload can only toggle the four built-in nodes, never arbitrary DOM.
- `_applyOverrides()` runs on **every** `init()` call (dashboard.js re-selects the built-in default on every show, so the override must re-assert).
- Default-selection fallback when a hidden tab was selected: landing-owning extension's tab → first extension tab → first still-visible built-in tab (headless-hide case) — the pane is never orphaned.
- New `mureo:ready` listener runs discovery at app boot; previously `init()` only ran on first dashboard show, so `replaces_landing` could never take effect on first load. The dashboard redirect is one-shot (`_landingRedirected`) so the operator can still navigate back to the wizard route afterwards.

## Test plan

- [x] 11 new discovery tests: defaults, round-trip, unknown-key drop + dedup, non-tuple / non-str / non-bool skips, downgrade-without-view, first-landing-owner-wins
- [x] Wire tests: override keys always present (no-op defaults) + override round-trip; headless exact-payload pin updated
- [x] 5 static-content pins for the `extensions.js` wiring (wire keys, `[data-landing]`, allowlist, `mureo:ready`, replacer-preference)
- [x] Full web suite: 312 passed
- [x] `ruff check mureo/` + `black --check` clean
- [x] Two code-reviewer passes: initial APPROVE with 2 MEDIUM findings (fallback should prefer the landing owner; headless-hide could orphan the pane) — both fixed, fix-up diff re-reviewed clean

## Docs

`docs/plugin-authoring.md` §13 gains a "Taking over built-in surfaces (full-surface plugins)" subsection documenting the attributes, validation discipline, and renderer behaviour.

## Out of scope (per issue)

- Per-locale tab labels for hidden surfaces (already handled by `display_name_i18n`)
- Reordering built-in tabs (future `tab_order` hook)
