### PR TITLE
fix(state): populate platforms + last_synced_at on campaign upsert

### DIFF
--- a/mureo/context/state.py
+++ b/mureo/context/state.py
@@ -7,6 +7,7 @@ import copy
 import json
 import os
 import tempfile
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -210,30 +211,83 @@ def write_state_file(path: Path, doc: StateDocument) -> None:
     _atomic_write(path, text)
 
 
-def upsert_campaign(path: Path, campaign: CampaignSnapshot) -> StateDocument:
-    """Upsert a campaign (update if exists, add if not).
+def _now_iso() -> str:
+    """Current time as a timezone-aware ISO 8601 UTC string."""
+    return datetime.now(timezone.utc).isoformat()
 
-    Returns:
-        Updated StateDocument
-    """
-    doc = read_state_file(path)
+
+def _upsert_into(
+    campaigns: tuple[CampaignSnapshot, ...], campaign: CampaignSnapshot
+) -> tuple[CampaignSnapshot, ...]:
+    """Return ``campaigns`` with ``campaign`` replacing any same-id entry
+    (or appended when new), preserving order."""
+    result: list[CampaignSnapshot] = []
     found = False
-    new_campaigns: list[CampaignSnapshot] = []
-    for c in doc.campaigns:
+    for c in campaigns:
         if c.campaign_id == campaign.campaign_id:
-            new_campaigns.append(campaign)
+            result.append(campaign)
             found = True
         else:
-            new_campaigns.append(c)
+            result.append(c)
     if not found:
-        new_campaigns.append(campaign)
+        result.append(campaign)
+    return tuple(result)
+
+
+def upsert_campaign(
+    path: Path,
+    campaign: CampaignSnapshot,
+    *,
+    platform: str,
+    account_id: str,
+) -> StateDocument:
+    """Upsert a campaign into STATE.json under its platform.
+
+    Writes the v2 ``platforms[platform]`` section — the schema the
+    dashboard reads — with the **required** ``account_id`` and the
+    campaign, and stamps ``last_synced_at`` to now. Without these the
+    document is schema-incomplete and the client renders as "not yet
+    bootstrapped" / inactive even though campaigns exist.
+
+    The legacy v1 flat ``campaigns`` list is updated in lockstep so
+    readers still on the v1 shape keep working (the field is retained
+    for backward compatibility — see :class:`StateDocument`).
+
+    Args:
+        path: STATE.json location.
+        campaign: The campaign snapshot to insert or update.
+        platform: Platform key the campaign belongs to (e.g.
+            ``"google_ads"``, ``"meta_ads"``) — the ``platforms`` dict key.
+        account_id: The platform account id (Google ``customer_id`` /
+            Meta ``act_*``). Always written onto the platform entry so a
+            per-account override is never silently dropped.
+
+    Returns:
+        The updated :class:`StateDocument`.
+    """
+    doc = read_state_file(path)
+
+    # v1 flat list — preserved for backward compatibility.
+    flat_campaigns = _upsert_into(doc.campaigns, campaign)
+
+    # v2 per-platform — the shape the dashboard reads. Ensure the platform
+    # entry exists, carries the (required) account_id, and holds the
+    # campaign.
+    platforms = dict(doc.platforms) if doc.platforms else {}
+    existing = platforms.get(platform)
+    platforms[platform] = PlatformState(
+        account_id=account_id,
+        campaigns=_upsert_into(
+            existing.campaigns if existing is not None else (), campaign
+        ),
+    )
 
     new_doc = StateDocument(
         version=doc.version,
-        last_synced_at=doc.last_synced_at,
+        last_synced_at=_now_iso(),
         customer_id=doc.customer_id,
-        campaigns=tuple(new_campaigns),
-        platforms=doc.platforms,
+        campaigns=flat_campaigns,
+        platforms=platforms,
         action_log=doc.action_log,
     )
     write_state_file(path, new_doc)

--- a/mureo/mcp/_handlers_mureo_context.py
+++ b/mureo/mcp/_handlers_mureo_context.py
@@ -185,6 +185,12 @@ async def handle_state_upsert_campaign(
     raw = _require(arguments, "campaign")
     if not isinstance(raw, dict):
         raise ValueError("campaign must be an object")
+    # Platform context is required so the v2 ``platforms`` section (the
+    # shape the dashboard reads) is always populated with the account id;
+    # without it a per-account override is silently dropped and the
+    # client renders as inactive.
+    platform = _require(raw, "platform")
+    account_id = _require(raw, "account_id")
     device_targeting = (
         tuple(raw["device_targeting"]) if raw.get("device_targeting") else None
     )
@@ -201,7 +207,7 @@ async def handle_state_upsert_campaign(
     )
     path = _resolve_path(arguments, "STATE.json", store_attr="state_path")
     try:
-        doc = upsert_campaign(path, campaign)
+        doc = upsert_campaign(path, campaign, platform=platform, account_id=account_id)
     except ContextFileError as exc:
         # Surface as ValueError so the MCP dispatcher's standard error
         # path translates this into a clean tool-error response rather

--- a/mureo/mcp/tools_mureo_context.py
+++ b/mureo/mcp/tools_mureo_context.py
@@ -65,14 +65,31 @@ _ACTION_LOG_ENTRY_PROPERTY = {
 _CAMPAIGN_PROPERTY = {
     "type": "object",
     "description": (
-        "A CampaignSnapshot for STATE.json. Required: campaign_id, "
-        "campaign_name, status. Optional fields mirror the snapshot "
+        "A CampaignSnapshot for STATE.json plus its platform context. "
+        "Required: campaign_id, campaign_name, status, platform, "
+        "account_id. The platform + account_id populate the per-platform "
+        "``platforms`` section the dashboard reads (omit them and the "
+        "client renders as inactive). Optional fields mirror the snapshot "
         "schema in docs/strategy-context.md."
     ),
     "properties": {
         "campaign_id": {"type": "string"},
         "campaign_name": {"type": "string"},
         "status": {"type": "string"},
+        "platform": {
+            "type": "string",
+            "description": (
+                "Platform key this campaign belongs to, e.g. "
+                "``google_ads`` / ``meta_ads``."
+            ),
+        },
+        "account_id": {
+            "type": "string",
+            "description": (
+                "Platform account id (Google ``customer_id`` / Meta "
+                "``act_*``) written onto the platform entry."
+            ),
+        },
         "bidding_strategy_type": {"type": "string"},
         "bidding_details": {"type": "object"},
         "daily_budget": {"type": "number"},
@@ -80,7 +97,13 @@ _CAMPAIGN_PROPERTY = {
         "campaign_goal": {"type": "string"},
         "notes": {"type": "string"},
     },
-    "required": ["campaign_id", "campaign_name", "status"],
+    "required": [
+        "campaign_id",
+        "campaign_name",
+        "status",
+        "platform",
+        "account_id",
+    ],
 }
 
 

--- a/tests/test_mcp_tools_mureo_context.py
+++ b/tests/test_mcp_tools_mureo_context.py
@@ -226,22 +226,25 @@ async def test_upsert_campaign_creates_when_missing(cwd_to_tmp) -> None:
         "campaign_name": "Generic",
         "status": "ENABLED",
         "daily_budget": 5000,
+        "platform": "google_ads",
+        "account_id": "act_123",
     }
     result = await mod.handle_tool(
         "mureo_state_upsert_campaign", {"campaign": campaign}
     )
     payload = json.loads(result[0].text)
-    # Either v1 (root campaigns) or v2 (platforms) shape is acceptable
-    # depending on how the underlying upsert helper reconciles.
-    flat = list(payload.get("campaigns", []))
+    # The v2 platforms section must carry the required account_id and the
+    # campaign, and last_synced_at must be stamped, or the client renders
+    # as inactive.
     plats = payload.get("platforms") or {}
+    assert plats["google_ads"]["account_id"] == "act_123"
     found_in_platforms = any(
         c["campaign_id"] == "camp_xyz"
         for plat in plats.values()
         for c in plat.get("campaigns", [])
     )
-    found_in_flat = any(c["campaign_id"] == "camp_xyz" for c in flat)
-    assert found_in_flat or found_in_platforms
+    assert found_in_platforms
+    assert payload.get("last_synced_at")
 
 
 async def test_upsert_campaign_updates_existing(cwd_to_tmp) -> None:
@@ -253,6 +256,8 @@ async def test_upsert_campaign_updates_existing(cwd_to_tmp) -> None:
         "campaign_name": "Generic",
         "status": "ENABLED",
         "daily_budget": 5000,
+        "platform": "google_ads",
+        "account_id": "act_123",
     }
     await mod.handle_tool("mureo_state_upsert_campaign", {"campaign": initial_campaign})
 
@@ -261,6 +266,8 @@ async def test_upsert_campaign_updates_existing(cwd_to_tmp) -> None:
         "campaign_name": "Generic",
         "status": "PAUSED",
         "daily_budget": 8000,
+        "platform": "google_ads",
+        "account_id": "act_123",
     }
     result = await mod.handle_tool("mureo_state_upsert_campaign", {"campaign": updated})
     payload = json.loads(result[0].text)
@@ -271,9 +278,16 @@ async def test_upsert_campaign_updates_existing(cwd_to_tmp) -> None:
         c for plat in plats.values() for c in plat.get("campaigns", [])
     ]
     matches = [c for c in all_snaps if c["campaign_id"] == "camp_xyz"]
-    assert len(matches) == 1, f"expected exactly one snapshot, got {len(matches)}"
-    assert matches[0]["status"] == "PAUSED"
-    assert matches[0]["daily_budget"] == 8000
+    # In-place replacement: every surviving snapshot reflects the update —
+    # no stale ENABLED/5000 copy lingers in either the v1 flat list or the
+    # v2 platforms section (which are dual-written in lockstep).
+    assert matches, "campaign should be present"
+    assert all(c["status"] == "PAUSED" and c["daily_budget"] == 8000 for c in matches)
+    # And neither shape holds a duplicate of the same id.
+    assert [c["campaign_id"] for c in flat].count("camp_xyz") <= 1
+    for plat in plats.values():
+        ids = [c["campaign_id"] for c in plat.get("campaigns", [])]
+        assert ids.count("camp_xyz") <= 1
 
 
 # ---------------------------------------------------------------------------
@@ -292,9 +306,7 @@ async def test_path_argument_refuses_traversal(cwd_to_tmp) -> None:
     ``Path.cwd()`` at construction), so this test exercises the
     workspace boundary while CWD is ``cwd_to_tmp``."""
     mod = _import_tools()
-    with pytest.raises(
-        ValueError, match="Refusing to read/write outside workspace"
-    ):
+    with pytest.raises(ValueError, match="Refusing to read/write outside workspace"):
         await mod.handle_tool("mureo_strategy_get", {"path": "/etc/passwd"})
 
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -199,15 +199,27 @@ class TestStateFile:
             status="PAUSED",
             daily_budget=10000.0,
         )
-        new_doc = upsert_campaign(fp, updated)
+        new_doc = upsert_campaign(
+            fp, updated, platform="google_ads", account_id="123-456-7890"
+        )
         assert len(new_doc.campaigns) == 1
         assert new_doc.campaigns[0].campaign_name == "New Name"
         assert new_doc.campaigns[0].status == "PAUSED"
         assert new_doc.campaigns[0].daily_budget == 10000.0
 
+        # v2 platforms section is populated with the required account_id +
+        # the campaign, and last_synced_at is stamped (without these the
+        # dashboard renders the client as inactive).
+        assert new_doc.platforms is not None
+        assert new_doc.platforms["google_ads"].account_id == "123-456-7890"
+        assert new_doc.platforms["google_ads"].campaigns[0].campaign_name == "New Name"
+        assert new_doc.last_synced_at is not None
+
         # Verify persisted to file
         reloaded = read_state_file(fp)
         assert reloaded.campaigns[0].campaign_name == "New Name"
+        assert reloaded.platforms["google_ads"].account_id == "123-456-7890"
+        assert reloaded.last_synced_at is not None
 
     @pytest.mark.unit
     def test_upsert_campaign_new(self, tmp_path: Path) -> None:
@@ -229,10 +241,16 @@ class TestStateFile:
             campaign_name="New Campaign",
             status="ENABLED",
         )
-        new_doc = upsert_campaign(fp, new_campaign)
+        new_doc = upsert_campaign(
+            fp, new_campaign, platform="google_ads", account_id="123-456-7890"
+        )
         assert len(new_doc.campaigns) == 2
         assert new_doc.campaigns[0].campaign_id == "1"
         assert new_doc.campaigns[1].campaign_id == "2"
+        # New campaign lands under the platform with its account_id.
+        assert new_doc.platforms["google_ads"].account_id == "123-456-7890"
+        assert new_doc.platforms["google_ads"].campaigns[0].campaign_id == "2"
+        assert new_doc.last_synced_at is not None
 
     @pytest.mark.unit
     def test_get_campaign(self) -> None:


### PR DESCRIPTION
## Summary

A client populated through `mureo_state_upsert_campaign` rendered as **"not yet bootstrapped" / inactive** even though it had campaigns. Root cause: STATE.json's v2 schema stores campaigns under per-platform entries (`platforms[<platform>]`, each with a required `account_id`), and the dashboard reads that shape plus `last_synced_at` to decide whether a client is active — but the upsert tool only wrote the legacy **v1 flat `campaigns`** list and **never stamped `last_synced_at`**. So `platforms` stayed empty and `last_synced_at` stayed `null`.

(Surfaced via a diagnosis screenshot: STATE.json had a missing `account_id` / `last_synced_at` and the client showed 未稼働.)

## Fix

`mureo_state_upsert_campaign` now **requires** `platform` and `account_id`, threaded through to:

```python
upsert_campaign(path, campaign, *, platform, account_id)
```

which:
- populates `platforms[platform]` with the required `account_id` + the campaign (the v2 shape the dashboard reads),
- stamps `last_synced_at` to the current UTC ISO-8601 time,
- keeps the v1 flat `campaigns` list in lockstep for backward-compatible readers.

So the required fields are always present after an upsert.

## Backward compatibility

- Existing STATE.json files are read unchanged; new writes additionally populate the v2 `platforms` section.
- The legacy v1 flat `campaigns` list is still maintained (dual-write), so v1 readers keep working.
- The MCP tool now lists `platform` + `account_id` as required, so callers (the LLM) always provide them.

## Test plan

- [x] `upsert_campaign` populates `platforms[platform].account_id` + the campaign and stamps `last_synced_at` (unit + handler level)
- [x] In-place update leaves no stale snapshot in either the v1 flat list or the v2 platforms section
- [x] 596 state / mcp-context / strategy-reminder / rollback / demo / core tests green; `mureo/` ruff + black clean
