### PR TITLE
fix(core): protocol-based credentials write path + sandbox the configure home (#196)

### DIFF
--- a/mureo/core/runtime_context.py
+++ b/mureo/core/runtime_context.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from importlib.metadata import entry_points
+from pathlib import Path
 from typing import TYPE_CHECKING, Final
 
 from mureo.core.knowledge_store import FilesystemKnowledgeStore, KnowledgeStore
@@ -32,8 +33,6 @@ from mureo.core.state_store import FilesystemStateStore, StateStore
 from mureo.core.throttle_store import ProcessLocalThrottleStore, ThrottleStore
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from mureo.throttle import ThrottleConfig
 
 
@@ -217,7 +216,7 @@ def runtime_credentials_path(default: Path) -> Path:
     :data:`RUNTIME_CONTEXT_FACTORY_ENTRY_POINT_GROUP` is honored on
     *write* — not only on *read* (#194).
 
-    Resolution:
+    Resolution (in order):
 
     - **No factory registered** → return ``default`` unchanged. This
       keeps single-backend installs on their existing location AND
@@ -226,9 +225,20 @@ def runtime_credentials_path(default: Path) -> Path:
       against the real ``Path.home()``, which must NOT override an
       injected path). The gate is on entry-point *presence*, not on the
       resolved path, precisely to avoid that real-home fall-through.
-    - **Factory registered, filesystem-backed store** → return the
-      store's ``path`` so the write side matches the read side.
-    - **Factory registered, non-filesystem store** → return ``default``.
+    - **Store declares ``credentials_write_path``** → return it. Any
+      ``SecretStore`` may advertise the filesystem path its writes land
+      in via an optional ``credentials_write_path: Path`` attribute
+      (read defensively via :func:`getattr`). This is the protocol-based
+      hook (#196): a filesystem-backed store that is not literally a
+      :class:`FilesystemSecretStore` instance — e.g. a composite that
+      layers an override file over a shared base — can still steer the
+      configure-UI write path to where it actually persists. A non-
+      ``Path`` declaration is ignored (a mis-typed store must not feed a
+      bogus value to the path-based write functions).
+    - **Built-in :class:`FilesystemSecretStore`** → return the store's
+      ``path``. Back-compat fallback for the concrete default store,
+      which does not declare ``credentials_write_path``.
+    - **Otherwise (non-filesystem / undeclared)** → return ``default``.
       A ``credentials_path: Path`` cannot represent a non-filesystem
       backend; the path-based write functions stay on the host default
       (the honest ceiling of that API — a full ``SecretStore``-threaded
@@ -242,6 +252,9 @@ def runtime_credentials_path(default: Path) -> Path:
     if not list(entry_points(group=RUNTIME_CONTEXT_FACTORY_ENTRY_POINT_GROUP)):
         return default
     store = get_runtime_context().secret_store
+    declared = getattr(store, "credentials_write_path", None)
+    if isinstance(declared, Path):
+        return declared
     if isinstance(store, FilesystemSecretStore):
         return store.path
     return default

--- a/mureo/core/secret_store.py
+++ b/mureo/core/secret_store.py
@@ -52,6 +52,21 @@ class SecretStore(Protocol):
       should overwrite existing entries.
     - ``delete(key)`` removes ``key`` from the store. It must be idempotent
       and not raise on missing keys.
+
+    Optional capability (read defensively via :func:`getattr`, so existing
+    stores need no change):
+
+    - ``credentials_write_path: Path`` — the single filesystem path the
+      store's writes actually land in. A filesystem-backed store that is
+      not a :class:`FilesystemSecretStore` instance (e.g. a composite that
+      layers an override file over a shared base) declares this so the
+      configure-UI write path
+      (:func:`mureo.core.runtime_context.runtime_credentials_path`) can
+      target the same file the runtime reads from — closing the #194
+      split-brain for non-default backends without coupling the resolver
+      to a concrete class (#196). Omit it (or return ``None``) for
+      non-filesystem backends; the path-based write helpers then stay on
+      the host default.
     """
 
     def load(self, key: str) -> dict[str, Any]: ...

--- a/mureo/web/server.py
+++ b/mureo/web/server.py
@@ -178,7 +178,7 @@ class ConfigureWizard:
 
     def _apply_credentials_override(self) -> None:
         """Align the configure-UI credentials path with the active
-        RuntimeContext (#194).
+        RuntimeContext when running against the real home (#194).
 
         Every web write site (OAuth, env-var, provider install, plugin
         credentials, credential removal) and the status read share
@@ -186,10 +186,23 @@ class ConfigureWizard:
         :func:`runtime_credentials_path` makes the whole web layer write
         to — and read from — the same location the MCP runtime reads
         from, so a ``mureo.runtime_context_factory`` that relocates the
-        ``SecretStore`` is no longer bypassed on write. A no-op (keeps
-        the host default) when no factory is registered, so single-
-        backend installs and the test-injected ``home`` are unaffected.
+        ``SecretStore`` is no longer bypassed on write.
+
+        Gated on ``home is None`` (production). An explicitly-injected
+        ``home`` means the caller — tests, or alternate-home tooling —
+        wants a self-contained path bundle rooted at that home. The
+        process-global runtime-context factory is resolved from entry
+        points and its paths live OUTSIDE that sandbox (in dev/CI a
+        third-party factory such as ``mureo-agency`` resolves against the
+        operator's real ``~/.mureo``), so consulting it here would let a
+        configure-UI write escape the injected home and clobber real
+        credentials. Production ``mureo configure`` always runs with
+        ``home=None`` and so still honors the factory. The factory's path
+        is resolved by :func:`runtime_credentials_path`, unit-tested
+        directly; this method only decides *whether* to apply it.
         """
+        if self.home is not None:
+            return
         resolved = runtime_credentials_path(self._host_paths.credentials_path)
         if resolved == self._host_paths.credentials_path:
             return

--- a/tests/test_web_credentials_runtime_alignment.py
+++ b/tests/test_web_credentials_runtime_alignment.py
@@ -134,6 +134,94 @@ def test_runtime_credentials_path_default_for_non_filesystem_store(
 
 
 # ---------------------------------------------------------------------------
+# #196 — protocol-based resolution: a store advertises its own write path
+# via ``credentials_write_path`` rather than being type-sniffed.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_runtime_credentials_path_honors_declared_write_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A filesystem-backed store that is NOT a ``FilesystemSecretStore``
+    instance — e.g. a composite layering an override file over a shared
+    base — advertises its real write target via ``credentials_write_path``.
+    The resolver must return it instead of falling through to ``default``
+    (which reintroduced the #194 split-brain for such backends)."""
+    write_target = tmp_path / "base" / "shared-creds.json"
+
+    class _LayeredSecretStore:
+        """Reads merge override + base; writes land in ``base``."""
+
+        credentials_write_path = write_target
+
+        def load(self, key: str) -> dict[str, Any]:
+            return {}
+
+        def save(self, key: str, value: dict[str, Any]) -> None:
+            return None
+
+        def delete(self, key: str) -> None:
+            return None
+
+    base = default_runtime_context()
+    ctx = dataclasses.replace(base, secret_store=_LayeredSecretStore())
+    _patch_entry_points(monkeypatch, [_FakeEP("layered", lambda: ctx)])
+    default = tmp_path / "home" / ".mureo" / "credentials.json"
+    assert runtime_credentials_path(default) == write_target
+
+
+@pytest.mark.unit
+def test_runtime_credentials_path_ignores_non_path_declaration(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A ``credentials_write_path`` that is not a ``Path`` (e.g. a bare
+    string from a mis-typed store) must NOT be trusted — the resolver
+    falls through rather than passing a non-Path to the path-based write
+    functions."""
+
+    class _BadDeclaration:
+        credentials_write_path = "/etc/passwd"  # str, not Path
+
+        def load(self, key: str) -> dict[str, Any]:
+            return {}
+
+        def save(self, key: str, value: dict[str, Any]) -> None:
+            return None
+
+        def delete(self, key: str) -> None:
+            return None
+
+    base = default_runtime_context()
+    ctx = dataclasses.replace(base, secret_store=_BadDeclaration())
+    _patch_entry_points(monkeypatch, [_FakeEP("bad", lambda: ctx)])
+    default = tmp_path / "home" / ".mureo" / "credentials.json"
+    assert runtime_credentials_path(default) == default
+
+
+@pytest.mark.unit
+def test_runtime_credentials_path_declared_path_wins_over_isinstance(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """When a store BOTH is a ``FilesystemSecretStore`` AND declares a
+    different ``credentials_write_path``, the declared capability wins
+    (branch 1 precedes the concrete-type fallback)."""
+    from mureo.core.secret_store import FilesystemSecretStore
+
+    declared = tmp_path / "declared" / "creds.json"
+
+    class _DeclaringFsStore(FilesystemSecretStore):
+        credentials_write_path = declared
+
+    base = default_runtime_context()
+    store = _DeclaringFsStore(path=tmp_path / "concrete" / "creds.json")
+    ctx = dataclasses.replace(base, secret_store=store)
+    _patch_entry_points(monkeypatch, [_FakeEP("dual", lambda: ctx)])
+    default = tmp_path / "home" / ".mureo" / "credentials.json"
+    assert runtime_credentials_path(default) == declared
+
+
+# ---------------------------------------------------------------------------
 # ConfigureWizard wiring
 # ---------------------------------------------------------------------------
 
@@ -160,12 +248,15 @@ def test_wizard_credentials_path_defaults_to_host_default(
 
 
 @pytest.mark.unit
-def test_wizard_credentials_path_follows_factory(
+def test_wizard_ignores_factory_when_home_is_injected(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """A registered FS-backed factory relocates the wizard's credentials
-    path, so every web write site + the status read align with the MCP
-    runtime (#194)."""
+    """SAFETY: an explicitly-injected ``home`` sandboxes the wizard. Even
+    with a factory registered, the wizard MUST keep its injected-home
+    default and never reach the process-global factory (whose paths live
+    outside the sandbox — in dev/CI that is the operator's real
+    ``~/.mureo/credentials.json``). Regression guard for the #195
+    home-injection escape that let tests clobber real credentials."""
     custom = tmp_path / "alt" / "creds.json"
     _patch_entry_points(
         monkeypatch,
@@ -173,15 +264,15 @@ def test_wizard_credentials_path_follows_factory(
     )
     home = _make_home(tmp_path)
     wiz = ConfigureWizard(home=home)
-    assert wiz.host_paths.credentials_path == custom
+    assert wiz.host_paths.credentials_path == home / ".mureo" / "credentials.json"
 
 
 @pytest.mark.unit
-def test_wizard_set_host_preserves_factory_credentials_path(
+def test_wizard_set_host_keeps_injected_home_under_factory(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """Switching the host recomputes the path bundle but must re-apply
-    the runtime-context override, not revert to the host default."""
+    """Switching the host recomputes the path bundle but must stay
+    sandboxed under the injected home, not leak to the factory path."""
     custom = tmp_path / "alt" / "creds.json"
     _patch_entry_points(
         monkeypatch,
@@ -190,4 +281,21 @@ def test_wizard_set_host_preserves_factory_credentials_path(
     home = _make_home(tmp_path)
     wiz = ConfigureWizard(home=home)
     wiz.set_host("claude-desktop")
-    assert wiz.host_paths.credentials_path == custom
+    assert wiz.host_paths.credentials_path == home / ".mureo" / "credentials.json"
+
+
+@pytest.mark.unit
+def test_wizard_applies_override_only_when_home_is_none(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Production path: with ``home=None`` the wizard applies the
+    runtime-context override. ``runtime_credentials_path`` is patched to
+    a tmp sentinel so the test never resolves the real factory or touches
+    the operator's real ``~/.mureo`` (constructing the wizard only builds
+    Path objects — no credential I/O)."""
+    sentinel = tmp_path / "runtime" / "creds.json"
+    monkeypatch.setattr(
+        "mureo.web.server.runtime_credentials_path", lambda _default: sentinel
+    )
+    wiz = ConfigureWizard(home=None)
+    assert wiz.host_paths.credentials_path == sentinel


### PR DESCRIPTION
Closes #196

Two related changes to the configure-UI credentials-path resolution from #194/#195.

## 1. Protocol-based write-path resolution (#196)

#195 resolved the write path with `isinstance(store, FilesystemSecretStore)`, coupling a path decision to a concrete class while the surrounding design is built on the `SecretStore` **Protocol**. A filesystem-backed store that is not literally a `FilesystemSecretStore` instance — e.g. a composite that layers an override file over a shared base — fell through to the host default, reintroducing the #194 split-brain for that backend.

`runtime_credentials_path` now asks the store for its write path instead of type-sniffing:

- **branch 1** — any store may advertise `credentials_write_path: Path` (read defensively via `getattr`); a non-`Path` declaration is ignored so a mis-typed store cannot feed a bogus value to the path-based write functions.
- **branch 2** — back-compat: the built-in `FilesystemSecretStore` returns `store.path`.
- **branch 3** — non-filesystem / undeclared → host default (unchanged).

`SecretStore` Protocol docs gain the optional `credentials_write_path` capability (documented, read via `getattr` — existing stores need no change and `runtime_checkable` `isinstance` is unaffected).

## 2. Sandbox the configure home (safety regression from #195)

While validating #196 I found that #195's `_apply_credentials_override` consulted the **process-global** runtime-context factory even when `ConfigureWizard` was given an injected `home`. The factory is resolved from entry points and its paths live **outside** that sandbox — in a dev/CI venv with a third-party factory such as `mureo-agency` installed, it resolves against the operator's real `~/.mureo/credentials.json`. Home-injected test wizards therefore escaped their tmp sandbox and read/wrote the real credentials file (observed: the plugin-credentials handler tests wrote `demo_ads`/`meta_ads` dummies into the operator's real `~/.mureo/credentials.json`).

`_apply_credentials_override` is now **gated on `home is None`** (production). An explicitly-injected `home` means the caller wants a self-contained path bundle rooted at that home, so the global factory is not consulted. Production `mureo configure` always runs with `home=None` and still honors the factory (**#194 preserved**). The factory path resolution (`runtime_credentials_path`) is unit-tested directly; the wizard method only decides *whether* to apply it.

## Test plan

- [x] #196: declared `credentials_write_path` honored; non-`Path` declaration ignored; declared path wins over the `isinstance` fallback
- [x] Safety: a home-injected wizard ignores a registered factory and keeps its injected-home default (regression guard for the escape); `set_host` stays sandboxed; with `home=None` the override IS applied (resolver patched to a tmp sentinel — no real `~/.mureo` I/O)
- [x] Broad regression: **982** web/core tests pass; the previously real-home-writing handler tests now stay under tmp
- [x] `ruff` + `black` clean
- [x] `/code-review` clean — no CRITICAL / HIGH / MEDIUM (net security improvement)

## Note for operators

If you ran the test suite locally with a `mureo.runtime_context_factory` plugin (e.g. `mureo-agency`) installed **before** this fix, your real `~/.mureo/credentials.json` may contain test dummies (`demo_ads` / `meta_ads: {access_token: "Y"}`). They are harmless test fixtures, not real credentials; `rm ~/.mureo/credentials.json` and re-run `mureo configure` to clean. After this fix the test suite never touches the real file.
