### PR TITLE
fix(google-ads): id-free accounts_list + correct skill CLI reference & customer_id recovery (closes #333)

### DIFF
--- a/mureo/_data/skills/_mureo-google-ads/SKILL.md
+++ b/mureo/_data/skills/_mureo-google-ads/SKILL.md
@@ -8,11 +8,43 @@ metadata:
     requires:
       bins:
         - mureo
-    cliHelp: "mureo google-ads --help"
+    cliHelp: "mureo --help"
 ---
 
 # Google Ads (v18)
 > PREREQUISITE: Read `../_mureo-shared/SKILL.md` for auth, global flags, and security rules.
+
+> **There is no `mureo google-ads …` CLI command.** Every operation below is an
+> **MCP tool** (`google_ads_*`). Call the tool directly — never run or suggest a
+> `mureo google-ads campaigns-list`-style shell command (it does not exist and
+> will error, which is NOT a mureo bug).
+
+## No customer_id? (recovery)
+
+Every Google Ads tool needs a `customer_id` (the target account). It is resolved
+from the stored credentials (set by `mureo auth setup`). When it is missing a
+tool returns **`customer_id is required. Provide it as a parameter or configure
+it …`** — auth is fine, only the *account* is unset (a common state when the
+operator finished sign-in but skipped account selection).
+
+When you see that error, **recover automatically — do NOT ask the operator to
+look up the ID in the Google Ads UI, and do NOT fall back to a CSV / "ask the
+agency"**:
+
+1. Call **`google_ads_accounts_list`** — it needs **no** `customer_id` and
+   returns every account reachable by the login.
+2. **Exactly one account** → use its id as `customer_id` on the retried call and
+   tell the operator which account you selected.
+3. **Several accounts** → show the list and ask the operator which one to use.
+4. **Zero accounts** → the login can't reach any Google Ads account; tell the
+   operator to re-run `mureo auth setup` (or grant the account access), and that
+   `customer_id` can be set there or via `GOOGLE_ADS_CUSTOMER_ID` (plus
+   `GOOGLE_ADS_LOGIN_CUSTOMER_ID` for an MCC).
+
+To persist the choice so it survives across sessions, point the operator at
+`mureo auth setup` (account picker) or the `configure` UI's env writer
+(`GOOGLE_ADS_CUSTOMER_ID`); passing `customer_id` per call works for the
+immediate request but is not remembered.
 
 ## Tool Summary
 

--- a/mureo/_data/skills/_mureo-meta-ads/SKILL.md
+++ b/mureo/_data/skills/_mureo-meta-ads/SKILL.md
@@ -8,7 +8,7 @@ metadata:
     requires:
       bins:
         - mureo
-    cliHelp: "mureo meta-ads --help"
+    cliHelp: "mureo --help"
 ---
 
 # Meta Ads (Marketing API v21.0)

--- a/mureo/_data/skills/_mureo-shared/SKILL.md
+++ b/mureo/_data/skills/_mureo-shared/SKILL.md
@@ -306,22 +306,28 @@ Canonical STATE.json shape (note `campaign_name` and `account_id`):
 
 ## CLI Quick Reference
 
+> **The `mureo` CLI covers setup, auth, and service management only — it has NO
+> ad-operation subcommands.** Listing campaigns, pulling insights, editing
+> budgets, etc. are done through the **MCP tools** (`google_ads_*`,
+> `meta_ads_*`, `search_console_*`) — there is **no** `mureo google-ads …` /
+> `mureo meta-ads …` shell command. Never run or suggest one (it will error with
+> "no such command"); call the corresponding MCP tool instead.
+
 | Command | Description |
 |---------|-------------|
-| `mureo auth setup` | Interactive authentication wizard |
+| `mureo auth setup` | Interactive auth wizard — records the Google Ads `customer_id` / Meta `account_id` |
 | `mureo auth status` | Show authentication status |
-| `mureo auth check-google` | Verify Google Ads credentials |
-| `mureo auth check-meta` | Verify Meta Ads credentials |
-| `mureo google-ads campaigns-list` | List Google Ads campaigns |
-| `mureo google-ads campaigns-get` | Get campaign details |
-| `mureo google-ads ads-list` | List ads |
-| `mureo google-ads keywords-list` | List keywords |
-| `mureo google-ads budget-get` | Get campaign budget |
-| `mureo google-ads performance-report` | Performance report |
-| `mureo meta-ads campaigns-list` | List Meta Ads campaigns |
-| `mureo meta-ads campaigns-get` | Get campaign details |
-| `mureo meta-ads ad-sets-list` | List ad sets |
-| `mureo meta-ads ads-list` | List ads |
-| `mureo meta-ads insights-report` | Performance report |
+| `mureo auth check-google` | Verify Google Ads credentials (masked) |
+| `mureo auth check-meta` | Verify Meta Ads credentials (masked) |
+| `mureo configure` | Launch the local configuration / Reports UI |
+| `mureo service {install,status,restart,uninstall}` | Manage the always-on daemon |
+| `mureo upgrade [--all]` | Upgrade mureo (also refreshes deployed skills + restarts the service) |
+| `mureo providers {list,add,remove}` | Manage official-MCP / plugin providers |
+| `mureo rollback {list,show}` | Inspect reversible actions in the `action_log` (apply a reversal via the `rollback_apply` MCP tool) |
 
-All CLI commands output JSON to stdout for easy piping and parsing.
+To **list Google Ads campaigns**, call the MCP tool `google_ads_campaigns_list`
+(it resolves `customer_id` from the stored credentials). If you hit
+`customer_id is required`, do **not** ask the operator to read it from the
+Google Ads UI or hand over a CSV — call `google_ads_accounts_list` to discover
+the accessible accounts and set it. See `../_mureo-google-ads/SKILL.md` →
+*No customer_id? (recovery)*.

--- a/mureo/mcp/_handlers_google_ads_analysis.py
+++ b/mureo/mcp/_handlers_google_ads_analysis.py
@@ -45,11 +45,36 @@ async def handle_budget_create(args: dict[str, Any]) -> list[TextContent]:
 
 @api_error_handler
 async def handle_accounts_list(args: dict[str, Any]) -> list[TextContent]:
-    client = _get_client(args)
-    if client is None:
+    """List the Google Ads accounts reachable by the login.
+
+    Account discovery is keyed on the authenticated OAuth user
+    (``listAccessibleCustomers``), NOT on a specific account — so unlike every
+    other Google Ads tool this one does **not** require a ``customer_id`` (its
+    schema marks it optional). That makes it the recovery path when no account
+    has been selected yet: an agent that hits ``customer_id is required`` on a
+    campaign call can call this to discover/choose the account. See
+    ``_mureo-google-ads/SKILL.md`` → "No customer_id? (recovery)".
+
+    An explicit ``customer_id`` (or BYOD mode) still routes through the
+    customer-scoped client; only the real-mode, no-customer_id case uses the
+    id-free :func:`mureo.google_ads.list_accessible_accounts` primitive.
+    """
+    from mureo.byod.runtime import byod_has
+
+    if byod_has("google_ads") or _opt(args, "customer_id"):
+        client = _get_client(args)
+        if client is None:
+            return _no_google_creds()
+        return _json_result(await client.list_accounts())
+
+    from mureo.auth import load_google_ads_credentials
+    from mureo.google_ads import list_accessible_accounts
+
+    creds = load_google_ads_credentials()
+    if creds is None:
         return _no_google_creds()
-    result = await client.list_accounts()
-    return _json_result(result)
+    accounts = await list_accessible_accounts(creds)
+    return _json_result(accounts)
 
 
 @api_error_handler

--- a/skills/_mureo-google-ads/SKILL.md
+++ b/skills/_mureo-google-ads/SKILL.md
@@ -8,11 +8,43 @@ metadata:
     requires:
       bins:
         - mureo
-    cliHelp: "mureo google-ads --help"
+    cliHelp: "mureo --help"
 ---
 
 # Google Ads (v18)
 > PREREQUISITE: Read `../_mureo-shared/SKILL.md` for auth, global flags, and security rules.
+
+> **There is no `mureo google-ads …` CLI command.** Every operation below is an
+> **MCP tool** (`google_ads_*`). Call the tool directly — never run or suggest a
+> `mureo google-ads campaigns-list`-style shell command (it does not exist and
+> will error, which is NOT a mureo bug).
+
+## No customer_id? (recovery)
+
+Every Google Ads tool needs a `customer_id` (the target account). It is resolved
+from the stored credentials (set by `mureo auth setup`). When it is missing a
+tool returns **`customer_id is required. Provide it as a parameter or configure
+it …`** — auth is fine, only the *account* is unset (a common state when the
+operator finished sign-in but skipped account selection).
+
+When you see that error, **recover automatically — do NOT ask the operator to
+look up the ID in the Google Ads UI, and do NOT fall back to a CSV / "ask the
+agency"**:
+
+1. Call **`google_ads_accounts_list`** — it needs **no** `customer_id` and
+   returns every account reachable by the login.
+2. **Exactly one account** → use its id as `customer_id` on the retried call and
+   tell the operator which account you selected.
+3. **Several accounts** → show the list and ask the operator which one to use.
+4. **Zero accounts** → the login can't reach any Google Ads account; tell the
+   operator to re-run `mureo auth setup` (or grant the account access), and that
+   `customer_id` can be set there or via `GOOGLE_ADS_CUSTOMER_ID` (plus
+   `GOOGLE_ADS_LOGIN_CUSTOMER_ID` for an MCC).
+
+To persist the choice so it survives across sessions, point the operator at
+`mureo auth setup` (account picker) or the `configure` UI's env writer
+(`GOOGLE_ADS_CUSTOMER_ID`); passing `customer_id` per call works for the
+immediate request but is not remembered.
 
 ## Tool Summary
 

--- a/skills/_mureo-meta-ads/SKILL.md
+++ b/skills/_mureo-meta-ads/SKILL.md
@@ -8,7 +8,7 @@ metadata:
     requires:
       bins:
         - mureo
-    cliHelp: "mureo meta-ads --help"
+    cliHelp: "mureo --help"
 ---
 
 # Meta Ads (Marketing API v21.0)

--- a/skills/_mureo-shared/SKILL.md
+++ b/skills/_mureo-shared/SKILL.md
@@ -306,22 +306,28 @@ Canonical STATE.json shape (note `campaign_name` and `account_id`):
 
 ## CLI Quick Reference
 
+> **The `mureo` CLI covers setup, auth, and service management only — it has NO
+> ad-operation subcommands.** Listing campaigns, pulling insights, editing
+> budgets, etc. are done through the **MCP tools** (`google_ads_*`,
+> `meta_ads_*`, `search_console_*`) — there is **no** `mureo google-ads …` /
+> `mureo meta-ads …` shell command. Never run or suggest one (it will error with
+> "no such command"); call the corresponding MCP tool instead.
+
 | Command | Description |
 |---------|-------------|
-| `mureo auth setup` | Interactive authentication wizard |
+| `mureo auth setup` | Interactive auth wizard — records the Google Ads `customer_id` / Meta `account_id` |
 | `mureo auth status` | Show authentication status |
-| `mureo auth check-google` | Verify Google Ads credentials |
-| `mureo auth check-meta` | Verify Meta Ads credentials |
-| `mureo google-ads campaigns-list` | List Google Ads campaigns |
-| `mureo google-ads campaigns-get` | Get campaign details |
-| `mureo google-ads ads-list` | List ads |
-| `mureo google-ads keywords-list` | List keywords |
-| `mureo google-ads budget-get` | Get campaign budget |
-| `mureo google-ads performance-report` | Performance report |
-| `mureo meta-ads campaigns-list` | List Meta Ads campaigns |
-| `mureo meta-ads campaigns-get` | Get campaign details |
-| `mureo meta-ads ad-sets-list` | List ad sets |
-| `mureo meta-ads ads-list` | List ads |
-| `mureo meta-ads insights-report` | Performance report |
+| `mureo auth check-google` | Verify Google Ads credentials (masked) |
+| `mureo auth check-meta` | Verify Meta Ads credentials (masked) |
+| `mureo configure` | Launch the local configuration / Reports UI |
+| `mureo service {install,status,restart,uninstall}` | Manage the always-on daemon |
+| `mureo upgrade [--all]` | Upgrade mureo (also refreshes deployed skills + restarts the service) |
+| `mureo providers {list,add,remove}` | Manage official-MCP / plugin providers |
+| `mureo rollback {list,show}` | Inspect reversible actions in the `action_log` (apply a reversal via the `rollback_apply` MCP tool) |
 
-All CLI commands output JSON to stdout for easy piping and parsing.
+To **list Google Ads campaigns**, call the MCP tool `google_ads_campaigns_list`
+(it resolves `customer_id` from the stored credentials). If you hit
+`customer_id is required`, do **not** ask the operator to read it from the
+Google Ads UI or hand over a CSV — call `google_ads_accounts_list` to discover
+the accessible accounts and set it. See `../_mureo-google-ads/SKILL.md` →
+*No customer_id? (recovery)*.

--- a/tests/test_mcp_tools_google_ads_analysis.py
+++ b/tests/test_mcp_tools_google_ads_analysis.py
@@ -79,6 +79,55 @@ class TestGoogleAdsBudgetCreateAndAccountsHandlers:
         parsed = json.loads(result[0].text)
         assert len(parsed) == 1
 
+    async def test_accounts_list_without_customer_id_uses_id_free_discovery(
+        self,
+    ) -> None:
+        """Recovery path: with NO customer_id, accounts-list must not require one
+        — it uses the id-free ``list_accessible_accounts`` primitive (keyed on
+        the OAuth user), not the customer-scoped client. This is what lets an
+        agent recover from an unset customer_id instead of dead-ending."""
+        mod = _import_google_ads_tools()
+        creds = MagicMock()
+        accounts = [
+            {"id": "111", "name": "Acct A", "is_manager": False, "parent_id": None},
+            {"id": "222", "name": "Acct B", "is_manager": False, "parent_id": None},
+        ]
+        with (
+            patch("mureo.byod.runtime.byod_has", return_value=False),
+            patch("mureo.auth.load_google_ads_credentials", return_value=creds),
+            patch(
+                "mureo.google_ads.list_accessible_accounts", return_value=accounts
+            ) as m_list,
+        ):
+            result = await mod.handle_tool("google_ads_accounts_list", {})
+
+        # The id-free primitive was used with the creds, and no customer_id
+        # was required (no "customer_id is required" error).
+        m_list.assert_called_once_with(creds)
+        parsed = json.loads(result[0].text)
+        assert [a["id"] for a in parsed] == ["111", "222"]
+
+    async def test_accounts_list_byod_keeps_scoped_client_path(self) -> None:
+        """BYOD must keep using the customer-scoped client (CSV-backed
+        `list_accounts`), NOT the id-free discovery primitive — even with no
+        customer_id. Locks the branch against regression."""
+        mod = _import_google_ads_tools()
+        client = AsyncMock()
+        client.list_accounts.return_value = [{"customer_id": "byod"}]
+        with (
+            patch("mureo.byod.runtime.byod_has", return_value=True),
+            patch(
+                "mureo.mcp._handlers_google_ads_analysis._get_client",
+                return_value=client,
+            ),
+            patch("mureo.google_ads.list_accessible_accounts") as m_list,
+        ):
+            result = await mod.handle_tool("google_ads_accounts_list", {})
+
+        client.list_accounts.assert_awaited_once()
+        m_list.assert_not_called()  # id-free path NOT taken in BYOD
+        assert json.loads(result[0].text) == [{"customer_id": "byod"}]
+
     async def test_network_performance_report(self) -> None:
         mod = _import_google_ads_tools()
         creds, client = _mock_google_ads_context()


### PR DESCRIPTION
Closes #333.

From a customer report: the agent dead-ended on "show Google Ads campaigns".

## Fixes
- **A (docs):** `_mureo-shared` CLI Quick Reference listed phantom `mureo google-ads/meta-ads *` commands (ad ops are MCP tools). Rewrote to real commands only + explicit "no such CLI, never run/suggest" note; fixed both skills `cliHelp` frontmatter; corrected stale `mureo rollback {plan,apply}` -> `{list,show}`.
- **B (code):** `google_ads_accounts_list` required a customer_id (via _get_client) despite optional schema. `handle_accounts_list` is now id-free in real mode (BYOD / explicit customer_id keep the scoped client; otherwise the id-free `list_accessible_accounts` primitive). Enables true auto-recovery from an unset customer_id.
- **C (docs):** added "No customer_id? (recovery)" to `_mureo-google-ads` — call `google_ads_accounts_list`, auto-set/ask/`auth setup`; never the UI-lookup/CSV dead-end.

skills/ <-> mureo/_data/skills parity kept.

## Test plan
- [x] new: id-free accounts_list path + BYOD path preserved; existing customer_id path unchanged
- [x] 257 passed across mcp/google-ads/skills suites; mypy/ruff/black clean; parity IDENTICAL
- [x] python-reviewer: APPROVE (no CRITICAL/HIGH/MEDIUM)

Note: the customer still needs to set their customer_id (re-run `mureo auth setup`); this fix makes the agent recover/guide correctly instead of dead-ending.

https://claude.ai/code/session_011rAu94b1o1xWYZhARk1VmL