### PR TITLE
fix(mcp): skip action_log promotion for error-envelope plugin results (post-#324 parity sweep)

### DIFF
--- a/mureo/mcp/_helpers.py
+++ b/mureo/mcp/_helpers.py
@@ -60,6 +60,29 @@ def _no_creds_result(msg: str) -> list[TextContent]:
     return [TextContent(type="text", text=msg)]
 
 
+# The single prefix ``api_error_handler`` stamps onto a caught-exception
+# result. Detectors key off this exact string to recognise "the API call
+# failed but was returned as content instead of raised" — kept here, next to
+# the producer, as the one source of truth.
+API_ERROR_PREFIX = "API error:"
+
+
+def is_error_result(result: list[Any] | None) -> bool:
+    """True if ``result`` is an :func:`api_error_handler` error envelope.
+
+    An ``api_error_handler``-wrapped mutation turns an API-level failure into
+    an ``"API error: ..."`` TextContent instead of raising. Detecting it lets
+    the dispatch paths skip recording an ``action_log`` entry for a mutation
+    that did not actually change platform state. Shared by the native
+    (:mod:`mureo.mcp.native_reversal`) and plugin (:mod:`mureo.mcp.server`)
+    promotion paths so both skip the identical envelope.
+    """
+    if not result:
+        return False
+    text = getattr(result[0], "text", "")
+    return isinstance(text, str) and text.startswith(API_ERROR_PREFIX)
+
+
 def api_error_handler(
     func: Callable[..., Coroutine[Any, Any, list[TextContent]]],
 ) -> Callable[..., Coroutine[Any, Any, list[TextContent]]]:
@@ -74,6 +97,6 @@ def api_error_handler(
             raise
         except Exception as exc:
             logger.exception("%s failed", func.__name__)
-            return [TextContent(type="text", text=f"API error: {exc}")]
+            return [TextContent(type="text", text=f"{API_ERROR_PREFIX} {exc}")]
 
     return wrapper

--- a/mureo/mcp/native_reversal.py
+++ b/mureo/mcp/native_reversal.py
@@ -168,15 +168,13 @@ def _status_of(record: Any) -> str | None:
 def _is_error_result(result: list[Any] | None) -> bool:
     """True if ``result`` is an ``api_error_handler`` error envelope.
 
-    Status-toggle handlers are wrapped by ``api_error_handler``, which turns
-    an API-level failure into a ``"API error: ..."`` TextContent instead of
-    raising. Detecting it lets us skip recording action_log entries for
-    mutations that did not actually change platform state.
+    Thin module-local alias for :func:`mureo.mcp._helpers.is_error_result`
+    (the one source of truth, kept next to the producer). Retained so the
+    in-module call site and its history stay stable.
     """
-    if not result:
-        return False
-    text = getattr(result[0], "text", "")
-    return isinstance(text, str) and text.startswith("API error:")
+    from mureo.mcp._helpers import is_error_result
+
+    return is_error_result(result)
 
 
 def record_native_mutation(

--- a/mureo/mcp/server.py
+++ b/mureo/mcp/server.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
     from mureo.core.policy import PolicyDecision, PolicyGate
     from mureo.mcp.tool_provider import MCPToolProvider
 
+from mureo.mcp._helpers import is_error_result
 from mureo.mcp.native_reversal import capture_before_state, record_native_mutation
 from mureo.mcp.plugin_audit import record_plugin_call
 from mureo.mcp.plugin_semantics import (
@@ -674,16 +675,24 @@ async def _dispatch_tool(name: str, arguments: dict[str, Any]) -> list[Any]:
         # / strategy review / rollback can see it like a built-in op.
         # Read-only tools stay in the jsonl audit only (no STATE bloat).
         if sem is None or sem.mutating:
-            record_mutation_action_log(
-                tool=name,
-                source=source,
-                reversal=None if sem is None else sem.reversal,
-                observation_days=None if sem is None else sem.observation_days,
-            )
+            # Skip the action_log promotion when the plugin returned an
+            # api_error_handler-style error envelope WITHOUT raising — the
+            # mutation did not change platform state, so promoting it would
+            # log a phantom action (and, via a declared reversal, leave a
+            # phantom executable rollback). Mirrors native_reversal's
+            # _is_error_result skip for built-in mutations. The jsonl audit
+            # (above) still captures the attempt regardless.
+            if not is_error_result(result):
+                record_mutation_action_log(
+                    tool=name,
+                    source=source,
+                    reversal=None if sem is None else sem.reversal,
+                    observation_days=None if sem is None else sem.observation_days,
+                )
             # Guardrail parity: a mutating plugin call re-surfaces the
             # operator's STRATEGY.md sections, exactly like a built-in
-            # mutation. Read-only plugin tools skip it (no mutation to
-            # check against strategy).
+            # mutation — appended regardless of the result envelope, matching
+            # the built-in dispatch. Read-only plugin tools skip it.
             result = _maybe_append_plugin_strategy_reminder(name, result)
         return result
     raise ValueError(f"Unknown tool: {name}")

--- a/tests/test_mcp_server_plugin_wiring.py
+++ b/tests/test_mcp_server_plugin_wiring.py
@@ -549,3 +549,135 @@ class TestGapCPluginReversalParamKeys:
             assert mod.plugin_reversal_param_keys("ro_plugin_report") == (True, None)
         finally:
             importlib.reload(mod)
+
+
+# ---------------------------------------------------------------------------
+# Error-envelope parity: a mutating plugin that returns an api_error_handler
+# -style "API error: ..." TextContent WITHOUT raising must NOT be promoted to
+# STATE.json's action_log (mirrors native_reversal's _is_error_result skip),
+# so no phantom mutation — and no phantom executable reversal — is recorded.
+# ---------------------------------------------------------------------------
+
+
+class _ErrorEnvelopePlugin:
+    """A mutating plugin that catches its own API error and returns it as
+    content (the built-in `api_error_handler` idiom) instead of raising. It
+    also declares an executable reversal, to prove the phantom-rollback case
+    is closed."""
+
+    name = "err_plugin"
+    display_name = "Err"
+    capabilities = frozenset({Capability.READ_CAMPAIGNS})
+
+    def mcp_tools(self) -> tuple[Tool, ...]:
+        return (
+            Tool(
+                name="err_plugin_pause",
+                description="pauses, but the API call failed",
+                inputSchema={
+                    "type": "object",
+                    "properties": {"campaign_id": {"type": "string"}},
+                },
+                meta={
+                    "mureo": {
+                        "reversal": {
+                            "operation": "err_plugin_resume",
+                            "params": {"campaign_id": "123"},
+                        }
+                    }
+                },
+            ),
+        )
+
+    async def handle_mcp_tool(self, name: str, arguments: dict[str, Any]) -> list[Any]:
+        return [TextContent(type="text", text="API error: quota exceeded")]
+
+
+@pytest.mark.unit
+class TestErrorEnvelopeNotPromoted:
+    async def test_error_result_skips_action_log_but_keeps_audit(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        import json
+
+        from mureo.context.state import read_state_file
+        from mureo.mcp import plugin_audit
+
+        _seed_state(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        audit = tmp_path / "audit.jsonl"
+        monkeypatch.setattr(plugin_audit, "_audit_path", lambda: audit)
+        monkeypatch.setattr(
+            "mureo.core.providers.registry.discover_providers",
+            _disc_for(_ErrorEnvelopePlugin),
+        )
+        from mureo.mcp import server as mod
+
+        mod = importlib.reload(mod)
+        try:
+            out = await mod.handle_call_tool("err_plugin_pause", {"campaign_id": "123"})
+            # The error envelope is returned to the agent unchanged.
+            assert out[0].text == "API error: quota exceeded"
+            # No phantom mutation in STATE.json → no phantom executable reversal.
+            doc = read_state_file(tmp_path / "STATE.json")
+            assert doc.action_log == ()
+            # The attempt is still captured in the jsonl audit (ok=True: it
+            # did not raise).
+            rec = json.loads(audit.read_text(encoding="utf-8").splitlines()[0])
+            assert rec["tool"] == "err_plugin_pause"
+            assert rec["ok"] is True
+        finally:
+            importlib.reload(mod)
+
+    async def test_error_result_still_appends_strategy_reminder(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """Parity lock-in: the strategy reminder is appended for a mutating
+        plugin call regardless of the error envelope (matching the built-in
+        dispatch, which appends it even when record_native_mutation skipped
+        the action_log)."""
+        from mureo.context.models import StrategyEntry
+        from mureo.mcp import plugin_audit
+
+        monkeypatch.setattr(
+            plugin_audit, "_audit_path", lambda: tmp_path / "audit.jsonl"
+        )
+        monkeypatch.setattr(
+            "mureo.core.providers.registry.discover_providers",
+            _disc_for(_ErrorEnvelopePlugin),
+        )
+        fake_ctx = MagicMock()
+        fake_ctx.state_store.read_strategy.return_value = [
+            StrategyEntry(context_type="goal", title="Q2 CPA target", content="x"),
+        ]
+        monkeypatch.setattr(
+            "mureo.core.strategy_reminder.get_runtime_context", lambda: fake_ctx
+        )
+        monkeypatch.delenv("MUREO_DISABLE_STRATEGY_REMINDER", raising=False)
+        from mureo.mcp import server as mod
+
+        mod = importlib.reload(mod)
+        try:
+            out = await mod.handle_call_tool("err_plugin_pause", {"campaign_id": "123"})
+            # Error envelope preserved AND the reminder still appended.
+            assert out[0].text == "API error: quota exceeded"
+            assert any("Q2 CPA target" in getattr(c, "text", "") for c in out)
+        finally:
+            importlib.reload(mod)
+
+    async def test_normal_result_still_promoted(
+        self, server_with_plugin, tmp_path, monkeypatch
+    ) -> None:
+        """Regression guard: a non-error mutating result is still promoted."""
+        from mureo.context.state import read_state_file
+        from mureo.mcp import plugin_audit
+
+        _seed_state(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(
+            plugin_audit, "_audit_path", lambda: tmp_path / "audit.jsonl"
+        )
+        await server_with_plugin.handle_call_tool("wired_plugin_echo", {"msg": "x"})
+        doc = read_state_file(tmp_path / "STATE.json")
+        assert len(doc.action_log) == 1
+        assert doc.action_log[0].action == "wired_plugin_echo"

--- a/tests/test_native_reversal.py
+++ b/tests/test_native_reversal.py
@@ -318,6 +318,48 @@ class TestRecordNativeMutation:
 
 
 # ---------------------------------------------------------------------------
+# shared is_error_result helper (one source of truth in _helpers)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSharedIsErrorResult:
+    def test_native_alias_delegates_to_helper(self) -> None:
+        # nr._is_error_result is a thin alias for the shared helper.
+        from mcp.types import TextContent
+
+        from mureo.mcp._helpers import is_error_result
+
+        envelope = [TextContent(type="text", text="API error: boom")]
+        assert is_error_result(envelope) is True
+        assert nr._is_error_result(envelope) is True
+
+    def test_empty_and_none_are_not_errors(self) -> None:
+        from mureo.mcp._helpers import is_error_result
+
+        assert is_error_result(None) is False
+        assert is_error_result([]) is False
+
+    def test_non_error_text_is_not_an_error(self) -> None:
+        from mcp.types import TextContent
+
+        from mureo.mcp._helpers import is_error_result
+
+        assert is_error_result([TextContent(type="text", text="ok")]) is False
+        # "Error:" alone is NOT the api_error_handler envelope — only the exact
+        # "API error:" prefix counts, so plugin data starting with "Error" is
+        # not mistaken for a failed mutation.
+        assert is_error_result([TextContent(type="text", text="Error: data")]) is False
+
+    def test_api_error_prefix_constant_matches_handler_output(self) -> None:
+        # Pin the producer/detector contract: the prefix the handler stamps is
+        # the prefix the detector keys off.
+        from mureo.mcp._helpers import API_ERROR_PREFIX
+
+        assert API_ERROR_PREFIX == "API error:"
+
+
+# ---------------------------------------------------------------------------
 # server.handle_call_tool wiring
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Post-merge parity sweep of #324 surfaced one genuine remaining gap (the rest were symmetric with the native auto-promotion path or inherent limitations). This closes it.

**Bug:** A plugin MCP tool that catches its own API error and *returns* it as an `"API error: ..."` TextContent (the built-in `api_error_handler` idiom) **without raising** was promoted to STATE.json's `action_log` as a successful mutation. That left:
- a **phantom action** (the daily-check evidence loop would set an `observation_due` and later evaluate the "outcome" of a no-op), and
- via a declared `meta["mureo"]["reversal"]`, a **phantom *executable* rollback** — `rollback_apply` could "reverse" a change that never happened (amplified by #324's GAP C, which made plugin reversals executable).

Built-in mutations already skip this via `native_reversal._is_error_result`. This brings the plugin dispatch path to the same behavior.

## Changes
- `mureo/mcp/_helpers.py` — add `API_ERROR_PREFIX` + public `is_error_result()` as the single source of truth; `api_error_handler` now uses the constant (output byte-identical).
- `mureo/mcp/native_reversal.py` — `_is_error_result` delegates to the shared helper.
- `mureo/mcp/server.py` — plugin branch gates `record_mutation_action_log` on `not is_error_result(result)`. The jsonl audit still records the attempt (`ok=True` — it did not raise); the strategy reminder is still appended for the mutating call, matching the built-in dispatch.

## Design notes
- **Fail-safe:** a plugin success payload literally starting with `"API error:"` would only lose a STATE.json audit row (still captured in the jsonl audit) — never gain a phantom mutation/rollback. The detector keys off the exact `"API error:"` prefix; `"Error: ..."` does not match.
- **Parity-precise:** matches the built-in path exactly — action_log gated by the error envelope, strategy reminder appended unconditionally for mutating tools.

## Test plan
- [x] `TestErrorEnvelopeNotPromoted` — error-envelope mutating plugin (with a declared reversal): no action_log entry → no phantom executable rollback; jsonl audit still records `ok=True`; strategy reminder still appended; non-error result still promoted (regression guard)
- [x] `TestSharedIsErrorResult` — delegation, None/empty, exact-prefix non-false-positive, producer/detector prefix contract
- [x] `ruff` + `black` clean on changed `mureo/` files
- [x] python-reviewer: APPROVE (no CRITICAL/HIGH/MEDIUM)

## Inspection note
The broader sweep also confirmed: GAP A schema validation is **safe for all currently-installed plugins** (integer-typed fields are budget/page/size which the agent passes as JSON numbers; IDs are `type:string`; no `additionalProperties:false`, no numeric bounds, enums benign). GAP B/C have no regressions. Remaining built-in-only items (`metrics_at_action` baseline, dynamic before-state capture) are symmetric with the native auto-promotion path or inherent limitations, documented honestly.

https://claude.ai/code/session_011rAu94b1o1xWYZhARk1VmL
