### PR TITLE
fix(web): force pip subprocess stdio to UTF-8 so update check/upgrade don't crash on Windows

### DIFF
--- a/mureo/cli/upgrade_cmd.py
+++ b/mureo/cli/upgrade_cmd.py
@@ -41,6 +41,8 @@ from importlib import metadata
 
 import typer
 
+from mureo.pip_env import pip_subprocess_env
+
 upgrade_app = typer.Typer(
     name="upgrade",
     help=(
@@ -136,6 +138,9 @@ def _pip_is_available() -> tuple[bool, str]:
         # capturing pip's output never raises UnicodeDecodeError.
         encoding="utf-8",
         errors="replace",
+        # …and force pip to ENCODE its stdout as UTF-8 too (cp932 cannot encode
+        # every char pip may emit, crashing the child). See pip_env.
+        env=pip_subprocess_env(),
         check=False,
     )
     return proc.returncode == 0, proc.stderr or ""
@@ -146,6 +151,9 @@ def _bootstrap_pip() -> int:
 
     proc = subprocess.run(
         [sys.executable, "-m", "ensurepip", "--upgrade"],
+        # UTF-8 child stdio so a cp932 console cannot crash the bootstrap on a
+        # non-cp932 char in its output. See pip_env.
+        env=pip_subprocess_env(),
         check=False,
     )
     return proc.returncode
@@ -163,7 +171,9 @@ def _run_pip_install(targets: list[str]) -> int:
         "--",
         *targets,
     ]
-    proc = subprocess.run(cmd, check=False)
+    # UTF-8 child stdio so streaming pip output to a cp932 console never crashes
+    # pip on a non-cp932 char (e.g. U+00B7 in a package's metadata). See pip_env.
+    proc = subprocess.run(cmd, env=pip_subprocess_env(), check=False)
     return proc.returncode
 
 

--- a/mureo/pip_env.py
+++ b/mureo/pip_env.py
@@ -1,0 +1,41 @@
+"""UTF-8 environment for pip subprocess invocations (Windows cp932 safety).
+
+Every pip / ensurepip subprocess mureo spawns must force its child stdio to
+UTF-8. On Windows a child Python defaults its stdout/stderr encoding to the
+active console code page — cp932 on a Japanese Windows. pip's rich-rendered
+``--report -`` JSON and install logs can contain characters outside cp932
+(e.g. ``U+00B7`` MIDDLE DOT), so the child raises ``UnicodeEncodeError`` and
+exits *before* emitting any output. Decoding our side as UTF-8 (done at each
+call site) is necessary but not sufficient — the child must also ENCODE as
+UTF-8. ``PYTHONIOENCODING`` + ``PYTHONUTF8`` force that regardless of the code
+page, and are a no-op on macOS/Linux (already UTF-8).
+
+Scope: this is for the pip / ensurepip subprocesses only. The pipx / npm
+installer in ``mureo.providers.installer`` deliberately runs WITHOUT a custom
+``env`` (its docstring explains the anti-tampering reason, and it emits no rich
+``--report`` JSON), so it must NOT adopt this helper.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+def pip_subprocess_env() -> dict[str, str]:
+    """Return a copy of ``os.environ`` with child stdio forced to UTF-8.
+
+    See the module docstring for why both variables are set: cp932 cannot
+    encode every character pip emits, so the child Python must be told to use
+    UTF-8 for its standard streams or it crashes on a Japanese Windows. The
+    ``:replace`` error handler is belt-and-suspenders — the encoding goal is
+    "the child never dies emitting output", so an unrepresentable byte degrades
+    to U+FFFD rather than raising (mirroring the ``errors="replace"`` we already
+    decode with on the parent side).
+    """
+    env = dict(os.environ)
+    env["PYTHONIOENCODING"] = "utf-8:replace"
+    env["PYTHONUTF8"] = "1"
+    return env
+
+
+__all__ = ["pip_subprocess_env"]

--- a/mureo/web/upgrade_action.py
+++ b/mureo/web/upgrade_action.py
@@ -24,6 +24,7 @@ import sys
 from typing import Any, Final
 
 from mureo.cli.upgrade_cmd import _discover_all_mureo_packages
+from mureo.pip_env import pip_subprocess_env
 
 logger = logging.getLogger(__name__)
 
@@ -89,6 +90,10 @@ def run_upgrade_all() -> dict[str, Any]:
             # log raises UnicodeDecodeError, which escapes the except below.
             encoding="utf-8",
             errors="replace",
+            # Force the child (pip) to ENCODE its stdout as UTF-8 too, or a
+            # Japanese Windows (cp932) crashes pip on a non-cp932 char in its
+            # install log before our UTF-8 decoding runs. See pip_env.
+            env=pip_subprocess_env(),
             check=False,
             timeout=_UPGRADE_TIMEOUT_SECONDS,
         )

--- a/mureo/web/version_check.py
+++ b/mureo/web/version_check.py
@@ -57,6 +57,7 @@ from mureo.cli.upgrade_cmd import (
     _discover_all_mureo_packages,
     _is_mureo_package,
 )
+from mureo.pip_env import pip_subprocess_env
 
 logger = logging.getLogger(__name__)
 
@@ -157,6 +158,11 @@ def _run_pip_report(packages: list[str]) -> dict[str, Any] | None:
             # caught below, so the update check silently dies on Windows.
             encoding="utf-8",
             errors="replace",
+            # Force the CHILD (pip) to ENCODE its stdout as UTF-8 too — decoding
+            # our side is not enough. On a Japanese Windows pip otherwise encodes
+            # its rich-rendered --report JSON with cp932 and crashes on a char
+            # outside it (e.g. U+00B7), exiting before any output. See pip_env.
+            env=pip_subprocess_env(),
             check=False,
             timeout=_PIP_TIMEOUT_SECONDS,
         )

--- a/tests/test_cli_upgrade.py
+++ b/tests/test_cli_upgrade.py
@@ -125,6 +125,21 @@ def test_pip_version_probe_captures_as_utf8(fake_pip: MagicMock) -> None:
     assert version_calls[0].kwargs["errors"] == "replace"
 
 
+def test_every_pip_subprocess_forces_utf8_child_stdio(fake_pip: MagicMock) -> None:
+    """Every pip / ensurepip subprocess must pass an ``env`` that forces the
+    CHILD to encode its stdio as UTF-8 — on a Japanese Windows pip otherwise
+    crashes encoding non-cp932 output (e.g. U+00B7) before we read it. Guards
+    all of `_pip_is_available`, `_run_pip_install`, and `_bootstrap_pip`."""
+    _runner().invoke(_app(), ["upgrade", "--all"])
+
+    assert fake_pip.call_args_list, "expected at least one pip subprocess"
+    for call in fake_pip.call_args_list:
+        env = call.kwargs.get("env")
+        assert env is not None, f"pip call missing env: {call.args[0]}"
+        assert env["PYTHONIOENCODING"] == "utf-8:replace"
+        assert env["PYTHONUTF8"] == "1"
+
+
 # ---------------------------------------------------------------------------
 # Explicit package + version pin
 # ---------------------------------------------------------------------------

--- a/tests/test_pip_env.py
+++ b/tests/test_pip_env.py
@@ -1,0 +1,41 @@
+"""Unit tests for :func:`mureo.pip_env.pip_subprocess_env`.
+
+The helper exists so every pip / ensurepip subprocess forces the child
+Python's stdio to UTF-8 — without it a Japanese Windows (cp932) crashes pip
+on a non-cp932 character (e.g. U+00B7) in its rich-rendered output before any
+of it reaches mureo. ``@pytest.mark.unit``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mureo.pip_env import pip_subprocess_env
+
+
+@pytest.mark.unit
+def test_sets_utf8_io_switches() -> None:
+    env = pip_subprocess_env()
+    assert env["PYTHONIOENCODING"] == "utf-8:replace"
+    assert env["PYTHONUTF8"] == "1"
+
+
+@pytest.mark.unit
+def test_preserves_existing_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The result is a COPY of os.environ plus the switches — pip still needs
+    PATH / index config, so we must not hand it a 2-key dict."""
+    monkeypatch.setenv("MUREO_TEST_SENTINEL", "kept")
+    env = pip_subprocess_env()
+    assert env["MUREO_TEST_SENTINEL"] == "kept"
+    assert "PATH" in env
+
+
+@pytest.mark.unit
+def test_does_not_mutate_os_environ(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mutating the returned dict must not leak back into the process env."""
+    import os
+
+    monkeypatch.delenv("PYTHONUTF8", raising=False)
+    env = pip_subprocess_env()
+    env["PYTHONUTF8"] = "tampered"
+    assert os.environ.get("PYTHONUTF8") != "tampered"

--- a/tests/test_web_upgrade_action.py
+++ b/tests/test_web_upgrade_action.py
@@ -93,6 +93,11 @@ class TestRunUpgradeAll:
         # Japanese Windows) — otherwise the upgrade raises UnicodeDecodeError.
         assert mock_run.call_args.kwargs["encoding"] == "utf-8"
         assert mock_run.call_args.kwargs["errors"] == "replace"
+        # …and force pip itself to ENCODE its stdout as UTF-8 (cp932 cannot
+        # encode every char pip emits, crashing the child before we decode).
+        env = mock_run.call_args.kwargs["env"]
+        assert env["PYTHONIOENCODING"] == "utf-8:replace"
+        assert env["PYTHONUTF8"] == "1"
 
     def test_output_is_capped(self) -> None:
         """A huge pip output is truncated so the JSON envelope stays small."""

--- a/tests/test_web_version_check.py
+++ b/tests/test_web_version_check.py
@@ -299,6 +299,14 @@ class TestRunPipReport:
         # the update check on Windows.
         assert kwargs["encoding"] == "utf-8"
         assert kwargs["errors"] == "replace"
+        # …and force the CHILD (pip) to ENCODE its stdout as UTF-8 too, or pip
+        # crashes on a non-cp932 char in its rich --report JSON before any
+        # output reaches us. The env must carry the whole environment plus the
+        # two UTF-8 switches.
+        env = kwargs["env"]
+        assert env["PYTHONIOENCODING"] == "utf-8:replace"
+        assert env["PYTHONUTF8"] == "1"
+        assert "PATH" in env  # a copy of os.environ, not a 2-key dict
 
     def test_nonzero_exit_returns_none(self) -> None:
         with patch(


### PR DESCRIPTION
## Problem
On a Japanese Windows, the configure daemon's pip update check crashed: pip exited 2 with `UnicodeEncodeError: 'cp932' codec can't encode character '\xb7'` inside pip's own rich `print_json` (the `pip install --report -` path), so the About-tab update check + one-click upgrade failed.

**Root cause**: when mureo spawns pip via subprocess, the CHILD Python (pip) defaults its stdout encoding to the active console code page — cp932 on a Japanese Windows. pip emits U+00B7 in its rich report/logs and crashes encoding it. The earlier fix (#313) set `encoding="utf-8"` on OUR (decode) side — necessary but not sufficient, because the child still ENCODES as cp932.

## Fix
New `mureo/pip_env.py` `pip_subprocess_env()` = `dict(os.environ)` + `PYTHONIOENCODING=utf-8:replace` + `PYTHONUTF8=1`, forcing the pip child's stdio to UTF-8 (no-op on macOS/Linux). Threaded `env=pip_subprocess_env()` through all 5 pip/ensurepip subprocess sites (version_check `_run_pip_report`, upgrade_action `run_upgrade_all`, CLI `_pip_is_available` / `_bootstrap_pip` / `_run_pip_install`). The pipx/npm installer in providers/installer.py keeps its env-free hardening and is intentionally excluded (documented).

Full `os.environ` copied (pip needs PATH/index config), not mutated; no new exposure (env was previously unset → child already inherited it). Tests: `tests/test_pip_env.py` + env-kwarg assertions at every pip site.

python-reviewer + code-reviewer: **APPROVE** (no CRITICAL/HIGH). Targets release **0.10.11**.

https://claude.ai/code/session_01NxBrN8Qn53Tpivt9SumdGn