### PR TITLE
chore(release): 0.10.15

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mureo",
-  "version": "0.10.14",
+  "version": "0.10.15",
   "description": "Your local-first AI ad ops crew for Google Ads, Meta Ads, Search Console & GA4. mureo sits on top of the official ad-platform MCPs, gates every change against your strategy, correlates outcomes locally, and keeps an auditable decision log — credentials never leave your machine.",
   "author": {
     "name": "Logly Inc.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.15] - 2026-07-03
+
+### Added
+
+- TikTok Ads official hosted MCP provider (`tiktok-ads-official`): a
+  `hosted_http` catalog entry targeting TikTok's official "TikTok for
+  Business MCP Server" Progressive Disclosure endpoint (~40 core tools plus
+  on-demand discovery, chosen over the ~400-tool flat endpoint to keep the
+  exposed surface small). Auth is interactive browser OAuth via a TikTok for
+  Business account on first connect — no developer token or env vars — and it
+  can be set up from both the `mureo configure` dashboard and the setup
+  wizard. TikTok supports OAuth Dynamic Client Registration, so
+  `claude mcp add --transport http` works directly (a claude.ai connector is
+  optional); it has no mureo-native platform, so the native↔official toggle
+  is correctly skipped (#348, #349, #350).
+- OpenAI Codex is now a full `mureo configure` host with parity to Claude
+  Code and Claude Desktop — basic setup, official-provider install/remove,
+  the native↔official disable toggle, status detection, and bulk clear.
+  Codex stores MCP servers in `~/.codex/config.toml`, so mureo manages its
+  own `[mcp_servers.<id>]` blocks as tagged regions (`# >>> mureo-mcp:<id>`
+  … `# <<< <id> <<<`), leaving operator hand-edits and unrelated servers
+  untouched (#346).
+- Web extensions can contribute cards into built-in dashboard groups via an
+  opt-in `dashboard_cards()` method. `DashboardCard` uses the same
+  sanitisation contract as `ViewContribution` (no inline-executable content;
+  behaviour ships as `StaticAsset`s) and is restricted to the fixed
+  `BUILTIN_CARD_GROUPS` allowlist; a headless extension may contribute a card
+  without a view (#351).
+- Plugin (third-party MCP) providers gain an OAuth account picker,
+  multi-account hiding, and a "configured" status indicator in the configure
+  UI (#339).
+- Meta Ads: an operator can declare the canonical conversion event used for
+  conversion counting, so custom conversion setups count against the intended
+  action type (#342).
+
+### Fixed
+
+- Meta Ads conversions are now counted via a canonical exact-match counter,
+  avoiding the over-/under-counting that arose when several related
+  `action_type` rows existed for one account (#340).
+
+### Changed
+
+- Skill docs now mutate STATE.json via the `mureo_state_*` MCP tools on
+  Claude Code (instead of prose that implied direct file edits) (#341).
+- Documentation: the official TikTok Ads MCP provider is now documented as a
+  full integration section, and an "Auth in OpenAI Codex" walkthrough plus a
+  Codex client-config section were added (#352, #347).
+- CI: bump `actions/checkout` from 6 to 7 (#316).
+
 ## [0.10.14] - 2026-06-24
 
 ### Fixed

--- a/mureo/__init__.py
+++ b/mureo/__init__.py
@@ -1,3 +1,3 @@
 """mureo — your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."""
 
-__version__ = "0.10.14"
+__version__ = "0.10.15"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mureo"
-version = "0.10.14"
+version = "0.10.15"
 description = "Your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."
 requires-python = ">=3.10"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Release **0.10.15**. Bumps the version across `pyproject.toml` / `mureo/__init__.py` / `.claude-plugin/plugin.json` and adds the CHANGELOG entry covering the 9 PRs merged since v0.10.14 (2026-06-24).

### Highlights
- **TikTok Ads official hosted MCP provider** (`tiktok-ads-official`) — catalog + dashboard + setup wizard + docs (#348, #349, #350, #352)
- **OpenAI Codex as a full `mureo configure` host** — parity with Claude Code / Desktop, `~/.codex/config.toml` tagged regions (#346, #347)
- **Web extensions can contribute dashboard cards** via opt-in `dashboard_cards()` (#351)
- **Plugin OAuth account picker / multi-account hide / configured status** (#339)
- **Meta Ads**: operator-specified canonical conversion event (#342) + exact-match conversion counter fix (#340)
- Skill docs use `mureo_state_*` MCP tools for STATE.json mutations (#341); CI bumps `actions/checkout` 6→7 (#316)

## Test plan
- [ ] CI green (lint, mypy, tests 3.10–3.12, windows, CodeQL)
- [ ] Version parity test passes (all three files at 0.10.15)

_Release (tag / GitHub Release / PyPI) is intentionally held until this merges and is separately approved._

https://claude.ai/code/session_011rAu94b1o1xWYZhARk1VmL
