### PR TITLE
feat(web): reports period-toggle backend (PR-A)

### DIFF
--- a/mureo/context/models.py
+++ b/mureo/context/models.py
@@ -111,8 +111,17 @@ class PlatformState:
     # Optional platform-level metric rollup (e.g. {"spend": ..., "clicks": ...})
     # and the period those totals cover (e.g. "LAST_30_DAYS"). Both default to
     # None so legacy platform entries parse unchanged and emit no extra keys.
+    # ``totals`` / ``metrics_period`` carry a SINGLE rollup (the most recent
+    # window a sync wrote); ``periods`` carries one rollup PER window so the
+    # dashboard can offer a period toggle.
     totals: dict[str, Any] | None = None
     metrics_period: str | None = None
+    # Optional per-period rollups keyed by canonical period token
+    # ({"YESTERDAY": {<totals>}, "LAST_30_DAYS": {<totals>}}). Each value is a
+    # totals-shaped dict (same canonical keys as ``totals``). None by default so
+    # legacy entries parse unchanged and emit no extra key. sync-state writes
+    # LAST_30_DAYS; daily-check writes YESTERDAY.
+    periods: dict[str, dict[str, Any]] | None = None
 
     def __post_init__(self) -> None:
         """Ensure campaigns is a tuple (defensive copy)."""
@@ -120,6 +129,8 @@ class PlatformState:
             object.__setattr__(self, "campaigns", tuple(self.campaigns))
         if self.totals is not None:
             object.__setattr__(self, "totals", copy.deepcopy(self.totals))
+        if self.periods is not None:
+            object.__setattr__(self, "periods", copy.deepcopy(self.periods))
 
 
 @dataclass(frozen=True)

--- a/mureo/context/state.py
+++ b/mureo/context/state.py
@@ -51,6 +51,7 @@ def parse_state(text: str) -> StateDocument:
                 campaigns=platform_campaigns,
                 totals=platform_data.get("totals"),
                 metrics_period=platform_data.get("metrics_period"),
+                periods=platform_data.get("periods"),
             )
 
     # v2: action_log
@@ -146,6 +147,10 @@ def _platform_state_to_dict(ps: PlatformState) -> dict[str, Any]:
         result["totals"] = copy.deepcopy(ps.totals)
     if ps.metrics_period is not None:
         result["metrics_period"] = ps.metrics_period
+    # Per-period rollups: emit only when non-empty so legacy files (and
+    # entries with no per-period data) stay byte-stable on round-trip.
+    if ps.periods:
+        result["periods"] = copy.deepcopy(ps.periods)
     return result
 
 
@@ -329,9 +334,11 @@ def upsert_campaign(
             ),
             # Preserve the platform-level rollup: it has no upsert input, so
             # a campaign upsert must inherit it rather than reset it to None
-            # (otherwise every upsert silently wipes the dashboard KPIs).
+            # (otherwise every upsert silently wipes the dashboard KPIs). The
+            # same applies to the per-period rollups.
             totals=existing.totals if existing is not None else None,
             metrics_period=existing.metrics_period if existing is not None else None,
+            periods=existing.periods if existing is not None else None,
         )
 
         return StateDocument(

--- a/mureo/web/reports.py
+++ b/mureo/web/reports.py
@@ -333,14 +333,10 @@ def _build_platforms(
     """One JSON-safe row per ``platforms`` key (insertion order preserved)."""
     if doc is None or not doc.platforms:
         return []
-    return [
-        _platform_row(key, state, period) for key, state in doc.platforms.items()
-    ]
+    return [_platform_row(key, state, period) for key, state in doc.platforms.items()]
 
 
-def _platform_row(
-    key: str, state: PlatformState, period: str | None
-) -> dict[str, Any]:
+def _platform_row(key: str, state: PlatformState, period: str | None) -> dict[str, Any]:
     """Shape a single platform's dashboard row (no account ids / secrets).
 
     ``period is None`` returns the stored single rollup (legacy passthrough);

--- a/mureo/web/reports.py
+++ b/mureo/web/reports.py
@@ -90,6 +90,17 @@ _BUILTIN_DISPLAY_NAMES: dict[str, str] = {
 
 _PLUGIN_PREFIX = "plugin:"
 
+# Canonical period tokens in dashboard-toggle order. The default view is the
+# most recent day (``YESTERDAY``) — daily-check runs every day, so the prior
+# day's state is what an operator checks first; ``LAST_30_DAYS`` is the
+# trend window written by sync-state. Windows not listed here sort after
+# these, alphabetically (see :func:`_available_periods`).
+_PERIOD_ORDER: tuple[str, ...] = (
+    "YESTERDAY",
+    "LAST_7_DAYS",
+    "LAST_30_DAYS",
+)
+
 
 def platform_display_name(key: str) -> str:
     """Resolve a human label for a ``platforms`` key.
@@ -251,8 +262,12 @@ def build_report_summary(
 
     - ``platforms``: one row per key in ``platforms`` — built-in AND
       ``plugin:<dist>`` — each ``{key, display_name, totals, metrics_period,
-      campaign_count}``. A platform without metrics still appears (``totals``
-      empty / ``metrics_period`` ``None``).
+      campaign_count}``. A platform without metrics for the resolved window
+      still appears (``totals`` ``None`` / ``metrics_period`` ``None``).
+    - ``periods``: the windows that have data SOMEWHERE in this document
+      (union over every platform's per-period rollups plus its legacy
+      single-rollup window), in canonical order — so the dashboard renders a
+      period toggle only for windows it can actually show.
     - ``last_synced_at``: the document's sync timestamp (or ``None``).
     - ``recent_actions``: the last :data:`_RECENT_ACTIONS_LIMIT` action-log
       entries, each ``{timestamp, action, platform, campaign_id, summary,
@@ -261,10 +276,20 @@ def build_report_summary(
     - ``reports``: the daily/weekly/goal summaries verbatim (or ``None``).
     - ``client`` / ``period``: echoed back so the caller knows what was read.
 
-    ``period`` is accepted for forward-compatibility (a future filtered view)
-    and echoed; the current STATE.json-sourced view returns whatever window
-    the sync wrote. Never raises on a missing/empty/malformed STATE.json —
-    it returns an empty-but-valid summary instead.
+    Period selection
+    ----------------
+    - ``period is None`` (the default) → backward-compatible passthrough:
+      each platform's stored single rollup (``totals`` / ``metrics_period``)
+      is returned as-is. No existing caller regresses.
+    - ``period`` set (e.g. ``"YESTERDAY"`` / ``"LAST_30_DAYS"``) → each
+      platform's totals are resolved FOR THAT WINDOW from its ``periods``
+      rollups, falling back to the legacy single rollup ONLY when its stored
+      ``metrics_period`` matches the requested window (never mislabels a
+      different window's totals). A platform with no data for the window gets
+      ``totals``/``metrics_period`` ``None``.
+
+    Never raises on a missing/empty/malformed STATE.json — it returns an
+    empty-but-valid summary instead.
     """
     store = _state_store_for_client(client)
     doc = _read_state_safe(store)
@@ -273,8 +298,9 @@ def build_report_summary(
     return {
         "client": resolved_client,
         "period": period,
+        "periods": _available_periods(doc),
         "last_synced_at": doc.last_synced_at if doc is not None else None,
-        "platforms": _build_platforms(doc),
+        "platforms": _build_platforms(doc, period),
         "recent_actions": _build_recent_actions(doc),
         # ``reports`` is relayed verbatim. Unlike ``totals`` / ``recent_actions``
         # it is NOT whitelisted: it holds the structured analysis summary written
@@ -301,22 +327,81 @@ def _read_state_safe(store: StateStore) -> StateDocument | None:
         return None
 
 
-def _build_platforms(doc: StateDocument | None) -> list[dict[str, Any]]:
+def _build_platforms(
+    doc: StateDocument | None, period: str | None
+) -> list[dict[str, Any]]:
     """One JSON-safe row per ``platforms`` key (insertion order preserved)."""
     if doc is None or not doc.platforms:
         return []
-    return [_platform_row(key, state) for key, state in doc.platforms.items()]
+    return [
+        _platform_row(key, state, period) for key, state in doc.platforms.items()
+    ]
 
 
-def _platform_row(key: str, state: PlatformState) -> dict[str, Any]:
-    """Shape a single platform's dashboard row (no account ids / secrets)."""
+def _platform_row(
+    key: str, state: PlatformState, period: str | None
+) -> dict[str, Any]:
+    """Shape a single platform's dashboard row (no account ids / secrets).
+
+    ``period is None`` returns the stored single rollup (legacy passthrough);
+    a set ``period`` resolves the totals for that window (see
+    :func:`_period_totals`).
+    """
+    if period is None:
+        totals = _safe_totals(state.totals)
+        metrics_period = state.metrics_period
+    else:
+        totals = _period_totals(state, period)
+        # Only label the row with the window once it actually carries totals,
+        # so the frontend can tell "no data for this window" from "this data
+        # covers <window>".
+        metrics_period = period if totals is not None else None
     return {
         "key": key,
         "display_name": platform_display_name(key),
-        "totals": _safe_totals(state.totals),
-        "metrics_period": state.metrics_period,
+        "totals": totals,
+        "metrics_period": metrics_period,
         "campaign_count": len(state.campaigns),
     }
+
+
+def _period_totals(state: PlatformState, period: str) -> dict[str, Any] | None:
+    """Resolve a platform's totals for ``period`` (whitelisted) or ``None``.
+
+    Precedence:
+    1. ``periods[period]`` when the key is PRESENT — authoritative, even if
+       it whitelists down to nothing (``None``).
+    2. else the legacy single rollup (``totals``) ONLY when its stored
+       ``metrics_period`` equals ``period`` — never mislabel another window.
+    3. else ``None`` (no data for this window).
+    """
+    if state.periods is not None and period in state.periods:
+        bucket = state.periods[period]
+        return _safe_totals(bucket if isinstance(bucket, dict) else None)
+    if state.metrics_period == period:
+        return _safe_totals(state.totals)
+    return None
+
+
+def _available_periods(doc: StateDocument | None) -> list[str]:
+    """Windows with data anywhere in the document, in canonical order.
+
+    Union over every platform's ``periods`` keys plus its legacy
+    ``metrics_period`` (so a legacy single-rollup window still advertises
+    itself). Sorted with :data:`_PERIOD_ORDER` first, unknown windows
+    appended alphabetically — gives the dashboard a stable toggle order.
+    """
+    if doc is None or not doc.platforms:
+        return []
+    found: set[str] = set()
+    for state in doc.platforms.values():
+        if state.periods:
+            found.update(k for k in state.periods if isinstance(k, str) and k)
+        if state.metrics_period:
+            found.add(state.metrics_period)
+    known = [p for p in _PERIOD_ORDER if p in found]
+    extra = sorted(p for p in found if p not in _PERIOD_ORDER)
+    return known + extra
 
 
 def _safe_totals(totals: dict[str, Any] | None) -> dict[str, Any] | None:

--- a/tests/test_reports_period_backend.py
+++ b/tests/test_reports_period_backend.py
@@ -1,0 +1,414 @@
+"""Period-toggle backend for the read-only reporting dashboard.
+
+These tests cover the ``periods`` extension layered onto the single-rollup
+reporting model (``PlatformState.totals`` / ``metrics_period``):
+
+  - ``PlatformState.periods`` model field: defensive copy + round-trip
+    through ``STATE.json`` (emitted only when non-empty → legacy files stay
+    byte-stable), and preservation across a campaign upsert;
+  - ``build_report_summary(period=...)`` window selection:
+      * ``period is None`` → backward-compatible passthrough (no regression);
+      * a set ``period`` → totals resolved for that window from ``periods``;
+      * legacy fallback ONLY when ``metrics_period`` matches the window
+        (never mislabels a different window's totals);
+      * an explicit ``periods`` key is authoritative over the legacy rollup;
+      * secret-shaped keys inside a period bucket are whitelisted away;
+  - ``summary["periods"]``: union of windows present anywhere, in canonical
+    toggle order.
+
+The runtime context is reset around every test so an injected state store
+never leaks into another test.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from mureo.context.models import (
+    CampaignSnapshot,
+    PlatformState,
+    StateDocument,
+)
+from mureo.core.runtime_context import (
+    default_runtime_context,
+    reset_runtime_context,
+)
+from mureo.web.reports import build_report_summary
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def _reset_ctx() -> Iterator[None]:
+    reset_runtime_context()
+    yield
+    reset_runtime_context()
+
+
+def _write_state(workspace: Path, doc: StateDocument) -> None:
+    from mureo.context.state import write_state_file
+
+    write_state_file(workspace / "STATE.json", doc)
+
+
+def _use_workspace(monkeypatch: pytest.MonkeyPatch, workspace: Path) -> None:
+    ctx = default_runtime_context(workspace=workspace)
+    monkeypatch.setattr("mureo.web.reports.get_runtime_context", lambda: ctx)
+
+
+def _row(summary: dict, key: str) -> dict:
+    return next(p for p in summary["platforms"] if p["key"] == key)
+
+
+# ---------------------------------------------------------------------------
+# Model: defensive copy + round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_periods_defensive_copy_on_construct() -> None:
+    """Mutating the dict passed in must not mutate the stored periods."""
+    src = {"YESTERDAY": {"spend": 10.0}}
+    state = PlatformState(account_id="x", periods=src)
+    src["YESTERDAY"]["spend"] = 999.0
+    src["LAST_30_DAYS"] = {"spend": 1.0}
+    assert state.periods == {"YESTERDAY": {"spend": 10.0}}
+
+
+@pytest.mark.unit
+def test_periods_round_trip_through_state_file(tmp_path: Path) -> None:
+    """periods survive a write→read cycle unchanged."""
+    from mureo.context.state import read_state_file
+
+    doc = StateDocument(
+        version="2",
+        platforms={
+            "google_ads": PlatformState(
+                account_id="123",
+                periods={
+                    "YESTERDAY": {"spend": 100.0, "conversions": 2},
+                    "LAST_30_DAYS": {"spend": 3000.0, "conversions": 60},
+                },
+            )
+        },
+    )
+    _write_state(tmp_path, doc)
+    reloaded = read_state_file(tmp_path / "STATE.json")
+    assert reloaded.platforms is not None
+    assert reloaded.platforms["google_ads"].periods == {
+        "YESTERDAY": {"spend": 100.0, "conversions": 2},
+        "LAST_30_DAYS": {"spend": 3000.0, "conversions": 60},
+    }
+
+
+@pytest.mark.unit
+def test_periods_omitted_from_json_when_absent(tmp_path: Path) -> None:
+    """A platform with no periods emits no ``periods`` key (legacy-stable)."""
+    doc = StateDocument(
+        version="2",
+        platforms={
+            "google_ads": PlatformState(
+                account_id="123",
+                totals={"spend": 5.0},
+                metrics_period="LAST_30_DAYS",
+            )
+        },
+    )
+    _write_state(tmp_path, doc)
+    raw = json.loads((tmp_path / "STATE.json").read_text(encoding="utf-8"))
+    assert "periods" not in raw["platforms"]["google_ads"]
+
+
+@pytest.mark.unit
+def test_periods_preserved_across_campaign_upsert(tmp_path: Path) -> None:
+    """A campaign upsert must not wipe the per-period rollups."""
+    from mureo.context.state import read_state_file, upsert_campaign
+
+    path = tmp_path / "STATE.json"
+    _write_state(
+        tmp_path,
+        StateDocument(
+            version="2",
+            platforms={
+                "google_ads": PlatformState(
+                    account_id="123",
+                    periods={"YESTERDAY": {"spend": 7.0}},
+                )
+            },
+        ),
+    )
+    upsert_campaign(
+        path,
+        CampaignSnapshot(campaign_id="g1", campaign_name="New", status="ENABLED"),
+        platform="google_ads",
+        account_id="123",
+    )
+    reloaded = read_state_file(path)
+    assert reloaded.platforms is not None
+    assert reloaded.platforms["google_ads"].periods == {"YESTERDAY": {"spend": 7.0}}
+
+
+# ---------------------------------------------------------------------------
+# build_report_summary — window selection
+# ---------------------------------------------------------------------------
+
+
+def _periods_state() -> StateDocument:
+    """google_ads with both windows; meta_ads with only the legacy rollup."""
+    google = PlatformState(
+        account_id="123",
+        campaigns=(
+            CampaignSnapshot(campaign_id="g1", campaign_name="Brand", status="ENABLED"),
+        ),
+        periods={
+            "YESTERDAY": {"spend": 100.0, "conversions": 2},
+            "LAST_30_DAYS": {"spend": 3000.0, "conversions": 60},
+        },
+    )
+    # Legacy single-rollup platform: no periods, only totals/metrics_period.
+    meta = PlatformState(
+        account_id="act_9",
+        totals={"spend": 500.0, "impressions": 9000},
+        metrics_period="LAST_30_DAYS",
+    )
+    return StateDocument(
+        version="2",
+        last_synced_at="2026-06-17T09:00:00+00:00",
+        platforms={"google_ads": google, "meta_ads": meta},
+    )
+
+
+@pytest.mark.unit
+def test_period_none_is_backward_compatible_passthrough(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """No period → stored single rollup returned as-is (no regression)."""
+    _use_workspace(monkeypatch, tmp_path)
+    _write_state(tmp_path, _periods_state())
+
+    summary = build_report_summary()  # period defaults to None
+    meta = _row(summary, "meta_ads")
+    assert meta["totals"] == {"spend": 500.0, "impressions": 9000}
+    assert meta["metrics_period"] == "LAST_30_DAYS"
+
+
+@pytest.mark.unit
+def test_period_selects_from_periods_dict(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _use_workspace(monkeypatch, tmp_path)
+    _write_state(tmp_path, _periods_state())
+
+    yesterday = _row(build_report_summary(period="YESTERDAY"), "google_ads")
+    assert yesterday["totals"] == {"spend": 100.0, "conversions": 2}
+    assert yesterday["metrics_period"] == "YESTERDAY"
+
+    last30 = _row(build_report_summary(period="LAST_30_DAYS"), "google_ads")
+    assert last30["totals"] == {"spend": 3000.0, "conversions": 60}
+    assert last30["metrics_period"] == "LAST_30_DAYS"
+
+
+@pytest.mark.unit
+def test_legacy_rollup_used_only_when_window_matches(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Legacy totals fill a window iff metrics_period equals it."""
+    _use_workspace(monkeypatch, tmp_path)
+    _write_state(tmp_path, _periods_state())
+
+    # meta_ads has metrics_period=LAST_30_DAYS → request matches → totals shown.
+    matched = _row(build_report_summary(period="LAST_30_DAYS"), "meta_ads")
+    assert matched["totals"] == {"spend": 500.0, "impressions": 9000}
+    assert matched["metrics_period"] == "LAST_30_DAYS"
+
+    # Request YESTERDAY → no match, never mislabel → no totals for the window.
+    mismatched = _row(build_report_summary(period="YESTERDAY"), "meta_ads")
+    assert mismatched["totals"] is None
+    assert mismatched["metrics_period"] is None
+
+
+@pytest.mark.unit
+def test_explicit_period_bucket_is_authoritative_over_legacy(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A present periods key wins over the legacy rollup for that window."""
+    _use_workspace(monkeypatch, tmp_path)
+    _write_state(
+        tmp_path,
+        StateDocument(
+            version="2",
+            platforms={
+                "google_ads": PlatformState(
+                    account_id="123",
+                    totals={"spend": 999.0},  # legacy says 999...
+                    metrics_period="LAST_30_DAYS",
+                    periods={"LAST_30_DAYS": {"spend": 42.0}},  # ...periods says 42
+                )
+            },
+        ),
+    )
+    row = _row(build_report_summary(period="LAST_30_DAYS"), "google_ads")
+    assert row["totals"] == {"spend": 42.0}
+
+
+@pytest.mark.unit
+def test_legacy_fills_window_periods_does_not_cover(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """periods present but missing the window → matching legacy rollup fills it."""
+    _use_workspace(monkeypatch, tmp_path)
+    _write_state(
+        tmp_path,
+        StateDocument(
+            version="2",
+            platforms={
+                "google_ads": PlatformState(
+                    account_id="123",
+                    totals={"spend": 3000.0},
+                    metrics_period="LAST_30_DAYS",
+                    # periods only covers YESTERDAY; LAST_30_DAYS must fall back.
+                    periods={"YESTERDAY": {"spend": 100.0}},
+                )
+            },
+        ),
+    )
+    row = _row(build_report_summary(period="LAST_30_DAYS"), "google_ads")
+    assert row["totals"] == {"spend": 3000.0}
+    assert row["metrics_period"] == "LAST_30_DAYS"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("bucket", [None, "not-a-dict", 42, ["spend", 1]])
+def test_malformed_period_bucket_degrades_to_none(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, bucket: object
+) -> None:
+    """A non-dict period bucket yields None totals, never raises."""
+    _use_workspace(monkeypatch, tmp_path)
+    _write_state(
+        tmp_path,
+        StateDocument(
+            version="2",
+            platforms={
+                "google_ads": PlatformState(
+                    account_id="123",
+                    periods={"YESTERDAY": bucket},  # type: ignore[dict-item]
+                )
+            },
+        ),
+    )
+    row = _row(build_report_summary(period="YESTERDAY"), "google_ads")
+    assert row["totals"] is None
+    assert row["metrics_period"] is None
+
+
+@pytest.mark.unit
+def test_available_periods_ignores_non_str_and_empty_keys(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Only non-empty string window tokens are advertised in periods."""
+    _use_workspace(monkeypatch, tmp_path)
+    _write_state(
+        tmp_path,
+        StateDocument(
+            version="2",
+            platforms={
+                "google_ads": PlatformState(
+                    account_id="123",
+                    periods={"YESTERDAY": {"spend": 1.0}, "": {"spend": 2.0}},
+                )
+            },
+        ),
+    )
+    assert build_report_summary()["periods"] == ["YESTERDAY"]
+
+
+@pytest.mark.unit
+def test_period_bucket_whitelists_secret_shaped_keys(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A stray/secret-shaped key inside a period bucket never surfaces."""
+    _use_workspace(monkeypatch, tmp_path)
+    _write_state(
+        tmp_path,
+        StateDocument(
+            version="2",
+            platforms={
+                "google_ads": PlatformState(
+                    account_id="123",
+                    periods={
+                        "YESTERDAY": {
+                            "spend": 10.0,
+                            "refresh_token": "SECRET",
+                            "account_id": "123-456",
+                        }
+                    },
+                )
+            },
+        ),
+    )
+    row = _row(build_report_summary(period="YESTERDAY"), "google_ads")
+    assert row["totals"] == {"spend": 10.0}
+    assert "refresh_token" not in row["totals"]
+    assert "account_id" not in row["totals"]
+
+
+@pytest.mark.unit
+def test_summary_periods_union_in_canonical_order(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """periods lists every window present anywhere, canonical order first."""
+    _use_workspace(monkeypatch, tmp_path)
+    _write_state(tmp_path, _periods_state())
+
+    # google_ads → {YESTERDAY, LAST_30_DAYS}; meta_ads legacy → {LAST_30_DAYS}.
+    assert build_report_summary()["periods"] == ["YESTERDAY", "LAST_30_DAYS"]
+
+
+@pytest.mark.unit
+def test_summary_periods_unknown_window_sorts_after_known(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _use_workspace(monkeypatch, tmp_path)
+    _write_state(
+        tmp_path,
+        StateDocument(
+            version="2",
+            platforms={
+                "google_ads": PlatformState(
+                    account_id="123",
+                    periods={
+                        "LAST_30_DAYS": {"spend": 1.0},
+                        "THIS_MONTH": {"spend": 2.0},
+                        "YESTERDAY": {"spend": 3.0},
+                    },
+                )
+            },
+        ),
+    )
+    # Known order (YESTERDAY, LAST_30_DAYS) first; unknown (THIS_MONTH) last.
+    assert build_report_summary()["periods"] == [
+        "YESTERDAY",
+        "LAST_30_DAYS",
+        "THIS_MONTH",
+    ]
+
+
+@pytest.mark.unit
+def test_summary_periods_empty_when_no_metrics(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """No rollups anywhere → empty periods so the toggle stays hidden."""
+    _use_workspace(monkeypatch, tmp_path)
+    _write_state(
+        tmp_path,
+        StateDocument(
+            version="2",
+            platforms={"google_ads": PlatformState(account_id="123")},
+        ),
+    )
+    assert build_report_summary()["periods"] == []


### PR DESCRIPTION
## Summary

PR-A of the reports **period toggle** (前日 `YESTERDAY` / 30日 `LAST_30_DAYS`). Adds the backend/model layer so a later frontend (PR-C) can switch the dashboard KPI window. Builds **on top of** the already-shipped single-rollup reporting model (#295/#296) without regressing it.

> Note: the original period-toggle branch was lost; this re-implements the backend against the current merged dashboard, which uses a single-rollup model (`PlatformState.totals` + `metrics_period`). This PR layers a per-period rollup on it.

## Changes

- **`models.py`** — `PlatformState.periods: dict[str, dict] | None`, one totals-shaped dict per window (`{"YESTERDAY": {…}, "LAST_30_DAYS": {…}}`). `frozen=True` + defensive deep-copy; `None` default so legacy entries parse unchanged.
- **`state.py`** — round-trip `periods` (emitted **only when non-empty** → legacy `STATE.json` stays byte-stable); a campaign upsert **preserves** `periods` alongside `totals`/`metrics_period`.
- **`reports.py`** — `build_report_summary(period)` window selection:
  - `period=None` → **backward-compatible passthrough** (stored single rollup as-is; no existing caller regresses).
  - `period` set → totals resolved for that window from `periods`, falling back to the legacy single rollup **only when `metrics_period == period`** (never mislabels another window's totals). No data for the window → `totals`/`metrics_period` `None`.
  - `summary["periods"]` → union of windows present anywhere, in canonical toggle order.
  - Secret-strip whitelist (`_safe_totals`) and never-raises behaviour preserved; each period bucket is whitelisted too.
  - The HTTP handler already forwards `?period=` → **no handler change**.

## Staging

PR-A (backend) → PR-B (sync-state/daily-check write the windows) → PR-C (frontend toggle). Order matters: A is invisible until B writes data; C is meaningless without A.

## Test plan

- [x] `tests/test_reports_period_backend.py` — **18 new** (round-trip, upsert preservation, backward-compat passthrough, no-mislabel, `periods` authority over legacy, secret-strip, malformed-bucket robustness, union ordering).
- [x] No regression: `test_web_reports`, `test_state`, `test_web_handlers`, `test_web_assets_dashboard_cards_and_toasts`, `test_state_concurrency` all green (297).
- [x] `ruff` + `mypy` clean.
- [x] python-reviewer: APPROVE (no CRITICAL/HIGH).

## Out of scope (follow-up)

Reviewer found a pre-existing bug: `upsert_campaign` drops `StateDocument.reports` (`state.py` rebuilds the doc without `reports=doc.reports`). Real data-loss, but predates this PR — will be a separate fix PR.

https://claude.ai/code/session_01NxBrN8Qn53Tpivt9SumdGn
