### PR TITLE
fix(configure): dedupe racing plugin-credentials render + pre-fill from current values (#223, #224)

### DIFF
--- a/mureo/_data/web/dashboard.js
+++ b/mureo/_data/web/dashboard.js
@@ -877,6 +877,13 @@
     renderByodStatus();
   }
 
+  // #223: monotonic render generation. renderPluginCredentials is async
+  // (clear → await fetch → append); during init renderAll() runs twice, so
+  // two calls can interleave and BOTH append, rendering every card twice.
+  // Each call captures its generation and bails if a newer render started
+  // while it awaited — so only the latest result ever clears + appends.
+  let pluginRenderSeq = 0;
+
   // Plugin credentials section — one collapsible form per provider
   // declaring AccountCredentialField entries. Fetches once per render
   // call. secret=True fields render as type="password" and submit
@@ -886,7 +893,7 @@
       "[data-dashboard-plugin-credentials-list]"
     );
     if (!container) return;
-    container.textContent = "";
+    const seq = ++pluginRenderSeq;
     let plugins = [];
     try {
       const res = await fetch("/api/credentials/plugins", { credentials: "same-origin" });
@@ -898,6 +905,12 @@
       // sections continue to function.
       return;
     }
+    // A newer render superseded us while we awaited — drop this stale
+    // result so concurrent renders can't both append (#223).
+    if (seq !== pluginRenderSeq) return;
+    // Clear AFTER the await, immediately before appending, so the section
+    // is never emptied by a render that then bails on the guard above.
+    container.textContent = "";
     if (plugins.length === 0) {
       const empty = document.createElement("p");
       empty.className = "muted";
@@ -951,11 +964,17 @@
     // Safari/Chrome on password inputs.
     input.autocomplete = field.secret ? "new-password" : "off";
     if (field.secret) {
-      input.placeholder = MUREO.t(
-        "dashboard.plugin_credentials_secret_placeholder"
-      );
-    } else if (field.placeholder) {
-      input.placeholder = field.placeholder;
+      // #224: a secret value never round-trips to the browser — pre-fill
+      // only the placeholder. A *configured* secret shows the
+      // leave-blank-to-keep hint; an unset one shows its own placeholder.
+      input.placeholder = field.configured
+        ? MUREO.t("dashboard.plugin_credentials_secret_placeholder")
+        : field.placeholder || "";
+    } else {
+      // #224: pre-fill the stored non-secret value (e.g. base_account_id)
+      // so a restart shows the current config instead of a blank form.
+      if (field.value) input.value = field.value;
+      if (field.placeholder) input.placeholder = field.placeholder;
     }
     label.appendChild(input);
     if (field.description) {

--- a/mureo/web/handlers.py
+++ b/mureo/web/handlers.py
@@ -312,6 +312,7 @@ class ConfigureHandler(BaseHTTPRequestHandler):
                 field_scope=self._resolve_field_scope(),
             )
             self._inject_saved_oauth_callback_urls(plugins)
+            self._inject_plugin_field_state(plugins)
             send_json(self, {"plugins": plugins})
             return
         match = _OAUTH_PROVIDER_RE.match(path)
@@ -508,6 +509,26 @@ class ConfigureHandler(BaseHTTPRequestHandler):
             url = saved.get(_OAUTH_CALLBACK_URL_KEY)
             if isinstance(url, str) and url:
                 plugin["oauth_callback_url"] = url
+
+    def _inject_plugin_field_state(self, plugins: list[dict[str, Any]]) -> None:
+        """Annotate each declared field with its stored state for pre-fill
+        after a configure restart (#224).
+
+        Per field: ``configured`` (a truthy value is stored) is always set;
+        a **non-secret** field additionally gets ``value`` (the stored value
+        verbatim, e.g. ``base_account_id`` / ``oauth_callback_url``). A
+        **secret** field NEVER ships its value — only the boolean — so a
+        secret never round-trips into the browser. The save side's
+        blank-keeps-stored contract is unchanged.
+        """
+        store = FilesystemSecretStore(path=self.wizard.host_paths.credentials_path)
+        for plugin in plugins:
+            saved = store.load(plugin["provider_name"])
+            for field in plugin.get("fields", []):
+                stored = saved.get(field["key"])
+                field["configured"] = bool(stored)
+                if field["configured"] and not field.get("secret"):
+                    field["value"] = str(stored)
 
     def _multi_account_active(self) -> bool:
         """True ⇔ a multi-account backend is active in production (#198/#222).

--- a/tests/test_web_assets_plugin_credentials_render.py
+++ b/tests/test_web_assets_plugin_credentials_render.py
@@ -1,0 +1,42 @@
+"""Static-content guards for the plugin-credentials render fixes.
+
+- #223: ``renderPluginCredentials`` is generation-guarded so two
+  concurrent renders (the double ``renderAll()`` at init) cannot both
+  append — the clear→await→append race that rendered every card twice.
+- #224: declared fields pre-fill from the list payload's current state —
+  non-secret values verbatim, secrets via a ``configured`` flag only.
+
+No JS test harness ships in the repo, so the contract is pinned by
+grepping the bundled ``dashboard.js``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_WEB = Path(__file__).resolve().parent.parent / "mureo" / "_data" / "web"
+
+
+def _read(name: str) -> str:
+    return (_WEB / name).read_text(encoding="utf-8")
+
+
+@pytest.mark.unit
+def test_render_plugin_credentials_is_generation_guarded() -> None:
+    """#223: a module-level generation counter (declared, incremented, and
+    compared after the await) drops a stale render so concurrent calls
+    cannot double-append."""
+    js = _read("dashboard.js")
+    assert js.count("pluginRenderSeq") >= 3
+
+
+@pytest.mark.unit
+def test_credential_input_prefills_current_values() -> None:
+    """#224: ``appendCredentialInput`` pre-fills a non-secret field from
+    ``field.value`` and keys the secret placeholder off ``field.configured``
+    (the secret value itself is never shipped)."""
+    js = _read("dashboard.js")
+    assert "field.value" in js
+    assert "field.configured" in js

--- a/tests/test_web_plugin_oauth_handlers.py
+++ b/tests/test_web_plugin_oauth_handlers.py
@@ -177,6 +177,36 @@ def test_plugin_list_surfaces_saved_callback_url(wizard: ConfigureWizard) -> Non
     assert "oauth_callback_url" not in by_name["demo_ads"]
 
 
+@pytest.mark.unit
+def test_plugin_list_surfaces_field_current_state(wizard: ConfigureWizard) -> None:
+    """#224: each declared field carries a ``configured`` flag; a non-secret
+    field also ships its stored value verbatim for pre-fill, while a secret
+    field NEVER ships its value (only the flag)."""
+    path = wizard.host_paths.credentials_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"yahoo_ads": {"client_id": "CID", "client_secret": "SECRET"}})
+    )
+    body = json.loads(_get(wizard, "/api/credentials/plugins").read())
+    fields = {
+        f["key"]: f
+        for p in body["plugins"]
+        if p["provider_name"] == "yahoo_ads"
+        for f in p["fields"]
+    }
+    # Non-secret, stored → configured + value verbatim.
+    assert fields["client_id"]["configured"] is True
+    assert fields["client_id"]["value"] == "CID"
+    # Secret, stored → configured True but NO value shipped to the browser.
+    assert fields["client_secret"]["configured"] is True
+    assert "value" not in fields["client_secret"]
+    # Unset field → not configured, no value.
+    assert fields["refresh_token"]["configured"] is False
+    assert "value" not in fields["refresh_token"]
+    # Defense in depth: the secret value never appears anywhere in payload.
+    assert "SECRET" not in json.dumps(body)
+
+
 # ---------------------------------------------------------------------------
 # POST …/oauth/start
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two coupled fixes for the dashboard "Plugin credentials" section (both touch `dashboard.js`, so they ship together). Closes #223, closes #224.

### #223 — cards rendered twice (concurrent render race)
`renderPluginCredentials()` is async (clear → await fetch → append). The double `renderAll()` at init runs two calls that interleave, so both append → every card twice.

- A monotonic `pluginRenderSeq` generation counter: a call bails after the await if a newer render started, so only the latest result appends.
- `container.textContent = ""` moved to **after** the await (right before append) so a superseded render never empties the section.

### #224 — forms blank after restart (no read-back)
The list endpoint shipped field specs only, so the form had nothing to pre-fill.

- The handler annotates each declared field with stored state: `configured` (truthy value stored) always; `value` (verbatim) for **non-secret** fields only.
- **Secret values never ship** — only the boolean — so a secret never round-trips to the browser. Blank-keeps-stored save contract unchanged.
- `dashboard.js` pre-fills non-secret inputs from `field.value` and keys the secret placeholder off `field.configured`.

## Security
- Secrets never leave the store (asserted: `"SECRET" not in json.dumps(body)`); only a boolean `configured` flag is exposed.
- Non-secret ids already appear in the operator's loopback UI elsewhere — no new exposure.

## Test plan
- [x] #223: asset guard pins the generation counter (declare + increment + compare)
- [x] #224: list payload — non-secret `configured`+`value` verbatim; secret `configured` only, no `value`; unset → not configured; secret value absent from whole payload
- [x] #224: asset guard pins `field.value` / `field.configured` pre-fill
- [x] broad regression green (1233); `ruff` + `black --check mureo/` + `mypy mureo/` clean
- [ ] CI green on this PR

_Note: the one local-only `test_mcp_server_plugin_wiring` failure is the dev venv's installed bridge adding plugins; passes in clean CI._
