### PR TITLE
chore(release): 0.10.10

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mureo",
-  "version": "0.10.9",
+  "version": "0.10.10",
   "description": "Your local-first AI ad ops crew for Google Ads, Meta Ads, Search Console & GA4. mureo sits on top of the official ad-platform MCPs, gates every change against your strategy, correlates outcomes locally, and keeps an auditable decision log — credentials never leave your machine.",
   "author": {
     "name": "Logly Inc.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   breaking the upgrade. The three capturing pip calls (`version_check`,
   `upgrade_action`, and the `mureo upgrade` CLI) now decode as UTF-8 with
   `errors="replace"`, matching pip's actual output on every platform.
+- The read-only Reports dashboard logged a parse traceback on every render and
+  returned an empty summary whenever STATE.json held a campaign entry that did
+  not match the strict schema (e.g. a hand-authored / variant campaign using
+  `name`/`id` instead of `campaign_name`/`campaign_id`). The strict campaign
+  validation is kept for writers, but the read-only view now re-reads
+  tolerantly and skips nonconforming entries, so the platform totals and
+  reports still render. Report KPIs come from platform totals/periods and the
+  stored reports, not the campaign list.
 
 ## [0.10.9] - 2026-06-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.10] - 2026-06-22
+
+### Fixed
+
+- The configure UI's "About mureo" update check and one-click upgrade failed
+  on Windows. The pip subprocess calls captured output in text mode without
+  specifying an encoding, so Python decoded pip's UTF-8 output with the
+  platform locale codec (cp932 on a Japanese Windows) and raised
+  `UnicodeDecodeError` — silently killing the background update check and
+  breaking the upgrade. The three capturing pip calls (`version_check`,
+  `upgrade_action`, and the `mureo upgrade` CLI) now decode as UTF-8 with
+  `errors="replace"`, matching pip's actual output on every platform.
+
 ## [0.10.9] - 2026-06-21
 
 ### Added

--- a/mureo/__init__.py
+++ b/mureo/__init__.py
@@ -1,3 +1,3 @@
 """mureo — your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."""
 
-__version__ = "0.10.9"
+__version__ = "0.10.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mureo"
-version = "0.10.9"
+version = "0.10.10"
 description = "Your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."
 requires-python = ">=3.10"
 license = "Apache-2.0"


### PR DESCRIPTION
Release 0.10.10: Windows fix (#313) — the configure "About mureo" update check + one-click upgrade now decode pip's UTF-8 output correctly under cp932 (Japanese Windows). Version bumped across pyproject / __init__ / .claude-plugin; CHANGELOG updated. On merge, tag v0.10.10 + a GitHub Release publishes to PyPI via release.yml.

https://claude.ai/code/session_01NxBrN8Qn53Tpivt9SumdGn