### PR TITLE
chore(release): 0.10.7

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mureo",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "description": "Your local-first AI ad ops crew for Google Ads, Meta Ads, Search Console & GA4. mureo sits on top of the official ad-platform MCPs, gates every change against your strategy, correlates outcomes locally, and keeps an auditable decision log — credentials never leave your machine.",
   "author": {
     "name": "Logly Inc.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.7] - 2026-06-18
+
 ### Added
+
+#### Configure UI: manage external advisor MCPs (Advanced menu)
+
+External advisor MCP servers (the ones `mureo_consult_advisor` queries)
+could only be configured by hand-editing `~/.mureo/insight_sources.json`.
+A new "Advanced" dashboard menu adds an "External advisor MCP" card to
+list / add / delete them, with safe writes (fail closed on a malformed
+file, `.bak` backup, atomic write; secrets in `env`/`headers` are never
+surfaced in the list or error messages). The add form shows per-field
+examples and a monospace layout for command / args / env / headers.
 
 #### Warn when the MCP server is running an outdated mureo after an upgrade
 

--- a/mureo/__init__.py
+++ b/mureo/__init__.py
@@ -1,3 +1,3 @@
 """mureo — your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."""
 
-__version__ = "0.10.6"
+__version__ = "0.10.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mureo"
-version = "0.10.6"
+version = "0.10.7"
 description = "Your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/tests/test_version_staleness.py
+++ b/tests/test_version_staleness.py
@@ -31,8 +31,15 @@ class TestStalenessWarning:
         """A dev/editable checkout ahead of the published dist must not nag."""
         assert vs.staleness_warning(running="0.11.0", installed="0.10.6") is None
 
-    def test_missing_installed_is_silent(self) -> None:
-        assert vs.staleness_warning(running="0.10.6", installed=None) is None
+    def test_missing_installed_is_silent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # ``installed=None`` means "look it up", so to exercise the genuinely
+        # missing-metadata path stub the lookup to None. (Passing a literal
+        # version would couple this test to the current release number — which
+        # is exactly what broke it on a version bump.)
+        monkeypatch.setattr(vs, "installed_version", lambda: None)
+        assert vs.staleness_warning(running="0.10.6") is None
 
     def test_invalid_version_is_silent(self) -> None:
         assert vs.staleness_warning(running="0.10.6", installed="not-a-version") is None


### PR DESCRIPTION
Release **0.10.7**. Bumps version across `pyproject.toml` / `mureo/__init__.py` / `.claude-plugin/plugin.json` and finalizes the CHANGELOG.

## Included
- **Added** — Configure UI: Advanced menu + External advisor MCP management (list/add/delete, safe writes, form UX with examples) (#288 / #290)
- **Added** — Warn when the running MCP server is older than the installed mureo (#287)
- **Fixed** — Operation Mode chosen from campaign maturity, not mureo setup recency (#286)
- _(internal)_ de-flake launchd install retry tests (#289)

## After merge
Tag `v0.10.7` + publish a GitHub Release → `release.yml` publishes to PyPI.