### PR TITLE
fix(web): localize macOS native picker prompts via session locale (#228)

### DIFF
--- a/mureo/web/handlers.py
+++ b/mureo/web/handlers.py
@@ -771,13 +771,19 @@ class ConfigureHandler(BaseHTTPRequestHandler):
 
     def _post_pick_directory(self, payload: dict[str, Any]) -> None:
         title = str(payload.get("title", "Select a folder"))
-        send_json(self, pick_directory(title=title).as_dict())
+        # #228: the macOS prompt is keyed by the SESSION locale — never
+        # by anything in the request body (zero-injection design).
+        locale = self.wizard.session.locale
+        send_json(self, pick_directory(title=title, locale=locale).as_dict())
 
     def _post_pick_file(self, payload: dict[str, Any]) -> None:
         title = str(payload.get("title", "Select a file"))
         kind = str(payload.get("kind", "xlsx"))
         patterns = ("*.xlsx", "*.xlsm") if kind == "xlsx" else ("*.*",)
-        send_json(self, pick_file(title=title, patterns=patterns).as_dict())
+        locale = self.wizard.session.locale
+        send_json(
+            self, pick_file(title=title, patterns=patterns, locale=locale).as_dict()
+        )
 
     def _post_oauth_start(
         self, provider: str, payload: dict[str, Any]

--- a/mureo/web/native_picker.py
+++ b/mureo/web/native_picker.py
@@ -32,10 +32,11 @@ The subprocess argv is always a FIXED list, ``shell=False``, with a
   The client-supplied ``title``/``patterns`` reach the child ONLY as
   discrete trailing argv elements (read via ``sys.argv`` in the child)
   and are never shell-interpolated into ``_SCRIPT``.
-* darwin: the AppleScript body is a module-level CONSTANT with a baked-in
-  generic prompt. The client ``title`` is **ignored** and the file-type
-  list is the hardcoded ``{"xlsx", "xlsm"}`` set — nothing client-supplied
-  is ever concatenated/interpolated into the AppleScript, so a hostile
+* darwin: the AppleScript body is one of the module-level CONSTANTS with
+  a baked-in prompt, selected by the server-side session locale (en/ja,
+  #228). The client ``title`` is **ignored** and the file-type list is
+  the hardcoded ``{"xlsx", "xlsm"}`` set — nothing client-supplied is
+  ever concatenated/interpolated into the AppleScript, so a hostile
   title cannot execute AppleScript or shell.
 
 The returned path is convenience only — callers still run it through the
@@ -60,13 +61,25 @@ _OSASCRIPT = "osascript"
 _MACOS_CANCEL_CODE = "-128"
 _MACOS_CANCEL_TEXT = "User canceled"
 
-# Baked-in generic prompts: NO client value is interpolated (zero AppleScript
-# / shell injection surface). Hardcoded xlsx/xlsm type list for file mode.
-_MACOS_DIR_SCRIPT = 'POSIX path of (choose folder with prompt "Select a folder")'
-_MACOS_FILE_SCRIPT = (
-    'POSIX path of (choose file with prompt "Select a file" '
-    'of type {"xlsx", "xlsm"})'
-)
+# Baked-in prompts, one constant per supported configure-UI locale
+# (#228): NO client value is ever interpolated (zero AppleScript / shell
+# injection surface) — the catalog is keyed by the SERVER-side session
+# locale, never by anything in the request body. Hardcoded xlsx/xlsm
+# type list for file mode. ``en`` is the fallback for unknown locales.
+_MACOS_DIR_SCRIPTS: dict[str, str] = {
+    "en": 'POSIX path of (choose folder with prompt "Select a folder")',
+    "ja": 'POSIX path of (choose folder with prompt "フォルダを選択してください")',
+}
+_MACOS_FILE_SCRIPTS: dict[str, str] = {
+    "en": (
+        'POSIX path of (choose file with prompt "Select a file" '
+        'of type {"xlsx", "xlsm"})'
+    ),
+    "ja": (
+        'POSIX path of (choose file with prompt "ファイルを選択してください" '
+        'of type {"xlsx", "xlsm"})'
+    ),
+}
 
 # Module-level CONSTANT (non-darwin path). Read mode/title/patterns from
 # sys.argv only; nothing is ever interpolated into this string.
@@ -181,15 +194,26 @@ def _run_macos(applescript: str) -> PickResult:
     return PickResult(status="ok", path=chosen, detail=None)
 
 
-def pick_directory(title: str) -> PickResult:
-    """Open a native folder picker; return the chosen absolute path."""
+def pick_directory(title: str, *, locale: str = "en") -> PickResult:
+    """Open a native folder picker; return the chosen absolute path.
+
+    ``locale`` selects the baked-in macOS prompt (#228) and must come
+    from the server-side session, never the request body; unknown
+    values fall back to ``en``. Non-darwin ignores it (the localized
+    client ``title`` is shown instead).
+    """
     if _is_macos():
-        return _run_macos(_MACOS_DIR_SCRIPT)
+        return _run_macos(_MACOS_DIR_SCRIPTS.get(locale, _MACOS_DIR_SCRIPTS["en"]))
     return _run([sys.executable, "-c", _SCRIPT, "dir", title])
 
 
-def pick_file(title: str, patterns: tuple[str, ...]) -> PickResult:
-    """Open a native file picker filtered by ``patterns`` (e.g. xlsx)."""
+def pick_file(
+    title: str, patterns: tuple[str, ...], *, locale: str = "en"
+) -> PickResult:
+    """Open a native file picker filtered by ``patterns`` (e.g. xlsx).
+
+    ``locale`` behaves exactly as in :func:`pick_directory`.
+    """
     if _is_macos():
-        return _run_macos(_MACOS_FILE_SCRIPT)
+        return _run_macos(_MACOS_FILE_SCRIPTS.get(locale, _MACOS_FILE_SCRIPTS["en"]))
     return _run([sys.executable, "-c", _SCRIPT, "file", title, *patterns])

--- a/tests/test_web_handlers.py
+++ b/tests/test_web_handlers.py
@@ -289,13 +289,9 @@ class TestSetupBasicMultiAccountGate:
     ONLY in production (``home is None``); a home-injected (sandboxed)
     wizard must never consult the process-global factory."""
 
-    def test_skip_mcp_false_when_home_injected(
-        self, wizard: ConfigureWizard
-    ) -> None:
+    def test_skip_mcp_false_when_home_injected(self, wizard: ConfigureWizard) -> None:
         with (
-            patch(
-                "mureo.web.handlers.runtime_multi_account_auth", return_value=True
-            ),
+            patch("mureo.web.handlers.runtime_multi_account_auth", return_value=True),
             patch(
                 "mureo.web.handlers.install_basic_setup",
                 return_value={"mureo_mcp": {"status": "ok"}},
@@ -336,12 +332,8 @@ class TestServeStatusMultiAccount:
     """#222 — ``GET /api/status`` surfaces ``multi_account_auth`` behind the
     same ``home is None`` gate so the UI can suppress the MCP section."""
 
-    def test_status_false_when_home_injected(
-        self, wizard: ConfigureWizard
-    ) -> None:
-        with patch(
-            "mureo.web.handlers.runtime_multi_account_auth", return_value=True
-        ):
+    def test_status_false_when_home_injected(self, wizard: ConfigureWizard) -> None:
+        with patch("mureo.web.handlers.runtime_multi_account_auth", return_value=True):
             resp = _get(wizard, "/api/status")
         body = json.loads(resp.read().decode("utf-8"))
         assert body["multi_account_auth"] is False
@@ -1613,6 +1605,28 @@ class TestPostPickDirectory:
         body = json.loads(resp.read().decode("utf-8"))
         assert body["status"] == "cancelled"
 
+    def test_forwards_session_locale(self, wizard: ConfigureWizard) -> None:
+        """#228 — the macOS prompt is keyed by the SERVER-side session
+        locale, so the route must forward it to the picker."""
+        wizard.session.set_locale("ja")
+        fake = MagicMock()
+        fake.as_dict.return_value = {"status": "cancelled", "path": None}
+        with patch("mureo.web.handlers.pick_directory", return_value=fake) as mock_pick:
+            _post(wizard, self.ROUTE, {"title": "t"})
+        assert mock_pick.call_args.kwargs["locale"] == "ja"
+
+    def test_request_body_locale_cannot_override_session(
+        self, wizard: ConfigureWizard
+    ) -> None:
+        """A ``locale`` field smuggled into the request body must NOT
+        influence the prompt — only the session locale may."""
+        wizard.session.set_locale("en")
+        fake = MagicMock()
+        fake.as_dict.return_value = {"status": "cancelled", "path": None}
+        with patch("mureo.web.handlers.pick_directory", return_value=fake) as mock_pick:
+            _post(wizard, self.ROUTE, {"title": "t", "locale": "ja"})
+        assert mock_pick.call_args.kwargs["locale"] == "en"
+
     def test_error_envelope_surfaces_as_200(self, wizard: ConfigureWizard) -> None:
         """tkinter-unavailable degrades to an error envelope (UI falls
         back to manual entry), never a 500."""
@@ -1689,6 +1703,28 @@ class TestPostPickFile:
             resp = _post(wizard, self.ROUTE, {"kind": "xlsx"})
         body = json.loads(resp.read().decode("utf-8"))
         assert body["status"] == "cancelled"
+
+    def test_forwards_session_locale(self, wizard: ConfigureWizard) -> None:
+        """#228 — same server-side locale forwarding as the directory
+        route."""
+        wizard.session.set_locale("ja")
+        fake = MagicMock()
+        fake.as_dict.return_value = {"status": "cancelled", "path": None}
+        with patch("mureo.web.handlers.pick_file", return_value=fake) as mock_pick:
+            _post(wizard, self.ROUTE, {"kind": "xlsx"})
+        assert mock_pick.call_args.kwargs["locale"] == "ja"
+
+    def test_request_body_locale_cannot_override_session(
+        self, wizard: ConfigureWizard
+    ) -> None:
+        """Same smuggling guard as the directory route — the file route
+        parses extra body fields (``kind``), so pin it independently."""
+        wizard.session.set_locale("en")
+        fake = MagicMock()
+        fake.as_dict.return_value = {"status": "cancelled", "path": None}
+        with patch("mureo.web.handlers.pick_file", return_value=fake) as mock_pick:
+            _post(wizard, self.ROUTE, {"kind": "xlsx", "locale": "ja"})
+        assert mock_pick.call_args.kwargs["locale"] == "en"
 
     def test_error_envelope_surfaces_as_200(self, wizard: ConfigureWizard) -> None:
         fake = MagicMock()

--- a/tests/test_web_native_picker.py
+++ b/tests/test_web_native_picker.py
@@ -461,3 +461,97 @@ class TestMacOSInvocationShapeAndInjection:
         assert "do shell script" not in script
         assert "xlsx" in script
         assert "xlsm" in script
+
+
+# ---------------------------------------------------------------------------
+# darwin locale-keyed baked prompts (#228) — the prompt catalog grows to
+# en/ja, selected by the SERVER-side session locale, never from the
+# request body. Every prompt stays a hardcoded constant: no client value
+# is ever interpolated, so the zero-injection posture is unchanged.
+# ---------------------------------------------------------------------------
+
+
+def _applescript_of(mock_run: MagicMock) -> str:
+    argv = mock_run.call_args.args[0]
+    return str(argv[argv.index("-e") + 1])
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("darwin")
+class TestMacOSLocaleKeyedPrompts:
+    def test_default_locale_dir_prompt_is_english(self) -> None:
+        mock_run = MagicMock(return_value=_completed(stdout="/a"))
+        with patch("mureo.web.native_picker.subprocess.run", mock_run):
+            native_picker.pick_directory(title="ignored")
+        assert "Select a folder" in _applescript_of(mock_run)
+
+    def test_ja_locale_dir_prompt_is_japanese(self) -> None:
+        mock_run = MagicMock(return_value=_completed(stdout="/a"))
+        with patch("mureo.web.native_picker.subprocess.run", mock_run):
+            native_picker.pick_directory(title="ignored", locale="ja")
+        script = _applescript_of(mock_run)
+        assert "フォルダを選択してください" in script
+        assert "Select a folder" not in script
+
+    def test_default_locale_file_prompt_is_english(self) -> None:
+        mock_run = MagicMock(return_value=_completed(stdout="/a"))
+        with patch("mureo.web.native_picker.subprocess.run", mock_run):
+            native_picker.pick_file(title="ignored", patterns=("*.xlsx",))
+        assert "Select a file" in _applescript_of(mock_run)
+
+    def test_ja_locale_file_prompt_is_japanese_and_keeps_type_list(self) -> None:
+        mock_run = MagicMock(return_value=_completed(stdout="/a"))
+        with patch("mureo.web.native_picker.subprocess.run", mock_run):
+            native_picker.pick_file(title="ignored", patterns=("*.xlsx",), locale="ja")
+        script = _applescript_of(mock_run)
+        assert "ファイルを選択してください" in script
+        assert "xlsx" in script
+        assert "xlsm" in script
+
+    def test_unknown_locale_falls_back_to_english(self) -> None:
+        mock_run = MagicMock(return_value=_completed(stdout="/a"))
+        with patch("mureo.web.native_picker.subprocess.run", mock_run):
+            native_picker.pick_directory(title="ignored", locale="fr")
+        assert "Select a folder" in _applescript_of(mock_run)
+
+    def test_ja_script_is_constant_regardless_of_title(self) -> None:
+        """Per-locale prompts stay baked constants — the osascript body
+        must be byte-identical across calls whatever the client title."""
+        mock_run = MagicMock(return_value=_completed(stdout="/a"))
+        with patch("mureo.web.native_picker.subprocess.run", mock_run):
+            native_picker.pick_directory(title="alpha", locale="ja")
+            native_picker.pick_directory(title="beta-DIFFERENT", locale="ja")
+        first = mock_run.call_args_list[0].args[0]
+        second = mock_run.call_args_list[1].args[0]
+        assert first[first.index("-e") + 1] == second[second.index("-e") + 1]
+
+    def test_hostile_title_never_reaches_ja_applescript(self) -> None:
+        evil = '" & (do shell script "id") & "'
+        mock_run = MagicMock(return_value=_completed(stdout="/a"))
+        with patch("mureo.web.native_picker.subprocess.run", mock_run):
+            native_picker.pick_directory(title=evil, locale="ja")
+            native_picker.pick_file(title=evil, patterns=("*.xlsx",), locale="ja")
+        for call in mock_run.call_args_list:
+            joined = " ".join(str(a) for a in call.args[0])
+            assert evil not in joined
+            assert "do shell script" not in joined
+
+    def test_prompt_catalogs_cover_exactly_en_and_ja(self) -> None:
+        """Both catalogs carry the same locale set as the configure UI
+        (en/ja); ``en`` must exist as the fallback key."""
+        assert set(native_picker._MACOS_DIR_SCRIPTS) == {"en", "ja"}
+        assert set(native_picker._MACOS_FILE_SCRIPTS) == {"en", "ja"}
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("non_darwin")
+class TestLocaleKwargNonDarwin:
+    def test_locale_kwarg_accepted_and_title_still_forwarded(self) -> None:
+        """Non-darwin keeps the tkinter path: ``locale`` is accepted (the
+        callers pass it unconditionally) but the localized client title
+        still travels as a discrete argv element."""
+        mock_run = MagicMock(return_value=_completed(stdout="/a"))
+        with patch("mureo.web.native_picker.subprocess.run", mock_run):
+            result = native_picker.pick_directory(title="フォルダを選択", locale="ja")
+        assert result.status == "ok"
+        assert "フォルダを選択" in mock_run.call_args.args[0]


### PR DESCRIPTION
## Summary

Localizes the macOS native folder/file picker prompts in the configure UI (#228). The prompts were hardcoded English AppleScript constants; they now come from a locale-keyed catalog (en/ja) selected by the **server-side session locale** — the zero-injection design is unchanged.

## Design

- `mureo/web/native_picker.py`: `_MACOS_DIR_SCRIPT` / `_MACOS_FILE_SCRIPT` become `_MACOS_DIR_SCRIPTS` / `_MACOS_FILE_SCRIPTS` dicts keyed `"en"` / `"ja"`. Every prompt stays a hardcoded constant — no client value is ever interpolated into the AppleScript. `pick_directory` / `pick_file` gain a keyword-only `locale: str = "en"`; unknown locales fall back to `en`.
- `mureo/web/handlers.py`: `_post_pick_directory` / `_post_pick_file` forward `locale=self.wizard.session.locale`. The session locale is only settable through `POST /api/locale` with an `{"en","ja"}` allow-list, so the value is provably never client text.
- Non-darwin (tkinter) path is unchanged: it keeps showing the localized client `title`, which already worked.

## Security

The injection posture is unchanged and re-pinned by tests: the osascript `-e` body is byte-identical per locale regardless of the client title, a hostile title never reaches argv on darwin, and a `locale` field smuggled into the request body cannot override the session locale (tested on both routes).

## Test plan

- [x] `tests/test_web_native_picker.py` — `TestMacOSLocaleKeyedPrompts` (en default, ja prompts for dir/file, unknown-locale fallback, constant-per-locale body, hostile-title re-check under ja, catalog key set) + `TestLocaleKwargNonDarwin`
- [x] `tests/test_web_handlers.py` — locale forwarding on both pick routes + body-smuggling negative tests
- [x] 187 tests pass across the two files; ruff + black clean
- [ ] CI green on the PR

Closes #228
