### PR TITLE
fix(meta-ads): read-modify-write guard for ad set targeting (#273)

### DIFF
--- a/mureo/mcp/_handlers_meta_ads.py
+++ b/mureo/mcp/_handlers_meta_ads.py
@@ -191,7 +191,10 @@ async def handle_ad_sets_update(args: dict[str, Any]) -> list[TextContent]:
         val = _opt(args, key)
         if val is not None:
             update_kwargs[key] = val
-    result = await client.update_ad_set(ad_set_id, **update_kwargs)
+    replace_targeting = bool(args.get("replace_targeting", False))
+    result = await client.update_ad_set(
+        ad_set_id, replace_targeting=replace_targeting, **update_kwargs
+    )
     return _json_result(result)
 
 

--- a/mureo/mcp/_tools_meta_ads_campaigns.py
+++ b/mureo/mcp/_tools_meta_ads_campaigns.py
@@ -383,11 +383,14 @@ TOOLS: list[Tool] = [
         description=(
             "Updates one or more settings on an existing ad set. Partial "
             "update — only provided fields are changed. Returns the updated "
-            "ad set. Mutating, reversible via rollback_apply. For "
-            "status-only transitions prefer meta_ads_ad_sets_pause / "
-            "meta_ads_ad_sets_enable. Changing `targeting` replaces the "
-            "entire targeting spec — fetch the current spec via "
-            "meta_ads_ad_sets_get and merge client-side to avoid data loss."
+            "ad set. Mutating; not automatically reversible — record "
+            "before-state if you need to roll back. For status-only "
+            "transitions prefer meta_ads_ad_sets_pause / "
+            "meta_ads_ad_sets_enable. Changing `targeting` is a safe "
+            "read-modify-write by default: the supplied top-level keys are "
+            "merged onto the current spec, so keys you omit are preserved. "
+            "Set `replace_targeting` to true to replace the whole spec "
+            "instead (e.g. to clear a facet)."
         ),
         inputSchema={
             "type": "object",
@@ -420,10 +423,20 @@ TOOLS: list[Tool] = [
                 "targeting": {
                     "type": "object",
                     "description": (
-                        "Full targeting spec replacement. Any keys not "
-                        "supplied here are cleared — fetch current spec "
-                        "via meta_ads_ad_sets_get and merge before "
-                        "writing back."
+                        "Targeting spec changes. Merged onto the current "
+                        "spec by default (top-level keys you omit are kept). "
+                        "Supply only the facets you want to change, e.g. "
+                        '{"age_min": 25}. Set replace_targeting=true to '
+                        "replace the whole spec instead."
+                    ),
+                },
+                "replace_targeting": {
+                    "type": "boolean",
+                    "description": (
+                        "When true, `targeting` replaces the entire spec "
+                        "instead of merging onto the current one. Use only "
+                        "to deliberately clear targeting facets. Default "
+                        "false (safe merge)."
                     ),
                 },
             },

--- a/mureo/meta_ads/_ad_sets.py
+++ b/mureo/meta_ads/_ad_sets.py
@@ -125,12 +125,24 @@ class AdSetsMixin:
     async def update_ad_set(
         self,
         ad_set_id: str,
+        *,
+        replace_targeting: bool = False,
         **kwargs: Any,
     ) -> dict[str, Any]:
-        """Update an ad set
+        """Update an ad set.
+
+        Meta replaces the **entire** targeting spec on write, so a partial
+        ``targeting`` dict would silently clear every key not supplied
+        (geo_locations, custom_audiences, interests, ...). To prevent that
+        data loss this method performs a read-modify-write by default: it
+        fetches the current spec and shallow-merges the supplied top-level
+        keys over it. Pass ``replace_targeting=True`` to skip the merge and
+        replace the whole spec deliberately (e.g. to clear a facet).
 
         Args:
             ad_set_id: Ad set ID
+            replace_targeting: When True, ``targeting`` replaces the whole
+                spec instead of being merged onto the current one.
             **kwargs: Fields to update (name, status, daily_budget,
                       targeting, optimization_goal, etc.)
 
@@ -139,13 +151,34 @@ class AdSetsMixin:
         """
         data: dict[str, Any] = {}
         for key, value in kwargs.items():
-            if value is not None:
-                if key == "targeting" and isinstance(value, dict):
-                    data[key] = json.dumps(value)
-                else:
-                    data[key] = value
+            if value is None:
+                continue
+            if key == "targeting" and isinstance(value, dict):
+                targeting = value
+                if not replace_targeting:
+                    targeting = await self._merge_targeting(ad_set_id, value)
+                data[key] = json.dumps(targeting)
+            else:
+                data[key] = value
 
         return await self._post(f"/{ad_set_id}", data)
+
+    async def _merge_targeting(
+        self, ad_set_id: str, delta: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Shallow-merge a targeting ``delta`` onto the ad set's current spec.
+
+        Read-modify-write guard against Meta's whole-spec replacement: the
+        current spec's top-level keys are preserved unless overridden by a
+        key present in ``delta``. Merging is top-level only — a supplied key
+        replaces that key wholesale (nested lists like ``flexible_spec`` are
+        not deep-merged, which would be ambiguous).
+        """
+        current = await self.get_ad_set(ad_set_id)
+        existing = current.get("targeting")
+        if not isinstance(existing, dict):
+            existing = {}
+        return {**existing, **delta}
 
     async def pause_ad_set(self, ad_set_id: str) -> dict[str, Any]:
         """Pause an ad set

--- a/tests/test_meta_ads_operations.py
+++ b/tests/test_meta_ads_operations.py
@@ -197,6 +197,65 @@ class TestAdSetsMixin:
         assert json.loads(data["targeting"]) == targeting
 
     @pytest.mark.asyncio
+    async def test_update_ad_set_targeting_merges_with_existing(self, client) -> None:
+        # Meta replaces the whole targeting spec on write. A partial delta
+        # must be merged onto the current spec so unrelated facets survive.
+        client._get = AsyncMock(
+            return_value={
+                "id": "1",
+                "targeting": {
+                    "geo_locations": {"countries": ["JP"]},
+                    "interests": [{"id": "6003", "name": "Tech"}],
+                },
+            }
+        )
+        await client.update_ad_set("1", targeting={"age_min": 25})
+        merged = json.loads(client._post.call_args[0][1]["targeting"])
+        # Unrelated keys must survive — this is the data-loss fix (#273).
+        assert merged["geo_locations"] == {"countries": ["JP"]}
+        assert merged["interests"] == [{"id": "6003", "name": "Tech"}]
+        assert merged["age_min"] == 25
+
+    @pytest.mark.asyncio
+    async def test_update_ad_set_targeting_merge_no_existing_spec(self, client) -> None:
+        # Ad set has no targeting yet (get returns no 'targeting' key): the
+        # merge must fall back to {} and write the delta as-is, not crash.
+        client._get = AsyncMock(return_value={"id": "1"})
+        await client.update_ad_set("1", targeting={"age_min": 25})
+        merged = json.loads(client._post.call_args[0][1]["targeting"])
+        assert merged == {"age_min": 25}
+
+    @pytest.mark.asyncio
+    async def test_update_ad_set_targeting_delta_overrides_key(self, client) -> None:
+        client._get = AsyncMock(
+            return_value={
+                "id": "1",
+                "targeting": {"geo_locations": {"countries": ["JP"]}},
+            }
+        )
+        await client.update_ad_set(
+            "1", targeting={"geo_locations": {"countries": ["US"]}}
+        )
+        merged = json.loads(client._post.call_args[0][1]["targeting"])
+        # A supplied top-level key replaces that key wholesale.
+        assert merged["geo_locations"] == {"countries": ["US"]}
+
+    @pytest.mark.asyncio
+    async def test_update_ad_set_targeting_replace_bypasses_merge(self, client) -> None:
+        client._get = AsyncMock(
+            return_value={"id": "1", "targeting": {"interests": [{"id": "6003"}]}}
+        )
+        await client.update_ad_set(
+            "1",
+            targeting={"geo_locations": {"countries": ["US"]}},
+            replace_targeting=True,
+        )
+        merged = json.loads(client._post.call_args[0][1]["targeting"])
+        # Explicit opt-in to full replacement: no read, only supplied keys.
+        assert merged == {"geo_locations": {"countries": ["US"]}}
+        client._get.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_pause_ad_set(self, client) -> None:
         await client.pause_ad_set("1")
         data = client._post.call_args[0][1]
@@ -408,9 +467,7 @@ class TestCreativesMixin:
         assert spec["link_data"]["call_to_action"] == {"type": "SIGN_UP"}
 
     @pytest.mark.asyncio
-    async def test_create_lead_ad_creative_accepts_alternate_cta(
-        self, client
-    ) -> None:
+    async def test_create_lead_ad_creative_accepts_alternate_cta(self, client) -> None:
         """Lead Ads support several CTAs (LEARN_MORE, APPLY_NOW,
         GET_QUOTE, SUBSCRIBE, ...) — the helper must pass through
         whatever the caller chooses without validation."""
@@ -460,9 +517,7 @@ class TestCreativesMixin:
             "https://example.com",
             image_url="https://img.example.com/x.jpg",
         )
-        client.upload_ad_image.assert_awaited_once_with(
-            "https://img.example.com/x.jpg"
-        )
+        client.upload_ad_image.assert_awaited_once_with("https://img.example.com/x.jpg")
         spec = json.loads(client._post.call_args[0][1]["object_story_spec"])
         assert spec["link_data"]["image_hash"] == "uploaded_hash"
 
@@ -486,9 +541,7 @@ class TestCreativesMixin:
         assert "image_hash" not in spec["link_data"]
 
     @pytest.mark.asyncio
-    async def test_create_lead_ad_creative_calls_correct_endpoint(
-        self, client
-    ) -> None:
+    async def test_create_lead_ad_creative_calls_correct_endpoint(self, client) -> None:
         """The POST goes to ``/<ad_account_id>/adcreatives`` — same
         endpoint as ``create_ad_creative``, only the payload differs."""
         await client.create_lead_ad_creative(


### PR DESCRIPTION
Fixes #273 (CRITICAL — silent customer-data destruction).

## Problem
`meta_ads_ad_sets_update` passed the supplied `targeting` dict straight to Meta via `json.dumps`. Meta **replaces the entire targeting spec** on write, so an agent intending a partial change (e.g. `{"age_min": 25}`) silently cleared `geo_locations`, `custom_audiences`, `interests`, placements, etc. on a live, real-spend ad set. Same shape as the logly-bridge incident (collection full-replacement → data loss). The tool description correctly warned "fetch and merge" but no merge path existed in code.

## Fix
- `update_ad_set` now does a **read-modify-write by default**: when `targeting` is a dict, it `get_ad_set()`s the current spec and shallow-merges the supplied top-level keys over it (`_merge_targeting`). Omitted keys are preserved.
- New keyword-only `replace_targeting: bool = False` escape hatch for deliberate whole-spec replacement (e.g. to clear a facet); when true, no read is performed.
- Handler `handle_ad_sets_update` passes `replace_targeting` through.
- Tool description rewritten to "merge-by-default", documents `replace_targeting`, and corrects the false "reversible via rollback_apply" claim to "not automatically reversible".

Merge granularity is top-level only — a supplied key replaces that key wholesale (nested lists like `flexible_spec` are not deep-merged, which would be ambiguous).

## Tests (TDD)
- `test_update_ad_set_targeting_merges_with_existing` — unrelated keys survive a partial delta (the regression guard).
- `test_update_ad_set_targeting_delta_overrides_key` — a supplied top-level key wins.
- `test_update_ad_set_targeting_merge_no_existing_spec` — no existing spec falls back to `{}` (no crash).
- `test_update_ad_set_targeting_replace_bypasses_merge` — `replace_targeting=True` skips the read and replaces wholesale.

## Verification
- AdSetsMixin 14 tests + related regression (234) pass; ruff/black/mypy clean on changed files.
- code-reviewer: approved, no CRITICAL/HIGH/MEDIUM.

## Notes
- `test_mcp_server::test_list_tools_returns_all_tools` (331≠185) fails only in the local editable-install env due to discovered plugin tools — pre-existing, unrelated (this PR adds a property, not a tool; Meta tool count unchanged).
- Part of the mutation-safety audit batch (logly-bridge `reliability-audit-checklist`); remaining CRITICAL/HIGH tracked in #274–#277.