### PR TITLE
fix(reports): tolerate missing platform account_id + quiet tolerant read path (supersedes #323)

### DIFF
--- a/mureo/context/state.py
+++ b/mureo/context/state.py
@@ -52,7 +52,10 @@ def _parse_campaigns(
         try:
             parsed.append(_parse_campaign(c))
         except (ValueError, KeyError, TypeError) as exc:
-            logger.warning("skipping unparseable campaign entry: %s", exc)
+            # DEBUG, not WARNING: the read-only Reports view re-parses on every
+            # poll, so a per-entry WARNING would flood the log for a STATE.json
+            # with many nonconforming (e.g. legacy / hand-authored) campaigns.
+            logger.debug("skipping unparseable campaign entry: %s", exc)
     return tuple(parsed)
 
 
@@ -74,18 +77,46 @@ def _parse_action_log(
         try:
             parsed.append(_parse_action_log_entry(e))
         except (ValueError, KeyError, TypeError) as exc:
-            logger.warning("skipping unparseable action_log entry: %s", exc)
+            # DEBUG, not WARNING — see _parse_campaigns: avoid per-render log
+            # flood from a STATE.json with many nonconforming action_log entries.
+            logger.debug("skipping unparseable action_log entry: %s", exc)
     return tuple(parsed)
+
+
+def _platform_account_id(
+    platform_key: str, platform_data: dict[str, Any], *, strict: bool
+) -> str:
+    """Resolve a platform's ``account_id``.
+
+    ``strict=True`` (the writer contract) requires the key — a missing
+    ``account_id`` raises ``KeyError`` exactly as before. ``strict=False``
+    (the read-only Reports view) defaults a missing ``account_id`` to ``""``
+    so an agent-/hand-authored STATE.json that omitted it still renders its
+    platforms/totals/periods instead of blanking the whole dashboard. Logged
+    at DEBUG (expected for non-canonical files; never per-poll WARNING noise).
+    """
+    if strict or "account_id" in platform_data:
+        # KeyError in strict if absent — unchanged writer contract. Annotated
+        # local so mypy treats the dict[str, Any] value as the declared str.
+        account_id: str = platform_data["account_id"]
+        return account_id
+    logger.debug(
+        "platform %r missing 'account_id'; defaulting to '' for the tolerant "
+        "read-only view",
+        platform_key,
+    )
+    return ""
 
 
 def parse_state(text: str, *, strict: bool = True) -> StateDocument:
     """Parse a JSON string and return a StateDocument.
 
-    ``strict`` controls campaign-list AND action_log validation: ``True``
-    (default) preserves the strict writer contract (raises on a missing required
-    field); ``False`` tolerantly skips nonconforming campaign / action_log
-    entries for the read-only Reports view. Structural problems (invalid JSON, a
-    missing platform ``account_id``) always raise regardless of ``strict``.
+    ``strict`` controls campaign-list, action_log AND platform validation:
+    ``True`` (default) preserves the strict writer contract (raises on a missing
+    required field, including a platform ``account_id``); ``False`` tolerantly
+    skips nonconforming campaign / action_log entries and defaults a missing
+    platform ``account_id`` to ``""`` for the read-only Reports view. Invalid
+    JSON always raises regardless of ``strict``.
     """
     data = json.loads(text)
     campaigns_raw = data.get("campaigns", [])
@@ -101,7 +132,9 @@ def parse_state(text: str, *, strict: bool = True) -> StateDocument:
                 platform_data.get("campaigns", []), strict=strict
             )
             platforms[platform_key] = PlatformState(
-                account_id=platform_data["account_id"],
+                account_id=_platform_account_id(
+                    platform_key, platform_data, strict=strict
+                ),
                 campaigns=platform_campaigns,
                 totals=platform_data.get("totals"),
                 metrics_period=platform_data.get("metrics_period"),

--- a/mureo/web/reports.py
+++ b/mureo/web/reports.py
@@ -330,7 +330,13 @@ def _read_state_safe(store: StateStore) -> StateDocument | None:
     try:
         return store.read_state()
     except Exception:  # noqa: BLE001 — read-only view degrades, never raises
-        logger.warning(
+        # Expected + handled for a STATE.json with nonconforming entries (e.g. a
+        # hand-authored legacy campaign list, or a platform missing account_id):
+        # the tolerant retry below renders the view fine. The read-only
+        # dashboard re-reads on every poll, so log this at DEBUG — a per-render
+        # WARNING + traceback would flood the daemon log on every refresh and
+        # read as a failure when it is not.
+        logger.debug(
             "strict STATE.json read failed; retrying tolerantly for the "
             "read-only Reports view",
             exc_info=True,

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
@@ -447,6 +448,88 @@ class TestStateFileErrorHandling:
         data = {"campaigns": [{"id": "x", "name": "variant"}]}
         with pytest.raises(ValueError, match="campaign_id"):
             parse_state(json.dumps(data))
+
+    @pytest.mark.unit
+    def test_parse_state_strict_false_tolerates_missing_account_id(self) -> None:
+        """``strict=False`` defaults a platform's missing ``account_id`` to ''
+        instead of crashing, so the read-only Reports view still renders the
+        platform. Reproduces the customer case: an agent-authored STATE.json
+        whose platforms omit account_id and whose campaigns use `name` (skipped)
+        — the tolerant read must NOT blow up with KeyError('account_id')."""
+        data = {
+            "version": "2",
+            "platforms": {
+                "google_ads": {
+                    # no account_id
+                    "campaigns": [
+                        {"campaign_id": "22279041552", "name": "x", "status": "PAUSED"},
+                    ],
+                    "totals": {"spend": 180206.0},
+                    "metrics_period": "LAST_30_DAYS",
+                }
+            },
+        }
+        doc = parse_state(json.dumps(data), strict=False)
+        assert doc.platforms is not None
+        plat = doc.platforms["google_ads"]
+        assert plat.account_id == ""  # defaulted, not crashed
+        assert plat.campaigns == ()  # `name`-variant campaign skipped (by design)
+        assert plat.totals == {"spend": 180206.0}  # platform data still rendered
+
+    @pytest.mark.unit
+    def test_parse_state_strict_true_raises_on_missing_account_id(self) -> None:
+        """The writer contract is preserved: a platform missing account_id
+        still raises under strict (the default)."""
+        data = {
+            "version": "2",
+            "platforms": {
+                "google_ads": {
+                    "campaigns": [],
+                    "totals": {"spend": 1.0},
+                }
+            },
+        }
+        with pytest.raises(KeyError, match="account_id"):
+            parse_state(json.dumps(data))
+
+    @pytest.mark.unit
+    def test_missing_account_id_logs_at_debug_not_warning(self, caplog) -> None:
+        """The tolerant default must not add per-poll WARNING noise — the
+        customer complaint included a log flood, so the missing-account_id
+        fallback is logged at DEBUG only."""
+        data = {
+            "version": "2",
+            "platforms": {"google_ads": {"campaigns": [], "totals": {"spend": 1.0}}},
+        }
+        with caplog.at_level(logging.DEBUG, logger="mureo.context.state"):
+            parse_state(json.dumps(data), strict=False)
+        assert any(
+            "missing 'account_id'" in r.message and r.levelno == logging.DEBUG
+            for r in caplog.records
+        )
+        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+    @pytest.mark.unit
+    def test_parse_state_strict_false_skips_log_at_debug_not_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Skipped nonconforming entries log at DEBUG, never WARNING+.
+
+        The read-only Reports view re-parses STATE.json on every dashboard
+        poll, so a per-entry WARNING would flood the daemon log for an account
+        with many legacy / hand-authored campaigns — and read as a failure when
+        it is graceful degradation. Pin DEBUG so the noise never returns."""
+        data = {
+            "campaigns": [{"id": "x", "name": "variant, no campaign_id/_name"}],
+            "action_log": [{"summary": "legacy, no timestamp/action/platform"}],
+        }
+        with caplog.at_level(logging.DEBUG, logger="mureo.context.state"):
+            parse_state(json.dumps(data), strict=False)
+
+        # The skips still happen and are observable at DEBUG …
+        assert any("skipping unparseable" in r.message for r in caplog.records)
+        # … but nothing is emitted at WARNING or above (the per-render flood).
+        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
 
     @pytest.mark.unit
     def test_parse_state_strict_false_skips_malformed_action_log(self) -> None:

--- a/tests/test_web_reports.py
+++ b/tests/test_web_reports.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import dataclasses
 import json
+import logging
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -325,7 +326,9 @@ def test_summary_does_not_raise_on_broken_state(
 
 @pytest.mark.unit
 def test_summary_tolerates_nonconforming_campaign_entries(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """A STATE.json whose campaign list has a nonconforming entry — e.g. a
     hand-authored / variant campaign using ``id``/``name`` instead of
@@ -354,11 +357,16 @@ def test_summary_tolerates_nonconforming_campaign_entries(
     }
     (tmp_path / "STATE.json").write_text(json.dumps(raw), encoding="utf-8")
 
-    summary = build_report_summary()
+    with caplog.at_level(logging.DEBUG):
+        summary = build_report_summary()
     by_key = {p["key"]: p for p in summary["platforms"]}
     assert "logly_ads_context" in by_key, "platform blanked by a bad campaign entry"
     assert by_key["logly_ads_context"]["totals"] == {"spend": 8739.0, "conversions": 0}
     assert summary["reports"] == {"daily": {"verdict": "Watch", "note": "spend down"}}
+    # The strict-fail → tolerant-retry happens on EVERY dashboard poll, so it
+    # must not flood the daemon log: nothing at WARNING+ for this handled,
+    # gracefully-degraded read (the per-entry skips + retry trace are DEBUG).
+    assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

A customer's `mureo configure` Reports view crashed and flooded the daemon log on every poll, against an agent-/hand-authored `STATE.json` (platforms omit `account_id`; campaigns use `name` instead of `campaign_name`).

Two fixes, bundled (the second revives the halted #323 so the log noise is resolved in one go):

### 1. Tolerate a missing platform `account_id` (the crash)

`parse_state` accessed `platform_data["account_id"]` directly **regardless of strict mode**, so the read-only Reports view's tolerant fallback (`strict=False`) itself crashed with `KeyError: 'account_id'` → "empty summary" + traceback. The whole point of the tolerant read is to NOT crash/blank the dashboard.

New `_platform_account_id(platform_key, platform_data, *, strict)`:
- `strict=True` (writer contract): requires the key — `KeyError` exactly as before.
- `strict=False` (read-only Reports): defaults a missing `account_id` to `""` (DEBUG log) so the platform's totals/periods still render. `account_id` is not displayed by `_platform_row`, so this loses nothing visible.

### 2. Quiet the per-poll tolerant-read log flood (revives #323)

The read-only dashboard re-parses STATE.json on every poll, so the strict-fail→tolerant-retry path logged a full traceback + one WARNING per skipped entry **on every refresh** — reading as a failure when it is expected graceful degradation. Lowered to DEBUG:
- `web/reports.py` `_read_state_safe` — the strict-fail → tolerant-retry trace.
- `context/state.py` `_parse_campaigns` / `_parse_action_log` — the per-entry skips.

Genuinely-bad paths stay loud: `_read_state_tolerant`'s "no path to retry" (WARNING) and "tolerant read also failed" (exception + traceback), and structural raises. The new account_id default also logs at DEBUG.

## Not changed (by design)

The `name`-vs-`campaign_name` campaign skipping is unchanged — an existing test (`test_parse_state_strict_false_skips_malformed_campaigns`) pins that variant campaigns are SKIPPED, not aliased. This fix only stops the platform-level `account_id` crash.

## Test plan

- [x] `test_parse_state_strict_false_tolerates_missing_account_id` — customer scenario: missing account_id + `name`-campaigns skipped + totals preserved → `account_id == ""`, no crash
- [x] `test_parse_state_strict_true_raises_on_missing_account_id` — writer contract preserved
- [x] `test_missing_account_id_logs_at_debug_not_warning` + `test_parse_state_strict_false_skips_log_at_debug_not_warning` + `build_report_summary` caplog assertion — no WARNING+ on the per-poll path
- [x] `ruff` + `black` + `mypy` clean on changed `mureo/` files
- [x] python-reviewer APPROVE (account_id half this PR; the #323 log-level half is a verbatim re-apply of the already-approved commit 2d2bdad)

## Notes

- **Supersedes #323** (the halted log-noise PR) — its change is folded in here.
- Root cause is agent/skill STATE.json format drift (omitting `account_id`, using `name`). The parser is now robust to it (no crash, no flood); making the Reports view richer would need the skills to write platform rollups — separate follow-up.

https://claude.ai/code/session_011rAu94b1o1xWYZhARk1VmL
