### PR TITLE
feat(providers): add TikTok Ads official hosted MCP provider

### DIFF
--- a/mureo/cli/providers_cmd.py
+++ b/mureo/cli/providers_cmd.py
@@ -93,33 +93,41 @@ def _emit_coexistence(spec: ProviderSpec, *, mureo_block_present: bool) -> None:
 def _emit_hosted_auth_notice(spec: ProviderSpec, *, dry_run: bool) -> None:
     """Print how to wire a hosted MCP via a Claude.ai connector.
 
-    Meta's hosted Ads MCP cannot be OAuth-authenticated as a Claude Code
-    *user-scope* server: it does not support RFC 7591 Dynamic Client
-    Registration, so Claude Code's `/mcp` OAuth fails with
-    "redirect_uris are not registered for this client". mureo therefore
-    does NOT register it locally; the only path that works on Claude
-    Code today is adding it as a Claude.ai account connector (Anthropic
-    brokers the OAuth there). Once added at claude.ai it is available
-    account-wide and surfaces in Claude Code automatically.
+    Hosted providers are not registered locally: Claude Code cannot always
+    complete their OAuth as a *user-scope* server (e.g. Meta's endpoint has
+    no RFC 7591 Dynamic Client Registration, so ``/mcp`` fails with
+    "redirect_uris are not registered for this client"). The path that
+    works for every hosted provider is a Claude.ai account connector —
+    Anthropic brokers the OAuth there and the provider's tools then surface
+    in Claude Code automatically.
+
+    The copy is derived from ``spec`` (endpoint URL, and — only when the
+    provider overlaps a mureo-native platform — the native-coexistence
+    tail); it is deliberately vendor-neutral so a new hosted provider does
+    not inherit another vendor's sign-in wording.
     """
     url = spec.mcp_server_config.get("url", "")
     prefix = "[dry-run] " if dry_run else ""
-    typer.echo(
-        f"{prefix}{spec.id}: Meta's hosted MCP cannot be OAuth-"
-        f"authenticated as a Claude Code user-scope server (no dynamic "
-        f"client registration), so mureo does NOT register it locally. "
-        f"Add it as a Claude.ai connector instead:\n"
+    lines = [
+        f"{prefix}{spec.id}: hosted MCP — mureo does not register hosted "
+        f"providers locally. Add it as a Claude.ai connector so Anthropic "
+        f"brokers the sign-in:",
         f"{prefix}  1. Open claude.ai -> Settings -> Connectors "
         f"(https://claude.ai/customize/connectors). Requires a paid plan "
-        f"(Pro/Max/Team/Enterprise; Free cannot add connectors).\n"
+        f"(Pro/Max/Team/Enterprise; Free cannot add connectors).",
         f"{prefix}  2. Add custom connector -> URL: {url} -> Add, then "
-        f"complete the Meta Business sign-in in the browser.\n"
-        f"{prefix}  3. In Claude Code run /mcp to verify — Meta tools "
-        f"load as mcp__claude_ai_MetaAds__* (free during Meta's beta).\n"
-        f"{prefix}mureo-native Meta stays active until you switch it off "
-        f"with `mureo providers confirm {spec.id}` (after the connector "
-        f"is Connected)."
-    )
+        f"complete the provider sign-in in the browser.",
+        f"{prefix}  3. In Claude Code run /mcp to verify the provider's "
+        f"tools load.",
+    ]
+    platform = spec.coexists_with_mureo_platform
+    if platform is not None:
+        lines.append(
+            f"{prefix}mureo-native {platform} stays active until you switch "
+            f"it off with `mureo providers confirm {spec.id}` (after the "
+            f"connector is Connected)."
+        )
+    typer.echo("\n".join(lines))
 
 
 def _dry_run_preview(spec: ProviderSpec) -> None:
@@ -157,20 +165,18 @@ def _add_one(spec: ProviderSpec, *, dry_run: bool) -> bool:
     degraded coexistence note is emitted instead.
     """
     if spec.install_kind == "hosted_http":
-        # Meta's hosted MCP has no Dynamic Client Registration, so it
-        # CANNOT be OAuth-authenticated as a Claude Code user-scope
-        # server (`/mcp` fails: "redirect_uris are not registered for
-        # this client"). mureo therefore does NOT register it locally —
-        # the only working Claude Code path is a Claude.ai account
-        # connector. We print those steps and do not touch
-        # ~/.claude.json. mureo-native Meta is left active (no-strand);
-        # it steps aside only via `providers confirm` once the connector
-        # is verified Connected.
+        # Hosted MCPs are NOT registered locally: Claude Code cannot always
+        # complete their user-scope OAuth (e.g. Meta has no Dynamic Client
+        # Registration, so `/mcp` fails with "redirect_uris are not
+        # registered"). The path that works for every hosted provider is a
+        # Claude.ai account connector, so we print those steps and do not
+        # touch ~/.claude.json. Any mureo-native platform the provider
+        # overlaps is left active (no-strand); it steps aside only via
+        # `providers confirm` once the connector is verified Connected.
         if dry_run:
             typer.echo(
-                f"[dry-run] {spec.id}: would NOT register locally "
-                f"(Meta has no dynamic client registration); add it via "
-                f"a Claude.ai connector instead (no native auto-disable)"
+                f"[dry-run] {spec.id}: would NOT register locally; add it "
+                f"via a Claude.ai connector instead (no native auto-disable)"
             )
             _emit_hosted_auth_notice(spec, dry_run=True)
             return True

--- a/mureo/providers/catalog.py
+++ b/mureo/providers/catalog.py
@@ -218,6 +218,48 @@ CATALOG: tuple[ProviderSpec, ...] = (
         ),
         coexists_with_mureo_platform="ga4",
     ),
+    ProviderSpec(
+        id="tiktok-ads-official",
+        display_name="TikTok Ads (official hosted MCP)",
+        install_kind="hosted_http",
+        # Hosted endpoint — no local install step. TikTok delivers its
+        # official "TikTok for Business MCP Server" as a hosted HTTP service
+        # (launched at TikTok World '26, 2026-05-13; docs at
+        # business-api.tiktok.com/portal/docs/tiktok-ads-mcp-server/v1.3,
+        # verified 2026-07-02). Two endpoints are published:
+        # `tt-ads-mcp-flat` loads all ~400 tools at connect, while
+        # `tt-ads-mcp-layer` (Progressive Disclosure) loads ~40 core tools
+        # and surfaces the rest on demand. mureo defaults to the layered
+        # endpoint to keep the exposed tool surface small.
+        install_argv=(),
+        mcp_server_config=_freeze_config(
+            {
+                "type": "http",
+                "url": "https://business-api.tiktok.com/open_mcp/tt-ads-mcp-layer",
+            }
+        ),
+        # Auth is interactive browser-OAuth via the user's TikTok for Business
+        # account on first connect (sign in to TikTok Ads Manager, then
+        # authorize) — no developer token or env vars are pre-populated.
+        required_env=(),
+        notes=(
+            "TikTok's official hosted MCP (\"TikTok for Business MCP "
+            "Server\", launched at TikTok World '26). mureo points at the "
+            "Progressive Disclosure endpoint "
+            "`business-api.tiktok.com/open_mcp/tt-ads-mcp-layer` (~40 core "
+            "tools, the rest discovered on demand); the full-surface "
+            "`tt-ads-mcp-flat` (~400 tools) is also published. Read-write "
+            "across campaign management, reporting, catalogs, creatives, "
+            "audiences, and Business Center. Auth is interactive browser "
+            "OAuth via your TikTok for Business account on first connect "
+            "(no developer token or env vars). Like other hosted providers, "
+            "mureo does not register it locally — add it as a Claude.ai "
+            "connector (mureo prints the steps). TikTok also documents "
+            "direct registration as a remote HTTP MCP server, which "
+            "advanced users can configure manually. Public beta."
+        ),
+        coexists_with_mureo_platform=None,
+    ),
 )
 
 

--- a/mureo/providers/config_writer.py
+++ b/mureo/providers/config_writer.py
@@ -447,10 +447,14 @@ def hosted_provider_connectivity(spec: ProviderSpec) -> HostedConnectivity:
         return "unknown"  # could not determine — not "not connected"
     if completed.returncode != 0:
         return "unknown"
-    # NOTE: substring match on the endpoint URL. Phase 1 has a single
-    # hosted provider (one Meta endpoint), so prefix collisions
-    # (e.g. ".../ads" vs ".../ads-v2") are not a concern; revisit if a
-    # second hosted endpoint sharing a prefix is ever added.
+    # NOTE: substring match on the endpoint URL. The two hosted providers
+    # (Meta `mcp.facebook.com/ads`, TikTok
+    # `business-api.tiktok.com/open_mcp/tt-ads-mcp-layer`) share no prefix,
+    # so cross-provider collisions are not a concern; revisit if a future
+    # hosted endpoint shares a prefix. Edge case: a user who manually
+    # registers TikTok's alternate `tt-ads-mcp-flat` endpoint (not the
+    # layered one mureo points at) will not match here and reads as
+    # not_connected — mureo only guides users to the layered endpoint.
     for line in completed.stdout.splitlines():
         if url not in line:
             continue

--- a/mureo/web/setup_actions.py
+++ b/mureo/web/setup_actions.py
@@ -76,6 +76,7 @@ _OFFICIAL_PROVIDER_IDS: tuple[str, ...] = (
     "google-ads-official",
     "meta-ads-official",
     "ga4-official",
+    "tiktok-ads-official",
 )
 
 

--- a/mureo/web/status_collector.py
+++ b/mureo/web/status_collector.py
@@ -31,6 +31,7 @@ OFFICIAL_PROVIDER_IDS: tuple[str, ...] = (
     "google-ads-official",
     "meta-ads-official",
     "ga4-official",
+    "tiktok-ads-official",
 )
 
 MUREO_NATIVE_ID = "mureo"

--- a/tests/test_cli_providers.py
+++ b/tests/test_cli_providers.py
@@ -164,6 +164,29 @@ def test_add_meta_dry_run_says_not_registered_connector(home: Path) -> None:
 
 
 @pytest.mark.integration
+def test_add_tiktok_prints_connector_steps_not_meta(home: Path) -> None:
+    """``add tiktok-ads-official``: a hosted provider that does NOT overlap a
+    mureo-native platform. It prints the vendor-neutral Claude.ai connector
+    steps with TikTok's endpoint — never any Meta-specific wording, and with
+    NO native-disable / ``providers confirm`` tail (``coexists`` is None)."""
+    result = _invoke("providers", "add", "tiktok-ads-official")
+    assert result.exit_code == 0, result.output
+
+    mock_run = _get_subprocess_mock()
+    mock_run.assert_not_called()
+
+    combined = (result.output or "") + (result.stderr or "")
+    lowered = combined.lower()
+    assert "connector" in lowered
+    assert "claude.ai" in lowered
+    assert "business-api.tiktok.com/open_mcp/tt-ads-mcp-layer" in combined
+    # No Meta contamination, and no native-coexistence tail (coexists=None).
+    assert "meta" not in lowered
+    assert "facebook" not in lowered
+    assert "providers confirm" not in lowered
+
+
+@pytest.mark.integration
 def test_add_writes_settings_json(home: Path) -> None:
     """``add`` writes ``mcpServers.<id>`` to ``~/.claude.json``."""
     result = _invoke("providers", "add", "google-ads-official")

--- a/tests/test_providers_catalog.py
+++ b/tests/test_providers_catalog.py
@@ -26,7 +26,27 @@ def test_catalog_has_phase1_providers() -> None:
     from mureo.providers.catalog import CATALOG
 
     ids = {spec.id for spec in CATALOG}
-    assert ids == {"google-ads-official", "meta-ads-official", "ga4-official"}
+    assert ids == {
+        "google-ads-official",
+        "meta-ads-official",
+        "ga4-official",
+        "tiktok-ads-official",
+    }
+
+
+@pytest.mark.unit
+def test_official_provider_id_lists_match_catalog() -> None:
+    """The hardcoded ``OFFICIAL_PROVIDER_IDS`` tuples (``status_collector``
+    and ``setup_actions``) must stay in sync with ``CATALOG`` — every
+    catalog entry is an official provider. Guards against silent drift when
+    a provider is added to only one of the three places."""
+    from mureo.providers.catalog import CATALOG
+    from mureo.web.setup_actions import _OFFICIAL_PROVIDER_IDS
+    from mureo.web.status_collector import OFFICIAL_PROVIDER_IDS
+
+    catalog_ids = {spec.id for spec in CATALOG}
+    assert set(OFFICIAL_PROVIDER_IDS) == catalog_ids
+    assert set(_OFFICIAL_PROVIDER_IDS) == catalog_ids
 
 
 @pytest.mark.unit
@@ -124,6 +144,29 @@ def test_required_env_documents_credentials() -> None:
     ga4 = get_provider("ga4-official")
     assert len(ga4.required_env) >= 1
 
+    tiktok = get_provider("tiktok-ads-official")
+    # TikTok uses interactive OAuth — no pre-populated env vars expected.
+    assert tiktok.required_env == ()
+
+
+@pytest.mark.unit
+def test_tiktok_ads_is_hosted_layered_endpoint() -> None:
+    """TikTok's official provider is a hosted HTTP MCP that mureo points at
+    the Progressive Disclosure (layered) endpoint, authenticates via browser
+    OAuth (no env vars), and does NOT overlap a mureo-native platform."""
+    from mureo.providers.catalog import get_provider
+
+    tiktok = get_provider("tiktok-ads-official")
+    assert tiktok.install_kind == "hosted_http"
+    assert tiktok.install_argv == ()
+    assert tiktok.mcp_server_config["type"] == "http"
+    assert (
+        tiktok.mcp_server_config["url"]
+        == "https://business-api.tiktok.com/open_mcp/tt-ads-mcp-layer"
+    )
+    # mureo has no native TikTok platform, so no coexistence toggle applies.
+    assert tiktok.coexists_with_mureo_platform is None
+
 
 @pytest.mark.unit
 def test_google_ads_required_env_is_adc_not_client_library() -> None:
@@ -184,3 +227,6 @@ def test_coexists_with_mureo_platform_correctly_set() -> None:
 
     ga4 = get_provider("ga4-official")
     assert ga4.coexists_with_mureo_platform == "ga4"
+
+    tiktok = get_provider("tiktok-ads-official")
+    assert tiktok.coexists_with_mureo_platform is None

--- a/tests/test_web_provider_host.py
+++ b/tests/test_web_provider_host.py
@@ -9,8 +9,9 @@ Behaviour matrix asserted (RED until the params + Desktop branch exist):
 
 - ``host="claude-code"`` (default, or explicit) → byte-for-byte the
   CURRENT behaviour: ``run_install`` then
-  ``add_provider_and_disable_in_mureo`` (all CATALOG entries coexist)
-  / ``add_provider_to_claude_settings``; the Desktop writer is NOT
+  ``add_provider_and_disable_in_mureo`` (for CATALOG entries that overlap
+  a mureo-native platform) / ``add_provider_to_claude_settings``; the
+  Desktop writer is NOT
   called and ``claude_desktop_config.json`` is never created.
 - ``host="claude-desktop"``:
   - hosted_http (meta-ads-official): ``run_install`` short-circuits
@@ -161,10 +162,11 @@ class TestInstallProviderCodeHostUnchanged:
         self, tmp_path: Path
     ) -> None:
         """No ``host`` arg → today's path: ``run_install`` then
-        ``add_provider_and_disable_in_mureo`` (every CATALOG provider
-        sets ``coexists_with_mureo_platform``). Desktop writer NOT called,
-        Desktop config NOT created. Credentials are present, so native IS
-        disabled (the #102 decision-C gate is satisfied)."""
+        ``add_provider_and_disable_in_mureo`` (the provider under test,
+        google-ads-official, sets ``coexists_with_mureo_platform``).
+        Desktop writer NOT called, Desktop config NOT created. Credentials
+        are present, so native IS disabled (the #102 decision-C gate is
+        satisfied)."""
         from mureo.web import setup_actions
 
         creds = _google_creds(tmp_path)
@@ -1404,7 +1406,10 @@ class TestHostedProviderStatus:
             "mureo.providers.config_writer.is_hosted_provider_connected",
             lambda spec: True,
         )
-        assert setup_actions.hosted_provider_status() == {"meta-ads-official": True}
+        assert setup_actions.hosted_provider_status() == {
+            "meta-ads-official": True,
+            "tiktok-ads-official": True,
+        }
 
     def test_returns_connected_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from mureo.web import setup_actions
@@ -1413,7 +1418,10 @@ class TestHostedProviderStatus:
             "mureo.providers.config_writer.is_hosted_provider_connected",
             lambda spec: False,
         )
-        assert setup_actions.hosted_provider_status() == {"meta-ads-official": False}
+        assert setup_actions.hosted_provider_status() == {
+            "meta-ads-official": False,
+            "tiktok-ads-official": False,
+        }
 
     def test_never_raises_returns_empty_on_error(
         self, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Summary

Adds **TikTok Ads** as an official hosted-MCP provider (`tiktok-ads-official`), modeled on the existing Meta Ads hosted provider. This is **PR-1 (backend)** of a phased rollout.

TikTok's official *"TikTok for Business MCP Server"* (launched at TikTok World '26; docs at `business-api.tiktok.com/portal/docs/tiktok-ads-mcp-server/v1.3`, verified 2026-07-02) is a hosted HTTP MCP. Two endpoints are published:

| Server type | URL | Tools |
|---|---|---|
| Progressive Disclosure (**mureo default**) | `business-api.tiktok.com/open_mcp/tt-ads-mcp-layer` | ~40 core + on-demand |
| Full Disclosure | `business-api.tiktok.com/open_mcp/tt-ads-mcp-flat` | ~400 at connect |

mureo points at the **layered** endpoint to keep the exposed tool surface small. Auth is interactive browser OAuth via a TikTok for Business account on first connect (no developer token / env vars). Read-write across campaign management, reporting, catalogs, creatives, audiences, and Business Center.

## What's in this PR (backend)

- `catalog.py`: new `ProviderSpec` for `tiktok-ads-official` — `install_kind="hosted_http"`, `coexists_with_mureo_platform=None`, `required_env=()`. `coexists=None` (mureo has no native TikTok) routes it through the generic hosted path and skips every native-disable branch — no strand.
- `status_collector.py` / `setup_actions.py`: registered in both `OFFICIAL_PROVIDER_IDS` tuples.
- `providers_cmd.py`: the CLI hosted-auth connector notice was **Meta-hardcoded** (it told any hosted provider to "sign in with Meta Business" and referenced the Meta tool namespace). Now **vendor-neutral / spec-driven** — the native-coexistence tail is emitted only when the provider overlaps a mureo-native platform.
- Tests: drift-guard (`OFFICIAL_PROVIDER_IDS` == catalog ids), TikTok catalog invariants, and a CLI test asserting the notice is TikTok-accurate with no Meta wording. Updated `hosted_provider_status()` dict assertions (now includes both hosted providers).

## Follow-ups (separate PRs)

- **PR-2 (frontend)**: dashboard/wizard rendering + connector guidance i18n strings (en/ja). The connector strings are currently Meta-specific and need parameterization.
- **PR-3 (docs)**: `native-vs-official.md` (+ `.ja`) etc.
- **Live verification (needs a TikTok for Business account)**: whether TikTok's MCP supports OAuth Dynamic Client Registration → direct `claude mcp add`, vs. requiring a Claude.ai custom connector like Meta.

## Known deferred item

`hosted_provider_status()` runs `claude mcp list` once per hosted provider (now 2x serial, up to ~30s worst case). Behavior is unchanged; a single-probe optimization is deferred.

## Test plan

- [x] `test_providers_catalog.py`, `test_cli_providers.py`, `test_web_provider_host.py`, `test_providers_coexistence.py`, `test_web_status_collector.py` — 132 passed locally
- [x] ruff clean on changed code
- [ ] CI green

https://claude.ai/code/session_011rAu94b1o1xWYZhARk1VmL
