### PR TITLE
test(adapters): stop leaked AsyncMock coroutines from flaking the suite

### DIFF
--- a/tests/adapters/conftest.py
+++ b/tests/adapters/conftest.py
@@ -1,0 +1,27 @@
+"""Test isolation for the adapter suites (google_ads / meta_ads).
+
+Both adapters expose a synchronous Protocol over an ``async`` client and the
+tests drive them with ``Mock(spec=...Client)`` whose async methods are
+``AsyncMock``. Speccing a class with async methods makes unittest.mock create
+``AsyncMockMixin._execute_mock_call`` coroutines that are never awaited; left to
+chance garbage collection one can survive a test boundary and surface inside a
+LATER async test's event loop (e.g. a Google Ads error popping up in a Meta
+test), producing an order/timing-dependent FLAKY failure.
+
+Collecting garbage at the end of every adapter test closes any such dangling
+coroutine in its own scope, so it can never contaminate a subsequent test.
+"""
+
+from __future__ import annotations
+
+import gc
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _flush_leaked_coroutines() -> object:
+    """Force GC after each adapter test so a never-awaited AsyncMock coroutine
+    is closed in-scope rather than surviving into a later async test."""
+    yield
+    gc.collect()

--- a/tests/adapters/conftest.py
+++ b/tests/adapters/conftest.py
@@ -15,9 +15,12 @@ coroutine in its own scope, so it can never contaminate a subsequent test.
 from __future__ import annotations
 
 import gc
-from collections.abc import Iterator
+from typing import TYPE_CHECKING
 
 import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 
 @pytest.fixture(autouse=True)

--- a/tests/adapters/conftest.py
+++ b/tests/adapters/conftest.py
@@ -15,13 +15,21 @@ coroutine in its own scope, so it can never contaminate a subsequent test.
 from __future__ import annotations
 
 import gc
+from collections.abc import Iterator
 
 import pytest
 
 
 @pytest.fixture(autouse=True)
-def _flush_leaked_coroutines() -> object:
+def _flush_leaked_coroutines() -> Iterator[None]:
     """Force GC after each adapter test so a never-awaited AsyncMock coroutine
-    is closed in-scope rather than surviving into a later async test."""
+    is closed in-scope rather than surviving into a later async test.
+
+    Known source: ``test_calling_from_running_loop_raises_runtime_error`` (both
+    suites) calls the adapter inside ``asyncio.run(...)``; the adapter raises on
+    the running-loop check BEFORE awaiting the coroutine that ``AsyncMock``
+    already built, orphaning it. The guard also covers any future test that
+    reintroduces the same pattern.
+    """
     yield
     gc.collect()


### PR DESCRIPTION
Fixes the intermittent CI failure where a Google Ads error (`INVALID_CUSTOMER_ID 'acct123'`) surfaced inside an unrelated **Meta** adapter test — an order/timing-dependent flake that repeatedly blocked releases this week.

## Root cause (test isolation, NOT shipped code)
Both adapter suites drive a synchronous Protocol over an `async` client using `Mock(spec=...Client)` whose async methods are `AsyncMock`. Speccing a class with async methods makes unittest.mock create `AsyncMockMixin._execute_mock_call` coroutines that are **never awaited**. Left to chance garbage collection, one such dangling coroutine could survive a test boundary and surface inside a **later** async test's event loop, contaminating it. The adapters themselves are clean (`asyncio.run` on a fresh loop) — this is purely a test-side leak.

## Fix
`tests/adapters/conftest.py` adds an autouse fixture that `gc.collect()`s after each adapter test, closing any dangling coroutine **in its own scope** so it can never reach a subsequent test.

## Why no version bump / release
Test-only change (`tests/`), nothing under `mureo/` — no runtime behavior changes, so no PyPI release is needed.

## Test plan
- [x] `tests/adapters/` — 189 passed; the never-awaited warnings are now collected at the gc point (contained per-test) instead of bleeding across tests.
- [x] `google_ads → meta_ads` order (the contamination path) — 126 passed, run twice, stable.
- [x] ruff clean.
