### PR TITLE
chore(release): v0.10.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mureo",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Your local-first AI ad ops crew for Google Ads, Meta Ads, Search Console & GA4. mureo sits on top of the official ad-platform MCPs, gates every change against your strategy, correlates outcomes locally, and keeps an auditable decision log — credentials never leave your machine.",
   "author": {
     "name": "Logly Inc.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.2] - 2026-06-14
+
+### Fixed
+
+#### About-tab one-click upgrade UX (#255)
+
+Three rough edges in the About tab's update / one-click-upgrade flow:
+
+- **One click upgrades.** "Update all" no longer opens a second in-page
+  confirm panel — clicking it runs the upgrade directly (still no native
+  dialog, targets still server-derived, double-click guarded).
+- **In-place result.** Progress / done / failed now appear in the SAME
+  summary line that showed "Updates are available." (instead of a separate
+  status line), and the About header re-renders on success so the displayed
+  version reflects the freshly-installed dist. The running process keeps the
+  old code until a restart, and the success message says so.
+- **No stale "update available."** A successful upgrade now invalidates the
+  cached update-check result and re-checks, and the red nav badge is cleared
+  on every up-to-date / post-upgrade path — so "Updates are available" and
+  the badge no longer linger after the upgrade is applied.
+
+The version check and "Update all" cover mureo plus every installed
+``mureo-*`` plugin (e.g. the agency and bridge packages), unchanged.
+
 ## [0.10.1] - 2026-06-14
 
 ### Fixed

--- a/mureo/__init__.py
+++ b/mureo/__init__.py
@@ -1,3 +1,3 @@
 """mureo — your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."""
 
-__version__ = "0.10.1"
+__version__ = "0.10.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mureo"
-version = "0.10.1"
+version = "0.10.2"
 description = "Your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."
 requires-python = ">=3.10"
 license = "Apache-2.0"


### PR DESCRIPTION
Release **v0.10.2** — patch.

Bumps the version across `pyproject.toml`, `mureo/__init__.py`, and `.claude-plugin/plugin.json`, and adds the CHANGELOG entry. Merging this and publishing a GitHub Release for `v0.10.2` triggers the PyPI publish (`release.yml`, trusted publishing).

## Included since 0.10.1
- **fix (#255):** About-tab one-click upgrade UX — "Update all" upgrades in one click (no second confirm panel); progress/result show in the same summary line; the version re-renders on success; a successful upgrade invalidates the update cache and clears the nav badge so "update available" no longer lingers. The check + upgrade cover mureo plus every installed `mureo-*` plugin (agency, bridges).

## Test plan
- [x] Version parity test — 9 passed.
- [x] #255 merged with full CI green + live browser verification (one-click upgrade, in-place success message, badge cleared, no console errors) + read-only verification that agency/bridge plugins are in both the check and upgrade scope.
- [ ] CI green on this release PR → merge → publish GitHub Release `v0.10.2` → PyPI.
