### PR TITLE
fix(ads): read-modify-write for RSA assets and ad rule specs (#275)

### DIFF
--- a/mureo/google_ads/_ads.py
+++ b/mureo/google_ads/_ads.py
@@ -72,6 +72,25 @@ class _AdsMixin:
             f"have access to this account."
         )
 
+    async def _get_rsa_assets(self, ad_id: str) -> tuple[list[str], list[str]]:
+        """Read an RSA's current headline and description texts.
+
+        Used to backfill the side of an ``update_ad`` the caller did not
+        supply, so a single-side update never wipes the other side.
+        """
+        query = (
+            "SELECT ad_group_ad.ad.responsive_search_ad.headlines, "
+            "ad_group_ad.ad.responsive_search_ad.descriptions "
+            f"FROM ad_group_ad WHERE ad_group_ad.ad.id = {ad_id}"
+        )
+        response = await self._search(query)
+        for row in response:
+            rsa = row.ad_group_ad.ad.responsive_search_ad
+            headlines = [asset.text for asset in rsa.headlines]
+            descriptions = [asset.text for asset in rsa.descriptions]
+            return headlines, descriptions
+        return [], []
+
     # === Ads ===
 
     @staticmethod
@@ -329,10 +348,14 @@ class _AdsMixin:
 
     @_wrap_mutate_error("ad text update")
     async def update_ad(self, params: dict[str, Any]) -> dict[str, Any]:
-        """Update headlines and descriptions of an existing responsive search ad.
+        """Update headlines and/or descriptions of an existing RSA.
 
-        Uses AdService.mutate_ads (not AdGroupAdService).
-        Headlines and descriptions are fully replaced, not patched.
+        Uses AdService.mutate_ads (not AdGroupAdService). A supplied side
+        (headlines or descriptions) is **fully replaced** — Google has no
+        per-asset patch. To avoid wiping the side you are not changing, omit
+        it: the omitted side is read from the current ad and left untouched
+        (its FieldMask path is not set). Supply at least one of headlines /
+        descriptions / final_url.
 
         This method currently supports RSA (Responsive Search Ad) only.
         If the target ad is a RDA (Responsive Display Ad), it raises
@@ -348,11 +371,46 @@ class _AdsMixin:
         # while processing ad text update." message for display ads.
         await self._assert_ad_is_rsa(ad_id)
 
+        supplied_headlines = params.get("headlines")
+        supplied_descriptions = params.get("descriptions")
+        if not supplied_headlines and not supplied_descriptions and not final_url:
+            raise ValueError(
+                "Supply headlines and/or descriptions (and/or final_url) to update."
+            )
+
+        # Read current assets only when a side is omitted, so the omitted
+        # side can be preserved (single-side update never wipes the other).
+        if supplied_headlines is None or supplied_descriptions is None:
+            current_headlines, current_descriptions = await self._get_rsa_assets(ad_id)
+        else:
+            current_headlines, current_descriptions = [], []
+        # If a side was omitted but its current assets could not be read, fail
+        # with a clear message rather than a misleading "min count" error from
+        # validation below (which would blame the side the caller never touched).
+        if supplied_headlines is None and not current_headlines:
+            raise ValueError(
+                "Could not read the ad's current headlines to preserve them; "
+                "supply headlines explicitly."
+            )
+        if supplied_descriptions is None and not current_descriptions:
+            raise ValueError(
+                "Could not read the ad's current descriptions to preserve them; "
+                "supply descriptions explicitly."
+            )
+        effective_headlines = (
+            supplied_headlines if supplied_headlines is not None else current_headlines
+        )
+        effective_descriptions = (
+            supplied_descriptions
+            if supplied_descriptions is not None
+            else current_descriptions
+        )
+
         # Use dummy URL for validation when final_url is not specified (URL itself is not updated)
         validation_url = final_url if final_url else "https://placeholder.example.com"
         headlines, descriptions, rsa_result = self._validate_and_prepare_rsa(
-            params.get("headlines", []),
-            params.get("descriptions", []),
+            effective_headlines,
+            effective_descriptions,
             validation_url,
         )
 
@@ -362,20 +420,21 @@ class _AdsMixin:
         ad = op.update
         ad.resource_name = ad_service.ad_path(self._customer_id, ad_id)
 
-        for h in headlines:
-            text_asset = self._client.get_type("AdTextAsset")
-            text_asset.text = h
-            ad.responsive_search_ad.headlines.append(text_asset)
-        for d in descriptions:
-            text_asset = self._client.get_type("AdTextAsset")
-            text_asset.text = d
-            ad.responsive_search_ad.descriptions.append(text_asset)
-
-        # Build FieldMask
-        paths = [
-            "responsive_search_ad.headlines",
-            "responsive_search_ad.descriptions",
-        ]
+        # Only mask the side(s) the caller actually supplied; the other side
+        # keeps its current assets untouched.
+        paths: list[str] = []
+        if supplied_headlines is not None:
+            for h in headlines:
+                text_asset = self._client.get_type("AdTextAsset")
+                text_asset.text = h
+                ad.responsive_search_ad.headlines.append(text_asset)
+            paths.append("responsive_search_ad.headlines")
+        if supplied_descriptions is not None:
+            for d in descriptions:
+                text_asset = self._client.get_type("AdTextAsset")
+                text_asset.text = d
+                ad.responsive_search_ad.descriptions.append(text_asset)
+            paths.append("responsive_search_ad.descriptions")
         if final_url:
             ad.final_urls.append(final_url)
             paths.append("final_urls")

--- a/mureo/mcp/_handlers_meta_ads_other.py
+++ b/mureo/mcp/_handlers_meta_ads_other.py
@@ -200,7 +200,8 @@ async def handle_ad_rules_update(args: dict[str, Any]) -> list[TextContent]:
         val = _opt(args, key)
         if val is not None:
             updates[key] = val
-    result = await client.update_ad_rule(rule_id, updates)
+    replace_specs = bool(args.get("replace_specs", False))
+    result = await client.update_ad_rule(rule_id, updates, replace_specs=replace_specs)
     return _json_result(result)
 
 

--- a/mureo/mcp/_tools_google_ads_campaigns.py
+++ b/mureo/mcp/_tools_google_ads_campaigns.py
@@ -579,11 +579,15 @@ TOOLS: list[Tool] = [
         name="google_ads_ads_update",
         description=(
             "Updates the creative copy of an existing Responsive Search Ad "
-            "by replacing headlines and/or descriptions. Returns the "
-            "updated ad. Google Ads does not support in-place edit of RSA "
-            "creative assets — this call typically replaces the ad with a "
-            "new one under the same ID, which resets learning and triggers "
-            "re-review. Mutating — not automatically reversible; record "
+            "by replacing headlines and/or descriptions. A supplied side is "
+            "fully replaced (Google has no per-asset patch); omit a side to "
+            "leave it unchanged — the omitted side is read from the current "
+            "ad and preserved, so updating headlines never wipes "
+            "descriptions. Returns the updated ad. Google Ads does not "
+            "support in-place edit of RSA creative assets — this call "
+            "typically replaces the ad with a new one under the same ID, "
+            "which resets learning and triggers re-review. Mutating — not "
+            "automatically reversible; record "
             "before-state with mureo_state_action_log_append if you may "
             "need to roll back. For "
             "status-only changes (pause/resume) use "
@@ -608,7 +612,9 @@ TOOLS: list[Tool] = [
                     "minItems": 3,
                     "maxItems": 15,
                     "description": (
-                        "Replacement headlines (3 to 15). Each max 30 "
+                        "Replacement headlines (3 to 15) — the full new set, "
+                        "since the supplied side is replaced wholesale. Omit "
+                        "to keep the current headlines unchanged. Each max 30 "
                         "characters display width."
                     ),
                 },
@@ -618,8 +624,10 @@ TOOLS: list[Tool] = [
                     "minItems": 2,
                     "maxItems": 4,
                     "description": (
-                        "Replacement descriptions (2 to 4). Each max 90 "
-                        "characters display width."
+                        "Replacement descriptions (2 to 4) — the full new "
+                        "set, since the supplied side is replaced wholesale. "
+                        "Omit to keep the current descriptions unchanged. "
+                        "Each max 90 characters display width."
                     ),
                 },
             },

--- a/mureo/mcp/_tools_meta_ads_other.py
+++ b/mureo/mcp/_tools_meta_ads_other.py
@@ -339,20 +339,36 @@ TOOLS: list[Tool] = [
                 "evaluation_spec": {
                     "type": "object",
                     "description": (
-                        "New trigger definition. Replaces the entire "
-                        "spec — fetch current via "
-                        "meta_ads_ad_rules_get first if merging."
+                        "Trigger changes. Merged onto the current spec by "
+                        "default (top-level keys you omit are kept), so you "
+                        "can change one facet without dropping the rest. "
+                        "Note: array values such as `filters` are replaced "
+                        "wholesale — include every condition you want to keep. "
+                        "Set replace_specs=true to replace the whole spec."
                     ),
                 },
                 "execution_spec": {
                     "type": "object",
                     "description": (
-                        "New action definition. Replaces the entire " "spec."
+                        "Action changes. Merged onto the current spec by "
+                        "default; array values are replaced wholesale. Set "
+                        "replace_specs=true to replace it."
                     ),
                 },
                 "schedule_spec": {
                     "type": "object",
-                    "description": "New schedule definition.",
+                    "description": (
+                        "Schedule changes. Merged onto the current spec by "
+                        "default; set replace_specs=true to replace it."
+                    ),
+                },
+                "replace_specs": {
+                    "type": "boolean",
+                    "description": (
+                        "When true, supplied spec objects replace the whole "
+                        "spec instead of merging onto the current one. "
+                        "Default false (safe merge)."
+                    ),
                 },
                 "status": {
                     "type": "string",

--- a/mureo/meta_ads/_ad_rules.py
+++ b/mureo/meta_ads/_ad_rules.py
@@ -98,27 +98,68 @@ class AdRulesMixin:
         logger.info("Automated rule creation: name=%s", name)
         return await self._post(f"/{self._ad_account_id}/adrules_library", data)
 
+    # Spec fields Meta full-replaces on write; merged read-modify-write by default.
+    _SPEC_FIELDS = ("evaluation_spec", "execution_spec", "schedule_spec")
+
     async def update_ad_rule(
-        self, rule_id: str, updates: dict[str, Any]
+        self,
+        rule_id: str,
+        updates: dict[str, Any],
+        *,
+        replace_specs: bool = False,
     ) -> dict[str, Any]:
         """Update an automated rule.
+
+        Meta full-replaces the evaluation/execution/schedule specs on write,
+        so a partial spec would silently drop the rest of the rule's
+        triggers/actions (e.g. a "pause when ROAS drops" guard). By default
+        this method read-modify-writes each supplied spec: it fetches the
+        current rule once and shallow-merges the supplied top-level keys onto
+        the current spec. Pass ``replace_specs=True`` to replace a spec
+        wholesale.
 
         Args:
             rule_id: Rule ID
             updates: Update contents (name, evaluation_spec, execution_spec, etc.)
+            replace_specs: When True, spec dicts replace the whole spec
+                instead of being merged onto the current one.
 
         Returns:
             Update result
         """
         data: dict[str, Any] = {}
+        current: dict[str, Any] | None = None
         for key, value in updates.items():
             if isinstance(value, dict):
+                if key in self._SPEC_FIELDS and not replace_specs:
+                    if current is None:
+                        current = await self.get_ad_rule(rule_id)
+                    value = self._merge_spec(current, key, value)
                 data[key] = json.dumps(value)
             else:
                 data[key] = value
 
         logger.info("Automated rule update: rule_id=%s", rule_id)
         return await self._post(f"/{rule_id}", data)
+
+    @staticmethod
+    def _merge_spec(
+        current: dict[str, Any], key: str, delta: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Shallow-merge a spec ``delta`` onto the rule's current ``key`` spec.
+
+        Top-level keys the caller omits are preserved. Meta may return the
+        spec as a dict or a JSON string; both are handled.
+        """
+        existing = current.get(key)
+        if isinstance(existing, str):
+            try:
+                existing = json.loads(existing)
+            except (ValueError, TypeError):
+                existing = {}
+        if not isinstance(existing, dict):
+            existing = {}
+        return {**existing, **delta}
 
     async def delete_ad_rule(self, rule_id: str) -> dict[str, Any]:
         """Delete an automated rule.

--- a/tests/test_google_ads_ads.py
+++ b/tests/test_google_ads_ads.py
@@ -915,6 +915,69 @@ class TestUpdateAd:
                     }
                 )
 
+    @staticmethod
+    async def _assets(self, ad_id: str):  # noqa: ARG004
+        return (["旧見出し1", "旧見出し2", "旧見出し3"], ["旧説明1", "旧説明2"])
+
+    def _mutate_client(self):
+        client = _make_client()
+        mock_result = MagicMock()
+        mock_result.resource_name = "customers/123/ads/456"
+        mock_response = MagicMock()
+        mock_response.results = [mock_result]
+        mock_service = MagicMock()
+        mock_service.mutate_ads.return_value = mock_response
+        client._client.get_service.return_value = mock_service
+        client._client.get_type.return_value = MagicMock()
+        return client
+
+    @pytest.mark.asyncio
+    async def test_headlines_only_preserves_descriptions(self) -> None:
+        # Supplying only headlines must NOT touch descriptions (no FieldMask
+        # path for descriptions), so the existing descriptions survive.
+        client = self._mutate_client()
+        with patch.object(type(client), "_assert_ad_is_rsa", self._noop_assert_rsa):
+            with patch.object(type(client), "_get_rsa_assets", self._assets):
+                await client.update_ad(
+                    {"ad_id": "456", "headlines": ["H1", "H2", "H3"]}
+                )
+        paths = list(client._client.copy_from.call_args[0][1].paths)
+        assert "responsive_search_ad.headlines" in paths
+        assert "responsive_search_ad.descriptions" not in paths
+
+    @pytest.mark.asyncio
+    async def test_descriptions_only_preserves_headlines(self) -> None:
+        client = self._mutate_client()
+        with patch.object(type(client), "_assert_ad_is_rsa", self._noop_assert_rsa):
+            with patch.object(type(client), "_get_rsa_assets", self._assets):
+                await client.update_ad({"ad_id": "456", "descriptions": ["D1", "D2"]})
+        paths = list(client._client.copy_from.call_args[0][1].paths)
+        assert "responsive_search_ad.descriptions" in paths
+        assert "responsive_search_ad.headlines" not in paths
+
+    @pytest.mark.asyncio
+    async def test_no_headlines_or_descriptions_raises(self) -> None:
+        client = self._mutate_client()
+        with patch.object(type(client), "_assert_ad_is_rsa", self._noop_assert_rsa):
+            with pytest.raises(ValueError, match="Supply headlines"):
+                await client.update_ad({"ad_id": "456"})
+
+    @pytest.mark.asyncio
+    async def test_unreadable_omitted_side_raises_clear_error(self) -> None:
+        # Only headlines supplied; current descriptions can't be read (empty)
+        # -> a clear error, not a misleading "min descriptions" message.
+        client = self._mutate_client()
+
+        async def _no_desc(self, ad_id: str):  # noqa: ARG001
+            return (["旧1", "旧2", "旧3"], [])
+
+        with patch.object(type(client), "_assert_ad_is_rsa", self._noop_assert_rsa):
+            with patch.object(type(client), "_get_rsa_assets", _no_desc):
+                with pytest.raises(ValueError, match="current descriptions"):
+                    await client.update_ad(
+                        {"ad_id": "456", "headlines": ["H1", "H2", "H3"]}
+                    )
+
 
 # ---------------------------------------------------------------------------
 # update_ad_status

--- a/tests/test_meta_ads_ad_rules.py
+++ b/tests/test_meta_ads_ad_rules.py
@@ -125,6 +125,74 @@ class TestAdRulesMixin:
         data = call_args[1].get("data") or call_args[0][1]
         assert data["name"] == "更新後ルール名"
 
+    @pytest.mark.asyncio
+    async def test_update_ad_rule_merges_spec(self, client: AdRulesMixin) -> None:
+        """A partial evaluation_spec is merged onto the current one, not
+        replacing it — unrelated keys (evaluation_type) must survive."""
+        client._get = AsyncMock(
+            return_value={
+                "id": "rule_001",
+                "evaluation_spec": {
+                    "evaluation_type": "SCHEDULE",
+                    "filters": [{"field": "roas", "operator": "LESS_THAN", "value": 1}],
+                },
+            }
+        )
+        await client.update_ad_rule(
+            "rule_001",
+            {"evaluation_spec": {"filters": [{"field": "spend", "value": 100}]}},
+        )
+        data = client._post.call_args[0][1]
+        merged = json.loads(data["evaluation_spec"])
+        # evaluation_type preserved; filters replaced by the supplied list.
+        assert merged["evaluation_type"] == "SCHEDULE"
+        assert merged["filters"] == [{"field": "spend", "value": 100}]
+
+    @pytest.mark.asyncio
+    async def test_update_ad_rule_replace_specs_bypasses_merge(
+        self, client: AdRulesMixin
+    ) -> None:
+        client._get = AsyncMock(
+            return_value={
+                "id": "rule_001",
+                "evaluation_spec": {"evaluation_type": "SCHEDULE", "filters": []},
+            }
+        )
+        await client.update_ad_rule(
+            "rule_001",
+            {"evaluation_spec": {"filters": [{"field": "spend"}]}},
+            replace_specs=True,
+        )
+        merged = json.loads(client._post.call_args[0][1]["evaluation_spec"])
+        assert merged == {"filters": [{"field": "spend"}]}
+        client._get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_update_ad_rule_name_only_skips_get(
+        self, client: AdRulesMixin
+    ) -> None:
+        await client.update_ad_rule("rule_001", {"name": "x"})
+        client._get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_update_ad_rule_merges_json_string_spec(
+        self, client: AdRulesMixin
+    ) -> None:
+        # Meta may return the spec as a JSON string; merge must still preserve
+        # the omitted top-level keys.
+        client._get = AsyncMock(
+            return_value={
+                "id": "rule_001",
+                "evaluation_spec": '{"evaluation_type": "SCHEDULE", "filters": []}',
+            }
+        )
+        await client.update_ad_rule(
+            "rule_001", {"evaluation_spec": {"filters": [{"field": "spend"}]}}
+        )
+        merged = json.loads(client._post.call_args[0][1]["evaluation_spec"])
+        assert merged["evaluation_type"] == "SCHEDULE"
+        assert merged["filters"] == [{"field": "spend"}]
+
     # -----------------------------------------------------------------------
     # 5. test_delete_ad_rule
     # -----------------------------------------------------------------------


### PR DESCRIPTION
Fixes #275 (HIGH — full-replacement without read-modify-write).

Two more collection/spec surfaces could silently drop data on a partial update — the same shape as the logly-bridge incident and #273.

## A. Google RSA `update_ad` (`mureo/google_ads/_ads.py`)
Headlines and descriptions were fully replaced, and both were effectively required, so an agent updating one side risked wiping the other.

- New `_get_rsa_assets(ad_id)` reads the ad's current headline/description texts via GAQL.
- `update_ad` now scopes the FieldMask to the **supplied** side(s) only; an omitted side is read from the current ad and left untouched, so updating headlines never wipes descriptions. Supplying neither side (nor `final_url`) raises a clear error, and an omitted side that can't be read raises a specific error instead of a misleading "min count" message.
- Reading current assets is skipped when both sides are supplied (preserves the existing behavior and saves an API call).
- The handler already passed headlines/descriptions as optional, so single-side updates work end-to-end. Tool description updated to explain the omit-to-preserve behavior and that a supplied side is replaced wholesale.

## B. Meta `update_ad_rule` (`mureo/meta_ads/_ad_rules.py`)
The evaluation/execution/schedule specs were full-replaced, so a partial spec could silently drop the rest of a rule's triggers/actions (e.g. a "pause when ROAS drops" guard).

- `update_ad_rule(..., *, replace_specs=False)` now shallow-merges each supplied spec onto the current rule's spec (fetched once via `get_ad_rule`); `replace_specs=true` opts into full replacement. `_merge_spec` handles specs returned as either a dict or a JSON string.
- Handler passes `replace_specs` through; tool description updated to merge-by-default and notes that array values (`filters`, etc.) are replaced wholesale.

## Tests
- RSA: single-side update preserves the other side (asserts FieldMask paths), neither-side raises, unreadable omitted side raises a clear error; existing both-sided tests unchanged (read skipped).
- Ad rule: partial spec merge preserves omitted top-level keys, `replace_specs=true` bypasses merge, name-only skips the GET, JSON-string spec merges correctly.

## Verification
- 252 tests pass across the affected suites; ruff/black/mypy clean on changed source.
- 2 code reviews (approved); both flagged MEDIUMs (misleading error on unreadable backfill; array-replacement doc) fixed in this PR.

Part of the mutation-safety audit batch (logly-bridge `reliability-audit-checklist`); remaining HIGH issues #276–#277.
