### PR TITLE
fix(meta-ads): align AccountCredentialField key with the loader (account_id) (#202)

### DIFF
--- a/mureo/adapters/meta_ads/adapter.py
+++ b/mureo/adapters/meta_ads/adapter.py
@@ -139,11 +139,19 @@ class MetaAdsAdapter:
     # Per-account credential the operator must supply for Meta Ads.
     # Token-level material (the System User access token / app id /
     # app secret) is operator-shared in the common Business Manager
-    # setup and lives outside this declaration; ``ad_account_id`` is
+    # setup and lives outside this declaration; the ad account id is
     # the only field that varies per account.
+    #
+    # The key is ``account_id`` — deliberately matching the credential
+    # dict key ``load_meta_ads_credentials`` reads (``mureo.auth``) and
+    # the key the configure wizard persists. They must agree, or a
+    # per-account override supplied under this field name is silently
+    # ignored and the connection falls back to the shared/default
+    # account (#202). The internal ``MetaAdsApiClient(ad_account_id=…)``
+    # parameter keeps its own name; only this credential key is aligned.
     account_credential_fields: tuple[AccountCredentialField, ...] = (
         AccountCredentialField(
-            key="ad_account_id",
+            key="account_id",
             display_name="Ad Account ID",
             placeholder="act_1234567890",
             required=True,

--- a/mureo/core/providers/credentials.py
+++ b/mureo/core/providers/credentials.py
@@ -2,7 +2,7 @@
 
 A provider (built-in or third-party) often needs identifiers that
 vary per platform account — Google Ads ``customer_id``, Meta Ads
-``ad_account_id``, an analytics product's ``advertiser_id``. These
+``account_id``, an analytics product's ``advertiser_id``. These
 are distinct from operator-shared OAuth credentials (developer
 tokens, refresh tokens) which typically apply to every account on
 the same platform.
@@ -56,7 +56,7 @@ class AccountCredentialField:
             for the active locale. Default: ``""``.
         secret: ``True`` when the field carries a secret value (API
             key, per-account OAuth token, etc.) rather than a public
-            identifier (``customer_id``, ``ad_account_id``, …). Like
+            identifier (``customer_id``, ``account_id``, …). Like
             the other attributes this flag is declarative metadata
             only — mureo itself does not redact or remask the value.
             Consumers — configure wizards, third-party setup UIs —

--- a/tests/adapters/meta_ads/test_adapter.py
+++ b/tests/adapters/meta_ads/test_adapter.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import json
 from datetime import date
 from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, Mock
@@ -254,11 +255,13 @@ def test_capabilities_match_exact_expected_set() -> None:
 
 
 @pytest.mark.unit
-def test_account_credential_fields_declared_for_ad_account_id() -> None:
-    """Meta Ads is per-account-identified by ``ad_account_id`` (the
-    ``act_*`` form Meta Ads Manager exposes). The declarative field
-    lets generic introspection tooling render setup prompts without
-    hardcoding per-provider knowledge."""
+def test_account_credential_fields_declared_for_account_id() -> None:
+    """Meta Ads is per-account-identified by its ad account id (the
+    ``act_*`` form Meta Ads Manager exposes). The declared field key is
+    ``account_id`` — the same key ``load_meta_ads_credentials`` reads
+    (#202); a mismatch silently ignores per-account overrides. The
+    declarative field lets generic introspection tooling render setup
+    prompts without hardcoding per-provider knowledge."""
     from mureo.core.providers.credentials import AccountCredentialField
 
     fields = MetaAdsAdapter.account_credential_fields  # type: ignore[attr-defined]
@@ -266,10 +269,37 @@ def test_account_credential_fields_declared_for_ad_account_id() -> None:
     assert len(fields) == 1
     field = fields[0]
     assert isinstance(field, AccountCredentialField)
-    assert field.key == "ad_account_id"
+    assert field.key == "account_id"
     assert field.required is True
     # Placeholder hint carries the canonical ``act_`` prefix.
     assert field.placeholder.startswith("act_")
+
+
+@pytest.mark.unit
+def test_declared_account_field_key_is_read_by_loader(tmp_path: Any) -> None:
+    """Regression for #202: a value stored under the *declared*
+    per-account field key must be picked up by
+    ``load_meta_ads_credentials``. If the declaration and the loader
+    disagree on the key (the original ``ad_account_id`` vs ``account_id``
+    bug), an operator-supplied per-account override is silently dropped
+    and the connection falls back to the shared/default account."""
+    from mureo.auth import load_meta_ads_credentials
+
+    declared_key = MetaAdsAdapter.account_credential_fields[0].key  # type: ignore[attr-defined]
+    creds_path = tmp_path / "credentials.json"
+    creds_path.write_text(
+        json.dumps(
+            {
+                "meta_ads": {
+                    "access_token": "TOKEN",
+                    declared_key: "act_PERCLIENT",
+                }
+            }
+        )
+    )
+    loaded = load_meta_ads_credentials(creds_path)
+    assert loaded is not None
+    assert loaded.account_id == "act_PERCLIENT"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

Closes #202. The Meta adapter declared its per-account credential field as `ad_account_id`, but `load_meta_ads_credentials` (`mureo/auth.py`) reads `account_id` — and the configure wizard persists `account_id`. The names disagreed, so a per-account override supplied under the **declared** field name was silently ignored; the loader kept reading `account_id` from the operator-shared base and connected to the **wrong ad account**.

Hit in production with multi-account / agency shared-base layering (surfaced while integrating #194/#195/#196/#198): a per-client `ad_account_id` had no effect; the client kept resolving to a stale shared `account_id`.

## Fix

Rename the declared credential key `ad_account_id` → `account_id` (`mureo/adapters/meta_ads/adapter.py`) so the **declaration**, the **wizard output**, and the **loader** all agree. The internal `MetaAdsApiClient(ad_account_id=…)` parameter keeps its own name — only the credential dict key is aligned. Google Ads was already correct (`customer_id` matches its loader).

## Backward compatibility

The loader never read `ad_account_id`, so no working setup relied on it. Existing `account_id` values keep working; per-account overrides supplied under the declared field name now take effect (the intended behaviour).

## Test plan

- [x] Declared field key is `account_id` (updated assertion)
- [x] **End-to-end regression**: a value stored under `MetaAdsAdapter.account_credential_fields[0].key` is read back by `load_meta_ads_credentials` — fails loudly if declaration/loader drift again
- [x] RED→GREEN confirmed; 383 adapter/providers/plugin-credentials/demo tests green; ruff/black clean
