### PR TITLE
feat(web): multi-client overview on the Reports tab (closes #307)

### DIFF
--- a/mureo/_data/web/app.css
+++ b/mureo/_data/web/app.css
@@ -1392,6 +1392,102 @@ dialog[data-confirm-dialog] [data-confirm-ok] {
   color: var(--muted);
 }
 
+/* Multi-client overview (#307): one selectable card per client, above the
+   per-client detail. A single-workspace install shows one card. */
+.dashboard-reports-clients {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 10px;
+  margin: 12px 0 4px;
+}
+
+.dashboard-reports-clients[hidden] {
+  display: none;
+}
+
+.reports-client-card {
+  appearance: none;
+  text-align: left;
+  font: inherit;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px 13px;
+  background: var(--surface);
+  border: 1px solid var(--hairline);
+  border-radius: 12px;
+}
+
+.reports-client-card:hover {
+  border-color: var(--hairline-strong);
+}
+
+.reports-client-card.is-selected {
+  border-color: var(--accent);
+  box-shadow: inset 0 0 0 1px var(--accent);
+}
+
+.reports-client-card:focus-visible {
+  outline: 2px solid var(--accent-ring);
+  outline-offset: 1px;
+}
+
+.reports-client-card-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.reports-client-card-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--ink);
+}
+
+.reports-client-card-fresh {
+  font-size: 11px;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.reports-client-card-kpis {
+  display: flex;
+  gap: 14px;
+}
+
+.reports-client-kpi {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.reports-client-kpi-value {
+  font-size: 15px;
+  font-weight: 600;
+  font-family: var(--font-mono);
+  color: var(--ink);
+}
+
+.reports-client-kpi-label {
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.reports-client-card-flags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.reports-client-flag-more {
+  background: var(--surface-2);
+  color: var(--muted);
+}
+
 /* Responsive KPI card grid — auto-fits cards, never less than ~260px. */
 .dashboard-reports-cards {
   display: grid;

--- a/mureo/_data/web/app.html
+++ b/mureo/_data/web/app.html
@@ -166,12 +166,6 @@
               <div class="dashboard-reports-head">
                 <h2 data-i18n="dashboard.reports_title">Reports</h2>
                 <div class="dashboard-reports-meta">
-                  <!-- Client selector — only shown when more than one client
-                       (Agency seam). Populated by renderReports(). -->
-                  <label class="dashboard-reports-client" data-reports-client-wrap hidden>
-                    <span data-i18n="dashboard.reports_client_label">Client</span>
-                    <select data-reports-client></select>
-                  </label>
                   <!-- Period toggle (前日｜30日). Populated by renderReports()
                        from summary.periods; hidden unless >= 2 windows. -->
                   <div class="dashboard-reports-period" data-reports-period
@@ -181,6 +175,13 @@
                 </div>
               </div>
               <p class="dashboard-reports-hint" data-i18n="dashboard.reports_hint">Data reflects the latest sync-state run.</p>
+
+              <!-- Multi-client overview (#307): one card per client (KPIs +
+                   latest-report flags). Click a card to load its detail below.
+                   Replaces the old single-select dropdown. Hidden until built;
+                   a single-workspace install shows one card. -->
+              <div class="dashboard-reports-clients" data-reports-clients
+                   role="list" aria-label="Clients" hidden></div>
 
               <!-- Per-platform KPI cards (generic over the API's platforms). -->
               <div class="dashboard-reports-cards" data-reports-cards></div>

--- a/mureo/_data/web/dashboard.js
+++ b/mureo/_data/web/dashboard.js
@@ -1776,27 +1776,237 @@
     });
   }
 
-  // Populate / toggle the client selector. Only shown when >1 client.
-  function renderReportsClientSelector(clients, active) {
-    const wrap = document.querySelector("[data-reports-client-wrap]");
-    const select = document.querySelector("[data-reports-client]");
-    if (!wrap || !select) return;
+  // ----------------------------------------------------------------------
+  // Multi-client overview (#307): a card grid (one per client) replaces the
+  // old single-select dropdown. Each card shows that client's headline KPIs
+  // + latest report flags; clicking it loads the existing per-client detail.
+  // ----------------------------------------------------------------------
+
+  const REPORTS_CLIENT_FLAG_CAP = 3; // chips per card before collapsing to +N
+
+  // Fetch JSON defensively — null on any failure / non-object body.
+  async function fetchReportsJson(url) {
+    try {
+      const res = await fetch(url, { credentials: "same-origin" });
+      if (!res.ok) return null;
+      const body = await res.json();
+      return body && typeof body === "object" ? body : null;
+    } catch (_err) {
+      return null;
+    }
+  }
+
+  // Sum a client's headline KPIs across its platforms. null when absent so a
+  // missing metric reads as "—" rather than a misleading zero.
+  function aggregateClientKpis(summary) {
+    const platforms =
+      summary && Array.isArray(summary.platforms) ? summary.platforms : [];
+    let spend = 0;
+    let conv = 0;
+    let hasSpend = false;
+    let hasConv = false;
+    platforms.forEach(function (p) {
+      const t = p && typeof p.totals === "object" ? p.totals : null;
+      if (!t) return;
+      if (typeof t.spend === "number" && isFinite(t.spend)) {
+        spend += t.spend;
+        hasSpend = true;
+      }
+      if (typeof t.conversions === "number" && isFinite(t.conversions)) {
+        conv += t.conversions;
+        hasConv = true;
+      }
+    });
+    return {
+      spend: hasSpend ? spend : null,
+      conversions: hasConv ? conv : null,
+      cpa: hasSpend && hasConv && conv > 0 ? spend / conv : null,
+    };
+  }
+
+  // Flags from a client's latest report (daily → weekly → goal).
+  function clientReportFlags(summary) {
+    const reports =
+      summary && typeof summary.reports === "object" ? summary.reports : null;
+    if (!reports) return [];
+    const r = reports.daily || reports.weekly || reports.goal;
+    return r && Array.isArray(r.flags) ? r.flags : [];
+  }
+
+  // Sort flags danger → warn → success → neutral (most urgent first).
+  const REPORTS_FLAG_SEVERITY_ORDER = ["is-danger", "is-warn", "is-success", ""];
+  function flagSeverityRank(flag) {
+    const idx = REPORTS_FLAG_SEVERITY_ORDER.indexOf(reportFlagKind(flag));
+    return idx === -1 ? REPORTS_FLAG_SEVERITY_ORDER.length : idx;
+  }
+
+  // Fetch a client's summary for its overview card. Honours the period toggle,
+  // and when the selected window has no totals (a period-bucketed client whose
+  // passthrough rollup is blank) falls back to the first window with data.
+  async function fetchClientCardSummary(slug) {
+    function summaryUrl(period) {
+      const params = [];
+      if (slug) params.push("client=" + encodeURIComponent(slug));
+      if (period) params.push("period=" + encodeURIComponent(period));
+      return (
+        "/api/reports/summary" + (params.length ? "?" + params.join("&") : "")
+      );
+    }
+    let summary = (await fetchReportsJson(summaryUrl(reportsPeriod))) || {};
+    const kpis = aggregateClientKpis(summary);
+    const periods = Array.isArray(summary.periods)
+      ? summary.periods.filter(function (p) {
+          return typeof p === "string" && p;
+        })
+      : [];
+    if (kpis.spend == null && kpis.conversions == null && periods.length) {
+      const fallback = periods.indexOf(reportsPeriod) === -1 ? periods[0] : null;
+      if (fallback) {
+        const alt = await fetchReportsJson(summaryUrl(fallback));
+        if (alt) summary = alt;
+      }
+    }
+    return summary;
+  }
+
+  function clientKpiCell(labelKey, value) {
+    const cell = document.createElement("div");
+    cell.className = "reports-client-kpi";
+    const v = document.createElement("span");
+    v.className = "reports-client-kpi-value";
+    v.textContent = value;
+    const l = document.createElement("span");
+    l.className = "reports-client-kpi-label";
+    l.textContent = MUREO.t(labelKey);
+    cell.appendChild(v);
+    cell.appendChild(l);
+    return cell;
+  }
+
+  function buildClientCard(client, summary) {
+    const slug = client && client.slug ? client.slug : "";
+    const card = document.createElement("button");
+    card.type = "button";
+    card.className = "reports-client-card";
+    card.setAttribute("role", "listitem");
+    card.setAttribute("data-client", slug);
+
+    const head = document.createElement("div");
+    head.className = "reports-client-card-head";
+    const name = document.createElement("span");
+    name.className = "reports-client-card-name";
+    name.textContent = (client && (client.name || client.slug)) || "";
+    head.appendChild(name);
+    const fresh = document.createElement("span");
+    fresh.className = "reports-client-card-fresh";
+    fresh.textContent =
+      summary && summary.last_synced_at ? relativeAge(summary.last_synced_at) : "";
+    head.appendChild(fresh);
+    card.appendChild(head);
+
+    const kpis = aggregateClientKpis(summary);
+    const krow = document.createElement("div");
+    krow.className = "reports-client-card-kpis";
+    krow.appendChild(
+      clientKpiCell(
+        "dashboard.reports_kpi_spend",
+        // "—" (not 0) when absent — a no-data client must not read as zero
+        // spend in this at-a-glance triage view.
+        kpis.spend != null ? formatNumber(kpis.spend) : "—"
+      )
+    );
+    if (kpis.conversions != null) {
+      krow.appendChild(
+        clientKpiCell(
+          "dashboard.reports_kpi_conversions",
+          formatNumber(kpis.conversions)
+        )
+      );
+    }
+    if (kpis.cpa != null) {
+      krow.appendChild(
+        clientKpiCell(
+          "dashboard.reports_kpi_cpa",
+          formatNumber(Math.round(kpis.cpa))
+        )
+      );
+    }
+    card.appendChild(krow);
+
+    const flags = clientReportFlags(summary)
+      .slice()
+      .sort(function (a, b) {
+        return flagSeverityRank(a) - flagSeverityRank(b);
+      });
+    if (flags.length) {
+      const chips = document.createElement("div");
+      chips.className = "reports-client-card-flags";
+      flags.slice(0, REPORTS_CLIENT_FLAG_CAP).forEach(function (flag) {
+        const chip = document.createElement("span");
+        chip.className = "report-chip " + reportFlagKind(flag);
+        chip.textContent = humanizeReportFlag(flag);
+        chips.appendChild(chip);
+      });
+      const overflow = flags.length - REPORTS_CLIENT_FLAG_CAP;
+      if (overflow > 0) {
+        const more = document.createElement("span");
+        more.className = "report-chip reports-client-flag-more";
+        more.textContent = "+" + overflow;
+        chips.appendChild(more);
+      }
+      card.appendChild(chips);
+    }
+
+    card.addEventListener("click", function () {
+      selectReportsClient(slug);
+    });
+    return card;
+  }
+
+  // Build the client overview grid (one card per client). Returns the slug to
+  // select by default (first active, else first), or null when there are none.
+  async function renderReportsClientOverview(clients, seq) {
+    const wrap = document.querySelector("[data-reports-clients]");
     const rows = Array.isArray(clients) ? clients : [];
-    if (rows.length <= 1) {
+    if (!wrap) return null;
+    wrap.textContent = "";
+    if (!rows.length) {
       wrap.hidden = true;
-      return;
+      return null;
     }
     wrap.hidden = false;
-    select.textContent = "";
-    rows.forEach(function (c) {
-      const opt = document.createElement("option");
-      opt.value = c.slug || "";
-      opt.textContent = c.name || c.slug || "";
-      if ((active && c.slug === active) || (!active && c.active)) {
-        opt.selected = true;
-      }
-      select.appendChild(opt);
+    const summaries = await Promise.all(
+      rows.map(function (c) {
+        return fetchClientCardSummary(c && c.slug ? c.slug : "");
+      })
+    );
+    if (seq !== reportsRenderSeq) return null; // superseded by a newer render
+    wrap.textContent = "";
+    rows.forEach(function (c, i) {
+      wrap.appendChild(buildClientCard(c, summaries[i]));
     });
+    const active = rows.find(function (c) {
+      return c && c.active;
+    });
+    return ((active || rows[0]) || {}).slug || null;
+  }
+
+  // Select a client: highlight its card and load its detail below.
+  function selectReportsClient(slug) {
+    const wrap = document.querySelector("[data-reports-clients]");
+    if (wrap) {
+      const cards = wrap.querySelectorAll(".reports-client-card");
+      Array.prototype.forEach.call(cards, function (c) {
+        const isSel = (c.getAttribute("data-client") || "") === (slug || "");
+        c.classList.toggle("is-selected", isSel);
+        // aria-current present only on the selected card (absent, not "false").
+        if (isSel) c.setAttribute("aria-current", "true");
+        else c.removeAttribute("aria-current");
+      });
+    }
+    // Bump the generation so any in-flight detail render is dropped, then load.
+    reportsRenderSeq++;
+    renderReportsSummary(slug || null);
   }
 
   // Render the period toggle from the summary's `periods` union. Shown only
@@ -1915,39 +2125,20 @@
     renderReportsActions(summary.recent_actions);
   }
 
-  // Entry point: fetch the client list, wire the selector, then load the
-  // active client's summary. Re-runnable (locale change, client switch).
+  // Entry point: fetch the client list, render the overview grid, then load
+  // the default client's detail. Re-runnable (locale change, client switch).
   async function renderReports() {
     const cards = document.querySelector("[data-reports-cards]");
     if (!cards) return;
     const seq = ++reportsRenderSeq;
     let clients = [];
-    try {
-      const res = await fetch("/api/reports/clients", { credentials: "same-origin" });
-      if (res.ok) {
-        const body = await res.json();
-        clients = Array.isArray(body.clients) ? body.clients : [];
-      }
-    } catch (_err) {
-      // Tolerate a missing client list — fall back to the default summary.
-    }
+    const body = await fetchReportsJson("/api/reports/clients");
+    if (body && Array.isArray(body.clients)) clients = body.clients;
     if (seq !== reportsRenderSeq) return;
-    const activeClient = (clients.find(function (c) {
-      return c && c.active;
-    }) || {}).slug;
-    renderReportsClientSelector(clients, activeClient);
-    await renderReportsSummary(activeClient || null);
-  }
-
-  // Wire the client selector once — re-fetch the summary on change.
-  function wireReportsClientSelector() {
-    const select = document.querySelector("[data-reports-client]");
-    if (!select) return;
-    select.addEventListener("change", function () {
-      // Bump the generation so any in-flight summary render is dropped.
-      reportsRenderSeq++;
-      renderReportsSummary(select.value || null);
-    });
+    const defaultSlug = await renderReportsClientOverview(clients, seq);
+    if (seq !== reportsRenderSeq) return;
+    // selectReportsClient highlights the default card + loads its detail.
+    selectReportsClient(defaultSlug);
   }
 
   function renderAll() {
@@ -2278,7 +2469,6 @@
     wireByodImport();
     wireByodClear();
     wireAdvisorForm();
-    wireReportsClientSelector();
     wirePickers();
     if (MUREO.isDashboardRoute()) {
       show();

--- a/tests/test_web_assets_dashboard_cards_and_toasts.py
+++ b/tests/test_web_assets_dashboard_cards_and_toasts.py
@@ -194,7 +194,8 @@ def test_reports_section_shell_present() -> None:
     assert "data-reports-latest" in html
     assert "data-reports-actions" in html
     assert "data-reports-empty" in html
-    assert "data-reports-client" in html
+    # The multi-client overview grid (#307) replaced the old client dropdown.
+    assert "data-reports-clients" in html
 
 
 @pytest.mark.unit

--- a/tests/test_web_assets_reports_period_toggle.py
+++ b/tests/test_web_assets_reports_period_toggle.py
@@ -133,3 +133,37 @@ def test_report_flags_get_severity_colored_chips() -> None:
     assert "reportFlagKind(flag)" in js
     assert '"is-warn"' in js
     assert '"is-danger"' in js
+
+
+@pytest.mark.unit
+def test_reports_client_overview_replaces_dropdown() -> None:
+    """#307: the Reports tab renders a client overview grid (one card per
+    client with KPIs + flags) that loads the per-client detail on click —
+    not a single-select dropdown. The old <select> dropdown is gone."""
+    html = _read("app.html")
+    js = _read("dashboard.js")
+    css = _read("app.css")
+    # New overview container present; old dropdown markup removed.
+    assert "data-reports-clients" in html
+    assert "data-reports-client-wrap" not in html
+    assert "<select data-reports-client>" not in html
+    # JS builds the grid, aggregates KPIs, and selects a client on click.
+    assert "function renderReportsClientOverview(" in js
+    assert "function buildClientCard(" in js
+    assert "function aggregateClientKpis(" in js
+    assert "function selectReportsClient(" in js
+    assert "renderReportsClientSelector" not in js
+    # Card styling exists and uses the selected-state highlight.
+    assert ".reports-client-card" in css
+    assert ".reports-client-card.is-selected" in css
+
+
+@pytest.mark.unit
+def test_reports_client_card_flags_are_severity_capped() -> None:
+    """Client cards reuse the humanized + severity-coloured flag chips, sorted
+    most-urgent-first and capped with a +N overflow."""
+    js = _read("dashboard.js")
+    assert "REPORTS_CLIENT_FLAG_CAP" in js
+    assert "flagSeverityRank" in js
+    assert "humanizeReportFlag(flag)" in js
+    assert "reports-client-flag-more" in js


### PR DESCRIPTION
Closes #307.

## Summary

Replace the reports **client dropdown** with a **client overview card grid** — one card per client (the existing `StateStore` Agency seam: `list_clients()` / `state_store_for_client(slug)`). The Reports tab becomes a multi-client morning-triage view: see every client's headline KPIs + latest flags at a glance, click a card to drill into the existing per-client detail. The old single-select `<select>` dropdown is removed.

## Each card

- Client name + freshness (`last_synced_at` relative age).
- **Headline KPIs** aggregated across the client's platforms: spend, conversions, CPA (= total spend / total conversions). `"—"` (not `0`) when absent, so a no-data client never reads as zero activity.
- **Latest report flags** — reusing `humanizeReportFlag` / `reportFlagKind`, **severity-sorted** (danger → warn → success), capped at 3 with a `+N` overflow chip.

Clicking a card selects it (highlight) and loads the existing `renderReportsSummary` detail (per-platform KPIs, latest report, recent activity, period toggle).

## Changes (frontend only — no backend change)

- **`dashboard.js`** — `renderReportsClientOverview()` fetches every client's summary in parallel (`Promise.all`, guarded by the existing `reportsRenderSeq` stale-render counter; a single failing client degrades to an empty card via `fetchReportsJson`, never rejecting the batch). `fetchClientCardSummary()` honours the period toggle and falls back to the first window with data for period-bucketed clients. `buildClientCard()` / `selectReportsClient()` build + select. Removes `renderReportsClientSelector` / `wireReportsClientSelector`. Default selection = first `active` client, else the first. XSS-safe (`textContent`).
- **`app.html`** — drop the `<select>` dropdown; add the `data-reports-clients` grid.
- **`app.css`** — `.reports-client-card` with a selected-state highlight, on existing design tokens.

All data is already available from `/api/reports/clients` + `/api/reports/summary?client=&period=` — no backend change. A single-workspace OSS install shows one card (harmless); an Agency backend returning >1 client lights up the overview.

## Test plan

- [x] New asset tests (overview replaces dropdown; severity-capped flags); existing reports shell test updated. Web-asset + i18n suites green (253).
- [x] JS `node --check` clean; `ruff` / `black` clean.
- [x] ecc:typescript-reviewer: APPROVE (no CRITICAL/HIGH; stale-render guard, XSS, `Promise.all` safety verified; LOW notes addressed — `—` for absent spend, `aria-current` absent on unselected cards).
- [x] **Verified in a real browser (Playwright, JA)** — overview card (KPIs + severity-sorted flags + `+N`) above the per-client detail, selected-state highlight, detail loads on the default client.

https://claude.ai/code/session_01NxBrN8Qn53Tpivt9SumdGn
