### PR TITLE
fix(state): preserve reports across upsert_campaign / append_action_log

### DIFF
--- a/mureo/context/state.py
+++ b/mureo/context/state.py
@@ -348,6 +348,11 @@ def upsert_campaign(
             campaigns=flat_campaigns,
             platforms=platforms,
             action_log=doc.action_log,
+            # Preserve the analysis summaries: a campaign upsert has no reports
+            # input, so dropping this would silently wipe the daily/weekly/goal
+            # summaries the dashboard renders (every upsert after a report write
+            # erased it).
+            reports=doc.reports,
         )
 
     return _locked_state_mutation(path, _build)
@@ -370,6 +375,9 @@ def append_action_log(path: Path, entry: ActionLogEntry) -> StateDocument:
             campaigns=doc.campaigns,
             platforms=doc.platforms,
             action_log=(*doc.action_log, entry),
+            # Preserve the analysis summaries — appending an action must not
+            # wipe the daily/weekly/goal reports the dashboard renders.
+            reports=doc.reports,
         )
 
     return _locked_state_mutation(path, _build)

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1496,3 +1496,49 @@ class TestSetPlatformMetrics:
             fp, "google_ads", "act_123", periods={"YESTERDAY": {"spend": 1.0}}
         )
         assert doc.reports == {"daily": {"verdict": "Healthy"}}
+
+
+class TestMutatorsPreserveReports:
+    """Regression: every STATE.json mutator must preserve the reports section.
+
+    `set_report` writes reports[daily|weekly|goal]; a later `upsert_campaign`
+    or `append_action_log` rebuilds the document and historically dropped
+    `reports` (omitted from the StateDocument constructor), silently wiping
+    the dashboard's analysis summaries. These pin the preservation so the
+    bug cannot regress.
+    """
+
+    @pytest.mark.unit
+    def test_upsert_campaign_preserves_reports(self, tmp_path: Path) -> None:
+        fp = tmp_path / "STATE.json"
+        write_state_file(fp, StateDocument(version="2"))
+        set_report(fp, "daily", {"verdict": "Healthy", "note": "all good"})
+
+        doc = upsert_campaign(
+            fp,
+            CampaignSnapshot(campaign_id="g1", campaign_name="Brand", status="ENABLED"),
+            platform="google_ads",
+            account_id="act_123",
+        )
+        assert doc.reports == {"daily": {"verdict": "Healthy", "note": "all good"}}
+        # And it survives to disk, not just the returned object.
+        assert read_state_file(fp).reports == {
+            "daily": {"verdict": "Healthy", "note": "all good"}
+        }
+
+    @pytest.mark.unit
+    def test_append_action_log_preserves_reports(self, tmp_path: Path) -> None:
+        fp = tmp_path / "STATE.json"
+        write_state_file(fp, StateDocument(version="2"))
+        set_report(fp, "weekly", {"verdict": "Watch"})
+
+        doc = append_action_log(
+            fp,
+            ActionLogEntry(
+                timestamp="2026-06-19T00:00:00+00:00",
+                action="budget_update",
+                platform="google_ads",
+            ),
+        )
+        assert doc.reports == {"weekly": {"verdict": "Watch"}}
+        assert read_state_file(fp).reports == {"weekly": {"verdict": "Watch"}}


### PR DESCRIPTION
## Summary

Fix a silent data-loss bug in two STATE.json mutators. `upsert_campaign._build` and `append_action_log._build` rebuilt the `StateDocument` **without** `reports=doc.reports`, so any campaign upsert or action-log append **after** a `set_report` write silently wiped the `reports` section (the daily / weekly / goal analysis summaries the read-only dashboard renders).

The sibling mutators `set_report` and `set_platform_metrics` already preserve `reports`; this aligns the two that didn't. Surfaced by the period-toggle PR reviews (#297 / #298) — the new writers were careful to avoid exactly this omission.

## Changes

- **`mureo/context/state.py`** — pass `reports=doc.reports` in both `_build` closures. No other behavior change: `version`, `last_synced_at`, `customer_id`, `campaigns`, `platforms`, `action_log` are all preserved exactly as before. Safe against aliasing (`StateDocument.__post_init__` deep-copies `reports`).
- **`tests/test_state.py`** — `TestMutatorsPreserveReports`: assert reports survive an upsert / an append, both in the returned object **and on disk**. These fail on the pre-fix code (`assert None == {...}`).

## Test plan

- [x] `TestMutatorsPreserveReports` (2) — verified to fail on pre-fix code, pass after.
- [x] No regression: `test_state`, `test_web_reports`, `test_reports_period_backend`, `test_mcp_tools_mureo_context` green (140).
- [x] `ruff` / `black` / `mypy` clean.
- [x] python-reviewer: APPROVE (no CRITICAL/HIGH/MEDIUM).

https://claude.ai/code/session_01NxBrN8Qn53Tpivt9SumdGn
