### PR TITLE
feat(web): cleaner, colour-coded report flag chips

### DIFF
--- a/mureo/_data/web/dashboard.js
+++ b/mureo/_data/web/dashboard.js
@@ -1429,25 +1429,28 @@
   // analysis skill authors (e.g. "cpa_over_target_logly"). Map the common
   // bases to friendly localized labels; anything unknown is humanized
   // generically so a raw snake_case token never reaches the operator. The
-  // LONGEST matching base wins, and any trailing context (e.g. the platform)
-  // is humanized and shown in parentheses — UNLESS the base opts out with a
-  // third `true` element (for flags whose remainder is a noisy identifier,
-  // not a useful platform, e.g. a Search Console property name).
+  // LONGEST matching base wins. Only the base label is shown — the trailing
+  // remainder (a platform or a descriptor) is dropped: it was inconsistent
+  // across flags and read as distracting, ambiguous parentheses. Detail
+  // lives in the report narrative. The 3rd element is the chip severity
+  // (is-warn / is-danger / is-success) so flags read as coloured tags:
+  // off-target / setup gaps = warn (amber), data-integrity / runaway = danger
+  // (red), on-target = success (green).
   const REPORTS_FLAG_BASES = [
-    ["cpa_over_target", "dashboard.reports_flag_cpa_over_target"],
-    ["cpa_under_target", "dashboard.reports_flag_cpa_under_target"],
-    ["cv_below_target", "dashboard.reports_flag_cv_below_target"],
-    ["conversions_below_target", "dashboard.reports_flag_cv_below_target"],
-    ["cv_above_target", "dashboard.reports_flag_cv_above_target"],
-    ["operation_mode_mismatch", "dashboard.reports_flag_operation_mode_mismatch"],
-    ["low_cvr_lp_conversion", "dashboard.reports_flag_low_cvr_lp"],
-    ["low_cvr", "dashboard.reports_flag_low_cvr"],
-    ["sparse_conversions_tracking_suspect", "dashboard.reports_flag_tracking_suspect"],
-    ["tracking_suspect", "dashboard.reports_flag_tracking_suspect"],
-    ["zero_conversions", "dashboard.reports_flag_zero_conversions"],
-    ["budget_overspend", "dashboard.reports_flag_budget_overspend"],
-    ["spend_spike", "dashboard.reports_flag_spend_spike"],
-    ["search_console_no", "dashboard.reports_flag_sc_no_property", true],
+    ["cpa_over_target", "dashboard.reports_flag_cpa_over_target", "is-warn"],
+    ["cpa_under_target", "dashboard.reports_flag_cpa_under_target", "is-success"],
+    ["cv_below_target", "dashboard.reports_flag_cv_below_target", "is-warn"],
+    ["conversions_below_target", "dashboard.reports_flag_cv_below_target", "is-warn"],
+    ["cv_above_target", "dashboard.reports_flag_cv_above_target", "is-success"],
+    ["operation_mode_mismatch", "dashboard.reports_flag_operation_mode_mismatch", "is-warn"],
+    ["low_cvr_lp_conversion", "dashboard.reports_flag_low_cvr_lp", "is-warn"],
+    ["low_cvr", "dashboard.reports_flag_low_cvr", "is-warn"],
+    ["sparse_conversions_tracking_suspect", "dashboard.reports_flag_tracking_suspect", "is-danger"],
+    ["tracking_suspect", "dashboard.reports_flag_tracking_suspect", "is-danger"],
+    ["zero_conversions", "dashboard.reports_flag_zero_conversions", "is-danger"],
+    ["budget_overspend", "dashboard.reports_flag_budget_overspend", "is-danger"],
+    ["spend_spike", "dashboard.reports_flag_spend_spike", "is-warn"],
+    ["search_console_no", "dashboard.reports_flag_sc_no_property", "is-warn"],
   ];
 
   // snake_case tokens that read better upper-cased (metric acronyms).
@@ -1478,23 +1481,37 @@
     return s.charAt(0).toUpperCase() + s.slice(1);
   }
 
-  function humanizeReportFlag(flag) {
-    const raw = String(flag == null ? "" : flag);
+  // The longest base entry that a bare-string flag matches (or null).
+  function matchReportFlagBase(raw) {
     let best = null;
     for (let i = 0; i < REPORTS_FLAG_BASES.length; i++) {
       const base = REPORTS_FLAG_BASES[i][0];
-      if ((raw === base || raw.indexOf(base + "_") === 0) &&
-          (!best || base.length > best[0].length)) {
+      if (
+        (raw === base || raw.indexOf(base + "_") === 0) &&
+        (!best || base.length > best[0].length)
+      ) {
         best = REPORTS_FLAG_BASES[i];
       }
     }
-    if (!best) return humanizeFlagWords(raw);
-    const label = MUREO.t(best[1]);
-    // best[2] === true suppresses the parenthetical context (noisy remainder).
-    const ctx = best[2]
-      ? ""
-      : humanizeFlagWords(raw.slice(best[0].length).replace(/^_/, ""));
-    return ctx ? label + " (" + ctx + ")" : label;
+    return best;
+  }
+
+  function humanizeReportFlag(flag) {
+    const raw = String(flag == null ? "" : flag);
+    const best = matchReportFlagBase(raw);
+    // A matched base shows only its localized label (no trailing context).
+    return best ? MUREO.t(best[1]) : humanizeFlagWords(raw);
+  }
+
+  // Severity class for a flag's coloured chip. Object flags carry an explicit
+  // level; a bare string uses its base entry's curated severity, falling back
+  // to keyword inference (flagChipKind) for unmapped flags.
+  function reportFlagKind(flag) {
+    if (flag && typeof flag === "object") {
+      return flagChipKind(flag.level || flag.kind);
+    }
+    const best = matchReportFlagBase(String(flag == null ? "" : flag));
+    return (best && best[2]) || flagChipKind(flag);
   }
 
   // The selected window. Default = YESTERDAY (daily-check runs every day, so
@@ -1685,9 +1702,8 @@
         const label = isObj
           ? flag.label || flag.message || flag.level || ""
           : humanizeReportFlag(flag);
-        const level = isObj ? flag.level || flag.kind : flag;
         const chip = document.createElement("span");
-        chip.className = "report-chip " + flagChipKind(level);
+        chip.className = "report-chip " + reportFlagKind(flag);
         chip.textContent = String(label);
         chips.appendChild(chip);
       });

--- a/tests/test_web_assets_reports_period_toggle.py
+++ b/tests/test_web_assets_reports_period_toggle.py
@@ -120,3 +120,16 @@ def test_common_flag_labels_present_in_both_locales() -> None:
         for loc in ("en", "ja"):
             assert data[loc].get(key), f"{key} missing in {loc}"
         assert data["en"][key] != data["ja"][key], f"{key} not localized"
+
+
+@pytest.mark.unit
+def test_report_flags_get_severity_colored_chips() -> None:
+    """Flags render as coloured tags: each known base carries a severity
+    (is-warn / is-danger / is-success) and the chip class comes from
+    reportFlagKind(), not raw keyword inference alone — so issue flags are
+    not all neutral grey."""
+    js = _read("dashboard.js")
+    assert "function reportFlagKind(" in js
+    assert "reportFlagKind(flag)" in js
+    assert '"is-warn"' in js
+    assert '"is-danger"' in js


### PR DESCRIPTION
## Summary

Two refinements to the "Latest report" flag chips, following up on #304 (which humanized the raw `snake_case` flags into localized labels). Driven by user feedback that the chips were hard to scan.

1. **Drop the parenthetical context.** The trailing remainder was inconsistent — sometimes a platform (`(Logly)`), sometimes a descriptor (`(Mature campaign)`) — and read as distracting, ambiguous parentheses. A matched flag now shows **only its localized label**; the detail stays in the report narrative below.
2. **Colour the chips by severity.** `flagChipKind` keyed on keywords the flag *codes* never contain, so every issue flag rendered neutral grey. Each known base now carries a severity, and `reportFlagKind()` drives the chip class:
   - off-target / setup gaps → **warn** (amber)
   - data-integrity / runaway → **danger** (red)
   - on-target → **success** (green)
   - unmapped flags still fall back to keyword inference.

## Changes

- **`dashboard.js`** — factor the base-match loop into `matchReportFlagBase()`, shared by `humanizeReportFlag()` (label) and the new `reportFlagKind()` (severity). Add a 3rd `is-*` element to each `REPORTS_FLAG_BASES` entry. Object-shaped flags keep their author label + explicit level. XSS-safe (`textContent`); reuses the existing chip tint tokens (**no new CSS**).
- **test** — assert `reportFlagKind` exists, the chip uses it, and the bases carry severities.

## Result (bizhint, JA)

`CPAが目標超過` · `CVが目標未達` · `運用モードが不一致` · `LPのCVRが低い` · `Search Consoleプロパティ未設定` = amber (warn); `CV計測に懸念` = red (danger). No parentheses.

## Test plan

- [x] Asset tests green (11); `ruff` / `black` clean; JS `node --check` clean.
- [x] **Verified in a real browser (Playwright, JA)** — five amber warn chips + one red danger chip, no parens.

https://claude.ai/code/session_01NxBrN8Qn53Tpivt9SumdGn
