### PR TITLE
feat(configure): skippable account picker for multi-account backends (#198)

### DIFF
--- a/mureo/cli/web_auth.py
+++ b/mureo/cli/web_auth.py
@@ -725,6 +725,21 @@ class _WizardHandler(http.server.BaseHTTPRequestHandler):
             client_secret=sess.google_client_secret or "",
             refresh_token=refresh_token,
         )
+        if self.server.wizard.multi_account_auth:
+            # Multi-account backend (#198): the developer_token + OAuth
+            # client are operator-shared; the per-client ``customer_id``
+            # is supplied out of band. Persist the shared credentials and
+            # skip the account probe + picker entirely — going straight
+            # to /done without ever calling the Google Ads API.
+            save_credentials(
+                path=self.server.wizard.credentials_path,
+                google=probe_creds,
+            )
+            sess.clear_secrets()
+            self.send_response(302)
+            self.send_header("Location", "/done")
+            self.end_headers()
+            return
         try:
             accounts = _run_async(list_accessible_accounts(probe_creds))
         except Exception as exc:  # noqa: BLE001
@@ -956,6 +971,25 @@ class _WizardHandler(http.server.BaseHTTPRequestHandler):
             return
 
         access_token = result.access_token
+        if self.server.wizard.multi_account_auth:
+            # Multi-account backend (#198): the app creds + token are
+            # operator-shared; the per-client ``account_id`` is supplied
+            # out of band. Persist the shared credentials and skip the
+            # account probe + picker entirely.
+            creds = MetaAdsCredentials(
+                access_token=access_token,
+                app_id=sess.meta_app_id,
+                app_secret=sess.meta_app_secret or "",
+            )
+            save_credentials(
+                path=self.server.wizard.credentials_path,
+                meta=creds,
+            )
+            sess.clear_secrets()
+            self.send_response(302)
+            self.send_header("Location", "/done")
+            self.end_headers()
+            return
         try:
             accounts = _run_async(list_meta_ad_accounts(access_token))
         except Exception as exc:  # noqa: BLE001
@@ -1133,9 +1167,16 @@ class WebAuthWizard:
         *,
         bind_host: str = "127.0.0.1",
         credentials_path: Path | None = None,
+        multi_account_auth: bool = False,
     ) -> None:
         self._bind_host = bind_host
         self.credentials_path = credentials_path
+        # When set, the OAuth callbacks persist only the operator-shared
+        # credentials and skip the per-account picker (#198). Threaded in
+        # by the caller (the configure-UI bridge resolves it from the
+        # active RuntimeContext) rather than read from process globals
+        # here, so standalone WebAuthWizard use stays single-account.
+        self.multi_account_auth = multi_account_auth
         self.session = WizardSession()
         self.completed = False
 

--- a/mureo/core/runtime_context.py
+++ b/mureo/core/runtime_context.py
@@ -258,3 +258,40 @@ def runtime_credentials_path(default: Path) -> Path:
     if isinstance(store, FilesystemSecretStore):
         return store.path
     return default
+
+
+def runtime_multi_account_auth() -> bool:
+    """Return whether the active ``SecretStore`` is a multi-account backend.
+
+    A backend whose credentials are operator-shared across many client
+    accounts (e.g. an agency plugin: one Google ``developer_token`` +
+    OAuth client, one Meta app, serving N clients whose
+    ``customer_id`` / ``account_id`` are supplied per-request out of
+    band) advertises this by exposing ``multi_account_auth = True`` on
+    its store. The configure-UI OAuth flow then persists only the
+    shared credentials and skips the per-account picker (#198).
+
+    Resolution mirrors :func:`runtime_credentials_path`:
+
+    - **No factory registered** → ``False``. Single-backend OSS installs
+      (and any test- or caller-injected ``home``) keep the standalone
+      behavior — the picker is shown. The gate is on entry-point
+      *presence* so the default :class:`RuntimeContext` (whose
+      :class:`FilesystemSecretStore` never declares the capability) is
+      never even consulted.
+    - **Store declares ``multi_account_auth``** → the value, accepted
+      only when it is exactly ``True`` (read defensively via
+      :func:`getattr`). A truthy-but-not-``True`` declaration from a
+      mis-typed store must not silently suppress the picker, so
+      ``"yes"`` / ``1`` / a non-empty list all resolve to ``False``.
+    - **Otherwise** → ``False``.
+
+    A registered-but-broken factory surfaces its
+    :class:`RuntimeContextFactoryError` here, mirroring the read path —
+    a packaging mistake is made visible rather than hidden behind a
+    silent fall-back to the picker.
+    """
+    if not list(entry_points(group=RUNTIME_CONTEXT_FACTORY_ENTRY_POINT_GROUP)):
+        return False
+    store = get_runtime_context().secret_store
+    return getattr(store, "multi_account_auth", False) is True

--- a/mureo/core/secret_store.py
+++ b/mureo/core/secret_store.py
@@ -67,6 +67,18 @@ class SecretStore(Protocol):
       to a concrete class (#196). Omit it (or return ``None``) for
       non-filesystem backends; the path-based write helpers then stay on
       the host default.
+
+    - ``multi_account_auth: bool`` — set ``True`` to mark the store as a
+      multi-account backend whose OAuth credentials are operator-shared
+      across many client accounts (e.g. an agency plugin: one Google
+      ``developer_token`` + OAuth client, one Meta app, serving N
+      clients whose ``customer_id`` / ``account_id`` are supplied
+      per-request out of band). The ``mureo configure`` OAuth flow then
+      persists only the shared credentials and skips the per-account
+      picker, redirecting straight to ``/done`` (#198). Honored only
+      when exactly ``True`` (see
+      :func:`mureo.core.runtime_context.runtime_multi_account_auth`);
+      omit it for single-account stores so the picker is shown as today.
     """
 
     def load(self, key: str) -> dict[str, Any]: ...

--- a/mureo/web/handlers.py
+++ b/mureo/web/handlers.py
@@ -45,6 +45,7 @@ import urllib.parse
 from http.server import BaseHTTPRequestHandler
 from typing import TYPE_CHECKING, Any
 
+from mureo.core.runtime_context import runtime_multi_account_auth
 from mureo.core.secret_store import FilesystemSecretStore
 from mureo.web._helpers import (
     compare_csrf,
@@ -660,12 +661,24 @@ class ConfigureHandler(BaseHTTPRequestHandler):
             send_error_json(self, 404, "unknown_provider")
             return
         self.wizard.session.mark_oauth_pending(provider)
+        # A multi-account backend (#198) persists only the operator-
+        # shared credentials and skips the per-account picker. Resolve
+        # the capability from the active RuntimeContext, but ONLY in
+        # production (home is None). An injected ``home`` sandboxes the
+        # wizard; the process-global factory's store lives outside that
+        # sandbox (in dev/CI a third-party factory resolves against the
+        # operator's real ~/.mureo), so consulting it under an injected
+        # home would let test wizards inherit real-backend behavior —
+        # the same #195 escape the credentials-path override guards
+        # against.
+        multi_account = self.wizard.home is None and runtime_multi_account_auth()
         try:
             result = self.wizard.oauth_bridge.start(
                 provider=provider,
                 configure_wizard=self.wizard,
                 credentials_path=self.wizard.host_paths.credentials_path,
                 locale=self.wizard.session.locale,
+                multi_account_auth=multi_account,
             )
         except ValueError:
             send_error_json(self, 400, "unknown_provider")

--- a/mureo/web/oauth_bridge.py
+++ b/mureo/web/oauth_bridge.py
@@ -89,6 +89,7 @@ class OAuthBridge:
         configure_wizard: Any,
         credentials_path: Path | None = None,
         locale: str = "en",
+        multi_account_auth: bool = False,
     ) -> OAuthHandoffResult:
         """Spawn a wizard for ``provider`` and return the consent URL.
 
@@ -96,6 +97,14 @@ class OAuthBridge:
         per-platform form via a ``?locale=`` query string so the legacy
         wizard (English-only HTML) can switch its inline strings to
         Japanese when the operator picked JA in the configure UI.
+
+        ``multi_account_auth`` is threaded through to the spawned
+        ``WebAuthWizard`` so a multi-account backend persists only the
+        operator-shared credentials and skips the per-account picker
+        (#198). The caller (``ConfigureHandler``) resolves it from the
+        active ``RuntimeContext`` behind a ``home is None`` gate, so this
+        bridge stays oblivious to process globals and defaults to the
+        standalone single-account behavior.
         """
         if provider not in _PROVIDER_TO_PATH:
             raise ValueError(f"unknown provider: {provider!r}")
@@ -104,7 +113,10 @@ class OAuthBridge:
 
         from mureo.cli.web_auth import WebAuthWizard
 
-        wizard = WebAuthWizard(credentials_path=credentials_path)
+        wizard = WebAuthWizard(
+            credentials_path=credentials_path,
+            multi_account_auth=multi_account_auth,
+        )
         thread = threading.Thread(target=wizard.serve, daemon=True)
         thread.start()
         try:

--- a/tests/test_web_auth_multi_account.py
+++ b/tests/test_web_auth_multi_account.py
@@ -1,0 +1,308 @@
+"""#198 — the OAuth account-picker step is skippable for multi-account
+backends.
+
+A multi-account ``RuntimeContext`` backend (e.g. the agency plugin)
+advertises ``multi_account_auth`` on its ``SecretStore``. When set, the
+operator-wide OAuth wizard persists only the operator-shared credentials
+(Google ``developer_token`` + OAuth, or the Meta app creds/token) and
+skips the per-account picker — ``customer_id`` / ``account_id`` are
+per-client values supplied out-of-band.
+
+Default (standalone OSS): capability absent → ``False`` → picker shown
+exactly as today.
+
+The capability is threaded explicitly into ``WebAuthWizard``
+(default ``False``) rather than read from the process-global context in
+the request handler, so these tests — and every existing web_auth test —
+are isolated from whatever ``mureo.runtime_context_factory`` happens to
+be installed in the dev/CI venv. The production resolution + home gate
+lives in ``ConfigureHandler`` and is covered separately.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import threading
+import urllib.error
+import urllib.request
+from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mureo.cli.web_auth import WebAuthWizard
+from mureo.core.runtime_context import (
+    default_runtime_context,
+    reset_runtime_context,
+    runtime_multi_account_auth,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+
+class _FakeEP:
+    def __init__(self, name: str, target: Any) -> None:
+        self.name = name
+        self._target = target
+
+    def load(self) -> Any:
+        return self._target
+
+
+def _patch_eps(monkeypatch: pytest.MonkeyPatch, eps: list[_FakeEP]) -> None:
+    def fake_entry_points(*, group: str) -> list[_FakeEP]:
+        assert group == "mureo.runtime_context_factory"
+        return eps
+
+    monkeypatch.setattr("mureo.core.runtime_context.entry_points", fake_entry_points)
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """Surface 30x as an HTTPError so the test can read the Location
+    (mirrors ``tests/test_web_auth.py``)."""
+
+    def redirect_request(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+
+@pytest.fixture(autouse=True)
+def _reset_ctx() -> Iterator[None]:
+    reset_runtime_context()
+    yield
+    reset_runtime_context()
+
+
+# ---------------------------------------------------------------------------
+# runtime_multi_account_auth helper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_runtime_multi_account_auth_false_when_no_factory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_eps(monkeypatch, [])
+    assert runtime_multi_account_auth() is False
+
+
+@pytest.mark.unit
+def test_runtime_multi_account_auth_true_when_store_advertises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Store:
+        multi_account_auth = True
+
+        def load(self, key: str) -> dict[str, Any]:
+            return {}
+
+        def save(self, key: str, value: dict[str, Any]) -> None:
+            return None
+
+        def delete(self, key: str) -> None:
+            return None
+
+    ctx = dataclasses.replace(default_runtime_context(), secret_store=_Store())
+    _patch_eps(monkeypatch, [_FakeEP("agency", lambda: ctx)])
+    assert runtime_multi_account_auth() is True
+
+
+@pytest.mark.unit
+def test_runtime_multi_account_auth_false_when_store_silent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Factory present but its store doesn't advertise the flag (the
+    built-in FilesystemSecretStore) → False."""
+    _patch_eps(monkeypatch, [_FakeEP("x", default_runtime_context)])
+    assert runtime_multi_account_auth() is False
+
+
+@pytest.mark.unit
+def test_runtime_multi_account_auth_non_true_value_is_false(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A truthy-but-not-True declaration (mis-typed store) is rejected —
+    the flag must be exactly ``True`` to skip the picker."""
+
+    class _Store:
+        multi_account_auth = "yes"
+
+        def load(self, key: str) -> dict[str, Any]:
+            return {}
+
+        def save(self, key: str, value: dict[str, Any]) -> None:
+            return None
+
+        def delete(self, key: str) -> None:
+            return None
+
+    ctx = dataclasses.replace(default_runtime_context(), secret_store=_Store())
+    _patch_eps(monkeypatch, [_FakeEP("x", lambda: ctx)])
+    assert runtime_multi_account_auth() is False
+
+
+# ---------------------------------------------------------------------------
+# WebAuthWizard threading
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_web_auth_wizard_default_multi_account_false() -> None:
+    assert WebAuthWizard().multi_account_auth is False
+
+
+@pytest.mark.unit
+def test_web_auth_wizard_accepts_multi_account_flag() -> None:
+    assert WebAuthWizard(multi_account_auth=True).multi_account_auth is True
+
+
+@pytest.mark.unit
+def test_oauth_bridge_threads_multi_account_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``OAuthBridge.start`` must pass ``multi_account_auth`` through to
+    the spawned ``WebAuthWizard``."""
+    from mureo.web.oauth_bridge import OAuthBridge
+
+    captured: dict[str, Any] = {}
+
+    class _FakeWizard:
+        # Polled by OAuthBridge._watch_handoff on its daemon thread;
+        # defined so that watcher does not raise before bridge.cancel().
+        completed = False
+
+        def __init__(
+            self, *, credentials_path: Any = None, multi_account_auth: bool = False
+        ) -> None:
+            captured["multi_account_auth"] = multi_account_auth
+
+        def serve(self) -> None:
+            return None
+
+        def wait_until_ready(self, timeout: float = 5.0) -> None:
+            return None
+
+        def home_url(self) -> str:
+            return "http://127.0.0.1:0/"
+
+        def shutdown(self) -> None:
+            return None
+
+    monkeypatch.setattr("mureo.cli.web_auth.WebAuthWizard", _FakeWizard)
+    bridge = OAuthBridge()
+    try:
+        bridge.start(
+            provider="google",
+            configure_wizard=MagicMock(),
+            multi_account_auth=True,
+        )
+        assert captured["multi_account_auth"] is True
+    finally:
+        bridge.cancel("google")
+
+
+# ---------------------------------------------------------------------------
+# Callback skip behavior (Google + Meta)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def multi_wizard(tmp_path: Path) -> Iterator[Any]:
+    creds_path = tmp_path / ".mureo" / "credentials.json"
+    wiz = WebAuthWizard(credentials_path=creds_path, multi_account_auth=True)
+    thread = threading.Thread(target=wiz.serve, daemon=True)
+    thread.start()
+    wiz.wait_until_ready(timeout=2.0)
+    try:
+        yield wiz
+    finally:
+        wiz.shutdown()
+        thread.join(timeout=2.0)
+
+
+def _url(wiz: Any, path: str) -> str:
+    return f"http://127.0.0.1:{wiz.port}{path}"
+
+
+@pytest.mark.unit
+def test_google_callback_skips_picker_when_multi_account(multi_wizard: Any) -> None:
+    """With ``multi_account_auth``, the Google callback persists the
+    shared credentials (no ``customer_id``) and redirects straight to
+    /done — the account probe + picker are skipped entirely."""
+    from mureo.auth_setup import OAuthResult
+
+    sess = multi_wizard.session
+    sess.google_flow = MagicMock()
+    sess.google_developer_token = "DT-123"
+    sess.google_client_id = "CID-abc"
+    sess.google_client_secret = "SECRET-xyz"
+    sess.google_oauth_state = "state-xyz"
+
+    async def _must_not_probe(_creds: Any) -> list[dict[str, Any]]:
+        raise AssertionError("account probe must be skipped for multi-account")
+
+    with (
+        patch(
+            "mureo.cli.web_auth.exchange_google_code",
+            return_value=OAuthResult(
+                refresh_token="REFRESH_TOKEN", access_token="ACCESS_TOKEN"
+            ),
+        ),
+        patch(
+            "mureo.cli.web_auth.list_accessible_accounts", side_effect=_must_not_probe
+        ),
+    ):
+        opener = urllib.request.build_opener(_NoRedirect())
+        with pytest.raises(urllib.error.HTTPError) as exc:
+            opener.open(
+                _url(multi_wizard, "/google-ads/callback?code=AC&state=state-xyz"),
+                timeout=2.0,
+            )
+        assert exc.value.code == 302
+        assert exc.value.headers.get("Location", "") == "/done"
+
+    saved = json.loads(multi_wizard.credentials_path.read_text())
+    # No real account is recorded: ``save_credentials`` always emits the
+    # ``customer_id`` key for Google, so the multi-account marker is the
+    # null value (identical to the existing empty-accounts fallback) —
+    # the agency backend supplies the per-client customer_id out of band.
+    assert saved["google_ads"]["customer_id"] is None
+    assert saved["google_ads"]["developer_token"] == "DT-123"
+    assert saved["google_ads"]["refresh_token"] == "REFRESH_TOKEN"
+
+
+@pytest.mark.unit
+def test_meta_callback_skips_picker_when_multi_account(multi_wizard: Any) -> None:
+    """With ``multi_account_auth``, the Meta callback persists the shared
+    app credentials/token (no ``account_id``) and redirects to /done."""
+    from mureo.auth_setup import MetaOAuthResult
+
+    sess = multi_wizard.session
+    sess.meta_app_id = "APP-1"
+    sess.meta_app_secret = "APP-SECRET"
+    sess.meta_oauth_state = "state-xyz"
+
+    async def _must_not_probe(_token: str) -> list[dict[str, Any]]:
+        raise AssertionError("account probe must be skipped for multi-account")
+
+    with (
+        patch(
+            "mureo.cli.web_auth.exchange_meta_code",
+            return_value=MetaOAuthResult(access_token="META_TOKEN", expires_in=0),
+        ),
+        patch("mureo.cli.web_auth.list_meta_ad_accounts", side_effect=_must_not_probe),
+    ):
+        opener = urllib.request.build_opener(_NoRedirect())
+        with pytest.raises(urllib.error.HTTPError) as exc:
+            opener.open(
+                _url(multi_wizard, "/meta-ads/callback?code=AC&state=state-xyz"),
+                timeout=2.0,
+            )
+        assert exc.value.code == 302
+        assert exc.value.headers.get("Location", "") == "/done"
+
+    saved = json.loads(multi_wizard.credentials_path.read_text())
+    assert "account_id" not in saved.get("meta_ads", {})
+    assert saved["meta_ads"]["access_token"] == "META_TOKEN"

--- a/tests/test_web_handlers.py
+++ b/tests/test_web_handlers.py
@@ -797,6 +797,60 @@ class TestPostOauthStart:
                 _post(wizard, "/api/oauth/google/start", {})
             assert exc.value.code == 400
 
+    def test_multi_account_suppressed_when_home_injected(
+        self, wizard: ConfigureWizard
+    ) -> None:
+        """SAFETY (#195/#198): a home-injected wizard must NEVER enable
+        multi-account auth, even when the process-global factory
+        advertises it — that factory's store lives outside the injected
+        sandbox (in dev/CI it resolves against the operator's real
+        ~/.mureo). The ``home is None`` gate forces the flag to ``False``
+        so a sandboxed wizard cannot inherit real-backend behavior."""
+        fake_result = MagicMock()
+        fake_result.as_dict.return_value = {"state": "pending", "provider": "google"}
+        with (
+            patch("mureo.web.handlers.runtime_multi_account_auth", return_value=True),
+            patch.object(
+                wizard.oauth_bridge, "start", return_value=fake_result
+            ) as mock_start,
+        ):
+            _post(wizard, "/api/oauth/google/start", {})
+        assert mock_start.call_args.kwargs["multi_account_auth"] is False
+
+    def test_multi_account_forwarded_when_home_none(self, tmp_path: Path) -> None:
+        """Production path (``home is None``): the handler resolves the
+        multi-account capability and forwards it to the bridge.
+        ``runtime_credentials_path`` is patched to a tmp sentinel so
+        constructing the home=None wizard never resolves the real factory
+        or touches the operator's ~/.mureo."""
+        sentinel = tmp_path / "runtime" / "credentials.json"
+        with patch(
+            "mureo.web.server.runtime_credentials_path", lambda _default: sentinel
+        ):
+            wiz = ConfigureWizard(home=None)
+        thread = threading.Thread(target=wiz.serve, daemon=True)
+        thread.start()
+        wiz.wait_until_ready(timeout=5.0)
+        try:
+            fake_result = MagicMock()
+            fake_result.as_dict.return_value = {
+                "state": "pending",
+                "provider": "google",
+            }
+            with (
+                patch(
+                    "mureo.web.handlers.runtime_multi_account_auth", return_value=True
+                ),
+                patch.object(
+                    wiz.oauth_bridge, "start", return_value=fake_result
+                ) as mock_start,
+            ):
+                _post(wiz, "/api/oauth/google/start", {})
+            assert mock_start.call_args.kwargs["multi_account_auth"] is True
+        finally:
+            wiz.shutdown()
+            thread.join(timeout=2.0)
+
 
 # ---------------------------------------------------------------------------
 # Dashboard uninstall routes (planner HANDOFF

--- a/tests/test_web_oauth_bridge.py
+++ b/tests/test_web_oauth_bridge.py
@@ -68,11 +68,13 @@ class _FakeWizard:
         port: int = 12345,
         completed: bool = False,
         ready_timeout: bool = False,
+        multi_account_auth: bool = False,
     ) -> None:
         self.credentials_path = credentials_path
         self.port = port
         self.completed = completed
         self._ready_timeout = ready_timeout
+        self.multi_account_auth = multi_account_auth
         self.shutdown_called = False
         self.serve_called = False
 


### PR DESCRIPTION
## Summary

Closes #198. Makes the OAuth account-picker step in `mureo configure` skippable for multi-account backends.

A `SecretStore` can now advertise an optional capability `multi_account_auth: bool`. When set (exactly `True`), the configure-UI OAuth flow persists **only** the operator-shared credentials and skips the per-account probe + picker, redirecting straight to `/done`:

- **Google**: `developer_token` + OAuth `client_id`/`client_secret`/`refresh_token` (no `customer_id`)
- **Meta**: app creds + access token (no `account_id`)

The per-client `customer_id` / `account_id` are supplied out of band by the multi-account backend (e.g. an agency plugin: one developer_token + OAuth client, one Meta app, serving N clients).

**Default (standalone OSS): capability absent leads to `False`, picker shown exactly as today. Fully backward compatible.**

## Design

The capability is threaded **explicitly** rather than read from the process-global context inside the request handler:

`ConfigureHandler._post_oauth_start` resolves `home is None and runtime_multi_account_auth()`, passes it to `OAuthBridge.start(multi_account_auth=...)`, which forwards to `WebAuthWizard(multi_account_auth=False)`.

- `runtime_multi_account_auth()` mirrors `runtime_credentials_path` (#196): entry-point presence gate plus `getattr(store, "multi_account_auth", False) is True` (a truthy-but-not-`True` declaration from a mis-typed store is rejected).
- The `home is None` gate mirrors #195/#196: an injected `home` sandboxes the wizard, so a test/alt-home wizard must never inherit the process-global factory's real-backend behavior. Threading the flag (default `False`) gives every existing `web_auth` test free isolation from whatever `runtime_context_factory` is installed in the dev/CI venv.
- The skip branch is inserted **after** the CSRF/state validation and reuses the existing `save_credentials` path, so the security posture is unchanged, and it avoids the account-probe's token-handling path entirely.

## Files

| File | Change |
|------|--------|
| `core/runtime_context.py` | add `runtime_multi_account_auth()` |
| `core/secret_store.py` | document optional `multi_account_auth` capability on the Protocol |
| `cli/web_auth.py` | `WebAuthWizard(multi_account_auth=False)` plus Google/Meta callback skip branches |
| `web/oauth_bridge.py` | `start(multi_account_auth=False)` forwarded to `WebAuthWizard` |
| `web/handlers.py` | `_post_oauth_start` resolves the home-gated capability and forwards it |

## Test plan

- [x] `runtime_multi_account_auth()` — no factory / advertised / silent store / non-`True` value (4 cases)
- [x] `WebAuthWizard` threading — default `False`, accepts flag
- [x] `OAuthBridge.start` forwards the flag to the spawned wizard
- [x] Google callback skips probe and picker, goes to `/done`, no real `customer_id` (probe asserts it is never called)
- [x] Meta callback skips probe and picker, goes to `/done`, no `account_id`
- [x] **Handler home-gate**: suppressed to `False` when home injected even if factory advertises `True` (#195 regression guard); forwarded `True` when `home is None`
- [x] Full `test_web_handlers` + `test_web_oauth_bridge` + `test_web_auth` + `core/` suites green (158 plus regression), ruff/black clean
