### PR TITLE
fix(state): serialise STATE.json read-modify-write to stop dropped action_log entries

### DIFF
--- a/mureo/context/state.py
+++ b/mureo/context/state.py
@@ -11,6 +11,7 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
 
 from mureo.context.errors import ContextFileError
@@ -20,6 +21,7 @@ from mureo.context.models import (
     PlatformState,
     StateDocument,
 )
+from mureo.fsutil import file_lock
 
 # Required campaign fields
 _CAMPAIGN_REQUIRED_FIELDS: tuple[str, ...] = (
@@ -211,6 +213,31 @@ def write_state_file(path: Path, doc: StateDocument) -> None:
     _atomic_write(path, text)
 
 
+def _state_lock_path(path: Path) -> Path:
+    """Sidecar lock file for ``path`` (e.g. ``STATE.json`` -> ``STATE.json.lock``)."""
+    return path.with_name(path.name + ".lock")
+
+
+def _locked_state_mutation(
+    path: Path, build: Callable[[StateDocument], StateDocument]
+) -> StateDocument:
+    """Run a read -> ``build`` -> write cycle as one critical section.
+
+    ``_atomic_write`` only makes the file *replace* atomic; the surrounding
+    read-modify-write is not. Holding the cross-process ``file_lock`` across
+    read + write serialises every STATE.json mutator, so two concurrent calls
+    (built-in <-> built-in, or built-in <-> plugin dispatch) can no longer
+    last-writer-wins away each other's changes — e.g. drop an action_log
+    entry (issue #115). ``build(doc)`` returns the new document to persist.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with file_lock(_state_lock_path(path)):
+        doc = read_state_file(path)
+        new_doc = build(doc)
+        write_state_file(path, new_doc)
+    return new_doc
+
+
 def _now_iso() -> str:
     """Current time as a timezone-aware ISO 8601 UTC string."""
     return datetime.now(timezone.utc).isoformat()
@@ -265,33 +292,33 @@ def upsert_campaign(
     Returns:
         The updated :class:`StateDocument`.
     """
-    doc = read_state_file(path)
 
-    # v1 flat list — preserved for backward compatibility.
-    flat_campaigns = _upsert_into(doc.campaigns, campaign)
+    def _build(doc: StateDocument) -> StateDocument:
+        # v1 flat list — preserved for backward compatibility.
+        flat_campaigns = _upsert_into(doc.campaigns, campaign)
 
-    # v2 per-platform — the shape the dashboard reads. Ensure the platform
-    # entry exists, carries the (required) account_id, and holds the
-    # campaign.
-    platforms = dict(doc.platforms) if doc.platforms else {}
-    existing = platforms.get(platform)
-    platforms[platform] = PlatformState(
-        account_id=account_id,
-        campaigns=_upsert_into(
-            existing.campaigns if existing is not None else (), campaign
-        ),
-    )
+        # v2 per-platform — the shape the dashboard reads. Ensure the platform
+        # entry exists, carries the (required) account_id, and holds the
+        # campaign.
+        platforms = dict(doc.platforms) if doc.platforms else {}
+        existing = platforms.get(platform)
+        platforms[platform] = PlatformState(
+            account_id=account_id,
+            campaigns=_upsert_into(
+                existing.campaigns if existing is not None else (), campaign
+            ),
+        )
 
-    new_doc = StateDocument(
-        version=doc.version,
-        last_synced_at=_now_iso(),
-        customer_id=doc.customer_id,
-        campaigns=flat_campaigns,
-        platforms=platforms,
-        action_log=doc.action_log,
-    )
-    write_state_file(path, new_doc)
-    return new_doc
+        return StateDocument(
+            version=doc.version,
+            last_synced_at=_now_iso(),
+            customer_id=doc.customer_id,
+            campaigns=flat_campaigns,
+            platforms=platforms,
+            action_log=doc.action_log,
+        )
+
+    return _locked_state_mutation(path, _build)
 
 
 def append_action_log(path: Path, entry: ActionLogEntry) -> StateDocument:
@@ -302,18 +329,18 @@ def append_action_log(path: Path, entry: ActionLogEntry) -> StateDocument:
     Returns:
         Updated StateDocument
     """
-    doc = read_state_file(path)
-    new_log = (*doc.action_log, entry)
-    new_doc = StateDocument(
-        version=doc.version,
-        last_synced_at=doc.last_synced_at,
-        customer_id=doc.customer_id,
-        campaigns=doc.campaigns,
-        platforms=doc.platforms,
-        action_log=new_log,
-    )
-    write_state_file(path, new_doc)
-    return new_doc
+
+    def _build(doc: StateDocument) -> StateDocument:
+        return StateDocument(
+            version=doc.version,
+            last_synced_at=doc.last_synced_at,
+            customer_id=doc.customer_id,
+            campaigns=doc.campaigns,
+            platforms=doc.platforms,
+            action_log=(*doc.action_log, entry),
+        )
+
+    return _locked_state_mutation(path, _build)
 
 
 def get_campaign(doc: StateDocument, campaign_id: str) -> CampaignSnapshot | None:

--- a/mureo/fsutil.py
+++ b/mureo/fsutil.py
@@ -18,12 +18,34 @@ security regression.
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import os
+import time
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+try:  # POSIX advisory whole-file lock
+    import fcntl as _fcntl
+except ImportError:  # pragma: no cover - exercised on Windows only
+    _fcntl = None  # type: ignore[assignment]
+
+try:  # Windows byte-range lock
+    import msvcrt as _msvcrt
+except ImportError:  # pragma: no cover - exercised on POSIX only
+    _msvcrt = None  # type: ignore[assignment]
 
 logger = logging.getLogger(__name__)
 
 _OWNER_ONLY = 0o600
+
+#: Windows ``msvcrt.locking`` blocks ~10s then raises; retry a few rounds so a
+#: short critical section held just over that ceiling still serialises instead
+#: of erroring. POSIX ``flock`` blocks indefinitely and needs no retry.
+_WIN_LOCK_RETRIES = 6
+_WIN_LOCK_BACKOFF_S = 0.05
 
 
 def secure_fchmod(fd: int) -> None:
@@ -46,4 +68,66 @@ def secure_chmod(path: str | os.PathLike[str]) -> None:
         logger.debug("secure_chmod best-effort skip", exc_info=True)
 
 
-__all__ = ["secure_chmod", "secure_fchmod"]
+def _acquire_lock(fd: int) -> None:
+    """Block until an exclusive lock on ``fd`` is held (POSIX or Windows)."""
+    if _fcntl is not None:
+        _fcntl.flock(fd, _fcntl.LOCK_EX)
+        return
+    if _msvcrt is not None:  # pragma: no cover - Windows only
+        os.lseek(fd, 0, os.SEEK_SET)
+        for attempt in range(_WIN_LOCK_RETRIES):
+            try:
+                # ``LK_LOCK`` is msvcrt's *blocking* lock (retries internally
+                # for ~10s, then raises ``OSError``). There is no ``LK_LCK``.
+                _msvcrt.locking(fd, _msvcrt.LK_LOCK, 1)
+                return
+            except OSError:
+                if attempt == _WIN_LOCK_RETRIES - 1:
+                    raise
+                time.sleep(_WIN_LOCK_BACKOFF_S)
+    else:  # pragma: no cover - exotic platform with neither primitive
+        logger.warning("file_lock: no fcntl/msvcrt available; lock is a no-op")
+
+
+def _release_lock(fd: int) -> None:
+    """Release the lock held on ``fd``; best-effort (a failed unlock is freed
+    on the ``os.close`` that always follows)."""
+    try:
+        if _fcntl is not None:
+            _fcntl.flock(fd, _fcntl.LOCK_UN)
+        elif _msvcrt is not None:  # pragma: no cover - Windows only
+            os.lseek(fd, 0, os.SEEK_SET)
+            _msvcrt.locking(fd, _msvcrt.LK_UNLCK, 1)
+    except OSError:
+        logger.debug("file_lock release best-effort skip", exc_info=True)
+
+
+@contextlib.contextmanager
+def file_lock(lock_path: str | os.PathLike[str]) -> Iterator[None]:
+    """Hold an exclusive, cross-platform advisory lock on ``lock_path``.
+
+    Serialises a read-modify-write critical section across threads AND
+    processes — mureo's CLI, the MCP server, and the configure server can each
+    touch the same ``STATE.json``, so a thread-only or asyncio-only lock would
+    not be enough. POSIX uses ``fcntl.flock(LOCK_EX)``; Windows uses
+    ``msvcrt.locking(LK_LCK)`` on a one-byte region.
+
+    The lock is tied to the open file descriptor, so the OS releases it
+    automatically if the holder crashes — no stale ``.lock`` file can wedge a
+    later run. The sidecar is created ``0o600`` and left in place (an empty
+    lock file is cheap and avoids an unlink/recreate race). The lock degrades
+    to a no-op only on an exotic platform exposing neither primitive (logged at
+    WARNING), never on a supported OS.
+    """
+    fd = os.open(os.fspath(lock_path), os.O_RDWR | os.O_CREAT, _OWNER_ONLY)
+    try:
+        _acquire_lock(fd)
+        try:
+            yield
+        finally:
+            _release_lock(fd)
+    finally:
+        os.close(fd)
+
+
+__all__ = ["file_lock", "secure_chmod", "secure_fchmod"]

--- a/tests/test_fsutil.py
+++ b/tests/test_fsutil.py
@@ -12,12 +12,13 @@ from __future__ import annotations
 import os
 import stat
 import sys
-import tempfile
+import time
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
 
-from mureo.fsutil import secure_chmod, secure_fchmod
+from mureo.fsutil import file_lock, secure_chmod, secure_fchmod
 
 # POSIX file-mode assertions: on Windows chmod cannot set 0o600 — the
 # helpers are best-effort there (the never-raise contract is verified
@@ -86,3 +87,66 @@ class TestSecureChmod:
 
     def test_missing_path_does_not_raise(self, tmp_path: Path) -> None:
         secure_chmod(tmp_path / "does-not-exist")  # OSError swallowed
+
+
+@pytest.mark.unit
+class TestFileLock:
+    def test_serialises_concurrent_critical_sections(self, tmp_path: Path) -> None:
+        """Two threads running a deliberately non-atomic read-modify-write of a
+        shared file never lose an update when the section is held under the
+        lock — the mutual-exclusion contract the STATE.json mutators rely on."""
+        lock = tmp_path / "counter.lock"
+        counter = tmp_path / "counter.txt"
+        counter.write_text("0", encoding="utf-8")
+
+        def bump(_: int) -> None:
+            with file_lock(lock):
+                value = int(counter.read_text(encoding="utf-8"))
+                time.sleep(0.002)  # widen the window an unguarded RMW would lose
+                counter.write_text(str(value + 1), encoding="utf-8")
+
+        rounds = 40
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            list(pool.map(bump, range(rounds)))
+
+        assert int(counter.read_text(encoding="utf-8")) == rounds
+
+    def test_released_after_context_exit(self, tmp_path: Path) -> None:
+        """Sequential acquisitions of the same lock do not deadlock — the lock
+        is released on context exit."""
+        lock = tmp_path / "x.lock"
+        for _ in range(3):
+            with file_lock(lock):
+                pass
+
+    def test_creates_sidecar_file(self, tmp_path: Path) -> None:
+        lock = tmp_path / "s.lock"
+        assert not lock.exists()
+        with file_lock(lock):
+            assert lock.exists()
+
+    def test_windows_path_calls_msvcrt_blocking_lock(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The Windows branch must call ``msvcrt.locking`` with the real
+        blocking/unlock constants. Exercised on POSIX by faking ``msvcrt`` and
+        disabling ``fcntl`` — the only coverage of that branch, guarding
+        against constant typos (e.g. the non-existent ``LK_LCK``)."""
+        calls: list[tuple[int, int]] = []
+
+        class _FakeMsvcrt:
+            LK_LOCK = 1
+            LK_UNLCK = 0
+
+            def locking(self, _fd: int, mode: int, nbytes: int) -> None:
+                calls.append((mode, nbytes))
+
+        fake = _FakeMsvcrt()
+        monkeypatch.setattr("mureo.fsutil._fcntl", None)
+        monkeypatch.setattr("mureo.fsutil._msvcrt", fake)
+
+        with file_lock(tmp_path / "w.lock"):
+            pass
+
+        assert (fake.LK_LOCK, 1) in calls  # acquire used the blocking lock
+        assert (fake.LK_UNLCK, 1) in calls  # release used the unlock

--- a/tests/test_state_concurrency.py
+++ b/tests/test_state_concurrency.py
@@ -1,0 +1,120 @@
+"""Concurrency safety for STATE.json read-modify-write mutators (issue #115).
+
+``append_action_log`` / ``upsert_campaign`` each do read -> rebuild ->
+``write_state_file``. ``_atomic_write`` makes the file *replace* atomic, but the
+surrounding read-modify-write is NOT a critical section: two concurrent
+mutating calls (built-in <-> built-in, or built-in <-> plugin dispatch) can
+lose an entry under last-writer-wins on the whole ``StateDocument``.
+
+These tests deterministically widen the read->write window (a monkeypatched
+slow ``read_state_file``) so the race is exercised every run, then assert no
+``action_log`` entry is ever dropped under thread contention — across the
+single-mutator path and the mixed ``upsert_campaign`` + ``append_action_log``
+path.
+"""
+
+from __future__ import annotations
+
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+import mureo.context.state as state_mod
+from mureo.context.models import ActionLogEntry, CampaignSnapshot
+from mureo.context.state import append_action_log, read_state_file, upsert_campaign
+
+# Enough contention to surface the race; the injected delay (below) makes it
+# deterministic rather than timing-luck dependent.
+_THREADS = 8
+_PER_THREAD = 10
+_READ_DELAY_S = 0.003
+
+
+@pytest.fixture
+def slow_read(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Widen the read->write window so the RMW race is hit every run.
+
+    The delay sits *inside* whatever critical section the fix introduces, so a
+    correct lock serialises the slow read and still drops nothing; the
+    unguarded code interleaves and loses entries.
+    """
+    real_read = state_mod.read_state_file
+
+    def _slow(path: Path) -> object:
+        doc = real_read(path)
+        time.sleep(_READ_DELAY_S)
+        return doc
+
+    monkeypatch.setattr(state_mod, "read_state_file", _slow)
+
+
+def _entry(tag: str) -> ActionLogEntry:
+    return ActionLogEntry(
+        timestamp="2026-06-15T00:00:00+00:00",
+        action="test",
+        platform="google_ads",
+        summary=tag,
+    )
+
+
+@pytest.mark.unit
+def test_concurrent_append_action_log_drops_no_entries(
+    tmp_path: Path, slow_read: None
+) -> None:
+    path = tmp_path / "STATE.json"
+
+    def worker(thread_id: int) -> None:
+        for j in range(_PER_THREAD):
+            append_action_log(path, _entry(f"t{thread_id}-{j}"))
+
+    with ThreadPoolExecutor(max_workers=_THREADS) as pool:
+        list(pool.map(worker, range(_THREADS)))
+
+    doc = read_state_file(path)
+    summaries = [e.summary for e in doc.action_log]
+    assert len(summaries) == _THREADS * _PER_THREAD
+    # Every append is unique-tagged: no entry was overwritten/lost.
+    assert len(set(summaries)) == _THREADS * _PER_THREAD
+
+
+@pytest.mark.unit
+def test_concurrent_mixed_mutators_preserve_action_log(
+    tmp_path: Path, slow_read: None
+) -> None:
+    """``upsert_campaign`` and ``append_action_log`` share the whole-doc RMW, so
+    an unguarded ``upsert_campaign`` can clobber a concurrent log append. The
+    lock must cover both mutators."""
+    path = tmp_path / "STATE.json"
+
+    def appender(thread_id: int) -> None:
+        for j in range(_PER_THREAD):
+            append_action_log(path, _entry(f"a{thread_id}-{j}"))
+
+    def upserter(thread_id: int) -> None:
+        for j in range(_PER_THREAD):
+            upsert_campaign(
+                path,
+                CampaignSnapshot(
+                    campaign_id=f"c{thread_id}-{j}",
+                    campaign_name="x",
+                    status="ENABLED",
+                ),
+                platform="google_ads",
+                account_id="acct-1",
+            )
+
+    with ThreadPoolExecutor(max_workers=_THREADS) as pool:
+        futures = []
+        for tid in range(_THREADS):
+            target = appender if tid % 2 == 0 else upserter
+            futures.append(pool.submit(target, tid))
+        for f in futures:
+            f.result()
+
+    doc = read_state_file(path)
+    appends = _THREADS // 2 * _PER_THREAD
+    upserts = _THREADS // 2 * _PER_THREAD
+    assert len(doc.action_log) == appends
+    assert len(doc.campaigns) == upserts


### PR DESCRIPTION
Closes #115.

## Problem

`mureo/context/state.py` mutators `append_action_log` and `upsert_campaign` each do **read -> rebuild -> `write_state_file`**. `_atomic_write` makes the file *replace* atomic, but the surrounding read-modify-write is **not** a critical section. Two concurrent mutating calls (built-in <-> built-in, or built-in <-> plugin dispatch after #114 widened the caller set) can lose an `action_log` entry under last-writer-wins on the whole `StateDocument`.

## Approach

mureo is local-first, but **several processes** can touch the same `STATE.json` (the CLI, the MCP server, the configure web server), so an in-process or asyncio-only lock is insufficient. The fix uses a **cross-process advisory file lock**.

- **`mureo/fsutil.py`** — new `file_lock(lock_path)` context manager. POSIX uses `fcntl.flock(LOCK_EX)`; Windows uses `msvcrt.locking(LK_LOCK)` on a one-byte region with bounded retry. The lock is tied to the open fd, so the OS releases it automatically if the holder crashes (no stale `.lock` can wedge a later run). The sidecar `.lock` is created `0o600` and left in place. Degrades to a logged no-op only on an exotic platform exposing neither primitive.
- **`mureo/context/state.py`** — `_locked_state_mutation(path, build)` holds the lock across `read_state_file` + `write_state_file`. Both mutators are refactored to build-closures routed through it, so **every** whole-document mutation is serialised (an `upsert_campaign` can no longer clobber a concurrent log append). External signatures and `StateDocument` output are unchanged.

## Tests (TDD)

- `tests/test_state_concurrency.py` — thread-contention tests made deterministic by a monkeypatched slow `read_state_file` (the delay sits inside the critical section). Pre-fix they fail hard (80 appends -> **10** retained; mixed upsert+append 40 -> **2**); post-fix all entries survive.
- `tests/test_fsutil.py::TestFileLock` — direct `file_lock` unit tests: mutual exclusion (lost-update guard), release-after-exit, sidecar creation, and the **Windows `msvcrt` branch** exercised on POSIX via a faked `_msvcrt` so the `LK_LOCK` constant is covered.

## Notes

- Code review caught a Windows-only bug pre-merge: the blocking-lock constant was written as the non-existent `msvcrt.LK_LCK` (correct: `LK_LOCK`), which would have raised `AttributeError` on every STATE.json mutation on Windows. Fixed, and the new faked-`msvcrt` test guards against the regression.
- CI lint scope is `mureo/` only; `black`/`ruff`/`mypy` are clean there.

## Test plan

- [x] Reproduce the dropped-entry race locally (RED)
- [x] Confirm the lock serialises both mutators (GREEN)
- [x] `file_lock` direct unit tests incl. Windows branch
- [x] No regression across state/rollback/demo/strategy suites
- [x] `black` / `ruff` / `mypy` clean on `mureo/`
- [ ] CI green (incl. `test-windows`)
