### PR TITLE
feat(mcp): plugin provider guardrail parity (schema validation, strategy reminder, executable rollback)

### DIFF
--- a/mureo/core/strategy_reminder.py
+++ b/mureo/core/strategy_reminder.py
@@ -203,36 +203,61 @@ def build_reminder_text(entries: list[StrategyEntry]) -> str | None:
 # ---------------------------------------------------------------------------
 
 
-def maybe_build_reminder(tool_name: str) -> str | None:
-    """Best-effort: return the reminder text for ``tool_name`` if the
-    tool is mutating, the env var has not opted out, STRATEGY.md is
-    non-empty, and the state read succeeds. Returns ``None`` in every
-    other case so the caller can simply do
-    ``if text is not None: append`` without further error handling.
+def _read_strategy_reminder(tool_name: str) -> str | None:
+    """Env-gated STRATEGY.md reminder body shared by the built-in and
+    plugin entry points. Returns ``None`` when opted out, on a state-read
+    failure, or when STRATEGY.md is empty.
 
-    Any exception inside this function is caught and logged at DEBUG —
-    a broken reminder must never break a mutating tool dispatch.
+    The state read AND the text build are both inside the try: any
+    exception is caught and logged at DEBUG, so a broken reminder can
+    never break a mutating tool dispatch (the callers that append the
+    result do not wrap it in their own try/except).
     """
     if os.environ.get(_OPT_OUT_ENV_VAR) == "1":
-        return None
-    if not is_mutating_builtin_tool(tool_name):
         return None
     try:
         ctx = get_runtime_context()
         entries = list(ctx.state_store.read_strategy())
+        return build_reminder_text(entries)
     except Exception as exc:  # noqa: BLE001
         logger.debug(
-            "strategy reminder: state read failed for tool %s (%s); "
-            "skipping reminder",
+            "strategy reminder: build failed for tool %s (%s); skipping reminder",
             tool_name,
             exc,
         )
         return None
-    return build_reminder_text(entries)
+
+
+def maybe_build_reminder(tool_name: str) -> str | None:
+    """Best-effort: return the reminder text for ``tool_name`` if the
+    tool is a mutating *built-in*, the env var has not opted out,
+    STRATEGY.md is non-empty, and the state read succeeds. Returns
+    ``None`` in every other case so the caller can simply do
+    ``if text is not None: append`` without further error handling.
+    """
+    if not is_mutating_builtin_tool(tool_name):
+        return None
+    return _read_strategy_reminder(tool_name)
+
+
+def maybe_build_reminder_for_plugin(tool_name: str) -> str | None:
+    """Plugin counterpart of :func:`maybe_build_reminder` (guardrail
+    parity, #114 follow-up).
+
+    The dispatcher only calls this after a plugin tool has *already* been
+    classified as mutating by :func:`mureo.mcp.plugin_semantics.derive_semantics`
+    (standard MCP ``readOnlyHint``/``meta`` metadata). So unlike the built-in
+    entry point, it deliberately does NOT run :func:`is_mutating_builtin_tool`
+    — that classifier excludes the ``mcp__`` plugin namespace by design. Same
+    env opt-out and best-effort contract; the reminder body is identical, so a
+    plugin mutation re-surfaces STRATEGY.md exactly like a built-in one.
+    """
+    return _read_strategy_reminder(tool_name)
 
 
 __all__ = [
     "build_reminder_text",
     "is_mutating_builtin_tool",
     "maybe_build_reminder",
+    "maybe_build_reminder_for_plugin",
 ]

--- a/mureo/mcp/server.py
+++ b/mureo/mcp/server.py
@@ -157,18 +157,24 @@ _ALL_TOOLS.extend(_PLUGIN_TOOLS)
 _PLUGIN_NAMES: frozenset[str] = frozenset(_PLUGIN_DISPATCH)
 
 
-# Pre-compiled JSON Schema validators for every BUILT-IN tool, keyed by tool
-# name. The MCP framework does not enforce ``inputSchema``, so declared bounds
+# Pre-compiled JSON Schema validators for every tool, keyed by tool name.
+# The MCP framework does not enforce ``inputSchema``, so declared bounds
 # (``minimum``, ``required``, ``type``, ``enum``) are advisory until checked
 # server-side. Validating here is the single guard that makes them real for
-# every built-in mutation — most importantly the real-spend boundary values
-# (budget / bid ``minimum: 1``) flagged in issue #277. Plugin tools are
-# validated by their own providers and are intentionally excluded.
+# every mutation — most importantly the real-spend boundary values
+# (budget / bid ``minimum: 1``) flagged in issue #277.
+#
+# Plugin tools are validated here too (guardrail parity, #114 follow-up): a
+# plugin that declares ``minimum``/``required``/``enum`` on a real-spend
+# parameter now has those bounds enforced server-side, exactly like a
+# built-in, instead of relying on the (unverifiable) assumption that every
+# provider validates its own inputs. A plugin whose schema is permissive
+# (no constraints, ``additionalProperties`` open) is unaffected — the
+# validator simply finds nothing to reject. A malformed plugin schema is
+# skipped per-tool below, same as a malformed built-in schema.
 def _build_tool_validators() -> dict[str, Draft202012Validator]:
     validators: dict[str, Draft202012Validator] = {}
     for tool in _ALL_TOOLS:
-        if tool.name in _PLUGIN_NAMES:
-            continue
         schema = getattr(tool, "inputSchema", None)
         if not isinstance(schema, dict):
             continue
@@ -196,8 +202,9 @@ def _validate_tool_input(name: str, arguments: dict[str, Any]) -> None:
 
     Raises ``ValueError`` (the dispatcher's standard caller-error channel)
     on the first violation, before the tool handler runs — so an invalid
-    budget/bid never reaches a real-spend API call. No-op for tools without
-    a registered validator (plugins, or a tool with no schema).
+    budget/bid never reaches a real-spend API call. Applies to both built-in
+    and plugin tools. No-op for a tool without a registered validator (no
+    schema, or a schema that failed ``check_schema`` at build time).
     """
     validator = _TOOL_VALIDATORS.get(name)
     if validator is None:
@@ -233,6 +240,58 @@ _PLUGIN_TOOL_THROTTLERS: dict[str, Throttler] = {
     for name, sem in _PLUGIN_SEMANTICS.items()
     if sem.throttle is not None
 }
+
+
+# Guardrail parity (#114 follow-up): top-level ``inputSchema`` property names
+# per plugin tool. The rollback planner uses these to bound the params a
+# plugin-declared reversal may carry — the plugin counterpart of the static
+# ``_ALLOWED_OPERATIONS`` key-sets the planner enforces for built-in reversals.
+def _plugin_schema_property_keys(tool: Tool) -> frozenset[str] | None:
+    """Return the declared top-level object property names of ``tool``'s
+    ``inputSchema``, or ``None`` when the schema is absent or declares no
+    usable ``properties`` map (so the planner applies no key restriction
+    and leaves the bound to execution-time validation)."""
+    schema = getattr(tool, "inputSchema", None)
+    if not isinstance(schema, dict):
+        return None
+    props = schema.get("properties")
+    if not isinstance(props, dict) or not props:
+        return None
+    return frozenset(props)
+
+
+_PLUGIN_REVERSAL_KEYS: dict[str, frozenset[str] | None] = {
+    t.name: _plugin_schema_property_keys(t) for t in _PLUGIN_TOOLS
+}
+
+
+def plugin_reversal_param_keys(operation: str) -> tuple[bool, frozenset[str] | None]:
+    """Resolve a plugin reversal operation for the rollback planner (GAP C).
+
+    The planner calls this (lazily, to avoid an import cycle) when a reversal
+    ``operation`` is not in its static built-in allow-list, to decide whether
+    a plugin-declared reversal is executable.
+
+    Returns:
+        ``(False, None)`` when ``operation`` is not a registered plugin tool
+        — the planner then refuses it exactly as before (an arbitrary,
+        unregistered operation is never auto-reversible).
+
+        ``(True, frozenset(keys))`` when ``operation`` is a registered plugin
+        tool that declares an object ``inputSchema`` — the planner bounds the
+        reversal params to ``keys`` (defense-in-depth against an injected
+        agent smuggling extra params), mirroring the built-in key-set check.
+
+        ``(True, None)`` when ``operation`` is a registered plugin tool with
+        no usable schema — the planner applies no plan-time key restriction.
+        The reversal is still gated by the planner's destructive-verb refusal,
+        and at execution the dispatcher re-runs policy gates + ``inputSchema``
+        validation against the live tool, so an unbounded plan cannot bypass
+        the forward-action guardrails.
+    """
+    if operation not in _PLUGIN_NAMES:
+        return (False, None)
+    return (True, _PLUGIN_REVERSAL_KEYS.get(operation))
 
 
 # ---------------------------------------------------------------------------
@@ -466,6 +525,25 @@ def _maybe_append_strategy_reminder(name: str, result: list[Any]) -> list[Any]:
     return [*result, TextContent(type="text", text=reminder)]
 
 
+def _maybe_append_plugin_strategy_reminder(name: str, result: list[Any]) -> list[Any]:
+    """Plugin counterpart of :func:`_maybe_append_strategy_reminder`.
+
+    Called only for a successful *mutating* plugin tool (the dispatch branch
+    has already consulted ``derive_semantics``), so the reminder fires for a
+    plugin mutation exactly as it does for a built-in one — closing the
+    strategy-reminder guardrail gap. Same soft-enforcement contract: never
+    refuses, never replaces the tool's content, best-effort.
+    """
+    from mcp.types import TextContent
+
+    from mureo.core.strategy_reminder import maybe_build_reminder_for_plugin
+
+    reminder = maybe_build_reminder_for_plugin(name)
+    if reminder is None:
+        return result
+    return [*result, TextContent(type="text", text=reminder)]
+
+
 # Once-per-process latch: the stale-version banner is appended to the first
 # tool result that detects the mismatch, not every call (avoid spamming a
 # read-heavy daily-check). A fresh process after restart starts False again.
@@ -602,6 +680,11 @@ async def _dispatch_tool(name: str, arguments: dict[str, Any]) -> list[Any]:
                 reversal=None if sem is None else sem.reversal,
                 observation_days=None if sem is None else sem.observation_days,
             )
+            # Guardrail parity: a mutating plugin call re-surfaces the
+            # operator's STRATEGY.md sections, exactly like a built-in
+            # mutation. Read-only plugin tools skip it (no mutation to
+            # check against strategy).
+            result = _maybe_append_plugin_strategy_reminder(name, result)
         return result
     raise ValueError(f"Unknown tool: {name}")
 

--- a/mureo/rollback/planner.py
+++ b/mureo/rollback/planner.py
@@ -17,10 +17,15 @@ that performed the original action, and is therefore untrusted input
 for the rollback executor: a compromised or prompt-injected agent
 could otherwise log a "reversal" that points to a destructive
 operation. This module enforces that only operations explicitly
-listed in :data:`_ALLOWED_OPERATIONS` are planned, and that each plan
-carries only the keys that operation declares. Executors (Task #26)
-must still re-authorize against the same policy gate used for forward
-actions.
+listed in :data:`_ALLOWED_OPERATIONS` — or, via
+:func:`_plugin_reversal_keys`, naming a *registered* plugin tool —
+are planned, that no operation naming a destructive verb is ever
+planned, and that each plan carries only the param keys that operation
+declares (built-in: the static key-set; plugin: its ``inputSchema``
+property names). Executors (Task #26) must still re-authorize against
+the same policy gate used for forward actions; for a plugin reversal
+the dispatcher additionally re-validates the params against the live
+tool's ``inputSchema`` before the call runs.
 """
 
 from __future__ import annotations
@@ -85,6 +90,30 @@ _READ_ONLY_PREFIXES: tuple[str, ...] = (
 )
 
 
+def _plugin_reversal_keys(operation: str) -> tuple[bool, frozenset[str] | None]:
+    """Plugin escape hatch for :func:`plan_rollback` (guardrail parity).
+
+    A plugin tool may declare ``meta["mureo"]["reversal"]`` pointing at one of
+    its own operations. Such an operation can never appear in the static
+    :data:`_ALLOWED_OPERATIONS` (mureo cannot enumerate third-party tools at
+    author time), so before #114-follow-up it was always recorded-but-not-
+    executable. This hook lets the planner accept it when it names a
+    *registered* plugin tool, bounding params by that tool's declared schema.
+
+    Returns ``(is_registered_plugin_tool, allowed_keys_or_None)``. Resolved
+    lazily against the live MCP server to avoid the import cycle
+    ``server → tools_rollback → _handlers_rollback → rollback.planner``. A
+    server-import failure (e.g. this module imported in isolation in a test)
+    degrades safely to ``(False, None)`` — no plugin operation is planned.
+    Tests monkeypatch this function directly.
+    """
+    try:
+        from mureo.mcp.server import plugin_reversal_param_keys
+    except Exception:  # noqa: BLE001 — degrade to "not a plugin op"
+        return (False, None)
+    return plugin_reversal_param_keys(operation)
+
+
 def plan_rollback(entry: ActionLogEntry) -> RollbackPlan | None:
     """Build a :class:`RollbackPlan` for one action log entry.
 
@@ -136,21 +165,30 @@ def plan_rollback(entry: ActionLogEntry) -> RollbackPlan | None:
                 "and cannot be planned as a rollback."
             ),
         )
+    # Built-in allow-list first; fall back to the plugin escape hatch so a
+    # plugin-declared reversal naming a registered plugin tool is executable
+    # too (guardrail parity). ``allowed_keys is None`` means "no plan-time key
+    # restriction" — used both for an unrecognised built-in (rejected below)
+    # and for a registered schema-less plugin tool (accepted, bounded at
+    # execution by the dispatcher's re-validation + policy gates).
     allowed_keys = _ALLOWED_OPERATIONS.get(operation)
     if allowed_keys is None:
-        return _not_supported(
-            entry,
-            notes=(f"Operation {operation!r} is not in the rollback allow-list."),
-        )
-    extra = set(params) - allowed_keys
-    if extra:
-        return _not_supported(
-            entry,
-            notes=(
-                f"Operation {operation!r} received unexpected params: "
-                f"{sorted(extra)}."
-            ),
-        )
+        is_plugin_tool, allowed_keys = _plugin_reversal_keys(operation)
+        if not is_plugin_tool:
+            return _not_supported(
+                entry,
+                notes=(f"Operation {operation!r} is not in the rollback allow-list."),
+            )
+    if allowed_keys is not None:
+        extra = set(params) - allowed_keys
+        if extra:
+            return _not_supported(
+                entry,
+                notes=(
+                    f"Operation {operation!r} received unexpected params: "
+                    f"{sorted(extra)}."
+                ),
+            )
 
     raw_caveats = hint.get("caveats")
     if raw_caveats is not None and not isinstance(raw_caveats, list):

--- a/tests/test_mcp_input_validation.py
+++ b/tests/test_mcp_input_validation.py
@@ -26,15 +26,74 @@ _budget_registered = pytest.mark.skipif(
 
 
 def test_unknown_tool_is_noop() -> None:
-    """A tool with no registered validator (plugins, unknown) is skipped."""
+    """A tool with no registered validator (unknown name, or a tool with no
+    schema) is skipped."""
     _validate_tool_input("definitely_not_a_registered_tool", {"x": 1})
 
 
-def test_plugin_tools_are_not_validated() -> None:
-    """Plugin tool names must be excluded from the built-in validator map."""
-    from mureo.mcp.server import _PLUGIN_NAMES
+def test_plugin_tools_are_validated() -> None:
+    """Guardrail parity (#114 follow-up): a plugin tool that declares a valid
+    ``inputSchema`` is compiled into the validator map too, so its declared
+    bounds are enforced server-side exactly like a built-in. (Previously
+    ``_PLUGIN_NAMES`` were intentionally excluded — that exclusion is removed.)
 
-    assert _PLUGIN_NAMES.isdisjoint(_TOOL_VALIDATORS)
+    Exercised with a synthetic plugin so the assertion does not depend on
+    which third-party providers happen to be installed in the environment.
+    """
+    import importlib
+    from typing import Any
+
+    from mcp.types import TextContent, Tool
+
+    from mureo.core.providers.capabilities import Capability
+    from mureo.core.providers.registry import ProviderEntry
+
+    class _SchemaPlugin:
+        name = "iv_schema_plugin"
+        display_name = "IV"
+        capabilities = frozenset({Capability.READ_CAMPAIGNS})
+
+        def mcp_tools(self) -> tuple[Tool, ...]:
+            return (
+                Tool(
+                    name="iv_schema_plugin_spend",
+                    description="x",
+                    inputSchema={
+                        "type": "object",
+                        "properties": {"budget": {"type": "integer", "minimum": 1}},
+                        "required": ["budget"],
+                    },
+                ),
+            )
+
+        async def handle_mcp_tool(
+            self, name: str, arguments: dict[str, Any]
+        ) -> list[Any]:
+            return [TextContent(type="text", text="ok")]
+
+    def _disc(**_kw: Any) -> tuple[ProviderEntry, ...]:
+        return (
+            ProviderEntry(
+                name=_SchemaPlugin.name,
+                display_name=_SchemaPlugin.display_name,
+                capabilities=_SchemaPlugin.capabilities,
+                provider_class=_SchemaPlugin,
+                source_distribution="iv-dist",
+            ),
+        )
+
+    import mureo.core.providers.registry as registry
+    from mureo.mcp import server as mod
+
+    original = registry.discover_providers
+    registry.discover_providers = _disc
+    try:
+        mod = importlib.reload(mod)
+        assert "iv_schema_plugin_spend" in mod._PLUGIN_NAMES
+        assert "iv_schema_plugin_spend" in mod._TOOL_VALIDATORS
+    finally:
+        registry.discover_providers = original
+        importlib.reload(mod)
 
 
 @_budget_registered

--- a/tests/test_mcp_server_plugin_wiring.py
+++ b/tests/test_mcp_server_plugin_wiring.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 from mcp.types import TextContent, Tool, ToolAnnotations
@@ -382,5 +383,169 @@ class TestPhase2Promotion:
             assert (
                 mod._PLUGIN_TOOL_THROTTLERS["th_plugin_go"] is not mod._PLUGIN_THROTTLER
             )
+        finally:
+            importlib.reload(mod)
+
+
+# ---------------------------------------------------------------------------
+# Guardrail parity (#114 follow-up): plugin tools get the same three
+# guardrails built-ins have — server-side inputSchema validation (GAP A),
+# a STRATEGY.md reminder after mutating calls (GAP B), and executable
+# reversal lookup for the rollback planner (GAP C).
+# ---------------------------------------------------------------------------
+
+
+class _StrictSchemaPlugin:
+    """A plugin that declares a real-spend bound on its mutating tool."""
+
+    name = "strict_plugin"
+    display_name = "Strict"
+    capabilities = frozenset({Capability.READ_CAMPAIGNS})
+
+    def mcp_tools(self) -> tuple[Tool, ...]:
+        return (
+            Tool(
+                name="strict_plugin_spend",
+                description="spends real money",
+                inputSchema={
+                    "type": "object",
+                    "properties": {"budget": {"type": "integer", "minimum": 1}},
+                    "required": ["budget"],
+                },
+            ),
+        )
+
+    async def handle_mcp_tool(self, name: str, arguments: dict[str, Any]) -> list[Any]:
+        return [TextContent(type="text", text=f"spent {arguments['budget']}")]
+
+
+@pytest.mark.unit
+class TestGapAPluginSchemaValidation:
+    @pytest.fixture
+    def server_strict(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            "mureo.core.providers.registry.discover_providers",
+            _disc_for(_StrictSchemaPlugin),
+        )
+        # Keep the audit jsonl out of the developer's home/cwd.
+        from mureo.mcp import plugin_audit
+
+        monkeypatch.setattr(
+            plugin_audit, "_audit_path", lambda: tmp_path / "audit.jsonl"
+        )
+        from mureo.mcp import server as mod
+
+        mod = importlib.reload(mod)
+        yield mod
+        importlib.reload(mod)
+
+    def test_validator_built_for_plugin_tool(self, server_strict) -> None:
+        # GAP A: a plugin tool's schema is now compiled into a validator,
+        # same as a built-in (previously _PLUGIN_NAMES were skipped).
+        assert "strict_plugin_spend" in server_strict._TOOL_VALIDATORS
+
+    async def test_below_minimum_rejected_before_dispatch(self, server_strict) -> None:
+        with pytest.raises(ValueError, match="Invalid arguments"):
+            await server_strict.handle_call_tool("strict_plugin_spend", {"budget": 0})
+
+    async def test_missing_required_rejected(self, server_strict) -> None:
+        with pytest.raises(ValueError, match="Invalid arguments"):
+            await server_strict.handle_call_tool("strict_plugin_spend", {})
+
+    async def test_valid_args_pass_through(self, server_strict) -> None:
+        out = await server_strict.handle_call_tool("strict_plugin_spend", {"budget": 5})
+        assert out[0].text == "spent 5"
+
+
+@pytest.mark.unit
+class TestGapBPluginStrategyReminder:
+    async def test_mutating_plugin_gets_strategy_reminder(
+        self, server_with_plugin, monkeypatch, tmp_path
+    ) -> None:
+        from mureo.context.models import StrategyEntry
+        from mureo.mcp import plugin_audit
+
+        monkeypatch.setattr(
+            plugin_audit, "_audit_path", lambda: tmp_path / "audit.jsonl"
+        )
+        fake_ctx = MagicMock()
+        fake_ctx.state_store.read_strategy.return_value = [
+            StrategyEntry(context_type="goal", title="Q2 CPA target", content="x"),
+        ]
+        monkeypatch.setattr(
+            "mureo.core.strategy_reminder.get_runtime_context", lambda: fake_ctx
+        )
+        monkeypatch.delenv("MUREO_DISABLE_STRATEGY_REMINDER", raising=False)
+
+        out = await server_with_plugin.handle_call_tool(
+            "wired_plugin_echo", {"msg": "hi"}
+        )
+        # Original output preserved + reminder appended (GAP B).
+        assert out[0].text == "hi"
+        assert any("Q2 CPA target" in getattr(c, "text", "") for c in out)
+
+    async def test_readonly_plugin_gets_no_reminder(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        from mureo.context.models import StrategyEntry
+        from mureo.mcp import plugin_audit
+
+        monkeypatch.setattr(
+            plugin_audit, "_audit_path", lambda: tmp_path / "audit.jsonl"
+        )
+        monkeypatch.setattr(
+            "mureo.core.providers.registry.discover_providers",
+            _disc_for(_ReadOnlyPlugin),
+        )
+        fake_ctx = MagicMock()
+        fake_ctx.state_store.read_strategy.return_value = [
+            StrategyEntry(context_type="goal", title="Q2 CPA target", content="x"),
+        ]
+        monkeypatch.setattr(
+            "mureo.core.strategy_reminder.get_runtime_context", lambda: fake_ctx
+        )
+        monkeypatch.delenv("MUREO_DISABLE_STRATEGY_REMINDER", raising=False)
+        from mureo.mcp import server as mod
+
+        mod = importlib.reload(mod)
+        try:
+            out = await mod.handle_call_tool("ro_plugin_report", {})
+            assert all("Q2 CPA target" not in getattr(c, "text", "") for c in out)
+        finally:
+            importlib.reload(mod)
+
+
+@pytest.mark.unit
+class TestGapCPluginReversalParamKeys:
+    async def test_registered_tool_returns_schema_keys(
+        self, server_with_plugin
+    ) -> None:
+        # wired_plugin_echo declares {"msg": {...}} → keys = {"msg"}.
+        is_plugin, keys = server_with_plugin.plugin_reversal_param_keys(
+            "wired_plugin_echo"
+        )
+        assert is_plugin is True
+        assert keys == frozenset({"msg"})
+
+    async def test_unregistered_operation_returns_false(
+        self, server_with_plugin
+    ) -> None:
+        assert server_with_plugin.plugin_reversal_param_keys("not_a_real_tool") == (
+            False,
+            None,
+        )
+
+    def test_schemaless_plugin_tool_returns_true_none(self, monkeypatch) -> None:
+        # _ReadOnlyPlugin's tool declares empty properties → (True, None):
+        # registered but no plan-time key restriction.
+        monkeypatch.setattr(
+            "mureo.core.providers.registry.discover_providers",
+            _disc_for(_ReadOnlyPlugin),
+        )
+        from mureo.mcp import server as mod
+
+        mod = importlib.reload(mod)
+        try:
+            assert mod.plugin_reversal_param_keys("ro_plugin_report") == (True, None)
         finally:
             importlib.reload(mod)

--- a/tests/test_rollback.py
+++ b/tests/test_rollback.py
@@ -230,3 +230,131 @@ class TestStatusValues:
         assert RollbackStatus.SUPPORTED.value == "supported"
         assert RollbackStatus.PARTIAL.value == "partial"
         assert RollbackStatus.NOT_SUPPORTED.value == "not_supported"
+
+
+@pytest.mark.unit
+class TestPluginReversalEscapeHatch:
+    """Guardrail parity (#114 follow-up): a plugin-declared reversal that
+    names a *registered* plugin tool is planned (and so executable),
+    bounded by that tool's schema property keys. The plugin lookup is
+    monkeypatched so these stay pure — the live wiring is exercised in
+    ``test_mcp_server_plugin_wiring`` / ``test_rollback_execute``.
+    """
+
+    def test_registered_plugin_reversal_is_supported(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "mureo.rollback.planner._plugin_reversal_keys",
+            lambda op: (True, frozenset({"campaign_id"})),
+        )
+        entry = _entry(
+            action="acme_pause",
+            platform="plugin:acme-dist",
+            reversible_params={
+                "operation": "acme_resume",
+                "params": {"campaign_id": "123"},
+            },
+        )
+        plan = plan_rollback(entry)
+        assert plan is not None
+        assert plan.status == RollbackStatus.SUPPORTED
+        assert plan.operation == "acme_resume"
+        assert plan.params == {"campaign_id": "123"}
+
+    def test_unregistered_operation_still_not_supported(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "mureo.rollback.planner._plugin_reversal_keys",
+            lambda op: (False, None),
+        )
+        entry = _entry(
+            action="acme_pause",
+            reversible_params={
+                "operation": "acme_resume",
+                "params": {"campaign_id": "123"},
+            },
+        )
+        plan = plan_rollback(entry)
+        assert plan is not None
+        assert plan.status == RollbackStatus.NOT_SUPPORTED
+        assert "allow-list" in plan.notes
+
+    def test_plugin_reversal_extra_params_rejected(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "mureo.rollback.planner._plugin_reversal_keys",
+            lambda op: (True, frozenset({"campaign_id"})),
+        )
+        entry = _entry(
+            action="acme_pause",
+            reversible_params={
+                "operation": "acme_resume",
+                "params": {"campaign_id": "123", "smuggled": "evil"},
+            },
+        )
+        plan = plan_rollback(entry)
+        assert plan is not None
+        assert plan.status == RollbackStatus.NOT_SUPPORTED
+        assert "unexpected params" in plan.notes
+
+    def test_schemaless_plugin_reversal_skips_key_restriction(
+        self, monkeypatch
+    ) -> None:
+        # (True, None) = registered plugin tool with no usable schema:
+        # no plan-time key restriction (execution re-validates + re-gates).
+        monkeypatch.setattr(
+            "mureo.rollback.planner._plugin_reversal_keys",
+            lambda op: (True, None),
+        )
+        entry = _entry(
+            action="acme_pause",
+            reversible_params={
+                "operation": "acme_resume",
+                "params": {"anything": "goes", "more": 1},
+            },
+        )
+        plan = plan_rollback(entry)
+        assert plan is not None
+        assert plan.status == RollbackStatus.SUPPORTED
+
+    def test_reversal_naming_builtin_tool_is_not_a_plugin_op(self) -> None:
+        """Cross-namespace boundary: a plugin reversal whose ``operation``
+        names a *built-in* tool not in the static allow-list is refused — the
+        real ``_plugin_reversal_keys`` lazily resolves it against the live
+        server and returns ``(False, None)`` because built-in names are never
+        in ``_PLUGIN_NAMES``. No monkeypatch — exercises the real lazy import.
+        """
+        entry = _entry(
+            action="acme_pause",
+            reversible_params={
+                # A real built-in tool name, but NOT in _ALLOWED_OPERATIONS.
+                "operation": "google_ads_campaigns_create",
+                "params": {"campaign_id": "123"},
+            },
+        )
+        plan = plan_rollback(entry)
+        assert plan is not None
+        assert plan.status == RollbackStatus.NOT_SUPPORTED
+        assert "allow-list" in plan.notes
+
+    def test_destructive_plugin_reversal_rejected_before_lookup(
+        self, monkeypatch
+    ) -> None:
+        """The destructive-verb refusal runs *before* the plugin hook, so a
+        plugin can never declare a reversal that deletes."""
+        consulted: list[str] = []
+
+        def _spy(op: str):
+            consulted.append(op)
+            return (True, None)
+
+        monkeypatch.setattr("mureo.rollback.planner._plugin_reversal_keys", _spy)
+        entry = _entry(
+            action="acme_pause",
+            reversible_params={
+                "operation": "acme_campaigns_delete",
+                "params": {},
+            },
+        )
+        plan = plan_rollback(entry)
+        assert plan is not None
+        assert plan.status == RollbackStatus.NOT_SUPPORTED
+        assert "destructive" in plan.notes.lower()
+        assert consulted == []  # hook never reached for a destructive op

--- a/tests/test_rollback_execute.py
+++ b/tests/test_rollback_execute.py
@@ -329,3 +329,72 @@ class TestExecutorWiringContract:
         # Atomically written and re-parseable.
         data = json.loads(state_file.read_text(encoding="utf-8"))
         assert data["action_log"][1]["rollback_of"] == 0
+
+
+def _plugin_reversal_entry() -> ActionLogEntry:
+    """A plugin mutation whose declared reversal names another plugin tool."""
+    return ActionLogEntry(
+        timestamp="2026-04-15T10:00:00",
+        action="acme_pause",
+        platform="plugin:acme-dist",
+        summary="paused via acme plugin",
+        reversible_params={
+            "operation": "acme_resume",
+            "params": {"campaign_id": "123"},
+        },
+    )
+
+
+@pytest.mark.unit
+class TestExecutePluginReversal:
+    """Guardrail parity (#114 follow-up, GAP C): a plugin-declared reversal
+    naming a registered plugin tool is dispatched through the same executor
+    path as a built-in reversal. The planner's plugin lookup is monkeypatched
+    so the test stays free of the live MCP registry; the executor + planner
+    integration is what is exercised here."""
+
+    @pytest.mark.asyncio
+    async def test_registered_plugin_reversal_dispatched(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(
+            "mureo.rollback.planner._plugin_reversal_keys",
+            lambda op: (True, frozenset({"campaign_id"})),
+        )
+        state_file = tmp_path / "STATE.json"
+        _write_state(state_file, [_plugin_reversal_entry()])
+        dispatcher = _FakeDispatcher()
+
+        result = await execute_rollback(
+            state_file=state_file,
+            index=0,
+            confirm=True,
+            dispatcher=dispatcher,
+        )
+
+        assert result["status"] == "applied"
+        assert result["dispatched_tool"] == "acme_resume"
+        assert dispatcher.calls == [("acme_resume", {"campaign_id": "123"})]
+        doc = read_state_file(state_file)
+        assert doc.action_log[1].rollback_of == 0
+
+    @pytest.mark.asyncio
+    async def test_unregistered_plugin_reversal_refused(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(
+            "mureo.rollback.planner._plugin_reversal_keys",
+            lambda op: (False, None),
+        )
+        state_file = tmp_path / "STATE.json"
+        _write_state(state_file, [_plugin_reversal_entry()])
+        dispatcher = _FakeDispatcher()
+
+        with pytest.raises(RollbackExecutionError, match="not supported"):
+            await execute_rollback(
+                state_file=state_file,
+                index=0,
+                confirm=True,
+                dispatcher=dispatcher,
+            )
+        assert dispatcher.calls == []

--- a/tests/test_strategy_reminder.py
+++ b/tests/test_strategy_reminder.py
@@ -485,3 +485,96 @@ class TestDispatcherInjection:
         # Original output preserved; no reminder; no exception.
         assert len(result) == 1
         assert result[0].text == "original"
+
+
+@pytest.mark.unit
+class TestPluginReminderBuilder:
+    """``maybe_build_reminder_for_plugin`` — the plugin entry point used by
+    the dispatcher for a *mutating* plugin call. Unlike the built-in builder
+    it must NOT run the built-in suffix classifier (the caller has already
+    classified the tool via ``derive_semantics``), but it shares the same
+    env opt-out and best-effort contract."""
+
+    def _ctx(self, strategy):
+        ctx = MagicMock()
+        ctx.state_store.read_strategy.return_value = strategy
+        return ctx
+
+    def test_fires_for_plugin_namespaced_tool(self) -> None:
+        from mureo.core.strategy_reminder import maybe_build_reminder_for_plugin
+
+        ctx = self._ctx(
+            [StrategyEntry(context_type="goal", title="Q2 CPA target", content="x")]
+        )
+        with (
+            patch(
+                "mureo.core.strategy_reminder.get_runtime_context",
+                return_value=ctx,
+            ),
+            patch.dict("os.environ", {}, clear=False),
+        ):
+            import os
+
+            os.environ.pop("MUREO_DISABLE_STRATEGY_REMINDER", None)
+            # A plugin-namespaced name the built-in classifier would reject.
+            text = maybe_build_reminder_for_plugin("mcp__mureo__acme_create")
+        assert text is not None
+        assert "Q2 CPA target" in text
+
+    def test_empty_strategy_returns_none(self) -> None:
+        from mureo.core.strategy_reminder import maybe_build_reminder_for_plugin
+
+        with patch(
+            "mureo.core.strategy_reminder.get_runtime_context",
+            return_value=self._ctx([]),
+        ):
+            assert maybe_build_reminder_for_plugin("acme_resume") is None
+
+    def test_env_opt_out_suppresses(self) -> None:
+        from mureo.core.strategy_reminder import maybe_build_reminder_for_plugin
+
+        ctx = self._ctx(
+            [StrategyEntry(context_type="goal", title="Q2 CPA target", content="x")]
+        )
+        with (
+            patch(
+                "mureo.core.strategy_reminder.get_runtime_context",
+                return_value=ctx,
+            ),
+            patch.dict(
+                "os.environ",
+                {"MUREO_DISABLE_STRATEGY_REMINDER": "1"},
+                clear=False,
+            ),
+        ):
+            assert maybe_build_reminder_for_plugin("acme_resume") is None
+
+    def test_state_read_failure_returns_none(self) -> None:
+        from mureo.core.strategy_reminder import maybe_build_reminder_for_plugin
+
+        ctx = MagicMock()
+        ctx.state_store.read_strategy.side_effect = OSError("disk gone")
+        with patch(
+            "mureo.core.strategy_reminder.get_runtime_context", return_value=ctx
+        ):
+            assert maybe_build_reminder_for_plugin("acme_resume") is None
+
+    def test_text_build_failure_returns_none(self) -> None:
+        """The text builder is inside the try too — a raise there must
+        degrade to ``None``, never propagate into the dispatch."""
+        from mureo.core.strategy_reminder import maybe_build_reminder_for_plugin
+
+        ctx = self._ctx(
+            [StrategyEntry(context_type="goal", title="Q2 CPA target", content="x")]
+        )
+        with (
+            patch(
+                "mureo.core.strategy_reminder.get_runtime_context",
+                return_value=ctx,
+            ),
+            patch(
+                "mureo.core.strategy_reminder.build_reminder_text",
+                side_effect=RuntimeError("boom"),
+            ),
+        ):
+            assert maybe_build_reminder_for_plugin("acme_resume") is None


### PR DESCRIPTION
## Summary

Third-party plugin MCP tools now get the same three safety guardrails that built-in Google/Meta tools already enforce. Investigation traced every path through `handle_call_tool` → `_dispatch_tool` and found policy gates / staleness / throttle / action_log were already universal, while three guardrails were built-in-only.

### GAP A — server-side `inputSchema` validation
`_build_tool_validators()` no longer skips `_PLUGIN_NAMES`. A plugin that declares real-spend bounds (e.g. budget `minimum:1`, `required`, `enum`) now has them enforced server-side **before dispatch**, exactly like a built-in — instead of relying on the unverifiable assumption that every provider validates its own input. Permissive plugin schemas are unaffected; malformed schemas are skipped per-tool (same as built-ins).

### GAP B — STRATEGY.md reminder after mutating plugin calls
`maybe_build_reminder_for_plugin()` appends the operator's STRATEGY.md sections after a successful **mutating** plugin call (classified via `derive_semantics`), honoring `MUREO_DISABLE_STRATEGY_REMINDER`. Read-only plugin tools skip it. The reminder build is now fully inside the never-raise guard.

### GAP C — executable plugin rollback (bounded)
A plugin-declared `meta["mureo"]["reversal"]` is now **executable** (previously recorded-but-not-executable) when its `operation`:
1. is **non-destructive** (destructive-verb refusal runs first),
2. names a **registered** plugin tool (`plugin_reversal_param_keys` → `_PLUGIN_NAMES`),
3. carries only params within the tool's `inputSchema` property keys.

At apply time the existing executor re-enters `handle_call_tool`, which re-runs policy gates + GAP A validation and refuses recursion into `rollback_*`. The allow-list remains a real prompt-injection defense — the plugin path is strictly additive and bounded at both plan and execution time. The planner reaches the server via a lazy import that degrades to "not a plugin op" on failure (no import cycle).

## Files
- `mureo/mcp/server.py` — GAP A (validator build), GAP B (`_maybe_append_plugin_strategy_reminder`), GAP C (`plugin_reversal_param_keys` + per-tool schema keys)
- `mureo/core/strategy_reminder.py` — `maybe_build_reminder_for_plugin` + shared `_read_strategy_reminder`
- `mureo/rollback/planner.py` — plugin escape hatch in `plan_rollback` + trust-model docstring

## Test plan
- [x] GAP A: below-minimum / missing-required rejected before dispatch; valid passes; validator built for plugin tool
- [x] GAP B: mutating plugin gets reminder appended (output preserved); read-only plugin gets none; env opt-out; build failure → None
- [x] GAP C: registered→schema-keys, unregistered→`(False,None)`, schema-less→`(True,None)`, extra-params rejected, destructive-before-lookup, cross-namespace (built-in name) refused, end-to-end executor dispatch
- [x] `ruff check` + `black --check` clean on changed `mureo/` files
- [x] python-reviewer: APPROVE (no CRITICAL/HIGH)
- Note: `test_no_plugins_is_additive_no_op` fails **only** on dev machines with mureo-pro plugins installed (verified identical on pristine main); passes in clean CI.

https://claude.ai/code/session_011rAu94b1o1xWYZhARk1VmL