### PR TITLE
feat(configure): skip bare mureo MCP registration for multi-account backends (#222)

### DIFF
--- a/mureo/_data/web/dashboard.js
+++ b/mureo/_data/web/dashboard.js
@@ -179,7 +179,12 @@
     if (!list) return;
     while (list.firstChild) list.removeChild(list.firstChild);
     const parts = (status && status.setup_parts) || {};
+    // #222: a multi-account backend never registers the bare `mureo` MCP
+    // entry (per-client `mureo-<slug>` entries are the correct wiring), so
+    // the MCP row must not render here either.
+    const suppressMcp = Boolean(status && status.multi_account_auth);
     BASIC_ROWS.forEach(function (row) {
+      if (suppressMcp && row.key === "mureo_mcp") return;
       const li = document.createElement("li");
       const installed = parts[row.key] === true;
       const labelSpan = document.createElement("span");

--- a/mureo/_data/web/wizard.js
+++ b/mureo/_data/web/wizard.js
@@ -198,7 +198,11 @@
   function deriveCompletion(status) {
     if (!status) return false;
     const parts = status.setup_parts || {};
-    return Boolean(parts.mureo_mcp && parts.auth_hook && parts.skills);
+    // #222: a multi-account backend never registers the bare `mureo` MCP
+    // entry (per-client entries are the correct wiring), so it is not a
+    // completion requirement there.
+    const mcpOk = status.multi_account_auth || Boolean(parts.mureo_mcp);
+    return Boolean(mcpOk && parts.auth_hook && parts.skills);
   }
 
   function hydrateStateFromStatus(status) {
@@ -274,11 +278,17 @@
     if (STATE.host === "claude-desktop") {
       authHookLabel += " " + MUREO.t("wizard.basic.auth_hook_desktop_na");
     }
+    // #222: a multi-account backend wires per-client `mureo-<slug>` entries
+    // instead of the bare `mureo` MCP, so the registration pill must not
+    // render (the backend skips the write too).
+    const mcpRow = status.multi_account_auth
+      ? ""
+      : '<li>' + pill(parts.mureo_mcp, MUREO.t("wizard.basic.mureo_mcp")) + "</li>";
     wrap.innerHTML =
       '<h2>' + MUREO.t("wizard.basic.title") + "</h2>" +
       '<p>' + MUREO.t("wizard.basic.desc") + "</p>" +
       '<ul class="wizard-basic-parts">' +
-      '<li>' + pill(parts.mureo_mcp, MUREO.t("wizard.basic.mureo_mcp")) + "</li>" +
+      mcpRow +
       '<li>' + pill(parts.auth_hook, authHookLabel) + "</li>" +
       '<li>' + pill(parts.skills, MUREO.t("wizard.basic.skills")) + "</li>" +
       "</ul>" +

--- a/mureo/web/handlers.py
+++ b/mureo/web/handlers.py
@@ -407,7 +407,9 @@ class ConfigureHandler(BaseHTTPRequestHandler):
 
     def _serve_status(self) -> None:
         snapshot = collect_status(
-            self.wizard.session.host, paths=self.wizard.host_paths
+            self.wizard.session.host,
+            paths=self.wizard.host_paths,
+            multi_account_auth=self._multi_account_active(),
         )
         send_json(self, snapshot.as_dict())
 
@@ -460,7 +462,12 @@ class ConfigureHandler(BaseHTTPRequestHandler):
 
     def _post_setup_basic(self, payload: dict[str, Any]) -> None:  # noqa: ARG002
         result = install_basic_setup(
-            home=self.wizard.home, host=self.wizard.session.host
+            home=self.wizard.home,
+            host=self.wizard.session.host,
+            # #222: a multi-account backend must not get the bare `mureo`
+            # entry (per-client `mureo-<slug>` entries are the only correct
+            # wiring). Same production gate as the account-picker skip.
+            skip_mcp_registration=self._multi_account_active(),
         )
         send_json(self, result)
 
@@ -501,6 +508,21 @@ class ConfigureHandler(BaseHTTPRequestHandler):
             url = saved.get(_OAUTH_CALLBACK_URL_KEY)
             if isinstance(url, str) and url:
                 plugin["oauth_callback_url"] = url
+
+    def _multi_account_active(self) -> bool:
+        """True ⇔ a multi-account backend is active in production (#198/#222).
+
+        The single ``home is None and runtime_multi_account_auth()`` gate
+        shared by the account-picker skip (#198), the status flag, and the
+        MCP-registration skip (#222). Resolve the capability ONLY when
+        ``home is None`` (production): an injected ``home`` sandboxes the
+        wizard, and the process-global factory's store lives outside that
+        sandbox (in dev/CI a third-party factory resolves against the
+        operator's real ~/.mureo), so consulting it under an injected home
+        would let a sandboxed/test wizard inherit real-backend behaviour —
+        the #195 escape the credentials-path / field-scope gates guard.
+        """
+        return self.wizard.home is None and runtime_multi_account_auth()
 
     def _resolve_field_scope(self) -> Mapping[str, Collection[str]] | None:
         """Resolve the per-provider credential-field scope (#207/#211).
@@ -743,17 +765,11 @@ class ConfigureHandler(BaseHTTPRequestHandler):
             send_error_json(self, 404, "unknown_provider")
             return
         self.wizard.session.mark_oauth_pending(provider)
-        # A multi-account backend (#198) persists only the operator-
-        # shared credentials and skips the per-account picker. Resolve
-        # the capability from the active RuntimeContext, but ONLY in
-        # production (home is None). An injected ``home`` sandboxes the
-        # wizard; the process-global factory's store lives outside that
-        # sandbox (in dev/CI a third-party factory resolves against the
-        # operator's real ~/.mureo), so consulting it under an injected
-        # home would let test wizards inherit real-backend behavior —
-        # the same #195 escape the credentials-path override guards
-        # against.
-        multi_account = self.wizard.home is None and runtime_multi_account_auth()
+        # A multi-account backend (#198) persists only the operator-shared
+        # credentials and skips the per-account picker. Same production gate
+        # as the status flag / MCP-registration skip — see
+        # _multi_account_active for the home-is-None rationale.
+        multi_account = self._multi_account_active()
         try:
             result = self.wizard.oauth_bridge.start(
                 provider=provider,

--- a/mureo/web/setup_actions.py
+++ b/mureo/web/setup_actions.py
@@ -371,11 +371,26 @@ def install_workflow_skills(
 
 
 def install_basic_setup(
-    home: Path | None = None, host: str = _HOST_CODE
+    home: Path | None = None,
+    host: str = _HOST_CODE,
+    *,
+    skip_mcp_registration: bool = False,
 ) -> dict[str, Any]:
-    """Run all three basic-setup parts in order, forwarding ``host``."""
+    """Run all three basic-setup parts in order, forwarding ``host``.
+
+    ``skip_mcp_registration`` (#222): when ``True`` the bare ``mureo`` MCP
+    entry is NOT written — a multi-account backend wires per-client
+    ``mureo-<slug>`` entries instead, and the bare entry (``cwd=/``, no
+    tenant) is actively harmful. The MCP part reports ``skipped`` and the
+    hook + skills parts run unchanged. The caller (the handler) decides
+    this behind the ``home is None`` gate, so this stays a pure function.
+    """
+    if skip_mcp_registration:
+        mcp = ActionResult(status="skipped", detail="multi_account_auth")
+    else:
+        mcp = install_mureo_mcp(home=home, host=host)
     return {
-        PART_MCP: install_mureo_mcp(home=home, host=host).as_dict(),
+        PART_MCP: mcp.as_dict(),
         PART_HOOK: install_auth_hook(home=home, host=host).as_dict(),
         PART_SKILLS: install_workflow_skills(home=home, host=host).as_dict(),
     }

--- a/mureo/web/status_collector.py
+++ b/mureo/web/status_collector.py
@@ -63,6 +63,13 @@ class StatusSnapshot:
     # (mureo-native tools for that platform are stepped aside so the
     # official MCP is the single source). Drives the dashboard toggle.
     mureo_disable: dict[str, bool]
+    # #222: True ⇔ the active store declares ``multi_account_auth`` (a
+    # multi-account backend). The configure UI uses it to suppress the
+    # bare-``mureo`` MCP registration (the backend writes per-client
+    # ``mureo-<slug>`` entries instead). Computed by the handler behind the
+    # ``home is None`` gate and relayed through here; defaults False so
+    # standalone OSS and direct callers are unchanged.
+    multi_account_auth: bool = False
 
     def as_dict(self) -> dict[str, Any]:
         return {
@@ -74,6 +81,7 @@ class StatusSnapshot:
             "env_vars": {k: dict(v) for k, v in self.env_vars.items()},
             "legacy_commands_present": self.legacy_commands_present,
             "mureo_disable": dict(self.mureo_disable),
+            "multi_account_auth": self.multi_account_auth,
         }
 
 
@@ -202,8 +210,14 @@ def collect_status(
     *,
     home: Path | None = None,
     paths: HostPaths | None = None,
+    multi_account_auth: bool = False,
 ) -> StatusSnapshot:
-    """Build a status snapshot for ``host``."""
+    """Build a status snapshot for ``host``.
+
+    ``multi_account_auth`` (#222) is relayed verbatim onto the snapshot —
+    the caller (the handler) computes it behind the ``home is None`` gate,
+    so this stays a pure filesystem read with no runtime-context coupling.
+    """
     resolved = paths if paths is not None else get_host_paths(host, home)
     setup_parts = read_setup_state(home)
     providers = _detect_installed_providers(resolved.mcp_registry_path)
@@ -221,4 +235,5 @@ def collect_status(
         env_vars=env_vars,
         legacy_commands_present=legacy,
         mureo_disable=mureo_disable,
+        multi_account_auth=multi_account_auth,
     )

--- a/tests/test_web_assets_multi_account_mcp.py
+++ b/tests/test_web_assets_multi_account_mcp.py
@@ -1,0 +1,39 @@
+"""Static-content guards for the #222 multi-account MCP suppression.
+
+When the status snapshot carries ``multi_account_auth = true`` (a
+multi-account backend), the configure UI must not surface the bare
+``mureo`` MCP registration — neither the wizard's basic-setup pill nor the
+dashboard's basic-setup row — because that entry is harmful there
+(per-client ``mureo-<slug>`` entries are the correct wiring). No JS test
+harness ships in the repo, so the contract is pinned by grepping the
+bundled assets; a refactor that drops the gate flips a test red here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_WEB = Path(__file__).resolve().parent.parent / "mureo" / "_data" / "web"
+
+
+def _read(name: str) -> str:
+    return (_WEB / name).read_text(encoding="utf-8")
+
+
+@pytest.mark.unit
+def test_wizard_gates_basic_mcp_on_multi_account() -> None:
+    """``wizard.js`` consults ``multi_account_auth`` in both the completion
+    derivation (so a suppressed MCP part is not required for completion)
+    and the basic-step body (so the mureo_mcp pill is not rendered)."""
+    js = _read("wizard.js")
+    assert js.count("multi_account_auth") >= 2
+
+
+@pytest.mark.unit
+def test_dashboard_gates_basic_mcp_on_multi_account() -> None:
+    """``dashboard.js`` skips the mureo_mcp basic-setup row when the status
+    snapshot declares ``multi_account_auth``."""
+    js = _read("dashboard.js")
+    assert "multi_account_auth" in js

--- a/tests/test_web_handlers.py
+++ b/tests/test_web_handlers.py
@@ -282,6 +282,91 @@ class TestPostSetupBasic:
         mock_install.assert_called_once()
 
 
+@pytest.mark.unit
+class TestSetupBasicMultiAccountGate:
+    """#222 — a multi-account backend must not get the bare ``mureo`` MCP
+    entry. Mirrors the #198 account-picker gate: resolve the capability
+    ONLY in production (``home is None``); a home-injected (sandboxed)
+    wizard must never consult the process-global factory."""
+
+    def test_skip_mcp_false_when_home_injected(
+        self, wizard: ConfigureWizard
+    ) -> None:
+        with (
+            patch(
+                "mureo.web.handlers.runtime_multi_account_auth", return_value=True
+            ),
+            patch(
+                "mureo.web.handlers.install_basic_setup",
+                return_value={"mureo_mcp": {"status": "ok"}},
+            ) as mock_install,
+        ):
+            _post(wizard, "/api/setup/basic", {})
+        assert mock_install.call_args.kwargs["skip_mcp_registration"] is False
+
+    def test_skip_mcp_true_when_home_none(self, tmp_path: Path) -> None:
+        sentinel = tmp_path / "runtime" / "credentials.json"
+        with patch(
+            "mureo.web.server.runtime_credentials_path", lambda _default: sentinel
+        ):
+            wiz = ConfigureWizard(home=None)
+        thread = threading.Thread(target=wiz.serve, daemon=True)
+        thread.start()
+        wiz.wait_until_ready(timeout=5.0)
+        try:
+            with (
+                patch(
+                    "mureo.web.handlers.runtime_multi_account_auth",
+                    return_value=True,
+                ),
+                patch(
+                    "mureo.web.handlers.install_basic_setup",
+                    return_value={"mureo_mcp": {"status": "skipped"}},
+                ) as mock_install,
+            ):
+                _post(wiz, "/api/setup/basic", {})
+            assert mock_install.call_args.kwargs["skip_mcp_registration"] is True
+        finally:
+            wiz.shutdown()
+            thread.join(timeout=2.0)
+
+
+@pytest.mark.unit
+class TestServeStatusMultiAccount:
+    """#222 — ``GET /api/status`` surfaces ``multi_account_auth`` behind the
+    same ``home is None`` gate so the UI can suppress the MCP section."""
+
+    def test_status_false_when_home_injected(
+        self, wizard: ConfigureWizard
+    ) -> None:
+        with patch(
+            "mureo.web.handlers.runtime_multi_account_auth", return_value=True
+        ):
+            resp = _get(wizard, "/api/status")
+        body = json.loads(resp.read().decode("utf-8"))
+        assert body["multi_account_auth"] is False
+
+    def test_status_true_when_home_none(self, tmp_path: Path) -> None:
+        sentinel = tmp_path / "runtime" / "credentials.json"
+        with patch(
+            "mureo.web.server.runtime_credentials_path", lambda _default: sentinel
+        ):
+            wiz = ConfigureWizard(home=None)
+        thread = threading.Thread(target=wiz.serve, daemon=True)
+        thread.start()
+        wiz.wait_until_ready(timeout=5.0)
+        try:
+            with patch(
+                "mureo.web.handlers.runtime_multi_account_auth", return_value=True
+            ):
+                resp = _get(wiz, "/api/status")
+            body = json.loads(resp.read().decode("utf-8"))
+            assert body["multi_account_auth"] is True
+        finally:
+            wiz.shutdown()
+            thread.join(timeout=2.0)
+
+
 # ---------------------------------------------------------------------------
 # Session-host propagation into setup_actions (planner HANDOFF
 # feat-web-config-ui-phase1-desktop-host.md, Q5). The 5 setup handler

--- a/tests/test_web_setup_actions_host.py
+++ b/tests/test_web_setup_actions_host.py
@@ -648,3 +648,76 @@ class TestHostParamSignatures:
             )
 
         assert isinstance(result, dict)
+
+
+# ---------------------------------------------------------------------------
+# install_basic_setup — #222 skip the bare mureo MCP registration for a
+# multi-account backend (per-client entries are the correct wiring).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestInstallBasicSetupSkipMcp:
+    def test_skip_mcp_registration_skips_only_mcp(self, tmp_path: Path) -> None:
+        """``skip_mcp_registration=True`` returns a ``skipped`` MCP part and
+        never calls ``install_mureo_mcp`` — hook + skills still run."""
+        from mureo.web import setup_actions
+        from mureo.web.setup_actions import (
+            PART_HOOK,
+            PART_MCP,
+            PART_SKILLS,
+            install_basic_setup,
+        )
+
+        with (
+            patch.object(setup_actions, "install_mureo_mcp") as mock_mcp,
+            patch.object(
+                setup_actions,
+                "install_auth_hook",
+                return_value=ActionResult(status="ok"),
+            ) as mock_hook,
+            patch.object(
+                setup_actions,
+                "install_workflow_skills",
+                return_value=ActionResult(status="ok"),
+            ) as mock_skills,
+        ):
+            result = install_basic_setup(home=tmp_path, skip_mcp_registration=True)
+
+        mock_mcp.assert_not_called()
+        mock_hook.assert_called_once()
+        mock_skills.assert_called_once()
+        assert result[PART_MCP] == {
+            "status": "skipped",
+            "detail": "multi_account_auth",
+        }
+        assert result[PART_HOOK]["status"] == "ok"
+        assert result[PART_SKILLS]["status"] == "ok"
+
+    def test_default_installs_mcp(self, tmp_path: Path) -> None:
+        """Default (``skip_mcp_registration=False``) installs the MCP part as
+        before — regression guard for standalone OSS."""
+        from mureo.web import setup_actions
+        from mureo.web.setup_actions import PART_MCP, install_basic_setup
+
+        with (
+            patch.object(
+                setup_actions,
+                "install_mureo_mcp",
+                return_value=ActionResult(status="ok", detail="x"),
+            ) as mock_mcp,
+            patch.object(
+                setup_actions,
+                "install_auth_hook",
+                return_value=ActionResult(status="ok"),
+            ),
+            patch.object(
+                setup_actions,
+                "install_workflow_skills",
+                return_value=ActionResult(status="ok"),
+            ),
+        ):
+            result = install_basic_setup(home=tmp_path)
+
+        mock_mcp.assert_called_once()
+        assert result[PART_MCP]["status"] == "ok"

--- a/tests/test_web_status_collector.py
+++ b/tests/test_web_status_collector.py
@@ -315,3 +315,28 @@ class TestMureoDisableState:
             "meta_ads": False,
             "ga4": False,
         }
+
+
+@pytest.mark.unit
+class TestMultiAccountAuthFlag:
+    """#222 — the snapshot carries a ``multi_account_auth`` flag so the UI
+    can suppress the bare-``mureo`` MCP registration. The handler computes
+    it behind the ``home is None`` gate; ``collect_status`` just relays it.
+    """
+
+    def test_default_is_false(self, tmp_path: Path) -> None:
+        snap = collect_status(
+            "claude-code", home=_build_home(tmp_path), paths=_paths(tmp_path)
+        )
+        assert snap.multi_account_auth is False
+        assert snap.as_dict()["multi_account_auth"] is False
+
+    def test_flag_propagates_to_snapshot(self, tmp_path: Path) -> None:
+        snap = collect_status(
+            "claude-code",
+            home=_build_home(tmp_path),
+            paths=_paths(tmp_path),
+            multi_account_auth=True,
+        )
+        assert snap.multi_account_auth is True
+        assert snap.as_dict()["multi_account_auth"] is True


### PR DESCRIPTION
## Summary

Closes #222.

On a multi-account backend the bare `mureo` MCP entry is actively harmful: it launches with `cwd=/` (tenant resolution finds no `.mureo-tenant`, per-client overlays invisible) and the AI can route tool calls to it before the per-client `mureo-<slug>` entries, failing with e.g. "api_key is not set". Those per-client entries are the only correct wiring and the backend creates them at client-registration time — so the wizard must stop re-producing the bare entry.

When the active store declares `multi_account_auth = True` (#198, resolved behind the `home is None` production gate):

1. **Never write the bare `mureo` entry** — `install_basic_setup` gains `skip_mcp_registration`; the MCP part reports `skipped`, hook + skills run unchanged.
2. **Remove the MCP registration from the UI** — the status snapshot carries `multi_account_auth`; the wizard omits the `mureo_mcp` pill (and no longer requires it for completion), and the dashboard omits the basic-setup row.

A new `_multi_account_active()` handler helper consolidates the `home is None and runtime_multi_account_auth()` gate shared by the account-picker skip (#198), the status flag, and the registration skip.

## Backward compatibility
Capability absent (standalone OSS) → byte-identical wizard UI and registration. Same gate as the #198 account-picker skip — no new protocol surface.

## Test plan
- [x] `StatusSnapshot.multi_account_auth` default False; relayed when set
- [x] `install_basic_setup(skip_mcp_registration=True)` → MCP `skipped`, `install_mureo_mcp` not called, hook+skills run; default installs MCP (regression)
- [x] handler gate: `home`-injected → False (status + skip); `home=None` → True (#195 safety, both `_serve_status` and `_post_setup_basic`)
- [x] wizard/dashboard asset guards reference `multi_account_auth`
- [x] broad regression green (1766); `ruff` + `black --check mureo/` + `mypy mureo/` clean
- [ ] CI green on this PR

_Note: the one local-only `test_mcp_tool_provider` failure is the dev venv's installed bridge adding tools; passes in clean CI._
