### PR TITLE
chore(release): v0.10.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mureo",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Your local-first AI ad ops crew for Google Ads, Meta Ads, Search Console & GA4. mureo sits on top of the official ad-platform MCPs, gates every change against your strategy, correlates outcomes locally, and keeps an auditable decision log — credentials never leave your machine.",
   "author": {
     "name": "Logly Inc.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.1] - 2026-06-14
+
+### Fixed
+
+#### About-tab update check no longer times out (#253)
+
+The update check ran ``pip list --outdated``, which queries the package
+index for EVERY installed distribution; on a heavy venv (the Google Ads
+SDK and its dependency tree) it exceeded the 60s timeout and surfaced
+"could not check for updates". The query is now scoped to mureo and its
+``mureo-*`` plugins via ``pip install --dry-run --upgrade --no-deps
+--report -`` — a few seconds instead of a timeout — while still using pip
+so the operator's configured (possibly private) index is honored. A pip
+constraint that pins a package below the installed version can no longer
+be mis-reported as an available update. Adds ``packaging`` as a
+dependency.
+
 ## [0.10.0] - 2026-06-14
 
 Always-on lifecycle hooks for web extensions, plus a fix for the About

--- a/mureo/__init__.py
+++ b/mureo/__init__.py
@@ -1,3 +1,3 @@
 """mureo — your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."""
 
-__version__ = "0.10.0"
+__version__ = "0.10.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mureo"
-version = "0.10.0"
+version = "0.10.1"
 description = "Your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."
 requires-python = ">=3.10"
 license = "Apache-2.0"


### PR DESCRIPTION
Release **v0.10.1** — patch.

Bumps the version across `pyproject.toml`, `mureo/__init__.py`, and `.claude-plugin/plugin.json`, and adds the CHANGELOG entry. Merging this and publishing a GitHub Release for `v0.10.1` triggers the PyPI publish (`release.yml`, trusted publishing).

## Included since 0.10.0
- **fix (#253):** configure About-tab update check no longer times out. `pip list --outdated` queried the index for every installed distribution (60s+ timeout on a heavy venv); the query is now scoped to mureo + `mureo-*` plugins via `pip install --dry-run --upgrade --no-deps --report -` (~3s). Guards against a pinned-below downgrade being mis-reported as an update. Adds `packaging` as a dependency.

## Test plan
- [x] Version parity test (`tests/test_plugin_manifests.py`) — 9 passed.
- [x] #253 already merged with full CI green + live browser verification (resolves to "すべて最新です。", no timeout).
- [ ] CI green on this release PR → merge → publish GitHub Release `v0.10.1` → PyPI.
