### PR TITLE
fix(web): resolve configure-UI credentials path from the active RuntimeContext (#194)

### DIFF
--- a/mureo/core/runtime_context.py
+++ b/mureo/core/runtime_context.py
@@ -206,3 +206,42 @@ def reset_runtime_context() -> None:
     callers should not need this — a process has one workspace."""
     global _cached_context
     _cached_context = None
+
+
+def runtime_credentials_path(default: Path) -> Path:
+    """Return the credentials path the active ``RuntimeContext`` uses.
+
+    Bridges the path-based configure-UI write functions (which take a
+    ``credentials_path: Path``) to the pluggable ``SecretStore`` the MCP
+    runtime reads from, so an alternate backend registered via
+    :data:`RUNTIME_CONTEXT_FACTORY_ENTRY_POINT_GROUP` is honored on
+    *write* — not only on *read* (#194).
+
+    Resolution:
+
+    - **No factory registered** → return ``default`` unchanged. This
+      keeps single-backend installs on their existing location AND
+      preserves a test- or caller-injected ``home`` (the default
+      :class:`RuntimeContext`'s :class:`FilesystemSecretStore` resolves
+      against the real ``Path.home()``, which must NOT override an
+      injected path). The gate is on entry-point *presence*, not on the
+      resolved path, precisely to avoid that real-home fall-through.
+    - **Factory registered, filesystem-backed store** → return the
+      store's ``path`` so the write side matches the read side.
+    - **Factory registered, non-filesystem store** → return ``default``.
+      A ``credentials_path: Path`` cannot represent a non-filesystem
+      backend; the path-based write functions stay on the host default
+      (the honest ceiling of that API — a full ``SecretStore``-threaded
+      write path is a separate, larger change).
+
+    A registered-but-broken factory surfaces its
+    :class:`RuntimeContextFactoryError` here, mirroring the read path's
+    behavior — a packaging mistake is made visible rather than hidden
+    behind a silent fall-back to the default location.
+    """
+    if not list(entry_points(group=RUNTIME_CONTEXT_FACTORY_ENTRY_POINT_GROUP)):
+        return default
+    store = get_runtime_context().secret_store
+    if isinstance(store, FilesystemSecretStore):
+        return store.path
+    return default

--- a/mureo/web/server.py
+++ b/mureo/web/server.py
@@ -9,6 +9,7 @@ outlive the parent process.
 from __future__ import annotations
 
 import contextlib
+import dataclasses
 import http.server
 import logging
 import signal
@@ -18,6 +19,7 @@ import webbrowser
 from importlib import resources
 from pathlib import Path
 
+from mureo.core.runtime_context import runtime_credentials_path
 from mureo.web.extensions import discover_web_extensions
 from mureo.web.handlers import ConfigureHandler
 from mureo.web.host_paths import HostPaths, get_host_paths
@@ -73,6 +75,7 @@ class ConfigureWizard:
         self._host_paths: HostPaths = get_host_paths(self.session.host, home=home)
         self._commands_path_override = commands_path
         self._apply_commands_override()
+        self._apply_credentials_override()
         self.oauth_bridge = OAuthBridge()
         # Discover third-party extensions once at wizard construction.
         # ``discover_web_extensions`` caches internally, so this call
@@ -110,6 +113,7 @@ class ConfigureWizard:
         self.session.set_host(host)
         self._host_paths = get_host_paths(self.session.host, home=self.home)
         self._apply_commands_override()
+        self._apply_credentials_override()
 
     def mark_oauth_complete(
         self, provider: str, *, success: bool, error: str | None = None
@@ -170,6 +174,27 @@ class ConfigureWizard:
             commands_dir=self._commands_path_override,
             credentials_path=self._host_paths.credentials_path,
             mcp_registry_path=self._host_paths.mcp_registry_path,
+        )
+
+    def _apply_credentials_override(self) -> None:
+        """Align the configure-UI credentials path with the active
+        RuntimeContext (#194).
+
+        Every web write site (OAuth, env-var, provider install, plugin
+        credentials, credential removal) and the status read share
+        ``host_paths.credentials_path``. Resolving that one value from
+        :func:`runtime_credentials_path` makes the whole web layer write
+        to — and read from — the same location the MCP runtime reads
+        from, so a ``mureo.runtime_context_factory`` that relocates the
+        ``SecretStore`` is no longer bypassed on write. A no-op (keeps
+        the host default) when no factory is registered, so single-
+        backend installs and the test-injected ``home`` are unaffected.
+        """
+        resolved = runtime_credentials_path(self._host_paths.credentials_path)
+        if resolved == self._host_paths.credentials_path:
+            return
+        self._host_paths = dataclasses.replace(
+            self._host_paths, credentials_path=resolved
         )
 
 

--- a/tests/test_web_credentials_runtime_alignment.py
+++ b/tests/test_web_credentials_runtime_alignment.py
@@ -1,0 +1,193 @@
+"""#194 — the configure-UI credentials path must follow the active
+``RuntimeContext``.
+
+Before the fix the web layer hardcoded ``host_paths.credentials_path``
+(``~/.mureo/credentials.json``) for every credential write *and* its own
+status read, while the MCP runtime reads via
+``mureo.auth`` → ``get_runtime_context().secret_store``. A
+``mureo.runtime_context_factory`` that relocates the ``SecretStore``
+therefore produced a silent split-brain: the OAuth/setup wizard wrote
+one place, the runtime read another.
+
+The fix resolves the wizard's ``host_paths.credentials_path`` from the
+active ``RuntimeContext`` when (and only when) a factory is registered
+and its store is filesystem-backed, falling back to the host default
+otherwise. Because every web write site and the status read share
+``host_paths.credentials_path``, aligning that one value aligns the
+whole web layer with the runtime.
+
+These tests cover the core resolver helper and the wizard wiring.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from mureo.core.runtime_context import (
+    default_runtime_context,
+    reset_runtime_context,
+    runtime_credentials_path,
+)
+from mureo.web.server import ConfigureWizard
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Entry-point stubs (shape: ``.name`` + ``.load()``) — matches the
+# resolver's usage and the pattern in tests/core/test_runtime_resolver.py.
+# ---------------------------------------------------------------------------
+
+
+class _FakeEP:
+    def __init__(self, name: str, target: Any) -> None:
+        self.name = name
+        self._target = target
+
+    def load(self) -> Any:
+        return self._target
+
+
+def _patch_entry_points(monkeypatch: pytest.MonkeyPatch, eps: list[_FakeEP]) -> None:
+    """Stub ``mureo.core.runtime_context.entry_points`` for the
+    runtime-context factory group."""
+
+    def fake_entry_points(*, group: str) -> list[_FakeEP]:
+        assert group == "mureo.runtime_context_factory"
+        return eps
+
+    monkeypatch.setattr("mureo.core.runtime_context.entry_points", fake_entry_points)
+
+
+class _MemorySecretStore:
+    """Minimal non-filesystem ``SecretStore`` (no ``.path``)."""
+
+    def __init__(self) -> None:
+        self._data: dict[str, dict[str, Any]] = {}
+
+    def load(self, key: str) -> dict[str, Any]:
+        return dict(self._data.get(key, {}))
+
+    def save(self, key: str, value: dict[str, Any]) -> None:
+        self._data[key] = dict(value)
+
+
+@pytest.fixture(autouse=True)
+def _reset_ctx() -> Iterator[None]:
+    """Each test starts and ends with a clean resolver cache so the
+    process-wide singleton cannot bleed between tests."""
+    reset_runtime_context()
+    yield
+    reset_runtime_context()
+
+
+# ---------------------------------------------------------------------------
+# runtime_credentials_path helper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_runtime_credentials_path_default_when_no_factory(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """No factory registered → the supplied default is returned verbatim
+    (single-backend installs and the test-injected home are unaffected;
+    crucially the resolver must NOT fall through to the real-home
+    default store path)."""
+    _patch_entry_points(monkeypatch, [])
+    default = tmp_path / "home" / ".mureo" / "credentials.json"
+    assert runtime_credentials_path(default) == default
+
+
+@pytest.mark.unit
+def test_runtime_credentials_path_follows_factory_filesystem_store(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A registered factory whose store is a ``FilesystemSecretStore``
+    relocates the path — the write side now matches the read side."""
+    custom = tmp_path / "alt" / "creds.json"
+    _patch_entry_points(
+        monkeypatch,
+        [_FakeEP("alt", lambda: default_runtime_context(credentials_path=custom))],
+    )
+    default = tmp_path / "home" / ".mureo" / "credentials.json"
+    assert runtime_credentials_path(default) == custom
+
+
+@pytest.mark.unit
+def test_runtime_credentials_path_default_for_non_filesystem_store(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A non-filesystem store has no path to expose, so the path-based
+    write functions keep the host default (the honest ceiling of a
+    ``credentials_path: Path`` API)."""
+    base = default_runtime_context()
+    ctx = dataclasses.replace(base, secret_store=_MemorySecretStore())
+    _patch_entry_points(monkeypatch, [_FakeEP("vault", lambda: ctx)])
+    default = tmp_path / "home" / ".mureo" / "credentials.json"
+    assert runtime_credentials_path(default) == default
+
+
+# ---------------------------------------------------------------------------
+# ConfigureWizard wiring
+# ---------------------------------------------------------------------------
+
+
+def _make_home(tmp_path: Path) -> Path:
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".claude").mkdir()
+    (home / ".claude" / "commands").mkdir()
+    (home / ".mureo").mkdir()
+    return home
+
+
+@pytest.mark.unit
+def test_wizard_credentials_path_defaults_to_host_default(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """No factory → the wizard keeps the home-injected host default; it
+    must not leak to the real ``~/.mureo/credentials.json``."""
+    _patch_entry_points(monkeypatch, [])
+    home = _make_home(tmp_path)
+    wiz = ConfigureWizard(home=home)
+    assert wiz.host_paths.credentials_path == home / ".mureo" / "credentials.json"
+
+
+@pytest.mark.unit
+def test_wizard_credentials_path_follows_factory(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A registered FS-backed factory relocates the wizard's credentials
+    path, so every web write site + the status read align with the MCP
+    runtime (#194)."""
+    custom = tmp_path / "alt" / "creds.json"
+    _patch_entry_points(
+        monkeypatch,
+        [_FakeEP("alt", lambda: default_runtime_context(credentials_path=custom))],
+    )
+    home = _make_home(tmp_path)
+    wiz = ConfigureWizard(home=home)
+    assert wiz.host_paths.credentials_path == custom
+
+
+@pytest.mark.unit
+def test_wizard_set_host_preserves_factory_credentials_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Switching the host recomputes the path bundle but must re-apply
+    the runtime-context override, not revert to the host default."""
+    custom = tmp_path / "alt" / "creds.json"
+    _patch_entry_points(
+        monkeypatch,
+        [_FakeEP("alt", lambda: default_runtime_context(credentials_path=custom))],
+    )
+    home = _make_home(tmp_path)
+    wiz = ConfigureWizard(home=home)
+    wiz.set_host("claude-desktop")
+    assert wiz.host_paths.credentials_path == custom


### PR DESCRIPTION
Closes #194

## Summary

Credential **reads** and **writes** resolved their `SecretStore` differently. The MCP runtime reads via `mureo.auth` → `get_runtime_context().secret_store` (honors a `mureo.runtime_context_factory` that relocates the store), while the configure UI hardcoded `host_paths.credentials_path` (`~/.mureo/credentials.json`) for **every write AND its own status read**. A deployment whose factory relocated the `SecretStore` therefore wrote credentials to one place and read them from another — a silent split-brain where a just-authorized OAuth token was invisible to the runtime.

## Fix

Add `runtime_credentials_path(default)` to `mureo.core.runtime_context` and apply it once in `ConfigureWizard` so `host_paths.credentials_path` follows the active `RuntimeContext`. Because every web write site (OAuth, env-var, provider install, plugin credentials, credential removal) **and** the status read share `host_paths.credentials_path`, aligning that single value aligns the whole web layer with the runtime.

### Resolution rules

- **No factory registered** → host default unchanged. The gate is on entry-point **presence**, not on the resolved path, precisely so the default `RuntimeContext`'s `FilesystemSecretStore` (which binds to the real `Path.home()`) cannot override a test- or caller-injected `home`.
- **Factory + filesystem-backed store** → `store.path` (write matches read).
- **Factory + non-filesystem store** → default. A `credentials_path: Path` cannot represent a non-FS backend, so the path-based write functions stay on the host default (a full `SecretStore`-threaded write path is a separate, larger change).
- A registered-but-**broken** factory surfaces `RuntimeContextFactoryError` here, mirroring the read path — a packaging bug is made visible rather than hidden behind a silent fall-back.

## Backwards compatibility

No factory → identical behavior (default path). Single-backend installs and every existing test (all inject a tmp `home`) are unaffected — confirmed by the broad regression below.

## Test plan

- [x] `tests/test_web_credentials_runtime_alignment.py` — 3 helper cases (no-factory default, FS-factory relocation, non-FS fall-back) + 3 wizard cases (default keeps injected home, factory relocates, `set_host` re-applies the override)
- [x] Broad regression: **719** core + web tests pass (incl. all web tests that inject tmp home → no real-home leakage)
- [x] `ruff check mureo/` + `black --check` clean
- [x] `/code-review` clean — no CRITICAL / HIGH / MEDIUM

## Affected (per issue)

- `mureo/web/server.py` — `ConfigureWizard` now applies the runtime-context credentials override
- `mureo/core/runtime_context.py` — new `runtime_credentials_path` helper
- The 5 write sites + status read in `mureo/web/handlers.py` are fixed transitively (they all read `host_paths.credentials_path`); no per-site change needed

## Out of scope

- Threading a full `SecretStore` through the path-based write functions (`write_credential_env_var`, `install_provider`, `oauth_bridge.start`, …) to support non-filesystem backends end-to-end — a separate, larger refactor. Non-FS backends fall back to the host default here.
