### PR TITLE
feat(mcp): mureo_state_platform_metrics_set — write platform rollups (PR-B1)

### DIFF
--- a/mureo/context/state.py
+++ b/mureo/context/state.py
@@ -414,6 +414,93 @@ def set_report(path: Path, report: str, summary: dict[str, Any]) -> StateDocumen
     return _locked_state_mutation(path, _build)
 
 
+def set_platform_metrics(
+    path: Path,
+    platform: str,
+    account_id: str,
+    *,
+    totals: dict[str, Any] | None = None,
+    metrics_period: str | None = None,
+    periods: dict[str, dict[str, Any]] | None = None,
+) -> StateDocument:
+    """Set a platform's metric rollups in STATE.json's v2 ``platforms`` section.
+
+    Writes the platform-level KPI rollup the reporting dashboard reads — the
+    single ``totals`` + ``metrics_period`` (the most recent window) and/or the
+    per-period ``periods`` map (``{"YESTERDAY": {...}, "LAST_30_DAYS": {...}}``).
+    The platform's campaigns and every OTHER platform are preserved; only the
+    targeted platform's rollup fields are touched. The platform entry is
+    created (carrying ``account_id``) when absent.
+
+    Merge semantics — a partial write never clobbers an unrelated window:
+
+    - ``totals`` / ``metrics_period``: replaced when provided (non-``None``),
+      otherwise the existing value is preserved.
+    - ``periods``: merged PER WINDOW KEY into the existing map, so a
+      daily-check ``YESTERDAY`` write keeps the ``LAST_30_DAYS`` bucket a prior
+      sync wrote (and vice versa). A given window key is replaced wholesale.
+      ``None`` preserves the existing map untouched.
+
+    Re-stamps ``last_synced_at`` and writes back atomically under the state
+    lock. Other document sections (root campaigns, action_log, reports) are
+    preserved.
+
+    Args:
+        path: STATE.json location.
+        platform: Platform key (``"google_ads"`` / ``"meta_ads"`` /
+            ``"plugin:<dist>"`` / …) — the ``platforms`` dict key.
+        account_id: The platform account id, always written onto the entry.
+        totals: The single-rollup totals to set (or ``None`` to preserve).
+        metrics_period: The window ``totals`` covers (or ``None`` to preserve).
+        periods: Per-window rollups to merge in (or ``None`` to preserve).
+
+    Returns:
+        The updated :class:`StateDocument`.
+    """
+
+    def _build(doc: StateDocument) -> StateDocument:
+        platforms = dict(doc.platforms) if doc.platforms else {}
+        existing = platforms.get(platform)
+
+        merged_periods: dict[str, dict[str, Any]] | None
+        if periods is not None:
+            base = dict(existing.periods) if existing and existing.periods else {}
+            base.update(periods)
+            merged_periods = base
+        else:
+            merged_periods = existing.periods if existing is not None else None
+
+        platforms[platform] = PlatformState(
+            account_id=account_id,
+            # Rollups have no campaign input — inherit the campaigns a prior
+            # sync/upsert wrote rather than reset them.
+            campaigns=existing.campaigns if existing is not None else (),
+            totals=(
+                totals
+                if totals is not None
+                else (existing.totals if existing is not None else None)
+            ),
+            metrics_period=(
+                metrics_period
+                if metrics_period is not None
+                else (existing.metrics_period if existing is not None else None)
+            ),
+            periods=merged_periods,
+        )
+
+        return StateDocument(
+            version=doc.version,
+            last_synced_at=_now_iso(),
+            customer_id=doc.customer_id,
+            campaigns=doc.campaigns,
+            platforms=platforms,
+            action_log=doc.action_log,
+            reports=doc.reports,
+        )
+
+    return _locked_state_mutation(path, _build)
+
+
 def get_campaign(doc: StateDocument, campaign_id: str) -> CampaignSnapshot | None:
     """Search for a campaign by campaign_id."""
     for c in doc.campaigns:

--- a/mureo/mcp/_handlers_mureo_context.py
+++ b/mureo/mcp/_handlers_mureo_context.py
@@ -36,6 +36,7 @@ from mureo.context.state import (
     append_action_log,
     read_state_file,
     render_state,
+    set_platform_metrics,
     set_report,
     upsert_campaign,
 )
@@ -240,4 +241,44 @@ async def handle_state_report_set(
         raise ValueError("summary must be an object")
     path = _resolve_path(arguments, "STATE.json", store_attr="state_path")
     doc = set_report(path, report, summary)
+    return _json_result(_state_to_dict(doc))
+
+
+async def handle_state_platform_metrics_set(
+    arguments: dict[str, Any],
+) -> list[TextContent]:
+    # Platform context is required so the v2 ``platforms`` entry (the shape the
+    # dashboard reads) always carries the account id, mirroring upsert_campaign.
+    platform = _require(arguments, "platform")
+    account_id = _require(arguments, "account_id")
+    totals = arguments.get("totals")
+    metrics_period = arguments.get("metrics_period")
+    periods = arguments.get("periods")
+    # Validate the optional shapes before they reach the file: each rollup must
+    # be a JSON object (and each ``periods`` bucket too) so a malformed payload
+    # is rejected cleanly rather than corrupting STATE.json.
+    if totals is not None and not isinstance(totals, dict):
+        raise ValueError("totals must be an object")
+    if metrics_period is not None and not isinstance(metrics_period, str):
+        raise ValueError("metrics_period must be a string")
+    if periods is not None:
+        if not isinstance(periods, dict):
+            raise ValueError("periods must be an object")
+        for window, bucket in periods.items():
+            if not isinstance(bucket, dict):
+                raise ValueError(f"periods[{window!r}] must be an object")
+    path = _resolve_path(arguments, "STATE.json", store_attr="state_path")
+    try:
+        doc = set_platform_metrics(
+            path,
+            platform,
+            account_id,
+            totals=totals,
+            metrics_period=metrics_period,
+            periods=periods,
+        )
+    except ContextFileError as exc:
+        # Surface as ValueError so the MCP dispatcher returns a clean tool
+        # error rather than a 500-style server error (matches upsert_campaign).
+        raise ValueError(str(exc)) from exc
     return _json_result(_state_to_dict(doc))

--- a/mureo/mcp/tools_mureo_context.py
+++ b/mureo/mcp/tools_mureo_context.py
@@ -1,6 +1,6 @@
 """mureo's STRATEGY.md / STATE.json MCP tool surface.
 
-Six tools that expose mureo's context layer over MCP, so any MCP host
+Seven tools that expose mureo's context layer over MCP, so any MCP host
 (Claude Desktop chat, claude.ai web, Codex/Cursor, …) can read and
 update STRATEGY.md / STATE.json without direct filesystem access.
 
@@ -19,6 +19,7 @@ from mcp.types import Tool
 from mureo.mcp._handlers_mureo_context import (
     handle_state_action_log_append,
     handle_state_get,
+    handle_state_platform_metrics_set,
     handle_state_report_set,
     handle_state_upsert_campaign,
     handle_strategy_get,
@@ -244,6 +245,71 @@ TOOLS: list[Tool] = [
             "required": ["report", "summary"],
         },
     ),
+    Tool(
+        name="mureo_state_platform_metrics_set",
+        description=(
+            "Atomically set a platform's metric ROLLUP in STATE.json's v2 "
+            "``platforms`` section so the read-only reporting dashboard can "
+            "render per-platform KPIs (and the YESTERDAY / LAST_30_DAYS period "
+            "toggle) without re-querying. This writes the PLATFORM-LEVEL "
+            "rollup — distinct from mureo_state_upsert_campaign, which writes "
+            "per-campaign metrics. Pass ``totals`` + ``metrics_period`` for the "
+            "single most-recent window, and/or ``periods`` "
+            '({"YESTERDAY": {…}, "LAST_30_DAYS": {…}}) for the per-window '
+            "rollups the toggle reads. ``periods`` is merged per window key "
+            "(a YESTERDAY write keeps a prior LAST_30_DAYS bucket); omitted "
+            "fields preserve their existing value. Campaigns and every other "
+            "platform are preserved. ``account_id`` is required and always "
+            "written onto the entry. Returns the updated state document."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "platform": {
+                    "type": "string",
+                    "description": (
+                        "Platform key: a built-in (``google_ads`` / "
+                        "``meta_ads`` / ``search_console`` / ``ga4``) or a "
+                        "plugin bridge ``plugin:<dist>``."
+                    ),
+                },
+                "account_id": {
+                    "type": "string",
+                    "description": (
+                        "The platform account id (Google customer_id / Meta "
+                        "act_*). Always written onto the platform entry."
+                    ),
+                },
+                "totals": {
+                    "type": "object",
+                    "description": (
+                        "Single-rollup totals for the most recent window "
+                        "(spend, impressions, clicks, conversions, cpa, ctr, "
+                        "result_indicator, period, fetched_at). Omit to "
+                        "preserve the existing value."
+                    ),
+                },
+                "metrics_period": {
+                    "type": "string",
+                    "description": (
+                        "The window ``totals`` covers (e.g. ``LAST_30_DAYS``). "
+                        "Omit to preserve the existing value."
+                    ),
+                },
+                "periods": {
+                    "type": "object",
+                    "description": (
+                        "Per-window rollups keyed by period token "
+                        "(``YESTERDAY`` / ``LAST_30_DAYS`` / …); each value is "
+                        "a totals-shaped object. Merged per key into the "
+                        "existing map. Omit to preserve the existing map."
+                    ),
+                },
+                "path": _PATH_PROPERTY,
+            },
+            "required": ["platform", "account_id"],
+        },
+    ),
 ]
 
 
@@ -254,6 +320,7 @@ _HANDLERS = {
     "mureo_state_action_log_append": handle_state_action_log_append,
     "mureo_state_upsert_campaign": handle_state_upsert_campaign,
     "mureo_state_report_set": handle_state_report_set,
+    "mureo_state_platform_metrics_set": handle_state_platform_metrics_set,
 }
 
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -43,11 +43,11 @@ class TestListTools:
 
     async def test_list_tools_returns_all_tools(self) -> None:
         """list_tools returns all tools (Google Ads 83 + Meta Ads 82 + Search Console 10
-        + Rollback 2 + Analysis 1 + Mureo Context 6 + Analytics Registry 1
-        + Learning 2 = 187)."""
+        + Rollback 2 + Analysis 1 + Mureo Context 7 + Analytics Registry 1
+        + Learning 2 = 188)."""
         mod = _import_server_module()
         tools = await mod.handle_list_tools()
-        assert len(tools) == 187
+        assert len(tools) == 188
 
     async def test_list_tools_contains_google_and_meta(self) -> None:
         """Google Ads and Meta Ads tools are included."""

--- a/tests/test_mcp_tools_mureo_context.py
+++ b/tests/test_mcp_tools_mureo_context.py
@@ -57,9 +57,9 @@ def _import_tools():
 # ---------------------------------------------------------------------------
 
 
-def test_tools_module_exports_six_tools() -> None:
+def test_tools_module_exports_seven_tools() -> None:
     mod = _import_tools()
-    assert len(mod.TOOLS) == 6
+    assert len(mod.TOOLS) == 7
     expected = {
         "mureo_strategy_get",
         "mureo_strategy_set",
@@ -67,6 +67,7 @@ def test_tools_module_exports_six_tools() -> None:
         "mureo_state_action_log_append",
         "mureo_state_upsert_campaign",
         "mureo_state_report_set",
+        "mureo_state_platform_metrics_set",
     }
     assert {t.name for t in mod.TOOLS} == expected
 
@@ -547,3 +548,128 @@ async def test_default_path_follows_runtime_context_workspace(
     # NOT under CWD — proving the handler followed the RuntimeContext.
     assert (workspace_dir / "STATE.json").exists()
     assert not (cwd_dir / "STATE.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# mureo_state_platform_metrics_set
+# ---------------------------------------------------------------------------
+
+
+async def test_platform_metrics_set_creates_platform_with_periods(cwd_to_tmp) -> None:
+    """Writes the v2 platform entry with account_id + per-period rollups."""
+    mod = _import_tools()
+    result = await mod.handle_tool(
+        "mureo_state_platform_metrics_set",
+        {
+            "platform": "google_ads",
+            "account_id": "act_123",
+            "totals": {"spend": 3000.0, "conversions": 60},
+            "metrics_period": "LAST_30_DAYS",
+            "periods": {
+                "LAST_30_DAYS": {"spend": 3000.0, "conversions": 60},
+                "YESTERDAY": {"spend": 100.0, "conversions": 2},
+            },
+        },
+    )
+    payload = json.loads(result[0].text)
+    plat = payload["platforms"]["google_ads"]
+    assert plat["account_id"] == "act_123"
+    assert plat["totals"] == {"spend": 3000.0, "conversions": 60}
+    assert plat["metrics_period"] == "LAST_30_DAYS"
+    assert plat["periods"]["YESTERDAY"] == {"spend": 100.0, "conversions": 2}
+    assert payload.get("last_synced_at")
+
+
+async def test_platform_metrics_set_merges_periods_per_window(cwd_to_tmp) -> None:
+    """A YESTERDAY write must keep the LAST_30_DAYS bucket a prior call wrote."""
+    mod = _import_tools()
+    await mod.handle_tool(
+        "mureo_state_platform_metrics_set",
+        {
+            "platform": "google_ads",
+            "account_id": "act_123",
+            "periods": {"LAST_30_DAYS": {"spend": 3000.0}},
+        },
+    )
+    result = await mod.handle_tool(
+        "mureo_state_platform_metrics_set",
+        {
+            "platform": "google_ads",
+            "account_id": "act_123",
+            "periods": {"YESTERDAY": {"spend": 100.0}},
+        },
+    )
+    payload = json.loads(result[0].text)
+    periods = payload["platforms"]["google_ads"]["periods"]
+    assert periods == {"LAST_30_DAYS": {"spend": 3000.0}, "YESTERDAY": {"spend": 100.0}}
+
+
+async def test_platform_metrics_set_preserves_campaigns_and_other_platforms(
+    cwd_to_tmp,
+) -> None:
+    """Setting one platform's rollup leaves its campaigns + siblings intact."""
+    mod = _import_tools()
+    # Seed google_ads with a campaign, and meta_ads as a sibling platform.
+    await mod.handle_tool(
+        "mureo_state_upsert_campaign",
+        {
+            "campaign": {
+                "campaign_id": "g1",
+                "campaign_name": "Brand",
+                "status": "ENABLED",
+                "platform": "google_ads",
+                "account_id": "act_123",
+            }
+        },
+    )
+    await mod.handle_tool(
+        "mureo_state_platform_metrics_set",
+        {"platform": "meta_ads", "account_id": "act_9", "totals": {"spend": 5.0}},
+    )
+    # Now set google_ads rollup — campaign + meta_ads must survive.
+    result = await mod.handle_tool(
+        "mureo_state_platform_metrics_set",
+        {
+            "platform": "google_ads",
+            "account_id": "act_123",
+            "periods": {"YESTERDAY": {"spend": 100.0}},
+        },
+    )
+    payload = json.loads(result[0].text)
+    google = payload["platforms"]["google_ads"]
+    assert [c["campaign_id"] for c in google["campaigns"]] == ["g1"]
+    assert payload["platforms"]["meta_ads"]["totals"] == {"spend": 5.0}
+
+
+async def test_platform_metrics_set_requires_platform_and_account(cwd_to_tmp) -> None:
+    mod = _import_tools()
+    with pytest.raises(ValueError, match="platform"):
+        await mod.handle_tool(
+            "mureo_state_platform_metrics_set", {"account_id": "act_123"}
+        )
+    with pytest.raises(ValueError, match="account_id"):
+        await mod.handle_tool(
+            "mureo_state_platform_metrics_set", {"platform": "google_ads"}
+        )
+
+
+async def test_platform_metrics_set_rejects_malformed_shapes(cwd_to_tmp) -> None:
+    mod = _import_tools()
+    base = {"platform": "google_ads", "account_id": "act_123"}
+    with pytest.raises(ValueError, match="totals must be an object"):
+        await mod.handle_tool(
+            "mureo_state_platform_metrics_set", {**base, "totals": "nope"}
+        )
+    with pytest.raises(ValueError, match="periods must be an object"):
+        await mod.handle_tool(
+            "mureo_state_platform_metrics_set", {**base, "periods": [1, 2]}
+        )
+    with pytest.raises(ValueError, match=r"periods\['YESTERDAY'\] must be an object"):
+        await mod.handle_tool(
+            "mureo_state_platform_metrics_set",
+            {**base, "periods": {"YESTERDAY": "nope"}},
+        )
+    with pytest.raises(ValueError, match="metrics_period must be a string"):
+        await mod.handle_tool(
+            "mureo_state_platform_metrics_set", {**base, "metrics_period": 30}
+        )

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -22,6 +22,7 @@ from mureo.context.state import (
     parse_state,
     read_state_file,
     render_state,
+    set_platform_metrics,
     set_report,
     upsert_campaign,
     write_state_file,
@@ -1430,3 +1431,68 @@ class TestRenderParseV2Roundtrip:
         assert len(restored.action_log) == 1
         assert restored.action_log[0].action == "negative_keywords.add"
         assert restored.action_log[0].campaign_id == "111"
+
+
+class TestSetPlatformMetrics:
+    """set_platform_metrics — platform rollup write + preserve contracts."""
+
+    @pytest.mark.unit
+    def test_creates_platform_when_missing(self, tmp_path: Path) -> None:
+        fp = tmp_path / "STATE.json"
+        write_state_file(fp, StateDocument(version="2"))
+        doc = set_platform_metrics(
+            fp,
+            "google_ads",
+            "act_123",
+            totals={"spend": 3000.0},
+            metrics_period="LAST_30_DAYS",
+            periods={"YESTERDAY": {"spend": 100.0}},
+        )
+        assert doc.platforms is not None
+        ps = doc.platforms["google_ads"]
+        assert ps.account_id == "act_123"
+        assert ps.totals == {"spend": 3000.0}
+        assert ps.metrics_period == "LAST_30_DAYS"
+        assert ps.periods == {"YESTERDAY": {"spend": 100.0}}
+
+    @pytest.mark.unit
+    def test_omitted_fields_preserve_existing(self, tmp_path: Path) -> None:
+        """A periods-only call must not reset totals/metrics_period to None."""
+        fp = tmp_path / "STATE.json"
+        write_state_file(fp, StateDocument(version="2"))
+        set_platform_metrics(
+            fp,
+            "google_ads",
+            "act_123",
+            totals={"spend": 3000.0},
+            metrics_period="LAST_30_DAYS",
+        )
+        doc = set_platform_metrics(
+            fp, "google_ads", "act_123", periods={"YESTERDAY": {"spend": 100.0}}
+        )
+        ps = doc.platforms["google_ads"]
+        assert ps.totals == {"spend": 3000.0}  # preserved
+        assert ps.metrics_period == "LAST_30_DAYS"  # preserved
+        assert ps.periods == {"YESTERDAY": {"spend": 100.0}}
+
+    @pytest.mark.unit
+    def test_periods_none_preserves_existing_map(self, tmp_path: Path) -> None:
+        fp = tmp_path / "STATE.json"
+        write_state_file(fp, StateDocument(version="2"))
+        set_platform_metrics(
+            fp, "google_ads", "act_123", periods={"LAST_30_DAYS": {"spend": 1.0}}
+        )
+        doc = set_platform_metrics(fp, "google_ads", "act_123", totals={"spend": 2.0})
+        ps = doc.platforms["google_ads"]
+        assert ps.periods == {"LAST_30_DAYS": {"spend": 1.0}}  # untouched
+
+    @pytest.mark.unit
+    def test_preserves_reports_section(self, tmp_path: Path) -> None:
+        """Unlike the other mutators, this one must not drop reports."""
+        fp = tmp_path / "STATE.json"
+        write_state_file(fp, StateDocument(version="2"))
+        set_report(fp, "daily", {"verdict": "Healthy"})
+        doc = set_platform_metrics(
+            fp, "google_ads", "act_123", periods={"YESTERDAY": {"spend": 1.0}}
+        )
+        assert doc.reports == {"daily": {"verdict": "Healthy"}}

--- a/tests/test_strategy_reminder.py
+++ b/tests/test_strategy_reminder.py
@@ -207,6 +207,7 @@ _MUTATING_CATALOGUE: frozenset[str] = frozenset(
         "mureo_strategy_set",
         "mureo_state_action_log_append",
         "mureo_state_report_set",
+        "mureo_state_platform_metrics_set",
     }
 )
 


### PR DESCRIPTION
## Summary

PR-B1 of the reports **period toggle** (前日 `YESTERDAY` / 30日 `LAST_30_DAYS`). Adds the MCP write path so skills can persist a platform's metric **rollup** into STATE.json on hosts without filesystem access (Claude Desktop / Cowork) — not just in Code mode via file `Write`.

Until now there was no MCP tool to set platform-level `totals` / `metrics_period` / `periods` (the existing `mureo_state_upsert_campaign` only writes **per-campaign** metrics and preserves the platform rollup, never sets it). So the reporting dashboard's per-platform KPIs — and the new period toggle — only populated in Code mode. This closes that gap.

## Changes

- **`state.py`** — `set_platform_metrics(path, platform, account_id, *, totals=None, metrics_period=None, periods=None)`:
  - Atomic via `_locked_state_mutation` (cross-process lock + atomic replace), identical to the sibling mutators.
  - **Merge semantics — a partial write never clobbers unrelated data**: `periods` merges **per window key** (a `YESTERDAY` write keeps a prior `LAST_30_DAYS` bucket; `periods=None` preserves the map); `totals`/`metrics_period` replaced when provided, preserved when omitted; the platform's `campaigns` and **every other platform** are preserved.
  - Preserves the `reports` section — deliberately does **not** repeat the pre-existing `upsert_campaign`/`append_action_log` bug that drops it (tracked separately).
- **`_handlers_mureo_context.py`** — `handle_state_platform_metrics_set`: requires `platform` + `account_id`; rejects malformed `totals` / `periods` / period-bucket / `metrics_period` shapes with `ValueError`; translates `ContextFileError` like `upsert_campaign`.
- **`tools_mureo_context.py`** — `Tool` definition (`mureo_state_platform_metrics_set`) + handler registration; module docstring 6→7 tools.
- Classified **mutating** via the `_set` suffix (`strategy_reminder`) and added to the test truth-table; tool-count assertions bumped (server 187→188, context module 6→7).

## Test plan

- [x] **9 new tests** — create+periods, per-window merge, campaign + sibling-platform preservation, omitted-field preservation, `periods=None` preservation, `reports` preservation, required-field + malformed-shape rejection (incl. `metrics_period` non-str).
- [x] `ruff` + `black` + `mypy` clean on changed sources.
- [x] python-reviewer: APPROVE (no CRITICAL/HIGH).
- [ ] CI green (watching).

> Local note: `test_mcp_server::test_list_tools_returns_all_tools` only validates the absolute count in clean CI; this dev env has third-party plugins registered (documented plugin-env noise), so it reads 340 locally. The deterministic module-level count test (`== 7`) passes everywhere.

## Staging

This is **PR-B1** (write-path backend). **PR-B2** (skill updates: sync-state → `LAST_30_DAYS`, daily-check → `YESTERDAY`, `_mureo-strategy` canonical vocab) follows after merge. Then **PR-C** (frontend toggle).

https://claude.ai/code/session_01NxBrN8Qn53Tpivt9SumdGn
