### PR TITLE
fix(web): move the "← Clients" back link under the Reports heading

### DIFF
--- a/mureo/_data/web/app.css
+++ b/mureo/_data/web/app.css
@@ -1287,9 +1287,9 @@ dialog[data-confirm-dialog] [data-confirm-ok] {
 .dashboard-reports-head {
   display: flex;
   flex-wrap: wrap;
-  align-items: baseline;
+  align-items: flex-start;
   justify-content: space-between;
-  gap: 12px;
+  gap: 12px 16px;
 }
 
 .dashboard-reports-head h2 {
@@ -1500,7 +1500,7 @@ dialog[data-confirm-dialog] [data-confirm-ok] {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 4px;
+  gap: 3px;
 }
 
 .reports-back {
@@ -1526,11 +1526,13 @@ dialog[data-confirm-dialog] [data-confirm-ok] {
   border-radius: 4px;
 }
 
-/* Selected client name — a heading at the top of the detail view. */
+/* Selected client name — the prominent title leading the detail view, set
+   apart from the section heading + back link above it. */
 .dashboard-reports-detail-client {
-  margin: 0 0 12px;
-  font-size: 15px;
-  font-weight: 600;
+  margin: 10px 0 16px;
+  font-size: 18px;
+  font-weight: 650;
+  letter-spacing: -0.01em;
   color: var(--ink);
 }
 

--- a/mureo/_data/web/app.css
+++ b/mureo/_data/web/app.css
@@ -1488,17 +1488,19 @@ dialog[data-confirm-dialog] [data-confirm-ok] {
   color: var(--muted);
 }
 
-/* Index ↔ detail navigation (#307): the detail view's back bar. */
+/* Index ↔ detail navigation (#307). The "← Clients" back link sits directly
+   under the "Reports" heading (its own stacked column on the head's left). */
 .dashboard-reports-detail[hidden],
-.dashboard-reports-detailbar[hidden] {
+.reports-back[hidden],
+.dashboard-reports-detail-client[hidden] {
   display: none;
 }
 
-.dashboard-reports-detailbar {
+.dashboard-reports-head-title {
   display: flex;
-  align-items: center;
-  gap: 10px;
-  margin: 4px 0 12px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
 }
 
 .reports-back {
@@ -1507,25 +1509,27 @@ dialog[data-confirm-dialog] [data-confirm-ok] {
   font-size: 12px;
   font-weight: 600;
   cursor: pointer;
-  padding: 4px 10px;
-  color: var(--ink-soft);
-  background: var(--surface);
-  border: 1px solid var(--hairline);
-  border-radius: var(--r-pill);
+  padding: 0;
+  color: var(--accent);
+  background: transparent;
+  border: 0;
 }
 
 .reports-back:hover {
-  color: var(--ink);
-  border-color: var(--hairline-strong);
+  color: var(--accent-press);
+  text-decoration: underline;
 }
 
 .reports-back:focus-visible {
   outline: 2px solid var(--accent-ring);
-  outline-offset: 1px;
+  outline-offset: 2px;
+  border-radius: 4px;
 }
 
+/* Selected client name — a heading at the top of the detail view. */
 .dashboard-reports-detail-client {
-  font-size: 14px;
+  margin: 0 0 12px;
+  font-size: 15px;
   font-weight: 600;
   color: var(--ink);
 }

--- a/mureo/_data/web/app.html
+++ b/mureo/_data/web/app.html
@@ -164,7 +164,15 @@
           <div class="dashboard-group" data-dashboard-group="reports" hidden>
             <div class="dashboard-section dashboard-reports" data-dashboard-reports>
               <div class="dashboard-reports-head">
-                <h2 data-i18n="dashboard.reports_title">Reports</h2>
+                <div class="dashboard-reports-head-title">
+                  <h2 data-i18n="dashboard.reports_title">Reports</h2>
+                  <!-- Back to the client index — directly under the "Reports"
+                       heading. Shown only in the detail view of a multi-client
+                       (Agency) install. -->
+                  <button type="button" class="reports-back" data-reports-back hidden>
+                    <span data-i18n="dashboard.reports_back">← Clients</span>
+                  </button>
+                </div>
                 <div class="dashboard-reports-meta">
                   <!-- Period toggle (前日｜30日). Populated by renderReports()
                        from summary.periods; hidden unless >= 2 windows. -->
@@ -184,14 +192,8 @@
 
               <!-- DETAIL view: one client's full report. -->
               <div class="dashboard-reports-detail" data-reports-detail hidden>
-                <!-- Back-to-index bar + selected client name. Shown only when
-                     an index exists to return to (>1 client). -->
-                <div class="dashboard-reports-detailbar" data-reports-detailbar hidden>
-                  <button type="button" class="reports-back" data-reports-back>
-                    <span data-i18n="dashboard.reports_back">← Clients</span>
-                  </button>
-                  <span class="dashboard-reports-detail-client" data-reports-detail-client></span>
-                </div>
+                <!-- Selected client name (multi-client / Agency only). -->
+                <h3 class="dashboard-reports-detail-client" data-reports-detail-client hidden></h3>
 
                 <!-- Per-platform KPI cards (generic over the API's platforms). -->
                 <div class="dashboard-reports-cards" data-reports-cards></div>

--- a/mureo/_data/web/dashboard.js
+++ b/mureo/_data/web/dashboard.js
@@ -1985,13 +1985,16 @@
     reportsView = view;
     const index = document.querySelector("[data-reports-clients]");
     const detail = document.querySelector("[data-reports-detail]");
-    const detailbar = document.querySelector("[data-reports-detailbar]");
+    const back = document.querySelector("[data-reports-back]");
+    const nameEl = document.querySelector("[data-reports-detail-client]");
     if (index) index.hidden = view !== "index";
     if (detail) detail.hidden = view !== "detail";
-    if (detailbar) {
-      // A back bar only when a multi-client index exists to go back to.
-      detailbar.hidden = !(view === "detail" && reportsClients.length > 1);
-    }
+    // The back link (under the "Reports" heading) and the client-name heading
+    // appear only in a multi-client detail view — an OSS single client has no
+    // index to go back to and no sibling to disambiguate.
+    const showClientChrome = view === "detail" && reportsClients.length > 1;
+    if (back) back.hidden = !showClientChrome;
+    if (nameEl) nameEl.hidden = !showClientChrome;
   }
 
   // INDEX view: a card per client (KPIs + flags for the selected window).

--- a/tests/test_web_assets_reports_period_toggle.py
+++ b/tests/test_web_assets_reports_period_toggle.py
@@ -143,12 +143,14 @@ def test_reports_index_detail_navigation() -> None:
     html = _read("app.html")
     js = _read("dashboard.js")
     css = _read("app.css")
-    # Index grid + detail container + back bar present; old dropdown removed.
+    # Index grid + detail container present; old dropdown removed.
     assert "data-reports-clients" in html  # index grid
     assert "data-reports-detail" in html  # detail view wrapper
     assert "data-reports-back" in html  # back-to-index button
     assert "data-reports-client-wrap" not in html
     assert "<select data-reports-client>" not in html
+    # The back link sits under the "Reports" heading (its own head column).
+    assert "dashboard-reports-head-title" in html
     # JS builds the index, aggregates KPIs, opens detail, and toggles views.
     assert "function renderReportsIndex(" in js
     assert "function buildClientCard(" in js
@@ -156,9 +158,9 @@ def test_reports_index_detail_navigation() -> None:
     assert "function showReportsClientDetail(" in js
     assert "function setReportsView(" in js
     assert "renderReportsClientSelector" not in js
-    # Card + back-bar styling exists.
+    # Card + back-link styling exists.
     assert ".reports-client-card" in css
-    assert ".dashboard-reports-detailbar" in css
+    assert ".dashboard-reports-head-title" in css
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Move the back-to-index link to sit directly under the "Reports" heading (its own column under the h2), and promote the selected client name to a heading at the top of the detail content. setReportsView toggles both (shown only in a multi-client detail view). Frontend only; verified in a real browser; typescript-reviewer APPROVE.

https://claude.ai/code/session_01NxBrN8Qn53Tpivt9SumdGn