### PR TITLE
chore(release): 0.10.11

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mureo",
-  "version": "0.10.10",
+  "version": "0.10.11",
   "description": "Your local-first AI ad ops crew for Google Ads, Meta Ads, Search Console & GA4. mureo sits on top of the official ad-platform MCPs, gates every change against your strategy, correlates outcomes locally, and keeps an auditable decision log — credentials never leave your machine.",
   "author": {
     "name": "Logly Inc.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.11] - 2026-06-22
+
+### Fixed
+
+- The configure UI's "About mureo" update check and one-click upgrade crashed
+  on a Japanese Windows with `UnicodeEncodeError: 'cp932' codec can't encode
+  character` raised inside pip's own output rendering (the
+  `pip install --report -` JSON path), so pip exited before producing output.
+  When mureo spawns pip as a subprocess, the child Python defaulted its stdout
+  encoding to the console code page (cp932), which cannot encode characters
+  pip emits (e.g. `U+00B7`). 0.10.10 fixed the decode side; this fixes the
+  encode side by forcing the pip child's stdio to UTF-8
+  (`PYTHONIOENCODING=utf-8:replace`, `PYTHONUTF8=1`) across every
+  pip/ensurepip subprocess. No effect on macOS/Linux (already UTF-8).
+
 ## [0.10.10] - 2026-06-22
 
 ### Fixed

--- a/mureo/__init__.py
+++ b/mureo/__init__.py
@@ -1,3 +1,3 @@
 """mureo — your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."""
 
-__version__ = "0.10.10"
+__version__ = "0.10.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mureo"
-version = "0.10.10"
+version = "0.10.11"
 description = "Your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."
 requires-python = ">=3.10"
 license = "Apache-2.0"


### PR DESCRIPTION
Release 0.10.11: Windows pip-encode fix (#317) — forces the pip child's stdio to UTF-8 so the configure "About mureo" update check + one-click upgrade no longer crash with a cp932 UnicodeEncodeError on a Japanese Windows (encode-side companion to 0.10.10's decode-side fix). Version bumped across pyproject / __init__ / .claude-plugin; CHANGELOG updated. On merge, tag v0.10.11 + a GitHub Release publishes to PyPI via release.yml.

https://claude.ai/code/session_01NxBrN8Qn53Tpivt9SumdGn