### PR TITLE
feat(mcp): runtime-correct reversal capture for plugin tools (closes #327)

### DIFF
--- a/mureo/mcp/server.py
+++ b/mureo/mcp/server.py
@@ -28,8 +28,10 @@ comparison; multiple tests pin the contract.
 
 from __future__ import annotations
 
+import inspect
 import logging
 import os
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import jsonschema
@@ -51,7 +53,11 @@ from mureo.mcp.plugin_semantics import (
     derive_semantics,
     record_mutation_action_log,
 )
-from mureo.mcp.tool_provider import collect_plugin_tools, plugin_source
+from mureo.mcp.tool_provider import (
+    MCPReversibleToolProvider,
+    collect_plugin_tools,
+    plugin_source,
+)
 from mureo.mcp.tools_analysis import TOOLS as ANALYSIS_TOOLS
 from mureo.mcp.tools_analysis import handle_tool as handle_analysis_tool
 from mureo.mcp.tools_analytics_registry import (
@@ -545,6 +551,52 @@ def _maybe_append_plugin_strategy_reminder(name: str, result: list[Any]) -> list
     return [*result, TextContent(type="text", text=reminder)]
 
 
+async def _capture_plugin_reversal(
+    provider: MCPToolProvider, name: str, arguments: dict[str, Any]
+) -> dict[str, Any] | None:
+    """Best-effort runtime-correct reversal capture for a plugin mutation (#327).
+
+    Mirrors :func:`mureo.mcp.native_reversal.capture_before_state`: when the
+    provider opts into :class:`MCPReversibleToolProvider`, call its
+    ``capture_reversal`` **before** the mutation so it can read prior state and
+    return a reversal carrying the actual entity id + prior value — something a
+    static tool-definition ``meta`` reversal can never express.
+
+    Returns ``None`` (and the caller falls back to the static ``meta``
+    reversal) when the provider does not opt in, when there is no STATE.json in
+    cwd to record into (so we skip the read entirely), when the call raises, or
+    when the returned value is not a well-formed ``{operation: str, params:
+    dict}``. Never raises — a capture failure must not block the mutation.
+    """
+    if not isinstance(provider, MCPReversibleToolProvider):
+        return None
+    capture = getattr(provider, "capture_reversal", None)
+    if not inspect.iscoroutinefunction(capture):
+        return None
+    # No STATE.json ⇒ nothing will be recorded; skip the (network) read.
+    if not (Path.cwd() / "STATE.json").is_file():
+        return None
+    try:
+        reversal = await capture(name, dict(arguments))
+    except KeyboardInterrupt:
+        raise
+    except BaseException:  # noqa: BLE001 — capture must never block the mutation
+        logger.warning(
+            "plugin capture_reversal failed for %r; falling back to static "
+            "meta reversal",
+            name,
+            exc_info=True,
+        )
+        return None
+    if (
+        isinstance(reversal, dict)
+        and isinstance(reversal.get("operation"), str)
+        and isinstance(reversal.get("params"), dict)
+    ):
+        return reversal
+    return None
+
+
 # Once-per-process latch: the stale-version banner is appended to the first
 # tool result that detects the mismatch, not every call (avoid spamming a
 # read-heavy daily-check). A fresh process after restart starts False again.
@@ -652,6 +704,15 @@ async def _dispatch_tool(name: str, arguments: dict[str, Any]) -> list[Any]:
         provider = _PLUGIN_DISPATCH[name]
         source = plugin_source(provider)
         sem = _PLUGIN_SEMANTICS.get(name)
+        # Capture a runtime-correct reversal BEFORE the mutation (#327),
+        # mirroring the native before-state capture: an opted-in provider reads
+        # the entity's prior state and returns a reversal carrying the actual
+        # id + prior value. Only for mutating tools; best-effort, never blocks.
+        captured_reversal: dict[str, Any] | None = None
+        if sem is None or sem.mutating:
+            captured_reversal = await _capture_plugin_reversal(
+                provider, name, arguments
+            )
         await _acquire_plugin_throttle(name)
         try:
             result = await provider.handle_mcp_tool(name, arguments)
@@ -683,10 +744,18 @@ async def _dispatch_tool(name: str, arguments: dict[str, Any]) -> list[Any]:
             # _is_error_result skip for built-in mutations. The jsonl audit
             # (above) still captures the attempt regardless.
             if not is_error_result(result):
+                # Prefer the runtime-correct reversal captured before the
+                # mutation; fall back to the provider's static meta reversal
+                # when it did not opt into capture_reversal (#327).
+                reversal = (
+                    captured_reversal
+                    if captured_reversal is not None
+                    else (None if sem is None else sem.reversal)
+                )
                 record_mutation_action_log(
                     tool=name,
                     source=source,
-                    reversal=None if sem is None else sem.reversal,
+                    reversal=reversal,
                     observation_days=None if sem is None else sem.observation_days,
                 )
             # Guardrail parity: a mutating plugin call re-surfaces the

--- a/mureo/mcp/tool_provider.py
+++ b/mureo/mcp/tool_provider.py
@@ -88,6 +88,46 @@ class MCPToolProvider(Protocol):
         ...
 
 
+@runtime_checkable
+class MCPReversibleToolProvider(Protocol):
+    """Opt-in contract for **runtime-correct** reversal capture (#327).
+
+    A static ``meta["mureo"]["reversal"]`` on a :class:`Tool` is fixed at
+    server-start and therefore cannot carry the actual entity id of *this*
+    call, nor the entity's *prior* state — so it is useless for a real
+    status toggle (``set_ad_status(ad_id, status)``) or value edit. This
+    secondary Protocol closes that gap, mirroring mureo's native
+    before-state capture (:mod:`mureo.mcp.native_reversal`): the provider —
+    which owns the platform client and entity knowledge — builds the
+    reversal itself, capturing any prior state via its own read.
+
+    A provider opts in by *also* implementing this method. mureo calls it
+    **before** a mutating tool runs; the returned reversal (if any) is what
+    gets recorded into the ``action_log`` instead of the static ``meta``
+    reversal. The reversal's ``operation`` must name a registered,
+    non-destructive tool of the same plugin for ``rollback_apply`` to
+    execute it (the rollback planner enforces this — see
+    :mod:`mureo.rollback.planner`).
+    """
+
+    async def capture_reversal(
+        self, name: str, arguments: dict[str, Any]
+    ) -> dict[str, Any] | None:
+        """Return ``{"operation": <tool>, "params": {...}}`` that reverses the
+        mutation ``name`` is *about to* perform, or ``None`` when it is not
+        reversible.
+
+        Called **before** :meth:`MCPToolProvider.handle_mcp_tool`, so an
+        implementation can read the entity's prior state (e.g. GET the
+        current status) and bake a runtime-correct reversal. MUST be
+        best-effort from the caller's view: mureo swallows any exception so a
+        capture failure never blocks the actual mutation — but the
+        implementation should still avoid slow/expensive work on the hot
+        path.
+        """
+        ...
+
+
 def _warn(message: str) -> None:
     warnings.warn(message, PluginToolWarning, stacklevel=3)
 
@@ -227,6 +267,7 @@ def plugin_source(provider: object) -> str:
 
 
 __all__ = [
+    "MCPReversibleToolProvider",
     "MCPToolProvider",
     "PluginToolWarning",
     "collect_plugin_tools",

--- a/tests/test_mcp_server_plugin_wiring.py
+++ b/tests/test_mcp_server_plugin_wiring.py
@@ -681,3 +681,337 @@ class TestErrorEnvelopeNotPromoted:
         doc = read_state_file(tmp_path / "STATE.json")
         assert len(doc.action_log) == 1
         assert doc.action_log[0].action == "wired_plugin_echo"
+
+
+# ---------------------------------------------------------------------------
+# #327 — call-time reversal capture for plugins. A provider that opts into
+# MCPReversibleToolProvider builds a runtime-correct reversal (real entity id
+# + prior state) BEFORE the mutation; mureo records that instead of the static
+# tool-definition meta, so the reversal is actually executable via rollback.
+# ---------------------------------------------------------------------------
+
+
+# Module-level tracker so the fresh provider instance (built by discovery) can
+# report whether/how its capture_reversal hook was invoked.
+_CAPTURE_CALLS: list[tuple[str, dict]] = []
+
+
+class _CaptureReversalPlugin:
+    """Mutating status-toggle whose provider captures a runtime-correct
+    reversal (the real ad_id from args + the prior status it 'read')."""
+
+    name = "cap_plugin"
+    display_name = "Cap"
+    capabilities = frozenset({Capability.READ_CAMPAIGNS})
+
+    def mcp_tools(self) -> tuple[Tool, ...]:
+        return (
+            Tool(
+                name="cap_plugin_set_status",
+                description="toggle status",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "ad_id": {"type": "string"},
+                        "status": {"type": "string"},
+                    },
+                },
+            ),
+        )
+
+    async def capture_reversal(
+        self, name: str, arguments: dict[str, Any]
+    ) -> dict[str, Any] | None:
+        _CAPTURE_CALLS.append((name, dict(arguments)))
+        # Simulate reading the prior status (was "enabled") and building a
+        # reversal carrying the ACTUAL id from this call.
+        return {
+            "operation": "cap_plugin_set_status",
+            "params": {"ad_id": arguments["ad_id"], "status": "enabled"},
+        }
+
+    async def handle_mcp_tool(self, name: str, arguments: dict[str, Any]) -> list[Any]:
+        return [TextContent(type="text", text="ok")]
+
+
+class _StaticReversalPlugin:
+    """Mutating tool with only a STATIC meta reversal and NO capture hook —
+    the pre-#327 behavior must be preserved (static reversal recorded)."""
+
+    name = "static_plugin"
+    display_name = "Static"
+    capabilities = frozenset({Capability.READ_CAMPAIGNS})
+
+    def mcp_tools(self) -> tuple[Tool, ...]:
+        return (
+            Tool(
+                name="static_plugin_act",
+                description="x",
+                inputSchema={"type": "object", "properties": {}},
+                meta={
+                    "mureo": {
+                        "reversal": {
+                            "operation": "static_plugin_act",
+                            "params": {"k": "v"},
+                        }
+                    }
+                },
+            ),
+        )
+
+    async def handle_mcp_tool(self, name: str, arguments: dict[str, Any]) -> list[Any]:
+        return [TextContent(type="text", text="ok")]
+
+
+class _CaptureRaisesPlugin:
+    """capture_reversal raises — must fall back to the static meta reversal and
+    never block the mutation."""
+
+    name = "raise_plugin"
+    display_name = "Raise"
+    capabilities = frozenset({Capability.READ_CAMPAIGNS})
+
+    def mcp_tools(self) -> tuple[Tool, ...]:
+        return (
+            Tool(
+                name="raise_plugin_act",
+                description="x",
+                inputSchema={"type": "object", "properties": {}},
+                meta={
+                    "mureo": {
+                        "reversal": {
+                            "operation": "raise_plugin_act",
+                            "params": {},
+                        }
+                    }
+                },
+            ),
+        )
+
+    async def capture_reversal(
+        self, name: str, arguments: dict[str, Any]
+    ) -> dict[str, Any] | None:
+        raise RuntimeError("capture boom")
+
+    async def handle_mcp_tool(self, name: str, arguments: dict[str, Any]) -> list[Any]:
+        return [TextContent(type="text", text="ok")]
+
+
+class _ReadOnlyCapturePlugin:
+    """Read-only tool that also implements capture_reversal — the hook must
+    NOT be invoked (no mutation, no wasted read)."""
+
+    name = "ro_cap_plugin"
+    display_name = "ROCap"
+    capabilities = frozenset({Capability.READ_CAMPAIGNS})
+
+    def mcp_tools(self) -> tuple[Tool, ...]:
+        return (
+            Tool(
+                name="ro_cap_plugin_report",
+                description="x",
+                inputSchema={"type": "object", "properties": {}},
+                annotations=ToolAnnotations(readOnlyHint=True),
+            ),
+        )
+
+    async def capture_reversal(
+        self, name: str, arguments: dict[str, Any]
+    ) -> dict[str, Any] | None:
+        _CAPTURE_CALLS.append(("RO", dict(arguments)))
+        return {"operation": "ro_cap_plugin_report", "params": {}}
+
+    async def handle_mcp_tool(self, name: str, arguments: dict[str, Any]) -> list[Any]:
+        return [TextContent(type="text", text="ok")]
+
+
+class _CaptureButErrorsPlugin:
+    """capture_reversal succeeds, but the mutation handler returns an
+    api_error_handler-style error envelope — the captured reversal must be
+    dropped (no phantom executable rollback)."""
+
+    name = "cap_err_plugin"
+    display_name = "CapErr"
+    capabilities = frozenset({Capability.READ_CAMPAIGNS})
+
+    def mcp_tools(self) -> tuple[Tool, ...]:
+        return (
+            Tool(
+                name="cap_err_plugin_set_status",
+                description="toggle that fails",
+                inputSchema={
+                    "type": "object",
+                    "properties": {"ad_id": {"type": "string"}},
+                },
+            ),
+        )
+
+    async def capture_reversal(
+        self, name: str, arguments: dict[str, Any]
+    ) -> dict[str, Any] | None:
+        _CAPTURE_CALLS.append((name, dict(arguments)))
+        return {
+            "operation": "cap_err_plugin_set_status",
+            "params": {"ad_id": arguments["ad_id"]},
+        }
+
+    async def handle_mcp_tool(self, name: str, arguments: dict[str, Any]) -> list[Any]:
+        return [TextContent(type="text", text="API error: quota exceeded")]
+
+
+@pytest.mark.unit
+class TestCaptureReversal:
+    async def test_dynamic_reversal_recorded_and_executable(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        _CAPTURE_CALLS.clear()
+        from mureo.context.state import read_state_file
+        from mureo.mcp import plugin_audit
+        from mureo.rollback import RollbackStatus, plan_rollback
+
+        _seed_state(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(plugin_audit, "_audit_path", lambda: tmp_path / "a.jsonl")
+        monkeypatch.setattr(
+            "mureo.core.providers.registry.discover_providers",
+            _disc_for(_CaptureReversalPlugin),
+        )
+        from mureo.mcp import server as mod
+
+        mod = importlib.reload(mod)
+        try:
+            await mod.handle_call_tool(
+                "cap_plugin_set_status", {"ad_id": "A1", "status": "paused"}
+            )
+            # capture_reversal was called BEFORE the mutation, with real args.
+            assert _CAPTURE_CALLS == [
+                ("cap_plugin_set_status", {"ad_id": "A1", "status": "paused"})
+            ]
+            doc = read_state_file(tmp_path / "STATE.json")
+            assert len(doc.action_log) == 1
+            entry = doc.action_log[0]
+            # The RUNTIME-correct reversal (real id + prior status) was recorded,
+            # not a static template.
+            assert entry.reversible_params == {
+                "operation": "cap_plugin_set_status",
+                "params": {"ad_id": "A1", "status": "enabled"},
+            }
+            # ...and it is actually EXECUTABLE: the planner accepts it because
+            # the operation names a registered, non-destructive plugin tool.
+            plan = plan_rollback(entry)
+            assert plan is not None
+            assert plan.status == RollbackStatus.SUPPORTED
+            assert plan.operation == "cap_plugin_set_status"
+            assert plan.params == {"ad_id": "A1", "status": "enabled"}
+        finally:
+            importlib.reload(mod)
+
+    async def test_falls_back_to_static_when_no_capture_hook(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        from mureo.context.state import read_state_file
+        from mureo.mcp import plugin_audit
+
+        _seed_state(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(plugin_audit, "_audit_path", lambda: tmp_path / "a.jsonl")
+        monkeypatch.setattr(
+            "mureo.core.providers.registry.discover_providers",
+            _disc_for(_StaticReversalPlugin),
+        )
+        from mureo.mcp import server as mod
+
+        mod = importlib.reload(mod)
+        try:
+            await mod.handle_call_tool("static_plugin_act", {})
+            doc = read_state_file(tmp_path / "STATE.json")
+            assert doc.action_log[0].reversible_params == {
+                "operation": "static_plugin_act",
+                "params": {"k": "v"},
+            }
+        finally:
+            importlib.reload(mod)
+
+    async def test_capture_failure_falls_back_to_static_without_blocking(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        from mureo.context.state import read_state_file
+        from mureo.mcp import plugin_audit
+
+        _seed_state(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(plugin_audit, "_audit_path", lambda: tmp_path / "a.jsonl")
+        monkeypatch.setattr(
+            "mureo.core.providers.registry.discover_providers",
+            _disc_for(_CaptureRaisesPlugin),
+        )
+        from mureo.mcp import server as mod
+
+        mod = importlib.reload(mod)
+        try:
+            # The mutation still succeeds despite capture_reversal raising.
+            out = await mod.handle_call_tool("raise_plugin_act", {})
+            assert out[0].text == "ok"
+            doc = read_state_file(tmp_path / "STATE.json")
+            # Fell back to the static meta reversal.
+            assert doc.action_log[0].reversible_params == {
+                "operation": "raise_plugin_act",
+                "params": {},
+            }
+        finally:
+            importlib.reload(mod)
+
+    async def test_capture_not_called_for_read_only_tool(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        _CAPTURE_CALLS.clear()
+        from mureo.mcp import plugin_audit
+
+        _seed_state(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(plugin_audit, "_audit_path", lambda: tmp_path / "a.jsonl")
+        monkeypatch.setattr(
+            "mureo.core.providers.registry.discover_providers",
+            _disc_for(_ReadOnlyCapturePlugin),
+        )
+        from mureo.mcp import server as mod
+
+        mod = importlib.reload(mod)
+        try:
+            await mod.handle_call_tool("ro_cap_plugin_report", {})
+            assert _CAPTURE_CALLS == []  # read-only ⇒ capture skipped
+        finally:
+            importlib.reload(mod)
+
+    async def test_captured_reversal_dropped_on_error_envelope(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """Safety: even when capture_reversal succeeds, an error-envelope
+        result means the mutation did not happen — so nothing is promoted and
+        no phantom executable rollback is left behind (the is_error_result gate
+        wraps the captured-reversal selection too)."""
+        _CAPTURE_CALLS.clear()
+        from mureo.context.state import read_state_file
+        from mureo.mcp import plugin_audit
+
+        _seed_state(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(plugin_audit, "_audit_path", lambda: tmp_path / "a.jsonl")
+        monkeypatch.setattr(
+            "mureo.core.providers.registry.discover_providers",
+            _disc_for(_CaptureButErrorsPlugin),
+        )
+        from mureo.mcp import server as mod
+
+        mod = importlib.reload(mod)
+        try:
+            out = await mod.handle_call_tool(
+                "cap_err_plugin_set_status", {"ad_id": "A1"}
+            )
+            assert out[0].text == "API error: quota exceeded"
+            # capture ran, but the failed mutation is NOT promoted.
+            assert _CAPTURE_CALLS == [("cap_err_plugin_set_status", {"ad_id": "A1"})]
+            doc = read_state_file(tmp_path / "STATE.json")
+            assert doc.action_log == ()
+        finally:
+            importlib.reload(mod)


### PR DESCRIPTION
## Summary

Closes #327. That issue had two parts:

- **Point 1 — planner allow-list refused plugin operations.** Already resolved in #324 (the issue was observed on the stale 0.10.11 editable install). On `main`, `planner.py` consults `_plugin_reversal_keys` → `server.plugin_reversal_param_keys`, so a registered non-destructive plugin tool reversal is planned.
- **Point 2 — static reversal had no call-time capture.** This PR. A plugin's static `meta["mureo"]["reversal"]` is fixed at server start, so it cannot carry the actual entity id of a given call nor the entity's *prior* state — useless for a real status toggle (`set_ad_status(ad_id, status)`) or value edit. This adds the missing call-time capture, mirroring the built-in `native_reversal.capture_before_state` pattern.

## Changes

- `mureo/mcp/tool_provider.py` — new **optional** secondary Protocol `MCPReversibleToolProvider` with `async capture_reversal(name, arguments) -> dict | None`. A provider opts in by *also* implementing it; the provider owns the platform client and reads prior state itself.
- `mureo/mcp/server.py` — the plugin dispatch branch calls `capture_reversal` **before** the mutation (mirroring native before-state capture), then records the captured runtime-correct reversal in preference to the static `meta` reversal.
  - Best-effort: never raises into dispatch, never blocks the mutation, skipped for read-only tools and when no `STATE.json` exists in cwd (no wasted read).
  - Falls back to the static `meta` reversal when capture is absent / returns `None` / raises / returns a malformed shape.

## Trust model (unchanged)

The rollback planner and executor are untouched. The captured reversal's `operation` is still gated by the registered-non-destructive-plugin-tool check, schema-bounded params, and policy re-auth at apply time. The #325 error-envelope skip still applies — a captured reversal for a **failed** mutation is never promoted, so no phantom executable rollback is left behind.

## How a plugin opts in

```python
class MyProvider:  # also implements MCPToolProvider
    async def capture_reversal(self, name, arguments):
        if name != "my_set_status":
            return None
        prior = await self._client.get_status(arguments["ad_id"])  # read prior state
        return {"operation": "my_set_status",
                "params": {"ad_id": arguments["ad_id"], "status": prior}}
```

## Test plan

- [x] `TestCaptureReversal` — dynamic reversal recorded **and executable via `plan_rollback`** (real id + prior status); static fallback when no hook; capture-raises → static fallback + mutation still succeeds; read-only tool → capture skipped; **error envelope → captured reversal dropped (no phantom rollback)**
- [x] `ruff` + `black` clean on changed `mureo/` files
- [x] python-reviewer: APPROVE (no CRITICAL/HIGH)
- Note: `test_no_plugins_is_additive_no_op` fails only because real plugins are pip-installed in this dev env — pre-existing, passes in clean CI.

## Follow-ups (separate)

Update the bridge GAP C notes (logly/mureo-logly-bridge#51, logly/mureo-lineyahoo-bridge#13) to point at `capture_reversal` as the way to offer executable rollback for `set_ad_status`-style toggles.

https://claude.ai/code/session_011rAu94b1o1xWYZhARk1VmL
