### PR TITLE
chore(release): v0.10.4

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mureo",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Your local-first AI ad ops crew for Google Ads, Meta Ads, Search Console & GA4. mureo sits on top of the official ad-platform MCPs, gates every change against your strategy, correlates outcomes locally, and keeps an auditable decision log — credentials never leave your machine.",
   "author": {
     "name": "Logly Inc.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.4] - 2026-06-14
+
+### Fixed
+
+#### Reliable `mureo service install` re-install (launchd) (#259)
+
+Re-installing the always-on service (the way to pick up the new
+auto-restart marker from #257) could leave the service DOWN, needing a
+second run. ``launchctl bootout`` is asynchronous, so the immediately
+following ``bootstrap`` raced the teardown and could silently load
+nothing. ``install`` now confirms via ``launchctl print`` that the job
+actually stuck and re-bootstraps a few times if not; a hard error
+returns immediately, and exhausting the retries reports failure rather
+than a false "ok".
+
 ## [0.10.3] - 2026-06-14
 
 ### Added

--- a/mureo/__init__.py
+++ b/mureo/__init__.py
@@ -1,3 +1,3 @@
 """mureo — your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."""
 
-__version__ = "0.10.3"
+__version__ = "0.10.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mureo"
-version = "0.10.3"
+version = "0.10.4"
 description = "Your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."
 requires-python = ">=3.10"
 license = "Apache-2.0"


### PR DESCRIPTION
Release **v0.10.4** — patch.

Bumps the version across `pyproject.toml`, `mureo/__init__.py`, and `.claude-plugin/plugin.json`, plus the CHANGELOG.

## Included since 0.10.3
- **fix (#259):** `mureo service install` (launchd) is now reliable across the async `launchctl bootout` race. Re-installing the always-on service (to pick up the #257 auto-restart marker) no longer leaves it down needing a second run — install confirms the job actually loaded via `launchctl print` and retries, returns hard errors immediately, and reports failure rather than a false "ok" if it never sticks.

## Test plan
- [x] Version parity test — 9 passed.
- [x] #259 merged with full CI green (after a re-run of a pre-existing flaky meta_ads test, unrelated to the launchd change).
- [ ] CI green → merge → GitHub Release `v0.10.4` → PyPI.
