### PR TITLE
chore(release): v0.9.30 — dashboard plugin-credential field scoping capability (#207)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mureo",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "description": "Your local-first AI ad ops crew for Google Ads, Meta Ads, Search Console & GA4. mureo sits on top of the official ad-platform MCPs, gates every change against your strategy, correlates outcomes locally, and keeps an auditable decision log — credentials never leave your machine.",
   "author": {
     "name": "Logly Inc.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.30] - 2026-06-12
+
+### Added
+
+#### Scope dashboard plugin-credential fields via a store capability (#207)
+
+The configure dashboard's "Plugin credentials" section renders every
+`AccountCredentialField` a plugin declares — operator-shared auth and
+per-account ids alike. For a standalone single-account install that is
+correct and stays the default. For a multi-account backend (an agency
+whose operator-shared auth serves N clients, each with its own account
+id in per-client config), the account-id inputs there land in the
+operator-shared store and leak as a default into every client's runtime —
+the failure mode behind the 0.9.29 Meta `account_id` incident.
+
+The active `SecretStore` can now advertise an optional
+`ui_plugin_credential_fields: Mapping[str, Collection[str]]` capability —
+a per-provider allow-list of the field keys the section should render
+(joining the same store-capability family as `credentials_write_path`
+and `multi_account_auth`). A provider present in the mapping shows only
+the listed keys (its card is dropped if none remain); a provider absent
+keeps all fields. Only a `Mapping` is honored — a mis-typed declaration
+must not silently hide fields — and the capability is resolved behind a
+`home is None` gate so a sandboxed wizard never inherits a process-global
+factory's scoping. Capability absent (standalone OSS, default stores) →
+byte-identical behavior; account ids stay configurable in the dashboard.
+
 ## [0.9.29] - 2026-06-11
 
 Plugin OAuth onboarding plus two credential/state correctness fixes

--- a/mureo/__init__.py
+++ b/mureo/__init__.py
@@ -1,3 +1,3 @@
 """mureo — your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."""
 
-__version__ = "0.9.29"
+__version__ = "0.9.30"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mureo"
-version = "0.9.29"
+version = "0.9.30"
 description = "Your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."
 requires-python = ">=3.10"
 license = "Apache-2.0"


### PR DESCRIPTION
Release **v0.9.30**. Bumps version (pyproject / `__init__` / plugin.json) and adds the CHANGELOG section for the one unreleased commit since v0.9.29.

## Included

- **feat(configure)**: scope dashboard plugin-credential fields via a store capability — a multi-account backend can advertise `ui_plugin_credential_fields` so the dashboard "Plugin credentials" section renders only the listed per-provider field keys (hiding per-account ids that belong on a per-client form, the failure mode behind the v0.9.29 Meta `account_id` incident). Standalone OSS behavior is unchanged (capability absent → all fields render); resolved behind the same `home is None` gate as the other store capabilities (#207)

## On merge

Tag `v0.9.30` + publish a GitHub Release → `release.yml` publishes to PyPI via OIDC trusted publishing.
