### PR TITLE
fix(configure): re-assert cooked terminal mode every tick during the wait loop

### DIFF
--- a/mureo/web/server.py
+++ b/mureo/web/server.py
@@ -15,6 +15,7 @@ import logging
 import signal
 import socketserver
 import threading
+import time
 import webbrowser
 from importlib import resources
 from pathlib import Path
@@ -28,6 +29,12 @@ from mureo.web.oauth_bridge import OAuthBridge
 from mureo.web.session import ConfigureSession
 
 logger = logging.getLogger(__name__)
+
+# #227: how often the configure wait loop re-asserts cooked mode on the
+# controlling TTY. A leaked raw mode mid-session is healed within one
+# tick; the tcgetattr/tcsetattr pair costs microseconds, so a 1s cadence
+# is imperceptible. Tests shrink this to exercise the loop quickly.
+_COOKED_REASSERT_SECONDS = 1.0
 
 
 def _resolve_static_dir() -> Path:
@@ -253,9 +260,20 @@ def run_configure_wizard(
         # with ISIG off — Ctrl+C then never generates SIGINT, so _on_signal
         # never fires and the operator is stranded with a dead terminal
         # (no echo) for the full timeout. Force cooked mode before blocking
-        # so Ctrl+C reliably delivers the stop signal. No-op on a non-TTY.
-        force_cooked_mode(terminal_fd())
-        wizard.stop_event.wait(timeout=timeout_seconds)
+        # so Ctrl+C reliably delivers the stop signal, and RE-assert it on
+        # every tick: a configure action handled on the HTTP thread can
+        # run plugin code that re-flips the TTY to raw while we are
+        # already blocked here, which a one-shot fix cannot recover from.
+        # No-op on a non-TTY either way.
+        fd = terminal_fd()
+        force_cooked_mode(fd)
+        deadline = time.monotonic() + timeout_seconds
+        while not wizard.stop_event.is_set():
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            wizard.stop_event.wait(timeout=min(_COOKED_REASSERT_SECONDS, remaining))
+            force_cooked_mode(fd)
     except KeyboardInterrupt:
         # Belt-and-braces: if a KeyboardInterrupt still surfaces (e.g.
         # the handler could not be installed), treat it as a stop.

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -210,7 +210,29 @@ class TestRunConfigureWizardCli:
                 open_browser=False,
                 timeout_seconds=0.2,
             )
-        mock_cooked.assert_called_once()
+        assert mock_cooked.call_count >= 1
+
+    def test_reasserts_cooked_mode_during_wait(
+        self, home_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """#227 follow-up: a server-side action (a leaked menu in a
+        third-party backend) can re-flip the TTY to raw *while* the main
+        thread is already blocked on the stop event — a one-shot pre-wait
+        fix cannot recover Ctrl+C then. The wait must re-assert cooked
+        mode on every tick so a mid-session leak self-heals."""
+        monkeypatch.setattr("mureo.web.server._COOKED_REASSERT_SECONDS", 0.05)
+        with (
+            patch("mureo.web.server.webbrowser.open"),
+            patch("mureo.web.server.force_cooked_mode") as mock_cooked,
+        ):
+            run_configure_wizard(
+                home=home_dir,
+                open_browser=False,
+                timeout_seconds=0.4,
+            )
+        # Initial assert plus one per ~0.05s tick over a 0.4s wait; allow
+        # generous scheduling slack but require clearly more than one-shot.
+        assert mock_cooked.call_count >= 4
 
     def test_opens_browser_when_requested(self, home_dir: Path) -> None:
         with patch("mureo.web.server.webbrowser.open") as mock_open:


### PR DESCRIPTION
## Summary

Follow-up to #227 (PR #230): Ctrl+C could still go dead **during** a configure session. The merged fix forced cooked mode once before blocking on the stop event, but a configure action handled on the HTTP thread can run plugin code that re-flips the TTY into raw mode (ISIG off) *while* the main thread is already blocked — a one-shot pre-wait fix cannot recover from that, and the operator is stranded again. Reproduced in the field right after using the configure UI.

## Fix

`run_configure_wizard` now re-asserts cooked mode on a 1-second cadence instead of once: the single `stop_event.wait(timeout_seconds)` becomes a deadline-bounded loop that waits in `min(_COOKED_REASSERT_SECONDS, remaining)` slices and calls `force_cooked_mode(fd)` every tick. Any mid-session raw-mode leak self-heals within one tick, so Ctrl+C reliably delivers SIGINT for the whole session.

Properties (review-verified):
- Stop responsiveness unchanged: `stop_event.wait` returns immediately when `/api/shutdown` or the signal handler sets the event — no full-tick delay.
- Timeout never overshoots: deadline computed once from `time.monotonic()`; the final slice is clamped to the residual; `timeout_seconds <= 0` exits without spinning.
- The per-tick `tcgetattr`/`tcsetattr` pair costs microseconds and is OR-only (never clears bits), so an already-cooked terminal is untouched; non-TTY stdin stays a no-op.

## Verification

Real-pty end-to-end repro: spawn the wizard on a pty, flip the pty to raw (ISIG/ICANON/ECHO cleared) from another thread mid-wait, send `\x03` after >1 tick — SIGINT is delivered, the stop handler fires, and the wizard shuts down cleanly.

## Test plan

- [x] `tests/test_web_server.py` — new `test_reasserts_cooked_mode_during_wait` (shrinks the tick to 0.05s, asserts ≥4 force calls over a 0.4s wait; the mock is what is counted, so the loop is exercised identically on Windows); existing one-shot test relaxed to ≥1
- [x] 30 tests pass in test_web_server.py; ruff + black clean
- [ ] CI green on the PR
