### PR TITLE
feat(state): analysis skills persist report summaries to STATE.json (stage c)

### DIFF
--- a/mureo/_data/skills/daily-check/SKILL.md
+++ b/mureo/_data/skills/daily-check/SKILL.md
@@ -73,3 +73,12 @@ Run a daily health check on all marketing accounts using the strategy context.
     For each issue, suggest specific actions aligned with the current Operation Mode. Do NOT recommend actions based on single-day fluctuations — at least 7 consecutive days of critical metrics (>30% off target) before suggesting rescue.
 
 11. **Update STATE.json**: Update campaign snapshots, add notes for flagged issues, and log this daily check to the `action_log` with a summary of findings.
+
+12. **Persist the report summary** (best-effort): Call `mureo_state_report_set` with `report="daily"` and a concise `summary` object so the read-only dashboard can render this report without re-running you. Follow this convention:
+    - `generated_at`: ISO 8601 timestamp of this run
+    - `period`: the day reviewed (e.g. `"2026-06-17"`)
+    - `kpis`: per-platform and/or totals headline numbers (spend, conversions, cpa, ctr)
+    - `flags`: a list of notable items (e.g. `["cpa_over_target_google_ads"]`)
+    - `narrative`: a short text summary (the Healthy / Watch / Action-needed verdict in 1-2 sentences)
+
+    This is best-effort: if `mureo_state_report_set` is unavailable (e.g. a pure file-mode host without the context MCP), skip it silently — the rest of this skill still works.

--- a/mureo/_data/skills/goal-review/SKILL.md
+++ b/mureo/_data/skills/goal-review/SKILL.md
@@ -65,4 +65,13 @@ Review progress toward all marketing goals across all platforms.
    - Log the review to `action_log` with a summary of Goal statuses
    - Update Current values in STRATEGY.md Goal sections if approved
 
+9. **Persist the report summary** (best-effort): Call `mureo_state_report_set` with `report="goal"` and a concise `summary` object so the read-only dashboard can render this review without re-running you. Follow this convention:
+   - `generated_at`: ISO 8601 timestamp of this run
+   - `period`: the assessment window or "as of" date
+   - `kpis`: per-Goal headline numbers (target, current, % of target achieved)
+   - `flags`: a list of notable items (e.g. `["goal_cpa_off_track"]`)
+   - `narrative`: a short text summary of overall Goal health (on-track / at-risk / off-track)
+
+   This is best-effort: if `mureo_state_report_set` is unavailable (e.g. a pure file-mode host without the context MCP), skip it silently — the rest of this skill still works.
+
 IMPORTANT: When updating Goal "Current" values in STRATEGY.md, ask for approval first.

--- a/mureo/_data/skills/weekly-report/SKILL.md
+++ b/mureo/_data/skills/weekly-report/SKILL.md
@@ -64,3 +64,12 @@ Generate a weekly marketing operations report.
     - Recommendations for next week
 
 11. **Log to action_log** in STATE.json that a weekly report was generated, including the reporting period.
+
+12. **Persist the report summary** (best-effort): Call `mureo_state_report_set` with `report="weekly"` and a concise `summary` object so the read-only dashboard can render this report without re-running you. Follow this convention:
+    - `generated_at`: ISO 8601 timestamp of this run
+    - `period`: the reporting window (e.g. `"LAST_7_DAYS"` or an explicit date range)
+    - `kpis`: per-platform and/or totals headline numbers (spend, conversions, cpa, week-over-week change)
+    - `flags`: a list of notable items (e.g. `["meta_ads_cpa_up_15pct"]`)
+    - `narrative`: the 2-3 sentence executive summary
+
+    This is best-effort: if `mureo_state_report_set` is unavailable (e.g. a pure file-mode host without the context MCP), skip it silently — the rest of this skill still works.

--- a/mureo/context/state.py
+++ b/mureo/context/state.py
@@ -368,6 +368,45 @@ def append_action_log(path: Path, entry: ActionLogEntry) -> StateDocument:
     return _locked_state_mutation(path, _build)
 
 
+def set_report(path: Path, report: str, summary: dict[str, Any]) -> StateDocument:
+    """Persist a structured analysis ``summary`` into STATE.json ``reports``.
+
+    Merges ``reports[report] = summary`` into the document's ``reports``
+    section (a free-form ``{"daily": ..., "weekly": ..., "goal": ...}`` map
+    the read-only dashboard renders), re-stamps ``last_synced_at``, and writes
+    back atomically. Other report keys and the rest of the document
+    (campaigns, platforms, action_log) are preserved. When ``reports`` is
+    ``None`` (old STATE.json), it starts from ``{}`` — so the call is
+    backward compatible.
+
+    Args:
+        path: STATE.json location.
+        report: Report kind key (``"daily"`` / ``"weekly"`` / ``"goal"``).
+        summary: The free-form summary object to store under that key.
+
+    Returns:
+        The updated :class:`StateDocument`.
+    """
+
+    def _build(doc: StateDocument) -> StateDocument:
+        # Start from a shallow copy of the existing reports (or {} when the
+        # document predates the reports section) so sibling report kinds are
+        # preserved rather than wiped.
+        reports = dict(doc.reports) if doc.reports else {}
+        reports[report] = summary
+        return StateDocument(
+            version=doc.version,
+            last_synced_at=_now_iso(),
+            customer_id=doc.customer_id,
+            campaigns=doc.campaigns,
+            platforms=doc.platforms,
+            action_log=doc.action_log,
+            reports=reports,
+        )
+
+    return _locked_state_mutation(path, _build)
+
+
 def get_campaign(doc: StateDocument, campaign_id: str) -> CampaignSnapshot | None:
     """Search for a campaign by campaign_id."""
     for c in doc.campaigns:

--- a/mureo/mcp/_handlers_mureo_context.py
+++ b/mureo/mcp/_handlers_mureo_context.py
@@ -36,6 +36,7 @@ from mureo.context.state import (
     append_action_log,
     read_state_file,
     render_state,
+    set_report,
     upsert_campaign,
 )
 from mureo.context.strategy import RAW_HEADING_TYPE, parse_strategy, write_strategy_file
@@ -224,4 +225,19 @@ async def handle_state_upsert_campaign(
         # path translates this into a clean tool-error response rather
         # than a 500-style server error.
         raise ValueError(str(exc)) from exc
+    return _json_result(_state_to_dict(doc))
+
+
+async def handle_state_report_set(
+    arguments: dict[str, Any],
+) -> list[TextContent]:
+    report = _require(arguments, "report")
+    summary = _require(arguments, "summary")
+    # The free-form summary must be a JSON object so it round-trips into the
+    # reports section and the dashboard can render it. Reject anything else
+    # (string / list / number) before it reaches the file.
+    if not isinstance(summary, dict):
+        raise ValueError("summary must be an object")
+    path = _resolve_path(arguments, "STATE.json", store_attr="state_path")
+    doc = set_report(path, report, summary)
     return _json_result(_state_to_dict(doc))

--- a/mureo/mcp/tools_mureo_context.py
+++ b/mureo/mcp/tools_mureo_context.py
@@ -1,6 +1,6 @@
 """mureo's STRATEGY.md / STATE.json MCP tool surface.
 
-Five tools that expose mureo's context layer over MCP, so any MCP host
+Six tools that expose mureo's context layer over MCP, so any MCP host
 (Claude Desktop chat, claude.ai web, Codex/Cursor, …) can read and
 update STRATEGY.md / STATE.json without direct filesystem access.
 
@@ -19,6 +19,7 @@ from mcp.types import Tool
 from mureo.mcp._handlers_mureo_context import (
     handle_state_action_log_append,
     handle_state_get,
+    handle_state_report_set,
     handle_state_upsert_campaign,
     handle_strategy_get,
     handle_strategy_set,
@@ -204,6 +205,45 @@ TOOLS: list[Tool] = [
             "required": ["campaign"],
         },
     ),
+    Tool(
+        name="mureo_state_report_set",
+        description=(
+            "Atomically persist a structured analysis report summary into "
+            "STATE.json's ``reports`` section so the read-only configure "
+            "dashboard can render the latest daily / weekly / goal report "
+            "without re-running the agent. ``report`` selects the kind "
+            "(daily / weekly / goal); ``summary`` is a free-form object — by "
+            "convention generated_at (ISO 8601), period, kpis (per-platform "
+            "/ totals headline numbers), flags (notable items), narrative "
+            "(short text). Other report kinds are preserved. Best-effort: a "
+            "skill should skip this silently where the context MCP is "
+            "unavailable. Returns the updated state document."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "report": {
+                    "type": "string",
+                    "enum": ["daily", "weekly", "goal"],
+                    "description": (
+                        "Report kind: ``daily`` (daily-check), ``weekly`` "
+                        "(weekly-report), or ``goal`` (goal-review)."
+                    ),
+                },
+                "summary": {
+                    "type": "object",
+                    "description": (
+                        "Free-form summary object. Convention: generated_at "
+                        "(ISO 8601), period, kpis (per-platform / totals "
+                        "headline numbers), flags (list of notable items), "
+                        "narrative (short text)."
+                    ),
+                },
+                "path": _PATH_PROPERTY,
+            },
+            "required": ["report", "summary"],
+        },
+    ),
 ]
 
 
@@ -213,6 +253,7 @@ _HANDLERS = {
     "mureo_state_get": handle_state_get,
     "mureo_state_action_log_append": handle_state_action_log_append,
     "mureo_state_upsert_campaign": handle_state_upsert_campaign,
+    "mureo_state_report_set": handle_state_report_set,
 }
 
 

--- a/skills/daily-check/SKILL.md
+++ b/skills/daily-check/SKILL.md
@@ -73,3 +73,12 @@ Run a daily health check on all marketing accounts using the strategy context.
     For each issue, suggest specific actions aligned with the current Operation Mode. Do NOT recommend actions based on single-day fluctuations — at least 7 consecutive days of critical metrics (>30% off target) before suggesting rescue.
 
 11. **Update STATE.json**: Update campaign snapshots, add notes for flagged issues, and log this daily check to the `action_log` with a summary of findings.
+
+12. **Persist the report summary** (best-effort): Call `mureo_state_report_set` with `report="daily"` and a concise `summary` object so the read-only dashboard can render this report without re-running you. Follow this convention:
+    - `generated_at`: ISO 8601 timestamp of this run
+    - `period`: the day reviewed (e.g. `"2026-06-17"`)
+    - `kpis`: per-platform and/or totals headline numbers (spend, conversions, cpa, ctr)
+    - `flags`: a list of notable items (e.g. `["cpa_over_target_google_ads"]`)
+    - `narrative`: a short text summary (the Healthy / Watch / Action-needed verdict in 1-2 sentences)
+
+    This is best-effort: if `mureo_state_report_set` is unavailable (e.g. a pure file-mode host without the context MCP), skip it silently — the rest of this skill still works.

--- a/skills/goal-review/SKILL.md
+++ b/skills/goal-review/SKILL.md
@@ -65,4 +65,13 @@ Review progress toward all marketing goals across all platforms.
    - Log the review to `action_log` with a summary of Goal statuses
    - Update Current values in STRATEGY.md Goal sections if approved
 
+9. **Persist the report summary** (best-effort): Call `mureo_state_report_set` with `report="goal"` and a concise `summary` object so the read-only dashboard can render this review without re-running you. Follow this convention:
+   - `generated_at`: ISO 8601 timestamp of this run
+   - `period`: the assessment window or "as of" date
+   - `kpis`: per-Goal headline numbers (target, current, % of target achieved)
+   - `flags`: a list of notable items (e.g. `["goal_cpa_off_track"]`)
+   - `narrative`: a short text summary of overall Goal health (on-track / at-risk / off-track)
+
+   This is best-effort: if `mureo_state_report_set` is unavailable (e.g. a pure file-mode host without the context MCP), skip it silently — the rest of this skill still works.
+
 IMPORTANT: When updating Goal "Current" values in STRATEGY.md, ask for approval first.

--- a/skills/weekly-report/SKILL.md
+++ b/skills/weekly-report/SKILL.md
@@ -64,3 +64,12 @@ Generate a weekly marketing operations report.
     - Recommendations for next week
 
 11. **Log to action_log** in STATE.json that a weekly report was generated, including the reporting period.
+
+12. **Persist the report summary** (best-effort): Call `mureo_state_report_set` with `report="weekly"` and a concise `summary` object so the read-only dashboard can render this report without re-running you. Follow this convention:
+    - `generated_at`: ISO 8601 timestamp of this run
+    - `period`: the reporting window (e.g. `"LAST_7_DAYS"` or an explicit date range)
+    - `kpis`: per-platform and/or totals headline numbers (spend, conversions, cpa, week-over-week change)
+    - `flags`: a list of notable items (e.g. `["meta_ads_cpa_up_15pct"]`)
+    - `narrative`: the 2-3 sentence executive summary
+
+    This is best-effort: if `mureo_state_report_set` is unavailable (e.g. a pure file-mode host without the context MCP), skip it silently — the rest of this skill still works.

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -43,11 +43,11 @@ class TestListTools:
 
     async def test_list_tools_returns_all_tools(self) -> None:
         """list_tools returns all tools (Google Ads 83 + Meta Ads 82 + Search Console 10
-        + Rollback 2 + Analysis 1 + Mureo Context 5 + Analytics Registry 1
-        + Learning 2 = 186)."""
+        + Rollback 2 + Analysis 1 + Mureo Context 6 + Analytics Registry 1
+        + Learning 2 = 187)."""
         mod = _import_server_module()
         tools = await mod.handle_list_tools()
-        assert len(tools) == 186
+        assert len(tools) == 187
 
     async def test_list_tools_contains_google_and_meta(self) -> None:
         """Google Ads and Meta Ads tools are included."""
@@ -213,3 +213,13 @@ class TestCallToolErrors:
         assert len(result) == 1
         assert result[0].type == "text"
         assert "Credentials not found" in result[0].text
+
+    async def test_report_set_invalid_report_rejected_by_schema(self) -> None:
+        """mureo_state_report_set with a ``report`` outside the enum is rejected
+        by the dispatcher's schema pass (#277) before any handler runs."""
+        mod = _import_server_module()
+        with pytest.raises(ValueError, match="report"):
+            await mod.handle_call_tool(
+                "mureo_state_report_set",
+                {"report": "monthly", "summary": {"narrative": "x"}},
+            )

--- a/tests/test_mcp_tools_mureo_context.py
+++ b/tests/test_mcp_tools_mureo_context.py
@@ -57,15 +57,16 @@ def _import_tools():
 # ---------------------------------------------------------------------------
 
 
-def test_tools_module_exports_five_tools() -> None:
+def test_tools_module_exports_six_tools() -> None:
     mod = _import_tools()
-    assert len(mod.TOOLS) == 5
+    assert len(mod.TOOLS) == 6
     expected = {
         "mureo_strategy_get",
         "mureo_strategy_set",
         "mureo_state_get",
         "mureo_state_action_log_append",
         "mureo_state_upsert_campaign",
+        "mureo_state_report_set",
     }
     assert {t.name for t in mod.TOOLS} == expected
 
@@ -394,6 +395,85 @@ async def test_upsert_campaign_without_metrics_still_works(cwd_to_tmp) -> None:
     plat = payload["platforms"]["google_ads"]
     snap = next(c for c in plat["campaigns"] if c["campaign_id"] == "camp_abc")
     assert "metrics" not in snap
+
+
+# ---------------------------------------------------------------------------
+# mureo_state_report_set (stage c)
+# ---------------------------------------------------------------------------
+
+
+async def test_report_set_persists_summary(cwd_to_tmp) -> None:
+    """A report summary is written into STATE.json ``reports[report]`` and
+    round-trips via a subsequent read."""
+    initial = {"version": "2", "platforms": {}, "action_log": []}
+    (cwd_to_tmp / "STATE.json").write_text(json.dumps(initial), encoding="utf-8")
+    mod = _import_tools()
+    summary = {
+        "generated_at": "2026-06-17T00:00:00+00:00",
+        "period": "2026-06-17",
+        "kpis": {"google_ads": {"cpa": 4800}},
+        "flags": ["cpa_over_target"],
+        "narrative": "One campaign over target.",
+    }
+    result = await mod.handle_tool(
+        "mureo_state_report_set", {"report": "daily", "summary": summary}
+    )
+    payload = json.loads(result[0].text)
+    assert payload["reports"]["daily"] == summary
+
+    # Round-trip via a fresh read of STATE.json.
+    result2 = await mod.handle_tool("mureo_state_get", {})
+    payload2 = json.loads(result2[0].text)
+    assert payload2["reports"]["daily"]["flags"] == ["cpa_over_target"]
+
+
+async def test_report_set_preserves_other_reports(cwd_to_tmp) -> None:
+    """Writing one report kind does not clobber a previously written one."""
+    initial = {
+        "version": "2",
+        "platforms": {},
+        "action_log": [],
+        "reports": {"weekly": {"narrative": "ok"}},
+    }
+    (cwd_to_tmp / "STATE.json").write_text(json.dumps(initial), encoding="utf-8")
+    mod = _import_tools()
+    result = await mod.handle_tool(
+        "mureo_state_report_set",
+        {"report": "daily", "summary": {"narrative": "healthy"}},
+    )
+    payload = json.loads(result[0].text)
+    assert payload["reports"]["daily"] == {"narrative": "healthy"}
+    assert payload["reports"]["weekly"] == {"narrative": "ok"}
+
+
+async def test_report_set_rejects_non_object_summary(cwd_to_tmp) -> None:
+    """A non-object ``summary`` is refused by the handler."""
+    mod = _import_tools()
+    with pytest.raises(ValueError):
+        await mod.handle_tool(
+            "mureo_state_report_set",
+            {"report": "daily", "summary": "not-a-dict"},
+        )
+
+
+async def test_report_set_requires_report_and_summary(cwd_to_tmp) -> None:
+    """Both ``report`` and ``summary`` are required."""
+    mod = _import_tools()
+    with pytest.raises(ValueError):
+        await mod.handle_tool("mureo_state_report_set", {"summary": {"narrative": "x"}})
+    with pytest.raises(ValueError):
+        await mod.handle_tool("mureo_state_report_set", {"report": "daily"})
+
+
+def test_report_set_schema_enum_constrains_report() -> None:
+    """The tool's inputSchema constrains ``report`` to the three known kinds
+    so the dispatcher's schema pass (#277) rejects anything else."""
+    mod = _import_tools()
+    tool = next(t for t in mod.TOOLS if t.name == "mureo_state_report_set")
+    props = tool.inputSchema["properties"]
+    assert props["report"]["enum"] == ["daily", "weekly", "goal"]
+    assert props["summary"]["type"] == "object"
+    assert set(tool.inputSchema["required"]) == {"report", "summary"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -22,6 +22,7 @@ from mureo.context.state import (
     parse_state,
     read_state_file,
     render_state,
+    set_report,
     upsert_campaign,
     write_state_file,
 )
@@ -981,6 +982,145 @@ class TestAppendActionLog:
         assert len(updated.action_log) == 1
 
 
+class TestSetReport:
+    """Stage c: set_report writes a structured analysis summary into the
+    STATE.json ``reports`` section so a read-only dashboard can render the
+    latest report without re-running the agent."""
+
+    @pytest.mark.unit
+    def test_set_report_writes_new_report_key(self, tmp_path: Path) -> None:
+        """set_report stores the summary under reports[report]."""
+        fp = tmp_path / "STATE.json"
+        doc = StateDocument(version="2")
+        write_state_file(fp, doc)
+
+        summary = {
+            "generated_at": "2026-06-17T00:00:00+00:00",
+            "period": "2026-06-17",
+            "kpis": {"google_ads": {"cpa": 4800}},
+            "flags": ["cpa_over_target"],
+            "narrative": "One campaign is over the CPA target.",
+        }
+        updated = set_report(fp, "daily", summary)
+        assert updated.reports is not None
+        assert updated.reports["daily"] == summary
+
+        reloaded = read_state_file(fp)
+        assert reloaded.reports is not None
+        assert reloaded.reports["daily"]["flags"] == ["cpa_over_target"]
+
+    @pytest.mark.unit
+    def test_set_report_preserves_other_report_keys(self, tmp_path: Path) -> None:
+        """Writing one report kind does not clobber the others."""
+        fp = tmp_path / "STATE.json"
+        doc = StateDocument(version="2", reports={"weekly": {"narrative": "ok"}})
+        write_state_file(fp, doc)
+
+        updated = set_report(fp, "daily", {"narrative": "healthy"})
+        assert updated.reports is not None
+        # New key added.
+        assert updated.reports["daily"] == {"narrative": "healthy"}
+        # Pre-existing key untouched.
+        assert updated.reports["weekly"] == {"narrative": "ok"}
+
+    @pytest.mark.unit
+    def test_set_report_overwrites_same_report_key(self, tmp_path: Path) -> None:
+        """Re-writing the same report kind replaces its summary."""
+        fp = tmp_path / "STATE.json"
+        doc = StateDocument(version="2", reports={"daily": {"narrative": "old"}})
+        write_state_file(fp, doc)
+
+        updated = set_report(fp, "daily", {"narrative": "new"})
+        assert updated.reports is not None
+        assert updated.reports["daily"] == {"narrative": "new"}
+
+    @pytest.mark.unit
+    def test_set_report_preserves_campaigns_and_action_log(
+        self, tmp_path: Path
+    ) -> None:
+        """The rest of the document (campaigns, action_log, platforms) survives
+        a report write."""
+        fp = tmp_path / "STATE.json"
+        ps = PlatformState(
+            account_id="123",
+            campaigns=(
+                CampaignSnapshot(campaign_id="1", campaign_name="C", status="ENABLED"),
+            ),
+        )
+        entry = ActionLogEntry(
+            timestamp="2026-06-17T09:00:00Z",
+            action="budget.update",
+            platform="google_ads",
+        )
+        doc = StateDocument(
+            version="2",
+            campaigns=(
+                CampaignSnapshot(campaign_id="1", campaign_name="C", status="ENABLED"),
+            ),
+            platforms={"google_ads": ps},
+            action_log=(entry,),
+        )
+        write_state_file(fp, doc)
+
+        updated = set_report(fp, "goal", {"narrative": "on track"})
+        assert updated.reports is not None
+        assert updated.reports["goal"] == {"narrative": "on track"}
+        # Untouched sections.
+        assert len(updated.campaigns) == 1
+        assert updated.campaigns[0].campaign_id == "1"
+        assert len(updated.action_log) == 1
+        assert updated.action_log[0].action == "budget.update"
+        assert updated.platforms is not None
+        assert updated.platforms["google_ads"].account_id == "123"
+
+    @pytest.mark.unit
+    def test_set_report_restamps_last_synced_at(self, tmp_path: Path) -> None:
+        """last_synced_at is re-stamped to now on a report write."""
+        fp = tmp_path / "STATE.json"
+        doc = StateDocument(version="2", last_synced_at="2020-01-01T00:00:00+00:00")
+        write_state_file(fp, doc)
+
+        updated = set_report(fp, "daily", {"narrative": "fresh"})
+        assert updated.last_synced_at is not None
+        assert updated.last_synced_at != "2020-01-01T00:00:00+00:00"
+
+    @pytest.mark.unit
+    def test_set_report_starts_from_none_reports(self, tmp_path: Path) -> None:
+        """Backward compat: a doc whose reports is None gains a {} that the new
+        report key is merged into."""
+        fp = tmp_path / "STATE.json"
+        doc = StateDocument(version="2")
+        assert doc.reports is None
+        write_state_file(fp, doc)
+
+        updated = set_report(fp, "weekly", {"narrative": "watch"})
+        assert updated.reports == {"weekly": {"narrative": "watch"}}
+
+    @pytest.mark.unit
+    def test_set_report_to_nonexistent_file_creates_it(self, tmp_path: Path) -> None:
+        """Writing a report to an absent STATE.json creates the file."""
+        fp = tmp_path / "STATE.json"
+        updated = set_report(fp, "daily", {"narrative": "first run"})
+        assert fp.exists()
+        assert updated.reports == {"daily": {"narrative": "first run"}}
+
+    @pytest.mark.unit
+    def test_set_report_roundtrips_to_disk(self, tmp_path: Path) -> None:
+        """The persisted summary round-trips through a fresh read."""
+        fp = tmp_path / "STATE.json"
+        summary = {
+            "generated_at": "2026-06-17T00:00:00+00:00",
+            "period": "LAST_7_DAYS",
+            "kpis": {"totals": {"spend": 12345.0, "conversions": 12}},
+            "flags": [],
+            "narrative": "Spend steady week over week.",
+        }
+        set_report(fp, "weekly", summary)
+        reloaded = read_state_file(fp)
+        assert reloaded.reports is not None
+        assert reloaded.reports["weekly"] == summary
+
+
 class TestStatePerformanceMetrics:
     """Stage a+b: optional performance metrics on snapshots / platforms /
     document. All fields are OPTIONAL with safe defaults so old STATE.json
@@ -989,9 +1129,7 @@ class TestStatePerformanceMetrics:
     @pytest.mark.unit
     def test_campaign_metrics_defaults_to_none(self) -> None:
         """CampaignSnapshot.metrics defaults to None."""
-        snap = CampaignSnapshot(
-            campaign_id="1", campaign_name="C", status="ENABLED"
-        )
+        snap = CampaignSnapshot(campaign_id="1", campaign_name="C", status="ENABLED")
         assert snap.metrics is None
 
     @pytest.mark.unit
@@ -1113,9 +1251,7 @@ class TestStatePerformanceMetrics:
         """metrics is omitted from JSON when None (no diff churn)."""
         doc = StateDocument(
             campaigns=(
-                CampaignSnapshot(
-                    campaign_id="1", campaign_name="C", status="ENABLED"
-                ),
+                CampaignSnapshot(campaign_id="1", campaign_name="C", status="ENABLED"),
             ),
         )
         rendered = render_state(doc)
@@ -1128,9 +1264,7 @@ class TestStatePerformanceMetrics:
         ps = PlatformState(
             account_id="123",
             campaigns=(
-                CampaignSnapshot(
-                    campaign_id="1", campaign_name="C", status="ENABLED"
-                ),
+                CampaignSnapshot(campaign_id="1", campaign_name="C", status="ENABLED"),
             ),
             totals={"spend": 5000.0, "conversions": 20},
             metrics_period="LAST_30_DAYS",

--- a/tests/test_strategy_reminder.py
+++ b/tests/test_strategy_reminder.py
@@ -206,6 +206,7 @@ _MUTATING_CATALOGUE: frozenset[str] = frozenset(
         "mureo_state_upsert_campaign",
         "mureo_strategy_set",
         "mureo_state_action_log_append",
+        "mureo_state_report_set",
     }
 )
 


### PR DESCRIPTION
## Summary
Stage **c** of the configure reporting-dashboard plan. The analysis skills produced a report but persisted nothing the dashboard could read. They now write a structured **summary** into STATE.json `reports` so a future read-only dashboard shows the latest report without re-running the agent.

## Changes
- **state.py** `set_report(path, report, summary)` — atomic mutator; merges `reports[report]=summary`, **preserving sibling report keys and the entire rest of the document** (campaigns/platforms/metrics/totals/action_log). Mirrors `append_action_log`; backward compatible (`reports=None` → `{}`).
- **`mureo_state_report_set`** MCP tool — `report` enum `[daily, weekly, goal]` + `summary` object (dispatcher schema-validated per #277); non-dict summary rejected.
- **daily-check / weekly-report / goal-review** (canonical + bundled, byte-identical) — final best-effort step persisting `{generated_at, period, kpis, flags, narrative}`; skipped silently where the context MCP is unavailable.
- tool count 186 → 187 (Mureo Context 6); tests updated.

## Test plan
- [x] `tests/test_state.py`: set_report writes/overwrites a key, **preserves campaigns/action_log/sibling reports**, `reports=None` start, round-trip.
- [x] `tests/test_mcp_tools_mureo_context.py`: tool exports 6; persist+read; non-dict summary rejected; bad enum rejected by dispatcher.
- [x] `tests/test_mcp_server.py` count 187; `test_plugin_manifests.py` byte-parity.
- [x] `ruff`/`black`/`mypy` on `mureo/` clean. Reviewed (code-reviewer agent) — APPROVE, no CRITICAL/HIGH; confirmed `set_report` preserves the full doc incl. stage a/b metrics.

_Stage **d** (metric vocabulary unification) then the dashboard UI follow._