### PR TITLE
fix(configure): scope About update check to mureo packages (no more 60s timeout)

### DIFF
--- a/mureo/web/version_check.py
+++ b/mureo/web/version_check.py
@@ -1,28 +1,39 @@
 """Update-availability check for the configure UI's "About mureo" tab (#239).
 
 Surfaces whether a newer ``mureo`` or any installed ``mureo-*`` plugin is
-available so the operator can upgrade with one click. The check shells out
-to ``python -m pip list --outdated --format=json`` on ``sys.executable``
-and FILTERS the result to mureo / ``mureo-*`` packages.
+available so the operator can upgrade with one click. The check enumerates
+the installed mureo / ``mureo-*`` distributions locally, then shells out to
+a SCOPED ``python -m pip install --dry-run --upgrade --no-deps --report -``
+on ``sys.executable`` for just those packages and reads pip's JSON report.
+
+Why scoped: ``pip list --outdated`` queries the index for EVERY installed
+distribution, which on a heavy venv (e.g. the Google Ads SDK and its deps)
+routinely exceeds the timeout and surfaces "could not check for updates".
+Restricting the query to mureo + its plugins keeps it to a few seconds.
 
 Why pip (not a direct PyPI query): running pip respects the operator's
 configured package index, so private bridges (``mureo-logly-bridge``,
 ``mureo-agency`` — potentially on a private index, not public PyPI) are
-checked correctly, and it shares the exact venv / index resolution that
-``mureo upgrade --all`` uses. "Update available" and "the upgrade" are
-then consistent by construction — no hand-rolled PEP 440 comparison, no
-HTTP client of our own.
+checked correctly, and it shares the venv / index resolution that
+``mureo upgrade`` uses. A package lands in the report's ``install`` list
+when pip's resolver would change its version; we additionally require the
+index version to be strictly newer than the installed one (a pinning
+constraint can otherwise surface a downgrade), restoring parity with the
+old ``pip list --outdated``. ``--no-deps`` scopes the query to the named
+packages, so the check answers "is a newer mureo / plugin published?"
+rather than fully simulating ``mureo upgrade --all``'s dependency
+resolution — close enough for an availability badge, and far faster.
 
 Fault isolation: any pip failure (non-zero exit, timeout, network down,
 unparseable JSON, OS error) degrades to ``status="error"`` with
 ``any_update=False``. This function NEVER raises and NEVER produces a 500.
 
 Non-blocking accessor: HTTP handlers must call :func:`get_update_status`,
-NOT :func:`check_for_updates` directly. ``pip list --outdated`` reaches
+NOT :func:`check_for_updates` directly. The scoped pip check still reaches
 the configured index and can take up to ``_PIP_TIMEOUT_SECONDS`` on a slow
 or unreachable network. Running it inline on every request blocks the
 request thread for that long — and the configure UI fetches ``/api/updates``
-more than once per page load — so the slow check is run once in a daemon
+more than once per page load — so the check is run once in a daemon
 thread and its result cached; the handler returns instantly.
 """
 
@@ -36,9 +47,16 @@ import subprocess
 import sys
 import threading
 import time
+from importlib import metadata
 from typing import Any, Final
 
-from mureo.cli.upgrade_cmd import _canonicalise, _is_mureo_package
+from packaging.version import InvalidVersion, Version
+
+from mureo.cli.upgrade_cmd import (
+    _canonicalise,
+    _discover_all_mureo_packages,
+    _is_mureo_package,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -82,13 +100,52 @@ def _error_result() -> dict[str, Any]:
     return {"status": "error", "any_update": False, "packages": []}
 
 
-def _run_pip_outdated() -> str | None:
-    """Return pip's ``--outdated --format=json`` stdout, or ``None``.
+def _installed_mureo_versions() -> dict[str, str]:
+    """``{canonical name: installed version}`` for installed mureo / ``mureo-*``
+    distributions.
 
-    ``None`` signals any failure mode (non-zero exit, timeout, OS error)
-    the caller must treat as "could not determine updates".
+    Resolved locally from installed metadata (no network). Reused both to
+    SCOPE the pip query below to just these packages and to fill the
+    ``installed`` field of each reported package.
     """
-    cmd = [sys.executable, "-m", "pip", "list", "--outdated", "--format=json"]
+    versions: dict[str, str] = {}
+    for name in _discover_all_mureo_packages():
+        try:
+            versions[name] = metadata.version(name)
+        except metadata.PackageNotFoundError:
+            continue
+    return versions
+
+
+def _run_pip_report(packages: list[str]) -> dict[str, Any] | None:
+    """Return pip's JSON install report for a scoped dry-run upgrade, or ``None``.
+
+    Runs ``pip install --dry-run --upgrade --no-deps --report -`` for ONLY the
+    given mureo packages. Scoping is what keeps this fast: ``pip list
+    --outdated`` queries the index for EVERY installed distribution (60s+ in a
+    heavy venv — the timeout operators hit), whereas this touches only mureo +
+    its plugins (~3s). ``--upgrade`` lets pip's own resolver decide what is
+    outdated — a package appears in the report's ``install`` list iff a newer
+    version is available — so "update available" stays consistent with
+    ``mureo upgrade`` and we never hand-roll a PEP 440 comparison.
+
+    ``None`` signals any failure mode (non-zero exit, timeout, OS error,
+    unparseable JSON) the caller must treat as "could not determine updates".
+    """
+    cmd = [
+        sys.executable,
+        "-m",
+        "pip",
+        "install",
+        "--dry-run",
+        "--upgrade",
+        "--no-deps",
+        "--quiet",
+        "--report",
+        "-",
+        "--",
+        *packages,
+    ]
     try:
         proc = subprocess.run(  # noqa: S603 — fixed argv, no shell, trusted exe
             cmd,
@@ -98,43 +155,71 @@ def _run_pip_outdated() -> str | None:
             timeout=_PIP_TIMEOUT_SECONDS,
         )
     except subprocess.TimeoutExpired:
-        # Expected on a slow / unreachable index — not a bug. Log one line,
-        # not a multi-line traceback that scares the operator on the console.
-        logger.warning("pip list --outdated timed out after %ss", _PIP_TIMEOUT_SECONDS)
+        # Should not happen now the query is scoped, but keep the guard. Log one
+        # line, not a multi-line traceback that scares the operator on the console.
+        logger.warning("pip update check timed out after %ss", _PIP_TIMEOUT_SECONDS)
         return None
     except OSError as exc:
-        logger.warning("pip list --outdated could not run: %s", exc)
+        logger.warning("pip update check could not run: %s", exc)
         return None
     if proc.returncode != 0:
-        logger.warning(
-            "pip list --outdated exited %s: %s", proc.returncode, proc.stderr
-        )
+        logger.warning("pip update check exited %s: %s", proc.returncode, proc.stderr)
         return None
-    return proc.stdout
+    try:
+        report = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        logger.warning("pip update check produced unparseable JSON")
+        return None
+    if not isinstance(report, dict):
+        logger.warning("pip update check report was not a JSON object")
+        return None
+    return report
 
 
-def _row_to_package(row: Any) -> dict[str, str] | None:
-    """Map one pip ``--outdated`` JSON row to ``{name, installed, latest}``.
+def _outdated_from_report(
+    report: dict[str, Any], installed: dict[str, str]
+) -> list[dict[str, str]]:
+    """Map pip's report ``install`` list to outdated mureo packages.
 
-    Returns ``None`` for a non-mureo package or a row missing the required
-    keys (so one malformed entry never breaks the whole check).
+    Each entry pip would install/upgrade becomes ``{name, installed, latest}``
+    (canonical name; ``installed`` filled from the local metadata snapshot).
+    A non-mureo, malformed, or not-locally-installed entry is dropped so one
+    bad row never breaks the whole check.
     """
-    if not isinstance(row, dict):
-        return None
-    name = row.get("name")
-    installed = row.get("version")
-    latest = row.get("latest_version")
-    if not isinstance(name, str) or not name or not _is_mureo_package(name):
-        return None
-    if not isinstance(installed, str) or not isinstance(latest, str):
-        return None
-    if not installed or not latest:
-        return None
-    return {
-        "name": _canonicalise(name),
-        "installed": installed,
-        "latest": latest,
-    }
+    install = report.get("install")
+    if not isinstance(install, list):
+        return []
+    packages: list[dict[str, str]] = []
+    for item in install:
+        if not isinstance(item, dict):
+            continue
+        meta = item.get("metadata")
+        if not isinstance(meta, dict):
+            continue
+        name = meta.get("name")
+        latest = meta.get("version")
+        if not isinstance(name, str) or not name or not _is_mureo_package(name):
+            continue
+        if not isinstance(latest, str) or not latest:
+            continue
+        canonical = _canonicalise(name)
+        installed_version = installed.get(canonical)
+        if not installed_version:
+            continue
+        # ``--upgrade`` can also list a DOWNGRADE target when a pip constraint
+        # pins the package below what is installed; only a strictly newer
+        # version is an "update available" (parity with pip list --outdated).
+        # An unparseable version is dropped rather than shown as a dubious update.
+        try:
+            if Version(latest) <= Version(installed_version):
+                continue
+        except InvalidVersion:
+            continue
+        packages.append(
+            {"name": canonical, "installed": installed_version, "latest": latest}
+        )
+    packages.sort(key=lambda pkg: pkg["name"])
+    return packages
 
 
 def check_for_updates() -> dict[str, Any]:
@@ -154,20 +239,15 @@ def check_for_updates() -> dict[str, Any]:
     On any pip failure the envelope degrades to ``status="error"`` /
     ``any_update=False`` / empty ``packages`` — never an exception.
     """
-    stdout = _run_pip_outdated()
-    if stdout is None:
+    installed = _installed_mureo_versions()
+    if not installed:
+        # No mureo distribution is resolvable (highly unusual). Nothing to
+        # check rather than an error — there is genuinely nothing to upgrade.
+        return {"status": "ok", "any_update": False, "packages": []}
+    report = _run_pip_report(sorted(installed))
+    if report is None:
         return _error_result()
-    try:
-        rows = json.loads(stdout)
-    except json.JSONDecodeError:
-        logger.warning("pip list --outdated produced unparseable JSON")
-        return _error_result()
-    if not isinstance(rows, list):
-        logger.warning("pip list --outdated did not return a JSON array")
-        return _error_result()
-
-    packages = [pkg for pkg in (_row_to_package(row) for row in rows) if pkg]
-    packages.sort(key=lambda pkg: pkg["name"])
+    packages = _outdated_from_report(report, installed)
     return {
         "status": "ok",
         "any_update": bool(packages),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,11 @@ dependencies = [
     # — re-implementing YAML escapes is a worse security surface than
     # the audited safe_load path.
     "pyyaml>=6.0,<7",
+    # packaging is used by mureo.web.version_check to PEP 440-compare an
+    # index version against the installed one, so a pip constraint that
+    # pins a package BELOW what is installed is never mis-reported as an
+    # available update. Ubiquitous, tiny, pure-Python; pinned <26 for room.
+    "packaging>=23.0,<26",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_web_version_check.py
+++ b/tests/test_web_version_check.py
@@ -1,12 +1,12 @@
 """Update-availability check for ``mureo.web.version_check``.
 
-``check_for_updates`` shells out to ``python -m pip list --outdated
---format=json`` on ``sys.executable`` and FILTERS the result to mureo /
-``mureo-*`` packages (reusing the scope helpers from
-``mureo.cli.upgrade_cmd``). Every test patches ``subprocess.run`` at the
-module's imported symbol, so nothing here depends on what is actually
-installed in the venv running the suite, nor does anything reach the
-network.
+``check_for_updates`` discovers the installed mureo / ``mureo-*``
+distributions locally, then runs a SCOPED ``pip install --dry-run
+--upgrade --no-deps --report -`` over just those packages and maps the
+report's ``install`` list to the API envelope. The mapping tests patch
+``_installed_mureo_versions`` and ``_run_pip_report``; the subprocess
+fault-isolation tests patch ``subprocess.run``. Either way nothing here
+depends on what is actually installed in the venv, nor reaches the network.
 """
 
 from __future__ import annotations
@@ -57,27 +57,39 @@ def _completed(
     )
 
 
-def _outdated_json(*rows: dict[str, Any]) -> str:
-    """Serialise ``pip list --outdated --format=json`` rows."""
+def _report(*entries: dict[str, str]) -> dict[str, Any]:
+    """Build a ``pip install --report`` dict whose ``install`` list carries the
+    given ``{name, version}`` metadata entries (``version`` = the latest pip
+    would install)."""
 
-    return json.dumps(list(rows))
+    return {
+        "version": "1",
+        "install": [
+            {"metadata": {"name": e["name"], "version": e["version"]}} for e in entries
+        ],
+    }
 
 
 @pytest.mark.unit
 class TestCheckForUpdates:
+    """``check_for_updates`` maps pip's scoped report to the API envelope.
+
+    The pure mapping is exercised by mocking ``_installed_mureo_versions``
+    (the local metadata snapshot) and ``_run_pip_report`` (the scoped pip
+    call). Subprocess-level fault isolation lives in ``TestRunPipReport``.
+    """
+
     def test_surfaces_outdated_mureo_packages(self) -> None:
         """An outdated ``mureo-*`` package is reported with installed→latest."""
-        payload = _outdated_json(
-            {
-                "name": "mureo-agency",
-                "version": "0.1.0",
-                "latest_version": "0.2.0",
-                "latest_filetype": "wheel",
-            },
-        )
-        with patch(
-            "mureo.web.version_check.subprocess.run",
-            return_value=_completed(stdout=payload),
+        with (
+            patch(
+                "mureo.web.version_check._installed_mureo_versions",
+                return_value={"mureo-agency": "0.1.0"},
+            ),
+            patch(
+                "mureo.web.version_check._run_pip_report",
+                return_value=_report({"name": "mureo-agency", "version": "0.2.0"}),
+            ),
         ):
             result = check_for_updates()
         assert result["status"] == "ok"
@@ -86,31 +98,40 @@ class TestCheckForUpdates:
             {"name": "mureo-agency", "installed": "0.1.0", "latest": "0.2.0"}
         ]
 
+    def test_scopes_query_to_installed_mureo_packages(self) -> None:
+        """The pip call is scoped to the installed mureo packages (sorted) —
+        the whole point of the fix vs. ``pip list --outdated`` over the venv."""
+        captured: dict[str, Any] = {}
+
+        def _capture(packages: list[str]) -> dict[str, Any]:
+            captured["packages"] = packages
+            return _report()
+
+        with (
+            patch(
+                "mureo.web.version_check._installed_mureo_versions",
+                return_value={"mureo-agency": "0.1.0", "mureo": "0.10.0"},
+            ),
+            patch("mureo.web.version_check._run_pip_report", side_effect=_capture),
+        ):
+            check_for_updates()
+        assert captured["packages"] == ["mureo", "mureo-agency"]
+
     def test_filters_out_non_mureo_packages(self) -> None:
-        """Outdated packages that are not mureo / mureo-* are dropped."""
-        payload = _outdated_json(
-            {
-                "name": "requests",
-                "version": "2.0.0",
-                "latest_version": "2.31.0",
-                "latest_filetype": "wheel",
-            },
-            {
-                "name": "mureology",  # prefix squatter — must NOT match
-                "version": "1.0.0",
-                "latest_version": "2.0.0",
-                "latest_filetype": "wheel",
-            },
-            {
-                "name": "mureo-logly-bridge",
-                "version": "0.3.0",
-                "latest_version": "0.4.0",
-                "latest_filetype": "wheel",
-            },
-        )
-        with patch(
-            "mureo.web.version_check.subprocess.run",
-            return_value=_completed(stdout=payload),
+        """Report entries that are not mureo / mureo-* are dropped."""
+        with (
+            patch(
+                "mureo.web.version_check._installed_mureo_versions",
+                return_value={"mureo-logly-bridge": "0.3.0"},
+            ),
+            patch(
+                "mureo.web.version_check._run_pip_report",
+                return_value=_report(
+                    {"name": "requests", "version": "2.31.0"},
+                    {"name": "mureology", "version": "2.0.0"},  # prefix squatter
+                    {"name": "mureo-logly-bridge", "version": "0.4.0"},
+                ),
+            ),
         ):
             result = check_for_updates()
         assert result["status"] == "ok"
@@ -120,17 +141,15 @@ class TestCheckForUpdates:
 
     def test_mureo_itself_outdated_is_included(self) -> None:
         """The ``mureo`` core distribution is included when outdated."""
-        payload = _outdated_json(
-            {
-                "name": "mureo",
-                "version": "0.9.31",
-                "latest_version": "0.9.32",
-                "latest_filetype": "wheel",
-            },
-        )
-        with patch(
-            "mureo.web.version_check.subprocess.run",
-            return_value=_completed(stdout=payload),
+        with (
+            patch(
+                "mureo.web.version_check._installed_mureo_versions",
+                return_value={"mureo": "0.9.31"},
+            ),
+            patch(
+                "mureo.web.version_check._run_pip_report",
+                return_value=_report({"name": "mureo", "version": "0.9.32"}),
+            ),
         ):
             result = check_for_updates()
         assert result["any_update"] is True
@@ -139,126 +158,178 @@ class TestCheckForUpdates:
         ]
 
     def test_up_to_date_reports_no_update(self) -> None:
-        """An empty outdated list → ``ok`` with ``any_update`` false."""
-        with patch(
-            "mureo.web.version_check.subprocess.run",
-            return_value=_completed(stdout="[]"),
+        """An empty ``install`` list → ``ok`` with ``any_update`` false."""
+        with (
+            patch(
+                "mureo.web.version_check._installed_mureo_versions",
+                return_value={"mureo": "0.10.0"},
+            ),
+            patch("mureo.web.version_check._run_pip_report", return_value=_report()),
         ):
             result = check_for_updates()
         assert result["status"] == "ok"
         assert result["any_update"] is False
         assert result["packages"] == []
 
-    def test_only_non_mureo_outdated_reports_no_update(self) -> None:
-        """When every outdated row is non-mureo, ``any_update`` is false."""
-        payload = _outdated_json(
-            {
-                "name": "pip",
-                "version": "23.0",
-                "latest_version": "24.0",
-                "latest_filetype": "wheel",
-            },
-        )
-        with patch(
-            "mureo.web.version_check.subprocess.run",
-            return_value=_completed(stdout=payload),
+    def test_no_mureo_installed_reports_no_update_without_pip(self) -> None:
+        """No resolvable mureo distribution → ``ok`` empty, and pip is never run."""
+        with (
+            patch("mureo.web.version_check._installed_mureo_versions", return_value={}),
+            patch("mureo.web.version_check._run_pip_report") as mock_report,
         ):
             result = check_for_updates()
-        assert result["status"] == "ok"
-        assert result["any_update"] is False
-        assert result["packages"] == []
+        assert result == {"status": "ok", "any_update": False, "packages": []}
+        mock_report.assert_not_called()
 
-    def test_pip_nonzero_exit_degrades_to_error(self) -> None:
-        """A non-zero pip exit → ``error`` envelope, no raise, no update."""
-        with patch(
-            "mureo.web.version_check.subprocess.run",
-            return_value=_completed(returncode=1, stderr="boom"),
+    def test_pip_failure_degrades_to_error(self) -> None:
+        """When the scoped pip call fails (``None``), degrade to ``error``."""
+        with (
+            patch(
+                "mureo.web.version_check._installed_mureo_versions",
+                return_value={"mureo": "0.10.0"},
+            ),
+            patch("mureo.web.version_check._run_pip_report", return_value=None),
         ):
             result = check_for_updates()
         assert result["status"] == "error"
         assert result["any_update"] is False
         assert result["packages"] == []
 
-    def test_timeout_degrades_to_error(self) -> None:
-        """A subprocess timeout must degrade, never propagate."""
-        with patch(
-            "mureo.web.version_check.subprocess.run",
-            side_effect=subprocess.TimeoutExpired(cmd="pip", timeout=60),
-        ):
-            result = check_for_updates()
-        assert result["status"] == "error"
-        assert result["any_update"] is False
-        assert result["packages"] == []
-
-    def test_unparseable_json_degrades_to_error(self) -> None:
-        """Garbage on stdout must not crash JSON parsing."""
-        with patch(
-            "mureo.web.version_check.subprocess.run",
-            return_value=_completed(stdout="not json at all"),
-        ):
-            result = check_for_updates()
-        assert result["status"] == "error"
-        assert result["any_update"] is False
-        assert result["packages"] == []
-
-    def test_subprocess_oserror_degrades_to_error(self) -> None:
-        """A missing interpreter / OS error must degrade, never raise."""
-        with patch(
-            "mureo.web.version_check.subprocess.run",
-            side_effect=OSError("no such executable"),
-        ):
-            result = check_for_updates()
-        assert result["status"] == "error"
-        assert result["any_update"] is False
-        assert result["packages"] == []
-
-    def test_non_list_json_payload_degrades_to_error(self) -> None:
-        """pip is documented to emit a JSON array; an object is malformed."""
-        with patch(
-            "mureo.web.version_check.subprocess.run",
-            return_value=_completed(stdout='{"name": "mureo"}'),
-        ):
-            result = check_for_updates()
-        assert result["status"] == "error"
-        assert result["any_update"] is False
-        assert result["packages"] == []
-
-    def test_malformed_row_is_skipped_not_fatal(self) -> None:
-        """A row missing required keys is dropped; valid rows still surface."""
-        payload = json.dumps(
-            [
-                {"name": "mureo-agency"},  # no version / latest_version
-                {
-                    "name": "mureo-logly-bridge",
-                    "version": "0.3.0",
-                    "latest_version": "0.4.0",
-                    "latest_filetype": "wheel",
-                },
-            ]
-        )
-        with patch(
-            "mureo.web.version_check.subprocess.run",
-            return_value=_completed(stdout=payload),
+    def test_malformed_entry_is_skipped_not_fatal(self) -> None:
+        """An ``install`` entry missing metadata is dropped; valid ones surface."""
+        report = {
+            "version": "1",
+            "install": [
+                {"metadata": {"name": "mureo-agency"}},  # no version
+                {"foo": "bar"},  # no metadata at all
+                {"metadata": {"name": "mureo-logly-bridge", "version": "0.4.0"}},
+            ],
+        }
+        with (
+            patch(
+                "mureo.web.version_check._installed_mureo_versions",
+                return_value={"mureo-agency": "0.1.0", "mureo-logly-bridge": "0.3.0"},
+            ),
+            patch("mureo.web.version_check._run_pip_report", return_value=report),
         ):
             result = check_for_updates()
         assert result["status"] == "ok"
         names = [pkg["name"] for pkg in result["packages"]]
         assert names == ["mureo-logly-bridge"]
 
-    def test_uses_sys_executable_pip_list_outdated_json(self) -> None:
-        """The command targets this venv's pip with the JSON outdated flags."""
+    def test_constraint_pinned_downgrade_is_not_an_update(self) -> None:
+        """``--upgrade`` can list a DOWNGRADE target when a pip constraint pins
+        the package below what is installed; that is NOT an available update."""
+        with (
+            patch(
+                "mureo.web.version_check._installed_mureo_versions",
+                return_value={"mureo": "0.10.0"},
+            ),
+            patch(
+                "mureo.web.version_check._run_pip_report",
+                return_value=_report({"name": "mureo", "version": "0.9.0"}),
+            ),
+        ):
+            result = check_for_updates()
+        assert result["status"] == "ok"
+        assert result["any_update"] is False
+        assert result["packages"] == []
+
+    def test_unparseable_index_version_is_dropped(self) -> None:
+        """A non-PEP 440 ``latest`` is dropped, never shown as a dubious update."""
+        with (
+            patch(
+                "mureo.web.version_check._installed_mureo_versions",
+                return_value={"mureo-agency": "0.1.0"},
+            ),
+            patch(
+                "mureo.web.version_check._run_pip_report",
+                return_value=_report(
+                    {"name": "mureo-agency", "version": "not-a-version"}
+                ),
+            ),
+        ):
+            result = check_for_updates()
+        assert result["any_update"] is False
+        assert result["packages"] == []
+
+
+@pytest.mark.unit
+class TestRunPipReport:
+    """Subprocess-level fault isolation and command shape of the scoped query."""
+
+    def test_success_returns_report_dict(self) -> None:
+        report_json = json.dumps({"version": "1", "install": []})
         with patch(
             "mureo.web.version_check.subprocess.run",
-            return_value=_completed(stdout="[]"),
+            return_value=_completed(stdout=report_json),
+        ):
+            assert version_check._run_pip_report(["mureo"]) == {
+                "version": "1",
+                "install": [],
+            }
+
+    def test_command_is_scoped_dry_run_for_given_packages(self) -> None:
+        with patch(
+            "mureo.web.version_check.subprocess.run",
+            return_value=_completed(stdout='{"install": []}'),
         ) as mock_run:
-            check_for_updates()
+            version_check._run_pip_report(["mureo", "mureo-agency"])
         args, kwargs = mock_run.call_args
         cmd = args[0]
-        assert cmd[1:] == ["-m", "pip", "list", "--outdated", "--format=json"]
+        assert cmd[1:10] == [
+            "-m",
+            "pip",
+            "install",
+            "--dry-run",
+            "--upgrade",
+            "--no-deps",
+            "--quiet",
+            "--report",
+            "-",
+        ]
+        # Packages follow the ``--`` sentinel so a name can never be read as a flag.
+        assert cmd[-3:] == ["--", "mureo", "mureo-agency"]
         assert kwargs["capture_output"] is True
         assert kwargs["text"] is True
         assert kwargs["check"] is False
         assert kwargs["timeout"] == 60
+
+    def test_nonzero_exit_returns_none(self) -> None:
+        with patch(
+            "mureo.web.version_check.subprocess.run",
+            return_value=_completed(returncode=1, stderr="boom"),
+        ):
+            assert version_check._run_pip_report(["mureo"]) is None
+
+    def test_timeout_returns_none(self) -> None:
+        with patch(
+            "mureo.web.version_check.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="pip", timeout=60),
+        ):
+            assert version_check._run_pip_report(["mureo"]) is None
+
+    def test_oserror_returns_none(self) -> None:
+        with patch(
+            "mureo.web.version_check.subprocess.run",
+            side_effect=OSError("no such executable"),
+        ):
+            assert version_check._run_pip_report(["mureo"]) is None
+
+    def test_unparseable_json_returns_none(self) -> None:
+        with patch(
+            "mureo.web.version_check.subprocess.run",
+            return_value=_completed(stdout="not json at all"),
+        ):
+            assert version_check._run_pip_report(["mureo"]) is None
+
+    def test_non_object_json_returns_none(self) -> None:
+        """pip's report is a JSON object; a bare array is malformed."""
+        with patch(
+            "mureo.web.version_check.subprocess.run",
+            return_value=_completed(stdout="[]"),
+        ):
+            assert version_check._run_pip_report(["mureo"]) is None
 
 
 @pytest.mark.unit
@@ -389,9 +460,7 @@ class TestPeriodicUpdateCheck:
 
     _OK: Any = {"status": "ok", "any_update": False, "packages": []}
 
-    def test_interval_resolves_from_env(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_interval_resolves_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("MUREO_UPDATE_CHECK_INTERVAL_SECONDS", "120")
         assert version_check._resolve_poll_interval(None) == 120.0
 
@@ -450,9 +519,7 @@ class TestPeriodicUpdateCheck:
 
     def test_start_is_idempotent(self) -> None:
         """A second start while one runs is a no-op (single-instance reuse)."""
-        with patch(
-            "mureo.web.version_check.check_for_updates", return_value=self._OK
-        ):
+        with patch("mureo.web.version_check.check_for_updates", return_value=self._OK):
             assert start_periodic_update_check(interval_seconds=3600) is True
             assert start_periodic_update_check(interval_seconds=3600) is False
             stop_periodic_update_check()
@@ -463,9 +530,7 @@ class TestPeriodicUpdateCheck:
 
     def test_restart_after_stop_launches_fresh_poller(self) -> None:
         """start → stop → start must work (each launch gets its own event)."""
-        with patch(
-            "mureo.web.version_check.check_for_updates", return_value=self._OK
-        ):
+        with patch("mureo.web.version_check.check_for_updates", return_value=self._OK):
             assert start_periodic_update_check(interval_seconds=3600) is True
             stop_periodic_update_check()
             assert version_check._poll_thread is None


### PR DESCRIPTION
Fixes the configure **About** tab's update check timing out — user-reported `pip list --outdated timed out after 60s` → "Could not check for updates."

## Root cause
`pip list --outdated --format=json` queries the package index for **every installed distribution**. In a heavy venv (Google Ads SDK + its dependency tree) this exceeds the 60s subprocess timeout, so the check degrades to `status="error"`.

## Fix — scope the query to mureo packages
- Enumerate the installed `mureo` / `mureo-*` distributions **locally** (`importlib.metadata`, no network).
- Run a single scoped `pip install --dry-run --upgrade --no-deps --quiet --report - -- <packages>` and read pip's JSON report. **~3s vs a 60s+ timeout** (measured live in this env).
- Still uses pip, so the operator's configured/private index is honored; the public `/api/updates` envelope is unchanged.

## Correctness guard
`pip --upgrade --report` can list a **downgrade** target when a pip constraint pins a package below what is installed. We require the index version to be **strictly newer** (PEP 440 compare via `packaging`) before reporting an update — restoring parity with `pip list --outdated`. Adds `packaging` as an explicit dependency.

## Test plan
- [x] `tests/test_web_version_check.py` rewritten + extended — 36 cases incl. scoping, downgrade-guard, unparseable-version, and `TestRunPipReport` (timeout / non-zero / OSError / unparseable / non-object JSON, `--` sentinel, command shape). Full suite: 44 passed with parity test.
- [x] Live: `check_for_updates()` returns `ok` in ~3.5s (was 60s→error); downgrade guard suppresses a pinned-below target; a real upgrade still surfaces.
- [x] ruff + black clean; mypy no new errors.
- [ ] CI green → merge → release follow-up (0.10.1).
