### PR TITLE
fix(configure): move the toast overlay out of <main> so dashboard toasts are visible (#214)

### DIFF
--- a/mureo/_data/web/app.html
+++ b/mureo/_data/web/app.html
@@ -205,11 +205,6 @@
       </div>
     </section>
 
-    <!-- TODO: when SR support lands, add aria-live="polite" here.
-         Inline status nodes in auth_wizards.js / dashboard.js share
-         the same message string; aria-atomic or scoping is required
-         to avoid double-announce. See #184 review notes. -->
-    <div class="app-toast" data-toast hidden></div>
   </main>
 
   <dialog data-confirm-dialog>
@@ -226,5 +221,17 @@
   <script src="/static/auth_wizards.js"></script>
   <script src="/static/dashboard.js"></script>
   <script src="/static/extensions.js"></script>
+
+  <!-- Toast overlay (#214): MUST be a body-level sibling, NOT inside
+       <main class="app-main">. .app-main carries a filled `rise`
+       transform animation, and a transformed ancestor becomes the
+       containing block for position:fixed descendants — a toast inside
+       <main> anchors to the bottom of the tall main element (~1700px
+       below the viewport on the dashboard) instead of the screen.
+       TODO: when SR support lands, add aria-live="polite" here. Inline
+       status nodes in auth_wizards.js / dashboard.js share the same
+       message string; aria-atomic or scoping is required to avoid
+       double-announce. See #184 review notes. -->
+  <div class="app-toast" data-toast hidden></div>
 </body>
 </html>

--- a/tests/test_web_assets_dashboard_cards_and_toasts.py
+++ b/tests/test_web_assets_dashboard_cards_and_toasts.py
@@ -133,3 +133,27 @@ def test_auth_wizard_error_sites_also_toast() -> None:
         'every wizard error toast must pass kind="error" — count '
         "below the expected sites suggests a typo or missing kind"
     )
+
+
+# ---------------------------------------------------------------------------
+# #214 — the toast overlay must live OUTSIDE <main class="app-main">
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_toast_node_lives_outside_main() -> None:
+    """``.app-main`` carries a filled ``rise`` transform animation, and a
+    transformed ancestor becomes the containing block for
+    ``position: fixed`` descendants. A toast inside ``<main>`` therefore
+    anchors to the bottom of the (tall) main element — ~1700px below the
+    viewport on the dashboard — instead of the screen, making every
+    dashboard toast invisible (#214). The overlay must be a body-level
+    sibling, after ``</main>``.
+    """
+    html = _read("app.html")
+    assert "data-toast" in html, "toast node missing from app.html"
+    assert html.index("</main>") < html.index("data-toast"), (
+        "the [data-toast] overlay must live OUTSIDE <main class='app-main'> "
+        "(after </main>) — a transformed ancestor hijacks position:fixed. "
+        "See #214."
+    )


### PR DESCRIPTION
## Summary

Closes #214. `MUREO.toast()` fired correctly, but on the dashboard the toast pill rendered **~1700px below the viewport** and was never seen — success and error alike.

**Root cause:** the toast node lived inside `<main class="app-main">`, and `.app-main` carries a filled `rise` transform animation (`animation-fill-mode: both`, so the final keyframe's `transform` stays applied forever). Per CSS spec a transformed ancestor becomes the **containing block for `position: fixed` descendants**, so `bottom: 26px` anchored the pill to the bottom of the (tall) `<main>` rather than the viewport. Wizard/landing pages are short enough that `<main>`'s bottom fell inside the viewport — which is why toasts appeared to work historically (#184); the long dashboard pushed the pill off-screen.

Surfaced while verifying #213 (plugin-credentials save succeeded but the "Saved." toast never appeared).

## Fix

Move the `[data-toast]` overlay to a **body-level sibling** (just before `</body>`, alongside the already-external `[data-confirm-dialog]`) so it is never inside a transformed container. `MUREO.toast()` selects it by `[data-toast]`, so the JS is unaffected.

(Issue's recommended fix #1 — overlay elements must not live inside a transformed/animated container.)

## Test plan

- [x] New static-asset regression test: `[data-toast]` appears after `</main>` in `app.html` (RED before the move → GREEN after)
- [x] 177 web-asset / static-serving / handlers tests green; existing toast JS + CSS guards (#184) unchanged
- Manual: visual confirmation that the pill appears bottom-right on the dashboard is recommended on merge (no browser in CI)
