### PR TITLE
feat(analysis): deterministic outcome evaluation (mureo_outcome_evaluate)

### DIFF
--- a/mureo/_data/skills/daily-check/SKILL.md
+++ b/mureo/_data/skills/daily-check/SKILL.md
@@ -2,7 +2,7 @@
 name: daily-check
 description: "Run a daily health check on all configured ad accounts (Google Ads, Meta Ads, Search Console, GA4). Use when the user asks for a daily review, health check, status update, anomaly detection, or 'how are my campaigns doing today'. Reads STRATEGY.md and STATE.json, runs platform-specific health diagnostics, checks goal progress, evaluates pending action_log observations, and reports findings as Healthy / Watch / Action-needed."
 metadata:
-  version: 0.8.0
+  version: 0.9.0
 ---
 
 # Daily Check
@@ -61,7 +61,7 @@ Run a daily health check on all marketing accounts using the strategy context.
    ```
 
 9. **Evidence check**: Review `action_log` entries that have `observation_due` dates:
-   - For entries whose observation window has passed: collect current metrics for the same campaign, compare with `metrics_at_action` (when present), and evaluate the outcome. Report findings with confidence level (see `_mureo-learning` skill).
+   - For entries whose observation window has passed: collect current metrics for the same campaign and call **`mureo_outcome_evaluate`** with `before` = the entry's `metrics_at_action` and `after` = the current metrics. It returns a deterministic per-metric + overall **improved / regressed / inconclusive** verdict (applying the ±noise band and metric directions for you) — use it instead of eyeballing the numbers, then report with the confidence it implies (see `_mureo-learning` skill). This tool is pure/platform-agnostic, so it works for **any** platform including hosted connectors and plugins — for those, first **normalize the connector's metric names to the standard keys** (`cpa`, `conversions`, `ctr`, `cost`, …) so they can be scored (unknown names are treated as neutral/no-verdict).
    - For entries still within their observation window: note them as "pending observation" and do NOT recommend further changes to those campaigns.
    - `platform="plugin:<dist>"` entries participate in this loop on equal footing with built-ins; they have no `metrics_at_action` baseline, so evaluate them **qualitatively/advisory** (see `_mureo-shared` → *Mutating plugin tools — structural strategy parity*).
    - Do NOT attribute metric movements to specific actions without checking sample sizes and observation windows.

--- a/mureo/analysis/outcome_eval.py
+++ b/mureo/analysis/outcome_eval.py
@@ -1,0 +1,205 @@
+"""Deterministic outcome evaluation for logged actions.
+
+Pure, I/O-free. Given the ``metrics_at_action`` baseline recorded on an
+``action_log`` entry and the current metrics for the same campaign, decide
+whether each key metric **improved**, **regressed**, or is **inconclusive**
+(the change is within day-to-day noise). This turns the observation-window
+review daily-check performs from an LLM judgement call into a reproducible
+verdict, and gives ``/learn`` a trustworthy signal.
+
+Platform-agnostic: it only compares numbers, so it works for any platform
+(google_ads / meta_ads / tiktok_ads / plugins) as long as the caller feeds
+comparable before/after metric names.
+
+Design notes:
+- A change smaller than ``noise_pct`` (default ±10%) is INCONCLUSIVE — the
+  same sample-size / noise discipline the anomaly detector and the
+  ``_mureo-learning`` skill use, so a single-day wobble is never a win or loss.
+- Metric direction is explicit: CPA is lower-is-better, conversions/CTR are
+  higher-is-better. Volume metrics with no inherent good/bad direction (cost,
+  clicks, impressions) are reported with their delta but no verdict.
+- A missing or zero baseline is INCONCLUSIVE (no ratio is computable) rather
+  than a fabricated 100% swing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+# A swing smaller than this (percent) is treated as day-to-day variance, not a
+# real outcome. Matches the anomaly detector's "a single bad day is noise".
+DEFAULT_NOISE_PCT = 10.0
+
+
+class Verdict(str, Enum):
+    """Outcome of a single metric (``str`` mixin → trivial JSON)."""
+
+    IMPROVED = "improved"
+    REGRESSED = "regressed"
+    INCONCLUSIVE = "inconclusive"
+
+
+class _Direction(str, Enum):
+    LOWER_IS_BETTER = "lower_is_better"
+    HIGHER_IS_BETTER = "higher_is_better"
+    NEUTRAL = "neutral"
+
+
+# Known metric directions, matched case-insensitively against metric names.
+_METRIC_DIRECTION: dict[str, _Direction] = {
+    "cpa": _Direction.LOWER_IS_BETTER,
+    "cost_per_conversion": _Direction.LOWER_IS_BETTER,
+    "cpc": _Direction.LOWER_IS_BETTER,
+    "cpl": _Direction.LOWER_IS_BETTER,
+    "cpm": _Direction.LOWER_IS_BETTER,
+    "conversions": _Direction.HIGHER_IS_BETTER,
+    "conversion_rate": _Direction.HIGHER_IS_BETTER,
+    "cvr": _Direction.HIGHER_IS_BETTER,
+    "ctr": _Direction.HIGHER_IS_BETTER,
+    "roas": _Direction.HIGHER_IS_BETTER,
+    # Volume metrics: report the delta but never call it good or bad — more
+    # spend or more clicks is only "good" relative to a goal, not on its own.
+    "cost": _Direction.NEUTRAL,
+    "spend": _Direction.NEUTRAL,
+    "clicks": _Direction.NEUTRAL,
+    "impressions": _Direction.NEUTRAL,
+}
+
+
+@dataclass(frozen=True)
+class MetricOutcome:
+    """Verdict for one metric between the baseline and the current value."""
+
+    metric: str
+    before: float
+    after: float
+    delta_pct: float | None
+    verdict: Verdict
+    note: str
+
+
+@dataclass(frozen=True)
+class OutcomeReport:
+    """Aggregate outcome across every comparable metric."""
+
+    metrics: tuple[MetricOutcome, ...]
+    overall: Verdict
+    summary: str
+
+
+def _direction(metric: str) -> _Direction:
+    return _METRIC_DIRECTION.get(metric.strip().lower(), _Direction.NEUTRAL)
+
+
+def _coerce_float(value: object) -> float | None:
+    """Best-effort float coercion; ``bool`` is rejected (it is an ``int``)."""
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value.replace(",", "").strip())
+        except ValueError:
+            return None
+    return None
+
+
+def evaluate_metric(
+    metric: str,
+    before: float,
+    after: float,
+    *,
+    noise_pct: float = DEFAULT_NOISE_PCT,
+) -> MetricOutcome:
+    """Evaluate a single metric's before→after change deterministically."""
+    direction = _direction(metric)
+
+    if before <= 0:
+        return MetricOutcome(
+            metric=metric,
+            before=before,
+            after=after,
+            delta_pct=None,
+            verdict=Verdict.INCONCLUSIVE,
+            note="baseline is zero/absent; change is not comparable",
+        )
+
+    delta_pct = round((after - before) / before * 100, 1)
+
+    if abs(delta_pct) < noise_pct:
+        return MetricOutcome(
+            metric=metric,
+            before=before,
+            after=after,
+            delta_pct=delta_pct,
+            verdict=Verdict.INCONCLUSIVE,
+            note=f"within ±{noise_pct:g}% noise band",
+        )
+
+    if direction is _Direction.NEUTRAL:
+        return MetricOutcome(
+            metric=metric,
+            before=before,
+            after=after,
+            delta_pct=delta_pct,
+            verdict=Verdict.INCONCLUSIVE,
+            note="volume metric has no inherent good/bad direction",
+        )
+
+    improved = (
+        (delta_pct < 0) if direction is _Direction.LOWER_IS_BETTER else (delta_pct > 0)
+    )
+    verdict = Verdict.IMPROVED if improved else Verdict.REGRESSED
+    return MetricOutcome(
+        metric=metric,
+        before=before,
+        after=after,
+        delta_pct=delta_pct,
+        verdict=verdict,
+        note=f"{direction.value}; {delta_pct:+g}%",
+    )
+
+
+def evaluate_outcome(
+    before: dict[str, object],
+    after: dict[str, object],
+    *,
+    noise_pct: float = DEFAULT_NOISE_PCT,
+) -> OutcomeReport:
+    """Compare two metric snapshots and return per-metric + overall verdicts.
+
+    Only metrics present (and numeric) in BOTH snapshots are compared. The
+    overall verdict weighs only directional metrics (CPA / conversions / …):
+    any regression → REGRESSED; else any improvement → IMPROVED; else
+    INCONCLUSIVE. Neutral/volume metrics never decide the overall verdict.
+    """
+    outcomes: list[MetricOutcome] = []
+    for metric in sorted(before):
+        b = _coerce_float(before.get(metric))
+        a = _coerce_float(after.get(metric))
+        if b is None or a is None:
+            continue
+        outcomes.append(evaluate_metric(metric, b, a, noise_pct=noise_pct))
+
+    directional = [
+        o for o in outcomes if _direction(o.metric) is not _Direction.NEUTRAL
+    ]
+    if any(o.verdict is Verdict.REGRESSED for o in directional):
+        overall = Verdict.REGRESSED
+    elif any(o.verdict is Verdict.IMPROVED for o in directional):
+        overall = Verdict.IMPROVED
+    else:
+        overall = Verdict.INCONCLUSIVE
+
+    improved = [o.metric for o in directional if o.verdict is Verdict.IMPROVED]
+    regressed = [o.metric for o in directional if o.verdict is Verdict.REGRESSED]
+    if overall is Verdict.REGRESSED:
+        summary = f"Regressed on {', '.join(regressed)}."
+    elif overall is Verdict.IMPROVED:
+        summary = f"Improved on {', '.join(improved)}."
+    else:
+        summary = "No change beyond the noise band on any directional metric."
+
+    return OutcomeReport(metrics=tuple(outcomes), overall=overall, summary=summary)

--- a/mureo/mcp/_handlers_mureo_context.py
+++ b/mureo/mcp/_handlers_mureo_context.py
@@ -302,3 +302,43 @@ async def handle_state_set_conversion_events(
     except ContextFileError as exc:
         raise ValueError(str(exc)) from exc
     return _json_result(_state_to_dict(doc))
+
+
+async def handle_outcome_evaluate(arguments: dict[str, Any]) -> list[TextContent]:
+    """Deterministically evaluate a before→after metric change.
+
+    Pure calculation (no state I/O), so it works for ANY platform — the caller
+    supplies the two metric maps (typically an action_log entry's
+    ``metrics_at_action`` as ``before`` and the current numbers as ``after``).
+    Returns per-metric and overall improved/regressed/inconclusive verdicts.
+    """
+    from mureo.analysis.outcome_eval import evaluate_outcome
+
+    before = _require(arguments, "before")
+    after = _require(arguments, "after")
+    if not isinstance(before, dict) or not isinstance(after, dict):
+        raise ValueError("before and after must be objects (metric name -> number)")
+    raw_noise = arguments.get("noise_pct", 10.0)
+    try:
+        noise_pct = float(raw_noise)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("noise_pct must be a number") from exc
+
+    report = evaluate_outcome(before, after, noise_pct=noise_pct)
+    return _json_result(
+        {
+            "overall": report.overall.value,
+            "summary": report.summary,
+            "metrics": [
+                {
+                    "metric": m.metric,
+                    "before": m.before,
+                    "after": m.after,
+                    "delta_pct": m.delta_pct,
+                    "verdict": m.verdict.value,
+                    "note": m.note,
+                }
+                for m in report.metrics
+            ],
+        }
+    )

--- a/mureo/mcp/tools_mureo_context.py
+++ b/mureo/mcp/tools_mureo_context.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any
 from mcp.types import Tool
 
 from mureo.mcp._handlers_mureo_context import (
+    handle_outcome_evaluate,
     handle_state_action_log_append,
     handle_state_get,
     handle_state_platform_metrics_set,
@@ -363,6 +364,48 @@ TOOLS: list[Tool] = [
             "required": ["platform", "account_id"],
         },
     ),
+    Tool(
+        name="mureo_outcome_evaluate",
+        description=(
+            "Deterministically evaluate whether a logged action's outcome "
+            "improved, regressed, or is inconclusive — the reproducible verdict "
+            "the observation-window review (daily-check) and /learn rely on, "
+            "instead of eyeballing the numbers. Pass ``before`` (typically the "
+            "action_log entry's ``metrics_at_action``) and ``after`` (the "
+            "current numbers). Pure calculation — works for ANY platform "
+            "(google_ads / meta_ads / tiktok_ads / plugins) as long as you feed "
+            "comparable metric names. Direction is built in: cpa/cpc/cpl/cpm "
+            "lower-is-better; conversions/ctr/cvr/roas higher-is-better; "
+            "cost/spend/clicks/impressions are volume-only (reported, never "
+            "scored). A change within ±noise_pct (default 10%) or a zero/absent "
+            "baseline is 'inconclusive' (no fabricated swing)."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "before": {
+                    "type": "object",
+                    "description": (
+                        "Baseline metrics — metric name → number (e.g. "
+                        '{"cpa": 5000, "conversions": 50}). Usually the '
+                        "action_log entry's metrics_at_action."
+                    ),
+                },
+                "after": {
+                    "type": "object",
+                    "description": "Current metrics, same shape as ``before``.",
+                },
+                "noise_pct": {
+                    "type": "number",
+                    "description": (
+                        "Noise band in percent (default 10). A change smaller "
+                        "than this is 'inconclusive' (day-to-day variance)."
+                    ),
+                },
+            },
+            "required": ["before", "after"],
+        },
+    ),
 ]
 
 
@@ -375,6 +418,7 @@ _HANDLERS = {
     "mureo_state_report_set": handle_state_report_set,
     "mureo_state_platform_metrics_set": handle_state_platform_metrics_set,
     "mureo_state_set_conversion_events": handle_state_set_conversion_events,
+    "mureo_outcome_evaluate": handle_outcome_evaluate,
 }
 
 

--- a/skills/daily-check/SKILL.md
+++ b/skills/daily-check/SKILL.md
@@ -2,7 +2,7 @@
 name: daily-check
 description: "Run a daily health check on all configured ad accounts (Google Ads, Meta Ads, Search Console, GA4). Use when the user asks for a daily review, health check, status update, anomaly detection, or 'how are my campaigns doing today'. Reads STRATEGY.md and STATE.json, runs platform-specific health diagnostics, checks goal progress, evaluates pending action_log observations, and reports findings as Healthy / Watch / Action-needed."
 metadata:
-  version: 0.8.0
+  version: 0.9.0
 ---
 
 # Daily Check
@@ -61,7 +61,7 @@ Run a daily health check on all marketing accounts using the strategy context.
    ```
 
 9. **Evidence check**: Review `action_log` entries that have `observation_due` dates:
-   - For entries whose observation window has passed: collect current metrics for the same campaign, compare with `metrics_at_action` (when present), and evaluate the outcome. Report findings with confidence level (see `_mureo-learning` skill).
+   - For entries whose observation window has passed: collect current metrics for the same campaign and call **`mureo_outcome_evaluate`** with `before` = the entry's `metrics_at_action` and `after` = the current metrics. It returns a deterministic per-metric + overall **improved / regressed / inconclusive** verdict (applying the ±noise band and metric directions for you) — use it instead of eyeballing the numbers, then report with the confidence it implies (see `_mureo-learning` skill). This tool is pure/platform-agnostic, so it works for **any** platform including hosted connectors and plugins — for those, first **normalize the connector's metric names to the standard keys** (`cpa`, `conversions`, `ctr`, `cost`, …) so they can be scored (unknown names are treated as neutral/no-verdict).
    - For entries still within their observation window: note them as "pending observation" and do NOT recommend further changes to those campaigns.
    - `platform="plugin:<dist>"` entries participate in this loop on equal footing with built-ins; they have no `metrics_at_action` baseline, so evaluate them **qualitatively/advisory** (see `_mureo-shared` → *Mutating plugin tools — structural strategy parity*).
    - Do NOT attribute metric movements to specific actions without checking sample sizes and observation windows.

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -43,11 +43,11 @@ class TestListTools:
 
     async def test_list_tools_returns_all_tools(self) -> None:
         """list_tools returns all tools (Google Ads 83 + Meta Ads 82 + Search Console 10
-        + Rollback 2 + Analysis 1 + Mureo Context 8 + Analytics Registry 1
-        + Learning 2 = 189)."""
+        + Rollback 2 + Analysis 1 + Mureo Context 9 + Analytics Registry 1
+        + Learning 2 = 190)."""
         mod = _import_server_module()
         tools = await mod.handle_list_tools()
-        assert len(tools) == 189
+        assert len(tools) == 190
 
     async def test_list_tools_contains_google_and_meta(self) -> None:
         """Google Ads and Meta Ads tools are included."""

--- a/tests/test_mcp_tools_mureo_context.py
+++ b/tests/test_mcp_tools_mureo_context.py
@@ -57,9 +57,9 @@ def _import_tools():
 # ---------------------------------------------------------------------------
 
 
-def test_tools_module_exports_eight_tools() -> None:
+def test_tools_module_exports_nine_tools() -> None:
     mod = _import_tools()
-    assert len(mod.TOOLS) == 8
+    assert len(mod.TOOLS) == 9
     expected = {
         "mureo_strategy_get",
         "mureo_strategy_set",
@@ -69,6 +69,7 @@ def test_tools_module_exports_eight_tools() -> None:
         "mureo_state_report_set",
         "mureo_state_platform_metrics_set",
         "mureo_state_set_conversion_events",
+        "mureo_outcome_evaluate",
     }
     assert {t.name for t in mod.TOOLS} == expected
 

--- a/tests/test_outcome_eval.py
+++ b/tests/test_outcome_eval.py
@@ -1,0 +1,115 @@
+"""Tests for deterministic outcome evaluation (mureo.analysis.outcome_eval)."""
+
+from __future__ import annotations
+
+import pytest
+
+from mureo.analysis.outcome_eval import Verdict, evaluate_metric, evaluate_outcome
+
+pytestmark = pytest.mark.unit
+
+
+class TestEvaluateMetric:
+    def test_cpa_drop_is_improvement(self) -> None:
+        o = evaluate_metric("cpa", 5000, 4000)
+        assert o.verdict is Verdict.IMPROVED
+        assert o.delta_pct == -20.0
+
+    def test_cpa_rise_is_regression(self) -> None:
+        assert evaluate_metric("cpa", 4000, 5000).verdict is Verdict.REGRESSED
+
+    def test_conversions_up_is_improvement(self) -> None:
+        assert evaluate_metric("conversions", 40, 60).verdict is Verdict.IMPROVED
+
+    def test_conversions_down_is_regression(self) -> None:
+        assert evaluate_metric("conversions", 60, 40).verdict is Verdict.REGRESSED
+
+    def test_small_change_within_noise_is_inconclusive(self) -> None:
+        assert evaluate_metric("cpa", 5000, 4750).verdict is Verdict.INCONCLUSIVE
+
+    def test_custom_noise_band(self) -> None:
+        assert (
+            evaluate_metric("cpa", 5000, 4750, noise_pct=2.0).verdict
+            is Verdict.IMPROVED
+        )
+
+    def test_zero_baseline_is_inconclusive(self) -> None:
+        o = evaluate_metric("conversions", 0, 30)
+        assert o.verdict is Verdict.INCONCLUSIVE
+        assert o.delta_pct is None
+
+    def test_volume_metric_has_no_verdict(self) -> None:
+        assert evaluate_metric("cost", 100000, 200000).verdict is Verdict.INCONCLUSIVE
+
+    def test_metric_name_is_case_insensitive(self) -> None:
+        assert evaluate_metric("CPA", 5000, 4000).verdict is Verdict.IMPROVED
+
+
+class TestEvaluateOutcome:
+    def test_regression_dominates_overall(self) -> None:
+        report = evaluate_outcome(
+            {"cpa": 5000, "conversions": 50},
+            {"cpa": 7000, "conversions": 55},
+        )
+        assert report.overall is Verdict.REGRESSED
+
+    def test_improvement_when_no_regression(self) -> None:
+        report = evaluate_outcome(
+            {"cpa": 5000, "conversions": 50},
+            {"cpa": 4000, "conversions": 50},
+        )
+        assert report.overall is Verdict.IMPROVED
+
+    def test_inconclusive_when_all_within_noise(self) -> None:
+        assert (
+            evaluate_outcome({"cpa": 5000}, {"cpa": 5100}).overall
+            is Verdict.INCONCLUSIVE
+        )
+
+    def test_only_common_numeric_metrics_compared(self) -> None:
+        report = evaluate_outcome(
+            {"cpa": 5000, "note": "text", "conversions": 50},
+            {"cpa": 4000},
+        )
+        assert {m.metric for m in report.metrics} == {"cpa"}
+
+    def test_volume_only_change_is_inconclusive_overall(self) -> None:
+        assert (
+            evaluate_outcome({"cost": 100000}, {"cost": 200000}).overall
+            is Verdict.INCONCLUSIVE
+        )
+
+    def test_string_numbers_coerced(self) -> None:
+        # Metrics arriving as formatted strings (e.g. from a hosted connector).
+        report = evaluate_outcome({"cpa": "5,000"}, {"cpa": "4,000"})
+        assert report.overall is Verdict.IMPROVED
+
+
+class TestMcpTool:
+    """The mureo_outcome_evaluate MCP tool is registered and returns JSON."""
+
+    @pytest.mark.asyncio
+    async def test_tool_registered_and_evaluates(self) -> None:
+        import json
+
+        from mureo.mcp.tools_mureo_context import TOOLS, handle_tool
+
+        assert any(t.name == "mureo_outcome_evaluate" for t in TOOLS)
+
+        result = await handle_tool(
+            "mureo_outcome_evaluate",
+            {"before": {"cpa": 5000}, "after": {"cpa": 4000}},
+        )
+        payload = json.loads(result[0].text)
+        assert payload["overall"] == "improved"
+        assert payload["metrics"][0]["metric"] == "cpa"
+        assert payload["metrics"][0]["delta_pct"] == -20.0
+
+    @pytest.mark.asyncio
+    async def test_tool_rejects_non_object_args(self) -> None:
+        from mureo.mcp.tools_mureo_context import handle_tool
+
+        with pytest.raises(ValueError):
+            await handle_tool(
+                "mureo_outcome_evaluate", {"before": [1, 2], "after": {"cpa": 1}}
+            )


### PR DESCRIPTION
## Summary

Feature 2 of the OSS roadmap. Turns the observation-window review (daily-check) and the `/learn` signal from an LLM judgement call into a **reproducible verdict**.

- **Pure engine** `mureo/analysis/outcome_eval.py`: `evaluate_metric` / `evaluate_outcome` compare a before/after metric snapshot → **improved / regressed / inconclusive** per metric + overall. Metric direction is explicit (cpa/cpc/cpl/cpm lower-is-better; conversions/ctr/cvr/roas higher-is-better; cost/spend/clicks/impressions volume-only, never scored). A change within ±`noise_pct` (default 10%) or a zero/absent baseline is **inconclusive** — no fabricated swing.
- **MCP tool** `mureo_outcome_evaluate` (before = action_log `metrics_at_action`, after = current numbers).
- **Skill wiring**: daily-check's evidence step now calls the tool instead of eyeballing, and normalizes hosted/plugin metric names to the standard keys first.
- **Platform-agnostic**: it's a pure calculation (no data-path interception), so unlike the policy gate it **works for TikTok / official MCPs / plugins** — the caller just feeds comparable metric names.

## Test plan
- [x] `tests/test_outcome_eval.py` — pure eval (directions, noise band, zero baseline, string coercion) + MCP tool registration/dispatch
- [x] Tool-count assertions updated (mureo context 8→9, total 189→190)
- [x] `ruff` / `black` / `mypy` clean on `mureo/` (244 files)
- [ ] CI green

Roadmap: #1 policy gate (merged #360) · **#2 outcome eval (this)** · #3 generic STATE.json anomaly (pending). Calculation-tier features (#2, #3) reach hosted MCPs; hard enforcement for those needs the gateway (#359).

https://claude.ai/code/session_0195WBK6YopTveq9RAQE2xMz