### PR TITLE
chore(release): 0.10.5

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mureo",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "description": "Your local-first AI ad ops crew for Google Ads, Meta Ads, Search Console & GA4. mureo sits on top of the official ad-platform MCPs, gates every change against your strategy, correlates outcomes locally, and keeps an auditable decision log — credentials never leave your machine.",
   "author": {
     "name": "Logly Inc.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.5] - 2026-06-16
+
+### Changed
+
+#### Recommend mureo-native over the official MCP for Meta in the configure wizard (#271)
+
+The configure wizard's connection-choice step labelled Meta's official
+hosted MCP as "recommended" while leaving mureo-native unmarked. Verified
+against Meta's official AI Connectors announcement and Help Centre, the
+official Meta MCP lacks creative generation, audience / lookalike
+creation, Conversions API event sending, lead forms, split tests and
+automation rules — so mureo-native is the better default for Meta. The
+"recommended" marker now sits on the native option instead of the
+official one (en + ja). Google is unchanged.
+
+### Removed
+
+#### Configure wizard shutdown button (#271)
+
+The wizard's completed step offered a "Finish & free the terminal" button
+that POSTed ``/api/shutdown``. Now that the configure server can run as a
+resident daemon, a UI shutdown button is no longer appropriate, so it has
+been removed. The ``/api/shutdown`` endpoint and ``server.shutdown()`` are
+kept for the SIGINT/SIGTERM path and non-daemon launches.
+
+### Added
+
+#### mureo-native vs official-MCP comparison docs (#271)
+
+New ``docs/native-vs-official.md`` (and ``.ja.md``) comparing mureo-native
+tools with Google's and Meta's official MCP servers, with capability
+tables verified against the platforms' official documentation.
+
 ## [0.10.4] - 2026-06-14
 
 ### Fixed

--- a/mureo/__init__.py
+++ b/mureo/__init__.py
@@ -1,3 +1,3 @@
 """mureo — your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."""
 
-__version__ = "0.10.4"
+__version__ = "0.10.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mureo"
-version = "0.10.4"
+version = "0.10.5"
 description = "Your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."
 requires-python = ">=3.10"
 license = "Apache-2.0"


### PR DESCRIPTION
## Release 0.10.5

Version bump (pyproject / `__init__` / `.claude-plugin`) + CHANGELOG for the changes already merged via #271:

- **Changed** — Recommend mureo-native over the official MCP for Meta in the configure wizard (verified Meta gaps: creative gen, audiences, CAPI send, lead forms, split tests, rules).
- **Removed** — Configure wizard "Finish & free the terminal" shutdown button (server now runs as a daemon; `/api/shutdown` backend kept).
- **Added (docs)** — `docs/native-vs-official.md` (+ `.ja.md`) comparison.

After merge: publish GitHub Release `v0.10.5` → `release.yml` auto-publishes to PyPI.

## Test plan
- [x] version parity across the 3 files (0.10.5)
- [x] plugin.json valid JSON
- [ ] CI green