### PR TITLE
feat(configure): make plugin-credential required-validation scope-aware (#211)

### DIFF
--- a/mureo/web/handlers.py
+++ b/mureo/web/handlers.py
@@ -102,7 +102,7 @@ from mureo.web.setup_actions import (
 from mureo.web.status_collector import collect_status
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Collection, Mapping
 
     from mureo.web.extensions import (
         RouteContribution,
@@ -298,29 +298,14 @@ class ConfigureHandler(BaseHTTPRequestHandler):
         if path == "/api/credentials/plugins":
             # Forward the session locale so plugin-declared
             # ``display_name_i18n`` / ``description_i18n`` entries are
-            # resolved against the operator's active locale (#186).
-            #
-            # A multi-account backend may scope which fields render via
-            # the store's ``ui_plugin_credential_fields`` capability
-            # (#207). Resolve it ONLY in production (home is None): an
-            # injected home sandboxes the wizard, and the process-global
-            # factory's store lives outside that sandbox (the dev/CI
-            # agency factory resolves against the operator's real
-            # ~/.mureo), so consulting it under an injected home would let
-            # a sandboxed/test wizard inherit a real backend's scoping —
-            # the same #195 gate the credentials-path / multi-account
-            # resolution use.
-            field_scope = (
-                None
-                if self.wizard.home is not None
-                else runtime_ui_plugin_credential_fields()
-            )
+            # resolved against the operator's active locale (#186). The
+            # field scope (#207) is home-gated — see _resolve_field_scope.
             send_json(
                 self,
                 {
                     "plugins": list_plugin_credential_fields(
                         locale=self.wizard.session.locale,
-                        field_scope=field_scope,
+                        field_scope=self._resolve_field_scope(),
                     )
                 },
             )
@@ -495,6 +480,25 @@ class ConfigureHandler(BaseHTTPRequestHandler):
         envelope = clear_all_setup(home=self.wizard.home, host=self.wizard.session.host)
         send_json(self, envelope)
 
+    def _resolve_field_scope(self) -> Mapping[str, Collection[str]] | None:
+        """Resolve the per-provider credential-field scope (#207/#211).
+
+        A multi-account backend may scope which fields the dashboard
+        renders / required-validates via the store's
+        ``ui_plugin_credential_fields`` capability. Resolve it ONLY in
+        production (``home is None``): an injected ``home`` sandboxes the
+        wizard, and the process-global factory's store lives outside that
+        sandbox (the dev/CI agency factory resolves against the operator's
+        real ~/.mureo), so consulting it under an injected home would let a
+        sandboxed/test wizard inherit a real backend's scoping — the same
+        #195 gate the credentials-path / multi-account resolution use.
+        Both the list (#207) and save (#211) sides read this one value so
+        they never diverge.
+        """
+        if self.wizard.home is not None:
+            return None
+        return runtime_ui_plugin_credential_fields()
+
     def _post_plugin_credentials_save(self, payload: dict[str, Any]) -> None:
         """Persist one plugin provider's per-account credential values.
 
@@ -513,7 +517,10 @@ class ConfigureHandler(BaseHTTPRequestHandler):
         store = FilesystemSecretStore(path=self.wizard.host_paths.credentials_path)
         try:
             result = save_plugin_credentials(
-                provider_name, raw_values, secret_store=store
+                provider_name,
+                raw_values,
+                secret_store=store,
+                field_scope=self._resolve_field_scope(),
             )
         except UnknownProviderError:
             send_error_json(self, 400, "unknown_provider")

--- a/mureo/web/plugin_credentials.py
+++ b/mureo/web/plugin_credentials.py
@@ -169,6 +169,7 @@ def save_plugin_credentials(
     values: dict[str, Any],
     *,
     secret_store: SecretStore | None = None,
+    field_scope: Mapping[str, Collection[str]] | None = None,
 ) -> dict[str, Any]:
     """Persist one provider's per-account credential values.
 
@@ -182,6 +183,17 @@ def save_plugin_credentials(
         secret_store: Persistence backend. Defaults to a fresh
             :class:`FilesystemSecretStore` pointing at
             ``~/.mureo/credentials.json``.
+        field_scope: Optional per-provider allow-list of field keys in
+            this surface's jurisdiction — the save-side mirror of #207's
+            list filtering (#211). When the provider is **present** in the
+            mapping, ``required=True`` is enforced only for fields whose
+            key is **listed**; a per-account required field the backend
+            scoped out of the dashboard (and supplies through its own
+            per-client flow) is not enforced here, so a scoped form can
+            actually save. ``None`` / provider absent → every declared
+            required field is enforced, exactly as before. Resolved by the
+            handler from the same ``ui_plugin_credential_fields``
+            capability used for listing, behind the ``home is None`` gate.
 
     Returns:
         A response envelope ``{"merged": <dict>, "accepted_keys":
@@ -207,6 +219,13 @@ def save_plugin_credentials(
     declared = get_account_credential_fields(entry.provider_class)
     declared_by_key: dict[str, AccountCredentialField] = {f.key: f for f in declared}
 
+    # Fields in this surface's jurisdiction for required-enforcement
+    # (#211). ``None`` means "no scoping" (standalone OSS, or the provider
+    # is not in the mapping) → enforce every declared required field. A
+    # set means enforce ``required`` only for the listed keys; the rest
+    # are supplied by the backend's own per-client flow.
+    scoped = field_scope.get(provider_name) if field_scope is not None else None
+
     # Validate the value type before reading the existing store — a bad
     # payload should not even cause a read.
     for key, value in values.items():
@@ -223,11 +242,15 @@ def save_plugin_credentials(
     accepted_keys: list[str] = []
     for field in declared:
         supplied = values.get(field.key)
+        # Scope-aware required-ness (#211): a field the active backend
+        # scoped OUT of this surface is not enforced here, so a scoped
+        # form (which never renders it) can still save.
+        required = field.required and (scoped is None or field.key in scoped)
         if supplied is None:
             # Absent from payload. Required fields without an existing
             # stored value are an error; otherwise the field is left
             # untouched.
-            if field.required and field.key not in existing:
+            if required and field.key not in existing:
                 raise RequiredFieldMissingError(
                     f"required field missing: {provider_name}.{field.key}"
                 )
@@ -236,13 +259,13 @@ def save_plugin_credentials(
             # Blank secret = "keep existing". Only OK when there is an
             # existing value to keep; otherwise the operator submitted
             # a fresh form with a blank required field.
-            if field.required and field.key not in existing:
+            if required and field.key not in existing:
                 raise RequiredFieldMissingError(
                     f"required secret field has no value to keep: "
                     f"{provider_name}.{field.key}"
                 )
             continue
-        if field.required and not field.secret and supplied == "":
+        if required and not field.secret and supplied == "":
             # Blank non-secret required field is taken literally as
             # "clear" — refuse so the operator does not silently land
             # in a state the plugin will reject at runtime.

--- a/tests/test_plugin_credentials_field_scope.py
+++ b/tests/test_plugin_credentials_field_scope.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import dataclasses
 import json
 import threading
+import urllib.error
 import urllib.request
 from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
@@ -34,7 +35,12 @@ from mureo.core.runtime_context import (
     reset_runtime_context,
     runtime_ui_plugin_credential_fields,
 )
-from mureo.web.plugin_credentials import list_plugin_credential_fields
+from mureo.core.secret_store import FilesystemSecretStore
+from mureo.web.plugin_credentials import (
+    RequiredFieldMissingError,
+    list_plugin_credential_fields,
+    save_plugin_credentials,
+)
 from mureo.web.server import ConfigureWizard
 
 if TYPE_CHECKING:
@@ -260,3 +266,145 @@ def test_handler_suppresses_scope_when_home_injected(
         "client_secret",
         "account_id",
     ]
+
+
+# ---------------------------------------------------------------------------
+# #211 — save-side: required-validation is scope-aware (default unchanged)
+# ---------------------------------------------------------------------------
+
+
+def _line_provider() -> ProviderEntry:
+    class _Line:
+        name = "line_ads"
+        display_name = "LINE Ads"
+        capabilities = frozenset()
+        account_credential_fields = (
+            AccountCredentialField(
+                key="access_key", display_name="Access Key", required=True, secret=True
+            ),
+            AccountCredentialField(
+                key="secret_key", display_name="Secret Key", required=True, secret=True
+            ),
+            AccountCredentialField(
+                key="adaccount_id", display_name="Ad Account ID", required=True
+            ),
+        )
+
+    return ProviderEntry(
+        name="line_ads",
+        display_name="LINE Ads",
+        capabilities=frozenset(),
+        provider_class=_Line,
+        source_distribution=None,
+    )
+
+
+@pytest.fixture
+def line_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(default_registry, "_entries", {"line_ads": _line_provider()})
+
+
+@pytest.mark.unit
+def test_save_unscoped_enforces_all_required(
+    line_provider: None, tmp_path: Path
+) -> None:
+    """Default (no field_scope): the per-account ``adaccount_id`` required
+    field is enforced — this is the #211 bug for scoped installs and the
+    correct behavior for standalone OSS."""
+    store = FilesystemSecretStore(path=tmp_path / "credentials.json")
+    with pytest.raises(RequiredFieldMissingError, match="adaccount_id"):
+        save_plugin_credentials(
+            "line_ads",
+            {"access_key": "AK", "secret_key": "SK"},
+            secret_store=store,
+        )
+
+
+@pytest.mark.unit
+def test_save_scoped_out_required_not_enforced(
+    line_provider: None, tmp_path: Path
+) -> None:
+    """With the provider scoped to auth-only, the scoped-out
+    ``adaccount_id`` required field is not enforced → the save succeeds."""
+    store = FilesystemSecretStore(path=tmp_path / "credentials.json")
+    scope = {"line_ads": frozenset({"access_key", "secret_key"})}
+    result = save_plugin_credentials(
+        "line_ads",
+        {"access_key": "AK", "secret_key": "SK"},
+        secret_store=store,
+        field_scope=scope,
+    )
+    assert set(result["accepted_keys"]) == {"access_key", "secret_key"}
+    saved = store.load("line_ads")
+    assert saved == {"access_key": "AK", "secret_key": "SK"}
+    assert "adaccount_id" not in saved
+
+
+@pytest.mark.unit
+def test_save_scoped_in_required_still_enforced(
+    line_provider: None, tmp_path: Path
+) -> None:
+    """A required field that IS in scope is still enforced — a blank
+    scoped-in secret with no stored value fails."""
+    store = FilesystemSecretStore(path=tmp_path / "credentials.json")
+    scope = {"line_ads": frozenset({"access_key", "secret_key"})}
+    with pytest.raises(RequiredFieldMissingError, match="access_key"):
+        save_plugin_credentials(
+            "line_ads",
+            {"access_key": "", "secret_key": "SK"},
+            secret_store=store,
+            field_scope=scope,
+        )
+
+
+@pytest.fixture
+def line_home_wizard(tmp_path: Path, line_provider: None) -> Iterator[ConfigureWizard]:
+    home = tmp_path / "home"
+    for sub in ("", ".claude", ".claude/commands", ".mureo"):
+        (home / sub).mkdir(parents=True, exist_ok=True)
+    wiz = ConfigureWizard(home=home)
+    thread = threading.Thread(target=wiz.serve, daemon=True)
+    thread.start()
+    wiz.wait_until_ready(timeout=5.0)
+    try:
+        yield wiz
+    finally:
+        wiz.shutdown()
+        thread.join(timeout=2.0)
+
+
+def _post(wiz: ConfigureWizard, path: str, payload: dict[str, Any]) -> Any:
+    req = urllib.request.Request(
+        f"http://127.0.0.1:{wiz.port}{path}",
+        data=json.dumps(payload).encode(),
+        method="POST",
+    )
+    req.add_header("Content-Type", "application/json")
+    req.add_header("X-CSRF-Token", wiz.session.csrf_token)
+    return urllib.request.urlopen(req, timeout=2.0)
+
+
+@pytest.mark.unit
+def test_save_handler_suppresses_scope_when_home_injected(
+    line_home_wizard: ConfigureWizard,
+) -> None:
+    """SAFETY (#195/#207/#211): a home-injected wizard must NOT apply a
+    process-global factory's scope, so required validation stays full — a
+    payload missing the per-account required field is rejected."""
+    scope = {"line_ads": frozenset({"access_key", "secret_key"})}
+    with (
+        patch(
+            "mureo.web.handlers.runtime_ui_plugin_credential_fields", return_value=scope
+        ),
+        pytest.raises(urllib.error.HTTPError) as exc,
+    ):
+        _post(
+            line_home_wizard,
+            "/api/credentials/plugins/save",
+            {
+                "provider_name": "line_ads",
+                "values": {"access_key": "AK", "secret_key": "SK"},
+            },
+        )
+    assert exc.value.code == 400
+    assert json.loads(exc.value.read())["error"] == "required_field_missing"


### PR DESCRIPTION
## Summary

Closes #211. #207 scoped which plugin-credential **fields the dashboard renders** via the store capability `ui_plugin_credential_fields`, but `save_plugin_credentials` still validated **every** `required=True` field the provider declares. A scoped form can never submit the per-account fields it no longer renders, so saving LINE / Yahoo auth from the Settings section **always failed** with `RequiredFieldMissingError` and nothing was persisted (hit in agency production verification).

| provider | required=True | scoped out by the capability |
|---|---|---|
| line_ads | access_key, secret_key, **adaccount_id** | adaccount_id |
| yahoo_ads | client_id, client_secret, refresh_token, **account_id** | account_id |

## Fix — make required-validation scope-aware (the save-side mirror of #207)

- `save_plugin_credentials` gains `field_scope`; `required` is enforced only for a scoped provider's listed keys:
  `required = field.required and (scoped is None or field.key in scoped)`.
  A per-account required field the backend scoped out is supplied through its own per-client flow, not the shared store (#202), so it is not enforced here.
- `handlers.py`: a new `_resolve_field_scope()` helper centralizes the `home is None` gate; **both** the list (#207) and save (#211) sides read it, so they never diverge.

## Backward compatibility

- Capability absent / provider not in the mapping → every declared required field is enforced, **byte-identical** to before (standalone OSS unchanged).
- Unknown-key dropping and blank-keeps-stored semantics are untouched.

## Test plan

- [x] Unscoped → `adaccount_id` required still enforced (default / the bug for scoped installs)
- [x] Scoped to auth-only → scoped-out `adaccount_id` not enforced → **save succeeds**, persists only the scoped keys
- [x] Scoped-in required field still enforced (blank `access_key` with no stored value → raises)
- [x] **Handler home-gate**: a home-injected wizard ignores a patched factory scope → full required validation → `400 required_field_missing` (#195/#207 isolation regression)
- [x] 226 plugin-cred / handlers / oauth / field-scope tests green; `mureo/` ruff + black clean
