### PR TITLE
feat(meta-ads): add end_time (0=no-end) and lifetime_budget to meta_ads_ad_sets_update (#367)

### DIFF
--- a/mureo/_data/skills/_mureo-strategy/SKILL.md
+++ b/mureo/_data/skills/_mureo-strategy/SKILL.md
@@ -180,6 +180,7 @@ keys (all optional):
 - max_daily_budget_per_campaign: 50000
 - max_daily_budget_increase_pct: 20
 - max_total_daily_budget: 300000
+- max_lifetime_budget_per_campaign: 900000
 - blocked_operations: google_ads_campaigns_remove, meta_ads_campaigns_delete
 ```
 
@@ -190,6 +191,10 @@ keys (all optional):
   `current_daily_budget`).
 - `max_total_daily_budget` — refused when a caller supplies
   `projected_total_daily_budget` above this.
+- `max_lifetime_budget_per_campaign` — a mutation proposing a `lifetime_budget`
+  (period-total, account currency) above this is refused. Lifetime and daily
+  budgets have distinct semantics, so declare this cap separately — a daily
+  cap alone does not constrain lifetime-budget mutations.
 - `blocked_operations` — comma-separated tool names that are always refused.
 
 Absent section (or an unparseable value) ⇒ no enforcement for that rule

--- a/mureo/mcp/_handlers_meta_ads.py
+++ b/mureo/mcp/_handlers_meta_ads.py
@@ -192,18 +192,72 @@ async def handle_ad_sets_create(args: dict[str, Any]) -> list[TextContent]:
     return _json_result(result)
 
 
+def _normalized_end_time(value: Any) -> int | str:
+    """Validate an ad-set ``end_time`` argument and normalize the zero form.
+
+    Meta's documented convention for "no end date, run continuously" is
+    ``end_time=0``; the string ``"0"`` is wire-identical once form-encoded,
+    so it is normalized to the integer ``0`` here — otherwise it could
+    sidestep the lifetime-budget contradiction guard below.
+    """
+    err = ValueError(
+        "end_time must be an ISO 8601 datetime string, a UNIX timestamp, "
+        f"or 0 to clear the end date (got {value!r})"
+    )
+    if isinstance(value, bool):
+        raise err
+    if isinstance(value, int):
+        if value < 0:
+            raise err
+        return value
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            raise err
+        return 0 if stripped == "0" else value
+    raise err
+
+
+def _validate_ad_set_schedule_and_budget(args: dict[str, Any]) -> int | str | None:
+    """Reject contradictory ad-set budget/schedule updates before dispatch.
+
+    Meta treats daily_budget and lifetime_budget as mutually exclusive on an
+    ad set, and a lifetime budget requires a schedule end — while end_time=0
+    means "no end date". Returns the normalized end_time (or None if absent).
+    """
+    if args.get("daily_budget") is not None and args.get("lifetime_budget") is not None:
+        raise ValueError(
+            "daily_budget and lifetime_budget are mutually exclusive on an "
+            "ad set — supply only one."
+        )
+    if args.get("end_time") is None:
+        return None
+    end_time = _normalized_end_time(args["end_time"])
+    if end_time == 0 and args.get("lifetime_budget") is not None:
+        raise ValueError(
+            "end_time=0 (no end date) cannot be combined with lifetime_budget "
+            "— a lifetime budget requires a schedule end."
+        )
+    return end_time
+
+
 @api_error_handler
 async def handle_ad_sets_update(args: dict[str, Any]) -> list[TextContent]:
-    _validate_positive_money(args, "daily_budget")
+    _validate_positive_money(args, "daily_budget", "lifetime_budget")
+    end_time = _validate_ad_set_schedule_and_budget(args)
     client = await _get_client(args)
     if client is None:
         return _no_meta_creds()
     ad_set_id = _require(args, "ad_set_id")
     update_kwargs: dict[str, Any] = {}
-    for key in ("name", "status", "daily_budget", "targeting"):
+    for key in ("name", "status", "daily_budget", "lifetime_budget", "targeting"):
         val = _opt(args, key)
         if val is not None:
             update_kwargs[key] = val
+    # end_time is handled outside the loop: 0 is a meaningful value (clear
+    # the end date, Meta convention), so a falsy check must not drop it.
+    if end_time is not None:
+        update_kwargs["end_time"] = end_time
     replace_targeting = bool(args.get("replace_targeting", False))
     result = await client.update_ad_set(
         ad_set_id, replace_targeting=replace_targeting, **update_kwargs

--- a/mureo/mcp/_tools_meta_ads_campaigns.py
+++ b/mureo/mcp/_tools_meta_ads_campaigns.py
@@ -421,7 +421,30 @@ TOOLS: list[Tool] = [
                     "minimum": 1,
                     "description": (
                         "New daily budget in account currency minor units. "
-                        "Only valid when the campaign is not using CBO."
+                        "Only valid when the campaign is not using CBO. "
+                        "Mutually exclusive with lifetime_budget."
+                    ),
+                },
+                "lifetime_budget": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": (
+                        "New lifetime budget in account currency minor units "
+                        "(cents for USD, yen for JPY). Mutually exclusive "
+                        "with daily_budget. Requires the ad set to have an "
+                        "end_time — supply one in the same call if it is "
+                        "not already set."
+                    ),
+                },
+                "end_time": {
+                    "type": ["string", "integer"],
+                    "description": (
+                        "New schedule end. Accepts an ISO 8601 datetime "
+                        "string (e.g. '2026-08-01T00:00:00+0900') or a UTC "
+                        "UNIX timestamp integer. Pass 0 to clear the end "
+                        "date so the ad set runs continuously (Meta API "
+                        "convention; only valid with a daily budget — a "
+                        "lifetime budget requires an end date)."
                     ),
                 },
                 "targeting": {

--- a/mureo/policy/strategy_gate.py
+++ b/mureo/policy/strategy_gate.py
@@ -52,6 +52,7 @@ class Guardrails:
     max_daily_budget_per_campaign: float | None = None
     max_daily_budget_increase_pct: float | None = None
     max_total_daily_budget: float | None = None
+    max_lifetime_budget_per_campaign: float | None = None
     blocked_operations: frozenset[str] = field(default_factory=frozenset)
 
     def is_empty(self) -> bool:
@@ -59,6 +60,7 @@ class Guardrails:
             self.max_daily_budget_per_campaign is None
             and self.max_daily_budget_increase_pct is None
             and self.max_total_daily_budget is None
+            and self.max_lifetime_budget_per_campaign is None
             and not self.blocked_operations
         )
 
@@ -80,6 +82,7 @@ def parse_guardrails(content: str) -> Guardrails:
     max_per_campaign: float | None = None
     max_increase_pct: float | None = None
     max_total: float | None = None
+    max_lifetime: float | None = None
     blocked: set[str] = set()
 
     for line in content.splitlines():
@@ -94,6 +97,8 @@ def parse_guardrails(content: str) -> Guardrails:
             max_increase_pct = _to_float(raw)
         elif key == "max_total_daily_budget":
             max_total = _to_float(raw)
+        elif key == "max_lifetime_budget_per_campaign":
+            max_lifetime = _to_float(raw)
         elif key == "blocked_operations":
             blocked = {op.strip() for op in raw.split(",") if op.strip()}
 
@@ -101,6 +106,7 @@ def parse_guardrails(content: str) -> Guardrails:
         max_daily_budget_per_campaign=max_per_campaign,
         max_daily_budget_increase_pct=max_increase_pct,
         max_total_daily_budget=max_total,
+        max_lifetime_budget_per_campaign=max_lifetime,
         blocked_operations=frozenset(blocked),
     )
 
@@ -186,6 +192,27 @@ def evaluate_guardrails(
                         f"(max_daily_budget_increase_pct)."
                     ),
                 )
+
+    # Lifetime (period-total) budgets have distinct semantics from daily
+    # budgets, so they get their own cap rather than reusing the daily one.
+    # Without this, a lifetime-budget mutation would sidestep every budget
+    # guardrail the operator wrote (#367).
+    lifetime = arguments.get("lifetime_budget")
+    lifetime_cap = guardrails.max_lifetime_budget_per_campaign
+    if (
+        lifetime_cap is not None
+        and isinstance(lifetime, (int, float))
+        and not isinstance(lifetime, bool)
+        and float(lifetime) > lifetime_cap
+    ):
+        return PolicyDecision(
+            allowed=False,
+            reason=(
+                f"Proposed lifetime budget {float(lifetime):,.0f} exceeds the "
+                f"STRATEGY.md Guardrails cap of {lifetime_cap:,.0f} "
+                f"(max_lifetime_budget_per_campaign)."
+            ),
+        )
 
     total = arguments.get("projected_total_daily_budget")
     total_cap = guardrails.max_total_daily_budget

--- a/skills/_mureo-strategy/SKILL.md
+++ b/skills/_mureo-strategy/SKILL.md
@@ -180,6 +180,7 @@ keys (all optional):
 - max_daily_budget_per_campaign: 50000
 - max_daily_budget_increase_pct: 20
 - max_total_daily_budget: 300000
+- max_lifetime_budget_per_campaign: 900000
 - blocked_operations: google_ads_campaigns_remove, meta_ads_campaigns_delete
 ```
 
@@ -190,6 +191,10 @@ keys (all optional):
   `current_daily_budget`).
 - `max_total_daily_budget` — refused when a caller supplies
   `projected_total_daily_budget` above this.
+- `max_lifetime_budget_per_campaign` — a mutation proposing a `lifetime_budget`
+  (period-total, account currency) above this is refused. Lifetime and daily
+  budgets have distinct semantics, so declare this cap separately — a daily
+  cap alone does not constrain lifetime-budget mutations.
 - `blocked_operations` — comma-separated tool names that are always refused.
 
 Absent section (or an unparseable value) ⇒ no enforcement for that rule

--- a/tests/test_mcp_tools_meta_ads.py
+++ b/tests/test_mcp_tools_meta_ads.py
@@ -93,6 +93,15 @@ class TestMetaAdsToolDefinitions:
         assert tool is not None, f"Tool {tool_name} not found"
         assert set(tool.inputSchema["required"]) == set(expected_required)
 
+    def test_ad_sets_update_exposes_schedule_and_lifetime_budget(self) -> None:
+        """meta_ads_ad_sets_update exposes end_time and lifetime_budget (#367)."""
+        mod = _import_meta_ads_tools()
+        tool = next(t for t in mod.TOOLS if t.name == "meta_ads_ad_sets_update")
+        props = tool.inputSchema["properties"]
+        assert "end_time" in props
+        assert "lifetime_budget" in props
+        assert props["lifetime_budget"]["type"] == "integer"
+
 
 # ---------------------------------------------------------------------------
 # Handler tests — helpers
@@ -274,6 +283,139 @@ class TestMetaAdsAdSetHandlers:
             )
 
         client.update_ad_set.assert_awaited_once()
+
+    async def test_ad_sets_update_forwards_lifetime_budget(self) -> None:
+        """lifetime_budget reaches update_ad_set unchanged (#367)."""
+        mod = _import_meta_ads_tools()
+        handlers = _import_handlers()
+        creds, client = _mock_meta_ads_context()
+        client.update_ad_set.return_value = {"success": True}
+
+        with (
+            patch.object(handlers, "load_meta_ads_credentials", return_value=creds),
+            patch.object(handlers, "create_meta_ads_client", return_value=client),
+        ):
+            await mod.handle_tool(
+                "meta_ads_ad_sets_update",
+                {"account_id": "act_123", "ad_set_id": "20", "lifetime_budget": 90000},
+            )
+
+        kwargs = client.update_ad_set.await_args.kwargs
+        assert kwargs["lifetime_budget"] == 90000
+
+    async def test_ad_sets_update_forwards_end_time_string(self) -> None:
+        """An ISO 8601 end_time string reaches update_ad_set unchanged (#367)."""
+        mod = _import_meta_ads_tools()
+        handlers = _import_handlers()
+        creds, client = _mock_meta_ads_context()
+        client.update_ad_set.return_value = {"success": True}
+
+        with (
+            patch.object(handlers, "load_meta_ads_credentials", return_value=creds),
+            patch.object(handlers, "create_meta_ads_client", return_value=client),
+        ):
+            await mod.handle_tool(
+                "meta_ads_ad_sets_update",
+                {
+                    "account_id": "act_123",
+                    "ad_set_id": "20",
+                    "end_time": "2026-08-01T00:00:00+09:00",
+                },
+            )
+
+        kwargs = client.update_ad_set.await_args.kwargs
+        assert kwargs["end_time"] == "2026-08-01T00:00:00+09:00"
+
+    async def test_ad_sets_update_end_time_zero_clears_end_date(self) -> None:
+        """end_time=0 (Meta convention: no end date) is forwarded, not dropped (#367)."""
+        mod = _import_meta_ads_tools()
+        handlers = _import_handlers()
+        creds, client = _mock_meta_ads_context()
+        client.update_ad_set.return_value = {"success": True}
+
+        with (
+            patch.object(handlers, "load_meta_ads_credentials", return_value=creds),
+            patch.object(handlers, "create_meta_ads_client", return_value=client),
+        ):
+            await mod.handle_tool(
+                "meta_ads_ad_sets_update",
+                {"account_id": "act_123", "ad_set_id": "20", "end_time": 0},
+            )
+
+        kwargs = client.update_ad_set.await_args.kwargs
+        assert kwargs["end_time"] == 0
+
+    async def test_ad_sets_update_rejects_both_budgets(self) -> None:
+        """daily_budget and lifetime_budget are mutually exclusive on Meta (#367)."""
+        mod = _import_meta_ads_tools()
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            await mod.handle_tool(
+                "meta_ads_ad_sets_update",
+                {
+                    "account_id": "act_123",
+                    "ad_set_id": "20",
+                    "daily_budget": 5000,
+                    "lifetime_budget": 90000,
+                },
+            )
+
+    @pytest.mark.parametrize("no_end", [0, "0", " 0 "])
+    async def test_ad_sets_update_rejects_lifetime_budget_with_no_end(
+        self, no_end: Any
+    ) -> None:
+        """A lifetime budget requires an end date — end_time=0 contradicts it,
+        including the string form "0" which is wire-identical to 0 (#367)."""
+        mod = _import_meta_ads_tools()
+        with pytest.raises(ValueError, match="end_time"):
+            await mod.handle_tool(
+                "meta_ads_ad_sets_update",
+                {
+                    "account_id": "act_123",
+                    "ad_set_id": "20",
+                    "lifetime_budget": 90000,
+                    "end_time": no_end,
+                },
+            )
+
+    async def test_ad_sets_update_normalizes_string_zero_end_time(self) -> None:
+        """end_time="0" is normalized to the integer 0 before forwarding (#367)."""
+        mod = _import_meta_ads_tools()
+        handlers = _import_handlers()
+        creds, client = _mock_meta_ads_context()
+        client.update_ad_set.return_value = {"success": True}
+
+        with (
+            patch.object(handlers, "load_meta_ads_credentials", return_value=creds),
+            patch.object(handlers, "create_meta_ads_client", return_value=client),
+        ):
+            await mod.handle_tool(
+                "meta_ads_ad_sets_update",
+                {"account_id": "act_123", "ad_set_id": "20", "end_time": "0"},
+            )
+
+        kwargs = client.update_ad_set.await_args.kwargs
+        assert kwargs["end_time"] == 0
+
+    async def test_ad_sets_update_rejects_zero_lifetime_budget(self) -> None:
+        """A 0 lifetime budget halts delivery — refuse before any API call (#367)."""
+        mod = _import_meta_ads_tools()
+        with pytest.raises(ValueError, match="greater than 0"):
+            await mod.handle_tool(
+                "meta_ads_ad_sets_update",
+                {"account_id": "act_123", "ad_set_id": "20", "lifetime_budget": 0},
+            )
+
+    @pytest.mark.parametrize("bad_end_time", [-1, True, "", "  "])
+    async def test_ad_sets_update_rejects_invalid_end_time(
+        self, bad_end_time: Any
+    ) -> None:
+        """Negative / boolean / blank end_time values are rejected (#367)."""
+        mod = _import_meta_ads_tools()
+        with pytest.raises(ValueError, match="end_time"):
+            await mod.handle_tool(
+                "meta_ads_ad_sets_update",
+                {"account_id": "act_123", "ad_set_id": "20", "end_time": bad_end_time},
+            )
 
     async def test_pages_upload_photo(self) -> None:
         """meta_ads_pages_upload_photo returns the PAGE photo_id (cover_photo_id)."""

--- a/tests/test_strategy_gate.py
+++ b/tests/test_strategy_gate.py
@@ -21,11 +21,13 @@ class TestParseGuardrails:
             "- max_daily_budget_per_campaign: 50,000\n"
             "- max_daily_budget_increase_pct: 20\n"
             "- max_total_daily_budget: 300000\n"
+            "- max_lifetime_budget_per_campaign: 900000\n"
             "- blocked_operations: google_ads_campaigns_remove, meta_ads_x\n"
         )
         assert g.max_daily_budget_per_campaign == 50000
         assert g.max_daily_budget_increase_pct == 20
         assert g.max_total_daily_budget == 300000
+        assert g.max_lifetime_budget_per_campaign == 900000
         assert g.blocked_operations == frozenset(
             {"google_ads_campaigns_remove", "meta_ads_x"}
         )
@@ -110,6 +112,36 @@ class TestEvaluateGuardrails:
             g,
         )
         assert d.allowed is False
+
+    def test_lifetime_cap_denies(self) -> None:
+        """lifetime_budget is gate-covered so it cannot sidestep caps (#367)."""
+        g = Guardrails(max_lifetime_budget_per_campaign=900000)
+        d = evaluate_guardrails(
+            "meta_ads_ad_sets_update",
+            {"ad_set_id": "1", "lifetime_budget": 1_000_000},
+            g,
+        )
+        assert d.allowed is False
+        assert "max_lifetime_budget_per_campaign" in d.reason
+
+    def test_lifetime_under_cap_allows(self) -> None:
+        g = Guardrails(max_lifetime_budget_per_campaign=900000)
+        d = evaluate_guardrails(
+            "meta_ads_ad_sets_update",
+            {"ad_set_id": "1", "lifetime_budget": 500000},
+            g,
+        )
+        assert d.allowed is True
+
+    def test_lifetime_budget_ignores_daily_cap(self) -> None:
+        """Daily and lifetime caps have distinct semantics — no cross-check."""
+        g = Guardrails(max_daily_budget_per_campaign=50000)
+        d = evaluate_guardrails(
+            "meta_ads_ad_sets_update",
+            {"ad_set_id": "1", "lifetime_budget": 80000},
+            g,
+        )
+        assert d.allowed is True
 
     def test_non_budget_tool_with_budget_cap_allows(self) -> None:
         # A status change carries no budget → the budget cap does not apply.


### PR DESCRIPTION
Closes #367

## Summary

`meta_ads_ad_sets_update` gains the two ad-set update fields the official Marketing API supports but mureo did not expose:

- **`end_time`** — ISO 8601 datetime string or UNIX timestamp integer. **`0` clears the end date** so the ad set runs continuously; confirmed against the Marketing API ad-set reference ("When creating a set with a daily budget, specify `end_time=0` to set the set to be ongoing and have no end date"). The string `"0"` is wire-identical once form-encoded, so it is normalized to the integer `0` before validation and forwarding.
- **`lifetime_budget`** — minor currency units, routed through `_validate_positive_money`.

## Validation

- `daily_budget` × `lifetime_budget` mutual exclusion (Meta rejects both on one ad set).
- `lifetime_budget` + `end_time=0` refused — a lifetime budget requires a schedule end.
- `end_time`: bool / negative int / blank string rejected; `0` survives the None-skipping kwarg loop via explicit handling.

## Guardrail composition (from security review)

The `StrategyPolicyGate` only evaluated daily-budget keys, so a lifetime-budget mutation would have sidestepped every budget cap the operator wrote. This PR adds the **`max_lifetime_budget_per_campaign`** guardrail key (parse + evaluate against the `lifetime_budget` argument), keeping the gate's fail-open contract — enforcement only when the operator declares the key. Documented in the `_mureo-strategy` skill (canonical + packaged copies, byte-identical).

## Test plan

- [x] Schema exposes `end_time` / `lifetime_budget` (tool-definition test)
- [x] Handler forwards `lifetime_budget`, ISO `end_time`, and `end_time=0` to `update_ad_set`
- [x] `"0"` / `" 0 "` normalized to int 0 (forwarding + contradiction-guard parametrize)
- [x] Mutual exclusion, zero lifetime budget, invalid `end_time` (`-1`, `True`, `""`, `"  "`) rejected
- [x] Gate: lifetime cap denies over / allows under; daily cap does not cross-apply to lifetime
- [x] ruff / black / mypy (CI flags) clean; full suite green except known local plugin-env noise

TDD (tests first), python-reviewer + security-reviewer both APPROVE after fix iteration.

https://claude.ai/code/session_0195WBK6YopTveq9RAQE2xMz
