### PR TITLE
style(configure): lay out About check and update-all buttons in one row

### DIFF
--- a/mureo/_data/web/app.css
+++ b/mureo/_data/web/app.css
@@ -1211,6 +1211,17 @@ dialog[data-confirm-dialog] [data-confirm-ok] {
   font-weight: 600;
 }
 
+/* #246 — "Check for updates" + "Update all" sit on one row. "Update all"
+   is hidden until an update exists, so on a fresh check only the check
+   button shows (left-aligned); wrap keeps it tidy on narrow widths. */
+.dashboard-about-update-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin-top: 10px;
+}
+
 .dashboard-about-update-status {
   margin-top: 10px;
 }

--- a/mureo/_data/web/app.html
+++ b/mureo/_data/web/app.html
@@ -215,16 +215,17 @@
                    hidden until the background check returns a result. -->
               <div class="dashboard-about-updates" data-about-updates hidden>
                 <p data-about-updates-summary></p>
-                <!-- #246 — manual "check now". Always visible so the operator
-                     can force a fresh check (the result is otherwise cached /
-                     polled on a wide cadence by the always-on service). -->
-                <button type="button" class="btn btn-secondary"
-                        data-about-check-button
-                        data-i18n="dashboard.about_check_button">Check for updates</button>
                 <ul data-about-updates-list></ul>
-                <button type="button" class="btn btn-primary"
-                        data-about-update-button hidden
-                        data-i18n="dashboard.about_update_button">Update all</button>
+                <!-- #246 — action row: manual "check now" (always visible) and
+                     "update all" (shown only when updates exist), side by side. -->
+                <div class="dashboard-about-update-actions">
+                  <button type="button" class="btn btn-secondary"
+                          data-about-check-button
+                          data-i18n="dashboard.about_check_button">Check for updates</button>
+                  <button type="button" class="btn btn-primary"
+                          data-about-update-button hidden
+                          data-i18n="dashboard.about_update_button">Update all</button>
+                </div>
                 <!-- In-page confirm panel (no native window.confirm).
                      Lists the packages, then Upgrade / Cancel. -->
                 <div class="dashboard-about-update-confirm" data-about-update-confirm hidden>


### PR DESCRIPTION
## 概要
About タブの「最新版を確認」ボタンと「すべて更新」ボタンが縦に離れて（間にパッケージ一覧が挟まって）配置されていたのを、横並びに整えた。

## 変更
- `app.html`: 2つのボタンを `.dashboard-about-update-actions` の flex 行にまとめ、更新可能パッケージ一覧(`ul`)はその上へ移動。
- `app.css`: `.dashboard-about-update-actions` を `display:flex; gap:8px; align-items:center; flex-wrap:wrap` で追加。「すべて更新」は更新がある時のみ表示なので通常は確認ボタンのみ左寄せ、狭幅では折り返し。

## 影響
- 表示のみの変更。ボタンは `data-*` フックで選択しているため `dashboard.js` への影響なし。
- About テスト 24 件合格。