### PR TITLE
fix(providers): credential google-ads-official via ADC (#102 B1)

### DIFF
--- a/mureo/providers/catalog.py
+++ b/mureo/providers/catalog.py
@@ -86,12 +86,18 @@ class ProviderSpec:
             ``Mapping`` (a read-only ``MappingProxyType`` in practice) so
             callers cannot mutate a shared catalog payload in place.
         required_env: tuple of environment variable names the user must
-            populate before the official server functions. Never logged or
-            printed with values.
+            populate before the official server functions. ALL must resolve
+            to a stored value for mureo to treat the provider as
+            credentialed (and only then step its native tools aside). Never
+            logged or printed with values.
         notes: short human note rendered alongside ``list``; may mention
             authentication caveats.
         coexists_with_mureo_platform: when non-None, mureo also serves this
             platform natively; the CLI emits a coexistence warning.
+        optional_env: tuple of environment variable names that are injected
+            into the upstream server's env block WHEN present, but are NOT
+            required to consider the provider credentialed (e.g. an MCC
+            login-customer-id). Defaults to the empty tuple.
     """
 
     id: str
@@ -102,6 +108,7 @@ class ProviderSpec:
     required_env: tuple[str, ...]
     notes: str
     coexists_with_mureo_platform: CoexistsPlatform | None
+    optional_env: tuple[str, ...] = ()
 
 
 CATALOG: tuple[ProviderSpec, ...] = (
@@ -131,18 +138,20 @@ CATALOG: tuple[ProviderSpec, ...] = (
         ),
         required_env=(
             "GOOGLE_ADS_DEVELOPER_TOKEN",
-            "GOOGLE_ADS_CLIENT_ID",
-            "GOOGLE_ADS_CLIENT_SECRET",
-            "GOOGLE_ADS_REFRESH_TOKEN",
+            "GOOGLE_APPLICATION_CREDENTIALS",
         ),
+        optional_env=("GOOGLE_ADS_LOGIN_CUSTOMER_ID",),
         notes=(
             "Installs the official Google Ads MCP from "
-            "github.com/googleads/google-ads-mcp via pipx. "
-            "Phase 1 uses Client Library config mode — env vars match "
-            "`mureo auth setup` output, so existing mureo users need no "
-            "additional credentials. OAuth Proxy and ADC modes are deferred "
-            "to Phase 2. Developer Token required "
-            "(see Google Cloud Console > Google Ads API)."
+            "github.com/googleads/google-ads-mcp via pipx. The upstream "
+            "authenticates via Application Default Credentials (ADC): set "
+            "`GOOGLE_APPLICATION_CREDENTIALS` to a Google Ads service-account "
+            "JSON (or run `gcloud auth application-default login`) and a "
+            "`GOOGLE_ADS_DEVELOPER_TOKEN` (Google Cloud Console > Google Ads "
+            "API). It does NOT read the Client-Library "
+            "client_id/secret/refresh_token. Optional "
+            "`GOOGLE_ADS_LOGIN_CUSTOMER_ID` for MCC access; a FastMCP OAuth "
+            "proxy is also supported upstream but not wired by mureo."
         ),
         coexists_with_mureo_platform="google_ads",
     ),

--- a/mureo/web/env_var_writer.py
+++ b/mureo/web/env_var_writer.py
@@ -15,9 +15,12 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from mureo.web._helpers import atomic_write_json, read_json_safe
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 logger = logging.getLogger(__name__)
 
@@ -71,42 +74,64 @@ def get_env_var_target(name: str) -> EnvVarTarget | None:
     return _ENV_VAR_TO_FIELD.get(name)
 
 
-# Reverse of the closed allow-list: credentials.json section → list of
-# (env var name, field). Built once at import. Used to materialise the
-# ``env`` block an official upstream MCP needs (it reads ONLY env vars,
-# never mureo's credentials.json).
-_SECTION_TO_ENV_VARS: dict[str, tuple[tuple[str, str], ...]] = {}
-for _name, _target in _ENV_VAR_TO_FIELD.items():
-    _SECTION_TO_ENV_VARS.setdefault(_target.section, ())
-    _SECTION_TO_ENV_VARS[_target.section] += ((_name, _target.field),)
-del _name, _target
+# Section-aware field overrides for env var names SHARED across more than
+# one credentials.json section. The base ``_ENV_VAR_TO_FIELD`` table is 1:1
+# (one canonical target per name — the source of truth for the single-write
+# and status surfaces), but ADC's ``GOOGLE_APPLICATION_CREDENTIALS`` is read
+# by BOTH the ga4 and google_ads official MCPs, which each store a
+# service-account path under their own section. This overlay lets the
+# provider-env build path resolve the shared name against the SPECIFIC
+# provider's section instead of always GA4 (the canonical binding).
+_SECTION_FIELD_OVERRIDES: dict[tuple[str, str], str] = {
+    ("GOOGLE_APPLICATION_CREDENTIALS", "google_ads"): "service_account_path",
+}
 
 
-def build_credentials_env(
+def _resolve_field(env_name: str, section: str) -> str | None:
+    """Resolve the credentials.json field for ``env_name`` within ``section``.
+
+    Section-aware: a shared env name (see ``_SECTION_FIELD_OVERRIDES``) maps
+    to the requested section's field; otherwise the canonical 1:1 binding is
+    used, but only when its section matches. Returns ``None`` when
+    ``env_name`` does not bind to ``section`` — defensive, so a name is never
+    resolved against the wrong platform's section.
+    """
+    override = _SECTION_FIELD_OVERRIDES.get((env_name, section))
+    if override is not None:
+        return override
+    target = _ENV_VAR_TO_FIELD.get(env_name)
+    if target is not None and target.section == section:
+        return target.field
+    return None
+
+
+def build_provider_env(
+    env_names: Iterable[str],
     section: str,
     *,
     credentials_path: Path | None = None,
 ) -> dict[str, str]:
     """Build the ``env`` block an official MCP needs from credentials.json.
 
-    Reverse of :func:`write_credential_env_var`: for every entry in the
-    closed allow-list whose target section is ``section``, read the
-    field from ``credentials.json`` and emit ``{ENV_NAME: str(value)}``
-    for every PRESENT, NON-EMPTY value (ints coerced to ``str``; only
-    allow-listed fields are ever surfaced).
+    Driven by the EXACT env var names a provider declares (its catalog
+    ``required_env`` + ``optional_env``) rather than a blanket section dump,
+    so it emits ONLY what the upstream reads — e.g. ``google-ads-mcp``
+    authenticates via ADC and reads ``GOOGLE_ADS_DEVELOPER_TOKEN`` +
+    ``GOOGLE_APPLICATION_CREDENTIALS`` (+ optional
+    ``GOOGLE_ADS_LOGIN_CUSTOMER_ID``), never the Client-Library trio.
 
-    The official upstream MCPs (e.g. ``google-ads-mcp``) read their
-    config ONLY from environment variables — they cannot see mureo's
-    ``credentials.json`` — so injecting this into the registered
-    ``mcpServers[<id>].env`` block is what makes a freshly added official
-    provider actually usable.
+    For each name in ``env_names`` that binds to ``section`` (section-aware
+    resolution — see :func:`_resolve_field`), read the field from
+    ``credentials.json`` and emit ``{ENV_NAME: str(value)}`` for every
+    PRESENT, NON-EMPTY value (ints coerced to ``str``). Names that do not
+    bind to the section, empty/missing values, a missing section and a
+    missing file all yield nothing.
 
-    Returns ``{}`` when the file or the section is absent (the caller
-    then writes a bare block, exactly the pre-fix shape).
+    The official upstream MCPs read their config ONLY from environment
+    variables — they cannot see mureo's ``credentials.json`` — so injecting
+    this into the registered ``mcpServers[<id>].env`` block is what makes a
+    freshly added official provider actually usable.
     """
-    pairs = _SECTION_TO_ENV_VARS.get(section)
-    if not pairs:
-        return {}
     path = _resolve_credentials_path(credentials_path)
     existing = read_json_safe(path)
     section_data = existing.get(section)
@@ -114,7 +139,10 @@ def build_credentials_env(
         return {}
 
     env: dict[str, str] = {}
-    for env_name, field in pairs:
+    for env_name in env_names:
+        field = _resolve_field(env_name, section)
+        if field is None:
+            continue
         value = section_data.get(field)
         if value is None or value == "":
             continue

--- a/mureo/web/setup_actions.py
+++ b/mureo/web/setup_actions.py
@@ -412,15 +412,49 @@ def _credential_env_for(
     be wrong. Returns ``{}`` (caller writes the pre-fix bare block) for
     hosted entries, providers with no overlapping platform, or when no
     matching credentials exist yet.
+
+    The env is built from the provider's declared ``required_env`` +
+    ``optional_env`` (not a blanket section dump), so only the names the
+    upstream actually reads are injected — e.g. Google Ads' ADC env
+    (dev-token + ``GOOGLE_APPLICATION_CREDENTIALS`` + optional MCC login id),
+    never the Client-Library trio the upstream ignores (#102).
     """
     if spec.install_kind == "hosted_http":
         return {}
     section = spec.coexists_with_mureo_platform
     if not section:
         return {}
-    from mureo.web.env_var_writer import build_credentials_env
+    from mureo.web.env_var_writer import build_provider_env
 
-    return build_credentials_env(section, credentials_path=credentials_path)
+    return build_provider_env(
+        (*spec.required_env, *spec.optional_env),
+        section,
+        credentials_path=credentials_path,
+    )
+
+
+def _is_credentialed(spec: ProviderSpec, extra_env: Mapping[str, str]) -> bool:
+    """True when EVERY ``required_env`` name resolved to a stored value.
+
+    This is the #102 native-disable gate: mureo steps its native tools aside
+    only when the official server can actually authenticate. ``extra_env`` is
+    built from the provider's ``required_env`` + ``optional_env``, so a
+    required name is "credentialed" exactly when it is present in
+    ``extra_env``. A client-library-only Google Ads user (no
+    ``GOOGLE_APPLICATION_CREDENTIALS``) is therefore correctly NOT
+    credentialed — the old ``bool(extra_env)`` gate wrongly treated them as
+    credentialed and stranded them (native off, official unable to auth).
+
+    The ``bool(spec.required_env)`` guard keeps a provider with NO declared
+    required env from being vacuously "credentialed" (``all(())`` is True):
+    such a provider could never authenticate from env alone, so native must
+    stay on. Unreachable today (the only empty-``required_env`` entry is the
+    hosted Meta provider, which short-circuits before the gate) but it
+    preserves the no-strand invariant if a future provider changes that.
+    """
+    return bool(spec.required_env) and all(
+        name in extra_env for name in spec.required_env
+    )
 
 
 def _install_provider_code(
@@ -484,28 +518,32 @@ def _install_provider_code(
 
     extra_env = _credential_env_for(spec, credentials_path)
     platform = spec.coexists_with_mureo_platform
-    # Decision C (#102): only disable the overlapping mureo-native platform
-    # once the official provider is actually credentialed. The upstream
-    # official MCP reads its config ONLY from env vars, so a credential-less
-    # registration cannot authenticate; disabling native at the same time
-    # would strand the user with zero working tools for that platform
-    # (official dead AND native off). Without creds we register the provider,
-    # (re-)enable native, and signal that credentials are still needed.
+    # Decision C + plan B (#102): only disable the overlapping mureo-native
+    # platform once the official provider is actually credentialed — meaning
+    # ALL of its ``required_env`` resolved to a stored value, not merely that
+    # SOME google_ads env exists. The upstream MCP reads its config ONLY from
+    # env vars (Google Ads via ADC: dev-token + GOOGLE_APPLICATION_CREDENTIALS),
+    # so a partially-credentialed registration cannot authenticate; disabling
+    # native then would strand the user with zero working tools for that
+    # platform (official dead AND native off). When not fully credentialed we
+    # register the provider (with whatever partial env is present), (re-)enable
+    # native, and signal that credentials are still needed.
+    credentialed = platform is not None and _is_credentialed(spec, extra_env)
     try:
-        if platform is not None and extra_env:
+        if credentialed:
             add_provider_and_disable_in_mureo(spec, extra_env=extra_env)
         else:
             add_provider_to_claude_settings(spec, extra_env=extra_env)
             if platform is not None:
                 # Clear any MUREO_DISABLE_<platform> a prior credentialed
-                # install left behind, so re-registering without creds never
-                # leaves the user with native off AND official unauthenticated.
+                # install left behind, so re-registering without full creds
+                # never leaves native off AND official unauthenticated.
                 unset_mureo_disable_env(platform)
     except Exception as exc:  # noqa: BLE001
         logger.exception("install_provider settings write failed")
         return ActionResult(status="error", detail=type(exc).__name__)
 
-    if platform is not None and not extra_env:
+    if platform is not None and not credentialed:
         return ActionResult(status="needs_credentials", detail=spec.id)
     return ActionResult(status="ok", detail=spec.id)
 

--- a/tests/test_providers_catalog.py
+++ b/tests/test_providers_catalog.py
@@ -126,6 +126,52 @@ def test_required_env_documents_credentials() -> None:
 
 
 @pytest.mark.unit
+def test_google_ads_required_env_is_adc_not_client_library() -> None:
+    """#102: ``google-ads-mcp`` authenticates via ADC, so the official
+    provider requires the developer token + a service-account path
+    (``GOOGLE_APPLICATION_CREDENTIALS``) — NOT the Client-Library trio,
+    which the upstream ignores. Declaring the trio as required made mureo
+    wrongly treat a client-library-only user as 'credentialed'."""
+    from mureo.providers.catalog import get_provider
+
+    google = get_provider("google-ads-official")
+
+    assert google.required_env == (
+        "GOOGLE_ADS_DEVELOPER_TOKEN",
+        "GOOGLE_APPLICATION_CREDENTIALS",
+    )
+    # The Client-Library trio must NOT be required (upstream ignores it).
+    assert "GOOGLE_ADS_CLIENT_ID" not in google.required_env
+    assert "GOOGLE_ADS_CLIENT_SECRET" not in google.required_env
+    assert "GOOGLE_ADS_REFRESH_TOKEN" not in google.required_env
+
+
+@pytest.mark.unit
+def test_provider_spec_has_optional_env_default_empty() -> None:
+    """``ProviderSpec`` gains an ``optional_env`` tuple (emitted into the
+    upstream env when present, but NOT gated on). It defaults to ``()`` so
+    existing entries need no change."""
+    from mureo.providers.catalog import get_provider
+
+    meta = get_provider("meta-ads-official")
+    assert meta.optional_env == ()
+
+    ga4 = get_provider("ga4-official")
+    assert ga4.optional_env == ()
+
+
+@pytest.mark.unit
+def test_google_ads_optional_env_carries_login_customer_id() -> None:
+    """The optional ``GOOGLE_ADS_LOGIN_CUSTOMER_ID`` (MCC login id) is
+    emitted into the upstream env when set, but is not required to
+    consider the provider credentialed."""
+    from mureo.providers.catalog import get_provider
+
+    google = get_provider("google-ads-official")
+    assert google.optional_env == ("GOOGLE_ADS_LOGIN_CUSTOMER_ID",)
+
+
+@pytest.mark.unit
 def test_coexists_with_mureo_platform_correctly_set() -> None:
     """Every Phase 1 provider declares the mureo platform it overlaps with."""
     from mureo.providers.catalog import get_provider

--- a/tests/test_web_provider_env.py
+++ b/tests/test_web_provider_env.py
@@ -1,17 +1,27 @@
-"""Unit tests for ``mureo.web.env_var_writer.build_credentials_env``.
+"""Unit tests for ``mureo.web.env_var_writer.build_provider_env``.
 
 The official upstream MCPs (e.g. ``google-ads-mcp``) read their config
 ONLY from environment variables — they never see mureo's
 ``~/.mureo/credentials.json``. A freshly registered official provider is
 therefore unusable unless mureo injects an ``env`` block built from the
-credentials the user already has. This module pins that builder:
+credentials the user already has. This module pins that builder.
 
-- reverse of the per-var writer's closed allow-list (env name →
-  (section, field)); never produces a name outside it;
+Unlike a blanket section dump, ``build_provider_env`` is driven by the
+EXACT env var names a provider declares (its catalog ``required_env`` +
+``optional_env``), so it emits only what the upstream reads (#102):
+
+- ``google-ads-mcp`` authenticates via ADC, so it needs
+  ``GOOGLE_ADS_DEVELOPER_TOKEN`` + ``GOOGLE_APPLICATION_CREDENTIALS`` (the
+  service-account path) + optional ``GOOGLE_ADS_LOGIN_CUSTOMER_ID`` — NOT
+  the Client-Library trio (client_id/secret/refresh_token), which the
+  upstream ignores entirely;
+- the resolution is SECTION-AWARE: the shared
+  ``GOOGLE_APPLICATION_CREDENTIALS`` name maps to
+  ``google_ads.service_account_path`` for the Google Ads provider but to
+  ``ga4.service_account_path`` for the GA4 provider;
 - emits one ``{ENV_NAME: str(value)}`` pair per PRESENT, NON-EMPTY field
-  in the requested section (ints coerced to str);
-- empty / missing values, missing section, and missing file all yield a
-  ``{}`` (caller then writes a bare block, exactly the pre-fix shape).
+  (ints coerced to str); empty / missing values, names not valid for the
+  section, missing section and missing file all yield nothing.
 
 All FS via ``tmp_path``. ``@pytest.mark.unit``.
 """
@@ -23,10 +33,21 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from mureo.web.env_var_writer import build_credentials_env
+from mureo.web.env_var_writer import build_provider_env
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+# The Google Ads ADC env the upstream actually reads (catalog
+# required_env + optional_env): dev token, service-account path (ADC), and
+# the optional login customer id. The Client-Library trio is deliberately
+# absent.
+_GOOGLE_ADS_ADC_NAMES = (
+    "GOOGLE_ADS_DEVELOPER_TOKEN",
+    "GOOGLE_APPLICATION_CREDENTIALS",
+    "GOOGLE_ADS_LOGIN_CUSTOMER_ID",
+)
+_GA4_NAMES = ("GOOGLE_APPLICATION_CREDENTIALS", "GOOGLE_PROJECT_ID")
 
 
 def _write(path: Path, payload: dict[str, object]) -> None:
@@ -34,114 +55,177 @@ def _write(path: Path, payload: dict[str, object]) -> None:
 
 
 @pytest.mark.unit
-class TestBuildCredentialsEnv:
-    def test_google_ads_full_section_maps_every_field(
+class TestBuildProviderEnv:
+    def test_google_ads_emits_adc_env_not_client_library_trio(
         self, tmp_path: Path
     ) -> None:
+        """The Google Ads ADC env is built from the provider's declared
+        names — dev token + GOOGLE_APPLICATION_CREDENTIALS (service-account
+        path) + optional login customer id. The Client-Library trio stored
+        in the same section is NEVER emitted (the upstream ignores it)."""
         creds = tmp_path / "credentials.json"
         _write(
             creds,
             {
                 "google_ads": {
                     "developer_token": "DT",
+                    "service_account_path": "/p/ads-sa.json",
+                    "login_customer_id": "123",
+                    # Client-Library secrets the upstream ADC client ignores.
                     "client_id": "CID",
                     "client_secret": "CS",
                     "refresh_token": "RT",
-                    "login_customer_id": "123",
-                    "customer_id": "456",
                 }
             },
         )
 
-        env = build_credentials_env("google_ads", credentials_path=creds)
+        env = build_provider_env(
+            _GOOGLE_ADS_ADC_NAMES, "google_ads", credentials_path=creds
+        )
 
         assert env == {
             "GOOGLE_ADS_DEVELOPER_TOKEN": "DT",
-            "GOOGLE_ADS_CLIENT_ID": "CID",
-            "GOOGLE_ADS_CLIENT_SECRET": "CS",
-            "GOOGLE_ADS_REFRESH_TOKEN": "RT",
+            "GOOGLE_APPLICATION_CREDENTIALS": "/p/ads-sa.json",
             "GOOGLE_ADS_LOGIN_CUSTOMER_ID": "123",
-            "GOOGLE_ADS_CUSTOMER_ID": "456",
         }
 
-    def test_empty_and_missing_fields_are_skipped(self, tmp_path: Path) -> None:
+    def test_google_application_credentials_is_section_aware(
+        self, tmp_path: Path
+    ) -> None:
+        """The shared ``GOOGLE_APPLICATION_CREDENTIALS`` name resolves to
+        ``google_ads.service_account_path`` for the Google Ads section —
+        NOT the GA4 binding (which is the historical 1:1 mapping)."""
         creds = tmp_path / "credentials.json"
         _write(
             creds,
             {
-                "google_ads": {
-                    "developer_token": "DT",
-                    "client_id": "",
-                    "client_secret": None,
-                    "refresh_token": "RT",
-                }
+                "google_ads": {"service_account_path": "/p/ads-sa.json"},
+                "ga4": {"service_account_path": "/p/ga4-sa.json"},
             },
         )
 
-        env = build_credentials_env("google_ads", credentials_path=creds)
+        env = build_provider_env(
+            ("GOOGLE_APPLICATION_CREDENTIALS",), "google_ads", credentials_path=creds
+        )
 
-        assert env == {
-            "GOOGLE_ADS_DEVELOPER_TOKEN": "DT",
-            "GOOGLE_ADS_REFRESH_TOKEN": "RT",
-        }
+        assert env == {"GOOGLE_APPLICATION_CREDENTIALS": "/p/ads-sa.json"}
 
-    def test_int_value_is_coerced_to_str(self, tmp_path: Path) -> None:
-        creds = tmp_path / "credentials.json"
-        _write(creds, {"google_ads": {"login_customer_id": 1234567890}})
-
-        env = build_credentials_env("google_ads", credentials_path=creds)
-
-        assert env == {"GOOGLE_ADS_LOGIN_CUSTOMER_ID": "1234567890"}
-
-    def test_ga4_section(self, tmp_path: Path) -> None:
+    def test_ga4_section_unchanged(self, tmp_path: Path) -> None:
+        """ga4-official still resolves GOOGLE_APPLICATION_CREDENTIALS /
+        GOOGLE_PROJECT_ID from the ga4 section (no behaviour change)."""
         creds = tmp_path / "credentials.json"
         _write(
             creds,
             {
                 "ga4": {
-                    "service_account_path": "/p/sa.json",
+                    "service_account_path": "/p/ga4-sa.json",
                     "project_id": "proj-1",
                 }
             },
         )
 
-        env = build_credentials_env("ga4", credentials_path=creds)
+        env = build_provider_env(_GA4_NAMES, "ga4", credentials_path=creds)
 
         assert env == {
-            "GOOGLE_APPLICATION_CREDENTIALS": "/p/sa.json",
+            "GOOGLE_APPLICATION_CREDENTIALS": "/p/ga4-sa.json",
             "GOOGLE_PROJECT_ID": "proj-1",
         }
 
-    def test_missing_section_yields_empty(self, tmp_path: Path) -> None:
-        creds = tmp_path / "credentials.json"
-        _write(creds, {"meta_ads": {"access_token": "T"}})
-
-        assert build_credentials_env("google_ads", credentials_path=creds) == {}
-
-    def test_missing_file_yields_empty(self, tmp_path: Path) -> None:
-        creds = tmp_path / "does-not-exist.json"
-
-        assert build_credentials_env("google_ads", credentials_path=creds) == {}
-
-    def test_unknown_section_yields_empty(self, tmp_path: Path) -> None:
-        creds = tmp_path / "credentials.json"
-        _write(creds, {"google_ads": {"developer_token": "DT"}})
-
-        assert build_credentials_env("nope", credentials_path=creds) == {}
-
-    def test_only_allow_listed_fields_are_emitted(self, tmp_path: Path) -> None:
-        """A stray/unknown field in the section is never surfaced as env."""
+    def test_empty_and_missing_values_are_skipped(self, tmp_path: Path) -> None:
         creds = tmp_path / "credentials.json"
         _write(
             creds,
             {
                 "google_ads": {
                     "developer_token": "DT",
-                    "totally_unknown_field": "leak?",
+                    "service_account_path": "",
+                    "login_customer_id": None,
                 }
             },
         )
 
-        env = build_credentials_env("google_ads", credentials_path=creds)
+        env = build_provider_env(
+            _GOOGLE_ADS_ADC_NAMES, "google_ads", credentials_path=creds
+        )
+
+        assert env == {"GOOGLE_ADS_DEVELOPER_TOKEN": "DT"}
+
+    def test_int_value_is_coerced_to_str(self, tmp_path: Path) -> None:
+        creds = tmp_path / "credentials.json"
+        _write(creds, {"google_ads": {"login_customer_id": 1234567890}})
+
+        env = build_provider_env(
+            ("GOOGLE_ADS_LOGIN_CUSTOMER_ID",), "google_ads", credentials_path=creds
+        )
+
+        assert env == {"GOOGLE_ADS_LOGIN_CUSTOMER_ID": "1234567890"}
+
+    def test_name_not_valid_for_section_is_skipped(self, tmp_path: Path) -> None:
+        """A requested name that does not bind to the section (e.g.
+        GOOGLE_PROJECT_ID, a GA4-only name, requested for google_ads) is
+        silently skipped — never resolved against the wrong section."""
+        creds = tmp_path / "credentials.json"
+        _write(
+            creds,
+            {"google_ads": {"developer_token": "DT", "project_id": "leak?"}},
+        )
+
+        env = build_provider_env(
+            ("GOOGLE_ADS_DEVELOPER_TOKEN", "GOOGLE_PROJECT_ID"),
+            "google_ads",
+            credentials_path=creds,
+        )
+
+        assert env == {"GOOGLE_ADS_DEVELOPER_TOKEN": "DT"}
+
+    def test_requested_but_absent_field_is_skipped(self, tmp_path: Path) -> None:
+        creds = tmp_path / "credentials.json"
+        _write(creds, {"google_ads": {"developer_token": "DT"}})
+
+        env = build_provider_env(
+            _GOOGLE_ADS_ADC_NAMES, "google_ads", credentials_path=creds
+        )
+
+        assert env == {"GOOGLE_ADS_DEVELOPER_TOKEN": "DT"}
+
+    def test_missing_section_yields_empty(self, tmp_path: Path) -> None:
+        creds = tmp_path / "credentials.json"
+        _write(creds, {"meta_ads": {"access_token": "T"}})
+
+        assert (
+            build_provider_env(
+                _GOOGLE_ADS_ADC_NAMES, "google_ads", credentials_path=creds
+            )
+            == {}
+        )
+
+    def test_missing_file_yields_empty(self, tmp_path: Path) -> None:
+        creds = tmp_path / "does-not-exist.json"
+
+        assert (
+            build_provider_env(
+                _GOOGLE_ADS_ADC_NAMES, "google_ads", credentials_path=creds
+            )
+            == {}
+        )
+
+    def test_only_requested_names_are_emitted(self, tmp_path: Path) -> None:
+        """A field present in the section but NOT requested is never
+        surfaced — the env block is driven by the provider's declared
+        names, not the on-disk section contents."""
+        creds = tmp_path / "credentials.json"
+        _write(
+            creds,
+            {
+                "google_ads": {
+                    "developer_token": "DT",
+                    "service_account_path": "/p/sa.json",
+                }
+            },
+        )
+
+        env = build_provider_env(
+            ("GOOGLE_ADS_DEVELOPER_TOKEN",), "google_ads", credentials_path=creds
+        )
 
         assert env == {"GOOGLE_ADS_DEVELOPER_TOKEN": "DT"}

--- a/tests/test_web_provider_host.py
+++ b/tests/test_web_provider_host.py
@@ -92,14 +92,19 @@ def _ok_install() -> InstallResult:
 
 
 def _google_creds(tmp_path: Path) -> Path:
-    """Write a synthetic credentials.json with a complete google_ads section
-    and return its path, so ``_credential_env_for`` resolves a non-empty
-    ``extra_env`` (the #102 decision-C gate that enables native auto-disable)."""
+    """Write a synthetic credentials.json with FULLY-credentialed Google Ads
+    ADC config (#102 plan B) and return its path, so ``_credential_env_for``
+    resolves all of the provider's ``required_env`` and the native
+    auto-disable gate fires.
+
+    The upstream ``google-ads-mcp`` authenticates via ADC, so 'credentialed'
+    means the developer token + a service-account path
+    (``GOOGLE_APPLICATION_CREDENTIALS``), NOT the Client-Library trio."""
     creds = tmp_path / ".mureo" / "credentials.json"
     creds.parent.mkdir(parents=True, exist_ok=True)
     creds.write_text(
-        '{"google_ads": {"developer_token": "DT", "client_id": "CID",'
-        ' "client_secret": "CS", "refresh_token": "RT"}}',
+        '{"google_ads": {"developer_token": "DT",'
+        ' "service_account_path": "/p/ads-sa.json"}}',
         "utf-8",
     )
     return creds
@@ -255,20 +260,23 @@ class TestInstallProviderInjectsCredentialEnv:
         assert "credentials_path" in params
         assert params["credentials_path"].default is None
 
-    def test_code_host_injects_google_env_from_credentials(
+    def test_code_host_injects_adc_env_not_client_library_trio(
         self, tmp_path: Path
     ) -> None:
-        """The official Google Ads block is registered WITH the env the
-        upstream MCP needs, resolved from credentials.json — without this
-        it registers but cannot authenticate (the reported bug)."""
+        """#102 plan B: the official Google Ads block is registered with the
+        ADC env the upstream actually reads — dev token +
+        GOOGLE_APPLICATION_CREDENTIALS (service-account path) + optional
+        login customer id. The Client-Library trio (which the upstream
+        ignores) is NEVER injected, even when present in credentials.json."""
         from mureo.web import setup_actions
 
         creds = tmp_path / ".mureo" / "credentials.json"
         creds.parent.mkdir(parents=True, exist_ok=True)
         creds.write_text(
-            '{"google_ads": {"developer_token": "DT", "client_id": "CID",'
-            ' "client_secret": "CS", "refresh_token": "RT",'
-            ' "login_customer_id": "123"}}',
+            '{"google_ads": {"developer_token": "DT",'
+            ' "service_account_path": "/p/ads-sa.json",'
+            ' "login_customer_id": "123",'
+            ' "client_id": "CID", "client_secret": "CS", "refresh_token": "RT"}}',
             "utf-8",
         )
 
@@ -287,11 +295,53 @@ class TestInstallProviderInjectsCredentialEnv:
         _, kwargs = mock_disable.call_args
         assert kwargs["extra_env"] == {
             "GOOGLE_ADS_DEVELOPER_TOKEN": "DT",
-            "GOOGLE_ADS_CLIENT_ID": "CID",
-            "GOOGLE_ADS_CLIENT_SECRET": "CS",
-            "GOOGLE_ADS_REFRESH_TOKEN": "RT",
+            "GOOGLE_APPLICATION_CREDENTIALS": "/p/ads-sa.json",
             "GOOGLE_ADS_LOGIN_CUSTOMER_ID": "123",
         }
+
+    def test_code_host_client_library_only_needs_credentials_no_disable(
+        self, tmp_path: Path
+    ) -> None:
+        """#102 plan B (the gate-tightening bug fix): a user with the
+        Client-Library trio + dev token but NO service-account path is NOT
+        credentialed for the official server (which authenticates via ADC).
+        Native must NOT be disabled (that would strand them — official can't
+        authenticate AND native off); the result is ``needs_credentials`` and
+        any stale MUREO_DISABLE is cleared. Only the dev token (the one
+        upstream-read value present) is injected into the bare block."""
+        from mureo.web import setup_actions
+
+        creds = tmp_path / ".mureo" / "credentials.json"
+        creds.parent.mkdir(parents=True, exist_ok=True)
+        creds.write_text(
+            '{"google_ads": {"developer_token": "DT", "client_id": "CID",'
+            ' "client_secret": "CS", "refresh_token": "RT"}}',
+            "utf-8",
+        )
+
+        with (
+            patch(
+                "mureo.providers.installer.run_install",
+                return_value=_ok_install(),
+            ),
+            patch(
+                "mureo.providers.config_writer.add_provider_to_claude_settings"
+            ) as mock_add,
+            patch(
+                "mureo.providers.mureo_env.add_provider_and_disable_in_mureo"
+            ) as mock_disable,
+            patch("mureo.providers.mureo_env.unset_mureo_disable_env") as mock_unset,
+        ):
+            result = setup_actions.install_provider(_GOOGLE, credentials_path=creds)
+
+        assert result.status == "needs_credentials"
+        assert result.detail == _GOOGLE
+        mock_disable.assert_not_called()
+        # Bare block written WITH the partial (dev-token-only) env, native on.
+        mock_add.assert_called_once()
+        _, kwargs = mock_add.call_args
+        assert kwargs["extra_env"] == {"GOOGLE_ADS_DEVELOPER_TOKEN": "DT"}
+        mock_unset.assert_called_once_with("google_ads")
 
     def test_code_host_injects_ga4_env_from_credentials(self, tmp_path: Path) -> None:
         """ga4-official is registered WITH GOOGLE_APPLICATION_CREDENTIALS
@@ -389,9 +439,7 @@ class TestInstallProviderInjectsCredentialEnv:
             patch(
                 "mureo.providers.mureo_env.add_provider_and_disable_in_mureo"
             ) as mock_disable,
-            patch(
-                "mureo.providers.mureo_env.unset_mureo_disable_env"
-            ) as mock_unset,
+            patch("mureo.providers.mureo_env.unset_mureo_disable_env") as mock_unset,
         ):
             result = setup_actions.install_provider(_GOOGLE, credentials_path=creds)
 
@@ -403,6 +451,59 @@ class TestInstallProviderInjectsCredentialEnv:
         # Any stale MUREO_DISABLE from a prior credentialed install is cleared,
         # so a re-install without creds never leaves native off (#102 dec. C).
         mock_unset.assert_called_once_with("google_ads")
+
+
+# ---------------------------------------------------------------------------
+# _is_credentialed — the native-disable gate (#102 plan B)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestIsCredentialedGate:
+    def test_all_required_present_is_credentialed(self) -> None:
+        from mureo.web.setup_actions import _is_credentialed
+
+        spec = get_provider(_GOOGLE)  # required: DEV_TOKEN + GAC
+        assert _is_credentialed(
+            spec,
+            {
+                "GOOGLE_ADS_DEVELOPER_TOKEN": "DT",
+                "GOOGLE_APPLICATION_CREDENTIALS": "/p/sa.json",
+            },
+        )
+
+    def test_missing_one_required_is_not_credentialed(self) -> None:
+        """The client-library-only case: dev token present but the ADC
+        service-account path missing → NOT credentialed (the core fix)."""
+        from mureo.web.setup_actions import _is_credentialed
+
+        spec = get_provider(_GOOGLE)
+        assert not _is_credentialed(spec, {"GOOGLE_ADS_DEVELOPER_TOKEN": "DT"})
+
+    def test_optional_env_is_not_required(self) -> None:
+        """A missing OPTIONAL name does not block credentialing."""
+        from mureo.web.setup_actions import _is_credentialed
+
+        spec = get_provider(_GOOGLE)
+        # No GOOGLE_ADS_LOGIN_CUSTOMER_ID (optional) → still credentialed.
+        assert _is_credentialed(
+            spec,
+            {
+                "GOOGLE_ADS_DEVELOPER_TOKEN": "DT",
+                "GOOGLE_APPLICATION_CREDENTIALS": "/p/sa.json",
+            },
+        )
+
+    def test_empty_required_env_is_not_vacuously_credentialed(self) -> None:
+        """No-strand invariant: a (hypothetical) overlapping provider with
+        NO declared required env must NOT be treated as credentialed — it
+        could never authenticate from env alone, so native must stay on.
+        Guards against ``all(())`` being vacuously True."""
+        from mureo.web.setup_actions import _is_credentialed
+
+        spec = replace(get_provider(_GOOGLE), required_env=(), optional_env=())
+        assert not _is_credentialed(spec, {})
+        assert not _is_credentialed(spec, {"ANYTHING": "X"})
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Backend half (**B1**) of issue #102 plan B: make `google-ads-official` actually authenticate.

The official `google-ads-mcp` authenticates via **ADC** — it reads `GOOGLE_ADS_DEVELOPER_TOKEN` + `GOOGLE_APPLICATION_CREDENTIALS` (a service-account JSON path), optionally `GOOGLE_ADS_LOGIN_CUSTOMER_ID`, and **ignores** the Client-Library trio (`client_id`/`client_secret`/`refresh_token`). mureo previously:

1. injected the useless Client-Library trio as the official server's `env` (so it could never authenticate), and
2. used a too-loose `bool(extra_env)` native-disable gate — a client-library-only user got mureo's **native** Google Ads tools disabled while the official server still couldn't authenticate (**stranded**: official dead AND native off).

## Changes

- **`catalog.py`**: `google-ads-official.required_env` → ADC reality `(GOOGLE_ADS_DEVELOPER_TOKEN, GOOGLE_APPLICATION_CREDENTIALS)`; new `optional_env=(GOOGLE_ADS_LOGIN_CUSTOMER_ID,)`; new `ProviderSpec.optional_env` field (default `()`); notes describe ADC. **ga4 unchanged** (already ADC, correct).
- **`env_var_writer.py`**: replace the blanket section-dump `build_credentials_env(section)` with `build_provider_env(env_names, section)` — driven by the provider's declared `required_env + optional_env` so it emits only what the upstream reads. Adds a **section-aware resolver** `_resolve_field` so the shared `GOOGLE_APPLICATION_CREDENTIALS` resolves to `google_ads.service_account_path` vs `ga4.service_account_path`.
- **`setup_actions.py`**: `_credential_env_for` builds from `required_env + optional_env`; new `_is_credentialed` requires **all** `required_env` present; the native-disable gate is tightened from `bool(extra_env)` to `_is_credentialed(...)` — native steps aside only when the official server can actually authenticate (no-strand invariant, guarded against an empty `required_env`).

Net effect: stops writing the real Client-Library secrets into `~/.claude.json` for the official server, and fixes the stranding bug.

## Test plan

- [x] `pytest tests/test_providers_catalog.py tests/test_web_provider_env.py tests/test_web_provider_host.py` — 84 passed
- [x] `ruff check mureo/` / `black --check mureo/` / `mypy mureo/ --ignore-missing-imports` clean
- [x] `python-reviewer` + `security-reviewer` — both APPROVE, no CRITICAL/HIGH
- New tests pin: Client-Library trio NOT injected even when present; section-aware resolution; client-library-only → `needs_credentials` + native NOT disabled + stale `MUREO_DISABLE` cleared; `_is_credentialed` gate (incl. empty-`required_env` no-strand guard)

## Follow-up (B2, separate PR)

Frontend: wizard service-account-path input for `google-ads-official`, `needs_credentials` UX branch, and bilingual i18n keys. The user must create + authorise a Google Ads service account to actually use the official server (a heavy user-side step B2 will surface honestly).

Refs #102