### PR TITLE
feat(google-ads): read-only demographic/audience criteria and image-asset retrievals (#366)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,7 +140,7 @@ docs/integrations.md         # Platform discovery + external MCP integration gui
 | Sitelinks | `sitelinks.list`, `sitelinks.create`, `sitelinks.remove` |
 | Callouts | `callouts.list`, `callouts.create`, `callouts.remove` |
 | Conversions | `conversions.list`, `conversions.get`, `conversions.performance`, `conversions.create`, `conversions.update`, `conversions.remove`, `conversions.tag` |
-| Targeting | `recommendations.list`, `recommendations.apply`, `device_targeting.get`, `device_targeting.set`, `bid_adjustments.get`, `bid_adjustments.update`, `location_targeting.list`, `location_targeting.update`, `schedule_targeting.list`, `schedule_targeting.update`, `change_history.list` |
+| Targeting | `recommendations.list`, `recommendations.apply`, `device_targeting.get`, `device_targeting.set`, `bid_adjustments.get`, `bid_adjustments.update`, `location_targeting.list`, `location_targeting.update`, `schedule_targeting.list`, `schedule_targeting.update`, `change_history.list`, `demographic_targeting.list`, `audience_targeting.list` |
 | Analysis | `performance.report`, `performance.analyze`, `cost_increase.investigate`, `health_check.all`, `ad_performance.compare`, `ad_performance.report`, `network_performance.report`, `budget.efficiency`, `budget.reallocation`, `auction_insights.get`, `rsa_assets.analyze`, `rsa_assets.audit`, `search_terms.review` |
 | B2B | `btob.optimizations` |
 | Creative | `landing_page.analyze`, `creative.research` |
@@ -148,7 +148,7 @@ docs/integrations.md         # Platform discovery + external MCP integration gui
 | Capture | `capture.screenshot` |
 | Device | `device.analyze` |
 | CPC | `cpc.detect_trend` |
-| Assets | `assets.upload_image` |
+| Assets | `assets.upload_image`, `image_assets.list` |
 
 ### Meta Ads
 

--- a/mureo/_data/skills/_mureo-google-ads/SKILL.md
+++ b/mureo/_data/skills/_mureo-google-ads/SKILL.md
@@ -133,6 +133,9 @@ immediate request but is not remembered.
 | 81 | `google_ads_capture_screenshot` | Capture | Read | Capture a screenshot of a URL |
 | 82 | `google_ads_assets_upload_image` | Asset | Write | Upload image as Google Ads asset |
 | 83 | `google_ads_ads_create_display` | Ad | Write | Create an RDA (responsive display ad); image files are uploaded automatically |
+| 84 | `google_ads_demographic_targeting_list` | Targeting | Read | List demographic criteria (age/gender/parental status/income) |
+| 85 | `google_ads_audience_targeting_list` | Targeting | Read | List audience criteria (user lists, interests, custom/combined audiences) |
+| 86 | `google_ads_image_assets_list` | Asset | Read | List image assets with names and dimensions |
 
 ## API Resources
 
@@ -476,6 +479,18 @@ immediate request but is not remembered.
   Required: customer_id (string)
   ```
 
+- `demographic_targeting.list` -- List explicit demographic criteria (age range, gender, parental status, income). Excluded segments have negative=true; segments with no explicit criterion are targeted by default and not returned.
+  ```
+  Required: customer_id (string)
+  Optional: ad_group_id (string), campaign_id (string)
+  ```
+
+- `audience_targeting.list` -- List audience-type criteria (user interests, user lists, custom/combined audiences). value is the criterion's resource name.
+  ```
+  Required: customer_id (string)
+  Optional: ad_group_id (string), campaign_id (string)
+  ```
+
 ### analysis & reporting
 
 - `performance.report` -- Get performance metrics aggregated by campaign.
@@ -611,6 +626,12 @@ immediate request but is not remembered.
 - `assets.upload_image` -- Upload a local image file as a Google Ads asset.
   ```
   Required: customer_id, file_path (string)
+  ```
+
+- `image_assets.list` -- List image assets with names, dimensions, and serving URLs.
+  ```
+  Required: customer_id (string)
+  Optional: limit (integer 1-1000, default: 100)
   ```
 
 ## Common Workflows

--- a/mureo/google_ads/_extensions_targeting.py
+++ b/mureo/google_ads/_extensions_targeting.py
@@ -15,7 +15,17 @@ from typing import TYPE_CHECKING, Any
 from google.protobuf.field_mask_pb2 import FieldMask as PbFieldMask
 
 from mureo.google_ads.client import _wrap_mutate_error
-from mureo.google_ads.mappers import map_change_event, map_recommendation
+from mureo.google_ads.mappers import (
+    AD_GROUP_CRITERION_STATUS_MAP,
+    AGE_RANGE_TYPE_MAP,
+    CRITERION_TYPE_MAP,
+    GENDER_TYPE_MAP,
+    INCOME_RANGE_TYPE_MAP,
+    PARENTAL_STATUS_TYPE_MAP,
+    map_change_event,
+    map_enum_name,
+    map_recommendation,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +40,32 @@ _DEVICE_ENUM_MAP: dict[int, str] = {
     2: "MOBILE",
     3: "TABLET",
     4: "DESKTOP",
+}
+
+
+# Internal row cap for the criteria reads below. They allow account-wide,
+# unscoped queries (unlike the campaign-scoped sibling reads), so an explicit
+# LIMIT keeps a huge account from materializing an unbounded result set.
+_CRITERIA_READ_LIMIT = 1000
+
+# Demographic criterion types → (attribute carrying the value, enum map for
+# that value). Keys double as the GAQL type filter (whitelisted literals,
+# never user input).
+_DEMOGRAPHIC_VALUE_FIELDS: dict[str, tuple[str, dict[int, str]]] = {
+    "AGE_RANGE": ("age_range", AGE_RANGE_TYPE_MAP),
+    "GENDER": ("gender", GENDER_TYPE_MAP),
+    "PARENTAL_STATUS": ("parental_status", PARENTAL_STATUS_TYPE_MAP),
+    "INCOME_RANGE": ("income_range", INCOME_RANGE_TYPE_MAP),
+}
+
+# Audience criterion types → (attribute on ad_group_criterion, value field).
+_AUDIENCE_VALUE_FIELDS: dict[str, tuple[str, str]] = {
+    "USER_INTEREST": ("user_interest", "user_interest_category"),
+    "USER_LIST": ("user_list", "user_list"),
+    "AUDIENCE": ("audience", "audience"),
+    "CUSTOM_AFFINITY": ("custom_affinity", "custom_affinity"),
+    "CUSTOM_AUDIENCE": ("custom_audience", "custom_audience"),
+    "COMBINED_AUDIENCE": ("combined_audience", "combined_audience"),
 }
 
 
@@ -170,6 +206,118 @@ class _TargetingMixin:
             )
             for d in all_devices
         ]
+
+    def _criterion_scope_clause(
+        self, ad_group_id: str | None, campaign_id: str | None
+    ) -> str:
+        """Optional AND-clauses scoping an ad_group_criterion read (#366)."""
+        clause = ""
+        if ad_group_id:
+            self._validate_id(ad_group_id, "ad_group_id")
+            clause += f"\n                AND ad_group.id = {ad_group_id}"
+        if campaign_id:
+            self._validate_id(campaign_id, "campaign_id")
+            clause += f"\n                AND campaign.id = {campaign_id}"
+        return clause
+
+    @staticmethod
+    def _criterion_row(row: Any, ctype: str, value: str | None) -> dict[str, Any]:
+        """Shape one ad_group_criterion search row for the criteria reads."""
+        crit = row.ad_group_criterion
+        return {
+            "criterion_id": str(crit.criterion_id),
+            "type": ctype,
+            "value": value,
+            "status": map_enum_name(crit.status, AD_GROUP_CRITERION_STATUS_MAP),
+            "negative": bool(crit.negative),
+            "campaign_id": str(row.campaign.id),
+            "ad_group_id": str(row.ad_group.id),
+            "ad_group_name": str(row.ad_group.name),
+        }
+
+    async def list_demographic_criteria(
+        self,
+        ad_group_id: str | None = None,
+        campaign_id: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """List demographic (age / gender / parental status / income) criteria.
+
+        Read-only. Returns one entry per explicit ad-group criterion;
+        segments without an explicit criterion are targeted by default and
+        do not appear (Google Ads convention).
+        """
+        type_filter = ", ".join(f"'{t}'" for t in _DEMOGRAPHIC_VALUE_FIELDS)
+        query = f"""
+            SELECT
+                campaign.id,
+                ad_group.id, ad_group.name,
+                ad_group_criterion.criterion_id,
+                ad_group_criterion.type,
+                ad_group_criterion.status,
+                ad_group_criterion.negative,
+                ad_group_criterion.age_range.type,
+                ad_group_criterion.gender.type,
+                ad_group_criterion.parental_status.type,
+                ad_group_criterion.income_range.type
+            FROM ad_group_criterion
+            WHERE ad_group_criterion.type IN ({type_filter})"""
+        query += self._criterion_scope_clause(ad_group_id, campaign_id)
+        query += f"\n            LIMIT {_CRITERIA_READ_LIMIT}"
+        response = await self._search(query)  # type: ignore[attr-defined]
+        results: list[dict[str, Any]] = []
+        for row in response:
+            crit = row.ad_group_criterion
+            ctype = map_enum_name(crit.type_, CRITERION_TYPE_MAP)
+            value_spec = _DEMOGRAPHIC_VALUE_FIELDS.get(ctype)
+            value = (
+                map_enum_name(getattr(crit, value_spec[0]).type_, value_spec[1])
+                if value_spec
+                else None
+            )
+            results.append(self._criterion_row(row, ctype, value))
+        return results
+
+    async def list_audience_criteria(
+        self,
+        ad_group_id: str | None = None,
+        campaign_id: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """List audience-type criteria attached to ad groups.
+
+        Read-only. Covers user interests, remarketing / customer-match user
+        lists, custom & combined audiences, and Audience resources. ``value``
+        is the criterion's resource name (e.g. 'customers/1/userLists/42').
+        """
+        type_filter = ", ".join(f"'{t}'" for t in _AUDIENCE_VALUE_FIELDS)
+        query = f"""
+            SELECT
+                campaign.id,
+                ad_group.id, ad_group.name,
+                ad_group_criterion.criterion_id,
+                ad_group_criterion.type,
+                ad_group_criterion.status,
+                ad_group_criterion.negative,
+                ad_group_criterion.user_interest.user_interest_category,
+                ad_group_criterion.user_list.user_list,
+                ad_group_criterion.audience.audience,
+                ad_group_criterion.custom_affinity.custom_affinity,
+                ad_group_criterion.custom_audience.custom_audience,
+                ad_group_criterion.combined_audience.combined_audience
+            FROM ad_group_criterion
+            WHERE ad_group_criterion.type IN ({type_filter})"""
+        query += self._criterion_scope_clause(ad_group_id, campaign_id)
+        query += f"\n            LIMIT {_CRITERIA_READ_LIMIT}"
+        response = await self._search(query)  # type: ignore[attr-defined]
+        results: list[dict[str, Any]] = []
+        for row in response:
+            crit = row.ad_group_criterion
+            ctype = map_enum_name(crit.type_, CRITERION_TYPE_MAP)
+            fields = _AUDIENCE_VALUE_FIELDS.get(ctype)
+            value = (
+                str(getattr(getattr(crit, fields[0]), fields[1])) if fields else None
+            )
+            results.append(self._criterion_row(row, ctype, value))
+        return results
 
     @_wrap_mutate_error("device targeting update")
     async def set_device_targeting(self, params: dict[str, Any]) -> dict[str, Any]:

--- a/mureo/google_ads/_media.py
+++ b/mureo/google_ads/_media.py
@@ -1,6 +1,6 @@
 """Google Ads media asset operations mixin.
 
-Provides image asset uploading.
+Provides image asset uploading and listing.
 """
 
 from __future__ import annotations
@@ -10,6 +10,7 @@ import logging
 from typing import Any
 
 from mureo._image_validation import validate_image_file
+from mureo.google_ads.mappers import ASSET_TYPE_MAP, MIME_TYPE_MAP, map_enum_name
 
 logger = logging.getLogger(__name__)
 
@@ -26,6 +27,56 @@ class _MediaMixin:
 
     _client: Any
     _customer_id: str
+
+    async def _search(self, query: str) -> Any: ...
+
+    async def list_image_assets(self, limit: int = 100) -> list[dict[str, Any]]:
+        """List image assets in the account with names and dimensions (#366).
+
+        Read-only. Returns id, name, type, file_size (bytes), mime_type,
+        full-size width/height in pixels, and the serving URL per asset.
+
+        Args:
+            limit: Maximum number of assets to return (1–1000).
+        """
+        if (
+            isinstance(limit, bool)
+            or not isinstance(limit, int)
+            or not (1 <= limit <= 1000)
+        ):
+            raise ValueError(f"limit must be an integer in 1..1000 (got {limit!r})")
+        query = f"""
+            SELECT
+                asset.id,
+                asset.name,
+                asset.type,
+                asset.image_asset.file_size,
+                asset.image_asset.mime_type,
+                asset.image_asset.full_size.width_pixels,
+                asset.image_asset.full_size.height_pixels,
+                asset.image_asset.full_size.url
+            FROM asset
+            WHERE asset.type = 'IMAGE'
+            LIMIT {limit}
+        """
+        response = await self._search(query)
+        results: list[dict[str, Any]] = []
+        for row in response:
+            asset = row.asset
+            image = asset.image_asset
+            results.append(
+                {
+                    "id": str(asset.id),
+                    "name": str(asset.name),
+                    "type": map_enum_name(asset.type_, ASSET_TYPE_MAP),
+                    "file_size": int(image.file_size),
+                    "mime_type": map_enum_name(image.mime_type, MIME_TYPE_MAP),
+                    "width_pixels": int(image.full_size.width_pixels),
+                    "height_pixels": int(image.full_size.height_pixels),
+                    "url": str(image.full_size.url),
+                }
+            )
+        return results
 
     async def upload_image_asset(
         self,

--- a/mureo/google_ads/mappers.py
+++ b/mureo/google_ads/mappers.py
@@ -5,11 +5,16 @@ from typing import Any, Protocol
 from google.ads.googleads.v23.enums.types.ad_group_criterion_approval_status import (
     AdGroupCriterionApprovalStatusEnum,
 )
+from google.ads.googleads.v23.enums.types.ad_group_criterion_status import (
+    AdGroupCriterionStatusEnum,
+)
 from google.ads.googleads.v23.enums.types.ad_strength import AdStrengthEnum
 from google.ads.googleads.v23.enums.types.ad_type import AdTypeEnum
 from google.ads.googleads.v23.enums.types.advertising_channel_type import (
     AdvertisingChannelTypeEnum,
 )
+from google.ads.googleads.v23.enums.types.age_range_type import AgeRangeTypeEnum
+from google.ads.googleads.v23.enums.types.asset_type import AssetTypeEnum
 from google.ads.googleads.v23.enums.types.bidding_strategy_system_status import (
     BiddingStrategySystemStatusEnum,
 )
@@ -18,6 +23,15 @@ from google.ads.googleads.v23.enums.types.bidding_strategy_type import (
 )
 from google.ads.googleads.v23.enums.types.campaign_primary_status_reason import (
     CampaignPrimaryStatusReasonEnum,
+)
+from google.ads.googleads.v23.enums.types.criterion_type import CriterionTypeEnum
+from google.ads.googleads.v23.enums.types.gender_type import GenderTypeEnum
+from google.ads.googleads.v23.enums.types.income_range_type import (
+    IncomeRangeTypeEnum,
+)
+from google.ads.googleads.v23.enums.types.mime_type import MimeTypeEnum
+from google.ads.googleads.v23.enums.types.parental_status_type import (
+    ParentalStatusTypeEnum,
 )
 from google.ads.googleads.v23.enums.types.policy_topic_entry_type import (
     PolicyTopicEntryTypeEnum,
@@ -134,11 +148,67 @@ _BIDDING_SYSTEM_STATUS_MAP: dict[int, str] = {
 }
 
 
+# Auto-generated criterion / asset enum maps for the read-only criteria and
+# asset retrievals (#366). The client runs with use_proto_plus=False, so the
+# search stream yields raw protobuf where enum fields are plain ints — these
+# maps recover the API enum names.
+CRITERION_TYPE_MAP: dict[int, str] = {
+    member.value: member.name for member in CriterionTypeEnum.CriterionType  # type: ignore[attr-defined]
+}
+
+AD_GROUP_CRITERION_STATUS_MAP: dict[int, str] = {
+    member.value: member.name
+    for member in AdGroupCriterionStatusEnum.AdGroupCriterionStatus  # type: ignore[attr-defined]
+}
+
+AGE_RANGE_TYPE_MAP: dict[int, str] = {
+    member.value: member.name for member in AgeRangeTypeEnum.AgeRangeType  # type: ignore[attr-defined]
+}
+
+GENDER_TYPE_MAP: dict[int, str] = {
+    member.value: member.name for member in GenderTypeEnum.GenderType  # type: ignore[attr-defined]
+}
+
+PARENTAL_STATUS_TYPE_MAP: dict[int, str] = {
+    member.value: member.name
+    for member in ParentalStatusTypeEnum.ParentalStatusType  # type: ignore[attr-defined]
+}
+
+INCOME_RANGE_TYPE_MAP: dict[int, str] = {
+    member.value: member.name
+    for member in IncomeRangeTypeEnum.IncomeRangeType  # type: ignore[attr-defined]
+}
+
+ASSET_TYPE_MAP: dict[int, str] = {
+    member.value: member.name for member in AssetTypeEnum.AssetType  # type: ignore[attr-defined]
+}
+
+MIME_TYPE_MAP: dict[int, str] = {
+    member.value: member.name for member in MimeTypeEnum.MimeType  # type: ignore[attr-defined]
+}
+
+
 def _map_enum(value: Any, mapping: dict[int, str]) -> str:
     """Generic helper to convert protobuf enum int to string."""
     if isinstance(value, int):
         return mapping.get(value, str(value))
     return str(value)
+
+
+def map_enum_name(value: Any, mapping: dict[int, str]) -> str:
+    """Convert a proto enum value to its bare name, whatever its shape.
+
+    Handles every representation the google-ads client can produce:
+    raw protobuf ints (use_proto_plus=False — the production path),
+    proto-plus members stringifying as 'EnumClass.NAME' (Python <= 3.10),
+    and members stringifying as the bare number (IntEnum on Python 3.11+).
+    """
+    if isinstance(value, int) and not isinstance(value, bool):
+        return mapping.get(value, str(value))
+    s = str(value)
+    if s.isdigit():
+        return mapping.get(int(s), s)
+    return s.rsplit(".", 1)[-1]
 
 
 # ---------------------------------------------------------------------------

--- a/mureo/mcp/_handlers_google_ads.py
+++ b/mureo/mcp/_handlers_google_ads.py
@@ -523,6 +523,15 @@ async def handle_assets_upload_image(args: dict[str, Any]) -> list[TextContent]:
     return _json_result(result)
 
 
+@api_error_handler
+async def handle_image_assets_list(args: dict[str, Any]) -> list[TextContent]:
+    client = _get_client(args)
+    if client is None:
+        return _no_google_creds()
+    result = await client.list_image_assets(limit=_opt(args, "limit", 100))
+    return _json_result(result)
+
+
 # ---------------------------------------------------------------------------
 # Handler mapping
 # ---------------------------------------------------------------------------
@@ -557,6 +566,7 @@ _HANDLERS_BASE: dict[str, Any] = {
     "google_ads_cpc_detect_trend": handle_cpc_detect_trend,
     "google_ads_device_analyze": handle_device_analyze,
     "google_ads_assets_upload_image": handle_assets_upload_image,
+    "google_ads_image_assets_list": handle_image_assets_list,
 }
 
 # Merge extension and analysis handlers

--- a/mureo/mcp/_handlers_google_ads_extensions.py
+++ b/mureo/mcp/_handlers_google_ads_extensions.py
@@ -259,6 +259,34 @@ async def handle_device_targeting_get(
 
 
 @api_error_handler
+async def handle_demographic_targeting_list(
+    args: dict[str, Any],
+) -> list[TextContent]:
+    client = _get_client(args)
+    if client is None:
+        return _no_google_creds()
+    result = await client.list_demographic_criteria(
+        ad_group_id=_opt(args, "ad_group_id"),
+        campaign_id=_opt(args, "campaign_id"),
+    )
+    return _json_result(result)
+
+
+@api_error_handler
+async def handle_audience_targeting_list(
+    args: dict[str, Any],
+) -> list[TextContent]:
+    client = _get_client(args)
+    if client is None:
+        return _no_google_creds()
+    result = await client.list_audience_criteria(
+        ad_group_id=_opt(args, "ad_group_id"),
+        campaign_id=_opt(args, "campaign_id"),
+    )
+    return _json_result(result)
+
+
+@api_error_handler
 async def handle_device_targeting_set(
     args: dict[str, Any],
 ) -> list[TextContent]:
@@ -398,6 +426,8 @@ HANDLERS_EXTENSIONS: dict[str, Any] = {
     "google_ads_recommendations_apply": handle_recommendations_apply,
     "google_ads_device_targeting_get": handle_device_targeting_get,
     "google_ads_device_targeting_set": handle_device_targeting_set,
+    "google_ads_demographic_targeting_list": handle_demographic_targeting_list,
+    "google_ads_audience_targeting_list": handle_audience_targeting_list,
     "google_ads_bid_adjustments_get": handle_bid_adjustments_get,
     "google_ads_bid_adjustments_update": handle_bid_adjustments_update,
     "google_ads_location_targeting_list": handle_location_targeting_list,

--- a/mureo/mcp/_tools_google_ads_assets.py
+++ b/mureo/mcp/_tools_google_ads_assets.py
@@ -59,4 +59,32 @@ TOOLS: list[Tool] = [
             "required": ["file_path"],
         },
     ),
+    Tool(
+        name="google_ads_image_assets_list",
+        description=(
+            "Lists image assets in the Google Ads account with their "
+            "names and dimensions. Returns one entry per asset shaped "
+            "{id, name (the display name shown in the Google Ads UI), "
+            "type ('IMAGE'), file_size (bytes), mime_type (e.g. "
+            "'IMAGE_PNG'), width_pixels, height_pixels, url (full-size "
+            "serving URL)}. Read-only. Use this to find an existing "
+            "asset id/name before referencing it in a Responsive "
+            "Display Ad, or to audit what imagery the account already "
+            "has instead of re-uploading duplicates via "
+            "google_ads_assets_upload_image."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 1000,
+                    "description": ("Maximum number of assets to return. Default 100."),
+                },
+            },
+            "required": [],
+        },
+    ),
 ]

--- a/mureo/mcp/_tools_google_ads_targeting.py
+++ b/mureo/mcp/_tools_google_ads_targeting.py
@@ -1,0 +1,87 @@
+"""Google Ads tool definitions — Demographic & audience criteria reads (#366)"""
+
+from __future__ import annotations
+
+from mcp.types import Tool
+
+_CUSTOMER_ID_PARAM = {
+    "type": "string",
+    "description": (
+        "Google Ads customer ID as a 10-digit string without dashes "
+        "(e.g. '1234567890'). Optional — falls back to "
+        "GOOGLE_ADS_CUSTOMER_ID / GOOGLE_ADS_LOGIN_CUSTOMER_ID from the "
+        "configured credentials when omitted."
+    ),
+}
+
+_AD_GROUP_ID_PARAM = {
+    "type": "string",
+    "description": (
+        "Restrict results to criteria on this ad group. Omit to read "
+        "across the whole account (or scope with campaign_id)."
+    ),
+}
+
+_CAMPAIGN_ID_PARAM = {
+    "type": "string",
+    "description": (
+        "Restrict results to criteria under this campaign. Omit to read "
+        "across the whole account."
+    ),
+}
+
+TOOLS: list[Tool] = [
+    Tool(
+        name="google_ads_demographic_targeting_list",
+        description=(
+            "Lists explicit demographic criteria (age range, gender, "
+            "parental status, household income) set on ad groups. Returns "
+            "one entry per criterion shaped {criterion_id, type "
+            "('AGE_RANGE'|'GENDER'|'PARENTAL_STATUS'|'INCOME_RANGE'), "
+            "value (the segment enum, e.g. 'AGE_RANGE_25_34', 'FEMALE'), "
+            "status, negative (true = excluded segment), campaign_id, "
+            "ad_group_id, ad_group_name}. Read-only. Segments with no "
+            "explicit criterion are targeted by default and do NOT appear "
+            "— an empty result means 'all demographics, no exclusions', "
+            "not 'nothing targeted'. Scope with ad_group_id and/or "
+            "campaign_id, or omit both for the whole account (capped at "
+            "1000 criteria)."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "ad_group_id": _AD_GROUP_ID_PARAM,
+                "campaign_id": _CAMPAIGN_ID_PARAM,
+            },
+            "required": [],
+        },
+    ),
+    Tool(
+        name="google_ads_audience_targeting_list",
+        description=(
+            "Lists audience-type criteria attached to ad groups: user "
+            "interests (affinity / in-market), remarketing & customer-match "
+            "user lists, custom / combined audiences, and Audience "
+            "resources. Returns one entry per criterion shaped "
+            "{criterion_id, type ('USER_INTEREST'|'USER_LIST'|'AUDIENCE'|"
+            "'CUSTOM_AFFINITY'|'CUSTOM_AUDIENCE'|'COMBINED_AUDIENCE'), "
+            "value (the criterion's resource name, e.g. "
+            "'customers/1/userLists/42'), status, negative, campaign_id, "
+            "ad_group_id, ad_group_name}. Read-only. Use this to audit "
+            "which audience segments an ad group targets or excludes "
+            "before proposing targeting changes. Scope with ad_group_id "
+            "and/or campaign_id, or omit both for the whole account "
+            "(capped at 1000 criteria)."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "ad_group_id": _AD_GROUP_ID_PARAM,
+                "campaign_id": _CAMPAIGN_ID_PARAM,
+            },
+            "required": [],
+        },
+    ),
+]

--- a/mureo/mcp/tools_google_ads.py
+++ b/mureo/mcp/tools_google_ads.py
@@ -1,6 +1,6 @@
 """Google Ads MCP tool definitions
 
-Provides 82 tool definitions (MCP Tool).
+Provides 86 tool definitions (MCP Tool).
 Handler implementations are separated into _handlers_google_ads.py /
 _handlers_google_ads_extensions.py / _handlers_google_ads_analysis.py.
 
@@ -8,6 +8,7 @@ Tool definitions are split into category sub-modules:
   _tools_google_ads_campaigns.py  -- Campaigns, ad groups, ads, budgets
   _tools_google_ads_keywords.py   -- Keywords, negative keywords
   _tools_google_ads_extensions.py -- Sitelinks, callouts, conversions, targeting
+  _tools_google_ads_targeting.py  -- Demographic & audience criteria reads
   _tools_google_ads_analysis.py   -- Performance analysis, search terms, monitoring, capture
   _tools_google_ads_assets.py     -- Image assets
 """
@@ -30,15 +31,17 @@ from mureo.mcp._tools_google_ads_assets import TOOLS as _TOOLS_ASSETS
 from mureo.mcp._tools_google_ads_campaigns import TOOLS as _TOOLS_CAMPAIGNS
 from mureo.mcp._tools_google_ads_extensions import TOOLS as _TOOLS_EXTENSIONS
 from mureo.mcp._tools_google_ads_keywords import TOOLS as _TOOLS_KEYWORDS
+from mureo.mcp._tools_google_ads_targeting import TOOLS as _TOOLS_TARGETING
 
 # ---------------------------------------------------------------------------
-# Tool definitions (82) -- aggregated from sub-modules
+# Tool definitions (86) -- aggregated from sub-modules
 # ---------------------------------------------------------------------------
 
 TOOLS: list[Tool] = (
     _TOOLS_CAMPAIGNS
     + _TOOLS_KEYWORDS
     + _TOOLS_EXTENSIONS
+    + _TOOLS_TARGETING
     + _TOOLS_ANALYSIS
     + _TOOLS_ASSETS
 )

--- a/skills/_mureo-google-ads/SKILL.md
+++ b/skills/_mureo-google-ads/SKILL.md
@@ -133,6 +133,9 @@ immediate request but is not remembered.
 | 81 | `google_ads_capture_screenshot` | Capture | Read | Capture a screenshot of a URL |
 | 82 | `google_ads_assets_upload_image` | Asset | Write | Upload image as Google Ads asset |
 | 83 | `google_ads_ads_create_display` | Ad | Write | Create an RDA (responsive display ad); image files are uploaded automatically |
+| 84 | `google_ads_demographic_targeting_list` | Targeting | Read | List demographic criteria (age/gender/parental status/income) |
+| 85 | `google_ads_audience_targeting_list` | Targeting | Read | List audience criteria (user lists, interests, custom/combined audiences) |
+| 86 | `google_ads_image_assets_list` | Asset | Read | List image assets with names and dimensions |
 
 ## API Resources
 
@@ -476,6 +479,18 @@ immediate request but is not remembered.
   Required: customer_id (string)
   ```
 
+- `demographic_targeting.list` -- List explicit demographic criteria (age range, gender, parental status, income). Excluded segments have negative=true; segments with no explicit criterion are targeted by default and not returned.
+  ```
+  Required: customer_id (string)
+  Optional: ad_group_id (string), campaign_id (string)
+  ```
+
+- `audience_targeting.list` -- List audience-type criteria (user interests, user lists, custom/combined audiences). value is the criterion's resource name.
+  ```
+  Required: customer_id (string)
+  Optional: ad_group_id (string), campaign_id (string)
+  ```
+
 ### analysis & reporting
 
 - `performance.report` -- Get performance metrics aggregated by campaign.
@@ -611,6 +626,12 @@ immediate request but is not remembered.
 - `assets.upload_image` -- Upload a local image file as a Google Ads asset.
   ```
   Required: customer_id, file_path (string)
+  ```
+
+- `image_assets.list` -- List image assets with names, dimensions, and serving URLs.
+  ```
+  Required: customer_id (string)
+  Optional: limit (integer 1-1000, default: 100)
   ```
 
 ## Common Workflows

--- a/tests/test_google_ads_criteria_reads.py
+++ b/tests/test_google_ads_criteria_reads.py
@@ -1,0 +1,331 @@
+"""Unit tests for the read-only Google Ads criteria / asset retrievals (#366).
+
+Covers _TargetingMixin.list_demographic_criteria /
+list_audience_criteria and _MediaMixin.list_image_assets with
+``_search`` mocked — no external API calls.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from mureo.google_ads._extensions_targeting import _TargetingMixin
+from mureo.google_ads._media import _MediaMixin
+
+
+class _MockTargetingClient(_TargetingMixin):
+    """Mock class that makes _TargetingMixin testable."""
+
+    def __init__(self) -> None:
+        self._customer_id = "1234567890"
+        self._search = AsyncMock(return_value=[])
+
+    @staticmethod
+    def _validate_id(value: str, field_name: str) -> str:
+        if not value or not value.isdigit():
+            raise ValueError(f"Invalid {field_name}: {value}")
+        return value
+
+    @staticmethod
+    def _validate_date(value: str, field_name: str) -> str:
+        return value
+
+    @staticmethod
+    def _validate_recommendation_type(rec_type: str) -> str:
+        return rec_type
+
+    @staticmethod
+    def _validate_resource_name(value: str, pattern: Any, field_name: str) -> str:
+        return value
+
+    def _get_service(self, service_name: str) -> Any:
+        return None
+
+
+class _MockMediaClient(_MediaMixin):
+    """Mock class that makes _MediaMixin testable."""
+
+    def __init__(self) -> None:
+        self._customer_id = "1234567890"
+        self._client = None
+        self._search = AsyncMock(return_value=[])
+
+
+def _demographic_row(
+    *,
+    criterion_type: Any = 10,  # CriterionType.AGE_RANGE (raw proto int)
+    age_range: Any = 503002,  # AgeRangeType.AGE_RANGE_25_34
+    gender: Any = 0,
+    status: Any = 2,  # AdGroupCriterionStatus.ENABLED
+    negative: bool = False,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        campaign=SimpleNamespace(id=111),
+        ad_group=SimpleNamespace(id=222, name="AG"),
+        ad_group_criterion=SimpleNamespace(
+            criterion_id=333,
+            type_=criterion_type,
+            status=status,
+            negative=negative,
+            age_range=SimpleNamespace(type_=age_range),
+            gender=SimpleNamespace(type_=gender),
+            parental_status=SimpleNamespace(type_=0),
+            income_range=SimpleNamespace(type_=0),
+        ),
+    )
+
+
+@pytest.mark.unit
+class TestListDemographicCriteria:
+    @pytest.fixture()
+    def client(self) -> _MockTargetingClient:
+        return _MockTargetingClient()
+
+    async def test_maps_age_range_row_from_raw_proto_ints(
+        self, client: _MockTargetingClient
+    ) -> None:
+        """The real API (use_proto_plus=False) yields int enums — map to names."""
+        client._search.return_value = [_demographic_row()]
+        result = await client.list_demographic_criteria()
+        assert result == [
+            {
+                "criterion_id": "333",
+                "type": "AGE_RANGE",
+                "value": "AGE_RANGE_25_34",
+                "status": "ENABLED",
+                "negative": False,
+                "campaign_id": "111",
+                "ad_group_id": "222",
+                "ad_group_name": "AG",
+            }
+        ]
+
+    async def test_maps_gender_row_from_raw_proto_ints(
+        self, client: _MockTargetingClient
+    ) -> None:
+        client._search.return_value = [
+            _demographic_row(
+                criterion_type=11,  # CriterionType.GENDER
+                gender=11,  # GenderType.FEMALE
+                negative=True,
+            )
+        ]
+        result = await client.list_demographic_criteria()
+        assert result[0]["type"] == "GENDER"
+        assert result[0]["value"] == "FEMALE"
+        assert result[0]["negative"] is True
+
+    async def test_maps_proto_plus_string_enums(
+        self, client: _MockTargetingClient
+    ) -> None:
+        """proto-plus members stringify as 'Enum.NAME' (py3.10) — same result."""
+        client._search.return_value = [
+            _demographic_row(
+                criterion_type="CriterionType.AGE_RANGE",
+                age_range="AgeRangeType.AGE_RANGE_25_34",
+                status="AdGroupCriterionStatus.ENABLED",
+            )
+        ]
+        result = await client.list_demographic_criteria()
+        assert result[0]["type"] == "AGE_RANGE"
+        assert result[0]["value"] == "AGE_RANGE_25_34"
+        assert result[0]["status"] == "ENABLED"
+
+    async def test_maps_numeric_string_enums(
+        self, client: _MockTargetingClient
+    ) -> None:
+        """py3.11+ IntEnum stringifies as the number — still mapped to names."""
+        client._search.return_value = [
+            _demographic_row(criterion_type="10", age_range="503002", status="2")
+        ]
+        result = await client.list_demographic_criteria()
+        assert result[0]["type"] == "AGE_RANGE"
+        assert result[0]["value"] == "AGE_RANGE_25_34"
+        assert result[0]["status"] == "ENABLED"
+
+    async def test_filters_by_ad_group_and_campaign(
+        self, client: _MockTargetingClient
+    ) -> None:
+        await client.list_demographic_criteria(ad_group_id="222", campaign_id="111")
+        query = client._search.await_args.args[0]
+        assert "ad_group.id = 222" in query
+        assert "campaign.id = 111" in query
+        assert "FROM ad_group_criterion" in query
+
+    async def test_unscoped_query_is_capped(self, client: _MockTargetingClient) -> None:
+        """Account-wide reads carry an internal LIMIT (unbounded-read guard)."""
+        await client.list_demographic_criteria()
+        assert "LIMIT 1000" in client._search.await_args.args[0]
+        await client.list_audience_criteria()
+        assert "LIMIT 1000" in client._search.await_args.args[0]
+
+    async def test_invalid_ad_group_id_raises(
+        self, client: _MockTargetingClient
+    ) -> None:
+        with pytest.raises(ValueError, match="ad_group_id"):
+            await client.list_demographic_criteria(ad_group_id="1 OR 1=1")
+
+    async def test_invalid_campaign_id_raises(
+        self, client: _MockTargetingClient
+    ) -> None:
+        with pytest.raises(ValueError, match="campaign_id"):
+            await client.list_demographic_criteria(campaign_id="abc")
+
+
+def _audience_row(
+    *,
+    criterion_type: Any = 16,  # CriterionType.USER_LIST (raw proto int)
+    user_list: str = "customers/1/userLists/42",
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        campaign=SimpleNamespace(id=111),
+        ad_group=SimpleNamespace(id=222, name="AG"),
+        ad_group_criterion=SimpleNamespace(
+            criterion_id=444,
+            type_=criterion_type,
+            status=2,  # AdGroupCriterionStatus.ENABLED
+            negative=False,
+            user_list=SimpleNamespace(user_list=user_list),
+            user_interest=SimpleNamespace(
+                user_interest_category="customers/1/userInterests/99"
+            ),
+            audience=SimpleNamespace(audience="customers/1/audiences/7"),
+            custom_affinity=SimpleNamespace(
+                custom_affinity="customers/1/customAffinities/5"
+            ),
+            custom_audience=SimpleNamespace(
+                custom_audience="customers/1/customAudiences/6"
+            ),
+            combined_audience=SimpleNamespace(
+                combined_audience="customers/1/combinedAudiences/8"
+            ),
+        ),
+    )
+
+
+@pytest.mark.unit
+class TestListAudienceCriteria:
+    @pytest.fixture()
+    def client(self) -> _MockTargetingClient:
+        return _MockTargetingClient()
+
+    async def test_maps_user_list_row_from_raw_proto_ints(
+        self, client: _MockTargetingClient
+    ) -> None:
+        client._search.return_value = [_audience_row()]
+        result = await client.list_audience_criteria()
+        assert result[0]["type"] == "USER_LIST"
+        assert result[0]["value"] == "customers/1/userLists/42"
+        assert result[0]["status"] == "ENABLED"
+        assert result[0]["criterion_id"] == "444"
+        assert result[0]["ad_group_id"] == "222"
+
+    async def test_maps_user_interest_row_from_raw_proto_ints(
+        self, client: _MockTargetingClient
+    ) -> None:
+        client._search.return_value = [
+            _audience_row(criterion_type=24)  # CriterionType.USER_INTEREST
+        ]
+        result = await client.list_audience_criteria()
+        assert result[0]["type"] == "USER_INTEREST"
+        assert result[0]["value"] == "customers/1/userInterests/99"
+
+    async def test_maps_proto_plus_string_enum(
+        self, client: _MockTargetingClient
+    ) -> None:
+        client._search.return_value = [
+            _audience_row(criterion_type="CriterionType.COMBINED_AUDIENCE")
+        ]
+        result = await client.list_audience_criteria()
+        assert result[0]["type"] == "COMBINED_AUDIENCE"
+        assert result[0]["value"] == "customers/1/combinedAudiences/8"
+
+    async def test_filters_by_ad_group(self, client: _MockTargetingClient) -> None:
+        await client.list_audience_criteria(ad_group_id="222")
+        query = client._search.await_args.args[0]
+        assert "ad_group.id = 222" in query
+        assert "USER_LIST" in query and "COMBINED_AUDIENCE" in query
+
+    async def test_invalid_campaign_id_raises(
+        self, client: _MockTargetingClient
+    ) -> None:
+        with pytest.raises(ValueError, match="campaign_id"):
+            await client.list_audience_criteria(campaign_id="x'; DROP")
+
+
+def _image_asset_row(
+    *,
+    asset_type: Any = 4,  # AssetType.IMAGE (raw proto int)
+    mime_type: Any = 4,  # MimeType.IMAGE_PNG
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        asset=SimpleNamespace(
+            id=555,
+            name="hero_banner",
+            type_=asset_type,
+            image_asset=SimpleNamespace(
+                file_size=204800,
+                mime_type=mime_type,
+                full_size=SimpleNamespace(
+                    width_pixels=1200,
+                    height_pixels=628,
+                    url="https://example.com/hero.png",
+                ),
+            ),
+        ),
+    )
+
+
+@pytest.mark.unit
+class TestListImageAssets:
+    @pytest.fixture()
+    def client(self) -> _MockMediaClient:
+        return _MockMediaClient()
+
+    async def test_maps_image_asset_row_from_raw_proto_ints(
+        self, client: _MockMediaClient
+    ) -> None:
+        """The real API (use_proto_plus=False) yields int enums — map to names."""
+        client._search.return_value = [_image_asset_row()]
+        result = await client.list_image_assets()
+        assert result == [
+            {
+                "id": "555",
+                "name": "hero_banner",
+                "type": "IMAGE",
+                "file_size": 204800,
+                "mime_type": "IMAGE_PNG",
+                "width_pixels": 1200,
+                "height_pixels": 628,
+                "url": "https://example.com/hero.png",
+            }
+        ]
+
+    async def test_maps_proto_plus_string_enums(self, client: _MockMediaClient) -> None:
+        client._search.return_value = [
+            _image_asset_row(
+                asset_type="AssetType.IMAGE", mime_type="MimeType.IMAGE_PNG"
+            )
+        ]
+        result = await client.list_image_assets()
+        assert result[0]["type"] == "IMAGE"
+        assert result[0]["mime_type"] == "IMAGE_PNG"
+
+    async def test_query_selects_asset_name(self, client: _MockMediaClient) -> None:
+        await client.list_image_assets(limit=25)
+        query = client._search.await_args.args[0]
+        assert "asset.name" in query
+        assert "FROM asset" in query
+        assert "asset.type = 'IMAGE'" in query
+        assert "LIMIT 25" in query
+
+    @pytest.mark.parametrize("bad_limit", [0, -5, 1001, True, "50", 2.5])
+    async def test_invalid_limit_raises(
+        self, client: _MockMediaClient, bad_limit: Any
+    ) -> None:
+        with pytest.raises(ValueError, match="limit"):
+            await client.list_image_assets(limit=bad_limit)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -42,12 +42,12 @@ class TestListTools:
     """Verify list_tools returns the correct tool definitions."""
 
     async def test_list_tools_returns_all_tools(self) -> None:
-        """list_tools returns all tools (Google Ads 83 + Meta Ads 82 + Search Console 10
+        """list_tools returns all tools (Google Ads 86 + Meta Ads 82 + Search Console 10
         + Rollback 2 + Analysis 1 + Mureo Context 9 + Analytics Registry 1
-        + Learning 2 = 190)."""
+        + Learning 2 = 193)."""
         mod = _import_server_module()
         tools = await mod.handle_list_tools()
-        assert len(tools) == 190
+        assert len(tools) == 193
 
     async def test_list_tools_contains_google_and_meta(self) -> None:
         """Google Ads and Meta Ads tools are included."""

--- a/tests/test_mcp_tools_google_ads.py
+++ b/tests/test_mcp_tools_google_ads.py
@@ -35,9 +35,9 @@ class TestGoogleAdsToolDefinitions:
     """Verify the Google Ads tool list is defined correctly."""
 
     def test_tool_count(self) -> None:
-        """All 83 tools are defined."""
+        """All 86 tools are defined (83 + demographic/audience/image-asset reads, #366)."""
         mod = _import_google_ads_tools()
-        assert len(mod.TOOLS) == 83
+        assert len(mod.TOOLS) == 86
 
     def test_all_tool_names(self) -> None:
         """Every tool name starts with google_ads_ (underscore-separated, per MCP spec)."""
@@ -130,6 +130,9 @@ class TestGoogleAdsToolDefinitions:
             ),
             ("google_ads_cpc_detect_trend", ["campaign_id"]),
             ("google_ads_device_analyze", ["campaign_id"]),
+            ("google_ads_demographic_targeting_list", []),
+            ("google_ads_audience_targeting_list", []),
+            ("google_ads_image_assets_list", []),
         ],
     )
     def test_required_fields(
@@ -152,6 +155,96 @@ def _mock_google_ads_context():
     mock_client = AsyncMock()
     mock_creds = MagicMock()
     return mock_creds, mock_client
+
+
+# ---------------------------------------------------------------------------
+# Handler tests — read-only criteria / asset retrievals (#366)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGoogleAdsCriteriaReadHandlers:
+    """Demographic / audience criteria and image-asset read handlers."""
+
+    async def test_demographic_targeting_list(self) -> None:
+        mod = _import_google_ads_tools()
+        creds, client = _mock_google_ads_context()
+        client.list_demographic_criteria.return_value = [
+            {"criterion_id": "1", "type": "AGE_RANGE", "value": "AGE_RANGE_25_34"}
+        ]
+
+        h = _import_handlers()
+        with (
+            patch.object(h, "load_google_ads_credentials", return_value=creds),
+            patch.object(h, "create_google_ads_client", return_value=client),
+        ):
+            result = await mod.handle_tool(
+                "google_ads_demographic_targeting_list",
+                {"customer_id": "123", "ad_group_id": "456"},
+            )
+
+        client.list_demographic_criteria.assert_awaited_once_with(
+            ad_group_id="456", campaign_id=None
+        )
+        parsed = json.loads(result[0].text)
+        assert parsed[0]["type"] == "AGE_RANGE"
+
+    async def test_audience_targeting_list(self) -> None:
+        mod = _import_google_ads_tools()
+        creds, client = _mock_google_ads_context()
+        client.list_audience_criteria.return_value = [
+            {"criterion_id": "2", "type": "USER_LIST", "value": "customers/1/x/9"}
+        ]
+
+        h = _import_handlers()
+        with (
+            patch.object(h, "load_google_ads_credentials", return_value=creds),
+            patch.object(h, "create_google_ads_client", return_value=client),
+        ):
+            result = await mod.handle_tool(
+                "google_ads_audience_targeting_list",
+                {"customer_id": "123", "campaign_id": "789"},
+            )
+
+        client.list_audience_criteria.assert_awaited_once_with(
+            ad_group_id=None, campaign_id="789"
+        )
+        parsed = json.loads(result[0].text)
+        assert parsed[0]["type"] == "USER_LIST"
+
+    async def test_image_assets_list(self) -> None:
+        mod = _import_google_ads_tools()
+        creds, client = _mock_google_ads_context()
+        client.list_image_assets.return_value = [{"id": "5", "name": "hero"}]
+
+        h = _import_handlers()
+        with (
+            patch.object(h, "load_google_ads_credentials", return_value=creds),
+            patch.object(h, "create_google_ads_client", return_value=client),
+        ):
+            result = await mod.handle_tool(
+                "google_ads_image_assets_list", {"customer_id": "123"}
+            )
+
+        client.list_image_assets.assert_awaited_once_with(limit=100)
+        parsed = json.loads(result[0].text)
+        assert parsed[0]["name"] == "hero"
+
+    async def test_image_assets_list_custom_limit(self) -> None:
+        mod = _import_google_ads_tools()
+        creds, client = _mock_google_ads_context()
+        client.list_image_assets.return_value = []
+
+        h = _import_handlers()
+        with (
+            patch.object(h, "load_google_ads_credentials", return_value=creds),
+            patch.object(h, "create_google_ads_client", return_value=client),
+        ):
+            await mod.handle_tool(
+                "google_ads_image_assets_list", {"customer_id": "123", "limit": 25}
+            )
+
+        client.list_image_assets.assert_awaited_once_with(limit=25)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Part of #366 (tasks 1, 2, 4 — the read-only retrievals; task 3 budget-type get/set ships separately given the guardrail interaction, per the issue's PR-split note).

## Summary

Three new read-only Google Ads MCP tools (83 → 86):

| Tool | What it returns |
|---|---|
| `google_ads_demographic_targeting_list` | Explicit age-range / gender / parental-status / income criteria per ad group, with `negative` (exclusion) flag |
| `google_ads_audience_targeting_list` | Audience criteria — user interests, user lists, custom/combined audiences, Audience resources — with the criterion's resource name as `value` |
| `google_ads_image_assets_list` | Image assets with name, dimensions, mime type, file size, serving URL |

## Design notes

- **GAQL safety**: type filters are hardcoded whitelist literals; `ad_group_id` / `campaign_id` route through `_validate_id` (digits-only); `limit` is a validated integer 1..1000. No user input reaches a query un-validated.
- **Enum mapping for the real API**: the client runs `use_proto_plus=False`, so search rows carry raw proto ints. New `map_enum_name` + auto-generated enum maps in `mappers.py` convert ints (and the `'Enum.NAME'` / numeric-string representations) to API enum names — caught in review as a would-be "value is always None" bug and fixed with wire-format tests.
- **Unbounded-read guard**: the criteria reads allow account-wide unscoped queries (unlike campaign-scoped siblings), so they carry an internal `LIMIT 1000`, stated in the tool descriptions.
- **BYOD**: read-only `list_*` methods fall through `ByodGoogleAdsClient.__getattr__` to `[]` — no BYOD changes needed (verified).
- Docs updated: AGENTS.md tool table, `_mureo-google-ads` SKILL.md catalog (canonical + packaged copies byte-identical, manifest test passes).

## Test plan

- [x] Client layer (22 tests, `_search` mocked): row mapping from raw proto ints, `'Enum.NAME'` strings, and numeric strings; scope filters; injection-shaped IDs rejected; LIMIT cap present; invalid `limit` values rejected (`0`, `-5`, `1001`, `True`, `"50"`, `2.5`)
- [x] MCP layer: tool count 86, schemas, handler forwarding (incl. default/custom `limit`)
- [x] ruff / black / mypy (CI flags) clean; full suite green except known local plugin-env noise

TDD (tests first). Reviews: python-reviewer (CRITICAL enum-int finding → fixed → re-review APPROVE) + security-reviewer (APPROVE; LOW unbounded-read hardening applied) + /code-review checklist (function-length fix applied).

https://claude.ai/code/session_0195WBK6YopTveq9RAQE2xMz
