### PR TITLE
fix(writers): fail closed on malformed credential/STRATEGY input (#276)

### DIFF
--- a/mureo/auth_setup.py
+++ b/mureo/auth_setup.py
@@ -37,7 +37,7 @@ from mureo.auth import GoogleAdsCredentials, MetaAdsCredentials
 # ``mureo.auth_setup._terminal_fd`` keep working now that the canonical
 # implementation lives in :mod:`mureo.core.terminal` (#227 follow-up).
 from mureo.core.terminal import terminal_fd as _terminal_fd
-from mureo.fsutil import secure_chmod
+from mureo.fsutil import backup_file
 
 # Backward-compat re-exports of the platform-level account-discovery
 # helpers that used to live in this module. The canonical homes are
@@ -53,9 +53,7 @@ from mureo.fsutil import secure_chmod
 from mureo.google_ads.accounts import (
     list_accessible_accounts as list_accessible_accounts,
 )
-from mureo.meta_ads.accounts import (
-    list_meta_ad_accounts as list_meta_ad_accounts,
-)
+from mureo.meta_ads.accounts import list_meta_ad_accounts as list_meta_ad_accounts
 
 logger = logging.getLogger(__name__)
 
@@ -180,10 +178,7 @@ def _select_account(
 # :mod:`mureo.meta_ads.accounts` (the public-API home for Meta account
 # discovery). Importing from there keeps a single source of truth so a
 # Graph API version bump only needs to land in one place.
-from mureo.meta_ads.accounts import (  # noqa: E402
-    _HTTP_TIMEOUT,
-    _META_GRAPH_API_BASE,
-)
+from mureo.meta_ads.accounts import _HTTP_TIMEOUT, _META_GRAPH_API_BASE  # noqa: E402
 
 _META_AUTH_URL = "https://www.facebook.com/v21.0/dialog/oauth"
 _META_OAUTH_SCOPES = (
@@ -548,10 +543,7 @@ def _register_user_scope_mcp() -> Path:
     # hardened atomic, refuse-malformed writer (mkstemp+0o600+fsync+
     # os.replace; raises ConfigWriteError rather than clobbering a
     # corrupt-but-recoverable file) instead of a plain truncating write.
-    from mureo.providers.config_writer import (
-        _atomic_write_json,
-        _load_existing,
-    )
+    from mureo.providers.config_writer import _atomic_write_json, _load_existing
 
     path = _claude_user_config_path()
     existing = _load_existing(path)  # {} if absent; raises on malformed
@@ -788,13 +780,16 @@ def save_credentials(
     # Create directory
     resolved.parent.mkdir(parents=True, exist_ok=True)
 
-    # Load existing data
-    existing: dict[str, Any] = {}
-    if resolved.exists():
-        try:
-            existing = json.loads(resolved.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError):
-            existing = {}
+    # Load existing data. Reuse the hardened reader/writer from
+    # config_writer: ``_load_existing`` returns {} only when the file is
+    # absent and RAISES ConfigWriteError on malformed JSON, instead of the
+    # old ``existing = {}`` reset that silently erased every other provider's
+    # auth on a slightly-corrupt file. ``_atomic_write_json`` (tmp + fsync +
+    # os.replace + 0o600) replaces the old truncating write so a crash mid-
+    # write can't brick all providers.
+    from mureo.providers.config_writer import _atomic_write_json, _load_existing
+
+    existing: dict[str, Any] = _load_existing(resolved)
 
     # Merge Google Ads credentials
     if google is not None:
@@ -828,14 +823,10 @@ def save_credentials(
             meta_data["account_id"] = account_id
         existing["meta_ads"] = meta_data
 
-    # Write file
-    resolved.write_text(
-        json.dumps(existing, indent=2, ensure_ascii=False),
-        encoding="utf-8",
-    )
-
-    # Set permissions (owner read/write only; best-effort on Windows)
-    secure_chmod(resolved)
+    # Keep a .bak of the prior good file, then write atomically. The atomic
+    # writer also applies owner-only (0o600) permissions.
+    backup_file(resolved)
+    _atomic_write_json(existing, resolved)
 
     logger.info("Credentials saved: %s", resolved)
 

--- a/mureo/context/strategy.py
+++ b/mureo/context/strategy.py
@@ -39,6 +39,12 @@ _PREFIX_TYPES: dict[str, str] = {
 # context_type -> prefix name (SUGGESTION-1: module-level constants)
 _TYPE_TO_PREFIX: dict[str, str] = {v: k for k, v in _PREFIX_TYPES.items()}
 
+# Sentinel context_type for headings we don't recognise. Rather than dropping
+# their content on a round-trip (silent data loss on a partial update or a
+# misspelled custom heading — issue #276), we keep the section verbatim: the
+# full heading is stored in ``title`` and rendered back unchanged.
+RAW_HEADING_TYPE = "raw_heading"
+
 # h2 heading pattern
 _H2_PATTERN = re.compile(r"^##\s+(.+)$")
 
@@ -78,10 +84,13 @@ def parse_strategy(text: str) -> list[StrategyEntry]:
     return entries
 
 
-def _resolve_heading(heading: str) -> tuple[str | None, str]:
+def _resolve_heading(heading: str) -> tuple[str, str]:
     """Resolve (context_type, title) from a heading string.
 
-    Returns (None, heading) for unknown headings and logs a warning.
+    Unknown headings are preserved as raw passthrough — returns
+    ``(RAW_HEADING_TYPE, heading)`` (the full heading kept as the title so it
+    renders back verbatim) and logs a warning so a likely misspelling is
+    still visible.
     """
     # Exact match check
     if heading in _SECTION_MAP:
@@ -93,9 +102,9 @@ def _resolve_heading(heading: str) -> tuple[str | None, str]:
             title = heading[len(prefix) + 1 :].strip()
             return ctx_type, title
 
-    # WARNING-3: logging.warning for unknown sections
-    logger.warning("Skipping unknown section heading: '%s'", heading)
-    return None, heading
+    # Unrecognised: keep it rather than drop it (issue #276), but warn.
+    logger.warning("Preserving unrecognized section heading as-is: '%s'", heading)
+    return RAW_HEADING_TYPE, heading
 
 
 def render_strategy(entries: list[StrategyEntry]) -> str:
@@ -120,6 +129,8 @@ def _make_heading(entry: StrategyEntry) -> str:
     if entry.context_type in _TYPE_TO_PREFIX:
         return f"{_TYPE_TO_PREFIX[entry.context_type]}: {entry.title}"
 
+    # RAW_HEADING_TYPE and any other unknown type: the original heading was
+    # stored verbatim in ``title``, so render it back unchanged.
     return entry.title
 
 

--- a/mureo/fsutil.py
+++ b/mureo/fsutil.py
@@ -21,11 +21,13 @@ from __future__ import annotations
 import contextlib
 import logging
 import os
+import shutil
 import time
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+    from pathlib import Path
 
 try:  # POSIX advisory whole-file lock
     import fcntl as _fcntl
@@ -66,6 +68,41 @@ def secure_chmod(path: str | os.PathLike[str]) -> None:
         os.chmod(path, _OWNER_ONLY)
     except (OSError, NotImplementedError):
         logger.debug("secure_chmod best-effort skip", exc_info=True)
+
+
+def backup_file(path: Path, *, timestamped: bool = False) -> Path | None:
+    """Copy ``path`` to a sibling backup before an in-place overwrite.
+
+    Returns the backup path, or ``None`` when ``path`` does not exist yet
+    (a first write has no prior state to preserve). With ``timestamped`` the
+    backup is ``<name>.bak.<unix_ns>`` so a history accrues (used for
+    ``STRATEGY.md``); without it a single rolling ``<name>.bak`` is kept
+    (used for ``credentials.json``). The copy inherits the source mode
+    (``0o600`` for credential files) and perms are hardened best-effort.
+
+    A symlinked ``path`` is dereferenced — the backup is a real-file copy of
+    the link target, not the link itself. Propagates ``OSError`` from the
+    copy so a caller never proceeds to overwrite the original when its backup
+    could not be made (fail closed).
+    """
+    if not path.exists():
+        return None
+    if timestamped:
+        # ``time.time_ns()`` is not guaranteed to be monotonic or unique on
+        # every platform (macOS truncates to ~µs), so two writes in the same
+        # tick could otherwise collide and silently clobber an earlier
+        # backup. Disambiguate with a counter so the history is never lost.
+        base = f"{path.name}.bak.{time.time_ns()}"
+        backup = path.with_name(base)
+        counter = 1
+        while backup.exists():
+            backup = path.with_name(f"{base}.{counter}")
+            counter += 1
+    else:
+        backup = path.with_name(f"{path.name}.bak")
+    shutil.copy2(path, backup)
+    secure_chmod(backup)
+    return backup
 
 
 def _acquire_lock(fd: int) -> None:
@@ -130,4 +167,4 @@ def file_lock(lock_path: str | os.PathLike[str]) -> Iterator[None]:
         os.close(fd)
 
 
-__all__ = ["file_lock", "secure_chmod", "secure_fchmod"]
+__all__ = ["backup_file", "file_lock", "secure_chmod", "secure_fchmod"]

--- a/mureo/mcp/_handlers_mureo_context.py
+++ b/mureo/mcp/_handlers_mureo_context.py
@@ -31,22 +31,16 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from mureo.context.errors import ContextFileError
-from mureo.context.models import (
-    ActionLogEntry,
-    CampaignSnapshot,
-    StateDocument,
-)
+from mureo.context.models import ActionLogEntry, CampaignSnapshot, StateDocument
 from mureo.context.state import (
     append_action_log,
     read_state_file,
     render_state,
     upsert_campaign,
 )
-from mureo.context.strategy import (
-    parse_strategy,
-    write_strategy_file,
-)
+from mureo.context.strategy import RAW_HEADING_TYPE, parse_strategy, write_strategy_file
 from mureo.core.runtime_context import get_runtime_context
+from mureo.fsutil import backup_file
 from mureo.mcp._helpers import _json_result, _require
 
 if TYPE_CHECKING:
@@ -119,14 +113,30 @@ async def handle_strategy_get(arguments: dict[str, Any]) -> list[TextContent]:
 
 async def handle_strategy_set(arguments: dict[str, Any]) -> list[TextContent]:
     markdown = _require(arguments, "markdown")
+    # Refuse empty / whitespace-only content: a full-replacement write of it
+    # would reduce STRATEGY.md to a bare "# Strategy", which a prompt-injected
+    # agent could use to wipe the strategy (issue #276). ``_require`` already
+    # rejects "" / None; this also catches whitespace-only payloads.
+    if not markdown.strip():
+        raise ValueError("markdown must not be empty or whitespace-only")
     path = _resolve_path(arguments, "STRATEGY.md", store_attr="strategy_path")
     # Round-trip through parse so callers can't write a STRATEGY.md
     # whose subsequent parse_strategy() call breaks downstream skills.
+    # Unrecognized headings are preserved (raw passthrough), not dropped.
     entries = parse_strategy(markdown)
+    # Keep a timestamped .bak before this full replacement so a bad
+    # round-trip is recoverable.
+    backup_file(path, timestamped=True)
     write_strategy_file(path, entries)
     rewritten = path.read_text(encoding="utf-8")
+    unrecognized = sum(1 for e in entries if e.context_type == RAW_HEADING_TYPE)
     return _json_result(
-        {"markdown": rewritten, "entries_count": len(entries), "path": str(path)}
+        {
+            "markdown": rewritten,
+            "entries_count": len(entries),
+            "unrecognized": unrecognized,
+            "path": str(path),
+        }
     )
 
 

--- a/mureo/web/env_var_writer.py
+++ b/mureo/web/env_var_writer.py
@@ -17,6 +17,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from mureo.fsutil import backup_file
+from mureo.providers.config_writer import _load_existing
 from mureo.web._helpers import atomic_write_json, read_json_safe
 
 if TYPE_CHECKING:
@@ -176,6 +178,12 @@ def write_credential_env_var(
     Raises ``ValueError`` if ``name`` is not on the allow-list, ``value`` is
     empty, or ``name`` does not bind to ``section``. The value is never
     logged.
+
+    Raises ``ConfigWriteError`` if ``credentials.json`` already exists but is
+    malformed JSON: this is a read-modify-write, and silently treating a
+    corrupt file as ``{}`` (the old ``read_json_safe`` behaviour) would drop
+    every other provider's saved credentials on the next single-field write.
+    We fail closed and keep a ``.bak`` of the prior file before overwriting.
     """
     if not is_allowed_env_var(name):
         raise ValueError(f"env var not allowed: {name!r}")
@@ -190,7 +198,10 @@ def write_credential_env_var(
             raise ValueError(f"env var {name!r} not valid for section {section!r}")
         target = EnvVarTarget(section, field)
     path = _resolve_credentials_path(credentials_path)
-    existing = read_json_safe(path)
+    # Strict read: {} only when the file is absent; raises ConfigWriteError on
+    # malformed JSON so a corrupt file is never clobbered into a one-section
+    # dict that erases other providers.
+    existing = _load_existing(path)
 
     section_payload_raw = existing.get(target.section)
     section_payload: dict[str, Any] = (
@@ -200,6 +211,7 @@ def write_credential_env_var(
     merged: dict[str, Any] = dict(existing)
     merged[target.section] = section_payload
 
+    backup_file(path)  # keep the prior good file before the overwrite
     atomic_write_json(path, merged)
     # Log the field, not the value.
     logger.info("Wrote credential env var %s into %s", name, target.section)
@@ -236,12 +248,19 @@ def remove_credential_section(
         raise ValueError(f"credential section not allowed: {section!r}")
 
     path = _resolve_credentials_path(credentials_path)
+    # Lenient read is safe HERE (unlike the single-field write above): on a
+    # malformed file ``read_json_safe`` yields ``{}``, the section reads as
+    # "absent", and we no-op (return False) WITHOUT writing — so a corrupt
+    # file is never clobbered. The cost is that removal silently reports
+    # "nothing to remove" instead of surfacing the corruption; acceptable for
+    # an idempotent delete, and out of scope for the #276 data-loss fix.
     existing = read_json_safe(path)
     if section not in existing:
         return False
 
     merged: dict[str, Any] = dict(existing)
     merged.pop(section, None)
+    backup_file(path)  # keep the prior good file before the overwrite
     atomic_write_json(path, merged)
     logger.info("Removed mureo credential section %s", section)
     return True

--- a/tests/test_auth_setup.py
+++ b/tests/test_auth_setup.py
@@ -192,6 +192,69 @@ def test_save_credentials_creates_directory(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# 6b. credentials.json — fail closed on a malformed existing file (#276)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_save_credentials_malformed_raises_and_preserves(tmp_path: Path) -> None:
+    """A corrupt credentials.json must NOT be silently reset to ``{}``.
+
+    The old code did ``existing = {}`` on JSONDecodeError, so the next save
+    erased every other provider's auth. It now refuses (ConfigWriteError) and
+    leaves the corrupt file untouched for the user to repair.
+    """
+    from mureo.auth_setup import save_credentials
+    from mureo.providers.config_writer import ConfigWriteError
+
+    cred_path = tmp_path / "credentials.json"
+    corrupt = '{"meta_ads": {"access_token": "keep-me"},,,'
+    cred_path.write_text(corrupt, encoding="utf-8")
+
+    google_creds = GoogleAdsCredentials(
+        developer_token="dev-tok",
+        client_id="cid",
+        client_secret="csec",
+        refresh_token="rtok",
+    )
+
+    with pytest.raises(ConfigWriteError):
+        save_credentials(path=cred_path, google=google_creds)
+
+    assert cred_path.read_text(encoding="utf-8") == corrupt
+
+
+@pytest.mark.unit
+def test_save_credentials_backs_up_before_overwrite(tmp_path: Path) -> None:
+    """A ``.bak`` of the prior good file is kept before the merge write."""
+    from mureo.auth_setup import save_credentials
+
+    cred_path = tmp_path / "credentials.json"
+    cred_path.write_text(
+        json.dumps({"meta_ads": {"access_token": "existing-meta-token"}}),
+        encoding="utf-8",
+    )
+
+    google_creds = GoogleAdsCredentials(
+        developer_token="dev-tok",
+        client_id="cid",
+        client_secret="csec",
+        refresh_token="rtok",
+    )
+    save_credentials(path=cred_path, google=google_creds)
+
+    data = json.loads(cred_path.read_text(encoding="utf-8"))
+    assert data["google_ads"]["developer_token"] == "dev-tok"
+    assert data["meta_ads"]["access_token"] == "existing-meta-token"
+
+    backup = tmp_path / "credentials.json.bak"
+    assert backup.exists()
+    assert json.loads(backup.read_text(encoding="utf-8")) == {
+        "meta_ads": {"access_token": "existing-meta-token"}
+    }
+
+
+# ---------------------------------------------------------------------------
 # 7. List accounts (API mocked)
 # ---------------------------------------------------------------------------
 
@@ -863,9 +926,7 @@ def test_install_mcp_config_global_fallback_no_cli(tmp_path: Path) -> None:
 
     claude_json = tmp_path / ".claude.json"
     claude_json.write_text(
-        json.dumps(
-            {"numStartups": 3, "mcpServers": {"figma": {"type": "http"}}}
-        ),
+        json.dumps({"numStartups": 3, "mcpServers": {"figma": {"type": "http"}}}),
         encoding="utf-8",
     )
 
@@ -905,9 +966,7 @@ def test_install_mcp_config_project_already_exists(tmp_path: Path) -> None:
 
     mcp_json = tmp_path / ".mcp.json"
     mcp_json.write_text(
-        json.dumps(
-            {"mcpServers": {"mureo": {"command": "python", "args": ["-m"]}}}
-        ),
+        json.dumps({"mcpServers": {"mureo": {"command": "python", "args": ["-m"]}}}),
         encoding="utf-8",
     )
 
@@ -1334,8 +1393,14 @@ def test_save_credentials_meta_ads(tmp_path: Path) -> None:
 
 @pytest.mark.unit
 def test_save_credentials_corrupted_existing(tmp_path: Path) -> None:
-    """A new file is created even when the existing credentials.json is corrupt."""
+    """A corrupt credentials.json is NOT silently overwritten (#276).
+
+    Previously this fell back to ``{}`` and wrote a fresh file, erasing any
+    other provider's auth that the corruption merely made unreadable. It now
+    fails closed so the user can repair (or delete) the file deliberately.
+    """
     from mureo.auth_setup import save_credentials
+    from mureo.providers.config_writer import ConfigWriteError
 
     cred_path = tmp_path / "credentials.json"
     cred_path.write_text("not valid json", encoding="utf-8")
@@ -1347,10 +1412,10 @@ def test_save_credentials_corrupted_existing(tmp_path: Path) -> None:
         refresh_token="rtok",
     )
 
-    save_credentials(path=cred_path, google=google_creds)
+    with pytest.raises(ConfigWriteError):
+        save_credentials(path=cred_path, google=google_creds)
 
-    data = json.loads(cred_path.read_text(encoding="utf-8"))
-    assert data["google_ads"]["developer_token"] == "dev-tok"
+    assert cred_path.read_text(encoding="utf-8") == "not valid json"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_fsutil_backup.py
+++ b/tests/test_fsutil_backup.py
@@ -1,0 +1,82 @@
+"""Tests for ``mureo.fsutil.backup_file`` (issue #276 before-state backup).
+
+A write path keeps a copy of the prior good file before an in-place
+overwrite so a botched round-trip is recoverable. ``timestamped`` keeps a
+history (STRATEGY.md); the rolling form keeps a single ``.bak``
+(credentials.json).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mureo.fsutil import backup_file
+
+
+@pytest.mark.unit
+def test_backup_absent_file_returns_none(tmp_path: Path) -> None:
+    """Nothing to back up on a first write — returns None, creates nothing."""
+    target = tmp_path / "credentials.json"
+    assert backup_file(target) is None
+    assert list(tmp_path.iterdir()) == []
+
+
+@pytest.mark.unit
+def test_rolling_backup_copies_prior_content(tmp_path: Path) -> None:
+    target = tmp_path / "credentials.json"
+    target.write_text('{"google_ads": {"developer_token": "DT"}}', encoding="utf-8")
+
+    backup = backup_file(target)
+
+    assert backup == tmp_path / "credentials.json.bak"
+    assert backup is not None and backup.exists()
+    assert "DT" in backup.read_text(encoding="utf-8")
+
+
+@pytest.mark.unit
+def test_rolling_backup_overwrites_single_bak(tmp_path: Path) -> None:
+    """The non-timestamped form keeps exactly one rolling ``.bak``."""
+    target = tmp_path / "credentials.json"
+    target.write_text("v1", encoding="utf-8")
+    backup_file(target)
+    target.write_text("v2", encoding="utf-8")
+    backup_file(target)
+
+    baks = list(tmp_path.glob("credentials.json.bak*"))
+    assert len(baks) == 1
+    assert baks[0].read_text(encoding="utf-8") == "v2"
+
+
+@pytest.mark.unit
+def test_timestamped_backup_keeps_history(tmp_path: Path) -> None:
+    target = tmp_path / "STRATEGY.md"
+    target.write_text("# Strategy\n\n## Persona\nv1\n", encoding="utf-8")
+    first = backup_file(target, timestamped=True)
+    target.write_text("# Strategy\n\n## Persona\nv2\n", encoding="utf-8")
+    second = backup_file(target, timestamped=True)
+
+    assert first is not None and second is not None
+    assert first != second
+    history = sorted(tmp_path.glob("STRATEGY.md.bak.*"))
+    assert len(history) == 2
+
+
+@pytest.mark.unit
+def test_timestamped_backup_disambiguates_same_tick(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Identical ``time.time_ns()`` (low-res clocks) must not clobber history."""
+    monkeypatch.setattr("mureo.fsutil.time.time_ns", lambda: 4242)
+
+    target = tmp_path / "STRATEGY.md"
+    target.write_text("v1", encoding="utf-8")
+    first = backup_file(target, timestamped=True)
+    target.write_text("v2", encoding="utf-8")
+    second = backup_file(target, timestamped=True)
+
+    assert first is not None and second is not None and first != second
+    history = sorted(tmp_path.glob("STRATEGY.md.bak.*"))
+    assert len(history) == 2
+    assert {p.read_text(encoding="utf-8") for p in history} == {"v1", "v2"}

--- a/tests/test_mcp_tools_mureo_context.py
+++ b/tests/test_mcp_tools_mureo_context.py
@@ -134,6 +134,54 @@ async def test_strategy_set_is_atomic(cwd_to_tmp, monkeypatch) -> None:
     assert (cwd_to_tmp / "STRATEGY.md").read_text(encoding="utf-8") == "# Original\n"
 
 
+@pytest.mark.parametrize("markdown", ["", "   ", "\n\t\n"])
+async def test_strategy_set_rejects_empty_markdown(cwd_to_tmp, markdown) -> None:
+    """Empty / whitespace-only markdown must NOT wipe STRATEGY.md (#276).
+
+    A prompt-injected agent posting blank content would otherwise reduce the
+    file to a bare ``# Strategy``. The pre-existing file must be untouched.
+    """
+    (cwd_to_tmp / "STRATEGY.md").write_text(
+        "# Strategy\n\n## Persona\nkeep me\n", encoding="utf-8"
+    )
+    mod = _import_tools()
+    # "" is rejected by _require ("not specified"); whitespace-only by the
+    # explicit guard ("empty or whitespace-only"). Either way: rejected.
+    with pytest.raises(ValueError, match="empty|not specified"):
+        await mod.handle_tool("mureo_strategy_set", {"markdown": markdown})
+    assert "keep me" in (cwd_to_tmp / "STRATEGY.md").read_text(encoding="utf-8")
+
+
+async def test_strategy_set_backs_up_before_overwrite(cwd_to_tmp) -> None:
+    """A timestamped ``.bak`` of the prior file is kept before replacement."""
+    (cwd_to_tmp / "STRATEGY.md").write_text(
+        "# Strategy\n\n## Persona\nold persona\n", encoding="utf-8"
+    )
+    mod = _import_tools()
+    await mod.handle_tool(
+        "mureo_strategy_set",
+        {"markdown": "# Strategy\n\n## USP\nnew usp\n"},
+    )
+
+    backups = list(cwd_to_tmp.glob("STRATEGY.md.bak.*"))
+    assert len(backups) == 1
+    assert "old persona" in backups[0].read_text(encoding="utf-8")
+
+
+async def test_strategy_set_preserves_unknown_heading(cwd_to_tmp) -> None:
+    """An unrecognized heading round-trips and is reported, not dropped."""
+    mod = _import_tools()
+    md = "# Strategy\n\n" "## Persona\n30s\n\n" "## Quarterly Notes\nlaunch in Q3\n"
+    result = await mod.handle_tool("mureo_strategy_set", {"markdown": md})
+    payload = json.loads(result[0].text)
+
+    assert payload["unrecognized"] == 1
+    assert "## Quarterly Notes" in payload["markdown"]
+    assert "launch in Q3" in payload["markdown"]
+    written = (cwd_to_tmp / "STRATEGY.md").read_text(encoding="utf-8")
+    assert "launch in Q3" in written
+
+
 # ---------------------------------------------------------------------------
 # mureo_state_get
 # ---------------------------------------------------------------------------
@@ -326,10 +374,7 @@ async def test_default_path_follows_runtime_context_workspace(
     Verified by injecting a :class:`FilesystemStateStore` whose
     workspace is a sibling of CWD, then asserting the on-disk write
     lands in the injected workspace (NOT in CWD)."""
-    from mureo.core.runtime_context import (
-        RuntimeContext,
-        default_runtime_context,
-    )
+    from mureo.core.runtime_context import RuntimeContext, default_runtime_context
 
     # CWD is one dir, the injected workspace is a SIBLING dir.
     cwd_dir = tmp_path / "cwd"

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -19,7 +19,6 @@ from mureo.context.strategy import (
     write_strategy_file,
 )
 
-
 # ============================================================
 # STRATEGY.md parse tests
 # ============================================================
@@ -100,18 +99,40 @@ class TestParseStrategy:
         assert result[0].content == "TURNAROUND_RESCUE"
 
     @pytest.mark.unit
-    def test_parse_strategy_unknown_section_ignored(self) -> None:
-        """Unknown sections are skipped."""
+    def test_parse_strategy_unknown_section_preserved(self) -> None:
+        """Unknown sections are PRESERVED as raw passthrough (#276).
+
+        Dropping them silently lost strategy text on a partial update or a
+        misspelled custom heading. They are now kept verbatim so a
+        round-trip write does not destroy content.
+        """
+        from mureo.context.strategy import RAW_HEADING_TYPE
+
         md = (
             "# Strategy\n\n"
             "## Persona\nターゲット\n\n"
-            "## Unknown Section\nこれは無視される\n\n"
+            "## Unknown Section\nこれは保持される\n\n"
             "## USP\n強み\n"
         )
         result = parse_strategy(md)
-        assert len(result) == 2
+        assert len(result) == 3
         assert result[0].context_type == "persona"
-        assert result[1].context_type == "usp"
+        assert result[1].context_type == RAW_HEADING_TYPE
+        assert result[1].title == "Unknown Section"
+        assert result[1].content == "これは保持される"
+        assert result[2].context_type == "usp"
+
+    @pytest.mark.unit
+    def test_unknown_section_survives_roundtrip(self) -> None:
+        """parse -> render keeps an unrecognized heading and its body."""
+        md = (
+            "# Strategy\n\n"
+            "## Persona\nターゲット\n\n"
+            "## Unknown Section\nこれは保持される\n"
+        )
+        rendered = render_strategy(parse_strategy(md))
+        assert "## Unknown Section" in rendered
+        assert "これは保持される" in rendered
 
 
 # ============================================================
@@ -298,7 +319,9 @@ class TestUnknownSectionWarning:
         with caplog.at_level(logging.WARNING, logger="mureo.context.strategy"):
             result = parse_strategy(md)
 
-        assert len(result) == 2
+        # Persona + raw passthrough + USP — the unknown section is kept,
+        # but still logged so an operator notices a likely misspelling.
+        assert len(result) == 3
         assert any("Unknown Section" in record.message for record in caplog.records)
 
 

--- a/tests/test_web_provider_env.py
+++ b/tests/test_web_provider_env.py
@@ -323,3 +323,55 @@ class TestWriteCredentialEnvVarSectionAware:
                 section="google_ads",
                 credentials_path=creds,
             )
+
+
+@pytest.mark.unit
+class TestWriteCredentialEnvVarMalformedGuard:
+    """``write_credential_env_var`` must FAIL CLOSED on a malformed file (#276).
+
+    The old ``read_json_safe`` returned ``{}`` on any JSON error, so a single
+    slightly-corrupt ``credentials.json`` made the next single-field write
+    erase every other provider's auth. The write now refuses (raises
+    ``ConfigWriteError``) and keeps a ``.bak`` of the prior file before any
+    legitimate overwrite.
+    """
+
+    def test_malformed_file_raises_and_preserves(self, tmp_path: Path) -> None:
+        from mureo.providers.config_writer import ConfigWriteError
+
+        creds = tmp_path / "credentials.json"
+        corrupt = '{"google_ads": {"developer_token": "DT"},,,'
+        creds.write_text(corrupt, encoding="utf-8")
+
+        with pytest.raises(ConfigWriteError):
+            write_credential_env_var(
+                "META_ADS_ACCESS_TOKEN",
+                "new-token",
+                credentials_path=creds,
+            )
+
+        # The corrupt file is untouched — NOT silently replaced by a
+        # single-section dict that drops google_ads.
+        assert creds.read_text(encoding="utf-8") == corrupt
+
+    def test_backup_written_before_overwrite(self, tmp_path: Path) -> None:
+        creds = tmp_path / "credentials.json"
+        creds.write_text(
+            json.dumps({"google_ads": {"developer_token": "DT"}}),
+            encoding="utf-8",
+        )
+
+        write_credential_env_var(
+            "META_ADS_ACCESS_TOKEN",
+            "new-token",
+            credentials_path=creds,
+        )
+
+        # New value landed; the sibling google_ads section was preserved.
+        merged = read_json_safe(creds)
+        assert merged["meta_ads"]["access_token"] == "new-token"
+        assert merged["google_ads"]["developer_token"] == "DT"
+        # The prior good file was backed up before the overwrite.
+        backup = tmp_path / "credentials.json.bak"
+        assert backup.exists()
+        assert read_json_safe(backup) == {"google_ads": {"developer_token": "DT"}}


### PR DESCRIPTION
## Summary
Fixes #276 (HIGH — silent loss of credentials / strategy on malformed or partial input). Several writers failed *open* on malformed existing files or dropped unrecognized content, destroying data the user never intended to touch.

### Part A — credential writers fail closed
- `web/env_var_writer.py::write_credential_env_var` and `auth_setup.py::save_credentials` no longer reset a malformed `credentials.json` to `{}` (which silently erased every other provider's auth). They now read via `config_writer._load_existing` — `{}` only when the file is **absent**, `ConfigWriteError` on malformed JSON (refuse to overwrite) — and keep a `.bak` before overwriting.
- `save_credentials` now writes **atomically** (tmp + fsync + `os.replace` + `0o600`) via `_atomic_write_json`, replacing the truncating `write_text` that a crash/disk-full mid-write could leave half-written.
- `remove_credential_section` also keeps a `.bak` before its overwrite (lenient read documented — it no-ops on malformed, never clobbers).

### Part B — STRATEGY.md writer
- `context/strategy.py`: unrecognized headings are **preserved as raw passthrough** (`RAW_HEADING_TYPE`) and round-trip verbatim, instead of being silently dropped on a partial update or a misspelled custom heading.
- `mcp/_handlers_mureo_context.py::handle_strategy_set`: rejects empty/whitespace `markdown` (prevents a prompt-injected wipe to a bare `# Strategy`), keeps a timestamped `STRATEGY.md.bak.<ts>` before the full replacement, and returns the `unrecognized` section count.

### Shared
- New `fsutil.backup_file(path, *, timestamped=False)` — `0o600`-hardened sibling backup with a same-tick collision guard so the timestamped history is never clobbered.

## Test plan
- [x] New unit tests: `tests/test_fsutil_backup.py` (rolling/timestamped backup, collision guard), malformed-guard + backup tests for `write_credential_env_var` and `save_credentials`, strategy passthrough/round-trip, empty-rejection, backup, unrecognized-count.
- [x] Updated stale tests that encoded the old unsafe behavior (`test_save_credentials_corrupted_existing`, unknown-section drop tests).
- [x] `ruff check mureo/` · `black --check mureo/` · `mypy mureo/ --ignore-missing-imports` all clean.
- [x] Full suite: 4412 passed (3 pre-existing MCP plugin-env-noise failures from a locally-registered third-party plugin, unrelated to this change).

*Part of the mutation-safety audit batch (follows #273/#274/#275).*
