### PR TITLE
docs(skill): use mureo_state_* MCP tools for STATE.json mutations on Code (#341)

### DIFF
--- a/mureo/_data/skills/_mureo-shared/SKILL.md
+++ b/mureo/_data/skills/_mureo-shared/SKILL.md
@@ -105,10 +105,12 @@ Skills and commands describe "Read STRATEGY.md", "Update STATE.json", and "Appen
 | Read STRATEGY.md | `Read` tool | `mureo_strategy_get` MCP tool |
 | Replace STRATEGY.md | `Write` / `Edit` tool | `mureo_strategy_set` MCP tool |
 | Read STATE.json | `Read` tool | `mureo_state_get` MCP tool |
-| Append action_log entry | `Edit` tool (modify JSON) | `mureo_state_action_log_append` MCP tool |
-| Upsert campaign snapshot | `Edit` tool (modify JSON) | `mureo_state_upsert_campaign` MCP tool |
+| Append action_log entry | `mureo_state_action_log_append` MCP tool | `mureo_state_action_log_append` MCP tool |
+| Upsert campaign snapshot | `mureo_state_upsert_campaign` MCP tool | `mureo_state_upsert_campaign` MCP tool |
 
 When you don't have direct filesystem tools (Desktop / Cowork / web), always reach for the corresponding `mureo_*` MCP tool — they encode the same atomic-write semantics so you can't corrupt the file mid-edit.
+
+For STATE.json **mutations** (`Upsert campaign snapshot` / `Append action_log entry`) prefer the `mureo_state_*` MCP tool on **every** host, **including Code**: they apply the correct schema atomically. A raw `Edit` easily omits the required `platforms[<platform>]` / `account_id`, and a platform/campaign missing those is **dropped** by the dashboard — the workspace then renders **empty / "not yet bootstrapped"** even after you wrote campaigns. Separately, `mureo_state_upsert_campaign` (and the metrics / report setters) stamp the top-level **`last_synced_at`** — the dashboard's "Synced N ago" freshness — which a hand-edit leaves stale (`mureo_state_action_log_append` does **not** re-stamp it). Hand-writing STATE.json directly with `Write` on Code is reserved for the **bulk-snapshot** flows (`sync-state` / `daily-check`); on that path you own replicating the full **STATE.json Schema** below, **including a fresh `last_synced_at`**.
 
 The platform tools (`google_ads_*`, `meta_ads_*`, `search_console_*`) are the same across all hosts because they only exist as MCP tools.
 
@@ -278,12 +280,19 @@ shows fewer campaigns than you wrote — get these exact names right:
 - **Platform entry** (`platforms[<platform>]`) — required: `account_id` (str;
   use `""` only if genuinely unknown). Plus `campaigns[]` and the rollups the
   dashboard actually renders: `totals`, `metrics_period`, `periods[<window>]`.
+- **Top-level** — required: `last_synced_at` (ISO-8601 string, **stamped to
+  _now_** by every campaign/metrics/report write). It drives the dashboard's
+  "Synced N ago" freshness; a missing or stale value makes the data read as
+  not-recently-synced. `mureo_state_upsert_campaign` / `_platform_metrics_set`
+  / `_report_set` set it for you (`_action_log_append` does not); on the Code
+  `Write` path you must set it yourself.
 
-Canonical STATE.json shape (note `campaign_name` and `account_id`):
+Canonical STATE.json shape (note `campaign_name`, `account_id`, `last_synced_at`):
 
 ```json
 {
   "version": "2",
+  "last_synced_at": "2026-06-26T10:00:00+09:00",
   "platforms": {
     "google_ads": {
       "account_id": "123-456-7890",

--- a/mureo/_data/skills/daily-check/SKILL.md
+++ b/mureo/_data/skills/daily-check/SKILL.md
@@ -72,7 +72,7 @@ Run a daily health check on all marketing accounts using the strategy context.
 
     For each issue, suggest specific actions aligned with the current Operation Mode. Do NOT recommend actions based on single-day fluctuations — at least 7 consecutive days of critical metrics (>30% off target) before suggesting rescue.
 
-11. **Update STATE.json**: Update campaign snapshots, add notes for flagged issues, and log this daily check to the `action_log` with a summary of findings. On the Code `Write` path, use the canonical STATE.json field names — `campaign_name` (NOT the tool-output `name`), `campaign_id`, and each platform's `account_id`; a snapshot/platform missing a required field is dropped by the reporting dashboard. See `../_mureo-shared/SKILL.md` → *STATE.json Schema*.
+11. **Update STATE.json**: Update campaign snapshots, add notes for flagged issues, and log this daily check to the `action_log` with a summary of findings. On the Code `Write` path, use the canonical STATE.json field names — `campaign_name` (NOT the tool-output `name`), `campaign_id`, and each platform's `account_id`; a snapshot/platform missing a required field is dropped by the reporting dashboard. On the Code `Write` path also **stamp the top-level `last_synced_at` to now** so the dashboard's "Synced N ago" freshness reflects this run (the `mureo_state_upsert_campaign` / `_platform_metrics_set` tools set it for you). See `../_mureo-shared/SKILL.md` → *STATE.json Schema*.
 
 12. **Persist the report summary** (best-effort): Call `mureo_state_report_set` with `report="daily"` and a concise `summary` object so the read-only dashboard can render this report without re-running you. Follow this convention:
     - `generated_at`: ISO 8601 timestamp of this run

--- a/skills/_mureo-shared/SKILL.md
+++ b/skills/_mureo-shared/SKILL.md
@@ -105,10 +105,12 @@ Skills and commands describe "Read STRATEGY.md", "Update STATE.json", and "Appen
 | Read STRATEGY.md | `Read` tool | `mureo_strategy_get` MCP tool |
 | Replace STRATEGY.md | `Write` / `Edit` tool | `mureo_strategy_set` MCP tool |
 | Read STATE.json | `Read` tool | `mureo_state_get` MCP tool |
-| Append action_log entry | `Edit` tool (modify JSON) | `mureo_state_action_log_append` MCP tool |
-| Upsert campaign snapshot | `Edit` tool (modify JSON) | `mureo_state_upsert_campaign` MCP tool |
+| Append action_log entry | `mureo_state_action_log_append` MCP tool | `mureo_state_action_log_append` MCP tool |
+| Upsert campaign snapshot | `mureo_state_upsert_campaign` MCP tool | `mureo_state_upsert_campaign` MCP tool |
 
 When you don't have direct filesystem tools (Desktop / Cowork / web), always reach for the corresponding `mureo_*` MCP tool — they encode the same atomic-write semantics so you can't corrupt the file mid-edit.
+
+For STATE.json **mutations** (`Upsert campaign snapshot` / `Append action_log entry`) prefer the `mureo_state_*` MCP tool on **every** host, **including Code**: they apply the correct schema atomically. A raw `Edit` easily omits the required `platforms[<platform>]` / `account_id`, and a platform/campaign missing those is **dropped** by the dashboard — the workspace then renders **empty / "not yet bootstrapped"** even after you wrote campaigns. Separately, `mureo_state_upsert_campaign` (and the metrics / report setters) stamp the top-level **`last_synced_at`** — the dashboard's "Synced N ago" freshness — which a hand-edit leaves stale (`mureo_state_action_log_append` does **not** re-stamp it). Hand-writing STATE.json directly with `Write` on Code is reserved for the **bulk-snapshot** flows (`sync-state` / `daily-check`); on that path you own replicating the full **STATE.json Schema** below, **including a fresh `last_synced_at`**.
 
 The platform tools (`google_ads_*`, `meta_ads_*`, `search_console_*`) are the same across all hosts because they only exist as MCP tools.
 
@@ -278,12 +280,19 @@ shows fewer campaigns than you wrote — get these exact names right:
 - **Platform entry** (`platforms[<platform>]`) — required: `account_id` (str;
   use `""` only if genuinely unknown). Plus `campaigns[]` and the rollups the
   dashboard actually renders: `totals`, `metrics_period`, `periods[<window>]`.
+- **Top-level** — required: `last_synced_at` (ISO-8601 string, **stamped to
+  _now_** by every campaign/metrics/report write). It drives the dashboard's
+  "Synced N ago" freshness; a missing or stale value makes the data read as
+  not-recently-synced. `mureo_state_upsert_campaign` / `_platform_metrics_set`
+  / `_report_set` set it for you (`_action_log_append` does not); on the Code
+  `Write` path you must set it yourself.
 
-Canonical STATE.json shape (note `campaign_name` and `account_id`):
+Canonical STATE.json shape (note `campaign_name`, `account_id`, `last_synced_at`):
 
 ```json
 {
   "version": "2",
+  "last_synced_at": "2026-06-26T10:00:00+09:00",
   "platforms": {
     "google_ads": {
       "account_id": "123-456-7890",

--- a/skills/daily-check/SKILL.md
+++ b/skills/daily-check/SKILL.md
@@ -72,7 +72,7 @@ Run a daily health check on all marketing accounts using the strategy context.
 
     For each issue, suggest specific actions aligned with the current Operation Mode. Do NOT recommend actions based on single-day fluctuations — at least 7 consecutive days of critical metrics (>30% off target) before suggesting rescue.
 
-11. **Update STATE.json**: Update campaign snapshots, add notes for flagged issues, and log this daily check to the `action_log` with a summary of findings. On the Code `Write` path, use the canonical STATE.json field names — `campaign_name` (NOT the tool-output `name`), `campaign_id`, and each platform's `account_id`; a snapshot/platform missing a required field is dropped by the reporting dashboard. See `../_mureo-shared/SKILL.md` → *STATE.json Schema*.
+11. **Update STATE.json**: Update campaign snapshots, add notes for flagged issues, and log this daily check to the `action_log` with a summary of findings. On the Code `Write` path, use the canonical STATE.json field names — `campaign_name` (NOT the tool-output `name`), `campaign_id`, and each platform's `account_id`; a snapshot/platform missing a required field is dropped by the reporting dashboard. On the Code `Write` path also **stamp the top-level `last_synced_at` to now** so the dashboard's "Synced N ago" freshness reflects this run (the `mureo_state_upsert_campaign` / `_platform_metrics_set` tools set it for you). See `../_mureo-shared/SKILL.md` → *STATE.json Schema*.
 
 12. **Persist the report summary** (best-effort): Call `mureo_state_report_set` with `report="daily"` and a concise `summary` object so the read-only dashboard can render this report without re-running you. Follow this convention:
     - `generated_at`: ISO 8601 timestamp of this run


### PR DESCRIPTION
## Summary

`skills/_mureo-shared/SKILL.md`'s "Tool Selection" table told **Claude Code**
agents to upsert campaign snapshots / append action_log entries to STATE.json
via the raw `Edit` tool. But the v2 schema the dashboard reads is non-trivial —
a `platforms[<platform>]` section with a **required `account_id`** — and a
platform/campaign missing it is silently **dropped**, so the workspace renders
**empty / "not yet bootstrapped"** even after campaigns were written
(`mureo/context/state.py:386`, `mureo/_data/web/dashboard.js:2155`). The
`mureo_state_*` MCP tools encode that schema atomically and are available on
Code too. Separately, `mureo_state_upsert_campaign` (and the metrics/report
setters) stamp the top-level `last_synced_at` that drives the dashboard's
"Synced N ago" freshness — and that field was **entirely absent** from the
SKILL.md STATE.json Schema docs.

## Changes (mirrored to both `skills/` and `mureo/_data/skills/`)

- **`_mureo-shared/SKILL.md`**
  - Table "Append action_log entry" / "Upsert campaign snapshot" Code column:
    `Edit` → the `mureo_state_*` MCP tool (matches the issue's suggested diff).
  - Note: STATE.json mutations prefer the MCP tool on every host; direct
    `Write` on Code is reserved for the **bulk-snapshot** flows
    (`sync-state` / `daily-check`), where the agent must replicate the full
    schema incl. a fresh `last_synced_at`.
  - Added `last_synced_at` as a **required top-level field** (bullet + JSON
    example) — the missing piece behind the reported failure.
- **`daily-check/SKILL.md`** step 11: a `last_synced_at` reminder for the Code
  `Write` path (`sync-state` already had step 9).

## Verification

- Code-reviewed (code-reviewer agent). It caught two prose inaccuracies in an
  earlier draft, now corrected and re-verified against the implementation:
  - `platforms` / `account_id` incompleteness — **not** `last_synced_at` — is
    what renders a workspace empty/inactive (`dashboard.js:2155` gates on
    `platforms.length === 0`); `last_synced_at` only drives the freshness label.
  - `mureo_state_action_log_append` does **not** re-stamp `last_synced_at`
    (`state.py:463` preserves it); only the campaign/metrics/report writers do.
- Mirror parity test `tests/test_plugin_manifests.py` passes (skills/ ↔
  mureo/_data/skills/ byte-identical); skill suite green (247 passed).
- Docs-only change.

Closes #341

https://claude.ai/code/session_011rAu94b1o1xWYZhARk1VmL
