### PR TITLE
fix(reports): quiet the tolerant STATE.json read path (no per-poll log flood)

### DIFF
--- a/mureo/context/state.py
+++ b/mureo/context/state.py
@@ -52,7 +52,10 @@ def _parse_campaigns(
         try:
             parsed.append(_parse_campaign(c))
         except (ValueError, KeyError, TypeError) as exc:
-            logger.warning("skipping unparseable campaign entry: %s", exc)
+            # DEBUG, not WARNING: the read-only Reports view re-parses on every
+            # poll, so a per-entry WARNING would flood the log for a STATE.json
+            # with many nonconforming (e.g. legacy / hand-authored) campaigns.
+            logger.debug("skipping unparseable campaign entry: %s", exc)
     return tuple(parsed)
 
 
@@ -74,7 +77,9 @@ def _parse_action_log(
         try:
             parsed.append(_parse_action_log_entry(e))
         except (ValueError, KeyError, TypeError) as exc:
-            logger.warning("skipping unparseable action_log entry: %s", exc)
+            # DEBUG, not WARNING — see _parse_campaigns: avoid per-render log
+            # flood from a STATE.json with many nonconforming action_log entries.
+            logger.debug("skipping unparseable action_log entry: %s", exc)
     return tuple(parsed)
 
 

--- a/mureo/web/reports.py
+++ b/mureo/web/reports.py
@@ -330,7 +330,12 @@ def _read_state_safe(store: StateStore) -> StateDocument | None:
     try:
         return store.read_state()
     except Exception:  # noqa: BLE001 — read-only view degrades, never raises
-        logger.warning(
+        # Expected + handled for a STATE.json with nonconforming entries (e.g. a
+        # hand-authored legacy campaign list): the tolerant retry below renders
+        # the view fine. The read-only dashboard re-reads on every poll, so log
+        # this at DEBUG — a per-render WARNING + traceback would flood the
+        # daemon log on every refresh and read as a failure when it is not.
+        logger.debug(
             "strict STATE.json read failed; retrying tolerantly for the "
             "read-only Reports view",
             exc_info=True,

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
@@ -483,6 +484,28 @@ class TestStateFileErrorHandling:
         data = {"action_log": [{"action": "x", "platform": "google_ads"}]}
         with pytest.raises(KeyError):
             parse_state(json.dumps(data))
+
+    @pytest.mark.unit
+    def test_parse_state_strict_false_skips_log_at_debug_not_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Skipped nonconforming entries log at DEBUG, never WARNING+.
+
+        The read-only Reports view re-parses STATE.json on every dashboard
+        poll, so a per-entry WARNING would flood the daemon log for an account
+        with many legacy / hand-authored campaigns — and read as a failure when
+        it is graceful degradation. Pin DEBUG so the noise never returns."""
+        data = {
+            "campaigns": [{"id": "x", "name": "variant, no campaign_id/_name"}],
+            "action_log": [{"summary": "legacy, no timestamp/action/platform"}],
+        }
+        with caplog.at_level(logging.DEBUG, logger="mureo.context.state"):
+            parse_state(json.dumps(data), strict=False)
+
+        # The skips still happen and are observable at DEBUG …
+        assert any("skipping unparseable" in r.message for r in caplog.records)
+        # … but nothing is emitted at WARNING or above (the per-render flood).
+        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
 
 
 class TestAtomicWrite:

--- a/tests/test_web_reports.py
+++ b/tests/test_web_reports.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import dataclasses
 import json
+import logging
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -325,7 +326,9 @@ def test_summary_does_not_raise_on_broken_state(
 
 @pytest.mark.unit
 def test_summary_tolerates_nonconforming_campaign_entries(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """A STATE.json whose campaign list has a nonconforming entry — e.g. a
     hand-authored / variant campaign using ``id``/``name`` instead of
@@ -354,11 +357,16 @@ def test_summary_tolerates_nonconforming_campaign_entries(
     }
     (tmp_path / "STATE.json").write_text(json.dumps(raw), encoding="utf-8")
 
-    summary = build_report_summary()
+    with caplog.at_level(logging.DEBUG):
+        summary = build_report_summary()
     by_key = {p["key"]: p for p in summary["platforms"]}
     assert "logly_ads_context" in by_key, "platform blanked by a bad campaign entry"
     assert by_key["logly_ads_context"]["totals"] == {"spend": 8739.0, "conversions": 0}
     assert summary["reports"] == {"daily": {"verdict": "Watch", "note": "spend down"}}
+    # The strict-fail → tolerant-retry happens on EVERY dashboard poll, so it
+    # must not flood the daemon log: nothing at WARNING+ for this handled,
+    # gracefully-degraded read (the per-entry skips + retry trace are DEBUG).
+    assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
 
 
 @pytest.mark.unit


### PR DESCRIPTION
The read-only Reports view tries a strict STATE.json parse, then re-reads tolerantly (skipping nonconforming entries). That **works** — the dashboard renders — but it logged a full traceback + one WARNING per skipped entry on **every dashboard poll**. On an account with many legacy / hand-authored campaigns (schema `name`/`id` instead of `campaign_name`/`campaign_id`), the daemon log floods with a traceback + dozens of warnings each refresh, reading as a failure when it is expected graceful degradation.

## Change
Lower the per-render tolerant-path logging WARNING → DEBUG:
- `web/reports.py` `_read_state_safe` (strict-fail → tolerant-retry trace)
- `context/state.py` `_parse_campaigns` / `_parse_action_log` (per-entry skips)

Genuinely-bad paths stay loud (no-path warning, tolerant-also-failed exception, structural errors still raise). Regression tests pin DEBUG-not-WARNING at parse + `build_report_summary` level.

No functional change — the view already rendered; this only quiets the log. python-reviewer: APPROVE. Targets 0.10.13.

https://claude.ai/code/session_01NxBrN8Qn53Tpivt9SumdGn