### PR TITLE
fix(configure): non-blocking /api/updates + periodic update poll for the always-on service

### DIFF
--- a/mureo/web/handlers.py
+++ b/mureo/web/handlers.py
@@ -108,7 +108,7 @@ from mureo.web.setup_actions import (
 )
 from mureo.web.status_collector import collect_status
 from mureo.web.upgrade_action import run_upgrade_all
-from mureo.web.version_check import check_for_updates
+from mureo.web.version_check import get_update_status
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Collection, Mapping
@@ -330,7 +330,9 @@ class ConfigureHandler(BaseHTTPRequestHandler):
             # #239 — available mureo/plugin updates (pip-derived). Read-
             # only and fault-isolated (never raises), so the Host-header
             # gate alone suffices like every other GET JSON endpoint.
-            send_json(self, check_for_updates())
+            # Non-blocking: the slow pip check runs in a daemon thread and
+            # its result is cached, so this handler never blocks (#244).
+            send_json(self, get_update_status())
             return
         if path == "/api/extensions":
             self._serve_extensions_index()

--- a/mureo/web/server.py
+++ b/mureo/web/server.py
@@ -28,6 +28,10 @@ from mureo.web.host_paths import HostPaths, get_host_paths
 from mureo.web.instance import probe_mureo_instance, write_state_file
 from mureo.web.oauth_bridge import OAuthBridge
 from mureo.web.session import ConfigureSession
+from mureo.web.version_check import (
+    start_periodic_update_check,
+    stop_periodic_update_check,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -333,6 +337,12 @@ def run_configure_wizard(
         with contextlib.suppress(Exception):
             webbrowser.open(url)
 
+    # #244: only the always-on service (``serve_forever``) polls for updates
+    # in the background. A short-lived interactive launch relies on the lazy
+    # check that fires when the UI is opened, so it never spawns a poller.
+    if serve_forever:
+        start_periodic_update_check()
+
     # Stop the moment the user finishes (UI POSTs /api/shutdown ->
     # request_stop), presses Ctrl+C (SIGINT) or the process is asked to
     # terminate (SIGTERM); fall back to timeout_seconds as a hard cap.
@@ -384,6 +394,8 @@ def run_configure_wizard(
         # the handler could not be installed), treat it as a stop.
         pass
     finally:
+        if serve_forever:
+            stop_periodic_update_check()
         for signum, prev in prev_handlers:
             with contextlib.suppress(ValueError, OSError):
                 signal.signal(signum, prev)  # type: ignore[arg-type]

--- a/mureo/web/version_check.py
+++ b/mureo/web/version_check.py
@@ -242,8 +242,9 @@ def get_update_status() -> dict[str, Any]:
     now = time.monotonic()
     with _cache_lock:
         cached = _cached_result
-        fresh = cached is not None and (now - _cached_at_monotonic) < _ttl_for(cached)
-        if fresh:
+        # Inline ``cached is not None`` (rather than via a ``fresh`` flag) so the
+        # type checker narrows ``cached`` to a dict in the return below.
+        if cached is not None and (now - _cached_at_monotonic) < _ttl_for(cached):
             return dict(cached)
         start_refresh = not _refresh_in_progress
         if start_refresh:

--- a/mureo/web/version_check.py
+++ b/mureo/web/version_check.py
@@ -87,9 +87,7 @@ def _run_pip_outdated() -> str | None:
     except subprocess.TimeoutExpired:
         # Expected on a slow / unreachable index — not a bug. Log one line,
         # not a multi-line traceback that scares the operator on the console.
-        logger.warning(
-            "pip list --outdated timed out after %ss", _PIP_TIMEOUT_SECONDS
-        )
+        logger.warning("pip list --outdated timed out after %ss", _PIP_TIMEOUT_SECONDS)
         return None
     except OSError as exc:
         logger.warning("pip list --outdated could not run: %s", exc)

--- a/mureo/web/version_check.py
+++ b/mureo/web/version_check.py
@@ -16,6 +16,14 @@ HTTP client of our own.
 Fault isolation: any pip failure (non-zero exit, timeout, network down,
 unparseable JSON, OS error) degrades to ``status="error"`` with
 ``any_update=False``. This function NEVER raises and NEVER produces a 500.
+
+Non-blocking accessor: HTTP handlers must call :func:`get_update_status`,
+NOT :func:`check_for_updates` directly. ``pip list --outdated`` reaches
+the configured index and can take up to ``_PIP_TIMEOUT_SECONDS`` on a slow
+or unreachable network. Running it inline on every request blocks the
+request thread for that long — and the configure UI fetches ``/api/updates``
+more than once per page load — so the slow check is run once in a daemon
+thread and its result cached; the handler returns instantly.
 """
 
 from __future__ import annotations
@@ -24,6 +32,8 @@ import json
 import logging
 import subprocess
 import sys
+import threading
+import time
 from typing import Any, Final
 
 from mureo.cli.upgrade_cmd import _canonicalise, _is_mureo_package
@@ -33,6 +43,24 @@ logger = logging.getLogger(__name__)
 #: Hard ceiling on the pip subprocess so a hung index never blocks the
 #: dashboard's background check.
 _PIP_TIMEOUT_SECONDS: Final[int] = 60
+
+#: How long a successful check stays fresh. The package index rarely moves
+#: within a single configure session, so re-running the slow pip query on
+#: every page load buys nothing.
+_OK_TTL_SECONDS: Final[int] = 6 * 60 * 60
+
+#: A failed check (timeout / offline) is retried far sooner than a success,
+#: but not on every request — otherwise a slow index would spawn a fresh
+#: 60s pip run for each ``/api/updates`` fetch.
+_ERROR_TTL_SECONDS: Final[int] = 10 * 60
+
+#: Returned on a cold cache while the first background check is still in
+#: flight. The frontend treats any non-``ok`` status as "nothing to show".
+_CHECKING_RESULT: Final[dict[str, Any]] = {
+    "status": "checking",
+    "any_update": False,
+    "packages": [],
+}
 
 
 def _error_result() -> dict[str, Any]:
@@ -56,8 +84,15 @@ def _run_pip_outdated() -> str | None:
             check=False,
             timeout=_PIP_TIMEOUT_SECONDS,
         )
-    except (subprocess.TimeoutExpired, OSError):
-        logger.exception("pip list --outdated failed to run")
+    except subprocess.TimeoutExpired:
+        # Expected on a slow / unreachable index — not a bug. Log one line,
+        # not a multi-line traceback that scares the operator on the console.
+        logger.warning(
+            "pip list --outdated timed out after %ss", _PIP_TIMEOUT_SECONDS
+        )
+        return None
+    except OSError as exc:
+        logger.warning("pip list --outdated could not run: %s", exc)
         return None
     if proc.returncode != 0:
         logger.warning(
@@ -129,4 +164,95 @@ def check_for_updates() -> dict[str, Any]:
     }
 
 
-__all__ = ["check_for_updates"]
+# --- Non-blocking cache layer ------------------------------------------------
+#
+# ``check_for_updates`` shells out to pip and can block for up to
+# ``_PIP_TIMEOUT_SECONDS``. The HTTP handler must never pay that cost inline,
+# so the slow check runs in a daemon thread and its envelope is cached. The
+# server is threaded, hence the lock around the shared cache state.
+
+_cache_lock = threading.Lock()
+_cached_result: dict[str, Any] | None = None
+_cached_at_monotonic: float = 0.0
+_refresh_in_progress: bool = False
+#: Last spawned worker — exposed only so tests (and a future graceful
+#: shutdown) can join the background check deterministically.
+_refresh_thread: threading.Thread | None = None
+
+
+def _ttl_for(result: dict[str, Any]) -> int:
+    """A success is cached far longer than a transient failure."""
+
+    return _OK_TTL_SECONDS if result.get("status") == "ok" else _ERROR_TTL_SECONDS
+
+
+def _refresh_updates() -> None:
+    """Background worker: run the slow pip check and cache its result."""
+
+    global _cached_result, _cached_at_monotonic, _refresh_in_progress
+    try:
+        result = check_for_updates()
+    except Exception:  # noqa: BLE001 — a daemon thread must never die loudly;
+        # check_for_updates is contracted not to raise, this is belt-and-braces.
+        logger.warning("background update check failed unexpectedly", exc_info=True)
+        result = _error_result()
+    with _cache_lock:
+        _cached_result = result
+        _cached_at_monotonic = time.monotonic()
+        _refresh_in_progress = False
+
+
+def get_update_status() -> dict[str, Any]:
+    """Non-blocking accessor for ``GET /api/updates``.
+
+    Returns the cached envelope instantly so the request thread NEVER blocks
+    on pip. On a cold or stale cache a single background refresh is started
+    and the last-known result is returned — or the ``checking`` placeholder
+    on a cold start. Shape matches :func:`check_for_updates`.
+    """
+
+    global _refresh_in_progress, _refresh_thread
+    now = time.monotonic()
+    with _cache_lock:
+        cached = _cached_result
+        fresh = cached is not None and (now - _cached_at_monotonic) < _ttl_for(cached)
+        if fresh:
+            return dict(cached)
+        start_refresh = not _refresh_in_progress
+        if start_refresh:
+            _refresh_in_progress = True
+    if start_refresh:
+        worker = threading.Thread(
+            target=_refresh_updates, name="mureo-update-check", daemon=True
+        )
+        try:
+            worker.start()
+        except RuntimeError:
+            # Interpreter shutting down / out of threads. Clear the flag so a
+            # later request can retry instead of being wedged forever.
+            with _cache_lock:
+                _refresh_in_progress = False
+                _refresh_thread = None
+            logger.warning("could not start background update check")
+        else:
+            with _cache_lock:
+                _refresh_thread = worker
+    # Return a copy: a caller that mutates the result must never corrupt the
+    # shared cache (read by other request threads). Shallow is enough — the
+    # payload is read-only output. ``packages`` stays shared by reference.
+    return dict(cached) if cached is not None else dict(_CHECKING_RESULT)
+
+
+def _reset_update_cache() -> None:
+    """Test-only: clear cached state between cases (module globals persist)."""
+
+    global _cached_result, _cached_at_monotonic, _refresh_in_progress
+    global _refresh_thread
+    with _cache_lock:
+        _cached_result = None
+        _cached_at_monotonic = 0.0
+        _refresh_in_progress = False
+        _refresh_thread = None
+
+
+__all__ = ["check_for_updates", "get_update_status"]

--- a/mureo/web/version_check.py
+++ b/mureo/web/version_check.py
@@ -30,6 +30,8 @@ from __future__ import annotations
 
 import json
 import logging
+import math
+import os
 import subprocess
 import sys
 import threading
@@ -61,6 +63,17 @@ _CHECKING_RESULT: Final[dict[str, Any]] = {
     "any_update": False,
     "packages": [],
 }
+
+#: Env override for the always-on service's background poll cadence, in
+#: seconds. ``0`` or negative disables periodic polling; unset uses the
+#: default. A wide cadence is fine — the index moves at most a few times a day.
+_POLL_INTERVAL_ENV: Final[str] = "MUREO_UPDATE_CHECK_INTERVAL_SECONDS"
+
+#: Default poll cadence: every 6h, aligned with ``_OK_TTL_SECONDS`` so the
+#: cache is kept warm. At the exact tick/expiry boundary a UI hit may still
+#: land on a momentarily-stale entry — the lazy refresh in ``get_update_status``
+#: covers that window.
+_DEFAULT_POLL_INTERVAL_SECONDS: Final[int] = 6 * 60 * 60
 
 
 def _error_result() -> dict[str, Any]:
@@ -200,6 +213,22 @@ def _refresh_updates() -> None:
         _refresh_in_progress = False
 
 
+def _refresh_if_idle() -> None:
+    """Run the check inline now, unless one is already in flight.
+
+    Used by the periodic poller: it owns a daemon thread to block in, so it
+    refreshes on that thread rather than spawning another worker. Honours the
+    same single-flight gate as the lazy path so the two never double-run.
+    """
+
+    global _refresh_in_progress
+    with _cache_lock:
+        if _refresh_in_progress:
+            return
+        _refresh_in_progress = True
+    _refresh_updates()  # clears _refresh_in_progress when done
+
+
 def get_update_status() -> dict[str, Any]:
     """Non-blocking accessor for ``GET /api/updates``.
 
@@ -241,11 +270,122 @@ def get_update_status() -> dict[str, Any]:
     return dict(cached) if cached is not None else dict(_CHECKING_RESULT)
 
 
+# --- Periodic poll (always-on service) ---------------------------------------
+#
+# When `mureo configure` runs as a long-lived service (`--serve` / launchd /
+# systemd), nothing opens the UI to trigger the lazy check. This poller warms
+# the cache on a wide cadence so an operator who opens the dashboard later sees
+# an up-to-date badge immediately, without the request ever touching pip.
+
+# Each launch gets its OWN stop event, captured at start and passed into the
+# loop, so a stop/start race can never make a new poller exit early or leave an
+# old one running (a single module-level event would alias across generations).
+_poll_lock = threading.Lock()
+_poll_thread: threading.Thread | None = None
+_poll_stop: threading.Event | None = None
+
+
+def _resolve_poll_interval(explicit: float | None) -> float:
+    """Interval in seconds: explicit arg → env → default.
+
+    A non-finite env value (``nan`` / ``inf``) is treated as invalid so it can
+    never produce a degenerate ``Event.wait()`` timeout.
+    """
+
+    if explicit is not None:
+        return explicit
+    raw = os.environ.get(_POLL_INTERVAL_ENV)
+    if raw is None or not raw.strip():
+        return _DEFAULT_POLL_INTERVAL_SECONDS
+    try:
+        value = float(raw)
+        if not math.isfinite(value):
+            raise ValueError(raw)
+    except ValueError:
+        logger.warning(
+            "invalid %s=%r; using default %ss",
+            _POLL_INTERVAL_ENV,
+            raw,
+            _DEFAULT_POLL_INTERVAL_SECONDS,
+        )
+        return _DEFAULT_POLL_INTERVAL_SECONDS
+    return value
+
+
+def _poll_loop(interval: float, stop_event: threading.Event) -> None:
+    """Warm the cache now, then once per ``interval`` until ``stop_event``."""
+
+    while True:
+        _refresh_if_idle()
+        if stop_event.wait(interval):
+            return
+
+
+def start_periodic_update_check(interval_seconds: float | None = None) -> bool:
+    """Start the always-on service's background update poll (#244).
+
+    Idempotent — safe to call once per service launch. Returns ``True`` when a
+    poller thread was started, ``False`` when polling is disabled
+    (``interval <= 0``) or one is already running. Interval resolves from
+    ``interval_seconds`` → ``$MUREO_UPDATE_CHECK_INTERVAL_SECONDS`` →
+    ``_DEFAULT_POLL_INTERVAL_SECONDS``.
+    """
+
+    global _poll_thread, _poll_stop
+    interval = _resolve_poll_interval(interval_seconds)
+    if interval <= 0:
+        logger.info("periodic update check disabled (interval=%s)", interval)
+        return False
+    with _poll_lock:
+        if _poll_thread is not None and _poll_thread.is_alive():
+            return False
+        stop_event = threading.Event()
+        worker = threading.Thread(
+            target=_poll_loop,
+            args=(interval, stop_event),
+            name="mureo-update-poll",
+            daemon=True,
+        )
+        _poll_thread = worker
+        _poll_stop = stop_event
+    try:
+        worker.start()
+    except RuntimeError:
+        with _poll_lock:
+            _poll_thread = None
+            _poll_stop = None
+        logger.warning("could not start periodic update check")
+        return False
+    logger.debug("periodic update check started (every %ss)", interval)
+    return True
+
+
+def stop_periodic_update_check() -> None:
+    """Stop the background poll (service shutdown). No-op if not running.
+
+    The join is best-effort (the worker may be mid-pip, up to the pip timeout):
+    ``daemon=True`` is what actually guarantees no shutdown block, so a slow
+    worker is reaped at interpreter exit rather than blocking the caller.
+    """
+
+    global _poll_thread, _poll_stop
+    with _poll_lock:
+        worker = _poll_thread
+        stop_event = _poll_stop
+        _poll_thread = None
+        _poll_stop = None
+    if stop_event is not None:
+        stop_event.set()
+    if worker is not None:
+        worker.join(timeout=2.0)
+
+
 def _reset_update_cache() -> None:
-    """Test-only: clear cached state between cases (module globals persist)."""
+    """Test-only: stop polling and clear cached state between cases."""
 
     global _cached_result, _cached_at_monotonic, _refresh_in_progress
     global _refresh_thread
+    stop_periodic_update_check()
     with _cache_lock:
         _cached_result = None
         _cached_at_monotonic = 0.0
@@ -253,4 +393,9 @@ def _reset_update_cache() -> None:
         _refresh_thread = None
 
 
-__all__ = ["check_for_updates", "get_update_status"]
+__all__ = [
+    "check_for_updates",
+    "get_update_status",
+    "start_periodic_update_check",
+    "stop_periodic_update_check",
+]

--- a/tests/test_configure_serve.py
+++ b/tests/test_configure_serve.py
@@ -44,6 +44,15 @@ def home_dir(tmp_path: Path) -> Path:
     return home
 
 
+@pytest.fixture(autouse=True)
+def _no_update_poll(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Serve mode (#244) starts a background update poller; disable it here so
+    these serve tests never spawn a real ``pip`` subprocess / network call.
+    Interval ``0`` is the documented off-switch."""
+
+    monkeypatch.setenv("MUREO_UPDATE_CHECK_INTERVAL_SECONDS", "0")
+
+
 @pytest.mark.unit
 class TestConfigureServeFlagWiring:
     """``--serve`` maps to the headless contract at the CLI boundary."""

--- a/tests/test_web_handlers.py
+++ b/tests/test_web_handlers.py
@@ -2023,7 +2023,7 @@ class TestNativeToggleHostResolution:
 
 # ---------------------------------------------------------------------------
 # Update-availability + one-click upgrade (#239). 2 new endpoints:
-#   GET  /api/updates    (Host-gated only, no CSRF for GET) -> check_for_updates
+#   GET  /api/updates    (Host-gated only, no CSRF for GET) -> get_update_status
 #   POST /api/upgrade    (CSRF + Host gated)                -> run_upgrade_all
 # The version_check / upgrade_action wrappers are tested in
 # test_web_version_check.py / test_web_upgrade_action.py; here we pin only
@@ -2047,7 +2047,7 @@ class TestServeUpdates:
             ],
         }
         with patch(
-            "mureo.web.handlers.check_for_updates", return_value=fake_result
+            "mureo.web.handlers.get_update_status", return_value=fake_result
         ) as mock_check:
             resp = _get(wizard, self.ROUTE)
         assert resp.status == 200
@@ -2059,7 +2059,7 @@ class TestServeUpdates:
     def test_error_envelope_surfaces_as_200(self, wizard: ConfigureWizard) -> None:
         """A degraded pip check is a normal outcome, never a 500."""
         fake_result = {"status": "error", "any_update": False, "packages": []}
-        with patch("mureo.web.handlers.check_for_updates", return_value=fake_result):
+        with patch("mureo.web.handlers.get_update_status", return_value=fake_result):
             resp = _get(wizard, self.ROUTE)
         body = json.loads(resp.read().decode("utf-8"))
         assert body["status"] == "error"
@@ -2067,7 +2067,7 @@ class TestServeUpdates:
 
     def test_get_does_not_require_csrf(self, wizard: ConfigureWizard) -> None:
         fake_result = {"status": "ok", "any_update": False, "packages": []}
-        with patch("mureo.web.handlers.check_for_updates", return_value=fake_result):
+        with patch("mureo.web.handlers.get_update_status", return_value=fake_result):
             resp = _get(wizard, self.ROUTE)
         assert resp.status == 200
 

--- a/tests/test_web_version_check.py
+++ b/tests/test_web_version_check.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import threading
 from typing import Any
 from unittest.mock import patch
 
@@ -23,6 +24,8 @@ from mureo.web.version_check import (
     _reset_update_cache,
     check_for_updates,
     get_update_status,
+    start_periodic_update_check,
+    stop_periodic_update_check,
 )
 
 
@@ -360,3 +363,110 @@ class TestGetUpdateStatus:
             release.set()
             _join_refresh()
         assert calls == ["ran"]  # single-flight held: exactly one pip run
+
+
+@pytest.mark.unit
+class TestPeriodicUpdateCheck:
+    """The always-on service's background poll that warms the cache (#244)."""
+
+    _OK: Any = {"status": "ok", "any_update": False, "packages": []}
+
+    def test_interval_resolves_from_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("MUREO_UPDATE_CHECK_INTERVAL_SECONDS", "120")
+        assert version_check._resolve_poll_interval(None) == 120.0
+
+    def test_explicit_interval_overrides_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("MUREO_UPDATE_CHECK_INTERVAL_SECONDS", "120")
+        assert version_check._resolve_poll_interval(30) == 30.0
+
+    def test_invalid_env_falls_back_to_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("MUREO_UPDATE_CHECK_INTERVAL_SECONDS", "not-a-number")
+        assert (
+            version_check._resolve_poll_interval(None)
+            == version_check._DEFAULT_POLL_INTERVAL_SECONDS
+        )
+
+    def test_unset_env_uses_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("MUREO_UPDATE_CHECK_INTERVAL_SECONDS", raising=False)
+        assert (
+            version_check._resolve_poll_interval(None)
+            == version_check._DEFAULT_POLL_INTERVAL_SECONDS
+        )
+
+    def test_zero_interval_disables_polling(self) -> None:
+        """``interval <= 0`` is the documented "off" switch."""
+        assert start_periodic_update_check(interval_seconds=0) is False
+        assert version_check._poll_thread is None
+
+    def test_env_zero_disables_polling(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MUREO_UPDATE_CHECK_INTERVAL_SECONDS", "0")
+        assert start_periodic_update_check() is False
+        assert version_check._poll_thread is None
+
+    def test_start_warms_cache_immediately(self) -> None:
+        """The poll runs once on start so the UI shows fresh data right away."""
+        ran = threading.Event()
+        payload = {
+            "status": "ok",
+            "any_update": True,
+            "packages": [{"name": "mureo", "installed": "0.9.31", "latest": "0.9.32"}],
+        }
+
+        def _check() -> dict[str, Any]:
+            ran.set()
+            return payload
+
+        with patch("mureo.web.version_check.check_for_updates", side_effect=_check):
+            assert start_periodic_update_check(interval_seconds=3600) is True
+            assert ran.wait(5.0)
+            # stop() joins the worker, so the immediate refresh has stored its
+            # result by the time it returns.
+            stop_periodic_update_check()
+            assert get_update_status() == payload
+
+    def test_start_is_idempotent(self) -> None:
+        """A second start while one runs is a no-op (single-instance reuse)."""
+        with patch(
+            "mureo.web.version_check.check_for_updates", return_value=self._OK
+        ):
+            assert start_periodic_update_check(interval_seconds=3600) is True
+            assert start_periodic_update_check(interval_seconds=3600) is False
+            stop_periodic_update_check()
+
+    def test_stop_is_safe_when_not_running(self) -> None:
+        stop_periodic_update_check()  # must not raise
+        assert version_check._poll_thread is None
+
+    def test_restart_after_stop_launches_fresh_poller(self) -> None:
+        """start → stop → start must work (each launch gets its own event)."""
+        with patch(
+            "mureo.web.version_check.check_for_updates", return_value=self._OK
+        ):
+            assert start_periodic_update_check(interval_seconds=3600) is True
+            stop_periodic_update_check()
+            assert version_check._poll_thread is None
+            # A clean stop must not wedge the next launch.
+            assert start_periodic_update_check(interval_seconds=3600) is True
+            stop_periodic_update_check()
+
+    def test_refresh_if_idle_skips_when_a_refresh_is_in_flight(self) -> None:
+        """The poll tick yields to an in-flight lazy refresh (no double run)."""
+        calls: list[int] = []
+        with version_check._cache_lock:
+            version_check._refresh_in_progress = True
+        try:
+            with patch(
+                "mureo.web.version_check.check_for_updates",
+                side_effect=lambda: calls.append(1) or self._OK,
+            ):
+                version_check._refresh_if_idle()
+            assert calls == []
+        finally:
+            with version_check._cache_lock:
+                version_check._refresh_in_progress = False

--- a/tests/test_web_version_check.py
+++ b/tests/test_web_version_check.py
@@ -18,7 +18,29 @@ from unittest.mock import patch
 
 import pytest
 
-from mureo.web.version_check import check_for_updates
+from mureo.web import version_check
+from mureo.web.version_check import (
+    _reset_update_cache,
+    check_for_updates,
+    get_update_status,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_update_cache() -> Any:
+    """Each case starts and ends with a cold module-level cache."""
+
+    _reset_update_cache()
+    yield
+    _reset_update_cache()
+
+
+def _join_refresh(timeout: float = 5.0) -> None:
+    """Block until the in-flight background refresh (if any) finishes."""
+
+    thread = version_check._refresh_thread
+    if thread is not None:
+        thread.join(timeout)
 
 
 def _completed(
@@ -233,3 +255,108 @@ class TestCheckForUpdates:
         assert kwargs["text"] is True
         assert kwargs["check"] is False
         assert kwargs["timeout"] == 60
+
+
+@pytest.mark.unit
+class TestGetUpdateStatus:
+    """The non-blocking cache layer the HTTP handler actually calls."""
+
+    def test_cold_cache_returns_checking_without_blocking(self) -> None:
+        """First call returns the ``checking`` placeholder immediately."""
+        with patch(
+            "mureo.web.version_check.check_for_updates",
+            return_value={"status": "ok", "any_update": False, "packages": []},
+        ):
+            first = get_update_status()
+            assert first["status"] == "checking"
+            assert first["any_update"] is False
+            assert first["packages"] == []
+            _join_refresh()
+
+    def test_background_result_is_cached_and_served(self) -> None:
+        """Once the background check finishes, its result is returned."""
+        payload = {
+            "status": "ok",
+            "any_update": True,
+            "packages": [{"name": "mureo", "installed": "0.9.31", "latest": "0.9.32"}],
+        }
+        with patch(
+            "mureo.web.version_check.check_for_updates", return_value=payload
+        ) as mock_check:
+            assert get_update_status()["status"] == "checking"
+            _join_refresh()
+            second = get_update_status()
+        assert second == payload
+        # Fresh cache → the slow check ran exactly once, not per request.
+        mock_check.assert_called_once()
+
+    def test_handler_never_runs_pip_inline(self) -> None:
+        """The accessor must not call the blocking check on the caller's thread."""
+        slow_calls: list[str] = []
+
+        def _slow() -> dict[str, Any]:
+            slow_calls.append("ran")
+            return {"status": "ok", "any_update": False, "packages": []}
+
+        with patch("mureo.web.version_check.check_for_updates", side_effect=_slow):
+            result = get_update_status()
+            # Returned before the background worker necessarily ran.
+            assert result["status"] == "checking"
+            _join_refresh()
+        assert slow_calls == ["ran"]
+
+    def test_error_result_is_cached_with_short_ttl(self) -> None:
+        """A degraded check is cached (so it is not retried every request)."""
+        with patch(
+            "mureo.web.version_check.check_for_updates",
+            return_value={"status": "error", "any_update": False, "packages": []},
+        ) as mock_check:
+            assert get_update_status()["status"] == "checking"
+            _join_refresh()
+            assert get_update_status()["status"] == "error"
+            get_update_status()  # still within the error TTL
+        mock_check.assert_called_once()
+
+    def test_stale_cache_triggers_one_background_refresh(self) -> None:
+        """An expired cache serves the stale result and refreshes once."""
+        payload = {"status": "ok", "any_update": False, "packages": []}
+        with patch(
+            "mureo.web.version_check.check_for_updates", return_value=payload
+        ) as mock_check:
+            get_update_status()
+            _join_refresh()
+            assert get_update_status() == payload  # warm, fresh
+
+            # Force the cache to look stale, then assert exactly one refresh.
+            with version_check._cache_lock:
+                version_check._cached_at_monotonic -= version_check._OK_TTL_SECONDS + 1
+            served = get_update_status()
+            assert served == payload  # last-known served while refreshing
+            _join_refresh()
+        assert mock_check.call_count == 2
+
+    def test_concurrent_callers_spawn_one_worker(self) -> None:
+        """Two simultaneous requests must trigger only one pip run (#244).
+
+        This is the exact bug the cache exists to prevent: the configure UI
+        fetches ``/api/updates`` more than once per page load, and the old
+        synchronous handler spawned a 60s pip process for each.
+        """
+        import threading
+
+        release = threading.Event()
+        calls: list[str] = []
+
+        def _blocked() -> dict[str, Any]:
+            calls.append("ran")
+            release.wait(5.0)  # hold the worker so the 2nd caller overlaps it
+            return {"status": "ok", "any_update": False, "packages": []}
+
+        with patch("mureo.web.version_check.check_for_updates", side_effect=_blocked):
+            # 1st caller flips _refresh_in_progress (under the lock) before the
+            # worker even starts, so the 2nd caller is gated regardless of timing.
+            assert get_update_status()["status"] == "checking"
+            assert get_update_status()["status"] == "checking"
+            release.set()
+            _join_refresh()
+        assert calls == ["ran"]  # single-flight held: exactly one pip run


### PR DESCRIPTION
`mureo configure` で `pip list --outdated`（この環境では60秒タイムアウト）がリクエスト毎に同期実行され、UI起動の度にブロック＋トレースバック多発＋BrokenPipe を起こしていた問題への対応。2コミットで構成。

## 1) 非ブロッキング化（fix）

`GET /api/updates` が `pip list --outdated --format=json` を**リクエスト毎に同期実行**。遅い/到達不能な index ではこのサブプロセスが最大60秒かかり、configure UI は1ページロードあたり複数回フェッチするため、毎回リクエストスレッドをブロック→`TimeoutExpired` のフルトレースバックを連発→ブラウザが応答途中で切断 (`BrokenPipeError`)。

- `version_check.py`: 非ブロッキングアクセサ `get_update_status()` を追加。遅い `check_for_updates()` を**デーモンスレッドで1回だけ実行しキャッシュ**（TTL: 成功6h / 失敗10min）。ハンドラは即返却、cold時は `status="checking"`（フロントは非okを無視）。`_refresh_in_progress` の single-flight で「1ページロードで複数pip」を防止。共有状態はロック保護、戻り値はコピー。
- timeout/OSError のログを `logger.exception`（多行トレースバック）→ `logger.warning`（1行）に。
- `handlers.py`: `/api/updates` を `get_update_status()` に切替。コア `check_for_updates()` は不変。

## 2) 常時起動サービス向け定期ポーリング（feat）

非ブロッキングキャッシュは**UIを開いたとき**しか温まらない。常時起動サービス（`--serve` / launchd / systemd）では誰もUIを開かないためキャッシュが cold のままで、更新バッジが手動アクセスまで出ない。

- `version_check.py`: `start/stop_periodic_update_check()` がデーモンスレッドで「起動直後に1回 → 以降 interval 毎」にキャッシュを温める。デフォルト**6時間**、`MUREO_UPDATE_CHECK_INTERVAL_SECONDS` で上書き（**0/負で無効**、非finiteはデフォルトにフォールバック）。lazy 経路と single-flight ゲート (`_refresh_if_idle`) を共有し二重実行を防止。各起動が**自前の stop Event** を持つので stop/start 競合でポーラーが取り残されない。daemon スレッドなので shutdown の join はベストエフォート。
- `server.py`: `run_configure_wizard` が **serve_forever モードのみ**、サーバ ready 後にポーリング開始・`finally` で停止。短命な対話起動は従来の「UI起動時 lazy チェック」のまま。

## 設計判断（更新マークのタイミング）
- 更新チェックは**定期ポーリング無し**だった既存実装では「UIを開く度（ページロード/dashboard遷移/言語切替/ステータス更新後）」に発火。本PRで常時起動サービスのみ定期ポーリングを追加。
- 常時起動でもサーバが勝手にpipを叩き続けることはなく、cadence は最大6h。新版適用後はサービス再起動でキャッシュ（プロセスメモリ）がリセットされる。

## Test plan
- [x] `pytest tests/test_web_version_check.py tests/test_web_handlers.py tests/test_web_server.py tests/test_configure_serve.py` → **234 passed**
- [x] `ruff` / `black --check` クリーン
- [x] スモーク: アクセサは **0.2ms 即返却**（60秒ブロックなし）
- [x] 新規テスト: 非ブロッキング（cold/キャッシュ/error TTL/stale/並行 single-flight）＋ 定期ポーリング（interval解決 arg/env/default/invalid、0=無効、即時warm、idempotent、start→stop→start、single-flight skip）
- [x] serve テストは autouse フィクスチャで実pipを起動しない

## Review
code-reviewer を各コミット前に実施。指摘の thread-safety 項目を都度修正:
- 非ブロッキング: `_refresh_thread` のロック内書き込み / warm-path のコピー返し / 並行 single-flight テスト追加
- 定期ポーリング: module-level stop event の世代間エイリアシング競合 → **スレッド毎 stop Event** に変更、非finite interval ガード、再起動テスト追加
