### PR TITLE
fix(adapters): add ja translations to built-in Google/Meta account credential field labels (#237)

### DIFF
--- a/mureo/adapters/google_ads/adapter.py
+++ b/mureo/adapters/google_ads/adapter.py
@@ -134,6 +134,16 @@ class GoogleAdsAdapter:
                 "10-digit Google Ads customer ID (with or without dashes). "
                 "Find it in the Google Ads UI top-right corner."
             ),
+            # #237: ja translations via the #186 i18n hooks, same as
+            # plugin-declared fields. ``display_name`` stays the en
+            # fallback in the resolution chain.
+            display_name_i18n={"ja": "カスタマー ID"},
+            description_i18n={
+                "ja": (
+                    "10 桁の Google 広告カスタマー ID（ダッシュ有無は問いません）。"
+                    "Google 広告の管理画面右上で確認できます。"
+                ),
+            },
         ),
         AccountCredentialField(
             key="login_customer_id",
@@ -149,6 +159,17 @@ class GoogleAdsAdapter:
                 "populated automatically from the ``parent_id`` field "
                 "returned by ``mureo.google_ads.list_accessible_accounts``."
             ),
+            display_name_i18n={"ja": "ログインカスタマー ID（MCC）"},
+            description_i18n={
+                "ja": (
+                    "このアカウントの Google Ads API 呼び出しで "
+                    "``login_customer_id`` に使う MCC（マネージャー）アカウントの "
+                    "ID。空欄の場合は運用全体の MCC 既定値を継承します。対象の "
+                    "``customer_id`` が既定とは異なる MCC 配下にある場合のみ設定"
+                    "してください（通常はアカウント一覧の ``parent_id`` から自動"
+                    "設定されます）。"
+                ),
+            },
         ),
     )
 

--- a/mureo/adapters/meta_ads/adapter.py
+++ b/mureo/adapters/meta_ads/adapter.py
@@ -159,6 +159,15 @@ class MetaAdsAdapter:
                 "Meta ad account ID prefixed with ``act_``. "
                 "Find it in Meta Ads Manager > Account Settings."
             ),
+            # #237: ja translations via the #186 i18n hooks, same as
+            # plugin-declared fields.
+            display_name_i18n={"ja": "広告アカウント ID"},
+            description_i18n={
+                "ja": (
+                    "``act_`` で始まる Meta 広告アカウント ID。"
+                    "Meta 広告マネージャの「アカウント設定」で確認できます。"
+                ),
+            },
         ),
     )
 

--- a/tests/adapters/google_ads/test_adapter.py
+++ b/tests/adapters/google_ads/test_adapter.py
@@ -1216,3 +1216,21 @@ def test_create_campaign_passes_amount_micros_directly(
     # No float ``amount`` fallback when micros are available — the two
     # keys are mutually exclusive per client contract.
     assert "amount" not in sent_params
+
+
+def test_account_credential_fields_carry_ja_translations() -> None:
+    """#237: the built-in fields must localize in the Japanese configure
+    UI exactly like plugin-declared fields do — via the #186 i18n hooks,
+    with ``display_name`` kept as the English fallback."""
+    fields = GoogleAdsAdapter.account_credential_fields  # type: ignore[attr-defined]
+    by_key = {f.key: f for f in fields}
+
+    customer = by_key["customer_id"]
+    assert customer.display_name_i18n["ja"] == "カスタマー ID"
+    assert customer.display_name == "Customer ID"
+    assert customer.description_i18n["ja"]
+
+    login = by_key["login_customer_id"]
+    assert login.display_name_i18n["ja"] == "ログインカスタマー ID（MCC）"
+    assert login.display_name == "Login Customer ID (MCC)"
+    assert login.description_i18n["ja"]

--- a/tests/adapters/meta_ads/test_adapter.py
+++ b/tests/adapters/meta_ads/test_adapter.py
@@ -1176,3 +1176,15 @@ def test_adapter_does_not_advertise_keyword_or_extension_methods(
         assert not hasattr(
             adapter, method_name
         ), f"{method_name} must NOT be defined (Meta has no counterpart)"
+
+
+def test_account_credential_fields_carry_ja_translations() -> None:
+    """#237: the built-in ``account_id`` field must localize in the
+    Japanese configure UI exactly like plugin-declared fields do."""
+    fields = MetaAdsAdapter.account_credential_fields  # type: ignore[attr-defined]
+    by_key = {f.key: f for f in fields}
+
+    account = by_key["account_id"]
+    assert account.display_name_i18n["ja"] == "広告アカウント ID"
+    assert account.display_name == "Ad Account ID"
+    assert account.description_i18n["ja"]


### PR DESCRIPTION
## Summary

In the Japanese configure UI, the built-in Google Ads / Meta Ads per-account field labels stayed English ("Customer ID", "Login Customer ID (MCC)", "Ad Account ID") while plugin-declared fields localize. The built-in `AccountCredentialField` declarations simply never used the #186 i18n hooks.

## Changes

Adds `display_name_i18n` / `description_i18n` `{"ja": ...}` maps to the three built-in declarations, exactly per the issue's table:

| key | ja label |
|---|---|
| `customer_id` | カスタマー ID |
| `login_customer_id` | ログインカスタマー ID（MCC） |
| `account_id` | 広告アカウント ID |

Japanese descriptions are faithful translations of the English hints (review-verified: the `login_customer_id` semantics — MCC header use, blank-inherits-default, parent_id auto-population — carry over without drift). No consumer changes: the locale-resolved discovery path (`i18n[locale] → i18n["en"] → display_name`) already picks these up, and `en` keeps resolving to the bare `display_name`.

## Test plan

- [x] `tests/adapters/google_ads/test_adapter.py` / `tests/adapters/meta_ads/test_adapter.py` — new pins for the exact ja labels, unchanged en fallback, non-empty ja descriptions (non-empty matters: the resolver treats `""` as undeclared)
- [x] 229 tests pass across tests/adapters + plugin-credentials suites; ruff + black clean
- [ ] CI green on the PR

Closes #237
