### PR TITLE
feat(configure): localize provider credential section headings via display_name_i18n (#236)

### DIFF
--- a/mureo/core/providers/base.py
+++ b/mureo/core/providers/base.py
@@ -99,6 +99,16 @@ class BaseProvider(Protocol):
       the attribute behave as before — tooling assumes "no
       per-account fields" (operator-shared credentials are the entire
       credential set).
+
+    * ``display_name_i18n: Mapping[str, str]`` — optional BCP-47 →
+      localized heading map for the provider's configure section title
+      (#236). The configure UI resolves the section heading as
+      ``i18n[locale] → i18n["en"] → display_name`` (the same fallback
+      chain as the per-field ``display_name_i18n`` from #186). Providers
+      that omit it keep the bare ``display_name`` in every locale, so
+      this is fully backward-compatible. Example: a Yahoo! JAPAN Ads
+      bridge can show ``Yahoo! JAPAN 広告（検索）`` under a ``ja`` locale
+      while keeping ``Yahoo! JAPAN Ads (Search)`` as the ``en`` default.
     """
 
     name: str

--- a/mureo/web/plugin_credentials.py
+++ b/mureo/web/plugin_credentials.py
@@ -27,6 +27,7 @@ sensitive, and the configure-UI layer honours it.
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
 from mureo.core.providers import (
@@ -37,7 +38,7 @@ from mureo.core.providers import (
 from mureo.core.secret_store import FilesystemSecretStore, SecretStore
 
 if TYPE_CHECKING:
-    from collections.abc import Collection, Mapping
+    from collections.abc import Collection
 
     from mureo.core.providers.credentials import AccountCredentialField
 
@@ -135,7 +136,14 @@ def list_plugin_credential_fields(
         result.append(
             {
                 "provider_name": entry.name,
-                "display_name": entry.display_name,
+                # #236 — locale-resolve the section heading from an optional
+                # provider-declared ``display_name_i18n`` (read defensively;
+                # plugins that omit it keep the bare ``display_name`` in
+                # every locale). Same fallback chain as field labels (#186):
+                # ``i18n[locale] → i18n['en'] → display_name``.
+                "display_name": _resolve_localized(
+                    _heading_i18n(entry.provider_class), entry.display_name, locale
+                ),
                 "fields": [_field_to_dict(f, locale) for f in fields],
                 # OAuth descriptor (#201) — field *keys* only, never
                 # secret values; ``None`` for manual-entry providers so
@@ -346,6 +354,19 @@ def _field_to_dict(field: AccountCredentialField, locale: str) -> dict[str, Any]
             field.description_i18n, field.description, locale
         ),
     }
+
+
+def _heading_i18n(provider_class: type) -> Mapping[str, str]:
+    """Return a provider's optional ``display_name_i18n`` map (#236).
+
+    Read defensively via ``getattr`` so the provider Protocol body stays
+    stable (same convention as ``account_credential_fields``). A provider
+    that omits the attribute — or declares a non-Mapping by mistake —
+    yields an empty map, so :func:`_resolve_localized` falls straight
+    through to the bare ``display_name``.
+    """
+    candidate = getattr(provider_class, "display_name_i18n", None)
+    return candidate if isinstance(candidate, Mapping) else {}
 
 
 def _resolve_localized(i18n: Mapping[str, str], fallback: str, locale: str) -> str:

--- a/tests/test_web_plugin_credentials.py
+++ b/tests/test_web_plugin_credentials.py
@@ -42,6 +42,7 @@ def _make_class(
     *,
     fields: tuple[AccountCredentialField, ...] = (),
     display_name: str | None = None,
+    display_name_i18n: dict[str, str] | None = None,
     oauth: Any = None,
 ) -> type:
     """Build a minimal provider class with the requested credential fields.
@@ -49,6 +50,9 @@ def _make_class(
     ``oauth`` (an ``AccountOAuthConfig``) is attached as
     ``account_oauth`` only when supplied, so a manual-entry provider keeps
     no such attribute (``get_account_oauth_config`` → ``None``).
+    ``display_name_i18n`` (#236) is attached only when supplied, so a
+    provider that omits it keeps no such attribute (heading falls back to
+    ``display_name``).
     """
 
     class _Fake:
@@ -58,6 +62,8 @@ def _make_class(
     _Fake.display_name = display_name or name  # type: ignore[attr-defined]
     _Fake.capabilities = frozenset()  # type: ignore[attr-defined]
     _Fake.account_credential_fields = fields  # type: ignore[attr-defined]
+    if display_name_i18n is not None:
+        _Fake.display_name_i18n = display_name_i18n  # type: ignore[attr-defined]
     if oauth is not None:
         _Fake.account_oauth = oauth  # type: ignore[attr-defined]
     return _Fake
@@ -81,9 +87,16 @@ def _entry(
     *,
     fields: tuple[AccountCredentialField, ...] = (),
     display_name: str | None = None,
+    display_name_i18n: dict[str, str] | None = None,
     oauth: Any = None,
 ) -> ProviderEntry:
-    cls = _make_class(name, fields=fields, display_name=display_name, oauth=oauth)
+    cls = _make_class(
+        name,
+        fields=fields,
+        display_name=display_name,
+        display_name_i18n=display_name_i18n,
+        oauth=oauth,
+    )
     return ProviderEntry(
         name=name,
         display_name=display_name or name,
@@ -132,6 +145,97 @@ def test_list_skips_providers_without_account_credential_fields(
     result = list_plugin_credential_fields()
     names = [r["provider_name"] for r in result]
     assert names == ["with_fields"]
+
+
+@pytest.mark.unit
+def test_heading_localized_when_provider_declares_display_name_i18n(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#236 — a provider declaring ``display_name_i18n`` gets a locale-
+    resolved section heading (same fallback as field labels, #186)."""
+    from mureo.web.plugin_credentials import list_plugin_credential_fields
+
+    _register(
+        monkeypatch,
+        [
+            _entry(
+                "yahoo_search",
+                display_name="Yahoo! JAPAN Ads (Search)",
+                display_name_i18n={"ja": "Yahoo! JAPAN 広告（検索）"},
+                fields=(
+                    AccountCredentialField(key="account_id", display_name="Account ID"),
+                ),
+            ),
+        ],
+    )
+
+    ja = list_plugin_credential_fields(locale="ja")
+    assert ja[0]["display_name"] == "Yahoo! JAPAN 広告（検索）"
+    en = list_plugin_credential_fields(locale="en")
+    assert en[0]["display_name"] == "Yahoo! JAPAN Ads (Search)"
+
+
+@pytest.mark.unit
+def test_heading_falls_back_to_display_name_without_i18n(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A provider that omits ``display_name_i18n`` keeps the bare
+    ``display_name`` in every locale (regression-free)."""
+    from mureo.web.plugin_credentials import list_plugin_credential_fields
+
+    _register(
+        monkeypatch,
+        [
+            _entry(
+                "plain",
+                display_name="Plain Ads",
+                fields=(
+                    AccountCredentialField(key="account_id", display_name="Account ID"),
+                ),
+            ),
+        ],
+    )
+
+    assert list_plugin_credential_fields(locale="ja")[0]["display_name"] == "Plain Ads"
+    assert list_plugin_credential_fields(locale="en")[0]["display_name"] == "Plain Ads"
+
+
+@pytest.mark.unit
+def test_heading_unknown_locale_falls_back_to_en_then_display_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unknown locale resolves ``i18n['en']`` if present, else the bare
+    ``display_name`` — matching the field-label fallback chain (#186)."""
+    from mureo.web.plugin_credentials import list_plugin_credential_fields
+
+    _register(
+        monkeypatch,
+        [
+            _entry(
+                "with_en",
+                display_name="Bare",
+                display_name_i18n={"en": "English Heading"},
+                fields=(
+                    AccountCredentialField(key="account_id", display_name="Account ID"),
+                ),
+            ),
+            _entry(
+                "ja_only",
+                display_name="Bare JA-only",
+                display_name_i18n={"ja": "日本語のみ"},
+                fields=(
+                    AccountCredentialField(key="account_id", display_name="Account ID"),
+                ),
+            ),
+        ],
+    )
+
+    result = {
+        r["provider_name"]: r["display_name"]
+        for r in list_plugin_credential_fields(locale="fr")
+    }
+    assert result["with_en"] == "English Heading"
+    assert result["ja_only"] == "Bare JA-only"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

Closes #236. Localizes the **provider section heading** in the configure UI's Plugin credentials list — the follow-up #186/#187 explicitly deferred (it localized per-field labels but left the provider group heading English). Same mechanism as the per-field `display_name_i18n` (#186) and the built-in field translations (#237), applied at the heading level.

Example (`mureo-lineyahoo-bridge`): the section heading can now render `Yahoo! JAPAN 広告（検索）` / `（ディスプレイ）` under a `ja` locale while keeping `Yahoo! JAPAN Ads (Search)` / `(Display)` as the `en` default.

## Design

- A provider may declare an optional class attribute `display_name_i18n: Mapping[str, str]` (BCP-47 → localized heading). `list_plugin_credential_fields(locale)` resolves the heading through the **same** `_resolve_localized` helper used for field labels — fallback chain `i18n[locale] → i18n["en"] → display_name`.
- New `_heading_i18n(provider_class)` reads the attribute defensively (`getattr` + `isinstance(Mapping)`), so a provider that omits it — or declares a wrong type — yields `{}` and falls straight through to the bare `display_name`. **Fully backward-compatible**: providers without the attribute behave exactly as before, in every locale.
- Documented on the `BaseProvider` Protocol as an optional class attribute (same convention as `account_credential_fields`).
- No UI change: `handlers.py` already forwards the session locale to `list_plugin_credential_fields`, and `dashboard.js` renders the heading via `textContent` (no XSS). The heading localizes end-to-end automatically.

This is the OSS mechanism ("OSS = mechanism, plugin = values"); the agency overlay consumes it the same way and is out of scope here.

## Test plan

- [x] `tests/test_web_plugin_credentials.py` — localized heading (ja hit + en fallback), regression-free fallback when the provider omits `display_name_i18n`, unknown-locale → en → display_name matrix
- [x] 31 plugin-credential tests pass (+ field-scope/handlers suites, no regressions); mypy + ruff + black clean
- [ ] CI green on the PR

Closes #236.
