### PR TITLE
chore(release): 0.10.9

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mureo",
-  "version": "0.10.8",
+  "version": "0.10.9",
   "description": "Your local-first AI ad ops crew for Google Ads, Meta Ads, Search Console & GA4. mureo sits on top of the official ad-platform MCPs, gates every change against your strategy, correlates outcomes locally, and keeps an auditable decision log — credentials never leave your machine.",
   "author": {
     "name": "Logly Inc.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.9] - 2026-06-21
+
+### Added
+
+#### Multi-client overview on the Reports tab (index → detail)
+
+The Reports tab is now a two-view navigation built on the existing Agency
+seam (`list_clients()` / `state_store_for_client()`): an **index** page —
+one card per client showing aggregated KPIs (spend / conversions / CPA) and
+the latest report's flags (humanized, severity-coloured, capped with a `+N`
+overflow) — and a **detail** page for the selected client (per-platform
+KPIs, latest report, recent activity, period toggle) with a "← Clients"
+back link. A single-workspace (OSS) install skips the index and opens the
+detail directly. Replaces the single-select client dropdown.
+
+### Changed
+
+- The report-flag chips are now severity-coloured (off-target → amber,
+  data-integrity → red, on-target → green) and drop the inconsistent
+  parenthetical context for a cleaner read; the reports detail header
+  spacing was balanced (back link under the heading, prominent client name).
+- `daily-check` (and every report-writing skill) now persists its summary
+  **after** any STATE change it makes, with the narrative/flags describing
+  the post-change state — so the dashboard's "Latest report" can no longer
+  read as older than, and contradict, an `action_log` entry from the same
+  run (e.g. recommending a mode switch the run then executed).
+
 ## [0.10.8] - 2026-06-20
 
 ### Added

--- a/mureo/__init__.py
+++ b/mureo/__init__.py
@@ -1,3 +1,3 @@
 """mureo — your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."""
 
-__version__ = "0.10.8"
+__version__ = "0.10.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mureo"
-version = "0.10.8"
+version = "0.10.9"
 description = "Your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."
 requires-python = ">=3.10"
 license = "Apache-2.0"


### PR DESCRIPTION
Release 0.10.9: Reports tab multi-client index → detail navigation, severity-coloured flag chips + balanced detail header, and the daily-check summary-reflects-final-state fix. Version bumped across pyproject / __init__ / .claude-plugin; CHANGELOG updated. On merge, tag v0.10.9 + a GitHub Release publishes to PyPI via release.yml.

https://claude.ai/code/session_01NxBrN8Qn53Tpivt9SumdGn