### PR TITLE
fix(configure): poll until update check settles; gate "Update all" on availability

### DIFF
--- a/mureo/_data/web/app.css
+++ b/mureo/_data/web/app.css
@@ -984,6 +984,15 @@ dialog[data-confirm-dialog] [data-confirm-ok] {
     transform 0.12s var(--ease), box-shadow 0.15s var(--ease);
 }
 
+/* The `hidden` attribute must win over `.btn`'s `display: inline-flex`:
+   author styles override the UA `[hidden] { display: none }`, so without
+   this a `.btn` toggled via `hidden` (e.g. the About "Update all" button,
+   revealed only when an update exists) would stay visible. Mirrors the
+   targeted `.dashboard-group[hidden]` / `.app-toast[hidden]` rules. */
+.btn[hidden] {
+  display: none;
+}
+
 .btn:hover {
   background: var(--surface-2);
   border-color: var(--ink-soft);

--- a/mureo/_data/web/dashboard.js
+++ b/mureo/_data/web/dashboard.js
@@ -1040,7 +1040,6 @@
 
   // Wire the always-visible "check for updates" button. Idempotent (onclick,
   // not addEventListener) so repeated renders never stack handlers.
-  let checkInProgress = false;
   function wireCheckButton() {
     const btn = document.querySelector("[data-about-check-button]");
     if (!btn) return;
@@ -1049,44 +1048,70 @@
     };
   }
 
-  // POST /api/updates/refresh to drop the cache and start a fresh pip check,
-  // then poll GET /api/updates until the status settles. The check runs in a
-  // background thread server-side and can take up to the pip timeout, so the
-  // poll deadline comfortably exceeds it.
-  async function runCheckNow() {
-    if (checkInProgress) return;
-    const btn = document.querySelector("[data-about-check-button]");
+  // Poll GET /api/updates until the status settles (no longer "checking") or
+  // the deadline passes, then apply the result. The check runs server-side on
+  // a background thread and can take up to the pip timeout, so the deadline
+  // comfortably exceeds it. ``updatePollActive`` coalesces callers so the
+  // passive load (when the first fetch is still mid-check) and the manual
+  // "check now" button share ONE poll instead of stacking two — and a double
+  // renderAll() (#223) cannot start a second loop.
+  // Poll cadence for the background update check. The server runs pip on a
+  // worker thread (bounded by its own ~60s pip timeout), so a 75s deadline
+  // comfortably outlasts it; 1.5s between polls keeps the UI responsive
+  // without hammering the endpoint.
+  const UPDATE_POLL_DEADLINE_MS = 75000;
+  const UPDATE_POLL_INTERVAL_MS = 1500;
+  let updatePollActive = false;
+  async function pollUpdatesUntilSettled() {
+    if (updatePollActive) return;
+    updatePollActive = true;
     const summary = document.querySelector("[data-about-updates-summary]");
-    checkInProgress = true;
-    if (btn) btn.disabled = true;
-    if (summary) setSummary(summary, "dashboard.about_update_checking");
     try {
-      await MUREO.postJson("/api/updates/refresh", {});
-    } catch (_err) {
-      // Even if the trigger POST fails, poll the cache: a periodic refresh
-      // may already be in flight.
-    }
-    let body = null;
-    const deadline = Date.now() + 75000;
-    while (Date.now() < deadline) {
-      await sleep(1500);
-      try {
-        const res = await fetch("/api/updates");
-        body = res.ok ? await res.json() : null;
-      } catch (_e) {
-        body = null;
+      if (summary) setSummary(summary, "dashboard.about_update_checking");
+      let body = null;
+      const deadline = Date.now() + UPDATE_POLL_DEADLINE_MS;
+      while (Date.now() < deadline) {
+        await sleep(UPDATE_POLL_INTERVAL_MS);
+        try {
+          const res = await fetch("/api/updates");
+          body = res.ok ? await res.json() : null;
+        } catch (_e) {
+          body = null;
+        }
+        if (body && body.status && body.status !== "checking") break;
       }
-      if (body && body.status && body.status !== "checking") break;
+      if (!body || body.status === "checking") {
+        // Poll exhausted without the check settling — don't leave a stuck
+        // "Checking…"; surface that it couldn't complete.
+        if (summary) setSummary(summary, "dashboard.about_update_check_failed");
+      } else {
+        applyUpdatesBody(body);
+      }
+    } finally {
+      // Always clear the guard — even if a render/DOM op throws — so the
+      // feature can never wedge itself permanently.
+      updatePollActive = false;
     }
-    if (!body || body.status === "checking") {
-      // Poll exhausted without the check settling — don't leave a stuck
-      // "Checking…"; surface that it couldn't complete.
-      if (summary) setSummary(summary, "dashboard.about_update_check_failed");
-    } else {
-      applyUpdatesBody(body);
+  }
+
+  // POST /api/updates/refresh to drop the cache and start a fresh pip check,
+  // then poll until the status settles.
+  async function runCheckNow() {
+    if (updatePollActive) return;
+    const btn = document.querySelector("[data-about-check-button]");
+    if (btn) btn.disabled = true;
+    try {
+      try {
+        await MUREO.postJson("/api/updates/refresh", {});
+      } catch (_err) {
+        // Even if the trigger POST fails, poll the cache: a periodic refresh
+        // may already be in flight.
+      }
+      await pollUpdatesUntilSettled();
+    } finally {
+      // Re-enable the button no matter how the poll ends.
+      if (btn) btn.disabled = false;
     }
-    checkInProgress = false;
-    if (btn) btn.disabled = false;
   }
 
   async function renderUpdates() {
@@ -1102,6 +1127,16 @@
       body = res.ok ? await res.json() : null;
     } catch (_err) {
       body = null;
+    }
+    // A cold/stale cache answers "checking" while the background pip check
+    // runs (the server starts it on this very fetch). The passive load must
+    // then poll until it settles — otherwise the summary is stuck on
+    // "Checking…" forever, since only the manual button used to poll. Fire it
+    // without awaiting so renderAll() is not blocked; it repaints the DOM when
+    // the check completes.
+    if (body && body.status === "checking") {
+      pollUpdatesUntilSettled();
+      return;
     }
     applyUpdatesBody(body);
   }

--- a/tests/test_web_assets_about_update_check.py
+++ b/tests/test_web_assets_about_update_check.py
@@ -1,0 +1,86 @@
+"""Static-content guards for the About-tab update check.
+
+Two operator-visible regressions are pinned here (no build step — the
+assets are read straight from ``mureo/_data/web/`` at runtime):
+
+* The "Update all" button (``data-about-update-button``) carries the
+  ``hidden`` attribute and is revealed by JS only when an update exists.
+  Because ``.btn { display: inline-flex }`` is an author rule it overrides
+  the UA ``[hidden] { display: none }`` — so without a targeted
+  ``.btn[hidden]`` rule the button shows even when everything is up to
+  date.
+* The passive dashboard load (``renderUpdates``) must POLL when the
+  server answers ``status: "checking"`` (a cold/stale cache starts a pip
+  check in the background). Without polling the summary is stuck on
+  "Checking for updates…" forever, since only the manual button polled.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_WEB = Path(__file__).resolve().parent.parent / "mureo" / "_data" / "web"
+
+
+def _read(name: str) -> str:
+    return (_WEB / name).read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# "Update all" only shows when an update exists (CSS lets `hidden` win)
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_btn_hidden_rule_present() -> None:
+    """A targeted ``.btn[hidden]`` rule must hide the button — otherwise
+    ``.btn``'s ``display: inline-flex`` overrides the UA ``[hidden]`` rule
+    and "Update all" is visible with no updates."""
+    css = _read("app.css")
+    assert ".btn[hidden]" in css
+    idx = css.index(".btn[hidden]")
+    assert "display: none" in css[idx : idx + 80]
+
+
+@pytest.mark.unit
+def test_update_all_button_starts_hidden_in_markup() -> None:
+    """The markup default must be ``hidden`` so the button is absent until
+    JS reveals it on an available update."""
+    html = _read("app.html")
+    start = html.index("data-about-update-button")
+    # The attribute list for this button must include ``hidden``.
+    assert "hidden" in html[start : start + 60]
+
+
+# ---------------------------------------------------------------------------
+# Passive load polls when the server is still "checking"
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_shared_poll_helper_exists() -> None:
+    js = _read("dashboard.js")
+    assert "function pollUpdatesUntilSettled" in js
+
+
+@pytest.mark.unit
+def test_passive_render_polls_when_checking() -> None:
+    """``renderUpdates`` (the on-load path) must hand off to the poll loop
+    when the first ``/api/updates`` answer is ``checking`` — not just show
+    the message and stop."""
+    js = _read("dashboard.js")
+    start = js.index("async function renderUpdates()")
+    end = js.index("function renderAll", start)
+    body = js[start:end]
+    assert 'body.status === "checking"' in body
+    assert "pollUpdatesUntilSettled()" in body
+
+
+@pytest.mark.unit
+def test_manual_check_refreshes_then_polls() -> None:
+    """The manual "check now" button still forces a fresh check
+    (``/api/updates/refresh``) and then polls until it settles."""
+    js = _read("dashboard.js")
+    start = js.index("async function runCheckNow()")
+    end = js.index("async function renderUpdates()", start)
+    body = js[start:end]
+    assert "/api/updates/refresh" in body
+    assert "pollUpdatesUntilSettled()" in body


### PR DESCRIPTION
Fixes two operator-visible bugs on the **About (mureo)** tab of `mureo configure`.

## 1. "Checking for updates…" stuck forever

`renderUpdates()` (the passive on-load path) fetched `/api/updates` **once**. On a cold/stale cache the server answers `status: "checking"` and kicks off a pip check in the background — but the passive path only displayed "Checking for updates…" and never polled. Only the manual "Check for updates" button polled, so the summary stayed stuck until the user clicked it or reloaded.

**Fix:** extracted the poll loop into a shared `pollUpdatesUntilSettled()` (guarded by `updatePollActive`); `renderUpdates()` now hands off to it when the first answer is `checking`, and `runCheckNow()` reuses it. A double `renderAll()` (#223) or a button click during a passive poll coalesces into a single loop.

## 2. "Update all" button always visible

The button is `hidden` by default in markup and the JS reveals it only when `any_update` is true — but `.btn { display: inline-flex }` is an **author** rule and overrides the UA `[hidden] { display: none }`, so it showed even when everything was up to date.

**Fix:** added `.btn[hidden] { display: none; }` (specificity (0,2,0) beats `.btn`), mirroring the existing `.dashboard-group[hidden]` / `.app-toast[hidden]` rules.

## Robustness

Wrapped the poll body and the button-disable in `try/finally` so `updatePollActive` / `btn.disabled` can never wedge if a render throws (per code review).

## Files
- `mureo/_data/web/dashboard.js` — shared poll loop, passive-path handoff, try/finally guards, named poll-cadence consts.
- `mureo/_data/web/app.css` — `.btn[hidden]` rule.
- `tests/test_web_assets_about_update_check.py` — new static-content guard tests.

## Test plan
- [x] 5 new asset-content guard tests (`.btn[hidden]`, markup default `hidden`, shared poll helper, passive-render polls on `checking`, manual check still refreshes+polls).
- [x] 90 existing web/about/version-check/static tests pass.
- [x] `node --check` on dashboard.js; ruff + black clean.
- Manual: open About with a cold cache → "Checking…" resolves to up-to-date / updates without reload; "Update all" hidden when up to date.

_No JS test harness in the repo, so the dynamic coalescing/race behavior is covered by reasoning + the static guards rather than a DOM runner._