### PR TITLE
fix(providers): don't disable mureo-native until the official MCP is credentialed

### DIFF
--- a/mureo/web/setup_actions.py
+++ b/mureo/web/setup_actions.py
@@ -441,6 +441,7 @@ def _install_provider_code(
         from mureo.providers.installer import run_install
         from mureo.providers.mureo_env import (
             add_provider_and_disable_in_mureo,
+            unset_mureo_disable_env,
         )
 
         spec = get_provider(provider_id)
@@ -482,15 +483,30 @@ def _install_provider_code(
         )
 
     extra_env = _credential_env_for(spec, credentials_path)
+    platform = spec.coexists_with_mureo_platform
+    # Decision C (#102): only disable the overlapping mureo-native platform
+    # once the official provider is actually credentialed. The upstream
+    # official MCP reads its config ONLY from env vars, so a credential-less
+    # registration cannot authenticate; disabling native at the same time
+    # would strand the user with zero working tools for that platform
+    # (official dead AND native off). Without creds we register the provider,
+    # (re-)enable native, and signal that credentials are still needed.
     try:
-        if spec.coexists_with_mureo_platform is None:
-            add_provider_to_claude_settings(spec, extra_env=extra_env)
-        else:
+        if platform is not None and extra_env:
             add_provider_and_disable_in_mureo(spec, extra_env=extra_env)
+        else:
+            add_provider_to_claude_settings(spec, extra_env=extra_env)
+            if platform is not None:
+                # Clear any MUREO_DISABLE_<platform> a prior credentialed
+                # install left behind, so re-registering without creds never
+                # leaves the user with native off AND official unauthenticated.
+                unset_mureo_disable_env(platform)
     except Exception as exc:  # noqa: BLE001
         logger.exception("install_provider settings write failed")
         return ActionResult(status="error", detail=type(exc).__name__)
 
+    if platform is not None and not extra_env:
+        return ActionResult(status="needs_credentials", detail=spec.id)
     return ActionResult(status="ok", detail=spec.id)
 
 

--- a/tests/test_web_provider_host.py
+++ b/tests/test_web_provider_host.py
@@ -91,6 +91,20 @@ def _ok_install() -> InstallResult:
     return InstallResult(returncode=0, stdout="", stderr="", argv=[])
 
 
+def _google_creds(tmp_path: Path) -> Path:
+    """Write a synthetic credentials.json with a complete google_ads section
+    and return its path, so ``_credential_env_for`` resolves a non-empty
+    ``extra_env`` (the #102 decision-C gate that enables native auto-disable)."""
+    creds = tmp_path / ".mureo" / "credentials.json"
+    creds.parent.mkdir(parents=True, exist_ok=True)
+    creds.write_text(
+        '{"google_ads": {"developer_token": "DT", "client_id": "CID",'
+        ' "client_secret": "CS", "refresh_token": "RT"}}',
+        "utf-8",
+    )
+    return creds
+
+
 def _unfreeze(value: Any) -> Any:
     """Recursively convert MappingProxyType/tuple catalog blocks to plain
     dict/list so equality + json round-trips match the on-disk shape."""
@@ -144,9 +158,11 @@ class TestInstallProviderCodeHostUnchanged:
         """No ``host`` arg → today's path: ``run_install`` then
         ``add_provider_and_disable_in_mureo`` (every CATALOG provider
         sets ``coexists_with_mureo_platform``). Desktop writer NOT called,
-        Desktop config NOT created."""
+        Desktop config NOT created. Credentials are present, so native IS
+        disabled (the #102 decision-C gate is satisfied)."""
         from mureo.web import setup_actions
 
+        creds = _google_creds(tmp_path)
         cfg = _desktop_cfg(tmp_path)
         with (
             patch(
@@ -163,7 +179,7 @@ class TestInstallProviderCodeHostUnchanged:
                 setup_actions, "install_desktop_server_block", create=True
             ) as mock_desktop,
         ):
-            result = setup_actions.install_provider(_GOOGLE)
+            result = setup_actions.install_provider(_GOOGLE, credentials_path=creds)
 
         assert result.status == "ok"
         assert result.detail == _GOOGLE
@@ -175,9 +191,11 @@ class TestInstallProviderCodeHostUnchanged:
 
     def test_explicit_code_host_identical_to_default(self, tmp_path: Path) -> None:
         """``host="claude-code"`` is identical to the default — Code
-        writer invoked exactly as today, no Desktop file created."""
+        writer invoked exactly as today, no Desktop file created. Credentials
+        present, so native IS disabled."""
         from mureo.web import setup_actions
 
+        creds = _google_creds(tmp_path)
         cfg = _desktop_cfg(tmp_path)
         with (
             patch(
@@ -189,7 +207,7 @@ class TestInstallProviderCodeHostUnchanged:
             ) as mock_disable,
         ):
             result = setup_actions.install_provider(
-                _GOOGLE, host="claude-code", home=tmp_path
+                _GOOGLE, host="claude-code", home=tmp_path, credentials_path=creds
             )
 
         assert result.status == "ok"
@@ -348,14 +366,17 @@ class TestInstallProviderInjectsCredentialEnv:
         assert result.status == "manual_required"
         assert result.detail == _META
 
-    def test_code_host_missing_credentials_still_registers_bare(
+    def test_code_host_no_credentials_does_not_disable_native(
         self, tmp_path: Path
     ) -> None:
-        """No credentials.json yet → provider still registers (bare
-        block, pre-fix shape); no crash."""
+        """No credentials.json yet → register the official provider but DO
+        NOT disable mureo-native (#102 decision C). Disabling native for an
+        un-credentialed official server (which reads ONLY env vars) would
+        strand the user with zero working tools. The result signals
+        ``needs_credentials`` so the UI can guide the user."""
         from mureo.web import setup_actions
 
-        creds = tmp_path / ".mureo" / "credentials.json"
+        creds = tmp_path / ".mureo" / "credentials.json"  # never written
 
         with (
             patch(
@@ -363,14 +384,25 @@ class TestInstallProviderInjectsCredentialEnv:
                 return_value=_ok_install(),
             ),
             patch(
+                "mureo.providers.config_writer.add_provider_to_claude_settings"
+            ) as mock_add,
+            patch(
                 "mureo.providers.mureo_env.add_provider_and_disable_in_mureo"
             ) as mock_disable,
+            patch(
+                "mureo.providers.mureo_env.unset_mureo_disable_env"
+            ) as mock_unset,
         ):
             result = setup_actions.install_provider(_GOOGLE, credentials_path=creds)
 
-        assert result.status == "ok"
-        _, kwargs = mock_disable.call_args
-        assert not kwargs.get("extra_env")
+        assert result.status == "needs_credentials"
+        assert result.detail == _GOOGLE
+        # Provider registered (bare block), native NOT disabled.
+        mock_add.assert_called_once()
+        mock_disable.assert_not_called()
+        # Any stale MUREO_DISABLE from a prior credentialed install is cleared,
+        # so a re-install without creds never leaves native off (#102 dec. C).
+        mock_unset.assert_called_once_with("google_ads")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Refs #102 (Stage 1 of 3 — does not close the umbrella).

## Problem (decision C)

Installing an official MCP provider (`google-ads-official` / `ga4-official`) that overlaps a mureo-native platform set `MUREO_DISABLE_<PLATFORM>=1` on the mureo block **unconditionally** — even when the official provider received **no credentials**. The upstream official MCP reads its config only from environment variables, so a credential-less registration cannot authenticate. Disabling native at the same time left the user with **zero working tools** for that platform: official dead AND native off.

## Fix

Gate the native auto-disable on the official provider actually being credentialed (`extra_env` resolved from `credentials.json` via `_credential_env_for`):

- **Credentials present** -> register the official provider AND disable native (atomic, unchanged behaviour).
- **Credentials absent** -> register the provider, **leave native enabled**, clear any `MUREO_DISABLE_<platform>` a *prior* credentialed install left behind (so a re-install without creds re-enables native — idempotent), and return a new `needs_credentials` status so the UI can guide the user.

The Claude **Desktop** path writes `claude_desktop_config.json` only and never disabled native, so it is unaffected and out of scope.

## Tests (`tests/test_web_provider_host.py`)

- Rewrote `test_code_host_missing_credentials_still_registers_bare` -> `test_code_host_no_credentials_does_not_disable_native`: no creds -> provider registered, `add_provider_and_disable_in_mureo` NOT called, `unset_mureo_disable_env("google_ads")` called, status `needs_credentials`.
- Updated `test_default_host_runs_install_then_disable_in_mureo` and `test_explicit_code_host_identical_to_default` to pass an explicit synthetic `credentials_path` (new `_google_creds` helper), so they are hermetic (previously read the real `~/.mureo/credentials.json`) and native is disabled because creds are present — preserving their intent under the new gate.

## Reviews

- `code-reviewer` agent: APPROVE, no CRITICAL/HIGH. Caught a MEDIUM idempotency gap (stale `MUREO_DISABLE` on register-only re-install) — fixed in this PR via `unset_mureo_disable_env`.
- `/code-review` skill: no CRITICAL; the two HIGH-by-rule items (`setup_actions.py` is 1033 lines, `_install_provider_code` ~68 lines) are pre-existing and not worsened by this change; flagged for a future split.

## Remaining #102 work (follow-up PRs)

- **Stage 2**: wizard UX — surface `needs_credentials` and add a Developer-Token prerequisite step for `google-ads-official`.
- **Stage 3**: verify Client-Library vs ADC auth mode against the real upstream `google-ads-mcp` / GA4 packages (authenticated call), then remove the catalog "deferred to Phase 2" note.

## Test plan

- [x] No-creds install does not disable native; returns `needs_credentials`
- [x] Creds-present install disables native (unchanged)
- [x] Re-install without creds clears a stale `MUREO_DISABLE`
- [x] Updated tests are hermetic (no read of real `~/.mureo`)
- [x] `black` / `ruff` / `mypy` clean on `mureo/`; 289 passing across provider/handler/coexistence suites
- [ ] CI green
