### PR TITLE
feat(configure): scope dashboard plugin-credential fields via a store capability (#207)

### DIFF
--- a/mureo/core/runtime_context.py
+++ b/mureo/core/runtime_context.py
@@ -22,6 +22,7 @@ strings are rejected at construction time.
 
 from __future__ import annotations
 
+from collections.abc import Collection, Mapping
 from dataclasses import dataclass
 from importlib.metadata import entry_points
 from pathlib import Path
@@ -295,3 +296,52 @@ def runtime_multi_account_auth() -> bool:
         return False
     store = get_runtime_context().secret_store
     return getattr(store, "multi_account_auth", False) is True
+
+
+def runtime_ui_plugin_credential_fields() -> dict[str, frozenset[str]] | None:
+    """Return a per-provider allow-list of credential-field keys the
+    dashboard "Plugin credentials" section should render, or ``None``.
+
+    A multi-account backend whose per-account ids live in per-client
+    config (not the operator-shared credential store) advertises this so
+    the dashboard shows only operator-shared auth fields and stops
+    offering a second, competing input for an account id that belongs on
+    the backend's own per-client form — the failure mode behind the #202
+    incident (a stale shared ``account_id`` hijacking a client). It joins
+    the same store-capability family as :func:`runtime_credentials_path`
+    (#196) and :func:`runtime_multi_account_auth` (#198).
+
+    Resolution:
+
+    - **No factory registered** → ``None``. Standalone OSS / default
+      stores keep rendering every declared field (account ids included);
+      the gate is on entry-point *presence* so the default store is never
+      consulted.
+    - **Store declares ``ui_plugin_credential_fields``** as a
+      :class:`~collections.abc.Mapping` → a normalized
+      ``{provider: frozenset(keys)}`` dict. Each value must be a non-str
+      collection of keys; malformed entries are skipped.
+    - **Not a Mapping / empty after normalization / attribute absent** →
+      ``None``. A mis-typed declaration must NOT silently hide fields
+      (defensive, mirroring #198's strict ``is True``), so anything the
+      resolver cannot trust collapses to "no scoping".
+
+    Consumers (the dashboard list builder) treat a returned mapping as:
+    providers present → render only the listed keys (drop the card when
+    none remain); providers absent → keep all fields (so an unknown
+    future plugin stays fully usable).
+    """
+    if not list(entry_points(group=RUNTIME_CONTEXT_FACTORY_ENTRY_POINT_GROUP)):
+        return None
+    store = get_runtime_context().secret_store
+    declared = getattr(store, "ui_plugin_credential_fields", None)
+    if not isinstance(declared, Mapping):
+        return None
+    scoped: dict[str, frozenset[str]] = {}
+    for provider, keys in declared.items():
+        if not isinstance(provider, str):
+            continue
+        if isinstance(keys, (str, bytes)) or not isinstance(keys, Collection):
+            continue
+        scoped[provider] = frozenset(str(k) for k in keys)
+    return scoped or None

--- a/mureo/core/secret_store.py
+++ b/mureo/core/secret_store.py
@@ -79,6 +79,19 @@ class SecretStore(Protocol):
       when exactly ``True`` (see
       :func:`mureo.core.runtime_context.runtime_multi_account_auth`);
       omit it for single-account stores so the picker is shown as today.
+
+    - ``ui_plugin_credential_fields: Mapping[str, Collection[str]]`` —
+      a per-provider allow-list of the credential-field keys the
+      configure dashboard's "Plugin credentials" section should render
+      (e.g. ``{"yahoo_ads": {"client_id", "client_secret",
+      "refresh_token"}}``). A multi-account backend uses it to surface
+      only operator-shared auth fields and hide per-account ids that
+      belong on its own per-client form (#207). Providers absent from
+      the mapping keep all their fields. Read defensively (only a
+      ``Mapping`` is honored) via
+      :func:`mureo.core.runtime_context.runtime_ui_plugin_credential_fields`;
+      omit it for single-account stores so every declared field renders
+      as today.
     """
 
     def load(self, key: str) -> dict[str, Any]: ...

--- a/mureo/web/handlers.py
+++ b/mureo/web/handlers.py
@@ -46,7 +46,10 @@ from http.server import BaseHTTPRequestHandler
 from typing import TYPE_CHECKING, Any
 
 from mureo.core.providers import default_registry, get_account_oauth_config
-from mureo.core.runtime_context import runtime_multi_account_auth
+from mureo.core.runtime_context import (
+    runtime_multi_account_auth,
+    runtime_ui_plugin_credential_fields,
+)
 from mureo.core.secret_store import FilesystemSecretStore
 from mureo.web._helpers import (
     compare_csrf,
@@ -296,11 +299,28 @@ class ConfigureHandler(BaseHTTPRequestHandler):
             # Forward the session locale so plugin-declared
             # ``display_name_i18n`` / ``description_i18n`` entries are
             # resolved against the operator's active locale (#186).
+            #
+            # A multi-account backend may scope which fields render via
+            # the store's ``ui_plugin_credential_fields`` capability
+            # (#207). Resolve it ONLY in production (home is None): an
+            # injected home sandboxes the wizard, and the process-global
+            # factory's store lives outside that sandbox (the dev/CI
+            # agency factory resolves against the operator's real
+            # ~/.mureo), so consulting it under an injected home would let
+            # a sandboxed/test wizard inherit a real backend's scoping —
+            # the same #195 gate the credentials-path / multi-account
+            # resolution use.
+            field_scope = (
+                None
+                if self.wizard.home is not None
+                else runtime_ui_plugin_credential_fields()
+            )
             send_json(
                 self,
                 {
                     "plugins": list_plugin_credential_fields(
                         locale=self.wizard.session.locale,
+                        field_scope=field_scope,
                     )
                 },
             )

--- a/mureo/web/plugin_credentials.py
+++ b/mureo/web/plugin_credentials.py
@@ -37,7 +37,7 @@ from mureo.core.providers import (
 from mureo.core.secret_store import FilesystemSecretStore, SecretStore
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Collection, Mapping
 
     from mureo.core.providers.credentials import AccountCredentialField
 
@@ -70,6 +70,8 @@ class RequiredFieldMissingError(PluginCredentialsError):
 
 def list_plugin_credential_fields(
     locale: str = "en",
+    *,
+    field_scope: Mapping[str, Collection[str]] | None = None,
 ) -> list[dict[str, Any]]:
     """Enumerate providers that declare per-account credential fields.
 
@@ -82,6 +84,16 @@ def list_plugin_credential_fields(
             the locales it has translated. Defaults to ``"en"`` —
             matches pre-#186 behaviour for callers that don't yet
             pass a locale.
+        field_scope: Optional per-provider allow-list of field keys to
+            render (#207). ``None`` (the standalone-OSS default) renders
+            every declared field. When a mapping is supplied, a provider
+            **present** in it shows only the listed keys (and is dropped
+            entirely if none of its declared fields match); a provider
+            **absent** from it keeps all its fields. Resolved by the
+            handler from the active store's ``ui_plugin_credential_fields``
+            capability behind a ``home is None`` gate, so a multi-account
+            backend can hide per-account ids that live on its own
+            per-client form.
 
     Returns:
         A list of provider descriptors sorted alphabetically by
@@ -113,6 +125,13 @@ def list_plugin_credential_fields(
         fields = get_account_credential_fields(entry.provider_class)
         if not fields:
             continue
+        if field_scope is not None and entry.name in field_scope:
+            allowed = field_scope[entry.name]
+            fields = tuple(f for f in fields if f.key in allowed)
+            if not fields:
+                # Every declared field was scoped out — drop the card so
+                # the section shows no empty provider block.
+                continue
         result.append(
             {
                 "provider_name": entry.name,

--- a/tests/test_plugin_credentials_field_scope.py
+++ b/tests/test_plugin_credentials_field_scope.py
@@ -1,0 +1,262 @@
+"""#207 — a multi-account backend can scope which plugin credential
+fields the dashboard renders, via an optional ``SecretStore`` capability.
+
+Standalone OSS (no factory / default stores) is unchanged: every declared
+``AccountCredentialField`` renders, account ids included. An agency-style
+backend advertises ``ui_plugin_credential_fields`` (provider → allowed
+field keys); the dashboard then shows only the listed keys for those
+providers (e.g. operator-shared auth only, dropping per-client account
+ids that belong on the agency's own per-client form). Providers absent
+from the mapping keep all fields; a mis-typed (non-Mapping) declaration
+is ignored so it cannot silently hide fields.
+
+Mirrors the #196 / #198 store-capability + home-gate pattern: the
+capability is resolved behind a ``home is None`` gate in the handler, so
+these tests and every existing plugin-credentials test stay isolated from
+whatever ``mureo.runtime_context_factory`` is installed in the dev venv.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import threading
+import urllib.request
+from typing import TYPE_CHECKING, Any
+from unittest.mock import patch
+
+import pytest
+
+from mureo.core.providers import AccountCredentialField
+from mureo.core.providers.registry import ProviderEntry, default_registry
+from mureo.core.runtime_context import (
+    default_runtime_context,
+    reset_runtime_context,
+    runtime_ui_plugin_credential_fields,
+)
+from mureo.web.plugin_credentials import list_plugin_credential_fields
+from mureo.web.server import ConfigureWizard
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from http.client import HTTPResponse
+    from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Entry-point + store stubs
+# ---------------------------------------------------------------------------
+
+
+class _FakeEP:
+    def __init__(self, name: str, target: Any) -> None:
+        self.name = name
+        self._target = target
+
+    def load(self) -> Any:
+        return self._target
+
+
+def _patch_eps(monkeypatch: pytest.MonkeyPatch, eps: list[_FakeEP]) -> None:
+    def fake_entry_points(*, group: str) -> list[_FakeEP]:
+        assert group == "mureo.runtime_context_factory"
+        return eps
+
+    monkeypatch.setattr("mureo.core.runtime_context.entry_points", fake_entry_points)
+
+
+def _store(**attrs: Any) -> Any:
+    class _S:
+        def load(self, key: str) -> dict[str, Any]:
+            return {}
+
+        def save(self, key: str, value: dict[str, Any]) -> None:
+            return None
+
+        def delete(self, key: str) -> None:
+            return None
+
+    s = _S()
+    for k, v in attrs.items():
+        setattr(s, k, v)
+    return s
+
+
+@pytest.fixture(autouse=True)
+def _reset_ctx() -> Iterator[None]:
+    reset_runtime_context()
+    yield
+    reset_runtime_context()
+
+
+def _ctx_with(store: Any) -> Any:
+    return dataclasses.replace(default_runtime_context(), secret_store=store)
+
+
+# ---------------------------------------------------------------------------
+# runtime_ui_plugin_credential_fields resolver
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_resolver_none_when_no_factory(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_eps(monkeypatch, [])
+    assert runtime_ui_plugin_credential_fields() is None
+
+
+@pytest.mark.unit
+def test_resolver_returns_normalized_mapping(monkeypatch: pytest.MonkeyPatch) -> None:
+    store = _store(
+        ui_plugin_credential_fields={
+            "yahoo_ads": {"client_id", "client_secret"},
+            "line_ads": ["access_key", "secret_key"],
+        }
+    )
+    _patch_eps(monkeypatch, [_FakeEP("agency", lambda: _ctx_with(store))])
+    result = runtime_ui_plugin_credential_fields()
+    assert result == {
+        "yahoo_ads": frozenset({"client_id", "client_secret"}),
+        "line_ads": frozenset({"access_key", "secret_key"}),
+    }
+
+
+@pytest.mark.unit
+def test_resolver_none_when_store_silent(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_eps(monkeypatch, [_FakeEP("x", default_runtime_context)])
+    assert runtime_ui_plugin_credential_fields() is None
+
+
+@pytest.mark.unit
+def test_resolver_none_when_not_a_mapping(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A mis-typed declaration (list, not Mapping) must be ignored — it
+    must NOT silently hide fields."""
+    store = _store(ui_plugin_credential_fields=["yahoo_ads"])
+    _patch_eps(monkeypatch, [_FakeEP("bad", lambda: _ctx_with(store))])
+    assert runtime_ui_plugin_credential_fields() is None
+
+
+# ---------------------------------------------------------------------------
+# list_plugin_credential_fields(field_scope=...)
+# ---------------------------------------------------------------------------
+
+
+def _provider(name: str, *keys: str) -> ProviderEntry:
+    class _P:
+        pass
+
+    _P.name = name  # type: ignore[attr-defined]
+    _P.display_name = name  # type: ignore[attr-defined]
+    _P.capabilities = frozenset()  # type: ignore[attr-defined]
+    _P.account_credential_fields = tuple(  # type: ignore[attr-defined]
+        AccountCredentialField(key=k, display_name=k) for k in keys
+    )
+    return ProviderEntry(
+        name=name,
+        display_name=name,
+        capabilities=frozenset(),
+        provider_class=_P,
+        source_distribution=None,
+    )
+
+
+@pytest.fixture
+def two_providers(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        default_registry,
+        "_entries",
+        {
+            "yahoo_ads": _provider(
+                "yahoo_ads", "client_id", "client_secret", "account_id"
+            ),
+            "demo_ads": _provider("demo_ads", "api_key", "account_id"),
+        },
+    )
+
+
+def _by_name(rows: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    return {r["provider_name"]: r for r in rows}
+
+
+@pytest.mark.unit
+def test_list_unchanged_when_scope_none(two_providers: None) -> None:
+    by_name = _by_name(list_plugin_credential_fields(field_scope=None))
+    assert [f["key"] for f in by_name["yahoo_ads"]["fields"]] == [
+        "client_id",
+        "client_secret",
+        "account_id",
+    ]
+    assert [f["key"] for f in by_name["demo_ads"]["fields"]] == [
+        "api_key",
+        "account_id",
+    ]
+
+
+@pytest.mark.unit
+def test_list_filters_listed_provider_keeps_absent(two_providers: None) -> None:
+    scope = {"yahoo_ads": frozenset({"client_id", "client_secret"})}
+    by_name = _by_name(list_plugin_credential_fields(field_scope=scope))
+    # yahoo_ads scoped to auth only — account_id dropped.
+    assert [f["key"] for f in by_name["yahoo_ads"]["fields"]] == [
+        "client_id",
+        "client_secret",
+    ]
+    # demo_ads absent from the mapping → all fields kept.
+    assert [f["key"] for f in by_name["demo_ads"]["fields"]] == [
+        "api_key",
+        "account_id",
+    ]
+
+
+@pytest.mark.unit
+def test_list_drops_provider_when_no_keys_remain(two_providers: None) -> None:
+    scope = {"yahoo_ads": frozenset({"does_not_exist"})}
+    by_name = _by_name(list_plugin_credential_fields(field_scope=scope))
+    assert "yahoo_ads" not in by_name
+    assert "demo_ads" in by_name
+
+
+# ---------------------------------------------------------------------------
+# Handler home-gate (#195/#198 pattern)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def home_wizard(tmp_path: Path, two_providers: None) -> Iterator[ConfigureWizard]:
+    home = tmp_path / "home"
+    for sub in ("", ".claude", ".claude/commands", ".mureo"):
+        (home / sub).mkdir(parents=True, exist_ok=True)
+    wiz = ConfigureWizard(home=home)
+    thread = threading.Thread(target=wiz.serve, daemon=True)
+    thread.start()
+    wiz.wait_until_ready(timeout=5.0)
+    try:
+        yield wiz
+    finally:
+        wiz.shutdown()
+        thread.join(timeout=2.0)
+
+
+def _get(wiz: ConfigureWizard, path: str) -> HTTPResponse:
+    return urllib.request.urlopen(f"http://127.0.0.1:{wiz.port}{path}", timeout=2.0)
+
+
+@pytest.mark.unit
+def test_handler_suppresses_scope_when_home_injected(
+    home_wizard: ConfigureWizard,
+) -> None:
+    """SAFETY/isolation (#198 pattern): a home-injected wizard must NOT
+    apply a process-global factory's field scope — the dashboard keeps
+    every field. Guards the dev-venv agency factory from leaking into a
+    sandboxed wizard."""
+    scope = {"yahoo_ads": frozenset({"client_id"})}
+    with patch(
+        "mureo.web.handlers.runtime_ui_plugin_credential_fields", return_value=scope
+    ):
+        body = json.loads(_get(home_wizard, "/api/credentials/plugins").read())
+    by_name = {p["provider_name"]: p for p in body["plugins"]}
+    # Scope ignored under injected home → account_id still rendered.
+    assert [f["key"] for f in by_name["yahoo_ads"]["fields"]] == [
+        "client_id",
+        "client_secret",
+        "account_id",
+    ]


### PR DESCRIPTION
## Summary

Closes #207. The dashboard "Plugin credentials" section renders **every** `AccountCredentialField` a plugin declares — operator-shared auth (e.g. LINE `access_key`/`secret_key`, Yahoo `client_id`/`client_secret`/`refresh_token`) **and** per-account ids (`account_id`, …).

For a **standalone single-account install that is correct and stays the default**. For a **multi-account backend** (agency: operator-shared auth serving N clients whose account ids live in per-client config), the account-id inputs there land in the operator-shared store and leak as a default into every client's runtime — the exact failure mode behind the #202 incident (a stale shared `account_id` hijacking a client).

## Approach — capability-driven field scoping (default unchanged)

Joins the same store-capability family as #196 (`credentials_write_path`) and #198 (`multi_account_auth`): the active `SecretStore` may advertise, per provider, which credential-field keys the section should render.

```python
# optional on the store, read defensively
ui_plugin_credential_fields: Mapping[str, Collection[str]]
# {"yahoo_ads": {"client_id", "client_secret", "refresh_token"}}
```

- `runtime_context.runtime_ui_plugin_credential_fields()` — entry-point gate + `getattr`; **only a `Mapping` is honored** (a mis-typed declaration must not silently hide fields), normalized to `{provider: frozenset(keys)}`.
- `list_plugin_credential_fields(field_scope=...)` — provider **present** in the mapping renders only the listed keys (card dropped if none remain); provider **absent** keeps all fields (unknown future plugins stay usable).
- The handler resolves `field_scope` behind a **`home is None` gate** before passing it, so a sandboxed/test wizard never inherits the process-global factory's scoping (same #195 gate as the other capabilities).

## Backward compatibility

- Standalone / single-account OSS: capability absent → **byte-identical** behavior; account ids still configurable in the dashboard.
- Agency installs: the layered store declares the mapping → the section shows operator-shared auth only; per-account ids stay on the agency's per-client form.
- The save endpoint is unchanged (the UI simply stops rendering the filtered inputs); tightening it server-side is a follow-up. OAuth descriptors (#201) reference auth field keys, which a multi-account mapping keeps, so the Authenticate button keeps working.

## Test plan

- [x] Resolver: no factory → `None`; store advertises mapping → normalized `{provider: frozenset}`; store silent → `None`; non-`Mapping` → `None`
- [x] List: `field_scope=None` unchanged; listed provider filtered to its keys while an absent provider keeps all; provider dropped when no key matches
- [x] **Handler home-gate**: a home-injected wizard ignores a patched factory scope (account_id still rendered) — #195/#198 isolation regression
- [x] 652 plugin-cred / runtime-ctx / web-consumer / core tests green; `mureo/` ruff + black clean
