### PR TITLE
fix(meta_ads): count conversions via a canonical exact-match counter (#340)

### DIFF
--- a/mureo/analytics/builtin/_budget_efficiency.py
+++ b/mureo/analytics/builtin/_budget_efficiency.py
@@ -59,17 +59,17 @@ def _extract_cost_and_conversions(
     else:
         cost = float(row.get(spend_key) or 0)
         conversions = float(row.get("conversions") or 0)
-        # Meta Live shape: conversions live inside ``actions``. Sum
-        # leads/purchases there if no flat conversion field is set.
+        # Meta Live shape: conversions live inside ``actions``. Count via the
+        # canonical exact-match counter (#340) — the old substring scan here
+        # double-counted aggregate+component aliases and swept in custom
+        # slugs, skewing the budget-efficiency CPA. Lazy import keeps adapter
+        # registration free of the mureo.meta_ads client weight.
         if conversions == 0:
-            actions = row.get("actions")
-            if isinstance(actions, list):
-                for action in actions:
-                    if not isinstance(action, dict):
-                        continue
-                    action_type = str(action.get("action_type", ""))
-                    if "lead" in action_type or "purchase" in action_type:
-                        conversions += float(action.get("value") or 0)
+            from mureo.meta_ads._conversion_count import (
+                count_conversions_from_actions,
+            )
+
+            conversions = count_conversions_from_actions(row.get("actions"))
 
     if cost <= 0:
         return None

--- a/mureo/analytics/builtin/_common.py
+++ b/mureo/analytics/builtin/_common.py
@@ -85,14 +85,15 @@ def meta_row_conversions(row: dict[str, Any]) -> float:
     """
     actions = row.get("actions")
     if isinstance(actions, list):
-        total = 0.0
-        for action in actions:
-            if not isinstance(action, dict):
-                continue
-            action_type = str(action.get("action_type", ""))
-            if "lead" in action_type or "purchase" in action_type:
-                total += float(action.get("value") or 0)
-        return total
+        # #340 — count via the canonical exact-match counter (deduped
+        # generic conversion action_types) instead of a substring scan,
+        # which double-counted aggregate+component aliases (lead +
+        # offsite_conversion.fb_pixel_lead) and swept in custom-conversion
+        # slugs. Lazy import keeps adapter registration free of the
+        # mureo.meta_ads client weight (this runs only on the live path).
+        from mureo.meta_ads._conversion_count import count_conversions_from_actions
+
+        return count_conversions_from_actions(actions)
     return float(row.get("conversions") or 0)
 
 

--- a/mureo/meta_ads/_analysis.py
+++ b/mureo/meta_ads/_analysis.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from mureo.meta_ads._conversion_count import count_conversions_from_actions
 from mureo.meta_ads._period import previous_period as _previous_period
 
 logger = logging.getLogger(__name__)
@@ -21,13 +22,14 @@ def _safe_float(v: Any) -> float:
 
 
 def _extract_cv(row: dict[str, Any]) -> float:
-    actions = row.get("actions")
-    if not actions or not isinstance(actions, list):
-        return 0.0
-    cv_types = {"lead", "purchase", "complete_registration"}
-    return sum(
-        _safe_float(a.get("value")) for a in actions if a.get("action_type") in cv_types
-    )
+    """Conversion count for one insights row via the canonical counter (#340).
+
+    Delegates to the shared :func:`count_conversions_from_actions` so this
+    MCP-analysis path and the analytics/diagnose path
+    (:func:`mureo.analytics.builtin._common.meta_row_conversions`) can never
+    drift on what counts as a conversion.
+    """
+    return count_conversions_from_actions(row.get("actions"))
 
 
 class AnalysisMixin:

--- a/mureo/meta_ads/_conversion_count.py
+++ b/mureo/meta_ads/_conversion_count.py
@@ -1,0 +1,76 @@
+"""Canonical Meta conversion counting from an Insights ``actions`` array.
+
+Single source of truth for "how many conversions does this Meta row
+report", shared by every live counter so they cannot drift (#340).
+
+Why an exact-match allow-list, not a substring scan
+---------------------------------------------------
+A naive ``"lead" in action_type or "purchase" in action_type`` sum
+over-counts for two reasons:
+
+1. **Alias double-count.** Meta's Insights ``actions`` array returns a
+   conversion under several overlapping ``action_type`` rows. The generic
+   ``lead`` action_type is, by Meta's own definition, the *aggregate*
+   ("All offsite leads plus all On-Facebook leads") of its components
+   ``offsite_conversion.fb_pixel_lead`` + ``onsite_conversion.lead_grouped``;
+   ``purchase`` / ``omni_purchase`` is the analogous roll-up. Because mureo
+   fetches ``actions`` unfiltered, the aggregate row and its component rows
+   co-occur — summing every ``*lead*`` / ``*purchase*`` row counts the same
+   conversions two or three times.
+2. **Substring false positives.** Operator-named custom conversions
+   (``offsite_conversion.custom.<slug>``) carry free-text slugs that may
+   contain ``"lead"`` / ``"purchase"`` and would be swept in uncontrolled.
+
+Counting only the **deduped generic** action_types
+(:data:`CONVERSION_ACTION_TYPES`) takes each conversion family once — the
+aggregate already includes its components, so the components must NOT be
+added on top.
+
+Known limitation (deliberately out of scope here)
+-------------------------------------------------
+This counts a fixed default set of generic conversion events. An operator
+whose objective reports only a component row (no generic aggregate), or who
+wants a specific custom event, is not yet served — that needs an
+operator-specified canonical-event selection (a separate, larger change).
+This module fixes the over-count; it does not add per-account event config.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+# Deduped generic conversion ``action_type`` values. Each already rolls up
+# its offsite/onsite component aliases, so counting these — and ONLY these —
+# takes every conversion exactly once. Kept identical to the value the live
+# MCP analysis path uses (``mureo.meta_ads._analysis._extract_cv``) so the
+# two live counters agree byte-for-byte.
+CONVERSION_ACTION_TYPES: frozenset[str] = frozenset(
+    {"lead", "purchase", "complete_registration"}
+)
+
+
+def _safe_float(value: Any) -> float:
+    """Coerce a Meta numeric-string value to float; 0.0 on junk/None."""
+    try:
+        return float(value or 0)
+    except (ValueError, TypeError):
+        return 0.0
+
+
+def count_conversions_from_actions(actions: Any) -> float:
+    """Sum the values of the canonical conversion ``action_type`` rows.
+
+    ``actions`` is the Insights ``actions`` array — a list of
+    ``{"action_type": str, "value": str|number}`` mappings. A non-list
+    (``None`` / BYOD shape / malformed) yields ``0.0`` so callers can pass
+    ``row.get("actions")`` directly. Non-mapping entries are skipped.
+    """
+    if not isinstance(actions, list):
+        return 0.0
+    return sum(
+        _safe_float(entry.get("value"))
+        for entry in actions
+        if isinstance(entry, Mapping)
+        and entry.get("action_type") in CONVERSION_ACTION_TYPES
+    )

--- a/mureo/meta_ads/_insights.py
+++ b/mureo/meta_ads/_insights.py
@@ -4,6 +4,7 @@ import json
 import logging
 from typing import Any
 
+from mureo.meta_ads._conversion_count import count_conversions_from_actions
 from mureo.meta_ads._period import previous_period, resolve_period
 
 logger = logging.getLogger(__name__)
@@ -223,17 +224,9 @@ class InsightsMixin:
             impressions = int(row.get("impressions", 0) or 0)
             ctr = float(row.get("ctr", 0) or 0)
 
-            # Extract CV count from actions
-            actions = row.get("actions", [])
-            conversions = 0.0
-            if actions:
-                for a in actions:
-                    if a.get("action_type") in (
-                        "lead",
-                        "purchase",
-                        "complete_registration",
-                    ):
-                        conversions += float(a.get("value", 0))
+            # Conversions via the canonical exact-match counter (#340) so
+            # this breakdown agrees with every other live path.
+            conversions = count_conversions_from_actions(row.get("actions"))
 
             cpa = round(spend / conversions, 0) if conversions > 0 else None
 

--- a/tests/analytics/builtin/test_budget_efficiency.py
+++ b/tests/analytics/builtin/test_budget_efficiency.py
@@ -103,13 +103,18 @@ def test_scorer_accepts_byod_flat_google_shape() -> None:
 
 
 @pytest.mark.unit
-def test_scorer_meta_sums_actions_when_flat_conversions_zero() -> None:
+def test_scorer_meta_counts_actions_when_flat_conversions_zero() -> None:
+    # The canonical counter (#340) counts the deduped generic `lead`
+    # aggregate once; the `offsite_conversion.fb_pixel_lead` component is the
+    # SAME 10 leads and must NOT be added on top (the old substring scorer
+    # double-counted it to 20).
     rows: list[dict[str, Any]] = [
         {
             "campaign_id": "c",
             "spend": 100,
             "conversions": 0,
             "actions": [
+                {"action_type": "lead", "value": 10},
                 {"action_type": "offsite_conversion.fb_pixel_lead", "value": 10},
             ],
         },
@@ -121,7 +126,35 @@ def test_scorer_meta_sums_actions_when_flat_conversions_zero() -> None:
         spend_key="spend",
         nested_metrics=False,
     )
+    # Single campaign with conversions > 0 normalises to the top score.
     assert dict(result.per_campaign_score) == {"c": 1.0}
+
+
+@pytest.mark.unit
+def test_scorer_meta_ignores_custom_slug_so_zero_conversions_warns() -> None:
+    """A custom-conversion slug containing 'lead' is NOT a conversion (#340),
+    so a campaign reporting only that is treated as zero-conversions."""
+    rows: list[dict[str, Any]] = [
+        {
+            "campaign_id": "c",
+            "spend": 100,
+            "conversions": 0,
+            "actions": [
+                {"action_type": "offsite_conversion.custom.my_lead_form", "value": 9},
+            ],
+        },
+    ]
+    result = score_budget_efficiency(
+        rows,
+        platform="meta_ads",
+        account_id="act",
+        spend_key="spend",
+        nested_metrics=False,
+    )
+    # The custom slug is not a conversion → the campaign reads as zero
+    # conversions → the scorer surfaces the tracking warning (mirrors
+    # test_scorer_zero_conversions_returns_tracking_warning).
+    assert "tracking" in result.rebalance_suggestion
 
 
 @pytest.mark.unit

--- a/tests/analytics/builtin/test_live_clients.py
+++ b/tests/analytics/builtin/test_live_clients.py
@@ -95,6 +95,11 @@ def test_aggregate_meta_metrics_sums_actions() -> None:
             "impressions": "1000",
             "clicks": "40",
             "actions": [
+                # The same 3 leads reported BOTH as the deduped generic
+                # aggregate AND its pixel component. The canonical counter
+                # (#340) takes the generic ONCE (=3); the old substring scan
+                # summed both (=6) — a double-count.
+                {"action_type": "lead", "value": "3"},
                 {"action_type": "offsite_conversion.fb_pixel_lead", "value": "3"},
                 {"action_type": "link_click", "value": "40"},
             ],
@@ -113,7 +118,9 @@ def test_aggregate_meta_metrics_sums_actions() -> None:
     assert result.cost == 80.0
     assert result.impressions == 1500
     assert result.clicks == 55
-    # 3 (lead) + 2 (lead) + 1 (purchase) = 6
+    # Deduped: row1 = 3 (generic lead; component not added again),
+    # row2 = 2 (lead) + 1 (purchase) = 3 → 6. Old substring scan would
+    # have over-counted row1 as 6 → total 9.
     assert result.conversions == 6
 
 

--- a/tests/test_meta_conversion_count.py
+++ b/tests/test_meta_conversion_count.py
@@ -1,0 +1,108 @@
+"""Tests for the canonical Meta conversion counter (#340).
+
+``count_conversions_from_actions`` replaces the old substring scan that
+double-counted aggregate+component aliases and swept in custom-conversion
+slugs. It counts only the deduped generic action_types.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mureo.meta_ads._conversion_count import (
+    CONVERSION_ACTION_TYPES,
+    count_conversions_from_actions,
+)
+
+
+@pytest.mark.unit
+def test_counts_generic_conversion_types() -> None:
+    actions = [
+        {"action_type": "purchase", "value": "5"},
+        {"action_type": "lead", "value": "3"},
+        {"action_type": "complete_registration", "value": "1"},
+        {"action_type": "link_click", "value": "100"},
+    ]
+    assert count_conversions_from_actions(actions) == 9.0
+
+
+@pytest.mark.unit
+def test_does_not_double_count_aggregate_plus_component() -> None:
+    """#340 core fix: the generic ``lead`` aggregate already includes its
+    ``offsite_conversion.fb_pixel_lead`` / ``onsite_conversion.lead_grouped``
+    components, so the components must NOT be added on top."""
+    actions = [
+        {"action_type": "lead", "value": "10"},
+        {"action_type": "offsite_conversion.fb_pixel_lead", "value": "7"},
+        {"action_type": "onsite_conversion.lead_grouped", "value": "3"},
+        {"action_type": "purchase", "value": "4"},
+        {"action_type": "offsite_conversion.fb_pixel_purchase", "value": "4"},
+    ]
+    # Old substring scan: 10+7+3 + 4+4 = 28. Canonical: 10 (lead) + 4 (purchase).
+    assert count_conversions_from_actions(actions) == 14.0
+
+
+@pytest.mark.unit
+def test_ignores_custom_conversion_slug_containing_lead() -> None:
+    """#340 false-positive fix: an operator-named custom conversion whose
+    slug happens to contain 'lead'/'purchase' must not be counted."""
+    actions = [
+        {"action_type": "offsite_conversion.custom.my_lead_magnet", "value": "99"},
+        {"action_type": "offsite_conversion.custom.black_friday_purchase", "value": "50"},
+        {"action_type": "lead", "value": "2"},
+    ]
+    assert count_conversions_from_actions(actions) == 2.0
+
+
+@pytest.mark.unit
+def test_ignores_view_and_engagement_types() -> None:
+    actions = [
+        {"action_type": "offsite_conversion.fb_pixel_view_content", "value": "200"},
+        {"action_type": "post_engagement", "value": "50"},
+        {"action_type": "video_view", "value": "300"},
+    ]
+    assert count_conversions_from_actions(actions) == 0.0
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("bad", [None, "invalid", 42, {}, []])
+def test_non_list_or_empty_is_zero(bad: object) -> None:
+    assert count_conversions_from_actions(bad) == 0.0
+
+
+@pytest.mark.unit
+def test_skips_non_mapping_and_junk_values() -> None:
+    actions = [
+        "garbage",
+        {"action_type": "lead", "value": "not_a_number"},
+        {"action_type": "purchase", "value": None},
+        {"action_type": "purchase", "value": "5"},
+    ]
+    assert count_conversions_from_actions(actions) == 5.0
+
+
+@pytest.mark.unit
+def test_canonical_set_is_the_deduped_generics() -> None:
+    assert CONVERSION_ACTION_TYPES == frozenset(
+        {"lead", "purchase", "complete_registration"}
+    )
+
+
+@pytest.mark.unit
+def test_matches_extract_cv_byte_for_byte() -> None:
+    """The two live counters must agree — _extract_cv now delegates here."""
+    from mureo.meta_ads._analysis import _extract_cv
+
+    rows = [
+        {"actions": [{"action_type": "lead", "value": "3"}]},
+        {
+            "actions": [
+                {"action_type": "purchase", "value": "5"},
+                {"action_type": "offsite_conversion.fb_pixel_purchase", "value": "5"},
+            ]
+        },
+        {"actions": None},
+        {},
+    ]
+    for row in rows:
+        assert _extract_cv(row) == count_conversions_from_actions(row.get("actions"))


### PR DESCRIPTION
## Summary

`meta_row_conversions` (the Meta conversion counter feeding CPA → anomaly
detection / `diagnose_performance` / budget-efficiency) counted via a
**substring scan** `"lead" in action_type or "purchase" in action_type`, which
**over-counted** for two reasons:

1. **Alias double-count.** Meta's Insights `actions` array returns one
   conversion under several overlapping `action_type` rows. The generic `lead`
   is, by Meta's own definition, the *aggregate* ("all offsite + all
   On-Facebook leads") of its components `offsite_conversion.fb_pixel_lead` +
   `onsite_conversion.lead_grouped`; `purchase`/`omni_purchase` is the
   analogous roll-up. Because `actions` is fetched unfiltered, aggregate +
   component rows co-occur, so summing every `*lead*`/`*purchase*` row counted
   the same conversions two or three times.
2. **Substring false positives.** Operator-named custom conversions
   (`offsite_conversion.custom.<slug>`) carry free-text slugs that may contain
   `lead`/`purchase` and were swept in.

This deflated the **absolute CPA** emitted by `diagnose_performance` and the
budget-efficiency scorer (the anomaly-detector CPA-*spike* path is ratio-based
and largely shielded). It also diverged from the MCP-analysis counter
`_extract_cv`, which already used an exact `{lead, purchase,
complete_registration}` set — so multiple live counters disagreed on what
counts as a conversion.

## Fix

A single canonical counter `mureo/meta_ads/_conversion_count.py`
(`count_conversions_from_actions` + `CONVERSION_ACTION_TYPES`) that counts
**only the deduped generic** conversion action_types — the aggregate already
includes its components, so components are not added on top, and custom slugs
no longer match. **All four** live counters now route through it so they cannot
drift again:

- `mureo/analytics/builtin/_common.py` `meta_row_conversions` (lazy import to
  keep adapter registration free of the `mureo.meta_ads` client weight; BYOD
  branch unchanged)
- `mureo/meta_ads/_analysis.py` `_extract_cv` (delegates)
- `mureo/analytics/builtin/_budget_efficiency.py`
- `mureo/meta_ads/_insights.py` breakdown

The campaign-type classifier (`_classify_result_indicator`) keeps substring
matching — it is a boolean "any conversion signal?" check, not a counter, so
substring is correct there.

### Behaviour notes
- `complete_registration` is now counted on the analytics/CPA path (previously
  only `_extract_cv` counted it) — an intentional consistency change.
- Known **component-only / custom-event under-count** (a family reported only
  as a component row, or as a custom event) is tracked separately as the
  operator-canonical-event enhancement (#342).

## Test plan
- [x] `tests/test_meta_conversion_count.py` — dedup (aggregate+component),
  custom-slug false positive, view/engagement exclusion, non-list/empty/junk
  handling, `_extract_cv` byte-for-byte equivalence.
- [x] Updated the two fixtures that encoded the old substring behaviour
  (`test_live_clients.py`, `test_budget_efficiency.py`) to realistic
  aggregate+component arrays that prove the dedup; added a budget-efficiency
  custom-slug regression test.
- [x] `ruff` + `black` clean on `mureo/`; `mypy --strict` clean on changed
  modules; 1125 passed in the meta/analytics sweep (only the known
  installed-plugin env-gating noise excluded).
- [x] Reviewed by python-reviewer (adversarial) — it caught two further
  substring counters (`_budget_efficiency.py`, `_insights.py`) that this PR now
  also migrates.

Closes #340

https://claude.ai/code/session_011rAu94b1o1xWYZhARk1VmL
