### PR TITLE
chore(release): 0.10.12

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mureo",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "Your local-first AI ad ops crew for Google Ads, Meta Ads, Search Console & GA4. mureo sits on top of the official ad-platform MCPs, gates every change against your strategy, correlates outcomes locally, and keeps an auditable decision log — credentials never leave your machine.",
   "author": {
     "name": "Logly Inc.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.12] - 2026-06-23
+
+### Fixed
+
+- The read-only Reports dashboard crashed (and returned an empty summary) when
+  STATE.json held an old / hand-authored `action_log` entry missing a required
+  field (`timestamp` / `platform`). The strict parse is kept for writers, but
+  the read-only view now skips nonconforming `action_log` entries — the same
+  tolerance 0.10.10 added for campaign entries, which had not covered the
+  action log.
+- The Reports period toggle (Yesterday / Last 30 days) did not appear when only
+  `daily-check` had run, because the 30-day window was written solely by
+  `sync-state`. `daily-check` now also persists `LAST_30_DAYS` when it already
+  holds those numbers (no extra API call), so the toggle shows from a
+  daily-check-only routine.
+
+### Added
+
+- `mureo upgrade` now refreshes deployed skills (`~/.claude/skills`) and
+  restarts the always-on `mureo service` daemon after a successful upgrade, so
+  a new version actually takes effect instead of leaving stale skills and a
+  daemon running the old code. Use `--no-refresh` to skip. Best-effort: it
+  never fails the upgrade.
+
+### Documentation
+
+- Refreshed the Meta OAuth scope list (now the full 8 scopes), corrected the
+  MCP tool count (188), and documented the `mureo service` / `mureo open` /
+  `mureo configure --serve` / `mureo upgrade` commands.
+
 ## [0.10.11] - 2026-06-22
 
 ### Fixed

--- a/mureo/__init__.py
+++ b/mureo/__init__.py
@@ -1,3 +1,3 @@
 """mureo — your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."""
 
-__version__ = "0.10.11"
+__version__ = "0.10.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mureo"
-version = "0.10.11"
+version = "0.10.12"
 description = "Your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."
 requires-python = ">=3.10"
 license = "Apache-2.0"


### PR DESCRIPTION
Release 0.10.12:
- **#319** Reports reliability: tolerate malformed action_log entries; daily-check populates the 30-day window so the period toggle shows.
- **#320** `mureo upgrade` re-deploys skills + restarts the always-on service so an upgrade takes effect.
- **#321** docs refresh (Meta 8 scopes, tool count 188, service/upgrade CLI).

Version bumped across pyproject / __init__ / .claude-plugin; CHANGELOG updated. On merge, tag v0.10.12 + a GitHub Release publishes to PyPI via release.yml.

https://claude.ai/code/session_01NxBrN8Qn53Tpivt9SumdGn