### PR TITLE
fix(configure): force cooked terminal before the wait loop so Ctrl+C works (#227)

### DIFF
--- a/mureo/auth_setup.py
+++ b/mureo/auth_setup.py
@@ -32,6 +32,11 @@ import httpx
 from google_auth_oauthlib.flow import Flow, InstalledAppFlow
 
 from mureo.auth import GoogleAdsCredentials, MetaAdsCredentials
+
+# Private alias so existing call sites and test monkeypatches of
+# ``mureo.auth_setup._terminal_fd`` keep working now that the canonical
+# implementation lives in :mod:`mureo.core.terminal` (#227 follow-up).
+from mureo.core.terminal import terminal_fd as _terminal_fd
 from mureo.fsutil import secure_chmod
 
 # Backward-compat re-exports of the platform-level account-discovery
@@ -57,20 +62,6 @@ logger = logging.getLogger(__name__)
 _GOOGLE_ADS_SCOPE = "https://www.googleapis.com/auth/adwords"
 _SEARCH_CONSOLE_SCOPE = "https://www.googleapis.com/auth/webmasters"
 _GOOGLE_SCOPES = [_GOOGLE_ADS_SCOPE, _SEARCH_CONSOLE_SCOPE]
-
-
-def _terminal_fd() -> int | None:
-    """Resolve the controlling-terminal fd, or ``None`` for non-TTY.
-
-    Wraps ``sys.stdin.fileno()`` so the lookup itself does not raise
-    under pytest (the test harness replaces stdin with a pseudo-file
-    whose ``fileno()`` raises ``UnsupportedOperation``) or in any
-    other context where stdin is not a real file descriptor.
-    """
-    try:
-        return sys.stdin.fileno()
-    except (OSError, ValueError, AttributeError):
-        return None
 
 
 def _capture_terminal_state(fd: int | None) -> Any | None:

--- a/mureo/core/terminal.py
+++ b/mureo/core/terminal.py
@@ -1,0 +1,66 @@
+"""Keep the controlling TTY sane around long blocking waits (#227).
+
+An interactive arrow-key menu (``simple_term_menu``) flips the terminal
+into raw/cbreak mode (``ISIG`` / ``ICANON`` / ``ECHO`` cleared). If that
+mode leaks — an unwrapped menu in a third-party backend, a prior CLI
+step, or a suspend/resume during a menu — a later blocking wait such as
+``mureo configure`` is stranded: with ``ISIG`` off, Ctrl+C never becomes
+SIGINT, so the configure stop-signal never fires and the operator sees a
+dead terminal with no echo (the #190 family, the uncovered path in #227).
+
+``mureo configure`` is launched from a normal (cooked) shell, so the
+robust fix is to defensively force cooked mode right before the wait —
+re-enabling Ctrl+C and echo regardless of what was inherited. We do not
+snapshot-and-restore the inherited state: restoring a *leaked raw* mode
+on exit would simply re-strand the shell, and an interactive shell always
+wants cooked mode back.
+
+Every function is a no-op when stdin is not a TTY (pipe / redirect / CI /
+Windows, where ``termios`` is absent), so they are always safe to call.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import sys
+
+try:
+    import termios
+except ImportError:  # pragma: no cover - Windows (Unix-only stdlib)
+    termios = None  # type: ignore[assignment]
+
+
+def terminal_fd() -> int | None:
+    """Return stdin's file descriptor, or ``None`` when it has none.
+
+    ``None`` under pytest (stdin replaced), a pipe/redirect, or a closed
+    stream — the caller then skips the termios work.
+    """
+    try:
+        return sys.stdin.fileno()
+    except (OSError, ValueError, AttributeError):
+        return None
+
+
+def force_cooked_mode(fd: int | None) -> None:
+    """Re-enable ``ISIG`` / ``ICANON`` / ``ECHO`` on ``fd`` (cooked mode).
+
+    Makes Ctrl+C deliver SIGINT, line editing work, and typing echo again,
+    whatever a prior step left the terminal in (#227). Only ORs the three
+    local-mode bits in — it never clears anything, so a terminal already
+    in cooked mode is unchanged. Best-effort: a non-TTY ``fd`` (or
+    ``None``, or ``termios`` absent on Windows) is a silent no-op, and a
+    ``tcsetattr`` failure is swallowed rather than crashing the caller.
+    """
+    if termios is None or fd is None:
+        return
+    with contextlib.suppress(termios.error, OSError, ValueError, AttributeError):
+        attrs = termios.tcgetattr(fd)
+        # ``attrs[3]`` is the local-mode flags (lflag). ``TCSADRAIN`` lets
+        # pending output drain before the mode flip so no escape codes are
+        # left mid-stream.
+        attrs[3] |= termios.ISIG | termios.ICANON | termios.ECHO
+        termios.tcsetattr(fd, termios.TCSADRAIN, attrs)
+
+
+__all__ = ["force_cooked_mode", "terminal_fd"]

--- a/mureo/web/server.py
+++ b/mureo/web/server.py
@@ -20,6 +20,7 @@ from importlib import resources
 from pathlib import Path
 
 from mureo.core.runtime_context import runtime_credentials_path
+from mureo.core.terminal import force_cooked_mode, terminal_fd
 from mureo.web.extensions import discover_web_extensions
 from mureo.web.handlers import ConfigureHandler
 from mureo.web.host_paths import HostPaths, get_host_paths
@@ -247,6 +248,13 @@ def run_configure_wizard(
         for sig in (signal.SIGINT, signal.SIGTERM):
             with contextlib.suppress(ValueError, OSError):
                 prev_handlers.append((sig, signal.signal(sig, _on_signal)))
+        # #227: a prior step (a leaked arrow-key menu in a third-party
+        # backend, or an earlier CLI command) can leave the TTY in raw mode
+        # with ISIG off — Ctrl+C then never generates SIGINT, so _on_signal
+        # never fires and the operator is stranded with a dead terminal
+        # (no echo) for the full timeout. Force cooked mode before blocking
+        # so Ctrl+C reliably delivers the stop signal. No-op on a non-TTY.
+        force_cooked_mode(terminal_fd())
         wizard.stop_event.wait(timeout=timeout_seconds)
     except KeyboardInterrupt:
         # Belt-and-braces: if a KeyboardInterrupt still surfaces (e.g.

--- a/tests/test_core_terminal.py
+++ b/tests/test_core_terminal.py
@@ -1,0 +1,84 @@
+"""Unit tests for ``mureo.core.terminal`` (#227).
+
+``force_cooked_mode`` re-enables ``ISIG`` / ``ICANON`` / ``ECHO`` on a
+TTY so a blocking wait (``mureo configure``) can always be interrupted
+with Ctrl+C even if a prior step leaked raw/cbreak mode. Exercised
+against a real pseudo-terminal (``pty.openpty``) so the termios bit
+manipulation is verified for real, not just mocked.
+
+Unix-only: ``termios`` / ``pty`` are not available on Windows, where the
+helpers are import-guarded no-ops — there is nothing to test.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+termios = pytest.importorskip("termios")
+import pty  # noqa: E402 - after importorskip so Windows skips cleanly
+
+from mureo.core.terminal import force_cooked_mode, terminal_fd  # noqa: E402
+
+
+@pytest.mark.unit
+def test_force_cooked_mode_reenables_isig_icanon_echo() -> None:
+    """On a pty left in raw mode (the three bits cleared), the helper
+    turns ISIG/ICANON/ECHO back on — restoring Ctrl+C, line editing, and
+    echo (the #227 symptom signature)."""
+    master, slave = pty.openpty()
+    try:
+        attrs = termios.tcgetattr(slave)
+        attrs[3] &= ~(termios.ISIG | termios.ICANON | termios.ECHO)  # lflags
+        termios.tcsetattr(slave, termios.TCSANOW, attrs)
+        # Precondition: the bits really are off (this is "raw"-ish).
+        assert not termios.tcgetattr(slave)[3] & termios.ISIG
+
+        force_cooked_mode(slave)
+
+        after = termios.tcgetattr(slave)[3]
+        assert after & termios.ISIG, "Ctrl+C (SIGINT) must be re-enabled"
+        assert after & termios.ICANON, "canonical line input must be re-enabled"
+        assert after & termios.ECHO, "echo must be re-enabled"
+    finally:
+        os.close(master)
+        os.close(slave)
+
+
+@pytest.mark.unit
+def test_force_cooked_mode_preserves_already_cooked_bits() -> None:
+    """A terminal already in cooked mode is left with the three bits on
+    (the helper only ORs them in — it never clears anything)."""
+    master, slave = pty.openpty()
+    try:
+        force_cooked_mode(slave)
+        after = termios.tcgetattr(slave)[3]
+        assert after & termios.ISIG
+        assert after & termios.ECHO
+    finally:
+        os.close(master)
+        os.close(slave)
+
+
+@pytest.mark.unit
+def test_force_cooked_mode_none_is_noop() -> None:
+    force_cooked_mode(None)  # must not raise
+
+
+@pytest.mark.unit
+def test_force_cooked_mode_non_tty_fd_is_noop() -> None:
+    """A pipe fd is not a TTY — ``tcgetattr`` raises internally and the
+    helper swallows it (best-effort), never propagating."""
+    read_fd, write_fd = os.pipe()
+    try:
+        force_cooked_mode(read_fd)  # no raise
+    finally:
+        os.close(read_fd)
+        os.close(write_fd)
+
+
+@pytest.mark.unit
+def test_terminal_fd_returns_int_or_none() -> None:
+    fd = terminal_fd()
+    assert fd is None or isinstance(fd, int)

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -196,6 +196,22 @@ class TestRunConfigureWizardCli:
         mock_open.assert_not_called()
         assert elapsed < 5.0
 
+    def test_forces_cooked_mode_before_waiting(self, home_dir: Path) -> None:
+        """#227: before blocking on the stop event, the wizard normalises
+        the TTY to cooked mode so Ctrl+C delivers SIGINT (its stop signal)
+        even if a prior step leaked raw mode — otherwise the operator is
+        stranded with a dead terminal."""
+        with (
+            patch("mureo.web.server.webbrowser.open"),
+            patch("mureo.web.server.force_cooked_mode") as mock_cooked,
+        ):
+            run_configure_wizard(
+                home=home_dir,
+                open_browser=False,
+                timeout_seconds=0.2,
+            )
+        mock_cooked.assert_called_once()
+
     def test_opens_browser_when_requested(self, home_dir: Path) -> None:
         with patch("mureo.web.server.webbrowser.open") as mock_open:
             run_configure_wizard(


### PR DESCRIPTION
## Summary

Fixes the intermittent "dead terminal" during `mureo configure`: Ctrl+C does nothing and typing has no echo, leaving the operator stranded for the full wizard timeout (#227, the uncovered `TerminalMenu` path in the #190 family).

## Root cause

An interactive arrow-key menu (`simple_term_menu`) flips the TTY into raw/cbreak mode (`ISIG` / `ICANON` / `ECHO` cleared). If that mode leaks — an unwrapped menu in a third-party backend, a prior CLI step, or a suspend/resume during a menu — the subsequent blocking `wizard.stop_event.wait()` in `run_configure_wizard` is stranded: with `ISIG` off, Ctrl+C never becomes SIGINT, so the configure stop-signal handler never fires.

## Fix

- New `mureo/core/terminal.py` with `terminal_fd()` and `force_cooked_mode(fd)`: defensively re-enables `ISIG` / `ICANON` / `ECHO` (OR-only — never clears bits, so an already-cooked terminal is unchanged). Best-effort and a silent no-op on non-TTY stdin, pytest, pipes/redirects, and Windows (`termios` absent).
- `run_configure_wizard` calls `force_cooked_mode(terminal_fd())` right before the wait loop, after installing the signal handlers.
- No snapshot-and-restore of inherited state: restoring a *leaked raw* mode on exit would re-strand the shell; an interactive shell always wants cooked mode back.

## Test plan

- [x] `tests/test_core_terminal.py` — unit tests: cooked mode forced from raw state, OR-only semantics, no-op on non-TTY / `None` fd / missing `termios`, error swallowing
- [x] `tests/test_web_server.py` — `run_configure_wizard` calls `force_cooked_mode` before blocking
- [ ] CI green on the PR

Closes #227
