### PR TITLE
fix(web): keep the About mureo tab pinned as the last dashboard nav item

### DIFF
--- a/mureo/_data/web/app.html
+++ b/mureo/_data/web/app.html
@@ -79,14 +79,14 @@
                  data-i18n="dashboard.nav_byod">BYOD</a>
             </li>
             <li>
-              <a href="#" class="dashboard-nav-item" data-dashboard-nav="about"
-                 role="button" tabindex="0"
-                 data-i18n="dashboard.nav_about">About mureo</a>
-            </li>
-            <li>
               <a href="#" class="dashboard-nav-item" data-dashboard-nav="danger"
                  role="button" tabindex="0"
                  data-i18n="dashboard.nav_danger">Danger Zone</a>
+            </li>
+            <li>
+              <a href="#" class="dashboard-nav-item" data-dashboard-nav="about"
+                 role="button" tabindex="0"
+                 data-i18n="dashboard.nav_about">About mureo</a>
             </li>
           </ul>
         </nav>

--- a/mureo/_data/web/extensions.js
+++ b/mureo/_data/web/extensions.js
@@ -2,8 +2,9 @@
 // server (see ``mureo.web.extensions``) as additional dashboard tabs.
 //
 // Each extension with a non-null ``view`` becomes:
-//   * one ``<li><a data-dashboard-nav="ext-<name>">…</a></li>`` appended
-//     to the dashboard nav, sitting after the built-in tabs
+//   * one ``<li><a data-dashboard-nav="ext-<name>">…</a></li>`` inserted
+//     into the dashboard nav after the built-in tabs but BEFORE the
+//     "About mureo" item, which always stays the last tab
 //   * one ``<div class="dashboard-group" data-dashboard-group="ext-<name>"
 //     hidden></div>`` appended to the dashboard pane, populated lazily
 //     on first selection
@@ -175,7 +176,15 @@
       }
     });
     li.appendChild(a);
-    nav.appendChild(li);
+    // Keep "About mureo" pinned as the last tab: extension tabs slot in
+    // before it, however many plugins register one.
+    const aboutAnchor = nav.querySelector('[data-dashboard-nav="about"]');
+    const aboutItem = aboutAnchor ? aboutAnchor.closest("li") : null;
+    if (aboutItem) {
+      nav.insertBefore(li, aboutItem);
+    } else {
+      nav.appendChild(li);
+    }
 
     const group = document.createElement("div");
     group.className = "dashboard-group";

--- a/tests/test_web_about.py
+++ b/tests/test_web_about.py
@@ -10,6 +10,7 @@ so nothing here depends on what is actually installed.
 from __future__ import annotations
 
 import json
+import re
 from importlib.metadata import PackageNotFoundError
 from pathlib import Path
 from typing import Any
@@ -272,6 +273,22 @@ class TestAboutAssets:
     def test_dashboard_js_fetches_about_endpoint(self) -> None:
         js = (_WEB / "dashboard.js").read_text(encoding="utf-8")
         assert "/api/about" in js
+
+    def test_about_is_the_last_static_nav_item(self) -> None:
+        """The About tab must sit at the very bottom of the dashboard
+        nav — below Danger Zone in the static markup."""
+        html = (_WEB / "app.html").read_text(encoding="utf-8")
+        nav_keys = re.findall(r'data-dashboard-nav="([^"]+)"', html)
+        assert nav_keys, "no dashboard nav items found"
+        assert nav_keys[-1] == "about"
+
+    def test_extension_tabs_are_inserted_before_about(self) -> None:
+        """Extension nav items must be inserted BEFORE the About item
+        (not appended at the end of the list), so About stays the last
+        tab even when plugins such as the agency extension add tabs."""
+        js = (_WEB / "extensions.js").read_text(encoding="utf-8")
+        assert 'data-dashboard-nav="about"' in js
+        assert "insertBefore" in js
 
     def test_i18n_has_about_keys_in_both_locales(self) -> None:
         catalog = json.loads((_WEB / "i18n.json").read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary

Follow-up to #229: keep the "About mureo" tab pinned as the **last** dashboard nav item, even when web-extension plugins (e.g. the agency extension) register their own tabs.

Previously the static nav order was setup/demo/byod/**about**/danger and extension tabs were appended at the end of the nav list, so any installed plugin tab landed *below* About.

## Changes

- `mureo/_data/web/app.html`: static nav order is now setup / demo / byod / danger / **about**.
- `mureo/_data/web/extensions.js`: `_renderNavItem` inserts extension tabs **before** the About item (`nav.insertBefore(li, aboutItem)` via `closest("li")` on the `[data-dashboard-nav="about"]` anchor), falling back to the previous `appendChild` when the About item is absent. Extension tabs therefore slot between Danger Zone and About, however many plugins register one.
- `tests/test_web_about.py`: two new static pins — the last `data-dashboard-nav` key in `app.html` is `about`, and `extensions.js` carries the about-anchored `insertBefore` wiring.

No nav-order-dependent code exists elsewhere (verified: no `:last-child`/`nextSibling`/index-based selectors target the dashboard nav; `BUILTIN_TABS` and `DEFAULT_NAV` are position-independent). DOM order now matches visual order, so keyboard Tab reaches About last as well.

## Test plan

- [x] `tests/test_web_about.py` — 17 pass (incl. the two new order pins, TDD red→green)
- [x] 216 pass across test_web_about / test_web_handlers / test_web_static_serving / test_web_no_framework; ruff + black clean
- [ ] CI green on the PR
