### PR TITLE
feat(mcp): warn when the running MCP server is older than the installed mureo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+#### Warn when the MCP server is running an outdated mureo after an upgrade
+
+Upgrading mureo had no visible effect when the already-running MCP server
+process kept serving the old in-memory code (operator upgraded but did not
+fully restart the client) — e.g. a freshly written `STATE.json` still
+missing `last_synced_at`, because the *old* code wrote it. The server now
+compares its in-memory `__version__` against the on-disk installed
+distribution and, when the process is older, appends a one-time restart
+warning to tool output (push, not pull — the agent surfaces it without
+having to ask for a version, and the comparison baseline is the install
+itself). See `mureo.core.version_staleness`.
+
 ### Fixed
 
 #### Operation Mode is chosen from campaign maturity, not mureo setup recency

--- a/mureo/core/version_staleness.py
+++ b/mureo/core/version_staleness.py
@@ -1,0 +1,90 @@
+"""Detect when the running mureo MCP process is older than what is installed.
+
+A long-running MCP server loads mureo into memory **once**, at process start.
+If the operator then ``pip install -U mureo`` in the same environment but does
+not fully restart the client, the process keeps serving the OLD code — and
+there is no visible signal, so neither the operator nor the agent realises the
+upgrade had no effect (the exact failure behind the missing ``last_synced_at``
+report).
+
+We capture the in-memory ``__version__`` at import (frozen for the process
+lifetime) and compare it against the on-disk installed distribution metadata,
+which an in-place upgrade refreshes. ``running < installed`` means "you
+upgraded but this process is stale — restart". The server surfaces this by
+appending a warning to tool output (push, not pull: the agent never has to ask
+for a version), so a comparison baseline ("what is installed now") is built in.
+
+This does NOT catch the separate case where the client launches mureo from a
+wholly different environment that was never upgraded — that environment's
+on-disk metadata is also old, so there is nothing to compare against here. For
+that, re-running ``mureo setup`` re-points the launcher at the current
+interpreter, and the PyPI update check (``mureo.web.version_check``) nudges
+"a newer release exists".
+"""
+
+from __future__ import annotations
+
+import logging
+
+import mureo
+
+logger = logging.getLogger(__name__)
+
+# The version of the code actually loaded into THIS process's memory. Captured
+# at import time; it does not change when files on disk are upgraded.
+_RUNNING_VERSION = mureo.__version__
+
+
+def installed_version() -> str | None:
+    """Return the on-disk installed ``mureo`` distribution version, or ``None``.
+
+    Read fresh from the distribution metadata on every call so an in-session
+    ``pip install -U`` is observed. Never raises.
+    """
+    try:
+        from importlib import metadata
+
+        return metadata.version("mureo")
+    except Exception:  # pragma: no cover - exotic metadata/layout failures
+        logger.debug("could not read installed mureo version", exc_info=True)
+        return None
+
+
+def staleness_warning(
+    *,
+    running: str | None = None,
+    installed: str | None = None,
+) -> str | None:
+    """Return a restart warning when the running process is older than what is
+    installed on disk, else ``None``.
+
+    Only ``running < installed`` is flagged. Equal, or ``running > installed``
+    (a dev/editable checkout ahead of the published dist), returns ``None`` so
+    a developer is never nagged. Args are injectable for testing; production
+    callers pass neither.
+    """
+    running = running or _RUNNING_VERSION
+    installed = installed if installed is not None else installed_version()
+    if installed is None or installed == running:
+        return None
+
+    try:
+        from packaging.version import InvalidVersion, Version
+
+        try:
+            if Version(installed) <= Version(running):
+                return None
+        except InvalidVersion:
+            return None
+    except Exception:  # pragma: no cover - packaging always present (dependency)
+        return None
+
+    return (
+        f"⚠️ mureo MCP version mismatch: this server process is "
+        f"running {running}, but {installed} is installed on disk. mureo was "
+        f"upgraded, but this MCP process is still the OLD one, so every mureo "
+        f"tool call here runs the old code. Fully quit and restart Claude "
+        f"(quit the app completely — not just close the window — or "
+        f"restart the CLI) so the {installed} server loads. Tell the operator "
+        f"to do this before trusting further mureo results."
+    )

--- a/mureo/mcp/server.py
+++ b/mureo/mcp/server.py
@@ -466,6 +466,40 @@ def _maybe_append_strategy_reminder(name: str, result: list[Any]) -> list[Any]:
     return [*result, TextContent(type="text", text=reminder)]
 
 
+# Once-per-process latch: the stale-version banner is appended to the first
+# tool result that detects the mismatch, not every call (avoid spamming a
+# read-heavy daily-check). A fresh process after restart starts False again.
+_staleness_warned = False
+
+
+def _maybe_append_staleness_warning(result: list[Any]) -> list[Any]:
+    """Append a one-time restart warning when this MCP process is older than
+    the mureo installed on disk.
+
+    Push, not pull: the agent receives the warning in normal tool output and
+    never has to ask for a version. No-op once warned this process, or when the
+    running version is current. Best-effort — never raises, never replaces the
+    tool's own content. See :mod:`mureo.core.version_staleness`.
+    """
+    global _staleness_warned
+    if _staleness_warned:
+        return result
+    try:
+        from mureo.core.version_staleness import staleness_warning
+
+        warning = staleness_warning()
+        if warning is None:
+            return result
+        _staleness_warned = True
+        logger.warning("%s", warning)
+        from mcp.types import TextContent
+
+        return [*result, TextContent(type="text", text=warning)]
+    except Exception:  # noqa: BLE001 - a version check must never break a tool call
+        logger.debug("staleness warning check failed", exc_info=True)
+        return result
+
+
 async def handle_call_tool(name: str, arguments: dict[str, Any]) -> list[Any]:
     """Execute a tool and return the result.
 
@@ -492,6 +526,21 @@ async def handle_call_tool(name: str, arguments: dict[str, Any]) -> list[Any]:
     # capture, or real-spend API call — so an out-of-bounds budget/bid is
     # rejected before it can reach a live campaign.
     _validate_tool_input(name, arguments)
+    result = await _dispatch_tool(name, arguments)
+    # Push, not pull: if this MCP process is older than the mureo installed on
+    # disk (operator upgraded but did not fully restart Claude), append a
+    # one-time restart warning so the agent surfaces it WITHOUT having to ask
+    # for a version. See :mod:`mureo.core.version_staleness`.
+    return _maybe_append_staleness_warning(result)
+
+
+async def _dispatch_tool(name: str, arguments: dict[str, Any]) -> list[Any]:
+    """Route an already-gated, already-validated tool call to its handler.
+
+    Built-in tool families append their STRATEGY.md reminder per-branch; the
+    process-level staleness warning is applied once by the caller around the
+    whole result.
+    """
     if name in _GOOGLE_ADS_NAMES:
         before = await capture_before_state(name, arguments)
         result = await handle_google_ads_tool(name, arguments)

--- a/tests/test_version_staleness.py
+++ b/tests/test_version_staleness.py
@@ -1,0 +1,123 @@
+"""Tests for stale-MCP-version detection and its push into tool output.
+
+Covers `mureo.core.version_staleness` (the running-vs-installed comparison) and
+the server-side injection that surfaces a restart warning in tool results
+without the agent having to ask for a version.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from mureo.core import version_staleness as vs
+
+pytestmark = pytest.mark.unit
+
+
+class TestStalenessWarning:
+    def test_running_equals_installed_is_silent(self) -> None:
+        assert vs.staleness_warning(running="0.10.6", installed="0.10.6") is None
+
+    def test_running_older_than_installed_warns(self) -> None:
+        msg = vs.staleness_warning(running="0.10.5", installed="0.10.6")
+        assert msg is not None
+        assert "0.10.5" in msg and "0.10.6" in msg
+        assert "restart" in msg.lower()
+
+    def test_running_newer_than_installed_is_silent(self) -> None:
+        """A dev/editable checkout ahead of the published dist must not nag."""
+        assert vs.staleness_warning(running="0.11.0", installed="0.10.6") is None
+
+    def test_missing_installed_is_silent(self) -> None:
+        assert vs.staleness_warning(running="0.10.6", installed=None) is None
+
+    def test_invalid_version_is_silent(self) -> None:
+        assert vs.staleness_warning(running="0.10.6", installed="not-a-version") is None
+        assert vs.staleness_warning(running="garbage", installed="0.10.6") is None
+
+    def test_installed_version_returns_str_or_none(self) -> None:
+        v = vs.installed_version()
+        assert v is None or isinstance(v, str)
+
+
+@pytest.mark.asyncio
+class TestServerInjection:
+    async def _call(self, monkeypatch: pytest.MonkeyPatch, warning: str | None) -> Any:
+        import mureo.mcp.server as server
+
+        monkeypatch.setattr(server, "_staleness_warned", False)
+        monkeypatch.setattr(
+            server, "_dispatch_tool", AsyncMock(return_value=["RESULT"])
+        )
+        monkeypatch.setattr(
+            "mureo.core.version_staleness.staleness_warning",
+            lambda: warning,
+        )
+        return await server.handle_call_tool("some_tool", {})
+
+    async def test_stale_appends_warning(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        result = await self._call(monkeypatch, "RESTART NEEDED")
+        assert result[0] == "RESULT"
+        assert getattr(result[-1], "text", None) == "RESTART NEEDED"
+
+    async def test_current_appends_nothing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        result = await self._call(monkeypatch, None)
+        assert result == ["RESULT"]
+
+    async def test_warns_only_once_per_process(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import mureo.mcp.server as server
+
+        monkeypatch.setattr(server, "_staleness_warned", False)
+        monkeypatch.setattr(
+            server, "_dispatch_tool", AsyncMock(return_value=["RESULT"])
+        )
+        monkeypatch.setattr(
+            "mureo.core.version_staleness.staleness_warning",
+            lambda: "RESTART NEEDED",
+        )
+        first = await server.handle_call_tool("some_tool", {})
+        second = await server.handle_call_tool("some_tool", {})
+        assert len(first) == 2  # result + warning
+        assert second == ["RESULT"]  # latched — no repeat banner
+
+    async def test_gate_refusal_skips_warning(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A policy denial returns its refusal before dispatch — no banner."""
+        import mureo.mcp.server as server
+        from mureo.core.policy import PolicyDecision
+
+        monkeypatch.setattr(server, "_staleness_warned", False)
+        monkeypatch.setattr(
+            server,
+            "_evaluate_policy_gates",
+            lambda name, args: PolicyDecision(allowed=False, reason="blocked"),
+        )
+        monkeypatch.setattr(
+            "mureo.core.version_staleness.staleness_warning",
+            lambda: "RESTART NEEDED",
+        )
+        result = await server.handle_call_tool("some_tool", {})
+        text = " ".join(getattr(c, "text", "") for c in result)
+        assert "RESTART NEEDED" not in text
+        assert "blocked" in text
+
+    async def test_unknown_tool_error_propagates(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The wrapper does not swallow the real dispatch's Unknown-tool error."""
+        import mureo.mcp.server as server
+
+        monkeypatch.setattr(server, "_staleness_warned", False)
+        monkeypatch.setattr(
+            "mureo.core.version_staleness.staleness_warning", lambda: None
+        )
+        with pytest.raises(ValueError, match="Unknown tool"):
+            await server.handle_call_tool("definitely_not_a_registered_tool_xyz", {})


### PR DESCRIPTION
## Summary
Operator-reported bug: after `pip install -U mureo`, the **already-running MCP server process** kept serving the OLD in-memory code (the operator upgraded but didn't fully restart Claude), with **no visible signal**. The symptom was stale behavior — e.g. a freshly written `STATE.json` still missing `last_synced_at`, because the *old* code wrote it — and neither the operator nor the agent realised the upgrade had no effect.

The user's two requirements were explicit: the signal must be **push, not pull** (the agent shouldn't have to ask for a version — a passive "return version" tool nobody calls is useless), and it must have a **real comparison baseline** (just returning "I'm 0.10.5" doesn't tell you it's stale).

## How it works
- **`mureo/core/version_staleness.py`** — `_RUNNING_VERSION = mureo.__version__` is captured at import, so it's frozen to the code **actually loaded into this process's memory**. `installed_version()` reads `importlib.metadata.version("mureo")` **fresh each call** — an in-place `pip install -U` rewrites that on-disk metadata. `staleness_warning()` warns only when `running < installed` (via `packaging.version.Version`); it is silent on equal, on running-newer (dev/editable checkout ahead of the dist), on missing metadata, and on unparseable versions. Never raises.
- **`mureo/mcp/server.py`** — the dispatch chain is extracted into `_dispatch_tool`; `handle_call_tool` wraps the result with `_maybe_append_staleness_warning`, which appends a **once-per-process** `TextContent` restart banner when stale (mirrors the existing strategy-reminder injection). Wrapped in `try/except` so a version check can never break a tool call. The banner rides on normal tool output, so the agent surfaces it to the operator without being asked.

Banner text: *"this server process is running X, but Y is installed on disk … fully quit and restart Claude so the Y server loads."*

## Honest scope
This catches the **common** mistake (upgraded the same environment, didn't restart the process). It does **not** catch the client launching mureo from a *wholly different* un-upgraded environment — that env's on-disk metadata is also old, so there's nothing to compare against. For that, `mureo setup` re-points the launcher at the current interpreter, and `mureo.web.version_check` (PyPI) nudges "a newer release exists". Documented in the module docstring.

## Test plan
- [x] `tests/test_version_staleness.py`: stale→warn; equal/newer/missing/invalid(either side)→silent; server appends the banner once per process; **gate-refusal path skips** the banner; **unknown-tool ValueError still propagates** through the wrapper.
- [x] `_dispatch_tool` extraction verified behavior-preserving (all dispatch/policy/validation/native-reversal/strategy-reminder suites pass).
- [x] `ruff check mureo/` · `black --check mureo/` · `mypy mureo/ --ignore-missing-imports` clean; code-reviewer **APPROVE** (no CRITICAL/HIGH).
- [x] Full suite: 4448 passed; the remaining failures are pre-existing local plugin-env noise (installed `mureo-*` plugins inflate tool/plugin counts) — unaffected in clean CI.
