### PR TITLE
fix(security): silence bandit B310 on the loopback ping probe

### DIFF
--- a/mureo/web/instance.py
+++ b/mureo/web/instance.py
@@ -64,7 +64,9 @@ def probe_mureo_instance(
         # ``url`` is always a literal ``http://`` loopback probe — the scheme is
         # not user-controlled, so B310/S310's file:// / custom-scheme concern
         # does not apply. (``# noqa`` silences ruff; ``# nosec`` silences bandit.)
-        with urllib.request.urlopen(url, timeout=timeout) as resp:  # noqa: S310 # nosec B310
+        with urllib.request.urlopen(
+            url, timeout=timeout
+        ) as resp:  # noqa: S310 # nosec B310
             raw = resp.read()
     except Exception:  # noqa: BLE001 — a probe must never propagate failure
         logger.debug("probe_mureo_instance: %s unreachable", url, exc_info=True)

--- a/mureo/web/instance.py
+++ b/mureo/web/instance.py
@@ -61,7 +61,10 @@ def probe_mureo_instance(
     """
     url = f"http://{host}:{port}/api/ping"
     try:
-        with urllib.request.urlopen(url, timeout=timeout) as resp:  # noqa: S310
+        # ``url`` is always a literal ``http://`` loopback probe — the scheme is
+        # not user-controlled, so B310/S310's file:// / custom-scheme concern
+        # does not apply. (``# noqa`` silences ruff; ``# nosec`` silences bandit.)
+        with urllib.request.urlopen(url, timeout=timeout) as resp:  # noqa: S310 # nosec B310
             raw = resp.read()
     except Exception:  # noqa: BLE001 — a probe must never propagate failure
         logger.debug("probe_mureo_instance: %s unreachable", url, exc_info=True)


### PR DESCRIPTION
Fixes the failing **Security** workflow on `main` (bandit gate), which sent a "Run failed: Security" email.

## What failed
`bandit -r mureo/ -ll -ii` flagged **B310** (Medium/High) at `mureo/web/instance.py:64` — `urllib.request.urlopen` in `probe_mureo_instance`. B310 warns that `urlopen` could open `file://` / custom schemes.

## Why it's a false positive
The probe URL is always a literal `f"http://{host}:{port}/api/ping"` — the scheme is hardcoded `http://` and the host/port are the configure server's own loopback config, never user input. There is no file:// / custom-scheme exposure.

The line already had `# noqa: S310`, but that only silences **ruff**; bandit needs `# nosec`. This adds `# nosec B310` plus a one-line rationale.

## Verification
- `bandit -r mureo/ -ll -ii` → **No issues identified, exit 0** (was exit 1 on B310 only).
- ruff clean (the combined `# noqa: S310 # nosec B310` is accepted).
- 37 instance/probe tests pass.

Comment-only change — no runtime behavior change, no version bump needed.
