### PR TITLE
fix(web): decode pip output as UTF-8 so update check/upgrade work on Windows

### DIFF
--- a/mureo/cli/upgrade_cmd.py
+++ b/mureo/cli/upgrade_cmd.py
@@ -132,6 +132,10 @@ def _pip_is_available() -> tuple[bool, str]:
         [sys.executable, "-m", "pip", "--version"],
         capture_output=True,
         text=True,
+        # UTF-8, not the locale codec (cp932 on a Japanese Windows), so
+        # capturing pip's output never raises UnicodeDecodeError.
+        encoding="utf-8",
+        errors="replace",
         check=False,
     )
     return proc.returncode == 0, proc.stderr or ""

--- a/mureo/web/upgrade_action.py
+++ b/mureo/web/upgrade_action.py
@@ -84,6 +84,11 @@ def run_upgrade_all() -> dict[str, Any]:
             cmd,
             capture_output=True,
             text=True,
+            # Force UTF-8 decoding of pip's output — otherwise text mode uses
+            # the locale codec (cp932 on a Japanese Windows) and pip's install
+            # log raises UnicodeDecodeError, which escapes the except below.
+            encoding="utf-8",
+            errors="replace",
             check=False,
             timeout=_UPGRADE_TIMEOUT_SECONDS,
         )

--- a/mureo/web/version_check.py
+++ b/mureo/web/version_check.py
@@ -151,6 +151,12 @@ def _run_pip_report(packages: list[str]) -> dict[str, Any] | None:
             cmd,
             capture_output=True,
             text=True,
+            # Decode pip's output as UTF-8 explicitly. Without this, text mode
+            # uses the locale codec — cp932 on a Japanese Windows — and pip's
+            # JSON report / logs (UTF-8) raise UnicodeDecodeError, which is not
+            # caught below, so the update check silently dies on Windows.
+            encoding="utf-8",
+            errors="replace",
             check=False,
             timeout=_PIP_TIMEOUT_SECONDS,
         )

--- a/tests/test_cli_upgrade.py
+++ b/tests/test_cli_upgrade.py
@@ -113,6 +113,18 @@ def test_upgrade_default_upgrades_mureo_self(fake_pip: MagicMock) -> None:
     assert cmd[-1] == "mureo"
 
 
+def test_pip_version_probe_captures_as_utf8(fake_pip: MagicMock) -> None:
+    """The ``pip --version`` availability probe must decode output as UTF-8,
+    not the locale codec (cp932 on a Japanese Windows) — otherwise capturing
+    pip's output raises UnicodeDecodeError and ``mureo upgrade`` dies there."""
+    _runner().invoke(_app(), ["upgrade"])
+
+    version_calls = [c for c in fake_pip.call_args_list if c.args[0][-1] == "--version"]
+    assert version_calls, "expected a `pip --version` probe"
+    assert version_calls[0].kwargs["encoding"] == "utf-8"
+    assert version_calls[0].kwargs["errors"] == "replace"
+
+
 # ---------------------------------------------------------------------------
 # Explicit package + version pin
 # ---------------------------------------------------------------------------

--- a/tests/test_web_upgrade_action.py
+++ b/tests/test_web_upgrade_action.py
@@ -89,6 +89,10 @@ class TestRunUpgradeAll:
         assert cmd[1:6] == ["-m", "pip", "install", "--upgrade", "--"]
         assert cmd[6:] == ["mureo", "mureo-logly-bridge"]
         assert result["packages"] == ["mureo", "mureo-logly-bridge"]
+        # Decode pip output as UTF-8, not the locale codec (cp932 on a
+        # Japanese Windows) — otherwise the upgrade raises UnicodeDecodeError.
+        assert mock_run.call_args.kwargs["encoding"] == "utf-8"
+        assert mock_run.call_args.kwargs["errors"] == "replace"
 
     def test_output_is_capped(self) -> None:
         """A huge pip output is truncated so the JSON envelope stays small."""

--- a/tests/test_web_version_check.py
+++ b/tests/test_web_version_check.py
@@ -294,6 +294,11 @@ class TestRunPipReport:
         assert kwargs["text"] is True
         assert kwargs["check"] is False
         assert kwargs["timeout"] == 60
+        # Decode pip output as UTF-8 explicitly — NOT the locale codec (cp932
+        # on a Japanese Windows), which would raise UnicodeDecodeError and kill
+        # the update check on Windows.
+        assert kwargs["encoding"] == "utf-8"
+        assert kwargs["errors"] == "replace"
 
     def test_nonzero_exit_returns_none(self) -> None:
         with patch(


### PR DESCRIPTION
## Problem
The configure "About mureo" update check + one-click upgrade work on macOS/Linux but fail on Windows. The three capturing pip `subprocess.run(text=True)` calls omit `encoding=`, so text mode decodes pip's UTF-8 output with the locale codec — **cp932 on a Japanese Windows** — raising `UnicodeDecodeError`. In `_run_pip_report` that error isn't caught (only TimeoutExpired/OSError), so the update check silently dies; in `run_upgrade_all` it escapes the handler and breaks the upgrade.

## Fix
Add `encoding="utf-8", errors="replace"` to the three capturing pip calls (version_check `_run_pip_report`, upgrade_action `run_upgrade_all`, cli `_pip_is_available`). UTF-8 is pip's actual output encoding on every platform (no macOS/Linux behaviour change); `errors="replace"` makes decoding never raise. Regression tests assert the encoding kwargs on all three calls.

python-reviewer: APPROVE (no CRITICAL/HIGH).

https://claude.ai/code/session_01NxBrN8Qn53Tpivt9SumdGn