### PR TITLE
feat(state): STATE.json performance metrics + sync-state persistence (a+b)

### DIFF
--- a/mureo/_data/skills/sync-state/SKILL.md
+++ b/mureo/_data/skills/sync-state/SKILL.md
@@ -2,7 +2,7 @@
 name: sync-state
 description: "Sync STATE.json with current campaign data from all platforms. Use when the user asks to refresh state, sync campaigns, update STATE.json from live data, or pull latest campaign snapshots."
 metadata:
-  version: 0.7.1
+  version: 0.8.0
 ---
 
 # Sync State
@@ -21,8 +21,8 @@ Synchronize STATE.json with the current state of all marketing platforms.
 2. **Discover platforms**: Identify all platforms registered in STATE.json `platforms`.
 
 3. **Fetch platform data**: For each registered platform:
-   - **Google Ads**: prefer mureo native — call `google_ads_campaigns_list`, then `google_ads_performance_report` for the current period (last 30 days). Both work in BYOD and Live API modes. If mureo's Google Ads tools are unavailable (e.g. `MUREO_DISABLE_GOOGLE_ADS=1` after `mureo providers add google-ads-official`), fall back to the official `google-ads-official` MCP's equivalent campaign-list and performance-report tools for the same period.
-   - **Meta Ads**: prefer mureo native — call `meta_ads_campaigns_list`, then `meta_ads_insights_report` for the current period — capture `result_indicator` per campaign so STATE.json reflects whether each campaign's "results" are clicks or real leads. If mureo's Meta Ads tools are unavailable, fall back to the official `meta-ads-official` hosted MCP for the campaign list and insights; the `result_indicator` field is mureo-specific and will not be present — record the raw optimization goal / actions list per campaign in STATE.json instead and note that CV-definition disambiguation requires mureo's native MCP.
+   - **Google Ads**: prefer mureo native — call `google_ads_campaigns_list`, then `google_ads_performance_report` for the current period (last 30 days). Both work in BYOD and Live API modes. Keep the per-campaign numbers from the performance report — they become each campaign's `metrics` in step 7. If mureo's Google Ads tools are unavailable (e.g. `MUREO_DISABLE_GOOGLE_ADS=1` after `mureo providers add google-ads-official`), fall back to the official `google-ads-official` MCP's equivalent campaign-list and performance-report tools for the same period.
+   - **Meta Ads**: prefer mureo native — call `meta_ads_campaigns_list`, then `meta_ads_insights_report` for the current period — capture `result_indicator` per campaign so STATE.json reflects whether each campaign's "results" are clicks or real leads, and keep the per-campaign insight numbers for the `metrics` write in step 7. If mureo's Meta Ads tools are unavailable, fall back to the official `meta-ads-official` hosted MCP for the campaign list and insights; the `result_indicator` field is mureo-specific and will not be present — record the raw optimization goal / actions list per campaign in STATE.json instead and note that CV-definition disambiguation requires mureo's native MCP.
    - mureo BYOD data is centralized in the workspace `byod/` directory (or `~/.mureo/byod/` for legacy CLI users) and is only accessible through mureo MCP tools — do **not** look for raw CSVs in the project directory.
 
 4. **Check data sources**: If Search Console is configured, verify site access is still valid. If GA4 is available, verify connectivity.
@@ -31,7 +31,7 @@ Synchronize STATE.json with the current state of all marketing platforms.
 
 6. **Verify STRATEGY.md Data Sources**: If STRATEGY.md is missing a `## Data Sources` section (older setup), prompt the user to add it listing all configured platforms.
 
-7. **Update STATE.json** with all campaign snapshots.
+7. **Update STATE.json** with all campaign snapshots. For each campaign, also write the `metrics` you fetched in step 3 onto the snapshot: `spend`, `impressions`, `clicks`, `conversions`, `cpa`, `ctr`, the Meta `result_indicator` (when present), `period` (e.g. `LAST_30_DAYS`), and `fetched_at` (ISO 8601). On Code use `Write`; on Desktop / Cowork call `mureo_state_upsert_campaign` with the `metrics` object. Record the per-platform rollup on each `platforms[<platform>]` entry too — `totals` (summed `spend` / `clicks` / `conversions` / etc.) and `metrics_period` (the period the totals cover) — so the reporting dashboard can render KPIs from STATE.json without re-querying. All metric fields are optional: omit any a platform doesn't provide rather than writing nulls.
 
 8. **Show diff**: Compare old vs new state and highlight changes:
    - New campaigns added

--- a/mureo/context/models.py
+++ b/mureo/context/models.py
@@ -33,6 +33,13 @@ class CampaignSnapshot:
     device_targeting: tuple[dict[str, Any], ...] | None = None
     campaign_goal: str | None = None
     notes: str | None = None
+    # Optional performance metrics for the read-only reporting dashboard.
+    # Validation stays loose (free-form dict); intended keys are:
+    #   spend, impressions, clicks, conversions, cpa, ctr,
+    #   result_indicator (Meta: whether "results" are clicks vs leads),
+    #   period (e.g. "LAST_30_DAYS"), fetched_at (ISO 8601).
+    # Optional with a None default so old STATE.json files parse unchanged.
+    metrics: dict[str, Any] | None = None
 
     def __post_init__(self) -> None:
         """Take defensive copies of mutable fields."""
@@ -44,6 +51,8 @@ class CampaignSnapshot:
             # Convert lists to tuples and deepcopy contents
             copied = tuple(copy.deepcopy(item) for item in self.device_targeting)
             object.__setattr__(self, "device_targeting", copied)
+        if self.metrics is not None:
+            object.__setattr__(self, "metrics", copy.deepcopy(self.metrics))
 
 
 @dataclass(frozen=True)
@@ -99,11 +108,18 @@ class PlatformState:
 
     account_id: str
     campaigns: tuple[CampaignSnapshot, ...] = field(default_factory=tuple)
+    # Optional platform-level metric rollup (e.g. {"spend": ..., "clicks": ...})
+    # and the period those totals cover (e.g. "LAST_30_DAYS"). Both default to
+    # None so legacy platform entries parse unchanged and emit no extra keys.
+    totals: dict[str, Any] | None = None
+    metrics_period: str | None = None
 
     def __post_init__(self) -> None:
         """Ensure campaigns is a tuple (defensive copy)."""
         if not isinstance(self.campaigns, tuple):
             object.__setattr__(self, "campaigns", tuple(self.campaigns))
+        if self.totals is not None:
+            object.__setattr__(self, "totals", copy.deepcopy(self.totals))
 
 
 @dataclass(frozen=True)
@@ -120,6 +136,11 @@ class StateDocument:
     action_log: tuple[ActionLogEntry, ...] = field(
         default_factory=tuple
     )  # v2: action log
+    # Forward-ready section for stage-c analysis summaries (e.g.
+    # {"daily": ..., "weekly": ..., "goal": ...}). Round-tripped now; no
+    # skill writes it yet. Optional with a None default so old STATE.json
+    # files parse unchanged and emit no extra key.
+    reports: dict[str, Any] | None = None
 
     def __post_init__(self) -> None:
         """Defensive copies for mutable fields."""
@@ -127,3 +148,5 @@ class StateDocument:
             object.__setattr__(self, "platforms", dict(self.platforms))
         if not isinstance(self.action_log, tuple):
             object.__setattr__(self, "action_log", tuple(self.action_log))
+        if self.reports is not None:
+            object.__setattr__(self, "reports", copy.deepcopy(self.reports))

--- a/mureo/context/state.py
+++ b/mureo/context/state.py
@@ -49,6 +49,8 @@ def parse_state(text: str) -> StateDocument:
             platforms[platform_key] = PlatformState(
                 account_id=platform_data["account_id"],
                 campaigns=platform_campaigns,
+                totals=platform_data.get("totals"),
+                metrics_period=platform_data.get("metrics_period"),
             )
 
     # v2: action_log
@@ -62,6 +64,7 @@ def parse_state(text: str) -> StateDocument:
         campaigns=campaigns,
         platforms=platforms,
         action_log=action_log,
+        reports=data.get("reports"),
     )
 
 
@@ -100,6 +103,7 @@ def _parse_campaign(c: dict[str, Any]) -> CampaignSnapshot:
         device_targeting=device_targeting,
         campaign_goal=c.get("campaign_goal"),
         notes=c.get("notes"),
+        metrics=c.get("metrics"),
     )
 
 
@@ -123,15 +127,26 @@ def render_state(doc: StateDocument) -> str:
     # v2: action_log
     data["action_log"] = [_action_log_entry_to_dict(e) for e in doc.action_log]
 
+    # Optional reports section (stage-c forward-ready): emit only when present
+    # so old STATE.json files don't gain a new key.
+    if doc.reports is not None:
+        data["reports"] = copy.deepcopy(doc.reports)
+
     return json.dumps(data, ensure_ascii=False, indent=2)
 
 
 def _platform_state_to_dict(ps: PlatformState) -> dict[str, Any]:
     """Convert a PlatformState to a dictionary."""
-    return {
+    result: dict[str, Any] = {
         "account_id": ps.account_id,
         "campaigns": [_snapshot_to_dict(c) for c in ps.campaigns],
     }
+    # Optional platform-level rollup: emit only when present.
+    if ps.totals is not None:
+        result["totals"] = copy.deepcopy(ps.totals)
+    if ps.metrics_period is not None:
+        result["metrics_period"] = ps.metrics_period
+    return result
 
 
 def _action_log_entry_to_dict(e: ActionLogEntry) -> dict[str, Any]:
@@ -163,7 +178,7 @@ def _snapshot_to_dict(c: CampaignSnapshot) -> dict[str, Any]:
     device_targeting: list[dict[str, Any]] | None = None
     if c.device_targeting is not None:
         device_targeting = list(c.device_targeting)
-    return {
+    result: dict[str, Any] = {
         "campaign_id": c.campaign_id,
         "campaign_name": c.campaign_name,
         "status": c.status,
@@ -174,6 +189,11 @@ def _snapshot_to_dict(c: CampaignSnapshot) -> dict[str, Any]:
         "campaign_goal": c.campaign_goal,
         "notes": c.notes,
     }
+    # Optional metrics: emit only when present so old STATE.json files don't
+    # gain a new key (no diff churn / bloat).
+    if c.metrics is not None:
+        result["metrics"] = copy.deepcopy(c.metrics)
+    return result
 
 
 def _atomic_write(path: Path, content: str) -> None:
@@ -307,6 +327,11 @@ def upsert_campaign(
             campaigns=_upsert_into(
                 existing.campaigns if existing is not None else (), campaign
             ),
+            # Preserve the platform-level rollup: it has no upsert input, so
+            # a campaign upsert must inherit it rather than reset it to None
+            # (otherwise every upsert silently wipes the dashboard KPIs).
+            totals=existing.totals if existing is not None else None,
+            metrics_period=existing.metrics_period if existing is not None else None,
         )
 
         return StateDocument(

--- a/mureo/mcp/_handlers_mureo_context.py
+++ b/mureo/mcp/_handlers_mureo_context.py
@@ -214,6 +214,7 @@ async def handle_state_upsert_campaign(
         device_targeting=device_targeting,
         campaign_goal=raw.get("campaign_goal"),
         notes=raw.get("notes"),
+        metrics=raw.get("metrics"),
     )
     path = _resolve_path(arguments, "STATE.json", store_attr="state_path")
     try:

--- a/mureo/mcp/tools_mureo_context.py
+++ b/mureo/mcp/tools_mureo_context.py
@@ -70,7 +70,9 @@ _CAMPAIGN_PROPERTY = {
         "account_id. The platform + account_id populate the per-platform "
         "``platforms`` section the dashboard reads (omit them and the "
         "client renders as inactive). Optional fields mirror the snapshot "
-        "schema in docs/strategy-context.md."
+        "schema in docs/strategy-context.md, including ``metrics`` "
+        "(spend / impressions / clicks / conversions / cpa / ctr / "
+        "result_indicator / period / fetched_at) for dashboard KPIs."
     ),
     "properties": {
         "campaign_id": {"type": "string"},
@@ -96,6 +98,15 @@ _CAMPAIGN_PROPERTY = {
         "device_targeting": {"type": "array"},
         "campaign_goal": {"type": "string"},
         "notes": {"type": "string"},
+        "metrics": {
+            "type": "object",
+            "description": (
+                "Optional performance metrics for the reporting dashboard: "
+                "spend, impressions, clicks, conversions, cpa, ctr, "
+                "result_indicator (Meta: clicks vs leads), period (e.g. "
+                "``LAST_30_DAYS``), fetched_at (ISO 8601)."
+            ),
+        },
     },
     "required": [
         "campaign_id",
@@ -179,7 +190,10 @@ TOOLS: list[Tool] = [
             "Atomically upsert a CampaignSnapshot into STATE.json (root "
             "campaigns array). Use this to keep STATE.json in sync with "
             "campaign metadata changes the agent observes via vendor "
-            "MCPs or BYOD imports."
+            "MCPs or BYOD imports. Pass the optional ``metrics`` object to "
+            "persist the campaign's performance numbers (spend, clicks, "
+            "conversions, cpa, ctr, …) so the reporting dashboard can "
+            "render KPIs from STATE.json."
         ),
         inputSchema={
             "type": "object",

--- a/skills/sync-state/SKILL.md
+++ b/skills/sync-state/SKILL.md
@@ -2,7 +2,7 @@
 name: sync-state
 description: "Sync STATE.json with current campaign data from all platforms. Use when the user asks to refresh state, sync campaigns, update STATE.json from live data, or pull latest campaign snapshots."
 metadata:
-  version: 0.7.1
+  version: 0.8.0
 ---
 
 # Sync State
@@ -21,8 +21,8 @@ Synchronize STATE.json with the current state of all marketing platforms.
 2. **Discover platforms**: Identify all platforms registered in STATE.json `platforms`.
 
 3. **Fetch platform data**: For each registered platform:
-   - **Google Ads**: prefer mureo native — call `google_ads_campaigns_list`, then `google_ads_performance_report` for the current period (last 30 days). Both work in BYOD and Live API modes. If mureo's Google Ads tools are unavailable (e.g. `MUREO_DISABLE_GOOGLE_ADS=1` after `mureo providers add google-ads-official`), fall back to the official `google-ads-official` MCP's equivalent campaign-list and performance-report tools for the same period.
-   - **Meta Ads**: prefer mureo native — call `meta_ads_campaigns_list`, then `meta_ads_insights_report` for the current period — capture `result_indicator` per campaign so STATE.json reflects whether each campaign's "results" are clicks or real leads. If mureo's Meta Ads tools are unavailable, fall back to the official `meta-ads-official` hosted MCP for the campaign list and insights; the `result_indicator` field is mureo-specific and will not be present — record the raw optimization goal / actions list per campaign in STATE.json instead and note that CV-definition disambiguation requires mureo's native MCP.
+   - **Google Ads**: prefer mureo native — call `google_ads_campaigns_list`, then `google_ads_performance_report` for the current period (last 30 days). Both work in BYOD and Live API modes. Keep the per-campaign numbers from the performance report — they become each campaign's `metrics` in step 7. If mureo's Google Ads tools are unavailable (e.g. `MUREO_DISABLE_GOOGLE_ADS=1` after `mureo providers add google-ads-official`), fall back to the official `google-ads-official` MCP's equivalent campaign-list and performance-report tools for the same period.
+   - **Meta Ads**: prefer mureo native — call `meta_ads_campaigns_list`, then `meta_ads_insights_report` for the current period — capture `result_indicator` per campaign so STATE.json reflects whether each campaign's "results" are clicks or real leads, and keep the per-campaign insight numbers for the `metrics` write in step 7. If mureo's Meta Ads tools are unavailable, fall back to the official `meta-ads-official` hosted MCP for the campaign list and insights; the `result_indicator` field is mureo-specific and will not be present — record the raw optimization goal / actions list per campaign in STATE.json instead and note that CV-definition disambiguation requires mureo's native MCP.
    - mureo BYOD data is centralized in the workspace `byod/` directory (or `~/.mureo/byod/` for legacy CLI users) and is only accessible through mureo MCP tools — do **not** look for raw CSVs in the project directory.
 
 4. **Check data sources**: If Search Console is configured, verify site access is still valid. If GA4 is available, verify connectivity.
@@ -31,7 +31,7 @@ Synchronize STATE.json with the current state of all marketing platforms.
 
 6. **Verify STRATEGY.md Data Sources**: If STRATEGY.md is missing a `## Data Sources` section (older setup), prompt the user to add it listing all configured platforms.
 
-7. **Update STATE.json** with all campaign snapshots.
+7. **Update STATE.json** with all campaign snapshots. For each campaign, also write the `metrics` you fetched in step 3 onto the snapshot: `spend`, `impressions`, `clicks`, `conversions`, `cpa`, `ctr`, the Meta `result_indicator` (when present), `period` (e.g. `LAST_30_DAYS`), and `fetched_at` (ISO 8601). On Code use `Write`; on Desktop / Cowork call `mureo_state_upsert_campaign` with the `metrics` object. Record the per-platform rollup on each `platforms[<platform>]` entry too — `totals` (summed `spend` / `clicks` / `conversions` / etc.) and `metrics_period` (the period the totals cover) — so the reporting dashboard can render KPIs from STATE.json without re-querying. All metric fields are optional: omit any a platform doesn't provide rather than writing nulls.
 
 8. **Show diff**: Compare old vs new state and highlight changes:
    - New campaigns added

--- a/tests/test_mcp_tools_mureo_context.py
+++ b/tests/test_mcp_tools_mureo_context.py
@@ -338,6 +338,64 @@ async def test_upsert_campaign_updates_existing(cwd_to_tmp) -> None:
         assert ids.count("camp_xyz") <= 1
 
 
+async def test_upsert_campaign_persists_metrics(cwd_to_tmp) -> None:
+    """Stage a+b: an upsert carrying a ``metrics`` object persists it and
+    round-trips via a subsequent read."""
+    initial = {"version": "2", "platforms": {}, "action_log": []}
+    (cwd_to_tmp / "STATE.json").write_text(json.dumps(initial), encoding="utf-8")
+    mod = _import_tools()
+    campaign = {
+        "campaign_id": "camp_xyz",
+        "campaign_name": "Generic",
+        "status": "ENABLED",
+        "daily_budget": 5000,
+        "platform": "google_ads",
+        "account_id": "act_123",
+        "metrics": {
+            "spend": 12345.0,
+            "impressions": 10000,
+            "clicks": 250,
+            "conversions": 12,
+            "cpa": 1028.75,
+            "ctr": 0.025,
+            "period": "LAST_30_DAYS",
+            "fetched_at": "2026-06-17T00:00:00+00:00",
+        },
+    }
+    await mod.handle_tool("mureo_state_upsert_campaign", {"campaign": campaign})
+
+    # Round-trip via a fresh read of STATE.json.
+    result = await mod.handle_tool("mureo_state_get", {})
+    payload = json.loads(result[0].text)
+    plat = payload["platforms"]["google_ads"]
+    snap = next(c for c in plat["campaigns"] if c["campaign_id"] == "camp_xyz")
+    assert snap["metrics"]["spend"] == 12345.0
+    assert snap["metrics"]["conversions"] == 12
+    assert snap["metrics"]["period"] == "LAST_30_DAYS"
+
+
+async def test_upsert_campaign_without_metrics_still_works(cwd_to_tmp) -> None:
+    """Regression: an upsert with no ``metrics`` key still succeeds and the
+    persisted snapshot carries no ``metrics`` field."""
+    initial = {"version": "2", "platforms": {}, "action_log": []}
+    (cwd_to_tmp / "STATE.json").write_text(json.dumps(initial), encoding="utf-8")
+    mod = _import_tools()
+    campaign = {
+        "campaign_id": "camp_abc",
+        "campaign_name": "Brand",
+        "status": "ENABLED",
+        "platform": "google_ads",
+        "account_id": "act_123",
+    }
+    result = await mod.handle_tool(
+        "mureo_state_upsert_campaign", {"campaign": campaign}
+    )
+    payload = json.loads(result[0].text)
+    plat = payload["platforms"]["google_ads"]
+    snap = next(c for c in plat["campaigns"] if c["campaign_id"] == "camp_abc")
+    assert "metrics" not in snap
+
+
 # ---------------------------------------------------------------------------
 # Path traversal gate (security)
 # ---------------------------------------------------------------------------

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -222,6 +222,47 @@ class TestStateFile:
         assert reloaded.last_synced_at is not None
 
     @pytest.mark.unit
+    def test_upsert_campaign_preserves_platform_rollup(self, tmp_path: Path) -> None:
+        """A campaign upsert must NOT wipe the platform's totals/metrics_period.
+
+        Those have no upsert input, so the read-modify-write must inherit them
+        — otherwise every sync-state campaign upsert silently destroys the
+        dashboard KPIs (regression guard for the rollup-preservation fix).
+        """
+        fp = tmp_path / "STATE.json"
+        doc = StateDocument(
+            platforms={
+                "google_ads": PlatformState(
+                    account_id="123",
+                    campaigns=(
+                        CampaignSnapshot(
+                            campaign_id="1", campaign_name="A", status="ENABLED"
+                        ),
+                    ),
+                    totals={"spend": 100, "conversions": 5},
+                    metrics_period="LAST_30_DAYS",
+                )
+            },
+        )
+        write_state_file(fp, doc)
+
+        new_doc = upsert_campaign(
+            fp,
+            CampaignSnapshot(campaign_id="2", campaign_name="B", status="ENABLED"),
+            platform="google_ads",
+            account_id="123",
+        )
+
+        ga = new_doc.platforms["google_ads"]
+        assert ga.totals == {"spend": 100, "conversions": 5}
+        assert ga.metrics_period == "LAST_30_DAYS"
+        assert {c.campaign_id for c in ga.campaigns} == {"1", "2"}
+        # And it survives the round-trip to disk.
+        reloaded = read_state_file(fp).platforms["google_ads"]
+        assert reloaded.totals == {"spend": 100, "conversions": 5}
+        assert reloaded.metrics_period == "LAST_30_DAYS"
+
+    @pytest.mark.unit
     def test_upsert_campaign_new(self, tmp_path: Path) -> None:
         """Add new campaign."""
         fp = tmp_path / "STATE.json"
@@ -938,6 +979,255 @@ class TestAppendActionLog:
         updated = append_action_log(fp, entry)
         assert fp.exists()
         assert len(updated.action_log) == 1
+
+
+class TestStatePerformanceMetrics:
+    """Stage a+b: optional performance metrics on snapshots / platforms /
+    document. All fields are OPTIONAL with safe defaults so old STATE.json
+    files (without them) parse unchanged and emit no extra keys."""
+
+    @pytest.mark.unit
+    def test_campaign_metrics_defaults_to_none(self) -> None:
+        """CampaignSnapshot.metrics defaults to None."""
+        snap = CampaignSnapshot(
+            campaign_id="1", campaign_name="C", status="ENABLED"
+        )
+        assert snap.metrics is None
+
+    @pytest.mark.unit
+    def test_campaign_metrics_defensive_copy(self) -> None:
+        """metrics dict is defensively deep-copied on init."""
+        original: dict[str, Any] = {"spend": 1000, "nested": {"cpa": 5200}}
+        snap = CampaignSnapshot(
+            campaign_id="1",
+            campaign_name="C",
+            status="ENABLED",
+            metrics=original,
+        )
+        original["spend"] = 9999
+        original["nested"]["cpa"] = 1
+        assert snap.metrics is not None
+        assert snap.metrics["spend"] == 1000
+        assert snap.metrics["nested"]["cpa"] == 5200
+
+    @pytest.mark.unit
+    def test_platform_state_metrics_defaults(self) -> None:
+        """PlatformState.totals / metrics_period default to None."""
+        ps = PlatformState(account_id="123")
+        assert ps.totals is None
+        assert ps.metrics_period is None
+
+    @pytest.mark.unit
+    def test_platform_state_totals_defensive_copy(self) -> None:
+        """PlatformState.totals dict is defensively deep-copied on init."""
+        totals: dict[str, Any] = {"spend": 5000, "nested": {"clicks": 12}}
+        ps = PlatformState(account_id="123", totals=totals)
+        totals["spend"] = 1
+        totals["nested"]["clicks"] = 0
+        assert ps.totals is not None
+        assert ps.totals["spend"] == 5000
+        assert ps.totals["nested"]["clicks"] == 12
+
+    @pytest.mark.unit
+    def test_state_document_reports_defaults_to_none(self) -> None:
+        """StateDocument.reports defaults to None."""
+        doc = StateDocument()
+        assert doc.reports is None
+
+    @pytest.mark.unit
+    def test_state_document_reports_defensive_copy(self) -> None:
+        """StateDocument.reports dict is defensively deep-copied on init."""
+        reports: dict[str, Any] = {"daily": {"summary": "ok"}}
+        doc = StateDocument(reports=reports)
+        reports["daily"]["summary"] = "changed"
+        assert doc.reports is not None
+        assert doc.reports["daily"]["summary"] == "ok"
+
+    @pytest.mark.unit
+    def test_parse_campaign_metrics(self) -> None:
+        """Parse a campaign carrying a metrics object."""
+        data = {
+            "campaigns": [
+                {
+                    "campaign_id": "1",
+                    "campaign_name": "C",
+                    "status": "ENABLED",
+                    "metrics": {
+                        "spend": 12345.0,
+                        "impressions": 10000,
+                        "clicks": 250,
+                        "conversions": 12,
+                        "cpa": 1028.75,
+                        "ctr": 0.025,
+                        "result_indicator": "leads",
+                        "period": "LAST_30_DAYS",
+                        "fetched_at": "2026-06-17T00:00:00+00:00",
+                    },
+                }
+            ]
+        }
+        doc = parse_state(json.dumps(data))
+        metrics = doc.campaigns[0].metrics
+        assert metrics is not None
+        assert metrics["spend"] == 12345.0
+        assert metrics["result_indicator"] == "leads"
+        assert metrics["period"] == "LAST_30_DAYS"
+
+    @pytest.mark.unit
+    def test_parse_campaign_without_metrics_defaults_none(self) -> None:
+        """A campaign with no metrics key parses to None (backward compat)."""
+        data = {
+            "campaigns": [
+                {"campaign_id": "1", "campaign_name": "C", "status": "ENABLED"}
+            ]
+        }
+        doc = parse_state(json.dumps(data))
+        assert doc.campaigns[0].metrics is None
+
+    @pytest.mark.unit
+    def test_render_campaign_metrics_roundtrip(self) -> None:
+        """metrics round-trips through render -> parse."""
+        metrics = {
+            "spend": 1000.0,
+            "clicks": 50,
+            "conversions": 5,
+            "cpa": 200.0,
+            "period": "LAST_30_DAYS",
+            "fetched_at": "2026-06-17T00:00:00+00:00",
+        }
+        doc = StateDocument(
+            campaigns=(
+                CampaignSnapshot(
+                    campaign_id="1",
+                    campaign_name="C",
+                    status="ENABLED",
+                    metrics=metrics,
+                ),
+            ),
+        )
+        restored = parse_state(render_state(doc))
+        assert restored.campaigns[0].metrics == metrics
+
+    @pytest.mark.unit
+    def test_render_campaign_omits_none_metrics(self) -> None:
+        """metrics is omitted from JSON when None (no diff churn)."""
+        doc = StateDocument(
+            campaigns=(
+                CampaignSnapshot(
+                    campaign_id="1", campaign_name="C", status="ENABLED"
+                ),
+            ),
+        )
+        rendered = render_state(doc)
+        snap_dict = json.loads(rendered)["campaigns"][0]
+        assert "metrics" not in snap_dict
+
+    @pytest.mark.unit
+    def test_render_platform_totals_and_period_roundtrip(self) -> None:
+        """PlatformState.totals / metrics_period round-trip."""
+        ps = PlatformState(
+            account_id="123",
+            campaigns=(
+                CampaignSnapshot(
+                    campaign_id="1", campaign_name="C", status="ENABLED"
+                ),
+            ),
+            totals={"spend": 5000.0, "conversions": 20},
+            metrics_period="LAST_30_DAYS",
+        )
+        doc = StateDocument(version="2", platforms={"google_ads": ps})
+        restored = parse_state(render_state(doc))
+        rp = restored.platforms["google_ads"]
+        assert rp.totals == {"spend": 5000.0, "conversions": 20}
+        assert rp.metrics_period == "LAST_30_DAYS"
+
+    @pytest.mark.unit
+    def test_render_platform_omits_none_totals_and_period(self) -> None:
+        """totals / metrics_period are omitted from JSON when None."""
+        ps = PlatformState(account_id="123")
+        doc = StateDocument(version="2", platforms={"google_ads": ps})
+        plat_dict = json.loads(render_state(doc))["platforms"]["google_ads"]
+        assert "totals" not in plat_dict
+        assert "metrics_period" not in plat_dict
+
+    @pytest.mark.unit
+    def test_parse_platform_without_metrics_defaults_none(self) -> None:
+        """Legacy platform entry (no totals/metrics_period) parses to None."""
+        data = {
+            "version": "2",
+            "platforms": {
+                "google_ads": {
+                    "account_id": "123",
+                    "campaigns": [
+                        {
+                            "campaign_id": "1",
+                            "campaign_name": "C",
+                            "status": "ENABLED",
+                        }
+                    ],
+                }
+            },
+        }
+        doc = parse_state(json.dumps(data))
+        ps = doc.platforms["google_ads"]
+        assert ps.totals is None
+        assert ps.metrics_period is None
+
+    @pytest.mark.unit
+    def test_render_reports_roundtrip(self) -> None:
+        """StateDocument.reports round-trips through render -> parse."""
+        reports = {
+            "daily": {"summary": "healthy"},
+            "weekly": {"summary": "watch"},
+            "goal": {"progress": 0.8},
+        }
+        doc = StateDocument(version="2", reports=reports)
+        restored = parse_state(render_state(doc))
+        assert restored.reports == reports
+
+    @pytest.mark.unit
+    def test_render_omits_none_reports(self) -> None:
+        """reports is omitted from JSON when None."""
+        doc = StateDocument(version="2")
+        assert "reports" not in render_state(doc)
+
+    @pytest.mark.unit
+    def test_old_state_json_parses_to_safe_defaults(self) -> None:
+        """A complete old STATE.json (no metrics/totals/reports) parses
+        with every new field defaulting to None — the hard backward-compat
+        requirement."""
+        old = {
+            "version": "2",
+            "last_synced_at": "2026-04-03T10:00:00Z",
+            "customer_id": "1234567890",
+            "campaigns": [
+                {"campaign_id": "111", "campaign_name": "G", "status": "ENABLED"}
+            ],
+            "platforms": {
+                "google_ads": {
+                    "account_id": "1234567890",
+                    "campaigns": [
+                        {
+                            "campaign_id": "111",
+                            "campaign_name": "G",
+                            "status": "ENABLED",
+                        }
+                    ],
+                }
+            },
+            "action_log": [],
+        }
+        doc = parse_state(json.dumps(old))
+        assert doc.campaigns[0].metrics is None
+        assert doc.platforms["google_ads"].totals is None
+        assert doc.platforms["google_ads"].metrics_period is None
+        assert doc.reports is None
+        # And re-rendering does NOT introduce any of the new keys.
+        rendered = render_state(doc)
+        assert "metrics" not in rendered
+        assert "totals" not in rendered
+        assert "metrics_period" not in rendered
+        assert "reports" not in rendered
 
 
 class TestRenderParseV2Roundtrip:


### PR DESCRIPTION
## Summary
Stage **a+b** of the configure reporting-dashboard plan. STATE.json could not hold performance numbers (CampaignSnapshot had only structure: name/status/budget/bidding/goal), so the dashboard (Option A — render KPIs from STATE.json) lacked data. This adds optional metrics to the schema and makes `sync-state` persist what it already fetches.

## Changes (backward compatible — all new fields optional, emitted only when present)
- **models**: `CampaignSnapshot.metrics`, `PlatformState.totals` / `metrics_period`, `StateDocument.reports` (forward-ready for stage-c). None defaults, defensive-copied.
- **state.py**: round-trip the new fields; old STATE.json parses unchanged with no diff churn. `upsert_campaign` now **preserves** `totals`/`metrics_period` (they have no upsert input) so a campaign upsert never wipes the dashboard rollup.
- **mureo_state_upsert_campaign**: accepts optional `metrics` (validated by the #277 dispatcher schema pass).
- **sync-state skill** (canonical + bundled, byte-identical): persist the metrics already fetched from `*_performance_report` / `*_insights_report` per campaign + per-platform `totals`/`metrics_period`.

## Backward compatibility
Old STATE.json (no metrics/totals/reports) parses to `None` and re-renders without the keys. Verified all consumers (state_store, byod_actions, _handlers_analysis, context_builder, _handlers_rollback, tools_analytics_registry, open_cmd) only read pre-existing fields.

## Test plan
- [x] `tests/test_state.py` (round-trip incl. metrics/totals/reports; backward-compat old-file parse; defensive-copy; **upsert preserves platform rollup** regression).
- [x] `tests/test_mcp_tools_mureo_context.py` (upsert with/without metrics).
- [x] `tests/test_plugin_manifests.py` skill byte-parity.
- [x] `ruff` / `black --check` / `mypy` on `mureo/` clean. Two reviews (code-reviewer agent + /code-review skill); a CRITICAL rollup-wipe bug was found and fixed + regression-tested.
- [x] Full suite: 4500 passed (6 pre-existing local plugin-env-noise failures, unaffected in clean CI).

_Stages **c** (analysis-skill summary write-back to `reports`) and **d** (metric vocabulary unification) follow, then the dashboard UI._