### PR TITLE
feat(service): add `mureo service restart`

### DIFF
--- a/mureo/cli/service_cmd.py
+++ b/mureo/cli/service_cmd.py
@@ -1,12 +1,15 @@
-"""``mureo service`` — install/uninstall/status the auto-start daemon (#241).
+"""``mureo service`` — install/uninstall/restart/status the auto-start daemon (#241).
 
-Registers (or removes, or inspects) a *user-level* auto-start agent that
-runs the headless configure daemon (``mureo configure --serve``) at login:
+Registers (or removes, restarts, or inspects) a *user-level* auto-start
+agent that runs the headless configure daemon (``mureo configure
+--serve``) at login:
 
 * ``install``   — write the OS unit AND start it now; print the dashboard
   URL and that it will auto-start at login. Idempotent.
 * ``uninstall`` — stop the running daemon AND remove the unit. Idempotent
   (a clean no-op when nothing is installed).
+* ``restart``   — kill + relaunch the running daemon in place so it picks
+  up new code / static assets without a re-install (needs it installed).
 * ``status``    — report installed? (unit registered) and running? (probe
   ``/api/ping`` on the configured port) and print the URL.
 
@@ -92,6 +95,19 @@ def uninstall() -> None:
         typer.echo(f"Failed to uninstall mureo service: {result.message}", err=True)
         raise typer.Exit(code=1)
     typer.echo(f"mureo service uninstalled ({result.message}).")
+
+
+@service_app.command("restart")
+def restart() -> None:
+    """Restart the running service so it picks up new code / static assets."""
+    backend = _resolve_backend()
+    result = backend.restart(port=SERVICE_PORT)
+    if not result.ok:
+        typer.echo(f"Failed to restart mureo service: {result.message}", err=True)
+        raise typer.Exit(code=1)
+    url = dashboard_url(port=SERVICE_PORT)
+    typer.echo("mureo service restarted.")
+    typer.echo(f"Dashboard: {url}")
 
 
 @service_app.command("status")

--- a/mureo/web/service/__init__.py
+++ b/mureo/web/service/__init__.py
@@ -9,9 +9,9 @@ is no privilege escalation:
 * Windows → an on-logon Scheduled Task + ``schtasks`` (:mod:`.windows`).
 
 Each backend exposes the same small contract — ``install()`` /
-``uninstall()`` / ``status()`` — returning the structured results defined
-here so the command layer (:mod:`mureo.cli.service_cmd`) stays
-OS-agnostic. Every backend degrades gracefully: a missing loader binary,
+``uninstall()`` / ``restart()`` / ``status()`` — returning the structured
+results defined here so the command layer (:mod:`mureo.cli.service_cmd`)
+stays OS-agnostic. Every backend degrades gracefully: a missing loader binary,
 a nonzero exit, or a permission error becomes an :class:`OpResult` with
 ``ok=False`` and a message, never a traceback.
 

--- a/mureo/web/service/launchd.py
+++ b/mureo/web/service/launchd.py
@@ -198,6 +198,38 @@ def uninstall(*, home: Path | None = None) -> OpResult:
     return OpResult(ok=True, message="removed")
 
 
+def restart(*, home: Path | None = None, port: int = SERVICE_PORT) -> OpResult:
+    """Restart the running agent in place (kill + relaunch).
+
+    ``launchctl kickstart -k`` stops the job and immediately relaunches it
+    under launchd, so a running daemon picks up new code / static assets
+    without a re-install. Requires the plist to be installed — a clean
+    "not installed" message points the user at ``mureo service install``.
+    When the plist exists but the job is not currently loaded (e.g. booted
+    out by hand), it is bootstrapped instead so ``restart`` still ends with
+    the daemon running.
+    """
+    path = plist_path(home)
+    if not path.exists():
+        return OpResult(ok=False, message="not installed (run `mureo service install`)")
+    if not _is_loaded():
+        # Registered plist but not loaded — bring it up rather than kickstart
+        # a job launchd does not know about.
+        return _load(path)
+    uid = _current_uid()
+    try:
+        proc = _run(["launchctl", "kickstart", "-k", f"gui/{uid}/{LABEL}"])
+    except FileNotFoundError:
+        return OpResult(ok=False, message="launchctl not found on PATH")
+    except OSError as exc:  # pragma: no cover - defensive
+        return OpResult(ok=False, message=str(exc))
+    if proc.returncode == 0:
+        return OpResult(ok=True, message="restarted")
+    return OpResult(
+        ok=False, message=(proc.stderr or "launchctl kickstart failed").strip()
+    )
+
+
 def status(*, home: Path | None = None, port: int = SERVICE_PORT) -> StatusResult:
     """Report installed (plist exists) and running (``/api/ping``) state."""
     installed = plist_path(home).exists()
@@ -212,6 +244,7 @@ __all__ = [
     "build_plist",
     "install",
     "plist_path",
+    "restart",
     "status",
     "uninstall",
 ]

--- a/mureo/web/service/systemd.py
+++ b/mureo/web/service/systemd.py
@@ -137,6 +137,28 @@ def uninstall(*, home: Path | None = None) -> OpResult:
     return OpResult(ok=True, message="removed")
 
 
+def restart(*, home: Path | None = None, port: int = SERVICE_PORT) -> OpResult:
+    """Restart the user unit in place via ``systemctl --user restart``.
+
+    Picks up new code / static assets without a re-install. Requires the
+    unit to be installed — a clean "not installed" message points the user
+    at ``mureo service install``.
+    """
+    if not unit_path(home).exists():
+        return OpResult(ok=False, message="not installed (run `mureo service install`)")
+    try:
+        proc = _systemctl("restart", UNIT_NAME)
+    except FileNotFoundError:
+        return OpResult(ok=False, message="systemctl not found on PATH")
+    except OSError as exc:  # pragma: no cover - defensive
+        return OpResult(ok=False, message=str(exc))
+    if proc.returncode == 0:
+        return OpResult(ok=True, message="restarted")
+    return OpResult(
+        ok=False, message=(proc.stderr or "systemctl restart failed").strip()
+    )
+
+
 def status(*, home: Path | None = None, port: int = SERVICE_PORT) -> StatusResult:
     """Report installed (unit exists) and running (``/api/ping``) state."""
     installed = unit_path(home).exists()
@@ -150,6 +172,7 @@ __all__ = [
     "UNIT_NAME",
     "build_unit",
     "install",
+    "restart",
     "status",
     "uninstall",
     "unit_path",

--- a/mureo/web/service/windows.py
+++ b/mureo/web/service/windows.py
@@ -117,6 +117,35 @@ def uninstall(*, home: Path | None = None) -> OpResult:
     return OpResult(ok=True, message="removed")
 
 
+def restart(*, home: Path | None = None, port: int = SERVICE_PORT) -> OpResult:
+    """Restart the on-logon task: end the running instance, then run it.
+
+    Picks up new code / static assets without a re-install. Requires the
+    task to exist — a clean "not installed" message points the user at
+    ``mureo service install``. ``schtasks /End`` stops the current instance
+    (a not-running task makes ``/End`` return nonzero, which is ignored so
+    it never fails the restart) and ``/Run`` starts a fresh one.
+    """
+    try:
+        query = _run(["schtasks", "/Query", "/TN", TASK_NAME])
+        if query.returncode != 0:
+            return OpResult(
+                ok=False, message="not installed (run `mureo service install`)"
+            )
+        # Best-effort stop of any running instance before relaunching.
+        _run(["schtasks", "/End", "/TN", TASK_NAME])
+        proc = _run(["schtasks", "/Run", "/TN", TASK_NAME])
+        if proc.returncode != 0:
+            return OpResult(
+                ok=False, message=(proc.stderr or proc.stdout or "").strip()
+            )
+    except FileNotFoundError:
+        return OpResult(ok=False, message="schtasks not found on PATH")
+    except OSError as exc:  # pragma: no cover - defensive
+        return OpResult(ok=False, message=str(exc))
+    return OpResult(ok=True, message="restarted")
+
+
 def status(*, home: Path | None = None, port: int = SERVICE_PORT) -> StatusResult:
     """Report installed (task exists) and running (``/api/ping``) state."""
     installed = _task_exists()
@@ -129,6 +158,7 @@ def status(*, home: Path | None = None, port: int = SERVICE_PORT) -> StatusResul
 __all__ = [
     "TASK_NAME",
     "install",
+    "restart",
     "status",
     "task_run_command",
     "uninstall",

--- a/tests/test_cli_service.py
+++ b/tests/test_cli_service.py
@@ -53,6 +53,7 @@ class TestServiceSubcommandRegistered:
         assert result.exit_code == 0
         assert "install" in result.output
         assert "uninstall" in result.output
+        assert "restart" in result.output
         assert "status" in result.output
 
 
@@ -196,3 +197,52 @@ class TestUnsupportedPlatform:
         # No traceback — a clean, explained nonzero exit.
         assert result.exit_code != 0
         assert "not supported" in result.output.lower()
+
+
+@pytest.mark.unit
+class TestRestartDispatch:
+    @pytest.mark.parametrize(
+        ("platform", "backend_attr"),
+        [
+            ("darwin", "launchd"),
+            ("linux", "systemd"),
+            ("win32", "windows"),
+        ],
+    )
+    def test_restart_dispatches_to_backend(
+        self, platform: str, backend_attr: str
+    ) -> None:
+        with (
+            patch("mureo.cli.service_cmd.sys.platform", platform),
+            patch(
+                f"mureo.web.service.{backend_attr}.restart",
+                return_value=OpResult(ok=True, message="restarted"),
+            ) as mock_restart,
+        ):
+            result = _runner().invoke(_app(), ["service", "restart"])
+        assert result.exit_code == 0, result.output
+        mock_restart.assert_called_once()
+
+    def test_restart_nonzero_on_backend_error(self) -> None:
+        with (
+            patch("mureo.cli.service_cmd.sys.platform", "darwin"),
+            patch(
+                "mureo.web.service.launchd.restart",
+                return_value=OpResult(ok=False, message="not installed"),
+            ),
+        ):
+            result = _runner().invoke(_app(), ["service", "restart"])
+        assert result.exit_code != 0
+        assert "not installed" in result.output
+
+    def test_restart_prints_dashboard_url(self) -> None:
+        with (
+            patch("mureo.cli.service_cmd.sys.platform", "darwin"),
+            patch(
+                "mureo.web.service.launchd.restart",
+                return_value=OpResult(ok=True, message="restarted"),
+            ),
+        ):
+            result = _runner().invoke(_app(), ["service", "restart"])
+        assert result.exit_code == 0
+        assert "http://127.0.0.1:7613/" in result.output

--- a/tests/web/service/test_launchd.py
+++ b/tests/web/service/test_launchd.py
@@ -252,3 +252,92 @@ class TestStatus:
             result = launchd.status(home=home, port=7613)
         assert result.installed is False
         assert result.running is False
+
+
+@pytest.mark.unit
+class TestRestart:
+    """``restart`` kickstarts the loaded agent in place (kill + relaunch)."""
+
+    def _write_plist(self, home: Path) -> None:
+        launchd.plist_path(home).write_bytes(launchd.build_plist(home, port=7613))
+
+    def test_restart_kickstarts_when_loaded(self, home: Path) -> None:
+        self._write_plist(home)
+
+        def fake_run(argv: list[str], **kwargs: object) -> object:
+            if "print" in argv:  # _is_loaded probe → loaded
+                return _ok()
+            return _ok()  # kickstart
+
+        with patch.object(launchd.subprocess, "run", side_effect=fake_run) as mock_run:
+            result = launchd.restart(home=home, port=7613)
+        assert result.ok
+        assert result.message == "restarted"
+        argvs = [c.args[0] for c in mock_run.call_args_list]
+        assert any(
+            a[:3] == ["launchctl", "kickstart", "-k"] and a[-1].endswith(launchd.LABEL)
+            for a in argvs
+        )
+
+    def test_restart_not_installed_is_clear_error(self, home: Path) -> None:
+        # No plist written.
+        with patch.object(launchd.subprocess, "run", return_value=_ok()) as mock_run:
+            result = launchd.restart(home=home, port=7613)
+        assert not result.ok
+        assert "not installed" in result.message
+        mock_run.assert_not_called()
+
+    def test_restart_loads_when_registered_but_not_loaded(self, home: Path) -> None:
+        self._write_plist(home)
+
+        def fake_run(argv: list[str], **kwargs: object) -> object:
+            if "print" in argv:  # _is_loaded probe → NOT loaded
+                return _fail()
+            return _ok()  # bootstrap
+
+        with patch.object(launchd.subprocess, "run", side_effect=fake_run) as mock_run:
+            result = launchd.restart(home=home, port=7613)
+        assert result.ok
+        argvs = [c.args[0] for c in mock_run.call_args_list]
+        # It bootstrapped (loaded) rather than kickstarting an unloaded job.
+        assert any("bootstrap" in a for a in argvs)
+        assert not any("kickstart" in a for a in argvs)
+
+    def test_restart_propagates_load_failure_when_not_loaded(self, home: Path) -> None:
+        self._write_plist(home)
+
+        def fake_run(argv: list[str], **kwargs: object) -> object:
+            if "print" in argv:  # _is_loaded probe -> NOT loaded
+                return _fail()
+            return _fail("bootstrap boom")  # both bootstrap and load fail
+
+        with patch.object(launchd.subprocess, "run", side_effect=fake_run):
+            result = launchd.restart(home=home, port=7613)
+        assert not result.ok
+        assert "bootstrap boom" in result.message
+
+    def test_restart_reports_error_on_nonzero_kickstart(self, home: Path) -> None:
+        self._write_plist(home)
+
+        def fake_run(argv: list[str], **kwargs: object) -> object:
+            if "print" in argv:
+                return _ok()  # loaded
+            return _fail("kickstart boom")
+
+        with patch.object(launchd.subprocess, "run", side_effect=fake_run):
+            result = launchd.restart(home=home, port=7613)
+        assert not result.ok
+        assert "kickstart boom" in result.message
+
+    def test_restart_handles_missing_launchctl(self, home: Path) -> None:
+        self._write_plist(home)
+
+        def fake_run(argv: list[str], **kwargs: object) -> object:
+            if "print" in argv:
+                return _ok()  # loaded
+            raise FileNotFoundError
+
+        with patch.object(launchd.subprocess, "run", side_effect=fake_run):
+            result = launchd.restart(home=home, port=7613)
+        assert not result.ok
+        assert "launchctl not found" in result.message

--- a/tests/web/service/test_systemd.py
+++ b/tests/web/service/test_systemd.py
@@ -155,3 +155,45 @@ class TestStatus:
             result = systemd.status(home=home, port=7613)
         assert result.installed is False
         assert result.running is False
+
+
+@pytest.mark.unit
+class TestRestart:
+    """``restart`` runs ``systemctl --user restart`` on the installed unit."""
+
+    def _write_unit(self, home: Path) -> None:
+        path = systemd.unit_path(home)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(systemd.build_unit(port=7613), encoding="utf-8")
+
+    def test_restart_runs_systemctl_restart(self, home: Path) -> None:
+        self._write_unit(home)
+        with patch.object(systemd.subprocess, "run", return_value=_ok()) as mock_run:
+            result = systemd.restart(home=home, port=7613)
+        assert result.ok
+        assert result.message == "restarted"
+        argvs = [c.args[0] for c in mock_run.call_args_list]
+        assert ["systemctl", "--user", "restart", systemd.UNIT_NAME] in argvs
+
+    def test_restart_not_installed_is_clear_error(self, home: Path) -> None:
+        with patch.object(systemd.subprocess, "run", return_value=_ok()) as mock_run:
+            result = systemd.restart(home=home, port=7613)
+        assert not result.ok
+        assert "not installed" in result.message
+        mock_run.assert_not_called()
+
+    def test_restart_reports_error_on_nonzero_exit(self, home: Path) -> None:
+        self._write_unit(home)
+        with patch.object(systemd.subprocess, "run", return_value=_fail("nope")):
+            result = systemd.restart(home=home, port=7613)
+        assert not result.ok
+        assert "nope" in result.message
+
+    def test_restart_handles_missing_systemctl(self, home: Path) -> None:
+        self._write_unit(home)
+        with patch.object(
+            systemd.subprocess, "run", side_effect=FileNotFoundError("systemctl")
+        ):
+            result = systemd.restart(home=home, port=7613)
+        assert not result.ok
+        assert "systemctl not found" in result.message

--- a/tests/web/service/test_windows.py
+++ b/tests/web/service/test_windows.py
@@ -159,3 +159,52 @@ class TestStatus:
         ):
             result = windows.status(home=home, port=7613)
         assert result.installed is False
+
+
+@pytest.mark.unit
+class TestRestart:
+    """``restart`` ends the running task instance, then runs a fresh one."""
+
+    def test_restart_ends_and_runs_task(self, home: Path) -> None:
+        # query (found) → /End → /Run
+        with patch.object(
+            windows.subprocess, "run", side_effect=[_ok(), _ok(), _ok()]
+        ) as mock_run:
+            result = windows.restart(home=home, port=7613)
+        assert result.ok
+        assert result.message == "restarted"
+        argvs = [c.args[0] for c in mock_run.call_args_list]
+        assert any("/End" in a and windows.TASK_NAME in a for a in argvs)
+        assert any("/Run" in a and windows.TASK_NAME in a for a in argvs)
+
+    def test_restart_not_installed_is_clear_error(self, home: Path) -> None:
+        with patch.object(windows.subprocess, "run", return_value=_fail("not found")):
+            result = windows.restart(home=home, port=7613)
+        assert not result.ok
+        assert "not installed" in result.message
+
+    def test_restart_reports_error_on_run_failure(self, home: Path) -> None:
+        # query (found) → /End ok → /Run fails
+        with patch.object(
+            windows.subprocess, "run", side_effect=[_ok(), _ok(), _fail("denied")]
+        ):
+            result = windows.restart(home=home, port=7613)
+        assert not result.ok
+        assert "denied" in result.message
+
+    def test_restart_ignores_end_failure(self, home: Path) -> None:
+        # query (found) -> /End fails (task not running) -> /Run ok: still ok.
+        with patch.object(
+            windows.subprocess, "run", side_effect=[_ok(), _fail("not running"), _ok()]
+        ):
+            result = windows.restart(home=home, port=7613)
+        assert result.ok
+        assert result.message == "restarted"
+
+    def test_restart_handles_missing_schtasks(self, home: Path) -> None:
+        with patch.object(
+            windows.subprocess, "run", side_effect=FileNotFoundError("schtasks")
+        ):
+            result = windows.restart(home=home, port=7613)
+        assert not result.ok
+        assert "schtasks not found" in result.message


### PR DESCRIPTION
## Summary

Add a `mureo service restart` command. The auto-start configure daemon (`mureo configure --serve`, registered by `mureo service install`) had no first-class restart — the only ways to pick up new code / static assets were `launchctl kickstart -k …` by hand (macOS) or a full `mureo service install` re-register. This adds `restart` alongside `install` / `uninstall` / `status`.

## Changes

- **`cli/service_cmd.py`** — `restart` subcommand: dispatches to the platform backend, maps `ok` → exit code, prints the dashboard URL on success, errors to stderr + nonzero (structurally identical to `install`).
- **`web/service/launchd.py`** — `launchctl kickstart -k gui/<uid>/io.mureo.configure` (kill + relaunch). When the plist exists but the job is **not loaded**, it bootstraps instead of kickstarting an unknown job. Clean "not installed" guard before any `launchctl` call.
- **`web/service/systemd.py`** — `systemctl --user restart <unit>`.
- **`web/service/windows.py`** — `schtasks /End` (best-effort; a not-running task's nonzero `/End` is ignored) then `/Run`.
- All backends keep the shared contract: never raise; a missing binary / nonzero exit / not-installed becomes a structured `OpResult(ok=False)`. The `__init__` contract docstring and the CLI module docstring are updated.

## Behavior

```
$ mureo service restart
mureo service restarted.
Dashboard: http://127.0.0.1:7613/
```

Not installed → clear, non-destructive error:
```
Failed to restart mureo service: not installed (run `mureo service install`)
```

## Test plan

- [x] **16 new tests** across the CLI + three backends: happy-path argv, not-installed guard (no loader call), nonzero-exit, missing-binary, launchd not-loaded→bootstrap fallback (+ its failure propagation), windows `/End`-ignored-on-failure.
- [x] Service suites green (92); `ruff` / `black` / `mypy` clean.
- [x] python-reviewer: APPROVE (no CRITICAL/HIGH).

https://claude.ai/code/session_01NxBrN8Qn53Tpivt9SumdGn
