### PR TITLE
chore(release): v0.10.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mureo",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Your local-first AI ad ops crew for Google Ads, Meta Ads, Search Console & GA4. mureo sits on top of the official ad-platform MCPs, gates every change against your strategy, correlates outcomes locally, and keeps an auditable decision log — credentials never leave your machine.",
   "author": {
     "name": "Logly Inc.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.3] - 2026-06-14
+
+### Added
+
+#### Auto-restart the always-on service after a self-upgrade (#257)
+
+When mureo runs as an always-on service, a successful one-click "Update
+all" now restarts the daemon AUTOMATICALLY on the new code — no terminal,
+no manual restart. The dashboard shows "Restarting…", waits for the
+daemon to come back, and reloads itself; the operator does nothing.
+
+This applies ONLY under an auto-start supervisor: ``mureo service
+install`` stamps a marker into the launchd plist / systemd unit, and the
+daemon exits-to-restart so launchd ``KeepAlive`` / systemd
+``Restart=always`` relaunch it. A plain interactive ``mureo configure``
+(a terminal user) keeps the manual "restart" prompt, unchanged. Windows
+is excluded (Task Scheduler does not relaunch a clean exit).
+
+Existing always-on installs must re-run ``mureo service install`` once
+(idempotent) to gain the marker. The background update check still runs
+every 6h by default (``MUREO_UPDATE_CHECK_INTERVAL_SECONDS`` to tune).
+
 ## [0.10.2] - 2026-06-14
 
 ### Fixed

--- a/mureo/__init__.py
+++ b/mureo/__init__.py
@@ -1,3 +1,3 @@
 """mureo — your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."""
 
-__version__ = "0.10.2"
+__version__ = "0.10.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mureo"
-version = "0.10.2"
+version = "0.10.3"
 description = "Your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."
 requires-python = ">=3.10"
 license = "Apache-2.0"


### PR DESCRIPTION
Release **v0.10.3** — patch.

Bumps the version across `pyproject.toml`, `mureo/__init__.py`, and `.claude-plugin/plugin.json`, plus the CHANGELOG. Merging this and publishing a GitHub Release for `v0.10.3` triggers the PyPI publish (`release.yml`).

## Included since 0.10.2
- **feat (#257):** auto-restart the always-on service after a self-upgrade. A successful one-click "Update all" restarts the daemon automatically on the new code (launchd `KeepAlive` / systemd `Restart=always`); the dashboard shows "Restarting…" and reloads itself. Interactive `mureo configure` keeps the manual prompt; Windows excluded. Existing always-on installs must re-run `mureo service install` once for the marker.

## Test plan
- [x] Version parity test — 9 passed.
- [x] #257 merged with full CI green + live browser verification of the restart→auto-reload flow.
- [ ] CI green → merge → publish GitHub Release `v0.10.3` → PyPI.
