### PR TITLE
feat(skills): integrate TikTok hosted MCP at the orchestration layer

### DIFF
--- a/mureo/_data/skills/_mureo-shared/SKILL.md
+++ b/mureo/_data/skills/_mureo-shared/SKILL.md
@@ -2,7 +2,7 @@
 name: _mureo-shared
 description: "mureo: Shared patterns for authentication, security rules, and output formatting."
 metadata:
-  version: 0.2.0
+  version: 0.3.0
   openclaw:
     category: "advertising"
     requires:
@@ -142,6 +142,19 @@ A plugin author OR an official-MCP wrapper can opt into mureo's analytics surfac
 - The MCP tool `mureo_analytics_modules_list` reports which platforms have analytics and which capabilities each advertises (`detect_anomalies`, `diagnose_performance`, `audit_creative`, `analyze_budget_efficiency`).
 - Workflow skills (daily-check, rescue, …) consult that list **before** running deep diagnostics on an external-integration platform: if the platform has no module or the needed capability is missing, the skill must say `analytics_not_available_for_<platform>` in its output rather than invent heuristics from the integration's tool schemas. Auto-deriving analytics is unsafe (would produce plausible-but-wrong analysis) and is explicitly out of scope.
 - Built-in google_ads and meta_ads ship analytics modules for the capabilities they support today; new platforms get parity by **hand-authoring** a module, not by code generation.
+
+## Hosted-connector platforms (official MCPs added as connectors)
+
+Some official ad-platform MCPs are **hosted** services with no native mureo tools and no local install — you add them as a Claude.ai connector / remote HTTP MCP (`mureo providers add` prints the steps). **TikTok Ads** (`tiktok-ads-official`) is the current example; its tools appear in the session under the connector's **own** namespace (e.g. `tt-ads-*` / the TikTok MCP's tool names), **NOT** as `mcp__mureo__*`.
+
+When a workflow enumerates "all configured platforms", **also include a hosted connector** when its tools are present in the session, or when STATE.json `platforms` carries its key. Use the platform key **`tiktok_ads`** — a first-class ad-platform key alongside `google_ads` / `meta_ads`, **not** a `plugin:<dist>` key.
+
+Honest scope — like a plugin platform, but with one critical difference:
+
+- **Include** the basic listing / performance / reporting the connector's tools support (campaigns, spend, conversions). Drive it with the connector's own tools as their names/descriptions imply — **best-effort**; never fail the whole workflow because a hosted tool is missing, report it and continue with the other platforms.
+- **Skip** mureo-only value-adds (anomaly detection, `result_indicator` CV-mismatch, RSA-asset audit, rule-based scoring) and say `analytics_not_available_for_tiktok_ads` — no analytics module ships for it (see *analytics-module parity*).
+- **Gate mutations against strategy exactly like a built-in write** — *Confirm Before Write Operations* + read STRATEGY.md / STATE.json and refuse conflicts with the current Operation Mode or a Goal (all Security Rules apply).
+- **CRITICAL — mureo is NOT in the data path for a hosted connector.** Unlike a `mcp__mureo__*` plugin tool (which mureo audits and auto-promotes to `action_log`), a hosted-connector call goes client→platform directly, so mureo does **not** audit it or record it. After a confirmed hosted-connector **mutation** you MUST record it yourself with `mureo_state_action_log_append` (`platform="tiktok_ads"`, an `observation_due` window ~14 days out, and the pre-change values you could read) so daily-check's outcome review still evaluates it. Auto-rollback is **not** available (only built-in allow-listed operations are auto-reversible); record a reversal hint for visibility only and reverse manually via the connector if needed.
 
 ## MCP Server Configuration
 

--- a/mureo/_data/skills/budget-rebalance/SKILL.md
+++ b/mureo/_data/skills/budget-rebalance/SKILL.md
@@ -2,7 +2,7 @@
 name: budget-rebalance
 description: "Rebalance campaign budgets across all configured platforms based on strategy and performance signals. Use when the user asks to optimize budgets, redistribute spend, scale efficient campaigns, or cap overspending ones. Reads STRATEGY.md goals, analyzes campaign efficiency, and proposes budget changes with rationale."
 metadata:
-  version: 0.7.1
+  version: 0.8.0
 ---
 
 # Budget Rebalance
@@ -23,7 +23,7 @@ Analyze budget allocation and suggest rebalancing across all campaigns.
 
 1. **Load context**: Read STRATEGY.md (Operation Mode, Market Context, Goal sections, Data Sources) and STATE.json.
 
-2. **Discover platforms**: Identify all configured ad platforms from STATE.json `platforms`.
+2. **Discover platforms**: Identify all configured ad platforms from STATE.json `platforms`. Also include any **hosted official-MCP connector** present in the session (e.g. TikTok, key `tiktok_ads`) — drive it via its own tools and skip mureo-only value-adds; see `../_mureo-shared/SKILL.md` → *Hosted-connector platforms*.
 
 3. **Analyze budget efficiency**: For each ad platform:
    - **Google Ads**: prefer mureo native — call `google_ads_budget_efficiency` (campaign × budget × spend × conv ratio) and `google_ads_performance_report` for the period. In BYOD mode, `budget.efficiency` may return `[]` because daily budgets aren't carried in the Apps Script bundle — fall back to `performance.report` cost / conv numbers and rank by CPA. If mureo's Google Ads tools are unavailable (e.g. `MUREO_DISABLE_GOOGLE_ADS=1` after `mureo providers add google-ads-official`), fall back to the official `google-ads-official` MCP for the performance report only, then **skip `google_ads_budget_efficiency`** (mureo-only analysis) and rank campaigns by CPA from the raw cost / conv numbers yourself; note to the user that mureo's automated budget-efficiency scoring requires the native MCP (`mureo setup claude-code`).

--- a/mureo/_data/skills/competitive-scan/SKILL.md
+++ b/mureo/_data/skills/competitive-scan/SKILL.md
@@ -2,7 +2,7 @@
 name: competitive-scan
 description: "Scan competitor activity using auction insights and market signals. Use when the user asks about competitors, market dynamics, impression share changes, competitor moves, or competitive positioning."
 metadata:
-  version: 0.7.1
+  version: 0.8.0
 ---
 
 # Competitive Scan
@@ -23,7 +23,7 @@ Scan the competitive landscape and suggest strategic responses across all channe
 
 1. **Load context**: Read STRATEGY.md (Market Context, USP, Data Sources) and STATE.json.
 
-2. **Discover platforms**: Identify all configured platforms from STATE.json `platforms`.
+2. **Discover platforms**: Identify all configured platforms from STATE.json `platforms`. Also include any **hosted official-MCP connector** present in the session (e.g. TikTok, key `tiktok_ads`) where it exposes competitive/auction data — drive it via its own tools and skip mureo-only value-adds; see `../_mureo-shared/SKILL.md` → *Hosted-connector platforms*.
 
 3. **Paid competitive analysis**: For each ad platform that provides competitive/auction data:
    - **Google Ads**: prefer mureo native — call `google_ads_auction_insights_get` (raw impression-share / overlap rows) and `google_ads_auction_insights_analyze` (rule-based summary), then `google_ads_cpc_detect_trend` (CPC drift) and `google_ads_device_analyze` (device-level breakdown). **BYOD limitation**: Apps Script does not expose `auction_insight_domain` (GAQL) — auction insight tools return `[]` in BYOD mode. The remaining tools (CPC trend, device breakdown) work in BYOD against the bundle. If mureo's Google Ads tools are unavailable (e.g. `MUREO_DISABLE_GOOGLE_ADS=1` after `mureo providers add google-ads-official`), fall back to the official `google-ads-official` MCP for auction insights and per-device performance queries (the official MCP exposes the GAQL surface, so raw auction-insights rows are obtainable when not blocked by the Apps Script limitation), then **skip the mureo-only analysis layers** (`google_ads_auction_insights_analyze`, `google_ads_cpc_detect_trend`, `google_ads_device_analyze`); perform the rule-based summary / CPC trend regression / device CPA-gap analysis yourself from the raw rows, and note: "mureo's automated competitive-analysis layers (rule-based auction summary, CPC trend regression, device CPA-gap detection) require the native MCP — install via `mureo setup claude-code` for full coverage."

--- a/mureo/_data/skills/creative-refresh/SKILL.md
+++ b/mureo/_data/skills/creative-refresh/SKILL.md
@@ -2,7 +2,7 @@
 name: creative-refresh
 description: "Refresh ad copy and creative assets based on performance signals and brand voice. Use when the user asks to refresh creative, propose new ad copy, A/B test creatives, update RSA assets, rotate underperformers, or visually evaluate / compare banner (image) creatives."
 metadata:
-  version: 0.8.0
+  version: 0.9.0
 ---
 
 # Creative Refresh
@@ -23,7 +23,7 @@ Refresh ad creatives based on strategy context and performance data across all p
 
 1. **Load context**: Read STRATEGY.md (Persona, USP, Brand Voice, Data Sources) and STATE.json.
 
-2. **Discover platforms**: Identify all configured ad platforms from STATE.json `platforms`.
+2. **Discover platforms**: Identify all configured ad platforms from STATE.json `platforms`. Also include any **hosted official-MCP connector** present in the session (e.g. TikTok, key `tiktok_ads`) — drive it via its own tools and skip mureo-only value-adds; see `../_mureo-shared/SKILL.md` → *Hosted-connector platforms*.
 
 3. **Audit current creatives**: For each ad platform:
    - **Google Ads**: prefer mureo native — call `google_ads_ad_performance_report` per campaign, plus `google_ads_rsa_assets_audit` (per-asset CTR/CVR ratings) and `google_ads_rsa_assets_analyze` (LOW/POOR detection). In BYOD mode, the Apps Script bundle does not include per-asset ratings — these tools return `[]`; fall back to `google_ads_ads_list` for headline/description text and use `ad_performance.report` for ad-level CTR/conv only. If mureo's Google Ads tools are unavailable (e.g. `MUREO_DISABLE_GOOGLE_ADS=1` after `mureo providers add google-ads-official`), fall back to the official `google-ads-official` MCP for ad-level performance and ad listing, then **skip the mureo-only RSA asset audit tools** (`google_ads_rsa_assets_audit`, `google_ads_rsa_assets_analyze`) and note: "per-asset LOW/POOR detection and the RSA asset audit are mureo-specific value-add features — install or re-enable via `mureo setup claude-code` for the full creative audit."

--- a/mureo/_data/skills/daily-check/SKILL.md
+++ b/mureo/_data/skills/daily-check/SKILL.md
@@ -2,7 +2,7 @@
 name: daily-check
 description: "Run a daily health check on all configured ad accounts (Google Ads, Meta Ads, Search Console, GA4). Use when the user asks for a daily review, health check, status update, anomaly detection, or 'how are my campaigns doing today'. Reads STRATEGY.md and STATE.json, runs platform-specific health diagnostics, checks goal progress, evaluates pending action_log observations, and reports findings as Healthy / Watch / Action-needed."
 metadata:
-  version: 0.7.1
+  version: 0.8.0
 ---
 
 # Daily Check
@@ -23,11 +23,12 @@ Run a daily health check on all marketing accounts using the strategy context.
 
 1. **Load context**: Read STRATEGY.md (especially Operation Mode, Data Sources, and all Goal sections) and STATE.json.
 
-2. **Discover available platforms**: Identify all configured platforms from STATE.json `platforms` and check which data sources (Search Console, GA4) are accessible. Also enumerate installed **plugin** platforms (`mcp__mureo__<plugin>_*` tools) and include them best-effort — see `_mureo-shared` → *Plugin platforms*.
+2. **Discover available platforms**: Identify all configured platforms from STATE.json `platforms` and check which data sources (Search Console, GA4) are accessible. Also enumerate installed **plugin** platforms (`mcp__mureo__<plugin>_*` tools) and any **hosted official-MCP connector** present in the session (e.g. TikTok's `tt-ads-*` tools, STATE.json key `tiktok_ads`); include them best-effort — see `_mureo-shared` → *Plugin platforms* and *Hosted-connector platforms*.
 
 3. **Sync state**: For each platform in STATE.json `platforms`, fetch current campaign data and update STATE.json.
    - **Google Ads**: prefer mureo native `google_ads_campaigns_list`. If mureo's Google Ads tools are unavailable (i.e. `MUREO_DISABLE_GOOGLE_ADS=1` was set when the user installed the official MCP via `mureo providers add google-ads-official`), fall back to the official `google-ads-official` MCP's equivalent campaign-list tool (typically `list_campaigns` or `report_campaigns`).
    - **Meta Ads**: prefer mureo native `meta_ads_campaigns_list`. If unavailable, fall back to the official `meta-ads-official` hosted MCP's campaign-list tool (the official MCP exposes the Marketing API surface, so basic listing is available).
+   - **TikTok Ads (hosted connector, `tiktok_ads`)**: mureo has no native TikTok tools — call the TikTok connector's own campaign-list / reporting tools (e.g. `tt-ads-*`) for the current period, and write the per-campaign numbers to STATE.json via `mureo_state_upsert_campaign` (`platform="tiktok_ads"`). Skip mureo-only fields (`result_indicator`, anomaly, RSA audit). See `_mureo-shared` → *Hosted-connector platforms*.
    - mureo BYOD mode applies only to mureo native tools — do **not** look for raw CSVs in the project directory; mureo BYOD data is centralized in the workspace `byod/` directory (or `~/.mureo/byod/` for legacy CLI users) and is only accessible through mureo MCP tools.
 
 4. **Platform health checks**: Run health diagnostics on each configured ad platform.

--- a/mureo/_data/skills/goal-review/SKILL.md
+++ b/mureo/_data/skills/goal-review/SKILL.md
@@ -2,7 +2,7 @@
 name: goal-review
 description: "Review Goal progress against STRATEGY.md targets. Use when the user asks to evaluate goal achievement, review KPI progress, assess strategy performance, or check if targets are being met."
 metadata:
-  version: 0.7.1
+  version: 0.8.0
 ---
 
 # Goal Review
@@ -24,7 +24,7 @@ Review progress toward all marketing goals across all platforms.
 
 1. **Load context**: Read STRATEGY.md (all Goal sections, Data Sources) and STATE.json.
 
-2. **Discover platforms**: Identify all configured platforms and available data sources.
+2. **Discover platforms**: Identify all configured platforms and available data sources. Also include any **hosted official-MCP connector** present in the session (e.g. TikTok, key `tiktok_ads`) — drive it via its own tools and skip mureo-only value-adds; see `../_mureo-shared/SKILL.md` → *Hosted-connector platforms*.
 
 3. **For each Goal**, gather current metrics from all relevant platforms and data sources:
    - Ad platforms: Use performance reporting tools for each platform

--- a/mureo/_data/skills/onboard/SKILL.md
+++ b/mureo/_data/skills/onboard/SKILL.md
@@ -2,7 +2,7 @@
 name: onboard
 description: "Initial account setup — create STRATEGY.md and STATE.json from scratch, import platform data, and establish baseline metrics. Use when the user is starting fresh with mureo, has no STRATEGY.md yet, or asks to set up a new account."
 metadata:
-  version: 0.7.1
+  version: 0.8.0
 ---
 
 # Onboard
@@ -87,11 +87,12 @@ Guide me through setting up mureo for a new marketing account.
 
 4. **Discover platforms and data sources**:
    - For each advertising platform with configured credentials, discover accessible accounts and list campaigns
+   - **Hosted-connector platforms**: if a hosted official-MCP connector is present in the session (e.g. TikTok's `tt-ads-*` tools — `mureo providers add tiktok-ads-official` registers it as a Claude.ai connector), treat it as a discoverable platform under the key `tiktok_ads` and list its campaigns via the connector's own tools. See `../_mureo-shared/SKILL.md` → *Hosted-connector platforms*.
    - Check if Search Console credentials are available — if so, run site discovery and list verified sites
    - Check if GA4 MCP is available by probing for analytics tools
    - Record all available platforms and data sources in STRATEGY.md under a `## Data Sources` section
 
-5. **Initialize STATE.json**: For each discovered platform, snapshot campaigns into STATE.json under the corresponding `platforms` key.
+5. **Initialize STATE.json**: For each discovered platform, snapshot campaigns into STATE.json under the corresponding `platforms` key (e.g. `google_ads`, `meta_ads`, `tiktok_ads` for the TikTok hosted connector).
 
 6. **Set up Goals**: Ask about quantitative marketing goals:
    - "What are your key marketing goals? (e.g., CPA target, lead volume, ROAS target, organic traffic growth)"
@@ -103,6 +104,7 @@ Guide me through setting up mureo for a new marketing account.
 7. **Initial diagnosis**: Run health checks on each configured ad platform:
    - **Google Ads**: prefer mureo native — `google_ads_performance_report` (LAST_30_DAYS), `google_ads_campaigns_list`, `google_ads_health_check_all`. Iterate the campaigns and call `google_ads_monitoring_zero_conversions` per campaign_id for any with conv = 0. If mureo's Google Ads tools are unavailable (e.g. `MUREO_DISABLE_GOOGLE_ADS=1` after `mureo providers add google-ads-official`), fall back to the official `google-ads-official` MCP's equivalent campaign-list and performance-report tools, then **skip the mureo-only anomaly-detection tools** (`google_ads_health_check_all`, `google_ads_monitoring_zero_conversions`) and identify zero-conversion campaigns manually from the raw conv numbers; note: "anomaly detection requires mureo's native MCP — install or re-enable via `mureo setup claude-code` for full onboarding coverage."
    - **Meta Ads**: prefer mureo native — `meta_ads_insights_report` (LAST_30_DAYS) — surface `result_indicator` per campaign so the operator sees up front whether any campaigns are optimizing for `link_click` instead of true leads. If mureo's Meta Ads tools are unavailable, fall back to the official `meta-ads-official` hosted MCP for raw insights; note that the `result_indicator` field is mureo-specific — inspect each campaign's optimization goal / actions list yourself and warn the operator about any `link_click`-optimized campaigns where the user expects real leads.
+   - **TikTok Ads (hosted connector, `tiktok_ads`)**: call the connector's own reporting tools (e.g. `tt-ads-*`) for LAST_30_DAYS and record baseline per-campaign spend/conversions. mureo-only anomaly detection / RSA audit do not apply — report `analytics_not_available_for_tiktok_ads` and keep the diagnosis to the raw numbers. See `../_mureo-shared/SKILL.md` → *Hosted-connector platforms*.
    - mureo BYOD data is centralized in the workspace `byod/` directory (or `~/.mureo/byod/` for legacy CLI users) and is only accessible through mureo MCP tools — do **not** look for raw CSVs in the project directory.
    - If Search Console is available, run a top-queries check to establish an organic baseline. If GA4 is available, check overall site conversion metrics.
 

--- a/mureo/_data/skills/rescue/SKILL.md
+++ b/mureo/_data/skills/rescue/SKILL.md
@@ -2,7 +2,7 @@
 name: rescue
 description: "Emergency performance fix when an ad account is in trouble. Use when the user reports a sudden CPA spike, conversion drop, runaway spend, or asks for an urgent performance rescue. Sets Operation Mode to TURNAROUND_RESCUE and applies stabilization actions."
 metadata:
-  version: 0.7.1
+  version: 0.8.0
 ---
 
 # Rescue
@@ -23,7 +23,7 @@ Run an emergency performance rescue workflow for underperforming campaigns.
 
 1. **Load context**: Read STRATEGY.md (including Goal sections and Data Sources) and STATE.json. Set Operation Mode to `TURNAROUND_RESCUE` in STRATEGY.md.
 
-2. **Discover platforms**: Identify all configured ad platforms from STATE.json `platforms`.
+2. **Discover platforms**: Identify all configured ad platforms from STATE.json `platforms`. Also include any **hosted official-MCP connector** present in the session (e.g. TikTok, key `tiktok_ads`) — drive it via its own tools and skip mureo-only value-adds; see `../_mureo-shared/SKILL.md` → *Hosted-connector platforms*.
 
 3. **Diagnose: platform-side or site-side?** (if GA4 is available): Before making ad changes, check if the performance problem is platform-side or site-side. If LP conversion rates dropped in GA4 too, the issue may be the landing page, not the ads. Recommend LP investigation before ad changes.
 

--- a/mureo/_data/skills/search-term-cleanup/SKILL.md
+++ b/mureo/_data/skills/search-term-cleanup/SKILL.md
@@ -2,7 +2,7 @@
 name: search-term-cleanup
 description: "Audit and clean up search terms (negative keywords, intent classification, query hygiene). Use when the user asks to clean up search queries, add negative keywords, review search term reports, or improve match quality. Cross-references Search Console, GA4, and ad platform data."
 metadata:
-  version: 0.7.1
+  version: 0.8.0
 ---
 
 # Search Term Cleanup
@@ -23,7 +23,7 @@ Review and clean up search terms and keywords across all platforms.
 
 1. **Load context**: Read STRATEGY.md (Persona, USP, Target Audience, Data Sources) and STATE.json.
 
-2. **Discover platforms**: Identify all configured platforms that support search term data from STATE.json `platforms`.
+2. **Discover platforms**: Identify all configured platforms that support search term data from STATE.json `platforms`. Also include any **hosted official-MCP connector** present in the session (e.g. TikTok, key `tiktok_ads`) where it exposes search-term data — drive it via its own tools and skip mureo-only value-adds; see `../_mureo-shared/SKILL.md` → *Hosted-connector platforms*.
 
 3. **Review search terms**: For each ad platform that supports search term data:
    - **Google Ads**: prefer mureo native — call `google_ads_search_terms_report` for the raw query rows, then `google_ads_search_terms_review` (rule-based scoring) and `google_ads_search_terms_analyze` (intent classification) per campaign. **These tools work in both Live API and BYOD mode.** In BYOD they read from `~/.mureo/byod/google_ads/search_terms.csv` (the Apps Script bundle output) — do **not** look for raw CSVs in the project directory; mureo BYOD data is centralized in the workspace `byod/` directory (or `~/.mureo/byod/` for legacy CLI users) and is only accessible through mureo MCP tools. If mureo's Google Ads tools are unavailable (e.g. `MUREO_DISABLE_GOOGLE_ADS=1` after `mureo providers add google-ads-official`), fall back to the official `google-ads-official` MCP's search-terms report tool for the raw rows, then **skip the mureo-only rule-based scoring and intent-classification tools** (`google_ads_search_terms_review`, `google_ads_search_terms_analyze`) and do the scoring/classification yourself using the rules described in step 6 below; note to the user that mureo's automated scoring is only available with the native MCP (install or re-enable via `mureo setup claude-code`).

--- a/mureo/_data/skills/sync-state/SKILL.md
+++ b/mureo/_data/skills/sync-state/SKILL.md
@@ -2,7 +2,7 @@
 name: sync-state
 description: "Sync STATE.json with current campaign data from all platforms. Use when the user asks to refresh state, sync campaigns, update STATE.json from live data, or pull latest campaign snapshots."
 metadata:
-  version: 0.8.0
+  version: 0.9.0
 ---
 
 # Sync State
@@ -18,12 +18,13 @@ Synchronize STATE.json with the current state of all marketing platforms.
 
 1. **Read current STATE.json** (if exists) to track changes.
 
-2. **Discover platforms**: Identify all platforms registered in STATE.json `platforms` — built-in AND plugin/bridge platforms. Per `../_mureo-shared/SKILL.md` → *Plugin platforms*, also enumerate any installed entry-point plugin that exposes `mcp__mureo__<plugin>_*` tools; its STATE.json platform key is `plugin:<dist>` (the same convention mureo uses when promoting plugin mutations into `action_log`).
+2. **Discover platforms**: Identify all platforms registered in STATE.json `platforms` — built-in AND plugin/bridge platforms. Per `../_mureo-shared/SKILL.md` → *Plugin platforms*, also enumerate any installed entry-point plugin that exposes `mcp__mureo__<plugin>_*` tools; its STATE.json platform key is `plugin:<dist>` (the same convention mureo uses when promoting plugin mutations into `action_log`). Also enumerate any **hosted official-MCP connector** present in the session (e.g. TikTok's `tt-ads-*` tools) — its key is a first-class ad-platform key such as `tiktok_ads`; see `../_mureo-shared/SKILL.md` → *Hosted-connector platforms*.
 
 3. **Fetch platform data**: For each registered platform:
    - **Google Ads**: prefer mureo native — call `google_ads_campaigns_list`, then `google_ads_performance_report` for the current period (last 30 days). Both work in BYOD and Live API modes. Keep the per-campaign numbers from the performance report — they become each campaign's `metrics` in step 7. If mureo's Google Ads tools are unavailable (e.g. `MUREO_DISABLE_GOOGLE_ADS=1` after `mureo providers add google-ads-official`), fall back to the official `google-ads-official` MCP's equivalent campaign-list and performance-report tools for the same period.
    - **Meta Ads**: prefer mureo native — call `meta_ads_campaigns_list`, then `meta_ads_insights_report` for the current period — capture `result_indicator` per campaign so STATE.json reflects whether each campaign's "results" are clicks or real leads, and keep the per-campaign insight numbers for the `metrics` write in step 7. If mureo's Meta Ads tools are unavailable, fall back to the official `meta-ads-official` hosted MCP for the campaign list and insights; the `result_indicator` field is mureo-specific and will not be present — record the raw optimization goal / actions list per campaign in STATE.json instead and note that CV-definition disambiguation requires mureo's native MCP.
    - **Plugin / bridge platforms** (`plugin:<dist>`): where the plugin exposes a daily-report / insights / performance tool (infer from the live tool list — best-effort, not deterministic), call it for the current period and keep the per-campaign numbers for the `metrics` write in step 7. Honest scope per `../_mureo-shared/SKILL.md`: capture only the basic metrics the plugin's own tools return; **skip** mureo-only value-adds (`result_indicator` CV-mismatch, anomaly detection, RSA-asset audit, rule-based scoring) — they do not exist for plugins, so omit `result_indicator` for a plugin platform. If a plugin has no such reporting tool, leave its `metrics`/`totals` empty (it stays an advisory platform) and continue — never fail the whole sync because a plugin tool is missing.
+   - **Hosted-connector platforms** (`tiktok_ads` etc.): call the hosted connector's own campaign-list / reporting tools (e.g. `tt-ads-*`) for the current period and keep the per-campaign numbers for the `metrics` write in step 7. Same honest scope as a plugin platform (basic metrics only; omit `result_indicator` and other mureo-only value-adds). If the connector has no reporting tool available, leave its `metrics`/`totals` empty and continue. See `../_mureo-shared/SKILL.md` → *Hosted-connector platforms*.
    - mureo BYOD data is centralized in the workspace `byod/` directory (or `~/.mureo/byod/` for legacy CLI users) and is only accessible through mureo MCP tools — do **not** look for raw CSVs in the project directory.
 
 4. **Check data sources**: If Search Console is configured, verify site access is still valid. If GA4 is available, verify connectivity.

--- a/mureo/_data/skills/weekly-report/SKILL.md
+++ b/mureo/_data/skills/weekly-report/SKILL.md
@@ -2,7 +2,7 @@
 name: weekly-report
 description: "Generate a weekly summary report across all platforms. Use when the user asks for a weekly report, summary, recap, end-of-week review, or weekly digest."
 metadata:
-  version: 0.7.1
+  version: 0.8.0
 ---
 
 # Weekly Report
@@ -19,7 +19,7 @@ Generate a weekly marketing operations report.
 
 1. **Load context**: Read STRATEGY.md and STATE.json.
 
-2. **Discover platforms**: Identify all configured platforms and available data sources.
+2. **Discover platforms**: Identify all configured platforms and available data sources — built-in, `mcp__mureo__<plugin>_*` plugin platforms, and any **hosted official-MCP connector** present in the session (e.g. TikTok's `tt-ads-*` tools, key `tiktok_ads`). See `../_mureo-shared/SKILL.md` → *Plugin platforms* and *Hosted-connector platforms*; pull a hosted connector's numbers from its own reporting tools and omit mureo-only value-adds.
 
 3. **Period**: Determine the reporting period (last 7 days from today).
 

--- a/mureo/web/reports.py
+++ b/mureo/web/reports.py
@@ -87,6 +87,10 @@ _BUILTIN_DISPLAY_NAMES: dict[str, str] = {
     "meta_ads": "Meta Ads",
     "search_console": "Search Console",
     "ga4": "GA4",
+    # Hosted-connector platform (no native mureo tools; added as a Claude.ai
+    # connector). Skills write its snapshots under this key — give it a friendly
+    # dashboard label instead of falling back to the raw "tiktok_ads".
+    "tiktok_ads": "TikTok Ads",
 }
 
 _PLUGIN_PREFIX = "plugin:"

--- a/skills/_mureo-shared/SKILL.md
+++ b/skills/_mureo-shared/SKILL.md
@@ -2,7 +2,7 @@
 name: _mureo-shared
 description: "mureo: Shared patterns for authentication, security rules, and output formatting."
 metadata:
-  version: 0.2.0
+  version: 0.3.0
   openclaw:
     category: "advertising"
     requires:
@@ -142,6 +142,19 @@ A plugin author OR an official-MCP wrapper can opt into mureo's analytics surfac
 - The MCP tool `mureo_analytics_modules_list` reports which platforms have analytics and which capabilities each advertises (`detect_anomalies`, `diagnose_performance`, `audit_creative`, `analyze_budget_efficiency`).
 - Workflow skills (daily-check, rescue, …) consult that list **before** running deep diagnostics on an external-integration platform: if the platform has no module or the needed capability is missing, the skill must say `analytics_not_available_for_<platform>` in its output rather than invent heuristics from the integration's tool schemas. Auto-deriving analytics is unsafe (would produce plausible-but-wrong analysis) and is explicitly out of scope.
 - Built-in google_ads and meta_ads ship analytics modules for the capabilities they support today; new platforms get parity by **hand-authoring** a module, not by code generation.
+
+## Hosted-connector platforms (official MCPs added as connectors)
+
+Some official ad-platform MCPs are **hosted** services with no native mureo tools and no local install — you add them as a Claude.ai connector / remote HTTP MCP (`mureo providers add` prints the steps). **TikTok Ads** (`tiktok-ads-official`) is the current example; its tools appear in the session under the connector's **own** namespace (e.g. `tt-ads-*` / the TikTok MCP's tool names), **NOT** as `mcp__mureo__*`.
+
+When a workflow enumerates "all configured platforms", **also include a hosted connector** when its tools are present in the session, or when STATE.json `platforms` carries its key. Use the platform key **`tiktok_ads`** — a first-class ad-platform key alongside `google_ads` / `meta_ads`, **not** a `plugin:<dist>` key.
+
+Honest scope — like a plugin platform, but with one critical difference:
+
+- **Include** the basic listing / performance / reporting the connector's tools support (campaigns, spend, conversions). Drive it with the connector's own tools as their names/descriptions imply — **best-effort**; never fail the whole workflow because a hosted tool is missing, report it and continue with the other platforms.
+- **Skip** mureo-only value-adds (anomaly detection, `result_indicator` CV-mismatch, RSA-asset audit, rule-based scoring) and say `analytics_not_available_for_tiktok_ads` — no analytics module ships for it (see *analytics-module parity*).
+- **Gate mutations against strategy exactly like a built-in write** — *Confirm Before Write Operations* + read STRATEGY.md / STATE.json and refuse conflicts with the current Operation Mode or a Goal (all Security Rules apply).
+- **CRITICAL — mureo is NOT in the data path for a hosted connector.** Unlike a `mcp__mureo__*` plugin tool (which mureo audits and auto-promotes to `action_log`), a hosted-connector call goes client→platform directly, so mureo does **not** audit it or record it. After a confirmed hosted-connector **mutation** you MUST record it yourself with `mureo_state_action_log_append` (`platform="tiktok_ads"`, an `observation_due` window ~14 days out, and the pre-change values you could read) so daily-check's outcome review still evaluates it. Auto-rollback is **not** available (only built-in allow-listed operations are auto-reversible); record a reversal hint for visibility only and reverse manually via the connector if needed.
 
 ## MCP Server Configuration
 

--- a/skills/budget-rebalance/SKILL.md
+++ b/skills/budget-rebalance/SKILL.md
@@ -2,7 +2,7 @@
 name: budget-rebalance
 description: "Rebalance campaign budgets across all configured platforms based on strategy and performance signals. Use when the user asks to optimize budgets, redistribute spend, scale efficient campaigns, or cap overspending ones. Reads STRATEGY.md goals, analyzes campaign efficiency, and proposes budget changes with rationale."
 metadata:
-  version: 0.7.1
+  version: 0.8.0
 ---
 
 # Budget Rebalance
@@ -23,7 +23,7 @@ Analyze budget allocation and suggest rebalancing across all campaigns.
 
 1. **Load context**: Read STRATEGY.md (Operation Mode, Market Context, Goal sections, Data Sources) and STATE.json.
 
-2. **Discover platforms**: Identify all configured ad platforms from STATE.json `platforms`.
+2. **Discover platforms**: Identify all configured ad platforms from STATE.json `platforms`. Also include any **hosted official-MCP connector** present in the session (e.g. TikTok, key `tiktok_ads`) — drive it via its own tools and skip mureo-only value-adds; see `../_mureo-shared/SKILL.md` → *Hosted-connector platforms*.
 
 3. **Analyze budget efficiency**: For each ad platform:
    - **Google Ads**: prefer mureo native — call `google_ads_budget_efficiency` (campaign × budget × spend × conv ratio) and `google_ads_performance_report` for the period. In BYOD mode, `budget.efficiency` may return `[]` because daily budgets aren't carried in the Apps Script bundle — fall back to `performance.report` cost / conv numbers and rank by CPA. If mureo's Google Ads tools are unavailable (e.g. `MUREO_DISABLE_GOOGLE_ADS=1` after `mureo providers add google-ads-official`), fall back to the official `google-ads-official` MCP for the performance report only, then **skip `google_ads_budget_efficiency`** (mureo-only analysis) and rank campaigns by CPA from the raw cost / conv numbers yourself; note to the user that mureo's automated budget-efficiency scoring requires the native MCP (`mureo setup claude-code`).

--- a/skills/competitive-scan/SKILL.md
+++ b/skills/competitive-scan/SKILL.md
@@ -2,7 +2,7 @@
 name: competitive-scan
 description: "Scan competitor activity using auction insights and market signals. Use when the user asks about competitors, market dynamics, impression share changes, competitor moves, or competitive positioning."
 metadata:
-  version: 0.7.1
+  version: 0.8.0
 ---
 
 # Competitive Scan
@@ -23,7 +23,7 @@ Scan the competitive landscape and suggest strategic responses across all channe
 
 1. **Load context**: Read STRATEGY.md (Market Context, USP, Data Sources) and STATE.json.
 
-2. **Discover platforms**: Identify all configured platforms from STATE.json `platforms`.
+2. **Discover platforms**: Identify all configured platforms from STATE.json `platforms`. Also include any **hosted official-MCP connector** present in the session (e.g. TikTok, key `tiktok_ads`) where it exposes competitive/auction data — drive it via its own tools and skip mureo-only value-adds; see `../_mureo-shared/SKILL.md` → *Hosted-connector platforms*.
 
 3. **Paid competitive analysis**: For each ad platform that provides competitive/auction data:
    - **Google Ads**: prefer mureo native — call `google_ads_auction_insights_get` (raw impression-share / overlap rows) and `google_ads_auction_insights_analyze` (rule-based summary), then `google_ads_cpc_detect_trend` (CPC drift) and `google_ads_device_analyze` (device-level breakdown). **BYOD limitation**: Apps Script does not expose `auction_insight_domain` (GAQL) — auction insight tools return `[]` in BYOD mode. The remaining tools (CPC trend, device breakdown) work in BYOD against the bundle. If mureo's Google Ads tools are unavailable (e.g. `MUREO_DISABLE_GOOGLE_ADS=1` after `mureo providers add google-ads-official`), fall back to the official `google-ads-official` MCP for auction insights and per-device performance queries (the official MCP exposes the GAQL surface, so raw auction-insights rows are obtainable when not blocked by the Apps Script limitation), then **skip the mureo-only analysis layers** (`google_ads_auction_insights_analyze`, `google_ads_cpc_detect_trend`, `google_ads_device_analyze`); perform the rule-based summary / CPC trend regression / device CPA-gap analysis yourself from the raw rows, and note: "mureo's automated competitive-analysis layers (rule-based auction summary, CPC trend regression, device CPA-gap detection) require the native MCP — install via `mureo setup claude-code` for full coverage."

--- a/skills/creative-refresh/SKILL.md
+++ b/skills/creative-refresh/SKILL.md
@@ -2,7 +2,7 @@
 name: creative-refresh
 description: "Refresh ad copy and creative assets based on performance signals and brand voice. Use when the user asks to refresh creative, propose new ad copy, A/B test creatives, update RSA assets, rotate underperformers, or visually evaluate / compare banner (image) creatives."
 metadata:
-  version: 0.8.0
+  version: 0.9.0
 ---
 
 # Creative Refresh
@@ -23,7 +23,7 @@ Refresh ad creatives based on strategy context and performance data across all p
 
 1. **Load context**: Read STRATEGY.md (Persona, USP, Brand Voice, Data Sources) and STATE.json.
 
-2. **Discover platforms**: Identify all configured ad platforms from STATE.json `platforms`.
+2. **Discover platforms**: Identify all configured ad platforms from STATE.json `platforms`. Also include any **hosted official-MCP connector** present in the session (e.g. TikTok, key `tiktok_ads`) — drive it via its own tools and skip mureo-only value-adds; see `../_mureo-shared/SKILL.md` → *Hosted-connector platforms*.
 
 3. **Audit current creatives**: For each ad platform:
    - **Google Ads**: prefer mureo native — call `google_ads_ad_performance_report` per campaign, plus `google_ads_rsa_assets_audit` (per-asset CTR/CVR ratings) and `google_ads_rsa_assets_analyze` (LOW/POOR detection). In BYOD mode, the Apps Script bundle does not include per-asset ratings — these tools return `[]`; fall back to `google_ads_ads_list` for headline/description text and use `ad_performance.report` for ad-level CTR/conv only. If mureo's Google Ads tools are unavailable (e.g. `MUREO_DISABLE_GOOGLE_ADS=1` after `mureo providers add google-ads-official`), fall back to the official `google-ads-official` MCP for ad-level performance and ad listing, then **skip the mureo-only RSA asset audit tools** (`google_ads_rsa_assets_audit`, `google_ads_rsa_assets_analyze`) and note: "per-asset LOW/POOR detection and the RSA asset audit are mureo-specific value-add features — install or re-enable via `mureo setup claude-code` for the full creative audit."

--- a/skills/daily-check/SKILL.md
+++ b/skills/daily-check/SKILL.md
@@ -2,7 +2,7 @@
 name: daily-check
 description: "Run a daily health check on all configured ad accounts (Google Ads, Meta Ads, Search Console, GA4). Use when the user asks for a daily review, health check, status update, anomaly detection, or 'how are my campaigns doing today'. Reads STRATEGY.md and STATE.json, runs platform-specific health diagnostics, checks goal progress, evaluates pending action_log observations, and reports findings as Healthy / Watch / Action-needed."
 metadata:
-  version: 0.7.1
+  version: 0.8.0
 ---
 
 # Daily Check
@@ -23,11 +23,12 @@ Run a daily health check on all marketing accounts using the strategy context.
 
 1. **Load context**: Read STRATEGY.md (especially Operation Mode, Data Sources, and all Goal sections) and STATE.json.
 
-2. **Discover available platforms**: Identify all configured platforms from STATE.json `platforms` and check which data sources (Search Console, GA4) are accessible. Also enumerate installed **plugin** platforms (`mcp__mureo__<plugin>_*` tools) and include them best-effort — see `_mureo-shared` → *Plugin platforms*.
+2. **Discover available platforms**: Identify all configured platforms from STATE.json `platforms` and check which data sources (Search Console, GA4) are accessible. Also enumerate installed **plugin** platforms (`mcp__mureo__<plugin>_*` tools) and any **hosted official-MCP connector** present in the session (e.g. TikTok's `tt-ads-*` tools, STATE.json key `tiktok_ads`); include them best-effort — see `_mureo-shared` → *Plugin platforms* and *Hosted-connector platforms*.
 
 3. **Sync state**: For each platform in STATE.json `platforms`, fetch current campaign data and update STATE.json.
    - **Google Ads**: prefer mureo native `google_ads_campaigns_list`. If mureo's Google Ads tools are unavailable (i.e. `MUREO_DISABLE_GOOGLE_ADS=1` was set when the user installed the official MCP via `mureo providers add google-ads-official`), fall back to the official `google-ads-official` MCP's equivalent campaign-list tool (typically `list_campaigns` or `report_campaigns`).
    - **Meta Ads**: prefer mureo native `meta_ads_campaigns_list`. If unavailable, fall back to the official `meta-ads-official` hosted MCP's campaign-list tool (the official MCP exposes the Marketing API surface, so basic listing is available).
+   - **TikTok Ads (hosted connector, `tiktok_ads`)**: mureo has no native TikTok tools — call the TikTok connector's own campaign-list / reporting tools (e.g. `tt-ads-*`) for the current period, and write the per-campaign numbers to STATE.json via `mureo_state_upsert_campaign` (`platform="tiktok_ads"`). Skip mureo-only fields (`result_indicator`, anomaly, RSA audit). See `_mureo-shared` → *Hosted-connector platforms*.
    - mureo BYOD mode applies only to mureo native tools — do **not** look for raw CSVs in the project directory; mureo BYOD data is centralized in the workspace `byod/` directory (or `~/.mureo/byod/` for legacy CLI users) and is only accessible through mureo MCP tools.
 
 4. **Platform health checks**: Run health diagnostics on each configured ad platform.

--- a/skills/goal-review/SKILL.md
+++ b/skills/goal-review/SKILL.md
@@ -2,7 +2,7 @@
 name: goal-review
 description: "Review Goal progress against STRATEGY.md targets. Use when the user asks to evaluate goal achievement, review KPI progress, assess strategy performance, or check if targets are being met."
 metadata:
-  version: 0.7.1
+  version: 0.8.0
 ---
 
 # Goal Review
@@ -24,7 +24,7 @@ Review progress toward all marketing goals across all platforms.
 
 1. **Load context**: Read STRATEGY.md (all Goal sections, Data Sources) and STATE.json.
 
-2. **Discover platforms**: Identify all configured platforms and available data sources.
+2. **Discover platforms**: Identify all configured platforms and available data sources. Also include any **hosted official-MCP connector** present in the session (e.g. TikTok, key `tiktok_ads`) — drive it via its own tools and skip mureo-only value-adds; see `../_mureo-shared/SKILL.md` → *Hosted-connector platforms*.
 
 3. **For each Goal**, gather current metrics from all relevant platforms and data sources:
    - Ad platforms: Use performance reporting tools for each platform

--- a/skills/onboard/SKILL.md
+++ b/skills/onboard/SKILL.md
@@ -2,7 +2,7 @@
 name: onboard
 description: "Initial account setup — create STRATEGY.md and STATE.json from scratch, import platform data, and establish baseline metrics. Use when the user is starting fresh with mureo, has no STRATEGY.md yet, or asks to set up a new account."
 metadata:
-  version: 0.7.1
+  version: 0.8.0
 ---
 
 # Onboard
@@ -87,11 +87,12 @@ Guide me through setting up mureo for a new marketing account.
 
 4. **Discover platforms and data sources**:
    - For each advertising platform with configured credentials, discover accessible accounts and list campaigns
+   - **Hosted-connector platforms**: if a hosted official-MCP connector is present in the session (e.g. TikTok's `tt-ads-*` tools — `mureo providers add tiktok-ads-official` registers it as a Claude.ai connector), treat it as a discoverable platform under the key `tiktok_ads` and list its campaigns via the connector's own tools. See `../_mureo-shared/SKILL.md` → *Hosted-connector platforms*.
    - Check if Search Console credentials are available — if so, run site discovery and list verified sites
    - Check if GA4 MCP is available by probing for analytics tools
    - Record all available platforms and data sources in STRATEGY.md under a `## Data Sources` section
 
-5. **Initialize STATE.json**: For each discovered platform, snapshot campaigns into STATE.json under the corresponding `platforms` key.
+5. **Initialize STATE.json**: For each discovered platform, snapshot campaigns into STATE.json under the corresponding `platforms` key (e.g. `google_ads`, `meta_ads`, `tiktok_ads` for the TikTok hosted connector).
 
 6. **Set up Goals**: Ask about quantitative marketing goals:
    - "What are your key marketing goals? (e.g., CPA target, lead volume, ROAS target, organic traffic growth)"
@@ -103,6 +104,7 @@ Guide me through setting up mureo for a new marketing account.
 7. **Initial diagnosis**: Run health checks on each configured ad platform:
    - **Google Ads**: prefer mureo native — `google_ads_performance_report` (LAST_30_DAYS), `google_ads_campaigns_list`, `google_ads_health_check_all`. Iterate the campaigns and call `google_ads_monitoring_zero_conversions` per campaign_id for any with conv = 0. If mureo's Google Ads tools are unavailable (e.g. `MUREO_DISABLE_GOOGLE_ADS=1` after `mureo providers add google-ads-official`), fall back to the official `google-ads-official` MCP's equivalent campaign-list and performance-report tools, then **skip the mureo-only anomaly-detection tools** (`google_ads_health_check_all`, `google_ads_monitoring_zero_conversions`) and identify zero-conversion campaigns manually from the raw conv numbers; note: "anomaly detection requires mureo's native MCP — install or re-enable via `mureo setup claude-code` for full onboarding coverage."
    - **Meta Ads**: prefer mureo native — `meta_ads_insights_report` (LAST_30_DAYS) — surface `result_indicator` per campaign so the operator sees up front whether any campaigns are optimizing for `link_click` instead of true leads. If mureo's Meta Ads tools are unavailable, fall back to the official `meta-ads-official` hosted MCP for raw insights; note that the `result_indicator` field is mureo-specific — inspect each campaign's optimization goal / actions list yourself and warn the operator about any `link_click`-optimized campaigns where the user expects real leads.
+   - **TikTok Ads (hosted connector, `tiktok_ads`)**: call the connector's own reporting tools (e.g. `tt-ads-*`) for LAST_30_DAYS and record baseline per-campaign spend/conversions. mureo-only anomaly detection / RSA audit do not apply — report `analytics_not_available_for_tiktok_ads` and keep the diagnosis to the raw numbers. See `../_mureo-shared/SKILL.md` → *Hosted-connector platforms*.
    - mureo BYOD data is centralized in the workspace `byod/` directory (or `~/.mureo/byod/` for legacy CLI users) and is only accessible through mureo MCP tools — do **not** look for raw CSVs in the project directory.
    - If Search Console is available, run a top-queries check to establish an organic baseline. If GA4 is available, check overall site conversion metrics.
 

--- a/skills/rescue/SKILL.md
+++ b/skills/rescue/SKILL.md
@@ -2,7 +2,7 @@
 name: rescue
 description: "Emergency performance fix when an ad account is in trouble. Use when the user reports a sudden CPA spike, conversion drop, runaway spend, or asks for an urgent performance rescue. Sets Operation Mode to TURNAROUND_RESCUE and applies stabilization actions."
 metadata:
-  version: 0.7.1
+  version: 0.8.0
 ---
 
 # Rescue
@@ -23,7 +23,7 @@ Run an emergency performance rescue workflow for underperforming campaigns.
 
 1. **Load context**: Read STRATEGY.md (including Goal sections and Data Sources) and STATE.json. Set Operation Mode to `TURNAROUND_RESCUE` in STRATEGY.md.
 
-2. **Discover platforms**: Identify all configured ad platforms from STATE.json `platforms`.
+2. **Discover platforms**: Identify all configured ad platforms from STATE.json `platforms`. Also include any **hosted official-MCP connector** present in the session (e.g. TikTok, key `tiktok_ads`) — drive it via its own tools and skip mureo-only value-adds; see `../_mureo-shared/SKILL.md` → *Hosted-connector platforms*.
 
 3. **Diagnose: platform-side or site-side?** (if GA4 is available): Before making ad changes, check if the performance problem is platform-side or site-side. If LP conversion rates dropped in GA4 too, the issue may be the landing page, not the ads. Recommend LP investigation before ad changes.
 

--- a/skills/search-term-cleanup/SKILL.md
+++ b/skills/search-term-cleanup/SKILL.md
@@ -2,7 +2,7 @@
 name: search-term-cleanup
 description: "Audit and clean up search terms (negative keywords, intent classification, query hygiene). Use when the user asks to clean up search queries, add negative keywords, review search term reports, or improve match quality. Cross-references Search Console, GA4, and ad platform data."
 metadata:
-  version: 0.7.1
+  version: 0.8.0
 ---
 
 # Search Term Cleanup
@@ -23,7 +23,7 @@ Review and clean up search terms and keywords across all platforms.
 
 1. **Load context**: Read STRATEGY.md (Persona, USP, Target Audience, Data Sources) and STATE.json.
 
-2. **Discover platforms**: Identify all configured platforms that support search term data from STATE.json `platforms`.
+2. **Discover platforms**: Identify all configured platforms that support search term data from STATE.json `platforms`. Also include any **hosted official-MCP connector** present in the session (e.g. TikTok, key `tiktok_ads`) where it exposes search-term data — drive it via its own tools and skip mureo-only value-adds; see `../_mureo-shared/SKILL.md` → *Hosted-connector platforms*.
 
 3. **Review search terms**: For each ad platform that supports search term data:
    - **Google Ads**: prefer mureo native — call `google_ads_search_terms_report` for the raw query rows, then `google_ads_search_terms_review` (rule-based scoring) and `google_ads_search_terms_analyze` (intent classification) per campaign. **These tools work in both Live API and BYOD mode.** In BYOD they read from `~/.mureo/byod/google_ads/search_terms.csv` (the Apps Script bundle output) — do **not** look for raw CSVs in the project directory; mureo BYOD data is centralized in the workspace `byod/` directory (or `~/.mureo/byod/` for legacy CLI users) and is only accessible through mureo MCP tools. If mureo's Google Ads tools are unavailable (e.g. `MUREO_DISABLE_GOOGLE_ADS=1` after `mureo providers add google-ads-official`), fall back to the official `google-ads-official` MCP's search-terms report tool for the raw rows, then **skip the mureo-only rule-based scoring and intent-classification tools** (`google_ads_search_terms_review`, `google_ads_search_terms_analyze`) and do the scoring/classification yourself using the rules described in step 6 below; note to the user that mureo's automated scoring is only available with the native MCP (install or re-enable via `mureo setup claude-code`).

--- a/skills/sync-state/SKILL.md
+++ b/skills/sync-state/SKILL.md
@@ -2,7 +2,7 @@
 name: sync-state
 description: "Sync STATE.json with current campaign data from all platforms. Use when the user asks to refresh state, sync campaigns, update STATE.json from live data, or pull latest campaign snapshots."
 metadata:
-  version: 0.8.0
+  version: 0.9.0
 ---
 
 # Sync State
@@ -18,12 +18,13 @@ Synchronize STATE.json with the current state of all marketing platforms.
 
 1. **Read current STATE.json** (if exists) to track changes.
 
-2. **Discover platforms**: Identify all platforms registered in STATE.json `platforms` — built-in AND plugin/bridge platforms. Per `../_mureo-shared/SKILL.md` → *Plugin platforms*, also enumerate any installed entry-point plugin that exposes `mcp__mureo__<plugin>_*` tools; its STATE.json platform key is `plugin:<dist>` (the same convention mureo uses when promoting plugin mutations into `action_log`).
+2. **Discover platforms**: Identify all platforms registered in STATE.json `platforms` — built-in AND plugin/bridge platforms. Per `../_mureo-shared/SKILL.md` → *Plugin platforms*, also enumerate any installed entry-point plugin that exposes `mcp__mureo__<plugin>_*` tools; its STATE.json platform key is `plugin:<dist>` (the same convention mureo uses when promoting plugin mutations into `action_log`). Also enumerate any **hosted official-MCP connector** present in the session (e.g. TikTok's `tt-ads-*` tools) — its key is a first-class ad-platform key such as `tiktok_ads`; see `../_mureo-shared/SKILL.md` → *Hosted-connector platforms*.
 
 3. **Fetch platform data**: For each registered platform:
    - **Google Ads**: prefer mureo native — call `google_ads_campaigns_list`, then `google_ads_performance_report` for the current period (last 30 days). Both work in BYOD and Live API modes. Keep the per-campaign numbers from the performance report — they become each campaign's `metrics` in step 7. If mureo's Google Ads tools are unavailable (e.g. `MUREO_DISABLE_GOOGLE_ADS=1` after `mureo providers add google-ads-official`), fall back to the official `google-ads-official` MCP's equivalent campaign-list and performance-report tools for the same period.
    - **Meta Ads**: prefer mureo native — call `meta_ads_campaigns_list`, then `meta_ads_insights_report` for the current period — capture `result_indicator` per campaign so STATE.json reflects whether each campaign's "results" are clicks or real leads, and keep the per-campaign insight numbers for the `metrics` write in step 7. If mureo's Meta Ads tools are unavailable, fall back to the official `meta-ads-official` hosted MCP for the campaign list and insights; the `result_indicator` field is mureo-specific and will not be present — record the raw optimization goal / actions list per campaign in STATE.json instead and note that CV-definition disambiguation requires mureo's native MCP.
    - **Plugin / bridge platforms** (`plugin:<dist>`): where the plugin exposes a daily-report / insights / performance tool (infer from the live tool list — best-effort, not deterministic), call it for the current period and keep the per-campaign numbers for the `metrics` write in step 7. Honest scope per `../_mureo-shared/SKILL.md`: capture only the basic metrics the plugin's own tools return; **skip** mureo-only value-adds (`result_indicator` CV-mismatch, anomaly detection, RSA-asset audit, rule-based scoring) — they do not exist for plugins, so omit `result_indicator` for a plugin platform. If a plugin has no such reporting tool, leave its `metrics`/`totals` empty (it stays an advisory platform) and continue — never fail the whole sync because a plugin tool is missing.
+   - **Hosted-connector platforms** (`tiktok_ads` etc.): call the hosted connector's own campaign-list / reporting tools (e.g. `tt-ads-*`) for the current period and keep the per-campaign numbers for the `metrics` write in step 7. Same honest scope as a plugin platform (basic metrics only; omit `result_indicator` and other mureo-only value-adds). If the connector has no reporting tool available, leave its `metrics`/`totals` empty and continue. See `../_mureo-shared/SKILL.md` → *Hosted-connector platforms*.
    - mureo BYOD data is centralized in the workspace `byod/` directory (or `~/.mureo/byod/` for legacy CLI users) and is only accessible through mureo MCP tools — do **not** look for raw CSVs in the project directory.
 
 4. **Check data sources**: If Search Console is configured, verify site access is still valid. If GA4 is available, verify connectivity.

--- a/skills/weekly-report/SKILL.md
+++ b/skills/weekly-report/SKILL.md
@@ -2,7 +2,7 @@
 name: weekly-report
 description: "Generate a weekly summary report across all platforms. Use when the user asks for a weekly report, summary, recap, end-of-week review, or weekly digest."
 metadata:
-  version: 0.7.1
+  version: 0.8.0
 ---
 
 # Weekly Report
@@ -19,7 +19,7 @@ Generate a weekly marketing operations report.
 
 1. **Load context**: Read STRATEGY.md and STATE.json.
 
-2. **Discover platforms**: Identify all configured platforms and available data sources.
+2. **Discover platforms**: Identify all configured platforms and available data sources — built-in, `mcp__mureo__<plugin>_*` plugin platforms, and any **hosted official-MCP connector** present in the session (e.g. TikTok's `tt-ads-*` tools, key `tiktok_ads`). See `../_mureo-shared/SKILL.md` → *Plugin platforms* and *Hosted-connector platforms*; pull a hosted connector's numbers from its own reporting tools and omit mureo-only value-adds.
 
 3. **Period**: Determine the reporting period (last 7 days from today).
 

--- a/tests/test_web_reports.py
+++ b/tests/test_web_reports.py
@@ -171,6 +171,17 @@ def test_summary_lists_every_platform_with_display_names(
 
 
 @pytest.mark.unit
+def test_platform_display_name_labels() -> None:
+    from mureo.web.reports import platform_display_name
+
+    # Hosted-connector platform gets a friendly label, not the raw key.
+    assert platform_display_name("tiktok_ads") == "TikTok Ads"
+    # Built-ins and an unknown key (raw fallback) are unaffected.
+    assert platform_display_name("google_ads") == "Google Ads"
+    assert platform_display_name("some_unknown_key") == "some_unknown_key"
+
+
+@pytest.mark.unit
 def test_summary_carries_totals_period_and_campaign_count(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes the gap where TikTok's official MCP could be *connected* but was never actually *combined* with mureo: because it's a **hosted connector** (no native mureo tools, not a `mcp__mureo__*` plugin), the skills never enumerated or recorded it, so "show me campaigns" went client→TikTok with zero mureo involvement.

- **New `_mureo-shared` → *Hosted-connector platforms* convention**: how to discover a hosted connector, the first-class STATE.json key `tiktok_ads`, honest scope (skip mureo-only value-adds → `analytics_not_available_for_tiktok_ads`), and the **critical difference from plugin tools**: mureo is NOT in the data path, so it does not audit or auto-promote the call — after a confirmed mutation the skill must record it via `mureo_state_action_log_append` (no auto-rollback).
- **Threaded through the operational skills**: `daily-check`, `sync-state`, `weekly-report`, `onboard` (discovery + fetch + STATE recording), and a discovery pointer in `budget-rebalance` / `creative-refresh` / `competitive-scan` / `search-term-cleanup` / `rescue` / `goal-review`.
- **`reports.py`**: give `tiktok_ads` a friendly dashboard label ("TikTok Ads") — it previously rendered as the raw key.
- **Meta / Google official MCPs already had skill-layer fallback coverage** — unchanged (audit confirmed only TikTok was the gap).

Skill version bumps; both the shipped (`mureo/_data/skills/`) and dev (`skills/`) copies updated and identical.

## Test plan
- [x] All 22 edited SKILL.md files parse via `parse_skill_md` (both copies)
- [x] Skill/packaging tests: 186 pass
- [x] Reports tests: 15 pass, incl. a new `platform_display_name` label test
- [x] `ruff` / `black` / `mypy` clean on `mureo/`
- [ ] CI green on GitHub