### PR TITLE
chore(release): v0.10.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mureo",
-  "version": "0.9.33",
+  "version": "0.10.0",
   "description": "Your local-first AI ad ops crew for Google Ads, Meta Ads, Search Console & GA4. mureo sits on top of the official ad-platform MCPs, gates every change against your strategy, correlates outcomes locally, and keeps an auditable decision log — credentials never leave your machine.",
   "author": {
     "name": "Logly Inc.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-06-14
+
+Always-on lifecycle hooks for web extensions, plus a fix for the About
+tab's update checker.
+
+### Added
+
+#### WebExtension lifecycle hooks (#249)
+
+`WebExtension` may now declare optional `on_serve_start(ctx)` /
+`on_serve_stop()` hooks, invoked **only** by the always-on daemon
+(`mureo configure --serve`) and never by a short-lived interactive
+launch — mirroring the "only the always-on service runs background jobs"
+guard. An extension can use them to start and stop a self-managed
+background job (e.g. periodic health checks, proactive notifications)
+that rides the daemon's lifecycle. The hooks are captured at discovery,
+fault-isolated per extension, and fully backward compatible (an extension
+declaring neither behaves exactly as before). A new `ServeContext`
+carries a stop `threading.Event`, a `request_stop` callback, and the
+resolved home path.
+
+### Fixed
+
+#### About-tab update check (#251)
+
+The passive dashboard load now polls until the background update check
+settles, so "Checking for updates…" no longer stays on screen forever
+when the cache is cold (previously only the manual button polled). The
+"Update all" button is now hidden unless an update is actually available
+— a new `.btn[hidden]` rule lets the `hidden` attribute win over the
+button's `display`, which had been keeping it visible regardless.
+
 ## [0.9.33] - 2026-06-13
 
 Self-service updates and always-on operation for configure: a fixed

--- a/mureo/__init__.py
+++ b/mureo/__init__.py
@@ -1,3 +1,3 @@
 """mureo — your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."""
 
-__version__ = "0.9.33"
+__version__ = "0.10.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mureo"
-version = "0.9.33"
+version = "0.10.0"
 description = "Your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."
 requires-python = ">=3.10"
 license = "Apache-2.0"


### PR DESCRIPTION
Release **v0.10.0**.

Bumps the version across `pyproject.toml`, `mureo/__init__.py`, and `.claude-plugin/plugin.json`, and adds the CHANGELOG entry. Merging this and publishing a GitHub Release for `v0.10.0` triggers the PyPI publish (`release.yml`, trusted publishing).

## Included since 0.9.33
- **feat (#249, #250):** WebExtension always-on lifecycle hooks — `on_serve_start(ctx)` / `on_serve_stop()`, invoked only by the `--serve` daemon. New `ServeContext`; fault-isolated per extension; backward compatible.
- **fix (#251):** About-tab update check — passive load polls until the check settles (no more stuck "Checking for updates…"); "Update all" button hidden unless an update exists.

## Test plan
- [x] Version parity test (`tests/test_plugin_manifests.py`) — 9 passed.
- [x] Both feature PRs already merged with full CI green.
- [ ] CI green on this release PR → merge → publish GitHub Release `v0.10.0` → PyPI.
