### PR TITLE
fix(validation): guard budget/bid mutations and enforce tool inputSchema (#277)

### DIFF
--- a/mureo/google_ads/client.py
+++ b/mureo/google_ads/client.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import functools
 import logging
+import math
 import re
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, TypeVar
@@ -46,6 +47,14 @@ logger = logging.getLogger(__name__)
 
 
 _VALID_STATUSES = frozenset({"ENABLED", "PAUSED", "REMOVED"})
+
+# Absolute sanity ceiling for a single daily budget, in micros
+# (1e15 micros = 1,000,000,000 currency units / day). This is a last-line
+# CATASTROPHE guard against a digit slip / float overflow reaching a live
+# campaign — NOT a spend policy. Real per-account spend limits are enforced
+# by the Pro BudgetGuard on the Managed side; the OSS client only refuses
+# values so large they can only be a mistake.
+_MAX_BUDGET_AMOUNT_MICROS = 1_000_000_000_000_000
 _SMART_BIDDING_STRATEGIES = frozenset(
     {
         "MAXIMIZE_CONVERSIONS",
@@ -84,6 +93,59 @@ _BETWEEN_PATTERN = re.compile(
 )
 
 _F = TypeVar("_F", bound=Callable[..., Any])
+
+
+def _resolve_budget_amount_micros(params: dict[str, Any]) -> int:
+    """Resolve and validate a budget amount from ``params`` into micros.
+
+    Accepts ``amount`` (currency units) or ``amount_micros`` (exact int),
+    mutually exclusive; exactly one is required. Rejects non-numeric input,
+    non-positive values (a ``0`` budget halts delivery), and values above
+    :data:`_MAX_BUDGET_AMOUNT_MICROS` (catastrophe guard against a digit
+    slip / overflow). Raises ``ValueError`` on any violation.
+    """
+    has_amount = "amount" in params and params["amount"] is not None
+    has_micros = "amount_micros" in params and params["amount_micros"] is not None
+    if has_amount and has_micros:
+        raise ValueError(
+            "budget update: specify either 'amount' or 'amount_micros', not both"
+        )
+    if not has_amount and not has_micros:
+        raise ValueError(
+            "budget update: one of 'amount' or 'amount_micros' is required"
+        )
+
+    amount_micros: int
+    if has_micros:
+        value = params["amount_micros"]
+        # bool is an int subclass — reject it so True/False can't be a budget.
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise ValueError(f"amount_micros must be an integer (specified: {value!r})")
+        amount_micros = int(value)
+    else:
+        value = params["amount"]
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise ValueError(f"Daily budget must be a number (specified: {value!r})")
+        # Reject inf/nan so int() raises a clean ValueError (not OverflowError)
+        # on the direct-adapter path (MCP callers are already schema-bounded).
+        if not math.isfinite(value):
+            raise ValueError(
+                f"Daily budget must be a finite number (specified: {value!r})"
+            )
+        amount_micros = int(value * 1_000_000)
+
+    if amount_micros <= 0:
+        raise ValueError(
+            f"Daily budget must be a positive number (specified: "
+            f"{amount_micros} micros)"
+        )
+    if amount_micros > _MAX_BUDGET_AMOUNT_MICROS:
+        raise ValueError(
+            f"Daily budget {amount_micros} micros exceeds the sanity ceiling "
+            f"({_MAX_BUDGET_AMOUNT_MICROS} micros); refusing as a likely "
+            f"digit slip — pass a correct amount or raise the budget in steps"
+        )
+    return amount_micros
 
 
 def _wrap_mutate_error(label: str) -> Callable[[_F], _F]:
@@ -845,11 +907,22 @@ class GoogleAdsApiClient(  # type: ignore[misc]
 
     @_wrap_mutate_error("budget update")
     async def update_budget(self, params: dict[str, Any]) -> dict[str, Any]:
-        """Update budget
+        """Update a campaign budget's daily amount.
 
-        Note: BudgetGuard validation is performed on the Managed side.
+        Accepts EITHER ``amount`` (account currency units, e.g. ``5000`` for
+        ¥5,000 / day) OR ``amount_micros`` (exact integer micros) — mutually
+        exclusive, mirroring :meth:`create_budget`. ``amount_micros`` avoids
+        the ``amount * 1e6`` float round-trip and lets rollback restore an
+        exact prior value.
+
+        The resolved amount is validated ``> 0`` (a ``0`` budget silently
+        halts delivery) and against :data:`_MAX_BUDGET_AMOUNT_MICROS` (a
+        digit slip must not send a runaway value to a live campaign). This is
+        a client-layer guard so it also protects non-MCP callers (adapters).
+        Per-account spend *policy* (BudgetGuard) is enforced on the Managed
+        side.
         """
-        new_amount = params["amount"]
+        amount_micros = _resolve_budget_amount_micros(params)
 
         budget_service = self._get_service("CampaignBudgetService")
         budget_op = self._client.get_type("CampaignBudgetOperation")
@@ -857,7 +930,7 @@ class GoogleAdsApiClient(  # type: ignore[misc]
         budget.resource_name = budget_service.campaign_budget_path(
             self._customer_id, params["budget_id"]
         )
-        budget.amount_micros = int(new_amount * 1_000_000)
+        budget.amount_micros = amount_micros
         self._client.copy_from(
             budget_op.update_mask,
             PbFieldMask(paths=["amount_micros"]),

--- a/mureo/mcp/_handlers_google_ads.py
+++ b/mureo/mcp/_handlers_google_ads.py
@@ -400,10 +400,16 @@ async def handle_budget_update(args: dict[str, Any]) -> list[TextContent]:
     client = _get_client(args)
     if client is None:
         return _no_google_creds()
-    params: dict[str, Any] = {
-        "budget_id": _require(args, "budget_id"),
-        "amount": _require(args, "amount"),
-    }
+    params: dict[str, Any] = {"budget_id": _require(args, "budget_id")}
+    # Accept either currency-unit ``amount`` or exact ``amount_micros``
+    # (mutually exclusive). The client validates value bounds; here we only
+    # require that one of the two is present.
+    if args.get("amount_micros") is not None:
+        params["amount_micros"] = args["amount_micros"]
+    elif args.get("amount") is not None:
+        params["amount"] = args["amount"]
+    else:
+        raise ValueError("one of 'amount' or 'amount_micros' is required")
     result = await client.update_budget(params)
     return _json_result(result)
 

--- a/mureo/mcp/_handlers_meta_ads.py
+++ b/mureo/mcp/_handlers_meta_ads.py
@@ -25,6 +25,7 @@ from mureo.mcp._helpers import (
     _no_creds_result,
     _opt,
     _require,
+    _validate_positive_money,
     api_error_handler,
 )
 from mureo.throttle import META_ADS_THROTTLE, Throttler
@@ -109,6 +110,7 @@ async def handle_campaigns_get(args: dict[str, Any]) -> list[TextContent]:
 
 @api_error_handler
 async def handle_campaigns_create(args: dict[str, Any]) -> list[TextContent]:
+    _validate_positive_money(args, "daily_budget", "lifetime_budget")
     client = await _get_client(args)
     if client is None:
         return _no_meta_creds()
@@ -126,6 +128,7 @@ async def handle_campaigns_create(args: dict[str, Any]) -> list[TextContent]:
 
 @api_error_handler
 async def handle_campaigns_update(args: dict[str, Any]) -> list[TextContent]:
+    _validate_positive_money(args, "daily_budget")
     client = await _get_client(args)
     if client is None:
         return _no_meta_creds()
@@ -158,6 +161,7 @@ async def handle_ad_sets_list(args: dict[str, Any]) -> list[TextContent]:
 
 @api_error_handler
 async def handle_ad_sets_create(args: dict[str, Any]) -> list[TextContent]:
+    _validate_positive_money(args, "daily_budget", "bid_amount")
     client = await _get_client(args)
     if client is None:
         return _no_meta_creds()
@@ -182,6 +186,7 @@ async def handle_ad_sets_create(args: dict[str, Any]) -> list[TextContent]:
 
 @api_error_handler
 async def handle_ad_sets_update(args: dict[str, Any]) -> list[TextContent]:
+    _validate_positive_money(args, "daily_budget")
     client = await _get_client(args)
     if client is None:
         return _no_meta_creds()

--- a/mureo/mcp/_helpers.py
+++ b/mureo/mcp/_helpers.py
@@ -32,6 +32,24 @@ def _opt(arguments: dict[str, Any], key: str, default: Any = None) -> Any:
     return arguments.get(key, default)
 
 
+def _validate_positive_money(arguments: dict[str, Any], *keys: str) -> None:
+    """Reject non-positive monetary values before a real-spend mutation.
+
+    For each key present and not ``None``, require a positive number. Guards
+    against ``0`` (which silently halts delivery) and negatives reaching a
+    live budget/bid. ``bool`` is rejected even though it is an ``int``
+    subclass. No-op for absent keys (the field is simply not being changed).
+    """
+    for key in keys:
+        if key not in arguments or arguments[key] is None:
+            continue
+        value = arguments[key]
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise ValueError(f"{key} must be a positive number (got {value!r})")
+        if value <= 0:
+            raise ValueError(f"{key} must be greater than 0 (got {value!r})")
+
+
 def _json_result(data: Any) -> list[TextContent]:
     """Convert a result to a list of TextContent containing a JSON string."""
     return [TextContent(type="text", text=json.dumps(data, ensure_ascii=False))]

--- a/mureo/mcp/_tools_google_ads_campaigns.py
+++ b/mureo/mcp/_tools_google_ads_campaigns.py
@@ -749,11 +749,26 @@ TOOLS: list[Tool] = [
                     "description": (
                         "New daily budget in the account's currency "
                         "(JPY / USD / etc.). Not micros — e.g. pass 5000 "
-                        "for ¥5,000 / day."
+                        "for ¥5,000 / day. Mutually exclusive with "
+                        "amount_micros."
+                    ),
+                },
+                "amount_micros": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": (
+                        "New daily budget in micros (currency unit × "
+                        "1,000,000). Use this for an exact value with no "
+                        "float rounding (e.g. when restoring a prior amount "
+                        "on rollback). Mutually exclusive with amount."
                     ),
                 },
             },
-            "required": ["budget_id", "amount"],
+            "required": ["budget_id"],
+            "anyOf": [
+                {"required": ["amount"]},
+                {"required": ["amount_micros"]},
+            ],
         },
     ),
     # === Budget creation ===

--- a/mureo/mcp/server.py
+++ b/mureo/mcp/server.py
@@ -32,6 +32,8 @@ import logging
 import os
 from typing import TYPE_CHECKING, Any
 
+import jsonschema
+from jsonschema import Draft202012Validator
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
 
@@ -153,6 +155,60 @@ _PLUGIN_TOOLS, _PLUGIN_DISPATCH = collect_plugin_tools(
 )
 _ALL_TOOLS.extend(_PLUGIN_TOOLS)
 _PLUGIN_NAMES: frozenset[str] = frozenset(_PLUGIN_DISPATCH)
+
+
+# Pre-compiled JSON Schema validators for every BUILT-IN tool, keyed by tool
+# name. The MCP framework does not enforce ``inputSchema``, so declared bounds
+# (``minimum``, ``required``, ``type``, ``enum``) are advisory until checked
+# server-side. Validating here is the single guard that makes them real for
+# every built-in mutation — most importantly the real-spend boundary values
+# (budget / bid ``minimum: 1``) flagged in issue #277. Plugin tools are
+# validated by their own providers and are intentionally excluded.
+def _build_tool_validators() -> dict[str, Draft202012Validator]:
+    validators: dict[str, Draft202012Validator] = {}
+    for tool in _ALL_TOOLS:
+        if tool.name in _PLUGIN_NAMES:
+            continue
+        schema = getattr(tool, "inputSchema", None)
+        if not isinstance(schema, dict):
+            continue
+        try:
+            Draft202012Validator.check_schema(schema)
+        except jsonschema.exceptions.SchemaError as exc:
+            # A malformed built-in schema must not take the whole server
+            # offline — skip validation for that one tool and log it.
+            logger.warning(
+                "tool %s: inputSchema is not a valid JSON Schema (%s); "
+                "input validation skipped for it",
+                tool.name,
+                exc,
+            )
+            continue
+        validators[tool.name] = Draft202012Validator(schema)
+    return validators
+
+
+_TOOL_VALIDATORS: dict[str, Draft202012Validator] = _build_tool_validators()
+
+
+def _validate_tool_input(name: str, arguments: dict[str, Any]) -> None:
+    """Validate ``arguments`` against the tool's declared ``inputSchema``.
+
+    Raises ``ValueError`` (the dispatcher's standard caller-error channel)
+    on the first violation, before the tool handler runs — so an invalid
+    budget/bid never reaches a real-spend API call. No-op for tools without
+    a registered validator (plugins, or a tool with no schema).
+    """
+    validator = _TOOL_VALIDATORS.get(name)
+    if validator is None:
+        return
+    errors = sorted(validator.iter_errors(arguments), key=lambda e: list(e.path))
+    if not errors:
+        return
+    first = errors[0]
+    location = "/".join(str(p) for p in first.path) or "(root)"
+    raise ValueError(f"Invalid arguments for {name}: at '{location}': {first.message}")
+
 
 # One conservative shared bucket for all plugin tool calls. Built-in
 # platforms keep their own per-platform throttlers; this only gates the
@@ -425,11 +481,17 @@ async def handle_call_tool(name: str, arguments: dict[str, Any]) -> list[Any]:
     :mod:`mureo.core.strategy_reminder`.
 
     Raises:
-        ValueError: Unknown tool name or missing required parameter
+        ValueError: Unknown tool name, schema-invalid arguments, or a
+            missing required parameter.
     """
     decision = _evaluate_policy_gates(name, arguments)
     if decision is not None:
         return _refuse_text_content(name, decision)
+    # Schema-validate AFTER the gate decision (a policy denial is absolute and
+    # need not depend on arg validity) but BEFORE any handler, before-state
+    # capture, or real-spend API call — so an out-of-bounds budget/bid is
+    # rejected before it can reach a live campaign.
+    _validate_tool_input(name, arguments)
     if name in _GOOGLE_ADS_NAMES:
         before = await capture_before_state(name, arguments)
         result = await handle_google_ads_tool(name, arguments)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,12 @@ dependencies = [
     "rich>=13.0,<14",
     "simple-term-menu>=1.6,<2",
     "mcp>=1.0,<2",
+    # jsonschema validates every built-in tool's inputSchema at the MCP
+    # dispatch boundary (mureo.mcp.server._validate_tool_input) so declared
+    # bounds like budget/bid `minimum` are enforced server-side before a
+    # real-spend API call. Already a transitive dep of mcp; pinned explicitly
+    # because we import it directly.
+    "jsonschema>=4.20,<5",
     # openpyxl is used by the BYOD bundle importer (mureo byod import
     # --bundle <xlsx>) to read multi-tab Sheets exported from the
     # mureo Sheet template (Apps Script + Google Ads Script).

--- a/tests/test_google_ads_client.py
+++ b/tests/test_google_ads_client.py
@@ -9,19 +9,18 @@ from __future__ import annotations
 
 import asyncio
 from typing import Any
-from unittest.mock import MagicMock, AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from google.ads.googleads.errors import GoogleAdsException
 
 from mureo.google_ads.client import (
+    _VALID_MATCH_TYPES,
+    _VALID_STATUSES,
+    PARTNER_CPA_WARNING_RATIO,
     GoogleAdsApiClient,
     _wrap_mutate_error,
-    PARTNER_CPA_WARNING_RATIO,
-    _VALID_STATUSES,
-    _VALID_MATCH_TYPES,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -879,6 +878,68 @@ class TestBudget:
             }
         )
         assert result["resource_name"] == "customers/123/budgets/100"
+
+    @pytest.mark.asyncio
+    async def test_update_budget_amount_micros_exact(self) -> None:
+        """``amount_micros`` is sent verbatim — no float round-trip (#277)."""
+        client = _make_client()
+        mock_result = MagicMock()
+        mock_result.resource_name = "customers/123/budgets/100"
+        mock_response = MagicMock()
+        mock_response.results = [mock_result]
+        mock_service = MagicMock()
+        mock_service.mutate_campaign_budgets.return_value = mock_response
+        client._client.get_service.return_value = mock_service
+        budget_op = MagicMock()
+        client._client.get_type.return_value = budget_op
+
+        await client.update_budget({"budget_id": "100", "amount_micros": 1_234_567})
+
+        assert budget_op.update.amount_micros == 1_234_567
+
+    @pytest.mark.asyncio
+    async def test_update_budget_金額0以下(self) -> None:
+        client = _make_client()
+        with pytest.raises(ValueError, match="positive number"):
+            await client.update_budget({"budget_id": "100", "amount": 0})
+
+    @pytest.mark.asyncio
+    async def test_update_budget_負数(self) -> None:
+        client = _make_client()
+        with pytest.raises(ValueError, match="positive number"):
+            await client.update_budget({"budget_id": "100", "amount": -100})
+
+    @pytest.mark.asyncio
+    async def test_update_budget_上限超過(self) -> None:
+        client = _make_client()
+        with pytest.raises(ValueError, match="ceiling"):
+            await client.update_budget({"budget_id": "100", "amount": 2_000_000_000})
+
+    @pytest.mark.asyncio
+    async def test_update_budget_両方指定(self) -> None:
+        client = _make_client()
+        with pytest.raises(ValueError, match="not both"):
+            await client.update_budget(
+                {"budget_id": "100", "amount": 5000, "amount_micros": 5_000_000}
+            )
+
+    @pytest.mark.asyncio
+    async def test_update_budget_どちらもなし(self) -> None:
+        client = _make_client()
+        with pytest.raises(ValueError, match="required"):
+            await client.update_budget({"budget_id": "100"})
+
+    @pytest.mark.asyncio
+    async def test_update_budget_amount_micros_bool拒否(self) -> None:
+        client = _make_client()
+        with pytest.raises(ValueError, match="integer"):
+            await client.update_budget({"budget_id": "100", "amount_micros": True})
+
+    @pytest.mark.asyncio
+    async def test_update_budget_inf拒否(self) -> None:
+        client = _make_client()
+        with pytest.raises(ValueError, match="finite"):
+            await client.update_budget({"budget_id": "100", "amount": float("inf")})
 
     @pytest.mark.asyncio
     async def test_create_budget_正常(self) -> None:

--- a/tests/test_mcp_input_validation.py
+++ b/tests/test_mcp_input_validation.py
@@ -1,0 +1,65 @@
+"""MCP dispatch-layer JSON Schema validation (issue #277).
+
+The MCP framework does not enforce a tool's ``inputSchema``, so declared
+bounds (``minimum``, ``required``, ``type``) are advisory until checked
+server-side. ``mureo.mcp.server._validate_tool_input`` is the single guard
+that makes them real before any handler / real-spend API call runs.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mureo.mcp.server import (
+    _TOOL_VALIDATORS,
+    _validate_tool_input,
+    handle_call_tool,
+)
+
+pytestmark = pytest.mark.unit
+
+_BUDGET_TOOL = "google_ads_budget_update"
+_budget_registered = pytest.mark.skipif(
+    _BUDGET_TOOL not in _TOOL_VALIDATORS,
+    reason="google_ads tools disabled in this environment",
+)
+
+
+def test_unknown_tool_is_noop() -> None:
+    """A tool with no registered validator (plugins, unknown) is skipped."""
+    _validate_tool_input("definitely_not_a_registered_tool", {"x": 1})
+
+
+def test_plugin_tools_are_not_validated() -> None:
+    """Plugin tool names must be excluded from the built-in validator map."""
+    from mureo.mcp.server import _PLUGIN_NAMES
+
+    assert _PLUGIN_NAMES.isdisjoint(_TOOL_VALIDATORS)
+
+
+@_budget_registered
+class TestBudgetUpdateSchema:
+    def test_rejects_amount_below_minimum(self) -> None:
+        with pytest.raises(ValueError, match="Invalid arguments"):
+            _validate_tool_input(_BUDGET_TOOL, {"budget_id": "1", "amount": 0})
+
+    def test_rejects_negative_amount(self) -> None:
+        with pytest.raises(ValueError, match="Invalid arguments"):
+            _validate_tool_input(_BUDGET_TOOL, {"budget_id": "1", "amount": -5})
+
+    def test_requires_amount_or_amount_micros(self) -> None:
+        with pytest.raises(ValueError, match="Invalid arguments"):
+            _validate_tool_input(_BUDGET_TOOL, {"budget_id": "1"})
+
+    def test_accepts_valid_amount(self) -> None:
+        _validate_tool_input(_BUDGET_TOOL, {"budget_id": "1", "amount": 5000})
+
+    def test_accepts_amount_micros(self) -> None:
+        _validate_tool_input(
+            _BUDGET_TOOL, {"budget_id": "1", "amount_micros": 5_000_000}
+        )
+
+    async def test_dispatch_rejects_before_handler(self) -> None:
+        """An out-of-bounds budget is refused at dispatch — no creds touched."""
+        with pytest.raises(ValueError, match="Invalid arguments"):
+            await handle_call_tool(_BUDGET_TOOL, {"budget_id": "1", "amount": 0})

--- a/tests/test_mcp_tools_google_ads.py
+++ b/tests/test_mcp_tools_google_ads.py
@@ -43,7 +43,9 @@ class TestGoogleAdsToolDefinitions:
         """Every tool name starts with google_ads_ (underscore-separated, per MCP spec)."""
         mod = _import_google_ads_tools()
         for tool in mod.TOOLS:
-            assert tool.name.startswith("google_ads_"), f"Invalid tool name: {tool.name}"
+            assert tool.name.startswith(
+                "google_ads_"
+            ), f"Invalid tool name: {tool.name}"
 
     def test_all_tools_have_input_schema(self) -> None:
         """Every tool defines an inputSchema."""
@@ -111,8 +113,10 @@ class TestGoogleAdsToolDefinitions:
             ),
             ("google_ads_budget_get", ["campaign_id"]),
             (
+                # amount / amount_micros moved to an anyOf (one-of) so either
+                # may satisfy the schema (#277); only budget_id is unconditional.
                 "google_ads_budget_update",
-                ["budget_id", "amount"],
+                ["budget_id"],
             ),
             ("google_ads_performance_report", []),
             ("google_ads_search_terms_report", []),

--- a/tests/test_mcp_tools_meta_ads.py
+++ b/tests/test_mcp_tools_meta_ads.py
@@ -188,6 +188,28 @@ class TestMetaAdsCampaignHandlers:
 
         client.update_campaign.assert_awaited_once()
 
+    async def test_campaigns_create_rejects_zero_daily_budget(self) -> None:
+        """A 0 daily budget halts delivery — refuse before any API call (#277)."""
+        mod = _import_meta_ads_tools()
+        with pytest.raises(ValueError, match="greater than 0"):
+            await mod.handle_tool(
+                "meta_ads_campaigns_create",
+                {
+                    "account_id": "act_123",
+                    "name": "C",
+                    "objective": "CONVERSIONS",
+                    "daily_budget": 0,
+                },
+            )
+
+    async def test_campaigns_update_rejects_negative_daily_budget(self) -> None:
+        mod = _import_meta_ads_tools()
+        with pytest.raises(ValueError, match="greater than 0"):
+            await mod.handle_tool(
+                "meta_ads_campaigns_update",
+                {"account_id": "act_123", "campaign_id": "456", "daily_budget": -10},
+            )
+
 
 # ---------------------------------------------------------------------------
 # Handler tests — ad sets
@@ -252,6 +274,19 @@ class TestMetaAdsAdSetHandlers:
             )
 
         client.update_ad_set.assert_awaited_once()
+
+    async def test_ad_sets_create_rejects_zero_bid_amount(self) -> None:
+        mod = _import_meta_ads_tools()
+        with pytest.raises(ValueError, match="greater than 0"):
+            await mod.handle_tool(
+                "meta_ads_ad_sets_create",
+                {
+                    "account_id": "act_123",
+                    "campaign_id": "456",
+                    "name": "AS",
+                    "bid_amount": 0,
+                },
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_policy_gate.py
+++ b/tests/test_policy_gate.py
@@ -88,11 +88,13 @@ class TestDispatcherGateIntegration:
         from mureo.mcp.server import handle_call_tool
 
         fake_handler = AsyncMock(return_value=[MagicMock(text="result")])
+        # ``rollback_plan_get`` requires ``index`` — dispatch now runs the
+        # inputSchema validation pass (#277), so pass schema-valid args.
         with (
             patch("mureo.mcp.server._load_policy_gates", return_value=()),
             patch("mureo.mcp.server.handle_rollback_tool", new=fake_handler),
         ):
-            result = await handle_call_tool("rollback_plan_get", {})
+            result = await handle_call_tool("rollback_plan_get", {"index": 0})
         fake_handler.assert_awaited_once()
         assert result[0].text == "result"
 
@@ -105,8 +107,8 @@ class TestDispatcherGateIntegration:
             patch("mureo.mcp.server._load_policy_gates", return_value=(gate,)),
             patch("mureo.mcp.server.handle_rollback_tool", new=fake_handler),
         ):
-            result = await handle_call_tool("rollback_plan_get", {"k": "v"})
-        gate.evaluate.assert_called_once_with("rollback_plan_get", {"k": "v"})
+            result = await handle_call_tool("rollback_plan_get", {"index": 0})
+        gate.evaluate.assert_called_once_with("rollback_plan_get", {"index": 0})
         fake_handler.assert_awaited_once()
         assert result[0].text == "result"
 
@@ -161,7 +163,7 @@ class TestDispatcherGateIntegration:
             patch("mureo.mcp.server.handle_rollback_tool", new=fake_handler),
             caplog.at_level(logging.WARNING, logger="mureo.mcp.server"),
         ):
-            result = await handle_call_tool("rollback_plan_get", {})
+            result = await handle_call_tool("rollback_plan_get", {"index": 0})
         fake_handler.assert_awaited_once()
         assert result[0].text == "result"
         assert any(
@@ -194,7 +196,7 @@ class TestDispatcherGateIntegration:
             patch("mureo.mcp.server.handle_rollback_tool", new=fake_handler),
             caplog.at_level(logging.WARNING, logger="mureo.mcp.server"),
         ):
-            result = await handle_call_tool("rollback_plan_get", {})
+            result = await handle_call_tool("rollback_plan_get", {"index": 0})
         fake_handler.assert_awaited_once()
         assert result[0].text == "result"
         assert any(


### PR DESCRIPTION
## Summary
Fixes #277 (HIGH — unvalidated budget/bid values reach real-spend). Budget mutations were not validated for sign/upper-bound, and the MCP dispatcher performed no input-schema validation, so `inputSchema` constraints (`minimum: 1`, etc.) were advisory only.

### Client layer (defends non-MCP / adapter callers too)
- `google_ads/client.py::update_budget` now validates the amount `> 0` and against an absolute catastrophe ceiling (`_MAX_BUDGET_AMOUNT_MICROS` = 1e15 micros — a digit-slip/overflow guard, **not** a spend policy; per-account limits remain a Pro BudgetGuard concern).
- It accepts `amount` **or** `amount_micros` (mutually exclusive, mirroring `create_budget`) so callers can pass exact micros and avoid the `int(amount * 1e6)` float round-trip (cleaner rollback round-trip). `bool` and `inf`/`nan` are rejected with a clean `ValueError`.

### MCP dispatch — the single guard
- `mcp/server.py::handle_call_tool` now runs a pre-compiled **jsonschema** pass (`_validate_tool_input`) over each **built-in** tool's `inputSchema` — after the policy-gate decision (a denial is absolute and need not depend on arg validity), before the handler / before-state capture / real-spend call. This makes every mutation's declared bounds (`minimum`/`required`/`type`/`enum`) real server-side, most importantly budget/bid `minimum: 1`. Plugin tools are validated by their own providers and excluded.

### Meta handlers
- `daily_budget` / `lifetime_budget` / `bid_amount` validated `> 0` before the API call (defense-in-depth for direct handler callers).

### Schema / deps
- `google_ads_budget_update` schema gains `amount_micros` + an `anyOf` (`amount | amount_micros`); `required` is now just `["budget_id"]`.
- `jsonschema>=4.20,<5` declared as an explicit dependency (was transitive via `mcp`; now imported directly).

## Test plan
- [x] New: `tests/test_mcp_input_validation.py` (dispatch-layer schema pass: below-minimum, anyOf required, valid amount/amount_micros, unknown-tool no-op, plugin exclusion, dispatch-rejects-before-handler).
- [x] `update_budget` client tests: `> 0`, negative, ceiling, both/neither, exact `amount_micros`, bool & inf rejection.
- [x] Meta handler tests: zero/negative `daily_budget`, zero `bid_amount` rejected.
- [x] Updated policy-gate dispatcher tests to pass schema-valid args (`{"index": 0}`) now that dispatch validates input; deny-path tests unchanged (validation runs after the gate).
- [x] `ruff check mureo/` · `black --check mureo/` · `mypy mureo/ --ignore-missing-imports` all clean.
- [x] Full suite: 4431 passed (3 pre-existing plugin-env-noise failures from a locally-registered third-party plugin, unrelated).

*Part of the mutation-safety audit batch (follows #273/#274/#275/#276).*
