### PR TITLE
feat(web): always-on lifecycle hooks for web extensions (#249)

### DIFF
--- a/mureo/web/extensions.py
+++ b/mureo/web/extensions.py
@@ -64,8 +64,10 @@ from typing import (
 )
 
 if TYPE_CHECKING:
+    import threading
     from collections.abc import Callable
     from http.server import BaseHTTPRequestHandler
+    from pathlib import Path
 
 #: Entry-point group iterated by :func:`discover_web_extensions`.
 WEB_EXTENSIONS_ENTRY_POINT_GROUP: Final[str] = "mureo.web_extensions"
@@ -236,6 +238,27 @@ class ViewContribution:
             raise TypeError("ViewContribution.styles must be tuple[StaticAsset, ...]")
 
 
+@dataclass(frozen=True)
+class ServeContext:
+    """Context handed to :py:meth:`WebExtension.on_serve_start` by the
+    always-on daemon so an extension can run a clean background job (#249).
+
+    * ``stop_event`` — set when the daemon is shutting down. An extension's
+      own thread should ``wait()`` on it (never a bare ``sleep``) and exit
+      promptly when it fires.
+    * ``request_stop`` — ask the daemon itself to stop serving (the same
+      path ``/api/shutdown`` and SIGTERM use). Rarely needed; present so an
+      extension can trigger an orderly shutdown.
+    * ``home`` — the resolved home root (honours an injected ``home``, else
+      ``Path.home()``) so an extension reads its own state under
+      ``<home>/.mureo`` exactly as the rest of configure does.
+    """
+
+    stop_event: threading.Event
+    request_stop: Callable[[], None]
+    home: Path
+
+
 @runtime_checkable
 class WebExtension(Protocol):
     """Structural type a third-party web extension must satisfy.
@@ -270,6 +293,24 @@ class WebExtension(Protocol):
       :class:`WebExtensionWarning`. When several installed
       extensions claim the landing the first-discovered one wins
       (later claims are downgraded with a warning). Added in #189.
+    * ``on_serve_start(ctx: ServeContext) -> None`` and
+      ``on_serve_stop() -> None`` — lifecycle hooks invoked ONLY by the
+      always-on daemon (``mureo configure --serve``), never by a
+      short-lived interactive ``mureo configure`` (mirrors #244's "only
+      the always-on service runs background jobs"). ``on_serve_start``
+      fires once after the server is ready; ``on_serve_stop`` once at
+      shutdown. Use them to start/stop a self-managed background thread —
+      the extension owns its own scheduling, staggering, and backoff.
+      Both hooks run synchronously on the daemon's startup/shutdown path
+      (``on_serve_start`` BEFORE the SIGINT/SIGTERM handlers are
+      installed) and sequentially across extensions, so a hook MUST
+      return promptly: spawn a thread for any ongoing work and never
+      block in the hook body, or it will stall daemon startup/shutdown
+      and delay the other extensions. An extension that declares neither
+      behaves exactly as before. A hook
+      that raises is isolated as a :class:`WebExtensionWarning`, and an
+      extension whose ``on_serve_start`` raised does NOT receive
+      ``on_serve_stop``. Added in #249.
     """
 
     @property
@@ -306,6 +347,12 @@ class WebExtensionEntry:
     # before.
     hidden_builtin_tabs: tuple[str, ...] = ()
     replaces_landing: bool = False
+    # #249 — optional always-on lifecycle hooks, captured as bound
+    # callables during discovery (``None`` when the extension declares
+    # neither). Invoked only in ``serve_forever`` (daemon) mode by
+    # :func:`start_serve_lifecycles` / :func:`stop_serve_lifecycles`.
+    on_serve_start: Callable[[ServeContext], None] | None = None
+    on_serve_stop: Callable[[], None] | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -508,6 +555,23 @@ def _load_entry_point(ep: Any) -> WebExtensionEntry | None:
                 stacklevel=3,
             )
             replaces_landing = False
+        # #249 — capture optional lifecycle hooks as bound callables.
+        # Read defensively (``getattr``) so the Protocol stays additive;
+        # a non-callable hook is a packaging bug and skips the whole
+        # extension via the surrounding try/except (mirroring the
+        # ``display_name_i18n`` type-level discipline).
+        on_serve_start = getattr(extension, "on_serve_start", None)
+        if on_serve_start is not None and not callable(on_serve_start):
+            raise TypeError(
+                f"on_serve_start must be callable, "
+                f"got {type(on_serve_start).__name__}"
+            )
+        on_serve_stop = getattr(extension, "on_serve_stop", None)
+        if on_serve_stop is not None and not callable(on_serve_stop):
+            raise TypeError(
+                f"on_serve_stop must be callable, "
+                f"got {type(on_serve_stop).__name__}"
+            )
     except Exception as exc:  # noqa: BLE001 — per-plugin fault isolation
         warnings.warn(
             f"failed to load web extension {ep_name!r}: {exc!r}",
@@ -525,6 +589,8 @@ def _load_entry_point(ep: Any) -> WebExtensionEntry | None:
         display_name_i18n=i18n_normalised,
         hidden_builtin_tabs=tuple(hidden_tabs),
         replaces_landing=replaces_landing,
+        on_serve_start=on_serve_start,
+        on_serve_stop=on_serve_stop,
     )
 
 
@@ -543,12 +609,76 @@ def _resolve_source(ep: Any) -> str | None:
     return name if isinstance(name, str) else None
 
 
+# ---------------------------------------------------------------------------
+# Always-on lifecycle (#249)
+# ---------------------------------------------------------------------------
+
+
+def start_serve_lifecycles(
+    entries: tuple[WebExtensionEntry, ...], ctx: ServeContext
+) -> tuple[WebExtensionEntry, ...]:
+    """Call ``on_serve_start(ctx)`` on every entry that declares it (#249).
+
+    Returns the entries whose hook ran without raising — only those get a
+    matching :func:`stop_serve_lifecycles` call later. A hook that raises
+    is isolated as a :class:`WebExtensionWarning` so one bad extension can
+    neither crash the daemon nor block the others' startup.
+
+    Intended for the always-on daemon (``serve_forever``) only; a
+    short-lived interactive launch never calls this. Hooks run
+    sequentially on the caller's thread, so a hook that blocks delays the
+    daemon's startup and the other extensions — extensions must return
+    promptly and offload ongoing work to their own thread.
+    """
+    started: list[WebExtensionEntry] = []
+    for entry in entries:
+        hook = entry.on_serve_start
+        if hook is None:
+            continue
+        try:
+            hook(ctx)
+        except Exception as exc:  # noqa: BLE001 — per-plugin fault isolation
+            warnings.warn(
+                f"web extension {entry.name!r} on_serve_start raised "
+                f"{exc!r}; skipped (it will not be stopped)",
+                WebExtensionWarning,
+                stacklevel=2,
+            )
+            continue
+        started.append(entry)
+    return tuple(started)
+
+
+def stop_serve_lifecycles(entries: tuple[WebExtensionEntry, ...]) -> None:
+    """Call ``on_serve_stop()`` on each entry, isolating faults (#249).
+
+    Pass the tuple returned by :func:`start_serve_lifecycles` so only
+    extensions whose ``on_serve_start`` succeeded are stopped. A hook that
+    raises is isolated as a :class:`WebExtensionWarning`; the remaining
+    extensions are still stopped.
+    """
+    for entry in entries:
+        hook = entry.on_serve_stop
+        if hook is None:
+            continue
+        try:
+            hook()
+        except Exception as exc:  # noqa: BLE001 — per-plugin fault isolation
+            warnings.warn(
+                f"web extension {entry.name!r} on_serve_stop raised "
+                f"{exc!r}; ignored",
+                WebExtensionWarning,
+                stacklevel=2,
+            )
+
+
 __all__ = [
     "BUILTIN_DASHBOARD_TABS",
     "FILENAME_PATTERN",
     "NAME_PATTERN",
     "RouteContribution",
     "SUBPATH_PATTERN",
+    "ServeContext",
     "StaticAsset",
     "ViewContribution",
     "WEB_EXTENSIONS_ENTRY_POINT_GROUP",
@@ -557,4 +687,6 @@ __all__ = [
     "WebExtensionWarning",
     "discover_web_extensions",
     "reset_web_extensions",
+    "start_serve_lifecycles",
+    "stop_serve_lifecycles",
 ]

--- a/mureo/web/server.py
+++ b/mureo/web/server.py
@@ -22,7 +22,13 @@ from pathlib import Path
 
 from mureo.core.runtime_context import runtime_credentials_path
 from mureo.core.terminal import force_cooked_mode, terminal_fd
-from mureo.web.extensions import discover_web_extensions
+from mureo.web.extensions import (
+    ServeContext,
+    WebExtensionEntry,
+    discover_web_extensions,
+    start_serve_lifecycles,
+    stop_serve_lifecycles,
+)
 from mureo.web.handlers import ConfigureHandler
 from mureo.web.host_paths import HostPaths, get_host_paths
 from mureo.web.instance import probe_mureo_instance, write_state_file
@@ -340,8 +346,26 @@ def run_configure_wizard(
     # #244: only the always-on service (``serve_forever``) polls for updates
     # in the background. A short-lived interactive launch relies on the lazy
     # check that fires when the UI is opened, so it never spawns a poller.
+    #
+    # #249: the same guard governs extension lifecycle hooks — only the
+    # always-on daemon lets extensions run background jobs. The server is
+    # already serving (``wait_until_ready`` returned), so a hook may safely
+    # call its own routes. ``started_extensions`` is filled only here and
+    # consumed in ``finally`` for the symmetric stop.
+    started_extensions: tuple[WebExtensionEntry, ...] = ()
     if serve_forever:
         start_periodic_update_check()
+        # Hooks run synchronously here — before the SIGINT/SIGTERM
+        # handlers below — and sequentially across extensions, so a
+        # well-behaved hook returns promptly and offloads ongoing work to
+        # its own thread (see the WebExtension docstring). Faults are
+        # isolated inside ``start_serve_lifecycles``.
+        serve_ctx = ServeContext(
+            stop_event=wizard.stop_event,
+            request_stop=wizard.request_stop,
+            home=wizard.home if wizard.home is not None else Path.home(),
+        )
+        started_extensions = start_serve_lifecycles(wizard.extensions, serve_ctx)
 
     # Stop the moment the user finishes (UI POSTs /api/shutdown ->
     # request_stop), presses Ctrl+C (SIGINT) or the process is asked to
@@ -395,6 +419,10 @@ def run_configure_wizard(
         pass
     finally:
         if serve_forever:
+            # Reverse of startup: stop extension jobs first, then the
+            # update poller. ``stop_serve_lifecycles`` stops only the
+            # extensions whose ``on_serve_start`` actually ran.
+            stop_serve_lifecycles(started_extensions)
             stop_periodic_update_check()
         for signum, prev in prev_handlers:
             with contextlib.suppress(ValueError, OSError):

--- a/tests/test_web_extension_lifecycle.py
+++ b/tests/test_web_extension_lifecycle.py
@@ -1,0 +1,392 @@
+"""Always-on lifecycle hooks for web extensions (#249).
+
+A ``WebExtension`` MAY declare optional ``on_serve_start(ctx)`` /
+``on_serve_stop()`` hooks. They fire ONLY in the always-on daemon
+(``serve_forever`` — ``timeout_seconds is None``), never on a
+short-lived interactive ``mureo configure`` (the same "only the
+always-on service runs background jobs" guard #244 applies to the
+update poller).
+
+Discovery captures the bound hooks onto the frozen
+:class:`WebExtensionEntry` — mirroring the existing optional-attr
+capture (``display_name_i18n`` / ``hidden_builtin_tabs`` /
+``replaces_landing``). :func:`start_serve_lifecycles` /
+:func:`stop_serve_lifecycles` invoke them with per-extension fault
+isolation so one bad plugin can neither crash the daemon nor block the
+others, and only extensions whose ``on_serve_start`` ran are stopped.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import threading
+import time
+import warnings
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+from unittest.mock import patch
+
+import pytest
+
+from mureo.web.extensions import (
+    ServeContext,
+    WebExtensionEntry,
+    WebExtensionWarning,
+    discover_web_extensions,
+    reset_web_extensions,
+    start_serve_lifecycles,
+    stop_serve_lifecycles,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _entry(name: str = "agency", **overrides: Any) -> WebExtensionEntry:
+    """Build a minimal :class:`WebExtensionEntry`, hooks overridable."""
+    base: dict[str, Any] = dict(
+        name=name,
+        display_name=name.title(),
+        routes=(),
+        view=None,
+        source_distribution=None,
+    )
+    base.update(overrides)
+    return WebExtensionEntry(**base)
+
+
+def _ctx(home: Path = Path("/home")) -> ServeContext:
+    return ServeContext(
+        stop_event=threading.Event(), request_stop=lambda: None, home=home
+    )
+
+
+class _FakeEP:
+    """Minimal entry-point: ``.name``, ``.load()``, ``.dist`` (for discovery)."""
+
+    def __init__(self, name: str, obj: object, dist_name: str | None = None) -> None:
+        self.name = name
+        self._obj = obj
+        self.dist = type("D", (), {"name": dist_name})() if dist_name else None
+
+    def load(self) -> object:
+        return self._obj
+
+
+class _Ext:
+    """A WebExtension satisfying the structural Protocol, with hooks."""
+
+    name = "agency"
+    display_name = "Agency"
+
+    def __init__(
+        self,
+        on_serve_start: Callable[..., None] | None = None,
+        on_serve_stop: Callable[[], None] | None = None,
+    ) -> None:
+        if on_serve_start is not None:
+            self.on_serve_start = on_serve_start  # type: ignore[assignment]
+        if on_serve_stop is not None:
+            self.on_serve_stop = on_serve_stop  # type: ignore[assignment]
+
+    def routes(self) -> tuple[Any, ...]:
+        return ()
+
+    def view(self) -> None:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# ServeContext
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestServeContext:
+    def test_carries_stop_event_request_stop_and_home(self) -> None:
+        ev = threading.Event()
+        called: list[int] = []
+        ctx = ServeContext(
+            stop_event=ev, request_stop=lambda: called.append(1), home=Path("/x")
+        )
+        assert ctx.stop_event is ev
+        ctx.request_stop()
+        assert called == [1]
+        assert ctx.home == Path("/x")
+
+    def test_is_frozen(self) -> None:
+        ctx = _ctx()
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            ctx.home = Path("/other")  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# WebExtensionEntry backward compatibility
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestEntryDefaults:
+    def test_hooks_default_to_none(self) -> None:
+        e = _entry()
+        assert e.on_serve_start is None
+        assert e.on_serve_stop is None
+
+
+# ---------------------------------------------------------------------------
+# start_serve_lifecycles / stop_serve_lifecycles
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestLifecycleInvocation:
+    def test_start_passes_ctx_and_stop_roundtrips(self) -> None:
+        seen: dict[str, Any] = {}
+        e = _entry(
+            on_serve_start=lambda ctx: seen.__setitem__("ctx", ctx),
+            on_serve_stop=lambda: seen.__setitem__("stopped", True),
+        )
+        ctx = _ctx(home=Path("/h"))
+        started = start_serve_lifecycles((e,), ctx)
+        assert started == (e,)
+        assert seen["ctx"] is ctx
+        stop_serve_lifecycles(started)
+        assert seen["stopped"] is True
+
+    def test_entry_without_start_is_not_started(self) -> None:
+        e = _entry()  # no hooks
+        assert start_serve_lifecycles((e,), _ctx()) == ()
+
+    def test_entry_with_only_stop_is_not_stopped(self) -> None:
+        """No ``on_serve_start`` means it never started — so never stopped."""
+        seen: list[str] = []
+        e = _entry(on_serve_stop=lambda: seen.append("stopped"))
+        started = start_serve_lifecycles((e,), _ctx())
+        assert started == ()
+        stop_serve_lifecycles(started)
+        assert seen == []
+
+    def test_start_fault_isolation(self) -> None:
+        order: list[str] = []
+
+        def boom(_ctx: ServeContext) -> None:
+            raise RuntimeError("start boom")
+
+        bad = _entry(
+            name="bad",
+            on_serve_start=boom,
+            on_serve_stop=lambda: order.append("bad-stop"),
+        )
+        good = _entry(
+            name="good",
+            on_serve_start=lambda _c: order.append("good-start"),
+            on_serve_stop=lambda: order.append("good-stop"),
+        )
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            started = start_serve_lifecycles((bad, good), _ctx())
+        # The bad one is isolated; the good one still starts.
+        assert "good-start" in order
+        assert good in started
+        assert bad not in started
+        assert any(issubclass(w.category, WebExtensionWarning) for w in caught)
+        # A failed start must NOT receive a stop.
+        stop_serve_lifecycles(started)
+        assert "bad-stop" not in order
+        assert "good-stop" in order
+
+    def test_stop_fault_isolation(self) -> None:
+        order: list[str] = []
+
+        def boom() -> None:
+            raise RuntimeError("stop boom")
+
+        bad = _entry(name="bad", on_serve_start=lambda _c: None, on_serve_stop=boom)
+        good = _entry(
+            name="good",
+            on_serve_start=lambda _c: None,
+            on_serve_stop=lambda: order.append("good-stop"),
+        )
+        started = start_serve_lifecycles((bad, good), _ctx())
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            stop_serve_lifecycles(started)  # must not raise
+        assert "good-stop" in order
+        assert any(issubclass(w.category, WebExtensionWarning) for w in caught)
+
+
+# ---------------------------------------------------------------------------
+# Discovery capture
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestDiscoveryCapturesHooks:
+    def _discover_with(self, monkeypatch: pytest.MonkeyPatch, ext: object) -> Any:
+        ep = _FakeEP("agency", ext, dist_name="mureo-agency")
+
+        def fake_entry_points(*, group: str) -> list[Any]:
+            from mureo.web.extensions import WEB_EXTENSIONS_ENTRY_POINT_GROUP
+
+            return [ep] if group == WEB_EXTENSIONS_ENTRY_POINT_GROUP else []
+
+        monkeypatch.setattr("mureo.web.extensions.entry_points", fake_entry_points)
+        reset_web_extensions()
+        try:
+            entries = discover_web_extensions()
+        finally:
+            reset_web_extensions()
+        return entries
+
+    def test_captures_bound_hooks(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        marks: list[str] = []
+        ext = _Ext(
+            on_serve_start=lambda _c: marks.append("start"),
+            on_serve_stop=lambda: marks.append("stop"),
+        )
+        (entry,) = self._discover_with(monkeypatch, ext)
+        assert callable(entry.on_serve_start)
+        assert callable(entry.on_serve_stop)
+        entry.on_serve_start(_ctx())
+        entry.on_serve_stop()
+        assert marks == ["start", "stop"]
+
+    def test_extension_without_hooks_yields_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (entry,) = self._discover_with(monkeypatch, _Ext())
+        assert entry.on_serve_start is None
+        assert entry.on_serve_stop is None
+
+    def test_non_callable_hook_skips_extension(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        ext = _Ext()
+        ext.on_serve_start = "not-callable"  # type: ignore[assignment]
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            entries = self._discover_with(monkeypatch, ext)
+        assert entries == ()  # whole extension skipped (packaging bug)
+        assert any(issubclass(w.category, WebExtensionWarning) for w in caught)
+
+
+# ---------------------------------------------------------------------------
+# Server integration: serve_forever fires, serve-once does NOT
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def home_dir(tmp_path: Path) -> Path:
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".claude" / "commands").mkdir(parents=True)
+    (home / ".mureo").mkdir()
+    return home
+
+
+@pytest.fixture(autouse=True)
+def _no_update_poll(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Disable the #244 background update poller (interval 0 = off) so these
+    serve tests never spawn a real ``pip`` subprocess / network call."""
+    monkeypatch.setenv("MUREO_UPDATE_CHECK_INTERVAL_SECONDS", "0")
+
+
+def _run_wizard_with_extension(
+    home_dir: Path, fake_entry: WebExtensionEntry, timeout: Any
+) -> None:
+    """Drive ``run_configure_wizard`` to ready, then stop it — with a single
+    fake extension injected. Blocks until the wizard thread joins."""
+    from mureo.web.server import ConfigureWizard, run_configure_wizard
+
+    captured: dict[str, Any] = {}
+    real_ctor = ConfigureWizard
+
+    def _spy(**kwargs: object) -> ConfigureWizard:
+        wiz = real_ctor(**kwargs)  # type: ignore[arg-type]
+        captured["wiz"] = wiz
+        return wiz
+
+    with (
+        patch("mureo.web.server.webbrowser.open"),
+        patch("mureo.web.server.discover_web_extensions", return_value=(fake_entry,)),
+        patch("mureo.web.server.ConfigureWizard", side_effect=_spy),
+    ):
+        thread = threading.Thread(
+            target=run_configure_wizard,
+            kwargs={
+                "home": home_dir,
+                "open_browser": False,
+                "timeout_seconds": timeout,
+            },
+            daemon=True,
+        )
+        thread.start()
+        for _ in range(100):
+            if "wiz" in captured:
+                break
+            time.sleep(0.02)
+        captured["wiz"].wait_until_ready(timeout=5.0)
+        # Let any serve_forever start-hooks run before we stop.
+        time.sleep(0.1)
+        captured["wiz"].request_stop()
+        thread.join(timeout=5.0)
+    assert not thread.is_alive(), "wizard thread did not stop"
+
+
+@pytest.mark.unit
+class TestServerIntegration:
+    def test_serve_forever_fires_start_and_stop(self, home_dir: Path) -> None:
+        events: dict[str, Any] = {"start_ctx": None, "stopped": False}
+        fake = _entry(
+            on_serve_start=lambda ctx: events.__setitem__("start_ctx", ctx),
+            on_serve_stop=lambda: events.__setitem__("stopped", True),
+        )
+        _run_wizard_with_extension(home_dir, fake, timeout=None)  # serve_forever
+        assert events["start_ctx"] is not None, "on_serve_start never fired"
+        assert isinstance(events["start_ctx"], ServeContext)
+        assert events["start_ctx"].home == home_dir
+        assert events["stopped"] is True, "on_serve_stop never fired"
+
+    def test_serve_once_does_not_fire_lifecycle(self, home_dir: Path) -> None:
+        events: dict[str, int] = {"start": 0, "stop": 0}
+        fake = _entry(
+            on_serve_start=lambda _c: events.__setitem__("start", events["start"] + 1),
+            on_serve_stop=lambda: events.__setitem__("stop", events["stop"] + 1),
+        )
+        _run_wizard_with_extension(home_dir, fake, timeout=600.0)  # interactive
+        assert events["start"] == 0, "serve-once must NOT fire on_serve_start"
+        assert events["stop"] == 0, "serve-once must NOT fire on_serve_stop"
+
+    def test_start_hook_requesting_stop_shuts_down_cleanly(
+        self, home_dir: Path
+    ) -> None:
+        """An extension that calls ``ctx.request_stop()`` inside
+        ``on_serve_start`` ends the daemon on its own — the wizard thread
+        exits with NO external stop and ``on_serve_stop`` still fires."""
+        from mureo.web.server import ConfigureWizard, run_configure_wizard
+
+        events: dict[str, bool] = {"stopped": False}
+        fake = _entry(
+            on_serve_start=lambda ctx: ctx.request_stop(),
+            on_serve_stop=lambda: events.__setitem__("stopped", True),
+        )
+        captured: dict[str, Any] = {}
+        real_ctor = ConfigureWizard
+
+        def _spy(**kwargs: object) -> ConfigureWizard:
+            wiz = real_ctor(**kwargs)  # type: ignore[arg-type]
+            captured["wiz"] = wiz
+            return wiz
+
+        with (
+            patch("mureo.web.server.webbrowser.open"),
+            patch("mureo.web.server.discover_web_extensions", return_value=(fake,)),
+            patch("mureo.web.server.ConfigureWizard", side_effect=_spy),
+        ):
+            thread = threading.Thread(
+                target=run_configure_wizard,
+                kwargs={
+                    "home": home_dir,
+                    "open_browser": False,
+                    "timeout_seconds": None,  # serve_forever
+                },
+                daemon=True,
+            )
+            thread.start()
+            # No external request_stop: the start hook is the only stopper.
+            thread.join(timeout=5.0)
+        assert not thread.is_alive(), "hook request_stop did not end the daemon"
+        assert events["stopped"] is True, "on_serve_stop never fired"


### PR DESCRIPTION
Closes #249.

## What

Adds optional always-on lifecycle hooks to the `WebExtension` plugin system so an extension can run a deterministic background job that rides the always-on daemon's start/stop:

```python
def on_serve_start(self, ctx: ServeContext) -> None: ...  # once, when serve_forever starts
def on_serve_stop(self) -> None: ...                       # once, at shutdown
```

## Design (follows existing architecture)

- **Daemon-only:** hooks fire ONLY in `serve_forever` mode (`mureo configure --serve` / `timeout_seconds is None`), never on a short-lived interactive `mureo configure` — mirroring #244's "only the always-on service runs background jobs" guard.
- **`ServeContext`** (frozen) hands the hook `stop_event` (wait on it instead of `sleep`), `request_stop` (orderly shutdown), and `home` (read state under `<home>/.mureo`).
- **Capture at discovery:** because `WebExtensionEntry` stores the *results* of `routes()`/`view()` (not the instance), the bound hooks are captured onto the frozen entry during discovery — the same `getattr`-and-freeze discipline already used for `display_name_i18n` / `hidden_builtin_tabs` / `replaces_landing`. A non-callable hook skips the extension as a packaging bug.
- **Fault isolation:** a hook that raises becomes a `WebExtensionWarning` and never crashes the daemon or blocks the others; an extension whose `on_serve_start` raised does not receive `on_serve_stop`.
- **Backward compatible:** both `WebExtensionEntry` fields default `None`; existing consumers in `handlers.py` are unaffected.

## Files

- `mureo/web/extensions.py` — `ServeContext`, two `WebExtensionEntry` fields, hook capture in `_load_entry_point`, `start_serve_lifecycles` / `stop_serve_lifecycles` helpers, Protocol docstring + `__all__`.
- `mureo/web/server.py` — `run_configure_wizard` builds `ServeContext` and starts lifecycles in the `serve_forever` branch (after the update poller), stops them symmetrically in `finally`.
- `tests/test_web_extension_lifecycle.py` — new.

## Test plan

- [x] 14 new unit tests: `ServeContext` shape/frozen, default-None backward compat, start/stop round-trip, started-set discipline, start & stop fault isolation, discovery capture, non-callable skip, **serve_forever fires / serve-once does NOT**, start-hook `request_stop` → clean shutdown.
- [x] 323 existing web/server/extension tests pass (no regression).
- [x] ruff + black clean; mypy no new errors on changed modules.