### PR TITLE
feat(web): allow skipping the platform-selection wizard step

### DIFF
--- a/mureo/_data/web/wizard.js
+++ b/mureo/_data/web/wizard.js
@@ -85,12 +85,15 @@
     "completed",
   ];
 
-  const STEPS_WITHOUT_SKIP = new Set([
-    "host",
-    "basic",
-    "platforms",
-    "completed",
-  ]);
+  // Steps where the shared footer Skip button is hidden. ``platforms``
+  // is intentionally absent: its Next button is gated on at least one
+  // platform being selected, so an operator who wants to defer platform
+  // setup needs Skip to leave the step (Skip → gotoNext → with no
+  // platforms selected the provider/auth steps drop out and the wizard
+  // lands on ``completed``). ``host`` requires a host choice, ``basic``
+  // has its own inline advanced-skip link, and ``completed`` is
+  // terminal — all keep their no-skip status.
+  const STEPS_WITHOUT_SKIP = new Set(["host", "basic", "completed"]);
 
   function hasGoogleOrMetaPlatform() {
     return STATE.platforms.google_ads || STATE.platforms.meta_ads;

--- a/tests/test_web_assets_wizard_skip.py
+++ b/tests/test_web_assets_wizard_skip.py
@@ -1,0 +1,53 @@
+"""Static-content guard: the "Pick your platforms" wizard step is skippable.
+
+The configure wizard gates the Next button on the platforms step until
+at least one platform is selected (`isNextEnabled` → `platforms` branch).
+An operator who wants to defer platform setup and go straight to the
+dashboard would otherwise be stranded on a disabled Next with no way
+out. The shared Skip button (footer, `data-wizard-action="skip"`, wired
+to `gotoNext`) surfaces on any step NOT listed in `STEPS_WITHOUT_SKIP`,
+so the fix is to drop `"platforms"` from that set.
+
+These tests pin that behaviour so a future refactor of the step list
+cannot silently re-strand the operator.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_WEB = Path(__file__).resolve().parent.parent / "mureo" / "_data" / "web"
+
+
+def _steps_without_skip_block() -> str:
+    """Return the source slice of the ``STEPS_WITHOUT_SKIP`` Set literal.
+
+    Extracts everything between ``new Set([`` and the closing ``])`` so
+    membership assertions are scoped to that declaration and cannot be
+    fooled by the step keys appearing elsewhere in the file.
+    """
+    js = (_WEB / "wizard.js").read_text(encoding="utf-8")
+    marker = "STEPS_WITHOUT_SKIP = new Set(["
+    start = js.index(marker) + len(marker)
+    end = js.index("])", start)
+    return js[start:end]
+
+
+@pytest.mark.unit
+def test_platforms_step_is_skippable() -> None:
+    """``"platforms"`` must NOT be in ``STEPS_WITHOUT_SKIP`` so the Skip
+    button surfaces on the platform-selection step."""
+    assert '"platforms"' not in _steps_without_skip_block()
+
+
+@pytest.mark.unit
+def test_gateway_steps_stay_non_skippable() -> None:
+    """The terminal / prerequisite steps must keep their no-skip status:
+    `host` (a host must be chosen), `basic` (has its own advanced-skip
+    affordance), and `completed` (terminal — nothing to skip to)."""
+    block = _steps_without_skip_block()
+    assert '"host"' in block
+    assert '"basic"' in block
+    assert '"completed"' in block


### PR DESCRIPTION
## Summary

The configure wizard's **"Pick your platforms"** step (step 3/6) gates its Next button on at least one platform being selected. An operator who wants to defer platform setup and go straight to the dashboard was stranded — Next stayed disabled and the step carried no Skip button.

This drops `"platforms"` from `STEPS_WITHOUT_SKIP` so the existing shared footer Skip button surfaces on the step.

## Behaviour

- Skip is wired to `gotoNext`. With no platforms selected, `provider_choice` / `providers_install` / `auth` are all filtered out by `isStepRelevant`, so the wizard lands on the **completed** screen.
- If the operator did tick a platform, Skip behaves like Next (advances to the next relevant step) — non-destructive, and consistent with the existing Skip semantics on the `provider_choice` step.
- `host` (a host must be chosen), `basic` (has its own inline advanced-skip link), and `completed` (terminal) keep their no-skip status.

## Scope

- No new i18n keys — `wizard.skip` (`"Skip"` / `"スキップ"`) already exists in both locales.
- No CSS change — the Skip button sits between Back and Next via the existing `wizard-actions` flex layout.

## Test plan

- [x] New `tests/test_web_assets_wizard_skip.py`: pins `"platforms"` absent from `STEPS_WITHOUT_SKIP` + `host`/`basic`/`completed` still present (regression guard against re-stranding the operator)
- [x] Web regression: 72 passed (assets + static-serving + i18n-keys + extension-routing)
- [x] `ruff` + `black` clean
- [x] `/code-review` clean (no CRITICAL / HIGH / MEDIUM)
- [x] Manual: configure UI served from source — Skip button appears on the platforms step and lands on the completed screen with nothing selected
