### PR TITLE
fix(web): tolerate nonconforming campaign entries in the read-only Reports view

### DIFF
--- a/mureo/context/state.py
+++ b/mureo/context/state.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import contextlib
 import copy
 import json
+import logging
 import os
 import tempfile
 from datetime import datetime, timezone
@@ -23,6 +24,8 @@ from mureo.context.models import (
 )
 from mureo.fsutil import file_lock
 
+logger = logging.getLogger(__name__)
+
 # Required campaign fields
 _CAMPAIGN_REQUIRED_FIELDS: tuple[str, ...] = (
     "campaign_id",
@@ -31,11 +34,40 @@ _CAMPAIGN_REQUIRED_FIELDS: tuple[str, ...] = (
 )
 
 
-def parse_state(text: str) -> StateDocument:
-    """Parse a JSON string and return a StateDocument."""
+def _parse_campaigns(
+    raw: list[dict[str, Any]], *, strict: bool
+) -> tuple[CampaignSnapshot, ...]:
+    """Parse a campaign list.
+
+    ``strict=True`` (the canonical contract relied on by every writer) raises
+    on the first nonconforming entry. ``strict=False`` skips entries that fail
+    validation, logging each one — used only by the read-only Reports view so a
+    single variant/hand-authored campaign cannot blank out a whole document
+    (whose platforms/periods/reports the dashboard actually renders).
+    """
+    if strict:
+        return tuple(_parse_campaign(c) for c in raw)
+    parsed: list[CampaignSnapshot] = []
+    for c in raw:
+        try:
+            parsed.append(_parse_campaign(c))
+        except (ValueError, KeyError, TypeError) as exc:
+            logger.warning("skipping unparseable campaign entry: %s", exc)
+    return tuple(parsed)
+
+
+def parse_state(text: str, *, strict: bool = True) -> StateDocument:
+    """Parse a JSON string and return a StateDocument.
+
+    ``strict`` controls campaign-list validation only: ``True`` (default)
+    preserves the strict writer contract (raises on a missing required field);
+    ``False`` tolerantly skips nonconforming campaign entries for the read-only
+    Reports view. Structural problems (invalid JSON, a missing platform
+    ``account_id``) always raise regardless of ``strict``.
+    """
     data = json.loads(text)
     campaigns_raw = data.get("campaigns", [])
-    campaigns = tuple(_parse_campaign(c) for c in campaigns_raw)
+    campaigns = _parse_campaigns(campaigns_raw, strict=strict)
 
     # v2: platforms
     platforms: dict[str, PlatformState] | None = None
@@ -43,8 +75,8 @@ def parse_state(text: str) -> StateDocument:
     if platforms_raw is not None:
         platforms = {}
         for platform_key, platform_data in platforms_raw.items():
-            platform_campaigns = tuple(
-                _parse_campaign(c) for c in platform_data.get("campaigns", [])
+            platform_campaigns = _parse_campaigns(
+                platform_data.get("campaigns", []), strict=strict
             )
             platforms[platform_key] = PlatformState(
                 account_id=platform_data["account_id"],
@@ -215,10 +247,13 @@ def _atomic_write(path: Path, content: str) -> None:
         raise
 
 
-def read_state_file(path: Path) -> StateDocument:
+def read_state_file(path: Path, *, strict: bool = True) -> StateDocument:
     """Read a STATE.json file and return a StateDocument.
 
-    Returns a default StateDocument if the file does not exist.
+    Returns a default StateDocument if the file does not exist. ``strict`` is
+    forwarded to :func:`parse_state`: pass ``strict=False`` from the read-only
+    Reports view so a nonconforming campaign entry is skipped instead of
+    raising and blanking the whole document.
     """
     if not path.exists():
         return StateDocument()
@@ -227,7 +262,7 @@ def read_state_file(path: Path) -> StateDocument:
     except PermissionError as exc:
         raise ContextFileError(f"No read permission for STATE.json: {path}") from exc
     try:
-        return parse_state(text)
+        return parse_state(text, strict=strict)
     except json.JSONDecodeError as exc:
         raise ContextFileError(f"Failed to parse JSON in STATE.json: {path}") from exc
 

--- a/mureo/web/reports.py
+++ b/mureo/web/reports.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
+from mureo.context.state import read_state_file
 from mureo.core.runtime_context import get_runtime_context
 
 if TYPE_CHECKING:
@@ -319,11 +320,40 @@ def _read_state_safe(store: StateStore) -> StateDocument | None:
     file, but a malformed STATE.json raises ``ContextFileError`` and an
     alternate backend could raise anything — the dashboard must degrade to
     an empty summary, never 500.
+
+    When the strict read fails, retry tolerantly against the raw file before
+    giving up: ``store.read_state()`` validates the campaign list strictly, so
+    one variant / hand-authored campaign entry (e.g. ``name`` instead of
+    ``campaign_name``) would otherwise blank out a document whose
+    platforms/periods/reports the read-only dashboard can still render.
     """
     try:
         return store.read_state()
     except Exception:  # noqa: BLE001 — read-only view degrades, never raises
-        logger.exception("reading STATE.json failed; returning empty summary")
+        logger.warning(
+            "strict STATE.json read failed; retrying tolerantly for the "
+            "read-only Reports view",
+            exc_info=True,
+        )
+        return _read_state_tolerant(store)
+
+
+def _read_state_tolerant(store: StateStore) -> StateDocument | None:
+    """Re-read ``store``'s STATE.json skipping nonconforming campaign entries.
+
+    Needs the backing file path (``state_path``), which the filesystem store —
+    including the Agency per-client stores resolved by
+    :func:`_state_store_for_client` — exposes. A store without one cannot be
+    re-read tolerantly, so the view degrades to an empty summary.
+    """
+    path = getattr(store, "state_path", None)
+    if path is None:
+        logger.warning("STATE.json unreadable and no path to retry; empty summary")
+        return None
+    try:
+        return read_state_file(path, strict=False)
+    except Exception:  # noqa: BLE001 — last-resort guard; never raise from a read
+        logger.exception("tolerant STATE.json read also failed; empty summary")
         return None
 
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -404,6 +404,50 @@ class TestStateFileErrorHandling:
         with pytest.raises(ValueError, match="status"):
             parse_state(json.dumps(data))
 
+    @pytest.mark.unit
+    def test_parse_state_strict_false_skips_malformed_campaigns(self) -> None:
+        """``strict=False`` drops nonconforming campaign entries (top-level
+        AND per-platform) instead of raising, and preserves the rest of the
+        document. The read-only Reports view depends on this so a single
+        variant / hand-authored campaign cannot blank a whole STATE.json
+        whose platforms/totals/reports are perfectly readable."""
+        data = {
+            "version": "2",
+            "campaigns": [
+                {"id": "69680", "name": "variant shape"},  # no campaign_id/_name
+                {"campaign_id": "ok", "campaign_name": "Good", "status": "ENABLED"},
+            ],
+            "platforms": {
+                "logly_ads_context": {
+                    "account_id": "acct-1",
+                    "campaigns": [
+                        {"campaign_id": "72804", "name": "E2E", "status": "paused"},
+                    ],
+                    "totals": {"spend": 8739.0},
+                    "metrics_period": "YESTERDAY",
+                }
+            },
+            "reports": {"daily": {"verdict": "Healthy"}},
+        }
+        doc = parse_state(json.dumps(data), strict=False)
+
+        # The one conforming top-level campaign survives; the variant is gone.
+        assert [c.campaign_id for c in doc.campaigns] == ["ok"]
+        # The platform's nonconforming campaign is dropped, the platform kept.
+        assert doc.platforms is not None
+        plat = doc.platforms["logly_ads_context"]
+        assert plat.campaigns == ()
+        assert plat.totals == {"spend": 8739.0}
+        assert doc.reports == {"daily": {"verdict": "Healthy"}}
+
+    @pytest.mark.unit
+    def test_parse_state_strict_true_is_default_and_still_raises(self) -> None:
+        """The default (strict) path is unchanged — the writer contract still
+        hard-fails on a nonconforming campaign."""
+        data = {"campaigns": [{"id": "x", "name": "variant"}]}
+        with pytest.raises(ValueError, match="campaign_id"):
+            parse_state(json.dumps(data))
+
 
 class TestAtomicWrite:
     """Atomic write tests."""

--- a/tests/test_web_reports.py
+++ b/tests/test_web_reports.py
@@ -21,6 +21,7 @@ injected here never leaks into another test.
 from __future__ import annotations
 
 import dataclasses
+import json
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -320,6 +321,44 @@ def test_summary_does_not_raise_on_broken_state(
     summary = build_report_summary()
     assert summary["platforms"] == []
     assert summary["recent_actions"] == []
+
+
+@pytest.mark.unit
+def test_summary_tolerates_nonconforming_campaign_entries(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A STATE.json whose campaign list has a nonconforming entry — e.g. a
+    hand-authored / variant campaign using ``id``/``name`` instead of
+    ``campaign_id``/``campaign_name`` — must NOT blank the dashboard.
+
+    The strict read raises on that campaign, so the read-only view re-reads
+    tolerantly and still surfaces the platform totals + reports. Regression
+    for the field report where the dashboard logged a parse traceback on
+    every render and returned an empty summary (the campaign list is not even
+    used by the report KPIs — they come from platform totals/periods)."""
+    _use_workspace(monkeypatch, tmp_path)
+    raw = {
+        "version": "2",
+        "platforms": {
+            "logly_ads_context": {
+                "account_id": "acct-1",
+                "campaigns": [
+                    # Variant shape: no campaign_id / campaign_name.
+                    {"id": "69680", "name": "LOGLY Onemove", "status": "enabled"},
+                ],
+                "totals": {"spend": 8739.0, "conversions": 0},
+                "metrics_period": "YESTERDAY",
+            }
+        },
+        "reports": {"daily": {"verdict": "Watch", "note": "spend down"}},
+    }
+    (tmp_path / "STATE.json").write_text(json.dumps(raw), encoding="utf-8")
+
+    summary = build_report_summary()
+    by_key = {p["key"]: p for p in summary["platforms"]}
+    assert "logly_ads_context" in by_key, "platform blanked by a bad campaign entry"
+    assert by_key["logly_ads_context"]["totals"] == {"spend": 8739.0, "conversions": 0}
+    assert summary["reports"] == {"daily": {"verdict": "Watch", "note": "spend down"}}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem
The configure Reports dashboard logged a `ValueError: Campaign is missing required field 'campaign_name'` (and `'campaign_id'`) traceback on **every render** and returned an empty summary whenever STATE.json held a variant / hand-authored campaign entry (using `name`/`id` instead of `campaign_name`/`campaign_id`). `parse_state` validates the campaign list strictly, so one nonconforming entry raised and `_read_state_safe` swallowed it — even though the report KPIs come from `platforms[].totals/periods` + `reports`, **not** the campaign list. Confirmed OSS-side robustness bug (the `mureo-agency: no active client` line is just an informational banner, not the cause).

## Fix
Writers stay strict (pinned by tests, guards the read-modify-write cycle from silent data loss); the **read-only view** becomes resilient:
- `parse_state(text, *, strict=True)` / `read_state_file(path, *, strict=True)` — new `_parse_campaigns(raw, *, strict)` helper skips nonconforming entries (logged) at top-level + per-platform when `strict=False`. Default stays strict.
- `_read_state_safe` retries tolerantly via `_read_state_tolerant` (re-reads `store.state_path` with `strict=False`); degrades to empty summary, never raises into the route.

Structural problems (invalid JSON, missing platform `account_id`) still raise. Regression tests at parse + dashboard level. python-reviewer: APPROVE.

Targets release **0.10.10** (bundled with the Windows pip fix per plan A).

https://claude.ai/code/session_01NxBrN8Qn53Tpivt9SumdGn