### PR TITLE
fix(skills): choose Operation Mode from campaign maturity, not mureo setup recency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+#### Operation Mode is chosen from campaign maturity, not mureo setup recency
+
+Setting mureo up on an already long-running campaign made the first
+`daily-check` say "currently in learning mode — prioritize data
+accumulation", forcing the operator to re-issue the analysis request even
+though the campaign already had plenty of accumulated data. The `onboard`
+skill defaulted Operation Mode to `ONBOARDING_LEARNING` unconditionally.
+Now `onboard` chooses the mode from the imported campaigns' actual maturity
+(age + accumulated conversions) — reserving `ONBOARDING_LEARNING` for
+genuinely new campaigns and defaulting mature accounts to a steady-state
+mode (e.g. `EFFICIENCY_STABILIZE`). `daily-check` also no longer withholds
+analysis on `ONBOARDING_LEARNING` when the data shows a mature campaign; it
+proceeds and offers to switch the mode. (`onboard`, `daily-check`,
+`_mureo-strategy` skills.)
+
 ## [0.10.6] - 2026-06-17
 
 ### Added

--- a/mureo/_data/skills/_mureo-strategy/SKILL.md
+++ b/mureo/_data/skills/_mureo-strategy/SKILL.md
@@ -147,7 +147,7 @@ The `Operation Mode` section contains one of 7 predefined modes that control age
 
 | Mode | When to Use |
 |------|-------------|
-| `ONBOARDING_LEARNING` | New campaigns in learning period |
+| `ONBOARDING_LEARNING` | Genuinely new campaigns still in their learning period — set this from campaign maturity (age + accumulated conversions), NOT just because mureo was newly set up on an existing long-running account |
 | `TURNAROUND_RESCUE` | Campaigns with poor performance needing rescue |
 | `SCALE_EXPANSION` | Campaigns ready to scale up |
 | `EFFICIENCY_STABILIZE` | Mature campaigns optimizing for efficiency |
@@ -316,11 +316,15 @@ Priority: Grow while maintaining efficiency
 **ONBOARDING_LEARNING mode:**
 ```
 Priority: Let the algorithm learn, minimal changes
-1. Monitor performance but avoid making changes
-2. Warn before any budget or bid changes
-3. Check campaign diagnose for learning status
+Applies to a campaign genuinely IN its learning period — not to a mature
+campaign that mureo was simply set up on recently. If the campaign already
+has accumulated conversions / history, it is NOT learning: switch the mode
+(e.g. EFFICIENCY_STABILIZE) and analyze normally instead of withholding.
+1. Confirm the campaign is actually learning (recent start, sparse conversions)
    -> google_ads_campaigns_diagnose {customer_id, campaign_id}
-4. Wait until learning period completes before optimizing
+2. If still learning: monitor performance, warn before budget/bid changes,
+   wait until the learning period completes before optimizing
+3. If already mature: recommend updating Operation Mode and proceed
 ```
 
 ### 5. Market Context for Competitive Response

--- a/mureo/_data/skills/daily-check/SKILL.md
+++ b/mureo/_data/skills/daily-check/SKILL.md
@@ -40,7 +40,7 @@ Run a daily health check on all marketing accounts using the strategy context.
    - Present a unified health summary across all platforms, including any `analytics_not_available_for_<platform>` notices.
 
 5. **Mode-specific checks** based on Operation Mode:
-   - **ONBOARDING_LEARNING**: Check learning status on each platform. Warn against making changes.
+   - **ONBOARDING_LEARNING**: This mode means the *campaign* is in its learning period — NOT merely that mureo was recently set up. First confirm it still applies: check each platform's learning status and the accumulated conversion history. If the campaigns are actually mature (well past the learning window, with accumulated conversions — common when mureo is added to an already long-running account), do **not** blindly warn "prioritize data accumulation". Instead proceed with the full analysis and proactively offer to switch the Operation Mode to a steady-state mode (e.g. `EFFICIENCY_STABILIZE`). Only hold back on changes when the data confirms a genuine learning period is still underway.
    - **EFFICIENCY_STABILIZE**: Analyze CPA trends across all platforms. Flag if CPA increased >10% on any platform.
    - **TURNAROUND_RESCUE**: Identify zero-conversion campaigns and cost spikes across all platforms.
    - **SCALE_EXPANSION**: Check budget utilization across all platforms. Flag underspending campaigns.

--- a/mureo/_data/skills/onboard/SKILL.md
+++ b/mureo/_data/skills/onboard/SKILL.md
@@ -45,11 +45,31 @@ Guide me through setting up mureo for a new marketing account.
    - **Target Audience**: Demographics, geography, budget range
    - **Brand Voice**: Tone and style guidelines for ad copy
    - **Market Context**: Competitors, market trends, competitive advantages
-   - **Operation Mode**: Start with `ONBOARDING_LEARNING` for new accounts
+   - **Operation Mode**: Choose from the imported campaigns' **actual
+     maturity**, NOT from the fact that mureo was just set up:
+     - Use `ONBOARDING_LEARNING` only for genuinely **new** campaigns still
+       in their learning period — little/no accumulated conversions and
+       started recently (roughly the last 2-4 weeks).
+     - For campaigns that have already been running for a while with
+       accumulated conversion history, pick a steady-state mode — default to
+       `EFFICIENCY_STABILIZE` (mature campaigns optimizing for efficiency),
+       or another mode the imported data clearly warrants (e.g.
+       `SCALE_EXPANSION`, `TURNAROUND_RESCUE`).
+     - Base this on real delivery data, not setup recency: use the recent
+       conversion volume from `google_ads_performance_report` (LAST_30_DAYS)
+       and the learning status from `google_ads_campaigns_diagnose` — i.e.
+       the data fetched in step 7 below. If you reach this step before that
+       data is available, fetch it now (or finalize the mode right after the
+       step-7 diagnosis). STATE.json's campaign snapshots do not carry age /
+       conversion counts, so do not rely on them for this. If still unsure,
+       ask me. Picking `ONBOARDING_LEARNING` for a long-running campaign
+       makes the first daily-check wrongly tell me to "prioritize data
+       accumulation" when the data is already there.
 
    If I don't know the answers to any of the above sections (Persona, USP,
-   Target Audience, Brand Voice, Market Context — Operation Mode always
-   defaults to `ONBOARDING_LEARNING`), offer an alternative: ask me for the
+   Target Audience, Brand Voice, Market Context — Operation Mode is chosen
+   from campaign maturity per the rule above, not from the URL), offer an
+   alternative: ask me for the
    **product / landing-page URL** (or corporate site / competitor URLs).
    Then fetch the URL with WebFetch, read the page content, and draft a
    first-pass for **every** unknown section — Persona, USP, Target Audience,

--- a/skills/_mureo-strategy/SKILL.md
+++ b/skills/_mureo-strategy/SKILL.md
@@ -147,7 +147,7 @@ The `Operation Mode` section contains one of 7 predefined modes that control age
 
 | Mode | When to Use |
 |------|-------------|
-| `ONBOARDING_LEARNING` | New campaigns in learning period |
+| `ONBOARDING_LEARNING` | Genuinely new campaigns still in their learning period — set this from campaign maturity (age + accumulated conversions), NOT just because mureo was newly set up on an existing long-running account |
 | `TURNAROUND_RESCUE` | Campaigns with poor performance needing rescue |
 | `SCALE_EXPANSION` | Campaigns ready to scale up |
 | `EFFICIENCY_STABILIZE` | Mature campaigns optimizing for efficiency |
@@ -316,11 +316,15 @@ Priority: Grow while maintaining efficiency
 **ONBOARDING_LEARNING mode:**
 ```
 Priority: Let the algorithm learn, minimal changes
-1. Monitor performance but avoid making changes
-2. Warn before any budget or bid changes
-3. Check campaign diagnose for learning status
+Applies to a campaign genuinely IN its learning period — not to a mature
+campaign that mureo was simply set up on recently. If the campaign already
+has accumulated conversions / history, it is NOT learning: switch the mode
+(e.g. EFFICIENCY_STABILIZE) and analyze normally instead of withholding.
+1. Confirm the campaign is actually learning (recent start, sparse conversions)
    -> google_ads_campaigns_diagnose {customer_id, campaign_id}
-4. Wait until learning period completes before optimizing
+2. If still learning: monitor performance, warn before budget/bid changes,
+   wait until the learning period completes before optimizing
+3. If already mature: recommend updating Operation Mode and proceed
 ```
 
 ### 5. Market Context for Competitive Response

--- a/skills/daily-check/SKILL.md
+++ b/skills/daily-check/SKILL.md
@@ -40,7 +40,7 @@ Run a daily health check on all marketing accounts using the strategy context.
    - Present a unified health summary across all platforms, including any `analytics_not_available_for_<platform>` notices.
 
 5. **Mode-specific checks** based on Operation Mode:
-   - **ONBOARDING_LEARNING**: Check learning status on each platform. Warn against making changes.
+   - **ONBOARDING_LEARNING**: This mode means the *campaign* is in its learning period — NOT merely that mureo was recently set up. First confirm it still applies: check each platform's learning status and the accumulated conversion history. If the campaigns are actually mature (well past the learning window, with accumulated conversions — common when mureo is added to an already long-running account), do **not** blindly warn "prioritize data accumulation". Instead proceed with the full analysis and proactively offer to switch the Operation Mode to a steady-state mode (e.g. `EFFICIENCY_STABILIZE`). Only hold back on changes when the data confirms a genuine learning period is still underway.
    - **EFFICIENCY_STABILIZE**: Analyze CPA trends across all platforms. Flag if CPA increased >10% on any platform.
    - **TURNAROUND_RESCUE**: Identify zero-conversion campaigns and cost spikes across all platforms.
    - **SCALE_EXPANSION**: Check budget utilization across all platforms. Flag underspending campaigns.

--- a/skills/onboard/SKILL.md
+++ b/skills/onboard/SKILL.md
@@ -45,11 +45,31 @@ Guide me through setting up mureo for a new marketing account.
    - **Target Audience**: Demographics, geography, budget range
    - **Brand Voice**: Tone and style guidelines for ad copy
    - **Market Context**: Competitors, market trends, competitive advantages
-   - **Operation Mode**: Start with `ONBOARDING_LEARNING` for new accounts
+   - **Operation Mode**: Choose from the imported campaigns' **actual
+     maturity**, NOT from the fact that mureo was just set up:
+     - Use `ONBOARDING_LEARNING` only for genuinely **new** campaigns still
+       in their learning period — little/no accumulated conversions and
+       started recently (roughly the last 2-4 weeks).
+     - For campaigns that have already been running for a while with
+       accumulated conversion history, pick a steady-state mode — default to
+       `EFFICIENCY_STABILIZE` (mature campaigns optimizing for efficiency),
+       or another mode the imported data clearly warrants (e.g.
+       `SCALE_EXPANSION`, `TURNAROUND_RESCUE`).
+     - Base this on real delivery data, not setup recency: use the recent
+       conversion volume from `google_ads_performance_report` (LAST_30_DAYS)
+       and the learning status from `google_ads_campaigns_diagnose` — i.e.
+       the data fetched in step 7 below. If you reach this step before that
+       data is available, fetch it now (or finalize the mode right after the
+       step-7 diagnosis). STATE.json's campaign snapshots do not carry age /
+       conversion counts, so do not rely on them for this. If still unsure,
+       ask me. Picking `ONBOARDING_LEARNING` for a long-running campaign
+       makes the first daily-check wrongly tell me to "prioritize data
+       accumulation" when the data is already there.
 
    If I don't know the answers to any of the above sections (Persona, USP,
-   Target Audience, Brand Voice, Market Context — Operation Mode always
-   defaults to `ONBOARDING_LEARNING`), offer an alternative: ask me for the
+   Target Audience, Brand Voice, Market Context — Operation Mode is chosen
+   from campaign maturity per the rule above, not from the URL), offer an
+   alternative: ask me for the
    **product / landing-page URL** (or corporate site / competitor URLs).
    Then fetch the URL with WebFetch, read the page content, and draft a
    first-pass for **every** unknown section — Persona, USP, Target Audience,


### PR DESCRIPTION
## Summary
Customer feedback: setting mureo up on an **already long-running campaign** made the first `daily-check` say "currently in learning mode — large changes not recommended; prioritize data accumulation until CV measurement stabilizes", forcing the operator to re-issue the analysis even though plenty of data was already accumulated.

**Root cause:** `ONBOARDING_LEARNING` reflected *mureo setup recency*, not the campaign's actual learning state. `onboard` defaulted Operation Mode to `ONBOARDING_LEARNING` unconditionally, and `daily-check` then withheld changes whenever that mode was set.

## Fix (OSS skills only)
- **`onboard`** — choose Operation Mode from the imported campaigns' **real maturity**: recent conversion volume (`google_ads_performance_report`, LAST_30_DAYS) + learning status (`google_ads_campaigns_diagnose`), the data fetched in step 7. `ONBOARDING_LEARNING` is reserved for genuinely new campaigns; mature accounts default to a steady-state mode (e.g. `EFFICIENCY_STABILIZE`).
- **`daily-check`** — on `ONBOARDING_LEARNING`, re-confirm against live data; if the campaign is actually mature, **proceed with the analysis and offer to switch the mode** instead of withholding. This rescues `STRATEGY.md` files written by the old skill (defense-in-depth: fix at both writer and reader).
- **`_mureo-strategy`** — clarify `ONBOARDING_LEARNING` = the campaign's learning period, not setup recency.
- Bundled `mureo/_data/skills/` copies kept byte-identical (parity test); CHANGELOG.

## Note on `mureo-logly-bridge`
The customer's "logly ads context daily report" comes from the separate `mureo-logly-bridge`. Verified the bridge contains **no** `operation_mode` / learning-mode logic — its `daily_report` is a pure data tool. The recommendation is produced by these OSS skills reading STATE.json's `operation_mode`, so the fix is OSS-skill-only; **no bridge change needed**.

## Test plan
- [x] `tests/test_plugin_manifests.py::test_packaged_skills_match_canonical_byte_for_byte` passes (canonical ↔ bundled byte-identical for all 3 skills).
- [x] code-reviewer: **Approve** (no CRITICAL/HIGH). Addressed the one MEDIUM — `onboard` now points the maturity signal at real data sources (`google_ads_performance_report` / `google_ads_campaigns_diagnose`) instead of STATE.json fields that don't exist.
- Skill-content (prompt) change only — no code logic.

*Version bump deferred; counted under CHANGELOG `[Unreleased]` for the next release.*
