### PR TITLE
fix: batch of audit findings (2 CRITICAL, 6 HIGH, + MEDIUM/LOW)

### DIFF
--- a/mureo/_data/web/auth_wizards.js
+++ b/mureo/_data/web/auth_wizards.js
@@ -136,7 +136,12 @@
           ? res.body.detail || res.body.status
           : "request_failed";
         status.hidden = false;
-        status.textContent = tmpl.replace("{detail}", detail);
+        // Replacement via a function so a server-derived detail containing
+        // "$" sequences (e.g. "$&", "$1") is inserted literally rather than
+        // triggering String.replace's special-pattern substitution.
+        status.textContent = tmpl.replace("{detail}", function () {
+          return detail;
+        });
       }
       retryBtn.disabled = false;
     });
@@ -439,7 +444,12 @@
       statusLine.hidden = true;
       function fail(detail) {
         const tmpl = MUREO.t("wizard.providers_install.failed");
-        const msg = tmpl.replace("{detail}", detail || "unknown");
+        // Function replacement so a "$"-containing detail is inserted
+        // literally (see the note at the providers-install failure path).
+        const safeDetail = detail || "unknown";
+        const msg = tmpl.replace("{detail}", function () {
+          return safeDetail;
+        });
         statusLine.hidden = false;
         statusLine.textContent = msg;
         MUREO.toast(msg);
@@ -775,7 +785,7 @@
         );
         if (res.ok && res.body && res.body.url) {
           window.open(res.body.url, "_blank", "noopener");
-          pollOAuth(slot.oauthProvider, status, function () {
+          pollOAuth(slot.oauthProvider, status, btn, function () {
             // Auto-advance: intermediate slots roll to the next slot;
             // the final slot hands control back to the outer wizard.
             onAllDone();
@@ -796,10 +806,21 @@
     return wrap;
   }
 
-  function pollOAuth(provider, statusNode, onFinished) {
+  function pollOAuth(provider, statusNode, btn, onFinished) {
+    // Bounded poll (mirrors dashboard.js pollPluginOAuth): without a deadline
+    // the loop re-arms forever if the operator closes the consent tab, and the
+    // Connect button stays disabled until a full page reload. On timeout we
+    // re-enable the button and clear the status so the flow can be retried.
+    const deadline = Date.now() + 5 * 60 * 1000;
     let cancelled = false;
     function tick() {
       if (cancelled) return;
+      if (Date.now() > deadline) {
+        cancelled = true;
+        statusNode.textContent = "";
+        if (btn) btn.disabled = false;
+        return;
+      }
       fetch("/api/oauth/" + provider + "/status")
         .then(function (r) { return r.json(); })
         .then(function (data) {
@@ -812,6 +833,7 @@
             statusNode.textContent = msg;
             MUREO.toast(msg, "error");
             cancelled = true;
+            if (btn) btn.disabled = false;
           } else {
             setTimeout(tick, 750);
           }

--- a/mureo/_data/web/dashboard.js
+++ b/mureo/_data/web/dashboard.js
@@ -180,7 +180,13 @@
       if (!confirmed) return;
       let res;
       try {
-        res = await MUREO.postJson(row.removeUrl, {});
+        // Send the client's known host so the server self-heals a session
+        // whose host reset to the claude-code default after a daemon restart
+        // (see handlers._resolve_host); otherwise the removal could target
+        // the wrong host's config.
+        res = await MUREO.postJson(row.removeUrl, {
+          host: MUREO.state.status && MUREO.state.status.host,
+        });
       } catch (_err) {
         MUREO.toast(MUREO.t("dashboard.remove_failed"), "error");
         return;
@@ -473,7 +479,11 @@
     if (!ok2) return;
     let res;
     try {
-      res = await MUREO.postJson("/api/setup/basic/clear", {});
+      // Send the client's known host so the server self-heals a stale/reset
+      // session host (see handlers._resolve_host).
+      res = await MUREO.postJson("/api/setup/basic/clear", {
+        host: MUREO.state.status && MUREO.state.status.host,
+      });
     } catch (_err) {
       MUREO.toast(MUREO.t("dashboard.remove_failed"), "error");
       return;

--- a/mureo/adapters/google_ads/adapter.py
+++ b/mureo/adapters/google_ads/adapter.py
@@ -198,6 +198,13 @@ class GoogleAdsAdapter:
         ``asyncio.run`` raises ``RuntimeError`` when called from inside a
         running loop — that is the documented Phase 1 behaviour for
         async callers and is allowed to propagate.
+
+        HAZARD when wiring this adapter to a client that holds a persistent
+        connection/loop-bound resource: ``asyncio.run`` opens and closes a new
+        loop per call, so a method issuing two ``_run`` calls could reuse a
+        resource bound to the first, now-closed loop. Latent today (no
+        production code instantiates this adapter with a real client). See the
+        fuller note on ``MetaAdsAdapter._run``.
         """
         return asyncio.run(coro)  # type: ignore[arg-type]
 

--- a/mureo/adapters/meta_ads/adapter.py
+++ b/mureo/adapters/meta_ads/adapter.py
@@ -197,6 +197,17 @@ class MetaAdsAdapter:
         ``asyncio.run`` raises :class:`RuntimeError` when called from
         inside a running loop — that is the documented Phase 1 behaviour
         for async callers and is allowed to propagate.
+
+        HAZARD when wiring this adapter to a REAL ``MetaAdsApiClient``:
+        ``asyncio.run`` opens and closes a NEW event loop per call, but the
+        client holds one persistent ``httpx.AsyncClient`` created in
+        ``__init__``. A method that makes two ``_run`` calls (e.g.
+        ``create_campaign`` = create POST then refresh GET) would reuse a
+        pooled connection bound to the first, now-closed loop on the second
+        call → ``RuntimeError: Event loop is closed``. This is currently
+        latent (no production code instantiates ``MetaAdsAdapter`` with a real
+        client). Before wiring one up, either drive the client on a single
+        shared loop or give it a per-call ``httpx.AsyncClient``.
         """
         return asyncio.run(coro)  # type: ignore[arg-type]
 

--- a/mureo/analysis/lp_analyzer.py
+++ b/mureo/analysis/lp_analyzer.py
@@ -65,6 +65,11 @@ _EXCLUDE_TAGS = frozenset({"script", "style", "nav", "footer", "header", "noscri
 # SSRF protection: allowed URL schemes
 _ALLOWED_SCHEMES = frozenset({"http", "https"})
 
+# SSRF protection: max redirect hops. Each hop is validated BEFORE it is
+# followed (we do not let httpx auto-follow), so a public URL cannot bounce the
+# fetch to an internal host.
+_MAX_REDIRECTS = 5
+
 # SSRF protection: blocked hostnames
 _BLOCKED_HOSTS = frozenset(
     {
@@ -185,26 +190,44 @@ class LPAnalyzer:
                 pass  # DNS resolution failure will error at HTTP request time
 
     async def _fetch_html(self, url: str) -> str:
-        """Fetch HTML via HTTP."""
+        """Fetch HTML via HTTP, validating every redirect hop for SSRF.
+
+        Redirects are followed MANUALLY (``follow_redirects=False``) so each
+        ``Location`` is run through :meth:`_validate_url` *before* the next
+        request is issued. Letting httpx auto-follow would fetch an
+        intermediate hop pointing at an internal host (e.g. 169.254.169.254)
+        before the destination could be re-validated — a blind-SSRF gap. A
+        residual DNS-rebinding TOCTOU remains (httpx re-resolves the validated
+        hostname), acceptable for this read-only analyzer.
+        """
         self._validate_url(url)
         async with httpx.AsyncClient(
             timeout=_TIMEOUT_SECONDS,
-            follow_redirects=True,
-            max_redirects=5,
+            follow_redirects=False,
             headers={"User-Agent": _USER_AGENT},
         ) as client:
-            response = await client.get(url)
-            # Validate redirect destination for SSRF
-            final_url = str(response.url)
-            if final_url != url:
-                self._validate_url(final_url)
-            response.raise_for_status()
-            # Size limit
-            if len(response.content) > _MAX_BODY_BYTES:
-                return response.content[:_MAX_BODY_BYTES].decode(
-                    response.encoding or "utf-8", errors="replace"
-                )
-            return response.text
+            current_url = url
+            for _ in range(_MAX_REDIRECTS + 1):
+                response = await client.get(current_url)
+                # has_redirect_location (not is_redirect) is True only for a 3xx
+                # that actually carries a Location — so a 304/300 without one is
+                # treated as a terminal response rather than a phantom redirect.
+                if response.has_redirect_location:
+                    location = response.headers["location"]
+                    # Resolve a possibly-relative Location against the current
+                    # URL, then validate BEFORE following it.
+                    next_url = str(httpx.URL(current_url).join(location))
+                    self._validate_url(next_url)
+                    current_url = next_url
+                    continue
+                response.raise_for_status()
+                # Size limit
+                if len(response.content) > _MAX_BODY_BYTES:
+                    return response.content[:_MAX_BODY_BYTES].decode(
+                        response.encoding or "utf-8", errors="replace"
+                    )
+                return response.text
+            raise ValueError(f"Too many redirects (>{_MAX_REDIRECTS}) fetching {url}")
 
     def _parse_html(self, url: str, html: str) -> LPContent:
         """Parse HTML and build an LPContent."""

--- a/mureo/analytics/builtin/_live_clients.py
+++ b/mureo/analytics/builtin/_live_clients.py
@@ -55,13 +55,18 @@ class NoCredentialsError(RuntimeError):
 # Google Ads
 # ---------------------------------------------------------------------------
 
-_GOOGLE_PERIOD_MAP: dict[int, tuple[str, str]] = {
-    # window_days -> (current period token, baseline period token).
-    # Tokens passed to GoogleAdsApiClient.get_performance_report —
-    # see mureo/google_ads/_analysis_constants.py _PERIOD_DAYS.
-    7: ("LAST_7_DAYS", "LAST_30_DAYS"),
-    14: ("LAST_14_DAYS", "LAST_30_DAYS"),
-    30: ("LAST_30_DAYS", "LAST_30_DAYS"),
+_GOOGLE_WINDOW_TO_PERIOD: dict[int, str] = {
+    # window_days -> Google date-range constant. The baseline is derived as the
+    # equal-length window immediately *before* this one via
+    # ``_get_comparison_date_ranges`` — NOT a preset such as LAST_30_DAYS, which
+    # overlaps (7d ⊂ 30d) or, for the 30d case, is literally identical to the
+    # current window (baseline == current → ratio always 1.0 → no anomaly can
+    # fire). Same non-overlapping period-over-period contract the rest of the
+    # analysis layer uses (google_ads/_analysis_constants,
+    # meta_ads/_period, #134).
+    7: "LAST_7_DAYS",
+    14: "LAST_14_DAYS",
+    30: "LAST_30_DAYS",
 }
 
 
@@ -142,9 +147,15 @@ async def fetch_google_ads_metrics(
     """
     client = _open_google_ads_client(account_id)
 
-    current_period, baseline_period = _GOOGLE_PERIOD_MAP.get(
-        window_days, ("LAST_7_DAYS", "LAST_30_DAYS")
-    )
+    # Local import defers the google_ads analysis module until first use (the
+    # registry import must stay cheap; see the module docstring).
+    from mureo.google_ads._analysis_constants import _get_comparison_date_ranges
+
+    period_token = _GOOGLE_WINDOW_TO_PERIOD.get(window_days, "LAST_7_DAYS")
+    # Non-overlapping, equal-length current/previous BETWEEN clauses. The Google
+    # client's _period_to_date_clause accepts a BETWEEN clause and validates it
+    # against the GAQL whitelist, so this is injection-safe.
+    current_period, baseline_period = _get_comparison_date_ranges(period_token)
     current_rows = await client.get_performance_report(  # type: ignore[attr-defined]
         period=current_period
     )
@@ -269,9 +280,10 @@ async def fetch_google_ads_per_campaign_metrics(
     :func:`fetch_google_ads_metrics`.
     """
     client = _open_google_ads_client(account_id)
-    current_period, baseline_period = _GOOGLE_PERIOD_MAP.get(
-        window_days, ("LAST_7_DAYS", "LAST_30_DAYS")
-    )
+    from mureo.google_ads._analysis_constants import _get_comparison_date_ranges
+
+    period_token = _GOOGLE_WINDOW_TO_PERIOD.get(window_days, "LAST_7_DAYS")
+    current_period, baseline_period = _get_comparison_date_ranges(period_token)
     current_rows = await client.get_performance_report(  # type: ignore[attr-defined]
         period=current_period
     )
@@ -359,9 +371,10 @@ async def fetch_meta_ads_per_campaign_metrics(
     :func:`fetch_google_ads_per_campaign_metrics`.
     """
     client = _open_meta_ads_client(account_id)
-    current_period, baseline_period = _META_PERIOD_MAP.get(
-        window_days, ("last_7d", "last_30d")
-    )
+    from mureo.meta_ads._period import previous_period
+
+    current_period = _META_WINDOW_TO_PERIOD.get(window_days, "last_7d")
+    baseline_period = previous_period(current_period)
     current_rows = await client.get_performance_report(  # type: ignore[attr-defined]
         period=current_period
     )
@@ -385,13 +398,15 @@ async def fetch_meta_ads_per_campaign_metrics(
 # Meta Ads
 # ---------------------------------------------------------------------------
 
-_META_PERIOD_MAP: dict[int, tuple[str, str]] = {
-    # window_days -> (current period preset, baseline period preset).
-    # Tokens passed to MetaAdsApiClient.get_performance_report —
-    # see mureo/meta_ads/_period.py for supported presets.
-    7: ("last_7d", "last_30d"),
-    14: ("last_14d", "last_30d"),
-    30: ("last_30d", "last_30d"),
+_META_WINDOW_TO_PERIOD: dict[int, str] = {
+    # window_days -> Meta date preset. The baseline is derived from
+    # meta_ads._period.previous_period (the equal-length window immediately
+    # before this one), NOT last_30d — which overlaps last_7d/last_14d and is
+    # identical to last_30d for the 30d case, making the anomaly ratio a
+    # meaningless 1.0. This is exactly the #134 fix applied to the anomaly path.
+    7: "last_7d",
+    14: "last_14d",
+    30: "last_30d",
 }
 
 
@@ -450,10 +465,10 @@ async def fetch_meta_ads_metrics(
     documented on :func:`fetch_google_ads_metrics`.
     """
     client = _open_meta_ads_client(account_id)
+    from mureo.meta_ads._period import previous_period
 
-    current_period, baseline_period = _META_PERIOD_MAP.get(
-        window_days, ("last_7d", "last_30d")
-    )
+    current_period = _META_WINDOW_TO_PERIOD.get(window_days, "last_7d")
+    baseline_period = previous_period(current_period)
     current_rows = await client.get_performance_report(  # type: ignore[attr-defined]
         period=current_period
     )

--- a/mureo/auth.py
+++ b/mureo/auth.py
@@ -7,11 +7,9 @@ Falls back to environment variables if the file does not exist.
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import json
 import logging
 import os
-import tempfile
 from dataclasses import dataclass, replace
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -21,7 +19,6 @@ import httpx
 from google.oauth2.credentials import Credentials
 
 from mureo.core.secret_store import FilesystemSecretStore, SecretStore
-from mureo.fsutil import secure_fchmod
 from mureo.google_ads import GoogleAdsApiClient
 from mureo.meta_ads import MetaAdsApiClient
 from mureo.search_console import SearchConsoleApiClient
@@ -321,8 +318,18 @@ async def refresh_meta_token_if_needed(
         try:
             _save_meta_token(resolved, new_token, new_obtained_at)
         except Exception:
+            # The refreshed token works for THIS process (returned below) but is
+            # not on disk, so every future process re-refreshes from the aging
+            # stored token. If the underlying cause (read-only mount, bad perms,
+            # corrupt credentials.json) persists past the token's ~60-day life,
+            # Meta calls will start failing with an expired-token error that
+            # looks unrelated. Surface an actionable warning rather than a bare
+            # "failed to save".
             logger.warning(
-                "Failed to save refreshed Meta Ads token to %s",
+                "Meta Ads token was refreshed but could NOT be persisted to %s "
+                "— the new token is used for this session only. Check the file's "
+                "permissions/JSON validity and re-run `mureo auth setup` if Meta "
+                "tools later report an expired token.",
                 resolved,
                 exc_info=True,
             )
@@ -391,20 +398,22 @@ def _save_meta_token(
     new_token: str,
     new_obtained_at: str,
 ) -> None:
-    """Atomically update meta_ads token in credentials.json.
+    """Atomically update the meta_ads token in credentials.json.
 
-    Reads the current file, updates the meta_ads section, and writes back
-    using a temp file + os.replace for atomicity.
+    Reuses the hardened ``config_writer`` helpers rather than a local
+    read-modify-write: ``_load_existing`` returns ``{}`` only when the file is
+    absent and RAISES ``ConfigWriteError`` on malformed JSON — instead of the
+    old ``data = {}`` reset that silently erased every other provider's
+    credentials (google_ads etc.) on a slightly-corrupt file. On that raise the
+    caller (:func:`refresh_meta_token_if_needed`) skips the save and warns,
+    leaving the file intact. ``_atomic_write_json`` writes via tmp + fsync +
+    ``os.replace`` at ``0o600`` so a crash mid-write is durable and safe.
     """
-    data: dict[str, Any] = {}
-    if path.exists():
-        try:
-            data = json.loads(path.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError):
-            data = {}
+    # Lazy import mirrors ``auth_setup.save_credentials`` and avoids any
+    # import-time coupling to the providers package.
+    from mureo.providers.config_writer import _atomic_write_json, _load_existing
 
-    if not isinstance(data, dict):
-        data = {}
+    data = _load_existing(path)
 
     meta_section = data.get("meta_ads", {})
     if not isinstance(meta_section, dict):
@@ -414,18 +423,7 @@ def _save_meta_token(
     meta_section["token_obtained_at"] = new_obtained_at
     data["meta_ads"] = meta_section
 
-    content = json.dumps(data, indent=2, ensure_ascii=False)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    fd, tmp_path = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
-    secure_fchmod(fd)
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            f.write(content)
-        os.replace(tmp_path, path)
-    except BaseException:
-        with contextlib.suppress(OSError):
-            os.unlink(tmp_path)
-        raise
+    _atomic_write_json(data, path)
 
 
 # ---------------------------------------------------------------------------

--- a/mureo/auth_setup.py
+++ b/mureo/auth_setup.py
@@ -25,6 +25,7 @@ try:
 except ImportError:  # pragma: no cover - Windows (Unix-only stdlib)
     termios = None  # type: ignore[assignment]
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -797,6 +798,8 @@ def save_credentials(
 
     # Merge Google Ads credentials
     if google is not None:
+        prior_google = existing.get("google_ads")
+        prior_google = prior_google if isinstance(prior_google, dict) else {}
         google_data: dict[str, Any] = {
             "developer_token": google.developer_token,
             "client_id": google.client_id,
@@ -807,15 +810,25 @@ def save_credentials(
         # otherwise the account itself)
         google_data["login_customer_id"] = google.login_customer_id
         # customer_id: the account that operations target. Falls back to
-        # login_customer_id when not explicitly specified.
-        target_cid = customer_id or google.customer_id or google.login_customer_id
+        # login_customer_id when not explicitly specified, and finally to any
+        # previously-saved customer_id so a re-auth whose account listing
+        # transiently failed does not wipe the operator's prior selection.
+        target_cid = (
+            customer_id
+            or google.customer_id
+            or google.login_customer_id
+            or prior_google.get("customer_id")
+        )
         google_data["customer_id"] = target_cid
         existing["google_ads"] = google_data
 
     # Merge Meta Ads credentials
     if meta is not None:
+        prior_meta = existing.get("meta_ads")
+        prior_meta = prior_meta if isinstance(prior_meta, dict) else {}
+        access_token = getattr(meta, "access_token", "")
         meta_data: dict[str, Any] = {
-            "access_token": getattr(meta, "access_token", ""),
+            "access_token": access_token,
         }
         app_id = getattr(meta, "app_id", None)
         if app_id is not None:
@@ -823,8 +836,34 @@ def save_credentials(
         app_secret = getattr(meta, "app_secret", None)
         if app_secret is not None:
             meta_data["app_secret"] = app_secret
+        # Preserve a previously-saved account_id when this call couldn't
+        # resolve one (e.g. the account listing failed): the whole meta_ads
+        # section is replaced below, so without this a transient failure would
+        # silently drop the operator's prior selection.
         if account_id is not None:
             meta_data["account_id"] = account_id
+        elif prior_meta.get("account_id"):
+            meta_data["account_id"] = prior_meta["account_id"]
+        # Record when this token was obtained so the background 53-day refresh
+        # (auth.refresh_meta_token_if_needed) can actually fire. Without a
+        # persisted token_obtained_at, _should_refresh always returns False and
+        # the long-lived token silently expires at ~60 days. Prefer an explicit
+        # timestamp on the credentials object; keep the prior timestamp when the
+        # token is unchanged (a metadata-only re-save must not reset the clock);
+        # otherwise stamp now for a new/changed token.
+        obtained_at = getattr(meta, "token_obtained_at", None)
+        if obtained_at:
+            meta_data["token_obtained_at"] = obtained_at
+        elif access_token and access_token == prior_meta.get("access_token"):
+            prior_ts = prior_meta.get("token_obtained_at")
+            if prior_ts:
+                meta_data["token_obtained_at"] = prior_ts
+            else:
+                meta_data["token_obtained_at"] = datetime.now(
+                    tz=timezone.utc
+                ).isoformat()
+        elif access_token:
+            meta_data["token_obtained_at"] = datetime.now(tz=timezone.utc).isoformat()
         existing["meta_ads"] = meta_data
 
     # Keep a .bak of the prior good file, then write atomically. The atomic

--- a/mureo/byod/adapters/meta_ads.py
+++ b/mureo/byod/adapters/meta_ads.py
@@ -824,6 +824,15 @@ class MetaAdsAdapter:
                 # for the v1 BYOD path. (The export with both rollup
                 # AND breakdown rows takes the rollup-row branch above
                 # via has_non_demo and skips this fallback.)
+                # KNOWN LIMITATION: if a breakdown-ONLY export carries two or
+                # more distinct breakdown dimensions as separate row groups for
+                # the same (day, campaign) — e.g. Age rows AND Gender rows with
+                # no totals row — each group independently covers the full
+                # spend, so cost/clicks/conv are summed once per dimension and
+                # over-count. Deduplicating by dimension requires per-row
+                # dimension detection not modelled here; documented rather than
+                # silently mis-aggregated. Single-dimension exports (the common
+                # case) are correct.
                 if (day, cid) not in has_non_demo:
                     fb = metrics_agg.setdefault(
                         (day, cid),
@@ -1250,12 +1259,32 @@ def _to_float(value: str) -> float:
     s = (value or "").strip()
     if not s:
         return 0.0
-    s = s.replace(",", "")
-    # Strip a leading currency symbol from the known set. We do not
-    # strip arbitrary non-numeric leads because that would silently
-    # accept corrupted cells like "abc123" as 123.
+    # Strip a leading OR trailing currency symbol from the known set. Some
+    # locales place the symbol after the number (e.g. "1.234,56 €"); we do not
+    # strip arbitrary non-currency leads because that would silently accept
+    # corrupted cells like "abc123" as 123.
     if s and s[0] in _CURRENCY_SYMBOLS:
-        s = s[1:]
+        s = s[1:].strip()
+    if s and s[-1] in _CURRENCY_SYMBOLS:
+        s = s[:-1].strip()
+    if not s:
+        return 0.0
+    has_dot = "." in s
+    has_comma = "," in s
+    if has_dot and has_comma:
+        # Mixed grouping + decimal: the RIGHTMOST separator is the decimal
+        # point. Handles both "1,234.56" (US) and "1.234,56" (de_DE/es_ES/
+        # pt_BR/fr_FR); the other separator is thousands and is removed.
+        if s.rfind(",") > s.rfind("."):
+            s = s.replace(".", "").replace(",", ".")
+        else:
+            s = s.replace(",", "")
+    else:
+        # A single separator kind keeps the historical US/JP assumption: a
+        # comma is a thousands separator (removed); a lone dot is the decimal
+        # point. (A comma-decimal locale WITHOUT a thousands dot, e.g. a bare
+        # "12,5", stays ambiguous and is out of scope.)
+        s = s.replace(",", "")
     try:
         return float(s)
     except ValueError:

--- a/mureo/cli/setup_codex.py
+++ b/mureo/cli/setup_codex.py
@@ -33,6 +33,7 @@ import json
 import logging
 import os
 import shutil
+import sys
 import tempfile
 from pathlib import Path
 from typing import Any
@@ -43,17 +44,33 @@ logger = logging.getLogger(__name__)
 
 
 def _atomic_write_text(path: Path, content: str) -> None:
-    """Write ``content`` to ``path`` atomically (temp file + rename).
+    """Write ``content`` to ``path`` atomically and durably (temp + fsync +
+    rename).
 
     A crash mid-write leaves the original file intact, so the tag-based
-    idempotency check cannot be defeated by half-written output.
+    idempotency check cannot be defeated by half-written output. fsync before
+    the rename (and a best-effort directory fsync after) so a power loss just
+    after ``os.replace`` cannot leave a zero-length config.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp_path = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
         os.replace(tmp_path, path)
+        try:
+            dir_fd = os.open(str(path.parent), os.O_RDONLY)
+        except OSError:
+            dir_fd = None
+        if dir_fd is not None:
+            try:
+                os.fsync(dir_fd)
+            except OSError:
+                pass
+            finally:
+                os.close(dir_fd)
     except BaseException:
         with contextlib.suppress(OSError):
             os.unlink(tmp_path)
@@ -68,9 +85,15 @@ def _atomic_write_text(path: Path, content: str) -> None:
 _MCP_TAG = "[mureo-mcp-config]"
 _GUARD_TAG = "[mureo-credential-guard]"
 
+# Use the interpreter running `mureo setup codex` (sys.executable), the env
+# where mureo IS installed — a bare "python" resolves to a system Python that
+# may not have mureo installed (or not exist at all on modern macOS/Linux that
+# ship only python3), so the mureo MCP would silently fail to start. Mirrors
+# the Claude Code fix in auth_setup._MCP_SERVER_CONFIG. json.dumps yields a
+# TOML-safe basic string (correct quoting/backslash escaping on Windows paths).
 _MCP_CONFIG_BLOCK = f"""# >>> {_MCP_TAG} >>>
 [mcp_servers.mureo]
-command = "python"
+command = {json.dumps(sys.executable)}
 args = ["-m", "mureo.mcp"]
 # <<< {_MCP_TAG} <<<
 """

--- a/mureo/cli/setup_gemini.py
+++ b/mureo/cli/setup_gemini.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 import logging
+import sys
 from importlib import metadata
 from pathlib import Path
 from typing import Any
@@ -89,7 +90,10 @@ def install_gemini_extension() -> Path:
     mcp_servers: dict[str, Any] = (
         mcp_servers_raw if isinstance(mcp_servers_raw, dict) else {}
     )
-    mcp_servers["mureo"] = {"command": "python", "args": ["-m", "mureo.mcp"]}
+    # sys.executable (not a bare "python") is the interpreter where mureo is
+    # installed; a bare "python" may be missing or lack mureo, so the MCP would
+    # silently fail to start. Mirrors auth_setup._MCP_SERVER_CONFIG.
+    mcp_servers["mureo"] = {"command": sys.executable, "args": ["-m", "mureo.mcp"]}
     existing["mcpServers"] = mcp_servers
 
     manifest.write_text(

--- a/mureo/context/state.py
+++ b/mureo/context/state.py
@@ -310,17 +310,40 @@ def _snapshot_to_dict(c: CampaignSnapshot) -> dict[str, Any]:
 
 
 def _atomic_write(path: Path, content: str) -> None:
-    """Atomically write a file (temp file -> rename)."""
+    """Atomically and durably write a file (temp file -> fsync -> rename).
+
+    fsync the data before the rename so a crash/power loss just after
+    ``os.replace`` cannot leave STATE.json as a zero-length/partial file (which
+    would lose campaign history / action_log). Best-effort directory fsync makes
+    the rename itself durable on POSIX.
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp_path = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
         os.replace(tmp_path, path)
+        _fsync_dir(path.parent)
     except BaseException:
         with contextlib.suppress(OSError):
             os.unlink(tmp_path)
         raise
+
+
+def _fsync_dir(parent: Path) -> None:
+    """Best-effort fsync of ``parent`` so a rename is durable (POSIX-only)."""
+    try:
+        dir_fd = os.open(str(parent), os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(dir_fd)
+    except OSError:
+        pass
+    finally:
+        os.close(dir_fd)
 
 
 def read_state_file(path: Path, *, strict: bool = True) -> StateDocument:

--- a/mureo/core/secret_store.py
+++ b/mureo/core/secret_store.py
@@ -7,12 +7,16 @@ can swap the underlying storage without touching the rest of mureo.
 
 ``FilesystemSecretStore`` is the default implementation. It is
 behaviourally equivalent to the legacy ``~/.mureo/credentials.json``
-flow read by :func:`mureo.auth.load_credentials`: missing or corrupt
-files yield an empty result rather than raising; the on-disk root must
-be a JSON object keyed by platform name; saves preserve unrelated
-platform keys; saves land at ``0o600`` on POSIX so credential files
-stay owner-readable (via :func:`mureo.fsutil.secure_fchmod`, the
-cross-platform helper used elsewhere in the repo).
+flow read by :func:`mureo.auth.load_credentials`: on READS, missing or
+corrupt files yield an empty result rather than raising. On WRITES,
+however, an existing-but-corrupt file is backed up and the save is
+refused (:class:`SecretStoreError`) rather than silently reset to ``{}``
+— otherwise saving one provider would drop every other provider's
+credentials. The on-disk root must be a JSON object keyed by platform
+name; saves preserve unrelated platform keys; saves land at ``0o600`` on
+POSIX so credential files stay owner-readable (via
+:func:`mureo.fsutil.secure_fchmod`, the cross-platform helper used
+elsewhere in the repo).
 
 This default is **single-writer**. Concurrent writes from different
 processes can lose updates because the read-modify-write inside
@@ -32,9 +36,21 @@ import tempfile
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
-from mureo.fsutil import secure_fchmod
+from mureo.fsutil import backup_file, secure_fchmod
 
 logger = logging.getLogger(__name__)
+
+
+class SecretStoreError(Exception):
+    """Raised when a write would clobber an existing but unreadable/malformed
+    credentials file.
+
+    Reads stay tolerant (missing/corrupt → empty), but a *save* or *delete*
+    must not silently reset a corrupt file to ``{}`` and drop every other
+    provider's credentials — the same data-loss class fixed for the env-var and
+    Meta-token writers (#276). The corrupt file is backed up before the error is
+    raised so the operator can recover it.
+    """
 
 
 @runtime_checkable
@@ -131,12 +147,14 @@ class FilesystemSecretStore:
         return dict(value) if isinstance(value, dict) else {}
 
     def save(self, key: str, value: dict[str, Any]) -> None:
-        data = self._read_root()
+        # Strict read: refuse to overwrite a corrupt file (which would drop
+        # every other provider's credentials); back it up + raise instead.
+        data = self._read_root(strict=True)
         data[key] = dict(value)  # defensive copy of caller's input
         self._write_root(data)
 
     def delete(self, key: str) -> None:
-        data = self._read_root()
+        data = self._read_root(strict=True)
         if key in data:
             del data[key]
             self._write_root(data)
@@ -163,9 +181,17 @@ class FilesystemSecretStore:
 
     # ------------------------------------------------------------------
 
-    def _read_root(self) -> dict[str, Any]:
-        """Return the file's root object, tolerating every reasonable
-        failure mode (missing, unreadable, malformed, wrong type)."""
+    def _read_root(self, *, strict: bool = False) -> dict[str, Any]:
+        """Return the file's root object.
+
+        Non-strict (reads): tolerate every reasonable failure mode (missing,
+        unreadable, malformed, wrong type) by returning ``{}``.
+
+        Strict (writes): a genuinely absent file is still ``{}`` (a first
+        write), but an existing-yet-unreadable/malformed/non-object file backs
+        itself up and raises :class:`SecretStoreError` — overwriting it would
+        silently drop every other provider's credentials.
+        """
         if not self.path.exists():
             logger.debug("credentials file not found: %s", self.path)
             return {}
@@ -173,12 +199,36 @@ class FilesystemSecretStore:
             text = self.path.read_text(encoding="utf-8")
             data = json.loads(text)
         except (json.JSONDecodeError, OSError) as exc:
+            if strict:
+                self._backup_corrupt("unreadable or malformed JSON")
+                raise SecretStoreError(
+                    f"refusing to overwrite unreadable credentials file "
+                    f"{self.path} ({exc}); a .bak copy was kept"
+                ) from exc
             logger.warning("failed to read credentials file: %s", exc)
             return {}
         if not isinstance(data, dict):
+            # A valid-JSON but non-object root (e.g. a stray list) holds no
+            # provider entries, so replacing it loses nothing — stay tolerant
+            # even on writes. Only genuinely unreadable/malformed files (the
+            # branch above, which may have held real credentials) are refused.
             logger.warning("credentials file root is not an object: %s", self.path)
             return {}
         return data
+
+    def _backup_corrupt(self, reason: str) -> None:
+        """Best-effort backup of a corrupt file before a refused overwrite."""
+        try:
+            backup = backup_file(self.path)
+        except OSError:
+            logger.warning("could not back up corrupt credentials file %s", self.path)
+            return
+        logger.warning(
+            "credentials file %s is corrupt (%s); backed up to %s",
+            self.path,
+            reason,
+            backup,
+        )
 
     def _write_root(self, data: dict[str, Any]) -> None:
         """Atomically write the root object and apply secure permissions.

--- a/mureo/core/url_guard.py
+++ b/mureo/core/url_guard.py
@@ -41,7 +41,7 @@ class UnsafeUrlError(ValueError):
     """Raised when a URL targets an internal/blocked network location."""
 
 
-def _is_internal_ip(ip: ipaddress._BaseAddress) -> bool:
+def _is_internal_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
     return bool(
         ip.is_private
         or ip.is_loopback

--- a/mureo/core/url_guard.py
+++ b/mureo/core/url_guard.py
@@ -1,0 +1,98 @@
+"""Shared SSRF guard for outbound fetches of caller-supplied URLs.
+
+mureo fetches a few URLs that originate from LLM/MCP tool arguments or from
+untrusted content the agent already processed (landing-page text, ad data):
+the LP analyzer (``analysis.lp_analyzer``) and the Meta ad-image uploader
+(``meta_ads._creatives``). Both must refuse to fetch internal/loopback/
+link-local/cloud-metadata targets so a prompt-injection payload cannot turn a
+fetch into an internal read (e.g. ``http://169.254.169.254/...`` for cloud IAM
+credentials).
+
+This module is the single source of truth for that check. It validates the
+scheme, a denylist of obvious internal hostnames, and — for both literal IPs
+and DNS names — the resolved address ranges.
+
+Note: a DNS-rebinding TOCTOU remains possible because the actual HTTP client
+re-resolves the hostname when it connects. Callers that follow redirects must
+re-validate every hop with :func:`validate_public_url` before following it.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+_ALLOWED_SCHEMES = frozenset({"http", "https"})
+
+_BLOCKED_HOSTS = frozenset(
+    {
+        "localhost",
+        "127.0.0.1",
+        "0.0.0.0",  # nosec B104
+        "::1",
+        "169.254.169.254",  # Cloud metadata service (AWS/GCP/Azure)
+        "metadata.google.internal",
+    }
+)
+
+
+class UnsafeUrlError(ValueError):
+    """Raised when a URL targets an internal/blocked network location."""
+
+
+def _is_internal_ip(ip: ipaddress._BaseAddress) -> bool:
+    return bool(
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_reserved
+        or ip.is_multicast
+        or ip.is_unspecified
+    )
+
+
+def validate_public_url(url: str) -> None:
+    """Raise :class:`UnsafeUrlError` if ``url`` is not a safe public target.
+
+    Blocks non-http(s) schemes, a denylist of internal hostnames, literal
+    private/loopback/link-local/reserved IPs, and DNS names that resolve to any
+    such address.
+    """
+    parsed = urlparse(url)
+
+    if parsed.scheme not in _ALLOWED_SCHEMES:
+        raise UnsafeUrlError(f"URL scheme not allowed: {parsed.scheme!r}")
+
+    hostname = parsed.hostname
+    if not hostname:
+        raise UnsafeUrlError("URL does not contain a hostname")
+
+    if hostname.lower() in _BLOCKED_HOSTS:
+        raise UnsafeUrlError("Internal network URLs are not allowed")
+
+    # Literal IP in the host position.
+    try:
+        ip = ipaddress.ip_address(hostname)
+    except ValueError:
+        ip = None
+    if ip is not None:
+        if _is_internal_ip(ip):
+            raise UnsafeUrlError("Internal network URLs are not allowed")
+        return
+
+    # DNS name: reject if ANY resolved address is internal.
+    try:
+        resolved = socket.getaddrinfo(hostname, None, socket.AF_UNSPEC)
+    except socket.gaierror:
+        # Let the actual HTTP request surface the resolution failure.
+        return
+    for *_, addr in resolved:
+        try:
+            resolved_ip = ipaddress.ip_address(addr[0])
+        except ValueError:
+            continue
+        if _is_internal_ip(resolved_ip):
+            raise UnsafeUrlError(
+                "URLs that resolve to internal networks are not allowed"
+            )

--- a/mureo/google_ads/_ads.py
+++ b/mureo/google_ads/_ads.py
@@ -466,15 +466,19 @@ class _AdsMixin:
         self._validate_id(ad_id, "ad_id")
         validated_status = self._validate_status(status)
 
-        # Check RSA limit when changing to ENABLED
+        # Check RSA limit when changing to ENABLED. list_ads returns a
+        # list[dict] (not a {"ads": [...]} envelope), so iterate it directly —
+        # the old ads_data.get("ads", []) always yielded [] and made this guard
+        # dead code that never fired.
+        precheck_skipped = False
         if validated_status == "ENABLED":
             try:
-                ads_data = await self.list_ads(ad_group_id=ad_group_id)
-                ads = ads_data.get("ads", []) if isinstance(ads_data, dict) else []  # type: ignore[var-annotated]
+                ads = await self.list_ads(ad_group_id=ad_group_id)
                 enabled_rsa = sum(
-                    1  # type: ignore[misc]
+                    1
                     for a in ads
-                    if a.get("status") == "ENABLED"
+                    if isinstance(a, dict)
+                    and a.get("status") == "ENABLED"
                     and a.get("type") == "RESPONSIVE_SEARCH_AD"
                     and str(a.get("id", "")) != ad_id
                 )
@@ -489,7 +493,17 @@ class _AdsMixin:
                         ),
                     }
             except Exception:
-                logger.debug("RSA limit check failed (continuing)", exc_info=True)
+                # Advisory guard only — Google still enforces the RSA limit
+                # server-side. But do not silently bypass it: log at WARNING and
+                # thread a caveat into the result so the caller knows the
+                # friendly pre-check did not run for this call.
+                logger.warning(
+                    "RSA-limit pre-check failed for ad_group %s; proceeding "
+                    "(Google Ads still enforces the limit server-side).",
+                    ad_group_id,
+                    exc_info=True,
+                )
+                precheck_skipped = True
 
         ad_group_ad_service = self._get_service("AdGroupAdService")
         op = self._client.get_type("AdGroupAdOperation")
@@ -507,4 +521,10 @@ class _AdsMixin:
             customer_id=self._customer_id,
             operations=[op],
         )
-        return {"resource_name": response.results[0].resource_name}
+        result: dict[str, Any] = {"resource_name": response.results[0].resource_name}
+        if precheck_skipped:
+            result["caveat"] = (
+                "RSA-limit pre-check could not run; relied on the Google Ads "
+                "API's own enforcement."
+            )
+        return result

--- a/mureo/google_ads/_analysis_budget.py
+++ b/mureo/google_ads/_analysis_budget.py
@@ -40,6 +40,12 @@ class _BudgetAnalysisMixin:
         campaign_data: list[dict[str, Any]] = []
         total_cost: float = 0.0
         total_conversions: float = 0.0
+        # Campaigns whose performance fetch failed. They are EXCLUDED from the
+        # aggregates and share math below rather than folded in as fabricated
+        # zeros — a transient fetch error must not make a campaign look like it
+        # spent nothing and thereby skew every other campaign's cost_share /
+        # cv_share / efficiency_ratio, which drive real budget reallocation.
+        failed_campaigns: list[str] = []
 
         for camp in campaigns:
             cid = str(camp.get("id", ""))
@@ -54,8 +60,8 @@ class _BudgetAnalysisMixin:
                     cid,
                     exc_info=True,
                 )
-                cost = 0.0
-                convs = 0.0
+                failed_campaigns.append(cid)
+                continue
 
             total_cost += cost
             total_conversions += convs
@@ -131,6 +137,11 @@ class _BudgetAnalysisMixin:
                 f"Efficient: {len(efficient)}, Normal: {normal_count}, "
                 f"Inefficient: {len(inefficient)}"
             )
+        if failed_campaigns:
+            insights.append(
+                f"⚠️ Performance data unavailable for {len(failed_campaigns)} "
+                "campaign(s); excluded from shares/efficiency — analysis is partial."
+            )
 
         return {
             "period": period,
@@ -139,6 +150,9 @@ class _BudgetAnalysisMixin:
             "campaigns": enriched_data,
             "recommendations": recommendations,
             "insights": insights,
+            # Campaign ids omitted from the analysis due to fetch failures. Empty
+            # in the normal case; non-empty signals the numbers are incomplete.
+            "incomplete_data": failed_campaigns,
         }
 
     # =================================================================

--- a/mureo/google_ads/client.py
+++ b/mureo/google_ads/client.py
@@ -392,6 +392,10 @@ class GoogleAdsApiClient(  # type: ignore[misc]
             # Calculate daily budget from campaign_budget.amount_micros
             if hasattr(row, "campaign_budget") and row.campaign_budget.amount_micros:
                 camp["daily_budget"] = row.campaign_budget.amount_micros / 1_000_000
+                # Integer micros for the adapter/canonical layer, which coerces
+                # this via int(). This is the true amount — never the budget
+                # resource-name string.
+                camp["budget_amount_micros"] = int(row.campaign_budget.amount_micros)
             results.append(camp)
         return results
 
@@ -426,6 +430,8 @@ class GoogleAdsApiClient(  # type: ignore[misc]
             # Budget information
             b = row.campaign_budget
             result["budget_daily"] = b.amount_micros / 1_000_000
+            # Integer micros for the adapter/canonical layer (coerced via int()).
+            result["budget_amount_micros"] = int(b.amount_micros)
             result["budget_status"] = map_entity_status(b.status)
             # Bidding strategy detail parameters
             result["bidding_details"] = self._extract_bidding_details(row.campaign)

--- a/mureo/google_ads/mappers.py
+++ b/mureo/google_ads/mappers.py
@@ -222,9 +222,12 @@ def map_campaign(campaign: Any) -> dict[str, Any]:
         "id": str(campaign.id),
         "name": campaign.name,
         "status": map_entity_status(campaign.status),
-        "budget_amount_micros": (
-            campaign.campaign_budget if hasattr(campaign, "campaign_budget") else None
-        ),
+        # NOTE: the budget *amount* is not on the campaign proto — it lives on
+        # the sibling ``campaign_budget`` resource (``campaign_budget.amount_micros``)
+        # that the GAQL selects separately. Callers inject the true
+        # ``budget_amount_micros`` (integer micros) from that row; do NOT put
+        # ``campaign.campaign_budget`` (a resource-name string) here — that was
+        # the source of a ValueError when the adapter coerced it via ``int()``.
         "bidding_strategy_type": (
             map_bidding_strategy_type(campaign.bidding_strategy_type)
             if hasattr(campaign, "bidding_strategy_type")

--- a/mureo/learning/insight_sources.py
+++ b/mureo/learning/insight_sources.py
@@ -163,7 +163,11 @@ def load_insight_sources(path: Path | None = None) -> InsightSourceConfig:
             continue
         try:
             src = _build_source(entry)
-        except ValueError as exc:
+        except (ValueError, TypeError) as exc:
+            # TypeError guards against a JSON null/list/dict reaching int()/
+            # float() in _build_source (e.g. {"top_k": null}) — without it that
+            # one bad entry would crash the whole advisor-config load instead of
+            # being skipped, breaking the "empty config + WARNING" contract.
             logger.warning("insight_sources: entry %d invalid (%s), skipping", idx, exc)
             continue
         if src.name in seen_names:

--- a/mureo/mcp/_handlers_google_ads.py
+++ b/mureo/mcp/_handlers_google_ads.py
@@ -509,7 +509,11 @@ async def handle_assets_upload_image(args: dict[str, Any]) -> list[TextContent]:
     file_path = _require(args, "file_path")
     if not os.path.isfile(file_path):
         raise ValueError(f"File not found: {file_path}")
-    _allowed_image_ext = (".png", ".jpg", ".jpeg", ".gif", ".webp")
+    # Keep in sync with the tool schema/description in _tools_google_ads_assets
+    # (jpg/jpeg/png/gif). .webp was accepted here but not documented, letting an
+    # unsupported upload pass local validation only to be rejected later by the
+    # Google Ads API with a confusing error.
+    _allowed_image_ext = (".png", ".jpg", ".jpeg", ".gif")
     if not file_path.lower().endswith(_allowed_image_ext):
         raise ValueError(
             f"Unsupported image format. Allowed: {', '.join(_allowed_image_ext)}"

--- a/mureo/mcp/_handlers_meta_ads.py
+++ b/mureo/mcp/_handlers_meta_ads.py
@@ -27,6 +27,7 @@ from mureo.mcp._helpers import (
     _require,
     _validate_positive_money,
     api_error_handler,
+    register_client_for_cleanup,
 )
 from mureo.throttle import META_ADS_THROTTLE, Throttler
 
@@ -53,9 +54,11 @@ async def _get_client(arguments: dict[str, Any]) -> Any:
     """
     if byod_has("meta_ads"):
         account_id = _opt(arguments, "account_id") or "act_byod"
-        return get_meta_ads_client(
+        client = get_meta_ads_client(
             creds=None, account_id=account_id, throttler=_throttler
         )
+        register_client_for_cleanup(client)
+        return client
 
     creds = load_meta_ads_credentials()
     if creds is None:
@@ -73,7 +76,12 @@ async def _get_client(arguments: dict[str, Any]) -> Any:
         )
 
     creds = await refresh_meta_token_if_needed(creds)
-    return create_meta_ads_client(creds, account_id, throttler=_throttler)
+    client = create_meta_ads_client(creds, account_id, throttler=_throttler)
+    # Close the client's persistent httpx.AsyncClient after the handler returns
+    # (see register_client_for_cleanup) so the native server does not leak
+    # keep-alive sockets across tool calls.
+    register_client_for_cleanup(client)
+    return client
 
 
 def _no_meta_creds() -> list[TextContent]:

--- a/mureo/mcp/_handlers_search_console.py
+++ b/mureo/mcp/_handlers_search_console.py
@@ -19,6 +19,7 @@ from mureo.mcp._helpers import (
     _opt,
     _require,
     api_error_handler,
+    register_client_for_cleanup,
 )
 from mureo.throttle import SEARCH_CONSOLE_THROTTLE, Throttler
 
@@ -41,7 +42,11 @@ async def _get_client(arguments: dict[str, Any]) -> Any:
     creds = load_google_ads_credentials()
     if creds is None:
         return None
-    return create_search_console_client(creds, throttler=_throttler)
+    client = create_search_console_client(creds, throttler=_throttler)
+    # Close the persistent httpx.AsyncClient after the handler returns so the
+    # native server does not leak keep-alive sockets across tool calls.
+    register_client_for_cleanup(client)
+    return client
 
 
 def _no_sc_creds() -> list[TextContent]:

--- a/mureo/mcp/_helpers.py
+++ b/mureo/mcp/_helpers.py
@@ -6,7 +6,9 @@ shared by Google Ads / Meta Ads handlers.
 
 from __future__ import annotations
 
+import contextvars
 import functools
+import inspect
 import json
 import logging
 from typing import TYPE_CHECKING, Any
@@ -17,6 +19,42 @@ if TYPE_CHECKING:
 from mcp.types import TextContent
 
 logger = logging.getLogger(__name__)
+
+
+# Per-call registry of platform clients whose async resources must be released
+# once the handler returns. Handlers open a fresh client per tool call (Meta /
+# Search Console clients each hold a persistent ``httpx.AsyncClient``); without
+# an explicit close, the long-lived native MCP server accumulates idle
+# keep-alive sockets/file descriptors for the whole session. ``api_error_handler``
+# scopes a bucket around each handler; ``_get_client`` helpers register into it.
+_active_clients: contextvars.ContextVar[list[Any] | None] = contextvars.ContextVar(
+    "mureo_active_mcp_clients", default=None
+)
+
+
+def register_client_for_cleanup(client: Any) -> None:
+    """Register ``client`` for close after the current handler completes.
+
+    No-op when called outside a handler scope (no active bucket), so it is safe
+    for callers that may run without the ``api_error_handler`` wrapper.
+    """
+    bucket = _active_clients.get()
+    if bucket is not None and client is not None:
+        bucket.append(client)
+
+
+async def _close_clients(bucket: list[Any]) -> None:
+    """Best-effort close of every registered client. Never raises."""
+    for client in bucket:
+        close = getattr(client, "close", None)
+        if close is None:
+            continue
+        try:
+            result = close()
+            if inspect.isawaitable(result):
+                await result
+        except Exception:  # noqa: BLE001 - cleanup must not mask the handler result
+            logger.debug("client cleanup failed", exc_info=True)
 
 
 def _require(arguments: dict[str, Any], key: str) -> Any:
@@ -90,6 +128,10 @@ def api_error_handler(
 
     @functools.wraps(func)
     async def wrapper(*args: Any, **kwargs: Any) -> list[TextContent]:
+        # Scope a per-call client-cleanup bucket so any client opened via
+        # ``_get_client`` during this handler is closed on the way out,
+        # regardless of success/exception.
+        token = _active_clients.set([])
         try:
             return await func(*args, **kwargs)
         except ValueError:
@@ -98,5 +140,9 @@ def api_error_handler(
         except Exception as exc:
             logger.exception("%s failed", func.__name__)
             return [TextContent(type="text", text=f"{API_ERROR_PREFIX} {exc}")]
+        finally:
+            bucket = _active_clients.get() or []
+            _active_clients.reset(token)
+            await _close_clients(bucket)
 
     return wrapper

--- a/mureo/mcp/_tools_meta_ads_audiences.py
+++ b/mureo/mcp/_tools_meta_ads_audiences.py
@@ -263,8 +263,9 @@ TOOLS: list[Tool] = [
                     ),
                 },
             },
+            # account_id is optional: it falls back to META_ADS_ACCOUNT_ID from
+            # the configured credentials (see _ACCOUNT_ID_PARAM / _get_client).
             "required": [
-                "account_id",
                 "name",
                 "source_audience_id",
                 "country",

--- a/mureo/mcp/_tools_meta_ads_catalog.py
+++ b/mureo/mcp/_tools_meta_ads_catalog.py
@@ -265,8 +265,9 @@ TOOLS: list[Tool] = [
                     ),
                 },
             },
+            # account_id is optional: it falls back to META_ADS_ACCOUNT_ID from
+            # the configured credentials (see _ACCOUNT_ID_PARAM / _get_client).
             "required": [
-                "account_id",
                 "catalog_id",
                 "retailer_id",
                 "name",

--- a/mureo/mcp/_tools_meta_ads_conversions.py
+++ b/mureo/mcp/_tools_meta_ads_conversions.py
@@ -221,8 +221,9 @@ TOOLS: list[Tool] = [
                     "description": _TEST_EVENT_CODE_DESCRIPTION,
                 },
             },
+            # account_id is optional: it falls back to META_ADS_ACCOUNT_ID from
+            # the configured credentials (see _ACCOUNT_ID_PARAM / _get_client).
             "required": [
-                "account_id",
                 "pixel_id",
                 "event_time",
                 "user_data",

--- a/mureo/mcp/_tools_meta_ads_creatives.py
+++ b/mureo/mcp/_tools_meta_ads_creatives.py
@@ -372,8 +372,9 @@ TOOLS: list[Tool] = [
                     ),
                 },
             },
+            # account_id is optional: it falls back to META_ADS_ACCOUNT_ID from
+            # the configured credentials (see _ACCOUNT_ID_PARAM / _get_client).
             "required": [
-                "account_id",
                 "name",
                 "page_id",
                 "image_hashes",

--- a/mureo/mcp/_tools_meta_ads_other.py
+++ b/mureo/mcp/_tools_meta_ads_other.py
@@ -164,8 +164,9 @@ TOOLS: list[Tool] = [
                     ),
                 },
             },
+            # account_id is optional: it falls back to META_ADS_ACCOUNT_ID from
+            # the configured credentials (see _ACCOUNT_ID_PARAM / _get_client).
             "required": [
-                "account_id",
                 "name",
                 "cells",
                 "objectives",

--- a/mureo/mcp/native_reversal.py
+++ b/mureo/mcp/native_reversal.py
@@ -129,17 +129,23 @@ async def _read_status(
     platform, entity, _ = spec
     if platform == "meta_ads":
         from mureo.mcp._handlers_meta_ads import _get_client
+        from mureo.mcp._helpers import _close_clients
 
         client = await _get_client(args)
         if client is None:
             return None
-        if entity == "campaigns":
-            record = await client.get_campaign(args["campaign_id"])
-        elif entity == "ad_sets":
-            record = await client.get_ad_set(args["ad_set_id"])
-        else:
-            record = await client.get_ad(args["ad_id"])
-        return _status_of(record)
+        # before-state capture runs outside any handler's cleanup scope, so
+        # close the client's httpx pool here rather than leaking it.
+        try:
+            if entity == "campaigns":
+                record = await client.get_campaign(args["campaign_id"])
+            elif entity == "ad_sets":
+                record = await client.get_ad_set(args["ad_set_id"])
+            else:
+                record = await client.get_ad(args["ad_id"])
+            return _status_of(record)
+        finally:
+            await _close_clients([client])
 
     from mureo.mcp._handlers_google_ads import _get_client as _get_google_client
 

--- a/mureo/mcp/server.py
+++ b/mureo/mcp/server.py
@@ -78,6 +78,7 @@ from mureo.mcp.tools_rollback import TOOLS as ROLLBACK_TOOLS
 from mureo.mcp.tools_rollback import handle_tool as handle_rollback_tool
 from mureo.mcp.tools_search_console import TOOLS as SEARCH_CONSOLE_TOOLS
 from mureo.mcp.tools_search_console import handle_tool as handle_search_console_tool
+from mureo.rollback.executor import is_rollback_dispatch_active
 from mureo.throttle import PLUGIN_THROTTLE, Throttler
 
 logger = logging.getLogger(__name__)
@@ -672,15 +673,21 @@ async def _dispatch_tool(name: str, arguments: dict[str, Any]) -> list[Any]:
     process-level staleness warning is applied once by the caller around the
     whole result.
     """
+    # When this dispatch is the reversal leg of a rollback, executor.py appends
+    # the single authoritative rollback_of entry; skip the native recording so
+    # the reversal is not double-logged as a fresh reversible mutation.
+    record_mutations = not is_rollback_dispatch_active()
     if name in _GOOGLE_ADS_NAMES:
         before = await capture_before_state(name, arguments)
         result = await handle_google_ads_tool(name, arguments)
-        record_native_mutation(name, arguments, before, result)
+        if record_mutations:
+            record_native_mutation(name, arguments, before, result)
         return _maybe_append_strategy_reminder(name, result)
     if name in _META_ADS_NAMES:
         before = await capture_before_state(name, arguments)
         result = await handle_meta_ads_tool(name, arguments)
-        record_native_mutation(name, arguments, before, result)
+        if record_mutations:
+            record_native_mutation(name, arguments, before, result)
         return _maybe_append_strategy_reminder(name, result)
     if name in _SEARCH_CONSOLE_NAMES:
         return _maybe_append_strategy_reminder(
@@ -743,7 +750,7 @@ async def _dispatch_tool(name: str, arguments: dict[str, Any]) -> list[Any]:
             # phantom executable rollback). Mirrors native_reversal's
             # _is_error_result skip for built-in mutations. The jsonl audit
             # (above) still captures the attempt regardless.
-            if not is_error_result(result):
+            if record_mutations and not is_error_result(result):
                 # Prefer the runtime-correct reversal captured before the
                 # mutation; fall back to the provider's static meta reversal
                 # when it did not opt into capture_reversal (#327).

--- a/mureo/meta_ads/_creatives.py
+++ b/mureo/meta_ads/_creatives.py
@@ -19,6 +19,10 @@ logger = logging.getLogger(__name__)
 _META_MAX_IMAGE_SIZE_BYTES = 30 * 1024 * 1024  # 30MB
 _META_ALLOWED_IMAGE_EXTENSIONS = frozenset({"jpg", "jpeg", "png", "gif", "bmp", "tiff"})
 
+# Max redirect hops when downloading a remote image (each hop is SSRF-validated
+# before it is followed; see upload_ad_image).
+_MAX_IMAGE_REDIRECTS = 5
+
 # Meta Ads video upload limits
 _META_MAX_VIDEO_SIZE_BYTES = 100 * 1024 * 1024  # 100MB (practical limit)
 _META_ALLOWED_VIDEO_EXTENSIONS = frozenset({"mp4", "mov", "avi", "wmv", "mkv"})
@@ -303,12 +307,44 @@ class CreativesMixin:
         """
         import base64
 
+        from mureo.core.url_guard import UnsafeUrlError, validate_public_url
+
+        # SSRF guard: image_url originates from LLM/MCP tool arguments, so a
+        # prompt-injection payload could point it at an internal host (e.g. the
+        # cloud metadata endpoint) and exfiltrate the bytes into a Meta ad
+        # account. Validate before fetching, and follow redirects MANUALLY so
+        # each hop is validated before it is followed (httpx auto-follow would
+        # hit an internal redirect target before we could re-check it).
+        try:
+            validate_public_url(image_url)
+        except UnsafeUrlError as exc:
+            return {"error": f"Refusing to fetch image URL: {exc}"}
+
         # Download the image
         try:
-            async with httpx.AsyncClient(timeout=30.0) as http:
-                resp = await http.get(image_url)
+            async with httpx.AsyncClient(timeout=30.0, follow_redirects=False) as http:
+                current_url = image_url
+                resp = None
+                for _ in range(_MAX_IMAGE_REDIRECTS + 1):
+                    resp = await http.get(current_url)
+                    # has_redirect_location (not is_redirect) is True only for a
+                    # 3xx that carries a Location, so a 304/300 without one is a
+                    # terminal response rather than a phantom redirect hop.
+                    if not resp.has_redirect_location:
+                        break
+                    next_url = str(
+                        httpx.URL(current_url).join(resp.headers["location"])
+                    )
+                    validate_public_url(next_url)
+                    current_url = next_url
+                else:
+                    return {
+                        "error": (f"Too many redirects fetching image from {image_url}")
+                    }
                 resp.raise_for_status()
                 image_bytes = base64.b64encode(resp.content).decode("utf-8")
+        except UnsafeUrlError as exc:
+            return {"error": f"Refusing to follow image redirect: {exc}"}
         except Exception as exc:
             return {"error": f"Failed to download image from {image_url}: {exc}"}
 

--- a/mureo/meta_ads/_insights.py
+++ b/mureo/meta_ads/_insights.py
@@ -48,6 +48,36 @@ class InsightsMixin:
         self, path: str, params: dict[str, Any] | None = None
     ) -> dict[str, Any]: ...
 
+    async def _get_all_insights(
+        self, path: str, params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        """Fetch every insights page, following the Graph ``paging`` cursors.
+
+        A bare ``_get`` returns only Meta's default first page (~25 rows), so
+        on an account with many campaigns/ad-sets/ads the tail is silently
+        dropped and every downstream sum (spend, conversions, anomaly checks)
+        under-reports. This follows ``paging.next``/``cursors.after`` until
+        exhausted, reusing ``_get`` so throttling, retries, and error handling
+        stay identical. A larger ``limit`` reduces round-trips; the cursor set
+        guards against a malformed response that would otherwise loop forever.
+        """
+        collected: list[dict[str, Any]] = []
+        params = dict(params)
+        params.setdefault("limit", 500)
+        seen_cursors: set[str] = set()
+        while True:
+            result = await self._get(path, params)
+            collected.extend(result.get("data", []))
+            paging = result.get("paging") or {}
+            if not paging.get("next"):
+                break
+            after = (paging.get("cursors") or {}).get("after")
+            if not after or after in seen_cursors:
+                break
+            seen_cursors.add(after)
+            params["after"] = after
+        return collected
+
     async def get_performance_report(
         self,
         *,
@@ -80,8 +110,7 @@ class InsightsMixin:
             account_id = self._ad_account_id
             path = f"/{account_id}/insights"
 
-        result = await self._get(path, params)
-        return result.get("data", [])  # type: ignore[no-any-return]
+        return await self._get_all_insights(path, params)
 
     async def insights_time_range(
         self,
@@ -118,8 +147,7 @@ class InsightsMixin:
             "time_increment": time_increment,
             "level": level,
         }
-        result = await self._get(f"/{node_id}/insights", params)
-        return result.get("data", [])  # type: ignore[no-any-return]
+        return await self._get_all_insights(f"/{node_id}/insights", params)
 
     async def analyze_performance(
         self,
@@ -301,5 +329,4 @@ class InsightsMixin:
         params["fields"] = _INSIGHTS_FIELDS
         params["breakdowns"] = breakdown
 
-        result = await self._get(f"/{campaign_id}/insights", params)
-        return result.get("data", [])  # type: ignore[no-any-return]
+        return await self._get_all_insights(f"/{campaign_id}/insights", params)

--- a/mureo/meta_ads/mappers.py
+++ b/mureo/meta_ads/mappers.py
@@ -43,40 +43,17 @@ def _safe_int(value: str | int | None) -> int:
 def _extract_conversions(actions: list[dict[str, Any]] | None) -> float:
     """Extract conversion count from actions.
 
-    Meta API actions are an array in [{"action_type": "...", "value": "..."}] format.
-    Aggregates conversion-related action_types.
-
-    Args:
-        actions: Actions data
-
-    Returns:
-        Total conversion count
+    Delegates to the canonical :func:`count_conversions_from_actions`, which
+    counts only the deduped *generic* action_types. The previous local set
+    summed both aggregates (``purchase``/``lead``) AND their component aliases
+    (``offsite_conversion.fb_pixel_purchase``/``onsite_conversion.purchase``),
+    double- or triple-counting a single conversion — exactly what the canonical
+    counter exists to avoid. Kept as a thin wrapper so callers (and third
+    parties importing the public ``map_insights``) get the correct count.
     """
-    if not actions:
-        return 0.0
+    from mureo.meta_ads._conversion_count import count_conversions_from_actions
 
-    # action_types treated as conversions
-    cv_action_types = {
-        "offsite_conversion.fb_pixel_purchase",
-        "offsite_conversion.fb_pixel_lead",
-        "offsite_conversion.fb_pixel_complete_registration",
-        "offsite_conversion.fb_pixel_add_to_cart",
-        "offsite_conversion.fb_pixel_initiate_checkout",
-        "offsite_conversion.fb_pixel_custom",
-        "onsite_conversion.purchase",
-        "onsite_conversion.lead_grouped",
-        "lead",
-        "purchase",
-        "complete_registration",
-    }
-
-    total = 0.0
-    for action in actions:
-        action_type = action.get("action_type", "")
-        if action_type in cv_action_types:
-            total += _safe_float(action.get("value"))
-
-    return total
+    return count_conversions_from_actions(actions)
 
 
 def _extract_cost_per_conversion(

--- a/mureo/providers/coexistence.py
+++ b/mureo/providers/coexistence.py
@@ -73,18 +73,22 @@ def coexistence_warning(
     label = _PLATFORM_LABELS.get(platform, platform)
     env_var = _PLATFORM_TO_ENV_VAR.get(platform, f"MUREO_DISABLE_{platform.upper()}")
 
+    # Claude Code reads user-scope MCP servers (and their env) from
+    # ~/.claude.json — NOT ~/.claude/settings.json (that file is hooks/
+    # permissions/env only). config_writer writes the auto-disable there, so
+    # the remediation message must name the same file.
     if mureo_block_present:
         return (
             f"Note: mureo's {label} tools have been auto-disabled "
             f'(mcpServers.mureo.env.{env_var}="1"). To re-enable, run '
             f"'mureo providers remove {spec.id}' to remove the official "
             f"server and clear the env entry, or edit "
-            f"~/.claude/settings.json manually."
+            f"~/.claude.json manually."
         )
 
     return (
         f"Note: mureo's native MCP is not registered in "
-        f"~/.claude/settings.json — nothing to auto-disable for {label}. "
+        f"~/.claude.json — nothing to auto-disable for {label}. "
         f"If you later run 'mureo setup claude-code', re-run "
         f"'mureo providers add {spec.id}' to apply the auto-disable."
     )

--- a/mureo/rollback/executor.py
+++ b/mureo/rollback/executor.py
@@ -17,8 +17,10 @@ Safety contract:
   to recurse into itself.
 - A later ``action_log`` entry with ``rollback_of == index`` marks
   the source as already reversed; a second call is refused.
-- Dispatch failures never write to ``action_log``. The caller sees
-  the underlying exception and STATE.json stays consistent.
+- Dispatch failures never write to ``action_log``. A raised exception
+  propagates to the caller; an ``api_error_handler`` "API error: ..."
+  envelope is detected via ``is_error_result`` and returned with
+  ``status="error"``. Either way STATE.json stays consistent.
 - The appended rollback entry carries ``reversible_params=None`` so
   rollbacks of rollbacks do not chain by default.
 
@@ -30,6 +32,7 @@ against the same file can race each other.
 
 from __future__ import annotations
 
+import contextvars
 from collections.abc import Awaitable, Callable
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
@@ -44,6 +47,23 @@ if TYPE_CHECKING:
 
 
 Dispatcher = Callable[[str, dict[str, Any]], Awaitable[list[Any]]]
+
+
+# Set while ``execute_rollback`` is re-dispatching the reversal through the MCP
+# handler. The dispatch path (``mcp.server._dispatch_tool``) records every
+# native/plugin mutation into ``action_log``; during a rollback that would
+# double-record the reversal (once as a fresh reversible mutation carrying an
+# observation window, once as the authoritative ``rollback_of`` entry the
+# executor appends). ``_dispatch_tool`` checks this flag and skips its own
+# recording so only the executor's single tagged entry is written.
+_rollback_dispatch_active: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "mureo_rollback_dispatch_active", default=False
+)
+
+
+def is_rollback_dispatch_active() -> bool:
+    """True while a rollback reversal is being dispatched (see the contextvar)."""
+    return _rollback_dispatch_active.get()
 
 
 class RollbackExecutionError(Exception):
@@ -109,6 +129,11 @@ async def execute_rollback(
         raise RollbackExecutionError(
             f"Rollback not supported for entry #{index}: {plan.notes}"
         )
+    # Lazy import: ``mureo.mcp`` imports the rollback package, so importing the
+    # helper at module load would risk a circular import. ``_helpers`` itself
+    # pulls in nothing from mureo, so this is safe and cheap here.
+    from mureo.mcp._helpers import is_error_result
+
     # Planner guarantees these are populated when status != NOT_SUPPORTED.
     # Use explicit raises (not `assert`) so the contract holds under `python -O`.
     if plan.operation is None or plan.params is None:
@@ -137,7 +162,34 @@ async def execute_rollback(
     # plan.params directly is safe — the stored plan cannot be mutated by the
     # dispatcher since it's a fresh copy, and subsequent executor runs always
     # call plan_rollback again from the log entry's hint.
-    result = await dispatcher(plan.operation, plan.params)
+    #
+    # Flag the dispatch so the MCP dispatch path does not ALSO record this
+    # reversal in action_log — the executor appends the single authoritative
+    # rollback_of entry below. Without this the reversal is double-recorded
+    # (and the phantom entry carries an observation window, so the
+    # daily-check/outcome-review loop treats the rollback as a fresh mutation).
+    token = _rollback_dispatch_active.set(True)
+    try:
+        result = await dispatcher(plan.operation, plan.params)
+    finally:
+        _rollback_dispatch_active.reset(token)
+
+    # ``api_error_handler`` turns an API-level failure into an "API error: ..."
+    # envelope instead of raising, so a dispatch that did *not* change platform
+    # state can still return here without an exception. Detect that envelope and
+    # refuse to record the rollback — otherwise STATE.json would gain a
+    # ``rollback_of`` marker (blocking any retry via the already-rolled-back
+    # guard above) while the campaign keeps running at the un-reverted value.
+    # Mirrors the native (native_reversal) and plugin (server) promotion paths,
+    # which both skip ``action_log`` on ``is_error_result``.
+    if is_error_result(result):
+        return {
+            "status": "error",
+            "dispatched_tool": plan.operation,
+            "result": result,
+            "caveats": list(plan.caveats),
+            "rollback_of": index,
+        }
 
     new_entry = ActionLogEntry(
         timestamp=_utc_now_iso(),

--- a/mureo/web/codex_mcp.py
+++ b/mureo/web/codex_mcp.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 import contextlib
 import os
 import re
+import sys
 import tempfile
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
@@ -250,6 +251,15 @@ def _parse_region(region_text: str, server_id: str) -> dict[str, Any]:
         arr = _ARGS_RE.match(line)
         if arr:
             args = [_unescape_toml(i) for i in _ITEM_RE.findall(arr.group("body"))]
+    # Repair a hand-trimmed region: if the command/args lines were removed or
+    # malformed, re-rendering the parsed block would emit `command = ""`, which
+    # breaks Codex's launch of the mureo MCP. Restore the canonical mureo
+    # invocation (sys.executable -m mureo.mcp) so an env-toggle re-render can
+    # never blank the command.
+    if server_id == _MUREO_SERVER_ID and not command:
+        command = sys.executable
+        if not args:
+            args = ["-m", "mureo.mcp"]
     return {"command": command, "args": args, "env": env}
 
 
@@ -455,10 +465,16 @@ _REGION_ID_RE = re.compile(
 
 
 def installed_codex_server_ids(config_path: Path) -> set[str]:
-    """All mureo-managed server ids present in the Codex config (tag scan)."""
-    if not config_path.exists():
+    """All mureo-managed server ids present in the Codex config (tag scan).
+
+    Tolerant read: an existing-but-unreadable config (path is a directory,
+    permission denied) returns an empty set rather than raising — this feeds
+    the status snapshot, which must never crash on one host's bad config.
+    """
+    try:
+        text = config_path.read_text(encoding="utf-8")
+    except OSError:
         return set()
-    text = config_path.read_text(encoding="utf-8")
     return {m.group("id") for m in _REGION_ID_RE.finditer(text)}
 
 
@@ -470,9 +486,10 @@ def read_codex_server_env(config_path: Path, server_id: str) -> dict[str, str]:
     Parses only this module's own tagged region, never the operator's
     surrounding TOML.
     """
-    if not config_path.exists():
+    try:
+        text = config_path.read_text(encoding="utf-8")
+    except OSError:
         return {}
-    text = config_path.read_text(encoding="utf-8")
     span = _region_span(text, server_id)
     if span is None:
         return {}

--- a/mureo/web/handlers.py
+++ b/mureo/web/handlers.py
@@ -63,7 +63,7 @@ from mureo.core.runtime_context import (
     runtime_multi_account_auth,
     runtime_ui_plugin_credential_fields,
 )
-from mureo.core.secret_store import FilesystemSecretStore
+from mureo.core.secret_store import FilesystemSecretStore, SecretStoreError
 from mureo.oauth_authcode import parse_loopback_callback_url
 from mureo.web._helpers import (
     compare_csrf,
@@ -591,10 +591,14 @@ class ConfigureHandler(BaseHTTPRequestHandler):
         session_host: str = self.wizard.session.host
         return session_host
 
-    def _post_setup_basic(self, payload: dict[str, Any]) -> None:  # noqa: ARG002
+    def _post_setup_basic(self, payload: dict[str, Any]) -> None:
+        # Client-authoritative host (see _resolve_host): these host-dependent
+        # writes/removals must target the operator's actual host, not a
+        # session.host that reset to the claude-code default on a daemon
+        # restart. Symmetric with the providers endpoints.
         result = install_basic_setup(
             home=self.wizard.home,
-            host=self.wizard.session.host,
+            host=self._resolve_host(payload),
             # #222: a multi-account backend must not get the bare `mureo`
             # entry (per-client `mureo-<slug>` entries are the only correct
             # wiring). Same production gate as the account-picker skip.
@@ -602,24 +606,28 @@ class ConfigureHandler(BaseHTTPRequestHandler):
         )
         send_json(self, result)
 
-    def _post_setup_mcp_remove(self, payload: dict[str, Any]) -> None:  # noqa: ARG002
-        result = remove_mureo_mcp(home=self.wizard.home, host=self.wizard.session.host)
-        send_json(self, result.as_dict())
-
-    def _post_setup_hook_remove(self, payload: dict[str, Any]) -> None:  # noqa: ARG002
-        result = remove_auth_hook(home=self.wizard.home, host=self.wizard.session.host)
-        send_json(self, result.as_dict())
-
-    def _post_setup_skills_remove(
-        self, payload: dict[str, Any]
-    ) -> None:  # noqa: ARG002
-        result = remove_workflow_skills(
-            home=self.wizard.home, host=self.wizard.session.host
+    def _post_setup_mcp_remove(self, payload: dict[str, Any]) -> None:
+        result = remove_mureo_mcp(
+            home=self.wizard.home, host=self._resolve_host(payload)
         )
         send_json(self, result.as_dict())
 
-    def _post_setup_basic_clear(self, payload: dict[str, Any]) -> None:  # noqa: ARG002
-        envelope = clear_all_setup(home=self.wizard.home, host=self.wizard.session.host)
+    def _post_setup_hook_remove(self, payload: dict[str, Any]) -> None:
+        result = remove_auth_hook(
+            home=self.wizard.home, host=self._resolve_host(payload)
+        )
+        send_json(self, result.as_dict())
+
+    def _post_setup_skills_remove(self, payload: dict[str, Any]) -> None:
+        result = remove_workflow_skills(
+            home=self.wizard.home, host=self._resolve_host(payload)
+        )
+        send_json(self, result.as_dict())
+
+    def _post_setup_basic_clear(self, payload: dict[str, Any]) -> None:
+        envelope = clear_all_setup(
+            home=self.wizard.home, host=self._resolve_host(payload)
+        )
         send_json(self, envelope)
 
     def _post_upgrade(self, payload: dict[str, Any]) -> None:  # noqa: ARG002
@@ -793,6 +801,12 @@ class ConfigureHandler(BaseHTTPRequestHandler):
             return
         except RequiredFieldMissingError:
             send_error_json(self, 400, "required_field_missing")
+            return
+        except SecretStoreError:
+            # The credentials file is corrupt; the store backed it up and
+            # refused to overwrite (rather than dropping other providers).
+            # Surface a clean signal instead of a 500 / silent data loss.
+            send_error_json(self, 409, "credentials_file_corrupt")
             return
         send_json(
             self,

--- a/mureo/web/oauth_bridge.py
+++ b/mureo/web/oauth_bridge.py
@@ -160,6 +160,18 @@ class OAuthBridge:
             logger.warning("OAuth bridge bind timed out for %s", provider)
             return OAuthHandoffResult(url=None, state="pending", provider=provider)
 
+        # serve() sets the ready event even on a bind failure (leaving
+        # _server=None), so wait_until_ready returns normally; without this
+        # check the subsequent home_url() -> self.port would raise RuntimeError
+        # and escape the ValueError-only handler. Mirror start_plugin_oauth.
+        if wizard.bind_error is not None:
+            with contextlib.suppress(Exception):
+                wizard.shutdown()
+            logger.warning("OAuth bridge callback bind failed for %s", provider)
+            return OAuthHandoffResult(
+                url=None, state="pending", provider=provider, error="bind_failed"
+            )
+
         path = _PROVIDER_TO_PATH[provider]
         # Allow-list locales to keep the spawned URL injection-free.
         safe_locale = locale if locale in {"en", "ja"} else "en"

--- a/mureo/web/reports.py
+++ b/mureo/web/reports.py
@@ -205,8 +205,20 @@ def _agency_list_clients(store: StateStore) -> list[dict[str, Any]] | None:
 
 
 def _active_state_store() -> StateStore:
-    """The active workspace's ``StateStore`` (default single-workspace)."""
-    return get_runtime_context().state_store
+    """The active workspace's ``StateStore`` (default single-workspace).
+
+    Tolerant of a misconfigured ``mureo.runtime_context_factory`` (>1 entry
+    point raises ``RuntimeContextFactoryError``): fall back to the default
+    filesystem store so the Reports endpoints keep their documented "never
+    raises" contract instead of dropping the connection with no envelope.
+    """
+    try:
+        return get_runtime_context().state_store
+    except Exception:  # noqa: BLE001 — a broken factory must not 500 the reports view
+        logger.exception("runtime context factory failed; using default state store")
+        from mureo.core.state_store import FilesystemStateStore
+
+        return FilesystemStateStore()
 
 
 def _active_workspace_id(store: StateStore) -> str:
@@ -215,7 +227,10 @@ def _active_workspace_id(store: StateStore) -> str:
     Prefers the runtime context's opaque ``workspace_id`` (``"default"`` for
     OSS), falling back to a literal so the slug is never blank.
     """
-    workspace_id = getattr(get_runtime_context(), "workspace_id", "")
+    try:
+        workspace_id = getattr(get_runtime_context(), "workspace_id", "")
+    except Exception:  # noqa: BLE001 — mirror _active_state_store's tolerance
+        workspace_id = ""
     slug = str(workspace_id).strip()
     return slug or "default"
 

--- a/mureo/web/service/launchd.py
+++ b/mureo/web/service/launchd.py
@@ -23,7 +23,7 @@ import subprocess
 import time
 from pathlib import Path
 
-from mureo.web.instance import probe_mureo_instance
+from mureo.web.instance import probe_mureo_instance, read_state_file
 from mureo.web.service import (
     SERVICE_BIND_HOST,
     SERVICE_ENVIRONMENT,
@@ -231,12 +231,23 @@ def restart(*, home: Path | None = None, port: int = SERVICE_PORT) -> OpResult:
 
 
 def status(*, home: Path | None = None, port: int = SERVICE_PORT) -> StatusResult:
-    """Report installed (plist exists) and running (``/api/ping``) state."""
+    """Report installed (plist exists) and running (``/api/ping``) state.
+
+    Prefer the actually-bound port/url the daemon persisted in configure.json:
+    when SERVICE_PORT was busy at launch the daemon degrades to an ephemeral
+    port, so probing/reporting the fixed port would falsely say "not running"
+    and print a URL that may hit a foreign process.
+    """
     installed = plist_path(home).exists()
-    running = probe_mureo_instance(SERVICE_BIND_HOST, port)
-    return StatusResult(
-        installed=installed, running=running, url=dashboard_url(port=port)
-    )
+    persisted = read_state_file(_home(home))
+    if persisted is not None:
+        effective_port = int(persisted["port"])
+        url = str(persisted["url"])
+    else:
+        effective_port = port
+        url = dashboard_url(port=port)
+    running = probe_mureo_instance(SERVICE_BIND_HOST, effective_port)
+    return StatusResult(installed=installed, running=running, url=url)
 
 
 __all__ = [

--- a/mureo/web/service/systemd.py
+++ b/mureo/web/service/systemd.py
@@ -21,7 +21,7 @@ import logging
 import subprocess
 from pathlib import Path
 
-from mureo.web.instance import probe_mureo_instance
+from mureo.web.instance import probe_mureo_instance, read_state_file
 from mureo.web.service import (
     SERVICE_BIND_HOST,
     SERVICE_ENVIRONMENT,
@@ -160,12 +160,21 @@ def restart(*, home: Path | None = None, port: int = SERVICE_PORT) -> OpResult:
 
 
 def status(*, home: Path | None = None, port: int = SERVICE_PORT) -> StatusResult:
-    """Report installed (unit exists) and running (``/api/ping``) state."""
+    """Report installed (unit exists) and running (``/api/ping``) state.
+
+    Prefer the actually-bound port/url from configure.json so an ephemeral-port
+    fallback (SERVICE_PORT busy at launch) is not misreported as "not running".
+    """
     installed = unit_path(home).exists()
-    running = probe_mureo_instance(SERVICE_BIND_HOST, port)
-    return StatusResult(
-        installed=installed, running=running, url=dashboard_url(port=port)
-    )
+    persisted = read_state_file(_home(home))
+    if persisted is not None:
+        effective_port = int(persisted["port"])
+        url = str(persisted["url"])
+    else:
+        effective_port = port
+        url = dashboard_url(port=port)
+    running = probe_mureo_instance(SERVICE_BIND_HOST, effective_port)
+    return StatusResult(installed=installed, running=running, url=url)
 
 
 __all__ = [

--- a/mureo/web/service/windows.py
+++ b/mureo/web/service/windows.py
@@ -20,7 +20,7 @@ import logging
 import subprocess
 from typing import TYPE_CHECKING
 
-from mureo.web.instance import probe_mureo_instance
+from mureo.web.instance import probe_mureo_instance, read_state_file
 from mureo.web.service import (
     SERVICE_BIND_HOST,
     SERVICE_PORT,
@@ -147,12 +147,23 @@ def restart(*, home: Path | None = None, port: int = SERVICE_PORT) -> OpResult:
 
 
 def status(*, home: Path | None = None, port: int = SERVICE_PORT) -> StatusResult:
-    """Report installed (task exists) and running (``/api/ping``) state."""
+    """Report installed (task exists) and running (``/api/ping``) state.
+
+    Prefer the actually-bound port/url from configure.json so an ephemeral-port
+    fallback (SERVICE_PORT busy at launch) is not misreported as "not running".
+    """
+    from pathlib import Path as _Path
+
     installed = _task_exists()
-    running = probe_mureo_instance(SERVICE_BIND_HOST, port)
-    return StatusResult(
-        installed=installed, running=running, url=dashboard_url(port=port)
-    )
+    persisted = read_state_file(home if home is not None else _Path.home())
+    if persisted is not None:
+        effective_port = int(persisted["port"])
+        url = str(persisted["url"])
+    else:
+        effective_port = port
+        url = dashboard_url(port=port)
+    running = probe_mureo_instance(SERVICE_BIND_HOST, effective_port)
+    return StatusResult(installed=installed, running=running, url=url)
 
 
 __all__ = [

--- a/tests/core/test_filesystem_secret_store.py
+++ b/tests/core/test_filesystem_secret_store.py
@@ -18,13 +18,34 @@ from pathlib import Path
 
 import pytest
 
-from mureo.core.secret_store import FilesystemSecretStore, SecretStore
+from mureo.core.secret_store import (
+    FilesystemSecretStore,
+    SecretStore,
+    SecretStoreError,
+)
 
 
 @pytest.mark.unit
 def test_satisfies_protocol(tmp_path: Path) -> None:
     store = FilesystemSecretStore(path=tmp_path / "credentials.json")
     assert isinstance(store, SecretStore)
+
+
+@pytest.mark.unit
+def test_save_refuses_to_clobber_malformed_file(tmp_path: Path) -> None:
+    """A save must NOT reset a corrupt (truncated) file to ``{}`` — that would
+    drop every other provider's credentials. It backs the file up and raises."""
+    path = tmp_path / "credentials.json"
+    # Truncated JSON that once held multiple providers.
+    path.write_text('{"google_ads": {"developer_token": "abc"}, "meta_a', encoding="utf-8")
+    store = FilesystemSecretStore(path=path)
+
+    with pytest.raises(SecretStoreError):
+        store.save("meta_ads", {"access_token": "xyz"})
+
+    # Original corrupt bytes are preserved (not overwritten) and a .bak exists.
+    assert path.read_text(encoding="utf-8").startswith('{"google_ads"')
+    assert (tmp_path / "credentials.json.bak").exists()
 
 
 @pytest.mark.unit

--- a/tests/test_byod_to_float.py
+++ b/tests/test_byod_to_float.py
@@ -1,0 +1,30 @@
+"""Locale-aware numeric parsing for BYOD Meta Ads Excel exports."""
+
+from __future__ import annotations
+
+import pytest
+
+from mureo.byod.adapters.meta_ads import _to_float
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("cell", "expected"),
+    [
+        # US / JP grouping
+        ("1,234.56", 1234.56),
+        ("1,234", 1234.0),
+        ("$1,234.56", 1234.56),
+        ("¥1,234", 1234.0),
+        ("1234.56", 1234.56),
+        # EU (comma decimal) with a thousands dot — previously mis-parsed.
+        ("1.234,56", 1234.56),
+        ("1.234,56 €", 1234.56),
+        ("€1.234,56", 1234.56),
+        # Degenerate / corrupt
+        ("", 0.0),
+        ("abc123", 0.0),
+    ],
+)
+def test_to_float_locales(cell: str, expected: float) -> None:
+    assert _to_float(cell) == expected

--- a/tests/test_google_ads_mappers.py
+++ b/tests/test_google_ads_mappers.py
@@ -156,7 +156,10 @@ class TestMapCampaign:
         campaign.id = 12345
         campaign.name = "テストキャンペーン"
         campaign.status = 2
-        campaign.campaign_budget = 5_000_000
+        # On the real proto this is a resource-name string, not micros. It is
+        # deliberately NOT surfaced by map_campaign: the true amount comes from
+        # the sibling campaign_budget.amount_micros, injected by the client.
+        campaign.campaign_budget = "customers/123/campaignBudgets/456"
         campaign.bidding_strategy_type = "TARGET_CPA"
 
         result = map_campaign(campaign)
@@ -164,7 +167,10 @@ class TestMapCampaign:
         assert result["id"] == "12345"
         assert result["name"] == "テストキャンペーン"
         assert result["status"] == "ENABLED"
-        assert result["budget_amount_micros"] == 5_000_000
+        # map_campaign must not emit budget_amount_micros — doing so with the
+        # campaign proto would leak the resource-name string and crash the
+        # adapter's int() coercion.
+        assert "budget_amount_micros" not in result
 
     def test_オプションフィールド付き(self) -> None:
         campaign = MagicMock()

--- a/tests/test_meta_ads_mappers.py
+++ b/tests/test_meta_ads_mappers.py
@@ -90,13 +90,17 @@ class TestExtractConversions:
     def test_空リストは0(self) -> None:
         assert _extract_conversions([]) == 0.0
 
-    def test_複数のCV種別を集計(self) -> None:
+    def test_component_aliasは二重カウントしない(self) -> None:
+        # A purchase reported as BOTH the generic aggregate and its component
+        # alias must count ONCE (via the generic type only). The previous
+        # implementation summed both, double-counting the same conversion.
         actions = [
-            {"action_type": "offsite_conversion.fb_pixel_purchase", "value": "2"},
-            {"action_type": "offsite_conversion.fb_pixel_lead", "value": "4"},
+            {"action_type": "purchase", "value": "3"},
+            {"action_type": "offsite_conversion.fb_pixel_purchase", "value": "3"},
             {"action_type": "complete_registration", "value": "1"},
         ]
-        assert _extract_conversions(actions) == 7.0
+        # 3 (purchase) + 1 (complete_registration); the offsite alias is ignored.
+        assert _extract_conversions(actions) == 4.0
 
     def test_CV以外は無視(self) -> None:
         actions = [

--- a/tests/test_meta_ads_operations.py
+++ b/tests/test_meta_ads_operations.py
@@ -394,6 +394,10 @@ class TestCreativesMixin:
         mock_resp.status_code = 200
         mock_resp.content = b"fake-image-bytes"
         mock_resp.raise_for_status = MagicMock()
+        # The uploader follows redirects manually (validating each hop) and
+        # gates on has_redirect_location; a terminal response must report False
+        # rather than a truthy MagicMock.
+        mock_resp.has_redirect_location = False
 
         mock_http = AsyncMock()
         mock_http.get = AsyncMock(return_value=mock_resp)

--- a/tests/test_setup_codex.py
+++ b/tests/test_setup_codex.py
@@ -9,6 +9,7 @@ never touch the operator's real ``~/.codex``.
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 
 import pytest
@@ -38,7 +39,9 @@ class TestInstallCodexMcpConfig:
         assert config.exists()
         text = config.read_text(encoding="utf-8")
         assert "[mcp_servers.mureo]" in text
-        assert 'command = "python"' in text
+        # command must be the interpreter running mureo (sys.executable), not a
+        # bare "python" that may be missing or lack mureo installed.
+        assert f"command = {json.dumps(sys.executable)}" in text
         assert '"-m"' in text and '"mureo.mcp"' in text
 
     def test_preserves_existing_content(self, home: Path) -> None:

--- a/tests/test_setup_gemini.py
+++ b/tests/test_setup_gemini.py
@@ -10,6 +10,7 @@ this PR).
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 
 import pytest
@@ -38,7 +39,7 @@ class TestInstallGeminiExtension:
 
         mcp = data.get("mcpServers", {})
         assert "mureo" in mcp
-        assert mcp["mureo"]["command"] == "python"
+        assert mcp["mureo"]["command"] == sys.executable
         assert mcp["mureo"]["args"] == ["-m", "mureo.mcp"]
 
     def test_updates_stale_version_and_mcp(self, home: Path) -> None:
@@ -53,7 +54,7 @@ class TestInstallGeminiExtension:
 
         data = json.loads(manifest.read_text(encoding="utf-8"))
         assert data["version"] != "0.0.0-stale"
-        assert data["mcpServers"]["mureo"]["command"] == "python"
+        assert data["mcpServers"]["mureo"]["command"] == sys.executable
 
     def test_preserves_operator_added_fields(self, home: Path) -> None:
         """Unknown top-level keys and extra mcpServers entries survive reinstall."""
@@ -83,7 +84,7 @@ class TestInstallGeminiExtension:
         # Operator's allow/deny list is untouched.
         assert data["excludeTools"] == ["google_ads_budget_update"]
         # mureo's mcpServers.mureo is refreshed, but extra servers survive.
-        assert data["mcpServers"]["mureo"]["command"] == "python"
+        assert data["mcpServers"]["mureo"]["command"] == sys.executable
         assert data["mcpServers"]["other"] == {"command": "other-server"}
 
     def test_does_not_touch_other_extensions(self, home: Path) -> None:

--- a/tests/test_url_guard.py
+++ b/tests/test_url_guard.py
@@ -1,0 +1,73 @@
+"""Tests for the shared SSRF URL guard (``mureo.core.url_guard``) and its use
+in the Meta ad-image uploader.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from mureo.core.url_guard import UnsafeUrlError, validate_public_url
+
+
+@pytest.mark.unit
+class TestValidatePublicUrl:
+    def test_allows_public_https(self) -> None:
+        # Should not raise for a normal public URL (DNS resolves to a public IP).
+        validate_public_url("https://example.com/image.png")
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://169.254.169.254/latest/meta-data/",  # cloud metadata
+            "http://localhost:8080/",
+            "http://127.0.0.1/",
+            "http://[::1]/",
+            "http://metadata.google.internal/",
+            "http://10.0.0.5/internal",  # private range (literal IP)
+            "http://192.168.1.1/",
+        ],
+    )
+    def test_blocks_internal_targets(self, url: str) -> None:
+        with pytest.raises(UnsafeUrlError):
+            validate_public_url(url)
+
+    @pytest.mark.parametrize("url", ["file:///etc/passwd", "ftp://host/x", "gopher://x"])
+    def test_blocks_non_http_schemes(self, url: str) -> None:
+        with pytest.raises(UnsafeUrlError):
+            validate_public_url(url)
+
+    def test_blocks_dns_name_resolving_to_private(self) -> None:
+        # A public-looking hostname that resolves to a private IP must be rejected.
+        with patch(
+            "mureo.core.url_guard.socket.getaddrinfo",
+            return_value=[(2, 1, 6, "", ("10.1.2.3", 0))],
+        ), pytest.raises(UnsafeUrlError):
+            validate_public_url("https://sneaky.example.com/x")
+
+
+@pytest.mark.unit
+class TestUploadAdImageSsrf:
+    @pytest.fixture()
+    def meta_client(self) -> Any:
+        from mureo.meta_ads.client import MetaAdsApiClient
+
+        return MetaAdsApiClient(access_token="t", ad_account_id="act_1")
+
+    @pytest.mark.asyncio()
+    async def test_rejects_metadata_url_without_fetching(
+        self, meta_client: Any
+    ) -> None:
+        # The uploader must refuse an internal URL BEFORE any HTTP client is
+        # constructed, so patch AsyncClient to blow up if it is ever used.
+        with patch(
+            "mureo.meta_ads._creatives.httpx.AsyncClient",
+            side_effect=AssertionError("must not fetch an unsafe URL"),
+        ):
+            result = await meta_client.upload_ad_image(
+                "http://169.254.169.254/latest/meta-data/iam/"
+            )
+        assert "error" in result
+        assert "Refusing to fetch" in result["error"]

--- a/tests/test_web_auth_multi_account.py
+++ b/tests/test_web_auth_multi_account.py
@@ -172,6 +172,9 @@ def test_oauth_bridge_threads_multi_account_flag(
         # Polled by OAuthBridge._watch_handoff on its daemon thread;
         # defined so that watcher does not raise before bridge.cancel().
         completed = False
+        # Mirrors the real WebAuthWizard: the bridge checks bind_error after
+        # wait_until_ready before calling home_url().
+        bind_error = None
 
         def __init__(
             self, *, credentials_path: Any = None, multi_account_auth: bool = False


### PR DESCRIPTION
## Summary

Fixes a batch of ~35 findings from a full-codebase audit (2 CRITICAL, 6 HIGH, plus MEDIUM/LOW), organized into 10 focused commits. No behavioral changes beyond the fixes; ruff + black clean on `mureo/`.

### 🔴 CRITICAL
- **rollback**: `execute_rollback` now detects an `api_error_handler` error envelope (`is_error_result`) — a reversal that failed at the API returns `status="error"` and writes no `action_log` entry, so it is no longer reported as applied and a retry stays possible. A contextvar suppresses the native/plugin `action_log` promotion during the reversal leg so it isn't double-recorded as a fresh reversible mutation.
- **auth/secret store**: `_save_meta_token` and `FilesystemSecretStore.save/delete` refuse to overwrite an existing-but-corrupt `credentials.json` (back up + raise) instead of resetting it to `{}` and dropping every other provider's credentials.

### 🟠 HIGH
- **Meta token refresh** was dead code: `save_credentials` now records `token_obtained_at`, so the 53-day background refresh fires (was silently expiring at ~60 days).
- **Google Ads campaign listing** crashed: `budget_amount_micros` now carries integer micros (from `campaign_budget.amount_micros`), not the budget resource-name string.
- **Meta insights** returned only the first ~25 rows: now follows Graph paging cursors (`_get_all_insights`).
- **Anomaly detection** baseline windows overlapped/were identical to the current window: now non-overlapping, equal-length prior windows.
- **httpx client leak** in the native MCP server: `api_error_handler` closes each per-call Meta/Search Console client via a scoped cleanup bucket.
- **OAuth wizard poll** looped forever: added a 5-minute deadline + button re-enable.

### 🟡 MEDIUM / ⚪ LOW (selected)
Budget-reallocation data-quality (`incomplete_data`); host-authoritative setup/removal (`_resolve_host`); 5 Meta tools' `account_id` made optional; `sys.executable` for Codex/Gemini MCP; SSRF guard (shared `url_guard` + per-hop redirect validation for LP analyzer & image upload); `SecretStore` corrupt-file → 409; service `status()` reads the real bound port; reports/status/codex tolerant reads; `fsync` on STATE.json / codex config; conversion double-count dedup; BYOD locale number parsing; coexistence remediation path; TypeError guard in advisor-config load.

### Documented-but-not-fixed (design decisions, noted in code)
- Reports view empty under the always-on daemon (cwd=/) — workspace selection is a feature, not a bug fix.
- BYOD multi-dimension breakdown-only over-count — rare export shape; parser rewrite too risky for a LOW.
- Adapter `asyncio.run` + persistent client — latent (adapters not instantiated in production); hazard documented.
- Dashboard peer auth — single-user local-first threat model (intentional scope).
- `formatKpi` CTR unit — needs a backend unit contract.

## Test plan
- [x] `ruff check mureo/` clean
- [x] `black --check mureo/` clean
- [x] Full suite: 4801 passed. The 7 failures are pre-existing local-environment noise (MCP env-gating + plugin-count mismatches) confirmed to also fail on `main` — not introduced by this branch.
- [x] New tests added: `test_url_guard.py`, `test_byod_to_float.py`, secret-store corrupt-file refusal, mapper/insights/setup coverage updates.
- [ ] CI green on GitHub
