### PR TITLE
chore(release): v0.9.28 — configure-UI extensibility + multi-account OAuth & RuntimeContext fixes

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mureo",
-  "version": "0.9.27",
+  "version": "0.9.28",
   "description": "Your local-first AI ad ops crew for Google Ads, Meta Ads, Search Console & GA4. mureo sits on top of the official ad-platform MCPs, gates every change against your strategy, correlates outcomes locally, and keeps an auditable decision log — credentials never leave your machine.",
   "author": {
     "name": "Logly Inc.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,62 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.28] - 2026-06-10
+
+Configure-UI extensibility plus multi-account / `RuntimeContext` polish.
+As with 0.9.27, none of these change the MCP tool surface — every
+change is in the `mureo configure` local-only web UI, its OAuth wizard,
+or the `RuntimeContext` extension contract that third-party backends
+plug into. Standalone OSS behavior is unchanged across the board.
+
+### Added
+
+#### Skippable OAuth account-picker for multi-account backends (#198)
+
+A `SecretStore` can advertise an optional `multi_account_auth: bool`
+capability. When set, the `mureo configure` OAuth flow persists only
+the operator-shared credentials (Google `developer_token` + OAuth
+client, or the Meta app creds/token) and skips the per-account picker,
+redirecting straight to `/done`; the per-client `customer_id` /
+`account_id` are supplied out of band. Default (standalone OSS): the
+capability is absent, so the picker is shown exactly as before. The
+capability is resolved behind a `home is None` gate so a sandboxed
+wizard can never inherit a real backend's behavior.
+
+#### Skippable platform-selection wizard step (#193)
+
+The platform-selection step in `mureo configure` can now be skipped,
+matching the skippable-step affordance already offered elsewhere in
+the wizard.
+
+#### WebExtension surface overrides (#189)
+
+A registered web extension can now declare `hidden_builtin_tabs` and
+`replaces_landing`, letting a third-party surface hide built-in
+configure tabs and substitute its own landing view.
+
+### Fixed
+
+#### configure-UI credentials path follows the active RuntimeContext (#194, #195, #196)
+
+The configure web layer hard-coded `~/.mureo/credentials.json` for
+every credential write and its own status read, while the MCP runtime
+reads through the pluggable `SecretStore`. A `runtime_context_factory`
+that relocated the store therefore produced a silent split-brain — the
+wizard wrote one place, the runtime read another. The wizard now
+resolves its credentials path from the active `RuntimeContext`
+(protocol-based, via an optional `credentials_write_path` the store can
+advertise, rather than type-sniffing), gated so that an
+explicitly-injected `home` stays sandboxed and can never reach the
+process-global factory — closing a path by which a test or alternate-
+home wizard could clobber the operator's real credentials.
+
+#### Terminal state restored around the TerminalMenu picker (#190)
+
+`TerminalMenu.show()` could leave the terminal in an altered state on
+some exits; the CLI now saves and restores terminal state around the
+menu so the shell is returned clean.
+
 ## [0.9.27] - 2026-06-09
 
 ### Added — `configure` UI quality + locale-aware plugin credential fields (#183, #184, #186)

--- a/mureo/__init__.py
+++ b/mureo/__init__.py
@@ -1,3 +1,3 @@
 """mureo — your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."""
 
-__version__ = "0.9.27"
+__version__ = "0.9.28"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mureo"
-version = "0.9.27"
+version = "0.9.28"
 description = "Your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."
 requires-python = ">=3.10"
 license = "Apache-2.0"


### PR DESCRIPTION
Release **v0.9.28**. Bumps version (pyproject / `__init__` / plugin.json) and adds the CHANGELOG section for the 6 unreleased commits since v0.9.27 — all configure-UI / RuntimeContext, no MCP tool-surface change.

## Included
- feat(configure): skippable OAuth account-picker for multi-account backends (#198)
- feat(web): skippable platform-selection wizard step (#193)
- feat(web): WebExtension surface overrides — hidden_builtin_tabs + replaces_landing (#189)
- fix(web/core): configure-UI credentials path follows the active RuntimeContext + protocol-based write path + home-sandbox safety (#194, #195, #196)
- fix(cli): restore terminal state around TerminalMenu.show() (#190)

## On merge
Tag `v0.9.28` + publish a GitHub Release → `release.yml` publishes to PyPI via OIDC trusted publishing.