### PR TITLE
feat(configure): materialize the credentials file at the runtime path on wizard completion (#210)

### DIFF
--- a/mureo/core/secret_store.py
+++ b/mureo/core/secret_store.py
@@ -141,6 +141,26 @@ class FilesystemSecretStore:
             del data[key]
             self._write_root(data)
 
+    def ensure_exists(self) -> bool:
+        """Materialize an empty credentials file (``{}``) if absent.
+
+        Uses the same atomic-write + ``0o600`` machinery as :meth:`save`.
+        Returns ``True`` when a file was created, ``False`` when one
+        already existed (its contents are never touched).
+
+        Lets a caller record "setup completed" on disk even when no
+        credentials were registered — distinguishing "configured nothing
+        yet" (``{}``) from "setup never ran" (no file) for diagnostic
+        tooling that keys off file presence (#210). The
+        missing-equals-empty load contract means ``{}`` is
+        runtime-indistinguishable from no file, so this changes the
+        diagnostic signal only, not behaviour.
+        """
+        if self.path.exists():
+            return False
+        self._write_root({})
+        return True
+
     # ------------------------------------------------------------------
 
     def _read_root(self) -> dict[str, Any]:

--- a/mureo/web/handlers.py
+++ b/mureo/web/handlers.py
@@ -39,6 +39,7 @@ Routes
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import re
 import urllib.parse
@@ -681,6 +682,19 @@ class ConfigureHandler(BaseHTTPRequestHandler):
         then signal — the response still flushes because the daemon
         request thread outlives ``serve_forever`` returning.
         """
+        # #210: materialize the credentials file at the runtime write
+        # path BEFORE replying so the filesystem records "setup completed"
+        # even when every platform was skipped (no OAuth ran) — a missing
+        # file otherwise reads as "setup never ran" to diagnostic tooling.
+        # ``host_paths.credentials_path`` is already the runtime-resolved
+        # path (#195/#196) behind the home gate, so this serves both
+        # standalone and agency installs and never escapes an injected
+        # home. Best-effort: a write failure must not block freeing the
+        # terminal. ``ensure_exists`` never touches an existing file.
+        with contextlib.suppress(Exception):
+            FilesystemSecretStore(
+                path=self.wizard.host_paths.credentials_path
+            ).ensure_exists()
         send_json(self, {"status": "stopping"})
         self.wizard.request_stop()
 

--- a/tests/core/test_filesystem_secret_store.py
+++ b/tests/core/test_filesystem_secret_store.py
@@ -103,7 +103,9 @@ def test_corrupt_file_returns_empty_on_load(tmp_path: Path) -> None:
 
 
 @pytest.mark.unit
-def test_default_path_resolves_under_dot_mureo(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_default_path_resolves_under_dot_mureo(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     """Patches ``Path.home`` directly so the test is Windows-safe — see
     ``test_runtime_context.test_default_factory_no_args_uses_legacy_paths``
     for the rationale."""
@@ -132,3 +134,32 @@ def test_save_strips_non_dict_root(tmp_path: Path) -> None:
     store = FilesystemSecretStore(path=path)
     store.save("google_ads", {"developer_token": "abc"})
     assert store.load("google_ads") == {"developer_token": "abc"}
+
+
+# ---------------------------------------------------------------------------
+# ensure_exists — materialize an empty file so "configured nothing" is
+# distinguishable from "setup never ran" (#210)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_ensure_exists_creates_empty_file_when_absent(tmp_path: Path) -> None:
+    path = tmp_path / ".mureo" / "credentials.json"
+    store = FilesystemSecretStore(path=path)
+    created = store.ensure_exists()
+    assert created is True
+    assert path.exists()
+    assert json.loads(path.read_text(encoding="utf-8")) == {}
+    if os.name == "posix":
+        assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+
+@pytest.mark.unit
+def test_ensure_exists_noop_when_present(tmp_path: Path) -> None:
+    path = tmp_path / "credentials.json"
+    store = FilesystemSecretStore(path=path)
+    store.save("meta_ads", {"access_token": "X"})
+    created = store.ensure_exists()
+    assert created is False
+    # Existing content is never touched.
+    assert store.load("meta_ads") == {"access_token": "X"}

--- a/tests/test_web_handlers.py
+++ b/tests/test_web_handlers.py
@@ -725,6 +725,33 @@ class TestPostCredentialsRemove:
             "meta_ads": {"access_token": "Y"}
         }
 
+
+@pytest.mark.unit
+class TestPostShutdown:
+    def test_materializes_empty_credentials_file(self, wizard: ConfigureWizard) -> None:
+        """#210: finishing the wizard writes an empty credentials file at
+        the runtime write path so the filesystem records 'setup completed'
+        even when every platform was skipped (no OAuth ran)."""
+        creds = wizard.host_paths.credentials_path
+        assert not creds.exists()
+        resp = _post(wizard, "/api/shutdown", {})
+        assert json.loads(resp.read().decode("utf-8")) == {"status": "stopping"}
+        assert creds.exists()
+        assert json.loads(creds.read_text(encoding="utf-8")) == {}
+
+    def test_does_not_clobber_existing_credentials(
+        self, wizard: ConfigureWizard
+    ) -> None:
+        creds = wizard.host_paths.credentials_path
+        creds.parent.mkdir(parents=True, exist_ok=True)
+        creds.write_text(
+            json.dumps({"meta_ads": {"access_token": "Y"}}), encoding="utf-8"
+        )
+        _post(wizard, "/api/shutdown", {})
+        assert json.loads(creds.read_text(encoding="utf-8")) == {
+            "meta_ads": {"access_token": "Y"}
+        }
+
     def test_disallowed_section_returns_400(self, wizard: ConfigureWizard) -> None:
         with pytest.raises(urllib.error.HTTPError) as exc:
             _post(


### PR DESCRIPTION
## Summary

Closes #210. When the configure wizard's platform step is skipped for **every** platform (no Google/Meta OAuth), the wizard completes without ever writing a credentials file. Nothing is functionally wrong — `FilesystemSecretStore` treats a missing file as empty by contract — but the filesystem is then indistinguishable from "setup never ran".

This bit us in production support: a diagnostic agent (Claude reading the filesystem) found no `credentials.json` and concluded "credentials are not set up — run setup", sending the operator down the wrong path. The skip-everything path is **normal** for multi-account / plugin-only installs (an agency operator may use only LINE / Yahoo / Logly and configure those via the dashboard afterwards).

## Fix

On wizard completion (the `/api/shutdown` transition) materialize the credentials file at the **runtime write path**:

- `FilesystemSecretStore.ensure_exists()` — idempotent; writes an empty `{}` via the same atomic-write + `0o600` machinery as `save`, **only when the file is absent** (never touches an existing file).
- The shutdown handler calls it on `host_paths.credentials_path` — already the runtime-resolved path (#195/#196) behind the `home is None` gate, so it serves standalone and agency installs alike and never escapes an injected home. Materialize happens **before** the reply, and is best-effort (a write failure must not block freeing the terminal).

**Result:** file present ⇒ setup completed (with or without registered credentials); absent ⇒ setup never ran.

## Backward compatibility

- Runtime behavior is unchanged: the store's missing-equals-empty contract means `{}` loads identically to no file — this changes the diagnostic signal only.
- Standalone OSS: the all-skipped path is rare, and an empty `0600` file is harmless when it happens.
- Multi-account backends: existence-based downstream checks should treat an empty `{}` as absent; the agency plugin handles that on its side (noted in the issue).

## Test plan

- [x] `ensure_exists()`: creates `{}` at `0o600` when absent (returns `True`); no-op when present (returns `False`, content untouched)
- [x] `/api/shutdown`: materializes an empty `{}` credentials file at the runtime path; does NOT clobber an existing file
- [x] 194 web / core / auth-consumer tests green; `mureo/` ruff + black clean
