### PR TITLE
feat(oauth): provider callback port (#220) + token-endpoint auth style for plugin OAuth

### DIFF
--- a/mureo/_data/web/dashboard.js
+++ b/mureo/_data/web/dashboard.js
@@ -976,8 +976,13 @@
     cbInput.name = "oauth_callback_url";
     cbInput.type = "text";
     cbInput.autocomplete = "off";
+    // Pre-fill priority: the operator's saved URL, then the provider's
+    // declared canonical port (#220 — Yahoo et al. that pin an exact
+    // redirect_uri), then a generic loopback default.
     cbInput.value =
-      plugin.oauth_callback_url || "http://127.0.0.1:8765/oauth/callback";
+      plugin.oauth_callback_url ||
+      (plugin.oauth && plugin.oauth.default_callback_url) ||
+      "http://127.0.0.1:8765/oauth/callback";
     cbLabel.appendChild(cbInput);
     const cbHint = document.createElement("small");
     cbHint.className = "field-hint";

--- a/mureo/cli/web_auth.py
+++ b/mureo/cli/web_auth.py
@@ -1149,6 +1149,7 @@ class _WizardHandler(http.server.BaseHTTPRequestHandler):
                 client_id=spec.client_id,
                 client_secret=spec.client_secret,
                 redirect_uri=spec.redirect_uri,
+                client_auth=spec.token_auth_style,
             )
         except OAuthExchangeError:
             # Message-free log: the helper already guarantees no secret is
@@ -1289,6 +1290,10 @@ class PluginOAuthSpec:
     state: str
     callback_path: str = "/oauth/callback"
     persist_values: dict[str, str] = field(default_factory=dict)
+    # Token-endpoint client-auth style passed to ``exchange_authorization_code``
+    # (#201 follow-up): ``"basic"`` (default) or ``"body"`` for providers that
+    # reject HTTP Basic, e.g. Yahoo! JAPAN biz-oauth.
+    token_auth_style: str = "basic"
 
 
 class WebAuthWizard:

--- a/mureo/core/providers/credentials.py
+++ b/mureo/core/providers/credentials.py
@@ -141,9 +141,19 @@ class AccountOAuthConfig:
         callback_path: Path the provider redirects back to on the local
             loopback callback server. Default ``"/oauth/callback"``; the
             ephemeral port is chosen at runtime, mirroring the loopback
-            redirect flow Google's wizard already uses. A provider that
-            pins an exact redirect URI must register a loopback URI that
-            allows a variable port.
+            redirect flow Google's wizard already uses.
+        callback_port: Fixed loopback port the provider's redirect_uri is
+            registered on (#220). ``None`` (the default) keeps the
+            operator-supplied / ephemeral behaviour (#216). A provider
+            whose OAuth server requires the ``redirect_uri`` to match a
+            **pre-registered** value exactly (Yahoo! JAPAN Ads, whose port
+            cannot vary) declares the canonical port here; the configure UI
+            pre-fills the callback URL as
+            ``http://127.0.0.1:<callback_port><callback_path>`` so the
+            operator registers — and the wizard binds — that exact URL. It
+            is a *default* the operator can still override, not an
+            authority: the bind + verbatim redirect_uri path (#216) is
+            unchanged.
     """
 
     authorize_url: str
@@ -153,6 +163,7 @@ class AccountOAuthConfig:
     target_field: str
     scopes: tuple[str, ...] = ()
     callback_path: str = "/oauth/callback"
+    callback_port: int | None = None
 
 
 __all__ = ["AccountCredentialField", "AccountOAuthConfig"]

--- a/mureo/core/providers/credentials.py
+++ b/mureo/core/providers/credentials.py
@@ -154,6 +154,12 @@ class AccountOAuthConfig:
             is a *default* the operator can still override, not an
             authority: the bind + verbatim redirect_uri path (#216) is
             unchanged.
+        token_auth_style: How the client id/secret are presented at the
+            token endpoint. ``"basic"`` (default) sends them in the HTTP
+            ``Authorization`` header (RFC 6749 §2.3.1, what Google and most
+            providers expect); ``"body"`` sends them in the form body for
+            providers that reject Basic — Yahoo! JAPAN biz-oauth requires
+            this. Declarative only; the OSS exchange (#201) honours it.
     """
 
     authorize_url: str
@@ -164,6 +170,7 @@ class AccountOAuthConfig:
     scopes: tuple[str, ...] = ()
     callback_path: str = "/oauth/callback"
     callback_port: int | None = None
+    token_auth_style: str = "basic"
 
 
 __all__ = ["AccountCredentialField", "AccountOAuthConfig"]

--- a/mureo/oauth_authcode.py
+++ b/mureo/oauth_authcode.py
@@ -164,17 +164,21 @@ def exchange_authorization_code(
         "redirect_uri": redirect_uri,
     }
     # Pick the client-auth transport: Basic header (default) or in-body
-    # credentials (Yahoo! JAPAN biz-oauth rejects Basic).
-    auth: tuple[str, str] | None
+    # credentials (Yahoo! JAPAN biz-oauth rejects Basic). httpx's ``auth``
+    # parameter has no typed ``None``, so for body style we omit it entirely
+    # (the client configures no auth, so nothing is sent).
+    basic_auth: tuple[str, str] | None = None
     if client_auth == "body":
         body["client_id"] = client_id
         body["client_secret"] = client_secret
-        auth = None
     else:
-        auth = (client_id, client_secret)
+        basic_auth = (client_id, client_secret)
     try:
         with httpx.Client(timeout=_HTTP_TIMEOUT) as client:
-            response = client.post(token_url, data=body, auth=auth)
+            if basic_auth is None:
+                response = client.post(token_url, data=body)
+            else:
+                response = client.post(token_url, data=body, auth=basic_auth)
             response.raise_for_status()
             payload = response.json()
     except httpx.HTTPError as exc:

--- a/mureo/oauth_authcode.py
+++ b/mureo/oauth_authcode.py
@@ -136,14 +136,23 @@ def exchange_authorization_code(
     client_id: str,
     client_secret: str,
     redirect_uri: str,
+    client_auth: str = "basic",
 ) -> AuthCodeResult:
     """Exchange an authorization ``code`` for a ``refresh_token``.
 
     POSTs ``grant_type=authorization_code`` (form-encoded) to
-    ``token_url`` with HTTP Basic client authentication. Raises
-    :class:`OAuthExchangeError` on any transport/HTTP failure or when the
-    response carries no ``refresh_token`` (the whole point of the flow —
-    an access token alone cannot be persisted for later refresh).
+    ``token_url``. Client authentication follows ``client_auth``:
+
+    - ``"basic"`` (default, RFC 6749 §2.3.1) — client id/secret in the
+      HTTP ``Authorization`` header; the scheme Google and most providers
+      expect.
+    - ``"body"`` — client id/secret in the form body (RFC 6749 §2.3.1's
+      alternative). Required by providers that reject Basic, e.g. Yahoo!
+      JAPAN biz-oauth.
+
+    Raises :class:`OAuthExchangeError` on any transport/HTTP failure or
+    when the response carries no ``refresh_token`` (the whole point of the
+    flow — an access token alone cannot be persisted for later refresh).
 
     The exception message never includes the code, secret, or token; only
     the failure class is surfaced so a stack trace cannot leak material.
@@ -154,11 +163,18 @@ def exchange_authorization_code(
         "code": code,
         "redirect_uri": redirect_uri,
     }
+    # Pick the client-auth transport: Basic header (default) or in-body
+    # credentials (Yahoo! JAPAN biz-oauth rejects Basic).
+    auth: tuple[str, str] | None
+    if client_auth == "body":
+        body["client_id"] = client_id
+        body["client_secret"] = client_secret
+        auth = None
+    else:
+        auth = (client_id, client_secret)
     try:
         with httpx.Client(timeout=_HTTP_TIMEOUT) as client:
-            response = client.post(
-                token_url, data=body, auth=(client_id, client_secret)
-            )
+            response = client.post(token_url, data=body, auth=auth)
             response.raise_for_status()
             payload = response.json()
     except httpx.HTTPError as exc:

--- a/mureo/web/oauth_bridge.py
+++ b/mureo/web/oauth_bridge.py
@@ -274,6 +274,7 @@ class OAuthBridge:
             state=state,
             callback_path=callback_path,
             persist_values=dict(persist_values or {}),
+            token_auth_style=oauth_config.token_auth_style,
         )
         consent_url = build_authorization_code_url(
             authorize_url=oauth_config.authorize_url,

--- a/mureo/web/plugin_credentials.py
+++ b/mureo/web/plugin_credentials.py
@@ -153,15 +153,27 @@ def _oauth_to_dict(provider_class: type) -> dict[str, str] | None:
     render an Authenticate button next to the target field and know which
     fields must be saved first. The endpoints (``authorize_url`` /
     ``token_url``) and any secret values stay server-side.
+
+    A provider that declares a fixed ``callback_port`` (#220) additionally
+    gets a ``default_callback_url`` — the canonical
+    ``http://127.0.0.1:<port><path>`` the dashboard pre-fills so the
+    operator registers the exact loopback redirect URI the provider's
+    OAuth server requires. Omitted entirely when no port is declared (the
+    #216 default), keeping the block to its original three keys.
     """
     config = get_account_oauth_config(provider_class)
     if config is None:
         return None
-    return {
+    block = {
         "target_field": config.target_field,
         "client_id_field": config.client_id_field,
         "client_secret_field": config.client_secret_field,
     }
+    if config.callback_port is not None:
+        block["default_callback_url"] = (
+            f"http://127.0.0.1:{config.callback_port}{config.callback_path}"
+        )
+    return block
 
 
 def save_plugin_credentials(

--- a/tests/core/providers/test_account_oauth.py
+++ b/tests/core/providers/test_account_oauth.py
@@ -78,6 +78,24 @@ def test_config_defaults() -> None:
     # #220 — no fixed port by default (loopback uses an ephemeral port /
     # the operator-supplied callback URL, #216). Backward compatible.
     assert cfg.callback_port is None
+    # Token-endpoint client auth defaults to HTTP Basic (Google et al.).
+    assert cfg.token_auth_style == "basic"
+
+
+@pytest.mark.unit
+def test_config_accepts_body_token_auth_style() -> None:
+    """A provider whose token endpoint rejects HTTP Basic (Yahoo! JAPAN
+    biz-oauth) declares ``token_auth_style="body"`` so the client id/secret
+    travel in the form body instead of the Authorization header."""
+    cfg = AccountOAuthConfig(
+        authorize_url="https://a.test/authorize",
+        token_url="https://a.test/token",
+        client_id_field="client_id",
+        client_secret_field="client_secret",
+        target_field="refresh_token",
+        token_auth_style="body",
+    )
+    assert cfg.token_auth_style == "body"
 
 
 @pytest.mark.unit

--- a/tests/core/providers/test_account_oauth.py
+++ b/tests/core/providers/test_account_oauth.py
@@ -75,6 +75,26 @@ def test_config_defaults() -> None:
     )
     assert cfg.scopes == ()
     assert cfg.callback_path == "/oauth/callback"
+    # #220 — no fixed port by default (loopback uses an ephemeral port /
+    # the operator-supplied callback URL, #216). Backward compatible.
+    assert cfg.callback_port is None
+
+
+@pytest.mark.unit
+def test_config_accepts_fixed_callback_port() -> None:
+    """#220 — a provider that requires an exact redirect_uri (Yahoo! JAPAN)
+    declares the canonical loopback port; the configure UI pre-fills the
+    callback URL from it so the operator registers the right value."""
+    cfg = AccountOAuthConfig(
+        authorize_url="https://a.test/authorize",
+        token_url="https://a.test/token",
+        client_id_field="client_id",
+        client_secret_field="client_secret",
+        target_field="refresh_token",
+        callback_port=8765,
+    )
+    assert cfg.callback_port == 8765
+    assert cfg.callback_path == "/oauth/callback"
 
 
 @pytest.mark.unit

--- a/tests/test_oauth_authcode.py
+++ b/tests/test_oauth_authcode.py
@@ -130,6 +130,50 @@ def test_exchange_returns_refresh_token(monkeypatch: pytest.MonkeyPatch) -> None
     assert body["grant_type"] == "authorization_code"
     assert body["code"] == "AUTHCODE"
     assert body["redirect_uri"] == "http://127.0.0.1:5151/oauth/callback"
+    # Default is Basic: credentials must NOT also be duplicated into the body.
+    assert "client_id" not in body
+    assert "client_secret" not in body
+
+
+@pytest.mark.unit
+def test_exchange_basic_is_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``client_auth='basic'`` (the default) keeps the Authorization-header
+    scheme — regression guard for Google / existing providers."""
+    monkeypatch.setattr("mureo.oauth_authcode.httpx.Client", _FakeClient)
+    exchange_authorization_code(
+        token_url="https://a.test/token",
+        code="AC",
+        client_id="CID",
+        client_secret="SECRET",
+        redirect_uri="http://127.0.0.1:1/oauth/callback",
+        client_auth="basic",
+    )
+    assert _FakeClient.last_call["auth"] == ("CID", "SECRET")
+    assert "client_id" not in _FakeClient.last_call["data"]
+
+
+@pytest.mark.unit
+def test_exchange_body_style_puts_creds_in_form(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``client_auth='body'`` (Yahoo! JAPAN biz-oauth) sends client_id +
+    client_secret in the form body and NO HTTP Basic auth header."""
+    monkeypatch.setattr("mureo.oauth_authcode.httpx.Client", _FakeClient)
+    result = exchange_authorization_code(
+        token_url="https://biz-oauth.yahoo.co.jp/oauth/v1/token",
+        code="AUTHCODE",
+        client_id="CID",
+        client_secret="SECRET",
+        redirect_uri="http://127.0.0.1:5151/oauth/callback",
+        client_auth="body",
+    )
+    assert result.refresh_token == "RT-xyz"
+    # No Authorization header (Yahoo rejects Basic).
+    assert _FakeClient.last_call["auth"] is None
+    body = _FakeClient.last_call["data"]
+    assert body["client_id"] == "CID"
+    assert body["client_secret"] == "SECRET"
+    assert body["grant_type"] == "authorization_code"
 
 
 @pytest.mark.unit

--- a/tests/test_web_assets_plugin_oauth_card.py
+++ b/tests/test_web_assets_plugin_oauth_card.py
@@ -63,3 +63,13 @@ def test_dashboard_surfaces_new_oauth_error_keys() -> None:
     js = _read("dashboard.js")
     assert "dashboard.plugin_oauth_callback_invalid" in js
     assert "dashboard.plugin_oauth_port_unavailable" in js
+
+
+@pytest.mark.unit
+def test_dashboard_callback_url_prefill_consults_provider_default() -> None:
+    """#220: the callback URL input pre-fill consults the provider-declared
+    ``default_callback_url`` (between the saved value and the generic
+    fallback), so a provider with a fixed redirect_uri pre-fills the exact
+    URL the operator must register."""
+    js = _read("dashboard.js")
+    assert "default_callback_url" in js

--- a/tests/test_web_auth_plugin_oauth.py
+++ b/tests/test_web_auth_plugin_oauth.py
@@ -286,3 +286,71 @@ def test_authsave_failure_persists_nothing(authsave_wizard: Any) -> None:
 
     path = authsave_wizard.credentials_path
     assert not path.exists() or "yahoo_ads" not in json.loads(path.read_text())
+
+
+# ---------------------------------------------------------------------------
+# token_auth_style — the callback exchange honours the provider's declared
+# token-endpoint client-auth style (Yahoo! JAPAN biz-oauth needs "body").
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def body_auth_wizard(tmp_path: Path) -> Iterator[Any]:
+    creds_path = tmp_path / ".mureo" / "credentials.json"
+    creds_path.parent.mkdir(parents=True)
+    spec = PluginOAuthSpec(
+        provider="yahoo_ads",
+        target_field="refresh_token",
+        token_url="https://biz-oauth.yahoo.co.jp/oauth/v1/token",
+        client_id="CID",
+        client_secret="SECRET",
+        redirect_uri="http://127.0.0.1:8765/oauth/callback",
+        state="state-xyz",
+        token_auth_style="body",
+    )
+    wiz = WebAuthWizard(credentials_path=creds_path, plugin_oauth=spec)
+    thread = threading.Thread(target=wiz.serve, daemon=True)
+    thread.start()
+    wiz.wait_until_ready(timeout=2.0)
+    try:
+        yield wiz
+    finally:
+        wiz.shutdown()
+        thread.join(timeout=2.0)
+
+
+@pytest.mark.unit
+def test_plugin_callback_passes_declared_token_auth_style(
+    body_auth_wizard: Any,
+) -> None:
+    """The exchange is called with ``client_auth`` taken from the spec's
+    ``token_auth_style`` so a body-style provider authenticates correctly."""
+    from mureo.oauth_authcode import AuthCodeResult
+
+    with patch(
+        "mureo.cli.web_auth.exchange_authorization_code",
+        return_value=AuthCodeResult(refresh_token="RT", access_token="AT"),
+    ) as mock_exchange:
+        opener = urllib.request.build_opener(_NoRedirect())
+        with pytest.raises(urllib.error.HTTPError) as exc:
+            opener.open(
+                _url(body_auth_wizard, "/oauth/callback?code=AC&state=state-xyz"),
+                timeout=2.0,
+            )
+        assert exc.value.code == 302
+    assert mock_exchange.call_args.kwargs["client_auth"] == "body"
+
+
+@pytest.mark.unit
+def test_default_spec_token_auth_style_is_basic() -> None:
+    """A spec built without the field defaults to Basic (regression)."""
+    spec = PluginOAuthSpec(
+        provider="p",
+        target_field="refresh_token",
+        token_url="https://a.test/token",
+        client_id="c",
+        client_secret="s",
+        redirect_uri="http://127.0.0.1:1/oauth/callback",
+        state="x",
+    )
+    assert spec.token_auth_style == "basic"

--- a/tests/test_web_oauth_bridge.py
+++ b/tests/test_web_oauth_bridge.py
@@ -479,6 +479,42 @@ class TestStartPluginOAuth:
 
     _CALLBACK_URL = "http://127.0.0.1:8765/oauth/callback"
 
+    def test_threads_body_token_auth_style(
+        self,
+        patched_wizard_class: Any,
+        fake_configure_wizard: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """A provider declaring ``token_auth_style='body'`` (Yahoo! JAPAN)
+        has it pinned onto the spec so the callback exchange sends the
+        client creds in the form body, not an Authorization header."""
+        from mureo.core.providers import AccountOAuthConfig
+
+        config = AccountOAuthConfig(
+            authorize_url="https://biz-oauth.yahoo.co.jp/oauth/v1/authorize",
+            token_url="https://biz-oauth.yahoo.co.jp/oauth/v1/token",
+            client_id_field="client_id",
+            client_secret_field="client_secret",
+            target_field="refresh_token",
+            scopes=("scopeA",),
+            token_auth_style="body",
+        )
+        bridge = OAuthBridge()
+        try:
+            bridge.start_plugin_oauth(
+                provider="yahoo_ads",
+                configure_wizard=fake_configure_wizard,
+                oauth_config=config,
+                client_id="CID",
+                client_secret="SECRET",
+                callback_url=self._CALLBACK_URL,
+                credentials_path=tmp_path / "creds.json",
+            )
+            spec = patched_wizard_class.instances[0].plugin_oauth
+            assert spec.token_auth_style == "body"
+        finally:
+            bridge.cancel("yahoo_ads")
+
     def test_builds_external_consent_url_and_pins_spec(
         self,
         patched_wizard_class: Any,
@@ -529,6 +565,8 @@ class TestStartPluginOAuth:
             # #217: the operator's form values ride along for atomic save.
             assert spec.persist_values["client_id"] == "CID"
             assert spec.persist_values["oauth_callback_url"] == self._CALLBACK_URL
+            # Token-endpoint auth style defaults to Basic (regression).
+            assert spec.token_auth_style == "basic"
             assert spec.state  # non-empty CSRF nonce
             # The same state + redirect_uri are echoed into the consent URL.
             assert f"state={spec.state}" in result.url

--- a/tests/test_web_plugin_credentials.py
+++ b/tests/test_web_plugin_credentials.py
@@ -955,3 +955,64 @@ def test_save_still_requires_non_oauth_required_field(
             {"client_id": "CID", "client_secret": "SECRET"},
             secret_store=store,
         )
+
+
+# ---------------------------------------------------------------------------
+# #220 — a provider that declares a fixed callback_port surfaces the
+# canonical loopback callback URL in its oauth block, so the dashboard
+# pre-fills the exact URL the operator must register provider-side.
+# ---------------------------------------------------------------------------
+
+
+def _yahoo_oauth_with_port(port: int) -> Any:
+    from mureo.core.providers import AccountOAuthConfig
+
+    return AccountOAuthConfig(
+        authorize_url="https://biz-oauth.yahoo.co.jp/oauth/v1/authorize",
+        token_url="https://biz-oauth.yahoo.co.jp/oauth/v1/token",
+        client_id_field="client_id",
+        client_secret_field="client_secret",
+        target_field="refresh_token",
+        scopes=("scopeA",),
+        callback_port=port,
+    )
+
+
+@pytest.mark.unit
+def test_list_oauth_block_includes_default_callback_url_when_port_declared(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from mureo.web.plugin_credentials import list_plugin_credential_fields
+
+    _register(
+        monkeypatch,
+        [
+            _entry(
+                "yahoo_ads",
+                fields=_yahoo_fields(),
+                oauth=_yahoo_oauth_with_port(8765),
+            )
+        ],
+    )
+    [plugin] = list_plugin_credential_fields()
+    assert (
+        plugin["oauth"]["default_callback_url"]
+        == "http://127.0.0.1:8765/oauth/callback"
+    )
+
+
+@pytest.mark.unit
+def test_list_oauth_block_omits_default_callback_url_without_port(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A provider without callback_port (the #216 default) carries no
+    default_callback_url — the dashboard uses its generic fallback. The
+    oauth block keeps its original three keys."""
+    from mureo.web.plugin_credentials import list_plugin_credential_fields
+
+    _register(
+        monkeypatch,
+        [_entry("yahoo_ads", fields=_yahoo_fields(), oauth=_yahoo_oauth())],
+    )
+    [plugin] = list_plugin_credential_fields()
+    assert "default_callback_url" not in plugin["oauth"]


### PR DESCRIPTION
## Summary

Two coupled follow-ups that make plugin OAuth actually work for providers with strict token endpoints (Yahoo! JAPAN Ads), found during manual verification of #216/#217. Builds on #216 (operator callback URL) shipped in v0.9.31.

### #220 — provider-declared fixed callback port
- `AccountOAuthConfig.callback_port: int | None = None` (declarative, backward compatible).
- `_oauth_to_dict` surfaces `default_callback_url` (`http://127.0.0.1:<port><path>`) **only when a port is declared**.
- `dashboard.js` pre-fills the callback URL input: saved → provider `default_callback_url` → generic default. Operator can still override; #216 bind/validation unchanged.

### token-endpoint client-auth style (basic/body)
Yahoo biz-oauth's token endpoint **rejects HTTP Basic** and requires the client id/secret in the form body — the #201 exchange (Basic only) failed with "provider rejected".
- `exchange_authorization_code(..., client_auth="basic")`: `"basic"` keeps the Authorization header; `"body"` sends creds in the form body (no Basic).
- `AccountOAuthConfig.token_auth_style` declares it per provider, threaded via `PluginOAuthSpec` and the bridge into the callback exchange.
- Default `"basic"` keeps Google + every existing provider unchanged.

### Bridge follow-up (separate, after this ships)
`mureo-lineyahoo-bridge` will declare `callback_port=8765` + `token_auth_style="body"` on Yahoo and raise its mureo floor.

## Test plan
- [x] `AccountOAuthConfig.callback_port` / `token_auth_style` defaults + setters
- [x] oauth descriptor `default_callback_url` present iff port declared (3-key block preserved otherwise)
- [x] dashboard prefill consults provider default
- [x] `exchange_authorization_code` body → creds in form + no auth header; basic default → auth header, no body creds (regression)
- [x] `token_auth_style` threaded bridge → spec → callback `client_auth`
- [x] affected suites green; `ruff` + `black --check mureo/` clean
- [ ] CI green on this PR

_Note: the one local-only `test_mcp_tool_provider` failure is the dev venv's installed `mureo-lineyahoo-bridge` adding tools; passes in clean CI._
