### PR TITLE
fix(web): discover provider registry in configure path so plugin credentials populate (#268)

### DIFF
--- a/mureo/web/server.py
+++ b/mureo/web/server.py
@@ -20,6 +20,7 @@ import webbrowser
 from importlib import resources
 from pathlib import Path
 
+from mureo.core.providers import discover_providers
 from mureo.core.runtime_context import runtime_credentials_path
 from mureo.core.terminal import force_cooked_mode, terminal_fd
 from mureo.web.extensions import (
@@ -111,11 +112,44 @@ class ConfigureWizard:
         # plus every subsequent call within the same process re-uses
         # the same tuple — see :mod:`mureo.web.extensions`.
         self.extensions = discover_web_extensions()
+        # #268 — also populate the *provider* registry here. Without it the
+        # configure UI's Plugin-credentials section is always empty:
+        # ``/api/credentials/plugins`` iterates ``default_registry``, which
+        # only the MCP startup path otherwise discovers. Idempotent +
+        # cached and fault-isolated — see ``_discover_providers_safely``.
+        self._discover_providers_safely()
 
         self._server: _ConfigureServer | None = None
         self._ready = threading.Event()
         self._stop = threading.Event()
         self._lock = threading.Lock()
+
+    @staticmethod
+    def _discover_providers_safely() -> None:
+        """Populate the provider registry, never raising on failure.
+
+        Mirrors ``mcp.tool_provider.collect_plugin_tools``: ``discover``
+        already isolates per-plugin faults, so the only way out here is a
+        wholesale failure (e.g. the underlying ``entry_points`` call
+        raising). Swallow it with a warning rather than aborting
+        ``mureo configure`` — an empty Plugin-credentials section degrades
+        gracefully; a crashed configure UI does not.
+
+        ``BaseException`` (not just ``Exception``) is caught for parity
+        with the MCP path: a plugin whose discovery hook raises
+        ``SystemExit`` must not tear down configure startup. Only
+        ``KeyboardInterrupt`` is honoured so Ctrl+C still works.
+        """
+        try:
+            discover_providers()
+        except KeyboardInterrupt:
+            raise
+        except BaseException:  # noqa: BLE001 — fault isolation boundary
+            logger.warning(
+                "provider discovery failed; the configure UI's plugin "
+                "credentials section may be empty",
+                exc_info=True,
+            )
 
     # ------------------------------------------------------------------
     # Public surface

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -583,6 +583,34 @@ class TestResolveStaticDir:
 
 
 @pytest.mark.unit
+class TestConfigureWizardProviderDiscovery:
+    """#268 — the configure/web path must trigger provider-registry
+    discovery so the Plugin-credentials section is populated. Discovery
+    is only otherwise run from the MCP startup path, leaving the web UI
+    serving ``/api/credentials/plugins`` against an empty registry."""
+
+    def test_init_triggers_provider_discovery(self, home_dir: Path) -> None:
+        """Constructing the wizard must call ``discover_providers`` exactly
+        as it already discovers web extensions — otherwise the registry
+        the Plugin-credentials endpoint iterates is never populated."""
+        with patch("mureo.web.server.discover_providers") as mock_discover:
+            ConfigureWizard(home=home_dir)
+        mock_discover.assert_called_once()
+
+    def test_init_survives_provider_discovery_failure(self, home_dir: Path) -> None:
+        """A broken plugin's discovery must not crash ``mureo configure``
+        startup — fault isolation mirrors the MCP server path. The wizard
+        is still fully constructed and serves."""
+        with patch(
+            "mureo.web.server.discover_providers",
+            side_effect=RuntimeError("broken plugin"),
+        ):
+            wiz = ConfigureWizard(home=home_dir)
+        assert wiz.session.csrf_token
+        assert isinstance(wiz.host_paths, HostPaths)
+
+
+@pytest.mark.unit
 class TestSecurityBindLoopbackOnly:
     def test_server_binds_to_loopback_only(
         self, served_wizard: ConfigureWizard


### PR DESCRIPTION
## Summary

The configure web UI's **Plugin credentials** section was always empty because the configure/web server never triggered provider-registry discovery. `default_registry.discover()` was only called from the MCP server startup path (`mureo/mcp/tool_provider.py`), so `/api/credentials/plugins` iterated an un-discovered (empty) registry.

This populates the provider registry during web-server bootstrap in `ConfigureWizard.__init__`, alongside the existing `discover_web_extensions()` call — the fix suggested in the issue.

Fixes #268.

## Changes

- `mureo/web/server.py`
  - Import `discover_providers` from `mureo.core.providers`.
  - Add `_discover_providers_safely()` and call it in `ConfigureWizard.__init__`.
  - Discovery is idempotent + cached (`Registry.discover`), so it's a cheap no-op on re-construct.
  - Fault-isolated for parity with the MCP path: `BaseException` caught (a plugin's `SystemExit` must not abort `mureo configure`), `KeyboardInterrupt` propagated, failure logged with `exc_info`.
- `tests/test_web_server.py`
  - New `TestConfigureWizardProviderDiscovery`: asserts construction triggers discovery, and that a discovery failure does not crash startup.

## Verification

- Reproduced the issue end-to-end: with a cleared registry, `ConfigureWizard(...)` construction populates it (0 → N entries), so `list_plugin_credential_fields()` is no longer empty.
- `pytest tests/test_web_server.py` → 41 passed.
- Related suites (plugin credentials handlers, field scope, MCP plugin wiring, configure serve) pass.
- `ruff check mureo/` and `black --check` clean.

## Test plan

- [x] Unit: construction triggers `discover_providers()`
- [x] Unit: discovery failure is fault-isolated (wizard still constructs/serves)
- [ ] Manual: on an install with a `mureo.providers` plugin declaring `account_credential_fields`, the configure Setup tab lists the plugin's per-account fields

## Notes

The local failure of `test_mcp_server_plugin_wiring.py::test_no_plugins_is_additive_no_op` is pre-existing environment noise (real provider plugins are installed in this editable dev env) and is unrelated to this change; it passes in CI's clean environment.
