### PR TITLE
chore(release): v0.9.33

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mureo",
-  "version": "0.9.32",
+  "version": "0.9.33",
   "description": "Your local-first AI ad ops crew for Google Ads, Meta Ads, Search Console & GA4. mureo sits on top of the official ad-platform MCPs, gates every change against your strategy, correlates outcomes locally, and keeps an auditable decision log — credentials never leave your machine.",
   "author": {
     "name": "Logly Inc.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.33] - 2026-06-13
+
+Self-service updates and always-on operation for configure: a fixed
+default port with single-instance reuse, OS-level service auto-start, a
+headless `--serve` mode, and an About-tab update checker with one-click
+upgrade — plus localized provider credential headings.
+
+### Added
+
+#### Fixed default port + single-instance reuse + `mureo open` (#241, #242)
+
+`mureo configure` now binds a fixed default port with a fallback when it
+is taken, reuses a single running instance instead of spawning a second
+server, and adds `mureo open` to surface the already-running configure UI.
+
+#### `mureo service` auto-start + headless `--serve` mode (#241, #243)
+
+A new `mureo service` command registers configure as an always-on
+service via the native OS mechanism (launchd / systemd / Task
+Scheduler), and a `--serve` headless mode runs the server without
+opening a browser session.
+
+#### Surface available updates + one-click upgrade (#239, #240, #245, #246, #247)
+
+The About tab now checks for available mureo and plugin updates and
+offers a one-click upgrade. Update polling is non-blocking — `/api/updates`
+returns immediately and the always-on service refreshes the result on a
+periodic poll (#245). A "Check for updates" button triggers an on-demand
+check (#246), laid out in one row with the update-all button (#247).
+
+#### Localized provider credential section headings (#236, #244)
+
+Provider credential section headings in configure are now localized via
+`display_name_i18n`, matching the locale already applied to the field
+labels.
+
+### Fixed
+
+#### Japanese translations for built-in account credential labels (#237, #238)
+
+The built-in Google Ads and Meta Ads account credential field labels
+were English-only; they now carry Japanese translations.
+
 ## [0.9.32] - 2026-06-13
 
 Plugin OAuth flexibility for stricter providers, an "About mureo" menu

--- a/mureo/__init__.py
+++ b/mureo/__init__.py
@@ -1,3 +1,3 @@
 """mureo — your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."""
 
-__version__ = "0.9.32"
+__version__ = "0.9.33"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mureo"
-version = "0.9.32"
+version = "0.9.33"
 description = "Your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."
 requires-python = ">=3.10"
 license = "Apache-2.0"


### PR DESCRIPTION
## Release v0.9.33

Version bump (0.9.32 → 0.9.33) and CHANGELOG for the configure self-service / always-on cycle.

### Included since v0.9.32
- **#242** (#241 P1) — fixed default port + fallback, single-instance reuse, `mureo open`
- **#243** (#241 P2) — `mureo service` auto-start (launchd/systemd/Task Scheduler) + `--serve` headless mode
- **#240** (#239) — surface available mureo/plugin updates + one-click upgrade
- **#245** — non-blocking `/api/updates` + periodic update poll for the always-on service
- **#246** — "Check for updates" button on the About tab
- **#247** — lay out About check + update-all buttons in one row
- **#244** (#236) — localize provider credential section headings via `display_name_i18n`
- **#238** (#237) — ja translations for built-in Google/Meta account credential field labels

### Changes in this PR
- `pyproject.toml`, `mureo/__init__.py`, `.claude-plugin/plugin.json` → 0.9.33
- `CHANGELOG.md` → `[0.9.33]` section

### Release plan
After merge: tag `v0.9.33` + publish GitHub Release → `release.yml` publishes to PyPI automatically.