### PR TITLE
fix(service): make launchd re-install reliable across the async bootout race

### DIFF
--- a/mureo/web/service/launchd.py
+++ b/mureo/web/service/launchd.py
@@ -20,6 +20,7 @@ import logging
 import os
 import plistlib
 import subprocess
+import time
 from pathlib import Path
 
 from mureo.web.instance import probe_mureo_instance
@@ -130,8 +131,30 @@ def _unload(path: Path) -> None:
         logger.debug("launchctl unload best-effort skip", exc_info=True)
 
 
+#: ``launchctl bootout`` is asynchronous: bootstrapping the new agent while the
+#: previous one is still tearing down races and can leave NOTHING loaded (the
+#: bootstrap returns 0 but the job never sticks). After bootstrap we confirm the
+#: job is actually loaded and re-try a few times if not.
+_BOOTSTRAP_RETRIES = 4
+_BOOTSTRAP_RETRY_SECONDS = 0.75
+
+
+def _is_loaded() -> bool:
+    """``True`` if the agent is currently registered with launchd."""
+    uid = _current_uid()
+    return _run(["launchctl", "print", f"gui/{uid}/{LABEL}"]).returncode == 0
+
+
 def install(*, home: Path | None = None, port: int = SERVICE_PORT) -> OpResult:
-    """Write the plist and bootstrap it now. Idempotent (overwrites)."""
+    """Write the plist and bootstrap it now. Idempotent (overwrites).
+
+    On a RE-install the previous agent is booted out first. Because
+    ``launchctl bootout`` is asynchronous, a single bootstrap can race the
+    teardown and silently leave the service unloaded — so a bootstrap that
+    "succeeds" but does not actually stick is dropped and re-tried a few
+    times. A hard bootstrap error (missing launchctl, permission denied) is
+    returned immediately — retrying would not help.
+    """
     path = plist_path(home)
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -144,7 +167,22 @@ def install(*, home: Path | None = None, port: int = SERVICE_PORT) -> OpResult:
         return OpResult(ok=False, message=f"could not write plist: {exc}")
     # Re-install cleanly: drop any previous load before bootstrapping.
     _unload(path)
-    return _load(path)
+    result = _load(path)
+    for _ in range(_BOOTSTRAP_RETRIES):
+        if not result.ok:
+            return result  # a real bootstrap failure — retrying won't fix it
+        if _is_loaded():
+            return result  # bootstrapped AND stuck
+        # "Succeeded" but did not stick (still racing the async bootout):
+        # drop and re-bootstrap after a short pause.
+        time.sleep(_BOOTSTRAP_RETRY_SECONDS)
+        _unload(path)
+        result = _load(path)
+    # Out of retries — report failure rather than a false "ok" if the job
+    # still is not loaded.
+    if result.ok and _is_loaded():
+        return result
+    return OpResult(ok=False, message="service did not stay loaded after install")
 
 
 def uninstall(*, home: Path | None = None) -> OpResult:

--- a/tests/web/service/test_launchd.py
+++ b/tests/web/service/test_launchd.py
@@ -130,6 +130,54 @@ class TestInstall:
         assert result.ok is False
         assert result.message
 
+    def test_install_retries_until_job_sticks(self, home: Path) -> None:
+        """``launchctl bootout`` is async: a bootstrap can 'succeed' yet leave
+        nothing loaded. Install must re-bootstrap until the job is confirmed
+        loaded (regression for a re-install that silently killed the service)."""
+        print_calls = {"n": 0}
+
+        def fake_run(argv: list[str], **kwargs: object) -> object:
+            if "print" in argv:  # _is_loaded probe
+                print_calls["n"] += 1
+                # Not loaded on the first check; loaded after one retry.
+                return _ok() if print_calls["n"] >= 2 else _fail("could not find")
+            return _ok()  # bootout / bootstrap succeed
+
+        with (
+            patch.object(launchd.subprocess, "run", side_effect=fake_run),
+            patch.object(launchd.time, "sleep") as mock_sleep,
+        ):
+            result = launchd.install(home=home, port=7613)
+        assert result.ok is True
+        assert print_calls["n"] >= 2, "did not re-check after a non-sticking bootstrap"
+        mock_sleep.assert_called()  # it backed off before retrying
+
+    def test_install_does_not_retry_a_hard_bootstrap_failure(self, home: Path) -> None:
+        """A real bootstrap error returns immediately (no retry loop / sleep)."""
+        with (
+            patch.object(launchd.subprocess, "run", return_value=_fail("denied")),
+            patch.object(launchd.time, "sleep") as mock_sleep,
+        ):
+            result = launchd.install(home=home, port=7613)
+        assert result.ok is False
+        assert "denied" in (result.message or "")
+        mock_sleep.assert_not_called()
+
+    def test_install_fails_if_job_never_sticks(self, home: Path) -> None:
+        """If a bootstrap that returns 0 never actually loads, install exhausts
+        its retries and reports failure — not a false 'ok'."""
+
+        def fake_run(argv: list[str], **kwargs: object) -> object:
+            return _fail("could not find") if "print" in argv else _ok()
+
+        with (
+            patch.object(launchd.subprocess, "run", side_effect=fake_run),
+            patch.object(launchd.time, "sleep"),
+        ):
+            result = launchd.install(home=home, port=7613)
+        assert result.ok is False
+        assert "did not stay loaded" in (result.message or "")
+
 
 @pytest.mark.unit
 class TestUninstall:


### PR DESCRIPTION
Fixes a reliability bug in `mureo service install` (launchd) that surfaced when re-installing the always-on service to pick up the new `MUREO_MANAGED_SERVICE` marker (#257): the re-install could leave the service **down**, requiring a second run.

## Root cause
`install` booted out the previous agent then **immediately** bootstrapped the new one. `launchctl bootout` is asynchronous, so the bootstrap raced the teardown and could silently leave nothing loaded (`bootstrap` returns 0 but the job never sticks).

## Fix (`mureo/web/service/launchd.py`)
- After bootstrap, confirm via `launchctl print` that the job is actually loaded. If not (still racing the async bootout), drop + re-bootstrap after a short pause, up to a few retries.
- A **hard** bootstrap error (missing `launchctl`, permission denied) returns immediately — retrying won't help.
- Exhausting the retries reports **failure**, not a false `ok`.

## Test plan
- [x] 18 launchd tests (3 new): retries until the job sticks; a hard failure returns immediately with no sleep; never-sticks exhausts retries and fails. Plus existing normal/idempotent/error paths. Fast (mocked `time.sleep`).
- [x] 72 service + CLI-service tests pass; ruff + black + mypy clean.
- [x] Verified live on the reporter's machine: re-install now brings the service back up with the marker injected (`/api/ping` → 0.10.3, `MUREO_MANAGED_SERVICE=1` in the process env).
