### PR TITLE
fix(web): hide empty reports header controls via [hidden] override

### DIFF
--- a/mureo/_data/web/app.css
+++ b/mureo/_data/web/app.css
@@ -1309,6 +1309,14 @@ dialog[data-confirm-dialog] [data-confirm-ok] {
   margin: 0;
 }
 
+/* The explicit `display` above overrides the UA `[hidden] { display: none }`,
+   so the single-client case (renderReports sets the `hidden` attribute) would
+   otherwise leave an empty client dropdown on screen. Same gotcha handled for
+   .dashboard-group / .app-toast / .btn elsewhere. */
+.dashboard-reports-client[hidden] {
+  display: none;
+}
+
 .dashboard-reports-client span {
   font-size: 12px;
   font-weight: 600;
@@ -1339,6 +1347,13 @@ dialog[data-confirm-dialog] [data-confirm-ok] {
   background: var(--surface-2);
   border: 1px solid var(--hairline);
   border-radius: var(--r-pill);
+}
+
+/* Same `[hidden]`-override gotcha as .dashboard-reports-client: the explicit
+   `display` above would otherwise leave an empty toggle on screen when there
+   is only one (or zero) window to switch between. */
+.dashboard-reports-period[hidden] {
+  display: none;
 }
 
 .reports-period-btn {

--- a/tests/test_web_assets_reports_period_toggle.py
+++ b/tests/test_web_assets_reports_period_toggle.py
@@ -79,3 +79,16 @@ def test_css_styles_active_period_segment() -> None:
     css = _read("app.css")
     assert ".reports-period-btn" in css
     assert ".reports-period-btn.is-active" in css
+
+
+@pytest.mark.unit
+def test_hidden_attribute_collapses_reports_header_controls() -> None:
+    """The client selector and the period toggle both set ``display``
+    explicitly, which overrides the UA ``[hidden] { display: none }`` — so
+    each needs a targeted ``[hidden]`` rule, or it renders an empty control
+    when JS hides it (a single client / fewer than two windows). Regression
+    guard for the empty client dropdown that shipped in the reports UI.
+    """
+    css = _read("app.css")
+    assert ".dashboard-reports-client[hidden]" in css
+    assert ".dashboard-reports-period[hidden]" in css


### PR DESCRIPTION
## Summary

Fix an empty control that shows in the reports header. The client selector (`.dashboard-reports-client`) and the period toggle (`.dashboard-reports-period`) both set `display` explicitly, which **overrides the UA `[hidden] { display: none }`**. So when the frontend sets the `hidden` attribute — a **single reporting client** (the OSS default) or **fewer than two windows** — the control did not collapse and an **empty dropdown / toggle** stayed on screen.

User-visible symptom: on a standalone (single-client) install, the reports header showed an empty "Client" dropdown.

## Changes

- **`app.css`** — add targeted `.dashboard-reports-client[hidden]` and `.dashboard-reports-period[hidden]` rules (`display: none`), matching the existing `.dashboard-group[hidden]` / `.app-toast[hidden]` / `.btn[hidden]` pattern already used for this exact gotcha.
- **test** — assert both `[hidden]` rules exist (regression guard).

The client selector still appears (unchanged) when an Agency backend's `list_clients()` seam returns more than one client — only the empty single-client case is collapsed.

## Test plan

- [x] New regression test; web-asset + i18n suites green (53).
- [x] `ruff` / `black` clean.
- [x] **Verified in a real browser (Playwright)** against the live dashboard: single-client → client dropdown `display:none`; the 2-window period toggle still renders.

## Note

The Agency multi-client extension point (`list_clients()` / `state_store_for_client(slug)` seam in `reports.py`) is already present in OSS — no change needed here. An Agency plugin that returns multiple clients lights up this same (now correctly show/hide) selector.

https://claude.ai/code/session_01NxBrN8Qn53Tpivt9SumdGn
