### PR TITLE
docs: add OpenAI Codex as a configure host

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -236,6 +236,16 @@ The MCP server picks up the credentials from `~/.mureo/credentials.json` automat
 
 Same as Desktop chat — Cowork uses the same MCP entry. After `install-desktop` + `auth setup`, **connect the workspace folder** in Cowork (`~/mureo`) so the agent can also see local files when needed.
 
+### D. Auth in OpenAI Codex
+
+```bash
+pip install mureo
+mureo setup codex                   # wires the MCP server + credential-guard hook + skills into ~/.codex
+mureo configure                     # browser UI: OAuth + credentials (or do it all here by picking the "OpenAI Codex" host)
+```
+
+Restart Codex — the CLI, IDE extension, and desktop app all share `~/.codex/config.toml`, so one setup covers all three. Then run a workflow ("run a daily check", or `$daily-check` via the `/skills` picker). The MCP server reads credentials from `~/.mureo/credentials.json` automatically.
+
 ## Step 3 — Verify
 
 ```bash
@@ -271,6 +281,7 @@ Skill availability by host:
 | Claude Code | `/daily-check`, `/budget-rebalance`, … | All 11 operational skills + 6 foundation skills available locally |
 | Claude Desktop chat | natural language ("run a daily check") | Skills must be registered to claude.ai (manual upload or marketplace) |
 | Cowork | natural language | Same registration story as chat |
+| OpenAI Codex | `$daily-check` / the `/skills` picker, or natural language | Skills install to `~/.codex/skills` (CLI / IDE / desktop app share them) |
 
 ---
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -45,6 +45,20 @@ Add to `.cursor/mcp.json` in your project root:
 }
 ```
 
+### OpenAI Codex
+
+Codex reads MCP servers from `~/.codex/config.toml` (**TOML**, not JSON) — shared
+across the Codex CLI, IDE extension, and desktop app. The easiest path is
+`mureo setup codex` (or `mureo configure` → pick the **OpenAI Codex** host),
+which writes a tagged `[mcp_servers.mureo]` block and preserves the rest of the
+file. To wire it by hand:
+
+```toml
+[mcp_servers.mureo]
+command = "python"
+args = ["-m", "mureo.mcp"]
+```
+
 ### Using a Virtual Environment
 
 If mureo is installed in a virtual environment, use the full path to the Python interpreter:


### PR DESCRIPTION
## Summary

Follow-up to #346 (Codex as a full `mureo configure` host). The user-facing docs only walked through the Claude hosts; this adds Codex.

- **`docs/getting-started.md`**: a "D. Auth in OpenAI Codex" walkthrough (`mureo setup codex` + `mureo configure`, noting the CLI / IDE extension / desktop app all share `~/.codex/config.toml` so one setup covers all three) + a Codex row in the "Skill availability by host" table.
- **`docs/mcp-server.md`**: an "OpenAI Codex" client-config section (TOML `[mcp_servers.mureo]` block) alongside Claude Desktop / Cursor.

Docs only. The MCP tool count (189 / 8 context tools) and the README tagline were already current.

https://claude.ai/code/session_011rAu94b1o1xWYZhARk1VmL