### PR TITLE
feat(google-ads): budget type (daily vs CUSTOM_PERIOD total) get and set (#366)

### DIFF
--- a/mureo/_data/skills/_mureo-google-ads/SKILL.md
+++ b/mureo/_data/skills/_mureo-google-ads/SKILL.md
@@ -310,19 +310,20 @@ immediate request but is not remembered.
 
 ### budget
 
-- `get` -- Get the daily budget for a campaign.
+- `get` -- Get the budget attached to a campaign, including its type. Returns id, name, daily_budget(_micros), total_budget / total_amount_micros (null unless a CUSTOM_PERIOD total budget), period (DAILY / CUSTOM_PERIOD), delivery_method, status, reference_count.
   ```
   Required: customer_id, campaign_id (string)
   ```
 
-- `update` -- Update daily budget amount. **Requires user confirmation.** Always show current vs. new amount.
+- `update` -- Update the daily and/or total budget amount. **Requires user confirmation.** Always show current vs. new amount. The period is immutable -- total amounts only apply to CUSTOM_PERIOD budgets.
   ```
-  Required: customer_id, budget_id (string), amount (number)
+  Required: customer_id, budget_id (string), and one of amount / amount_micros / total_amount / total_amount_micros
   ```
 
-- `create` -- Create a new campaign budget. **Requires user confirmation.**
+- `create` -- Create a new campaign budget. **Requires user confirmation.** Pass period=CUSTOM_PERIOD with total_amount(_micros) for a campaign-lifetime total budget (immutable after creation); otherwise supply the daily amount.
   ```
-  Required: customer_id, name (string), amount (number)
+  Required: customer_id, name (string), and one of amount / total_amount / total_amount_micros
+  Optional: period (DAILY | CUSTOM_PERIOD)
   ```
 
 ### accounts

--- a/mureo/_data/skills/_mureo-strategy/SKILL.md
+++ b/mureo/_data/skills/_mureo-strategy/SKILL.md
@@ -191,10 +191,12 @@ keys (all optional):
   `current_daily_budget`).
 - `max_total_daily_budget` — refused when a caller supplies
   `projected_total_daily_budget` above this.
-- `max_lifetime_budget_per_campaign` — a mutation proposing a `lifetime_budget`
-  (period-total, account currency) above this is refused. Lifetime and daily
-  budgets have distinct semantics, so declare this cap separately — a daily
-  cap alone does not constrain lifetime-budget mutations.
+- `max_lifetime_budget_per_campaign` — a mutation proposing a lifetime /
+  period-total budget (Meta `lifetime_budget` in account currency, or a
+  Google Ads CUSTOM_PERIOD `total_amount_micros`, converted from micros)
+  above this is refused. Lifetime and daily budgets have distinct semantics,
+  so declare this cap separately — a daily cap alone does not constrain
+  lifetime-budget mutations.
 - `blocked_operations` — comma-separated tool names that are always refused.
 
 Absent section (or an unparseable value) ⇒ no enforcement for that rule

--- a/mureo/_data/skills/_mureo-strategy/SKILL.md
+++ b/mureo/_data/skills/_mureo-strategy/SKILL.md
@@ -180,6 +180,7 @@ keys (all optional):
 - max_daily_budget_per_campaign: 50000
 - max_daily_budget_increase_pct: 20
 - max_total_daily_budget: 300000
+- max_lifetime_budget_per_campaign: 900000
 - blocked_operations: google_ads_campaigns_remove, meta_ads_campaigns_delete
 ```
 
@@ -190,6 +191,10 @@ keys (all optional):
   `current_daily_budget`).
 - `max_total_daily_budget` — refused when a caller supplies
   `projected_total_daily_budget` above this.
+- `max_lifetime_budget_per_campaign` — a mutation proposing a `lifetime_budget`
+  (period-total, account currency) above this is refused. Lifetime and daily
+  budgets have distinct semantics, so declare this cap separately — a daily
+  cap alone does not constrain lifetime-budget mutations.
 - `blocked_operations` — comma-separated tool names that are always refused.
 
 Absent section (or an unparseable value) ⇒ no enforcement for that rule

--- a/mureo/byod/clients.py
+++ b/mureo/byod/clients.py
@@ -248,6 +248,12 @@ class ByodGoogleAdsClient:
                     "campaign_id": campaign_id,
                     "amount_micros": int(amt * 1_000_000),
                     "amount": amt,
+                    # Shape parity with GoogleAdsApiClient.get_budget (#366):
+                    # BYOD campaign CSVs only carry a daily budget.
+                    "period": "DAILY",
+                    "total_budget": None,
+                    "total_amount_micros": None,
+                    "reference_count": 1,
                     "delivery_method": "STANDARD",
                     "status": "ENABLED",
                 }

--- a/mureo/google_ads/client.py
+++ b/mureo/google_ads/client.py
@@ -35,11 +35,15 @@ from mureo.google_ads._gaql_validator import (
 from mureo.google_ads._media import _MediaMixin
 from mureo.google_ads._monitoring import _MonitoringMixin
 from mureo.google_ads.mappers import (
+    BUDGET_DELIVERY_METHOD_MAP,
+    BUDGET_PERIOD_MAP,
+    BUDGET_STATUS_MAP,
     map_ad_group,
     map_ad_performance_report,
     map_bidding_strategy_type,
     map_campaign,
     map_entity_status,
+    map_enum_name,
     map_performance_report,
 )
 
@@ -95,57 +99,94 @@ _BETWEEN_PATTERN = re.compile(
 _F = TypeVar("_F", bound=Callable[..., Any])
 
 
-def _resolve_budget_amount_micros(params: dict[str, Any]) -> int:
+def _resolve_amount_micros(
+    params: dict[str, Any],
+    *,
+    amount_key: str,
+    micros_key: str,
+    label: str,
+    required: bool,
+) -> int | None:
     """Resolve and validate a budget amount from ``params`` into micros.
 
-    Accepts ``amount`` (currency units) or ``amount_micros`` (exact int),
-    mutually exclusive; exactly one is required. Rejects non-numeric input,
-    non-positive values (a ``0`` budget halts delivery), and values above
-    :data:`_MAX_BUDGET_AMOUNT_MICROS` (catastrophe guard against a digit
-    slip / overflow). Raises ``ValueError`` on any violation.
+    Accepts ``amount_key`` (currency units) or ``micros_key`` (exact int),
+    mutually exclusive. When ``required`` neither being present is an error;
+    otherwise ``None`` is returned (the field is not being changed). Rejects
+    non-numeric input, non-positive values (a ``0`` budget halts delivery),
+    and values above :data:`_MAX_BUDGET_AMOUNT_MICROS` (catastrophe guard
+    against a digit slip / overflow). Raises ``ValueError`` on any violation.
     """
-    has_amount = "amount" in params and params["amount"] is not None
-    has_micros = "amount_micros" in params and params["amount_micros"] is not None
+    has_amount = params.get(amount_key) is not None
+    has_micros = params.get(micros_key) is not None
     if has_amount and has_micros:
         raise ValueError(
-            "budget update: specify either 'amount' or 'amount_micros', not both"
+            f"budget: specify either '{amount_key}' or '{micros_key}', not both"
         )
     if not has_amount and not has_micros:
-        raise ValueError(
-            "budget update: one of 'amount' or 'amount_micros' is required"
-        )
+        if required:
+            raise ValueError(
+                f"budget: one of '{amount_key}' or '{micros_key}' is required"
+            )
+        return None
 
     amount_micros: int
     if has_micros:
-        value = params["amount_micros"]
+        value = params[micros_key]
         # bool is an int subclass — reject it so True/False can't be a budget.
         if isinstance(value, bool) or not isinstance(value, int):
-            raise ValueError(f"amount_micros must be an integer (specified: {value!r})")
+            raise ValueError(f"{micros_key} must be an integer (specified: {value!r})")
         amount_micros = int(value)
     else:
-        value = params["amount"]
+        value = params[amount_key]
         if isinstance(value, bool) or not isinstance(value, (int, float)):
-            raise ValueError(f"Daily budget must be a number (specified: {value!r})")
+            raise ValueError(f"{label} must be a number (specified: {value!r})")
         # Reject inf/nan so int() raises a clean ValueError (not OverflowError)
         # on the direct-adapter path (MCP callers are already schema-bounded).
         if not math.isfinite(value):
-            raise ValueError(
-                f"Daily budget must be a finite number (specified: {value!r})"
-            )
+            raise ValueError(f"{label} must be a finite number (specified: {value!r})")
         amount_micros = int(value * 1_000_000)
 
     if amount_micros <= 0:
         raise ValueError(
-            f"Daily budget must be a positive number (specified: "
-            f"{amount_micros} micros)"
+            f"{label} must be a positive number (specified: " f"{amount_micros} micros)"
         )
     if amount_micros > _MAX_BUDGET_AMOUNT_MICROS:
         raise ValueError(
-            f"Daily budget {amount_micros} micros exceeds the sanity ceiling "
+            f"{label} {amount_micros} micros exceeds the sanity ceiling "
             f"({_MAX_BUDGET_AMOUNT_MICROS} micros); refusing as a likely "
             f"digit slip — pass a correct amount or raise the budget in steps"
         )
     return amount_micros
+
+
+def _resolve_budget_amount_micros(params: dict[str, Any]) -> int:
+    """Resolve/validate the required daily budget amount (legacy signature)."""
+    resolved = _resolve_amount_micros(
+        params,
+        amount_key="amount",
+        micros_key="amount_micros",
+        label="Daily budget",
+        required=True,
+    )
+    assert resolved is not None  # required=True never returns None
+    return resolved
+
+
+def _resolve_total_amount_micros(params: dict[str, Any]) -> int | None:
+    """Resolve/validate the optional total (CUSTOM_PERIOD) budget amount."""
+    return _resolve_amount_micros(
+        params,
+        amount_key="total_amount",
+        micros_key="total_amount_micros",
+        label="Total budget",
+        required=False,
+    )
+
+
+# Budget periods settable at creation. The Google Ads API marks
+# CampaignBudget.period as Immutable, so it is create-only — update_budget
+# deliberately does not accept it.
+_VALID_BUDGET_PERIODS = frozenset({"DAILY", "CUSTOM_PERIOD"})
 
 
 def _wrap_mutate_error(label: str) -> Callable[[_F], _F]:
@@ -888,14 +929,25 @@ class GoogleAdsApiClient(  # type: ignore[misc]
     # === Budgets ===
 
     async def get_budget(self, campaign_id: str) -> dict[str, Any] | None:
-        """Get campaign budget."""
+        """Get campaign budget, including its type (period) and total amount.
+
+        ``period`` distinguishes a DAILY budget from a CUSTOM_PERIOD (total)
+        budget; ``total_amount_micros`` / ``total_budget`` are ``None``
+        unless the budget is CUSTOM_PERIOD (the API only uses the total
+        amount for that period). ``reference_count`` tells how many
+        campaigns share this budget — check it before updating.
+        """
         self._validate_id(campaign_id, "campaign_id")
         query = f"""
             SELECT
                 campaign.id,
                 campaign_budget.id,
+                campaign_budget.name,
                 campaign_budget.amount_micros,
                 campaign_budget.total_amount_micros,
+                campaign_budget.period,
+                campaign_budget.delivery_method,
+                campaign_budget.reference_count,
                 campaign_budget.status
             FROM campaign_budget
             WHERE campaign.id = {campaign_id}
@@ -903,11 +955,22 @@ class GoogleAdsApiClient(  # type: ignore[misc]
         response = await self._search(query)
         for row in response:
             budget = row.campaign_budget
+            total_micros = int(budget.total_amount_micros) or None
             return {
                 "id": str(budget.id),
+                "name": str(budget.name),
                 "daily_budget": budget.amount_micros / 1_000_000,
                 "daily_budget_micros": budget.amount_micros,
-                "status": str(budget.status),
+                "total_budget": (
+                    total_micros / 1_000_000 if total_micros is not None else None
+                ),
+                "total_amount_micros": total_micros,
+                "period": map_enum_name(budget.period, BUDGET_PERIOD_MAP),
+                "delivery_method": map_enum_name(
+                    budget.delivery_method, BUDGET_DELIVERY_METHOD_MAP
+                ),
+                "reference_count": int(budget.reference_count),
+                "status": map_enum_name(budget.status, BUDGET_STATUS_MAP),
             }
         return None
 
@@ -927,8 +990,25 @@ class GoogleAdsApiClient(  # type: ignore[misc]
         a client-layer guard so it also protects non-MCP callers (adapters).
         Per-account spend *policy* (BudgetGuard) is enforced on the Managed
         side.
+
+        Total (CUSTOM_PERIOD) budgets: pass ``total_amount`` (currency
+        units) or ``total_amount_micros`` to change the lifetime cap —
+        validated with the same positive/ceiling guards. ``period`` itself
+        is immutable in the API, so it can only be set at creation.
         """
-        amount_micros = _resolve_budget_amount_micros(params)
+        amount_micros = _resolve_amount_micros(
+            params,
+            amount_key="amount",
+            micros_key="amount_micros",
+            label="Daily budget",
+            required=False,
+        )
+        total_micros = _resolve_total_amount_micros(params)
+        if amount_micros is None and total_micros is None:
+            raise ValueError(
+                "budget update: one of 'amount', 'amount_micros', "
+                "'total_amount' or 'total_amount_micros' is required"
+            )
 
         budget_service = self._get_service("CampaignBudgetService")
         budget_op = self._client.get_type("CampaignBudgetOperation")
@@ -936,10 +1016,16 @@ class GoogleAdsApiClient(  # type: ignore[misc]
         budget.resource_name = budget_service.campaign_budget_path(
             self._customer_id, params["budget_id"]
         )
-        budget.amount_micros = amount_micros
+        update_paths: list[str] = []
+        if amount_micros is not None:
+            budget.amount_micros = amount_micros
+            update_paths.append("amount_micros")
+        if total_micros is not None:
+            budget.total_amount_micros = total_micros
+            update_paths.append("total_amount_micros")
         self._client.copy_from(
             budget_op.update_mask,
-            PbFieldMask(paths=["amount_micros"]),
+            PbFieldMask(paths=update_paths),
         )
         response = budget_service.mutate_campaign_budgets(
             customer_id=self._customer_id,
@@ -1082,47 +1168,64 @@ class GoogleAdsApiClient(  # type: ignore[misc]
                 ``CreateCampaignRequest.daily_budget_micros``) should use
                 this key to preserve precision.
 
-        At least one of ``amount`` or ``amount_micros`` must be supplied.
-        Supplying both at the same time is a ``ValueError`` (ambiguous
-        intent).
+        Budget type: ``period`` (DAILY, the default, or CUSTOM_PERIOD) is
+        set at creation only — the API marks it immutable. A total
+        (lifetime) amount via ``total_amount`` / ``total_amount_micros`` is
+        only meaningful for CUSTOM_PERIOD budgets, so supplying one without
+        ``period='CUSTOM_PERIOD'`` is a ``ValueError``.
+
+        At least one of the daily (``amount`` / ``amount_micros``) or total
+        (``total_amount`` / ``total_amount_micros``) amounts must be
+        supplied. Supplying both keys of a pair at the same time is a
+        ``ValueError`` (ambiguous intent).
         """
         name = params["name"]
         if len(name) > 256:
             raise ValueError(
                 f"Budget name must be 256 characters or less (currently {len(name)} chars)"
             )
-        has_amount = "amount" in params
-        has_amount_micros = "amount_micros" in params
-        if has_amount and has_amount_micros:
-            raise ValueError(
-                "create_budget: specify either 'amount' or 'amount_micros', not both"
-            )
-        if not has_amount and not has_amount_micros:
-            raise ValueError(
-                "create_budget: one of 'amount' or 'amount_micros' is required"
-            )
-
-        if has_amount_micros:
-            amount_micros = int(params["amount_micros"])
-            if amount_micros <= 0:
+        period = params.get("period")
+        if period is not None:
+            period = str(period).upper()
+            if period not in _VALID_BUDGET_PERIODS:
                 raise ValueError(
-                    f"Daily budget must be a positive number (specified: "
-                    f"{amount_micros} micros)"
+                    f"Invalid budget period: {period} "
+                    f"(must be one of {sorted(_VALID_BUDGET_PERIODS)})"
                 )
-        else:
-            amount = params["amount"]
-            if amount <= 0:
-                raise ValueError(
-                    f"Daily budget must be a positive number (specified: {amount})"
-                )
-            amount_micros = int(amount * 1_000_000)
+        amount_micros = _resolve_amount_micros(
+            params,
+            amount_key="amount",
+            micros_key="amount_micros",
+            label="Daily budget",
+            required=False,
+        )
+        total_micros = _resolve_total_amount_micros(params)
+        if amount_micros is None and total_micros is None:
+            raise ValueError(
+                "create_budget: one of 'amount', 'amount_micros', "
+                "'total_amount' or 'total_amount_micros' is required"
+            )
+        if total_micros is not None and period != "CUSTOM_PERIOD":
+            raise ValueError(
+                "total_amount/total_amount_micros is only used by the API "
+                "when period='CUSTOM_PERIOD' — set the period explicitly"
+            )
+        if period == "CUSTOM_PERIOD" and total_micros is None:
+            raise ValueError(
+                "period='CUSTOM_PERIOD' requires total_amount or " "total_amount_micros"
+            )
 
         # Note: BudgetGuard absolute ceiling check is performed on the Managed side.
         budget_service = self._get_service("CampaignBudgetService")
         budget_op = self._client.get_type("CampaignBudgetOperation")
         budget = budget_op.create
         budget.name = name
-        budget.amount_micros = amount_micros
+        if amount_micros is not None:
+            budget.amount_micros = amount_micros
+        if total_micros is not None:
+            budget.total_amount_micros = total_micros
+        if period is not None:
+            budget.period = getattr(self._client.enums.BudgetPeriodEnum, period)
         budget.explicitly_shared = False
         budget.delivery_method = self._client.enums.BudgetDeliveryMethodEnum.STANDARD
         try:

--- a/mureo/google_ads/mappers.py
+++ b/mureo/google_ads/mappers.py
@@ -21,6 +21,11 @@ from google.ads.googleads.v23.enums.types.bidding_strategy_system_status import 
 from google.ads.googleads.v23.enums.types.bidding_strategy_type import (
     BiddingStrategyTypeEnum,
 )
+from google.ads.googleads.v23.enums.types.budget_delivery_method import (
+    BudgetDeliveryMethodEnum,
+)
+from google.ads.googleads.v23.enums.types.budget_period import BudgetPeriodEnum
+from google.ads.googleads.v23.enums.types.budget_status import BudgetStatusEnum
 from google.ads.googleads.v23.enums.types.campaign_primary_status_reason import (
     CampaignPrimaryStatusReasonEnum,
 )
@@ -185,6 +190,21 @@ ASSET_TYPE_MAP: dict[int, str] = {
 
 MIME_TYPE_MAP: dict[int, str] = {
     member.value: member.name for member in MimeTypeEnum.MimeType  # type: ignore[attr-defined]
+}
+
+
+# Auto-generated campaign-budget enum maps (#366 — budget type get/set).
+BUDGET_PERIOD_MAP: dict[int, str] = {
+    member.value: member.name for member in BudgetPeriodEnum.BudgetPeriod  # type: ignore[attr-defined]
+}
+
+BUDGET_DELIVERY_METHOD_MAP: dict[int, str] = {
+    member.value: member.name
+    for member in BudgetDeliveryMethodEnum.BudgetDeliveryMethod  # type: ignore[attr-defined]
+}
+
+BUDGET_STATUS_MAP: dict[int, str] = {
+    member.value: member.name for member in BudgetStatusEnum.BudgetStatus  # type: ignore[attr-defined]
 }
 
 

--- a/mureo/mcp/_handlers_google_ads.py
+++ b/mureo/mcp/_handlers_google_ads.py
@@ -401,15 +401,17 @@ async def handle_budget_update(args: dict[str, Any]) -> list[TextContent]:
     if client is None:
         return _no_google_creds()
     params: dict[str, Any] = {"budget_id": _require(args, "budget_id")}
-    # Accept either currency-unit ``amount`` or exact ``amount_micros``
-    # (mutually exclusive). The client validates value bounds; here we only
-    # require that one of the two is present.
-    if args.get("amount_micros") is not None:
-        params["amount_micros"] = args["amount_micros"]
-    elif args.get("amount") is not None:
-        params["amount"] = args["amount"]
-    else:
-        raise ValueError("one of 'amount' or 'amount_micros' is required")
+    # Accept currency-unit or exact-micros forms for the daily and/or total
+    # (CUSTOM_PERIOD) amounts. The client validates value bounds and pair
+    # exclusivity; here we only require that at least one is present.
+    for key in ("amount", "amount_micros", "total_amount", "total_amount_micros"):
+        if args.get(key) is not None:
+            params[key] = args[key]
+    if len(params) == 1:
+        raise ValueError(
+            "one of 'amount', 'amount_micros', 'total_amount' or "
+            "'total_amount_micros' is required"
+        )
     result = await client.update_budget(params)
     return _json_result(result)
 

--- a/mureo/mcp/_handlers_google_ads_analysis.py
+++ b/mureo/mcp/_handlers_google_ads_analysis.py
@@ -35,10 +35,14 @@ async def handle_budget_create(args: dict[str, Any]) -> list[TextContent]:
     client = _get_client(args)
     if client is None:
         return _no_google_creds()
-    params: dict[str, Any] = {
-        "name": _require(args, "name"),
-        "amount": _require(args, "amount"),
-    }
+    params: dict[str, Any] = {"name": _require(args, "name")}
+    # amount is no longer unconditionally required: a CUSTOM_PERIOD total
+    # budget is created with total_amount(_micros) instead. The client
+    # validates that at least one amount is present and that totals come
+    # with period='CUSTOM_PERIOD'.
+    for key in ("amount", "total_amount", "total_amount_micros", "period"):
+        if args.get(key) is not None:
+            params[key] = args[key]
     result = await client.create_budget(params)
     return _json_result(result)
 

--- a/mureo/mcp/_handlers_meta_ads.py
+++ b/mureo/mcp/_handlers_meta_ads.py
@@ -192,18 +192,72 @@ async def handle_ad_sets_create(args: dict[str, Any]) -> list[TextContent]:
     return _json_result(result)
 
 
+def _normalized_end_time(value: Any) -> int | str:
+    """Validate an ad-set ``end_time`` argument and normalize the zero form.
+
+    Meta's documented convention for "no end date, run continuously" is
+    ``end_time=0``; the string ``"0"`` is wire-identical once form-encoded,
+    so it is normalized to the integer ``0`` here — otherwise it could
+    sidestep the lifetime-budget contradiction guard below.
+    """
+    err = ValueError(
+        "end_time must be an ISO 8601 datetime string, a UNIX timestamp, "
+        f"or 0 to clear the end date (got {value!r})"
+    )
+    if isinstance(value, bool):
+        raise err
+    if isinstance(value, int):
+        if value < 0:
+            raise err
+        return value
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            raise err
+        return 0 if stripped == "0" else value
+    raise err
+
+
+def _validate_ad_set_schedule_and_budget(args: dict[str, Any]) -> int | str | None:
+    """Reject contradictory ad-set budget/schedule updates before dispatch.
+
+    Meta treats daily_budget and lifetime_budget as mutually exclusive on an
+    ad set, and a lifetime budget requires a schedule end — while end_time=0
+    means "no end date". Returns the normalized end_time (or None if absent).
+    """
+    if args.get("daily_budget") is not None and args.get("lifetime_budget") is not None:
+        raise ValueError(
+            "daily_budget and lifetime_budget are mutually exclusive on an "
+            "ad set — supply only one."
+        )
+    if args.get("end_time") is None:
+        return None
+    end_time = _normalized_end_time(args["end_time"])
+    if end_time == 0 and args.get("lifetime_budget") is not None:
+        raise ValueError(
+            "end_time=0 (no end date) cannot be combined with lifetime_budget "
+            "— a lifetime budget requires a schedule end."
+        )
+    return end_time
+
+
 @api_error_handler
 async def handle_ad_sets_update(args: dict[str, Any]) -> list[TextContent]:
-    _validate_positive_money(args, "daily_budget")
+    _validate_positive_money(args, "daily_budget", "lifetime_budget")
+    end_time = _validate_ad_set_schedule_and_budget(args)
     client = await _get_client(args)
     if client is None:
         return _no_meta_creds()
     ad_set_id = _require(args, "ad_set_id")
     update_kwargs: dict[str, Any] = {}
-    for key in ("name", "status", "daily_budget", "targeting"):
+    for key in ("name", "status", "daily_budget", "lifetime_budget", "targeting"):
         val = _opt(args, key)
         if val is not None:
             update_kwargs[key] = val
+    # end_time is handled outside the loop: 0 is a meaningful value (clear
+    # the end date, Meta convention), so a falsy check must not drop it.
+    if end_time is not None:
+        update_kwargs["end_time"] = end_time
     replace_targeting = bool(args.get("replace_targeting", False))
     result = await client.update_ad_set(
         ad_set_id, replace_targeting=replace_targeting, **update_kwargs

--- a/mureo/mcp/_tools_google_ads_campaigns.py
+++ b/mureo/mcp/_tools_google_ads_campaigns.py
@@ -701,10 +701,12 @@ TOOLS: list[Tool] = [
         name="google_ads_budget_get",
         description=(
             "Fetches the campaign-budget record attached to a campaign. "
-            "Returns budget_id, name, amount_micros, delivery_method "
-            "(STANDARD / ACCELERATED), period (DAILY), and "
-            "reference_count (how many campaigns share this budget). "
-            "Read-only. Shared budgets are common — confirm "
+            "Returns id, name, daily_budget / daily_budget_micros, "
+            "total_budget / total_amount_micros (null unless the budget "
+            "is a CUSTOM_PERIOD total budget), period (DAILY / "
+            "CUSTOM_PERIOD), delivery_method (STANDARD / ACCELERATED), "
+            "status, and reference_count (how many campaigns share this "
+            "budget). Read-only. Shared budgets are common — confirm "
             "reference_count before calling google_ads_budget_update, "
             "since changes affect all linked campaigns."
         ),
@@ -726,14 +728,18 @@ TOOLS: list[Tool] = [
     Tool(
         name="google_ads_budget_update",
         description=(
-            "Sets the daily amount on an existing campaign budget. Mutating "
+            "Sets the daily and/or total amount on an existing campaign "
+            "budget. Mutating "
             "— not automatically reversible; record before-state with "
             "mureo_state_action_log_append if you may need to roll back. "
             "Returns the updated budget. If the budget is shared "
             "across multiple campaigns, the change affects all of them — "
             "call google_ads_budget_get first to check reference_count. "
             "The `amount` parameter is in the account's currency unit "
-            "(JPY / USD / etc.), not micros."
+            "(JPY / USD / etc.), not micros. The budget's period (DAILY / "
+            "CUSTOM_PERIOD) is immutable in the Google Ads API — total "
+            "amounts only apply to budgets created with "
+            "period='CUSTOM_PERIOD'."
         ),
         inputSchema={
             "type": "object",
@@ -763,11 +769,34 @@ TOOLS: list[Tool] = [
                         "on rollback). Mutually exclusive with amount."
                     ),
                 },
+                "total_amount": {
+                    "type": "number",
+                    "minimum": 1,
+                    "description": (
+                        "New total (lifetime) amount in the account's "
+                        "currency. Only applies to CUSTOM_PERIOD budgets — "
+                        "the API rejects it on DAILY budgets. Mutually "
+                        "exclusive with total_amount_micros."
+                    ),
+                },
+                "total_amount_micros": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": (
+                        "New total (lifetime) amount in micros. Only "
+                        "applies to CUSTOM_PERIOD budgets — the API "
+                        "rejects it on DAILY budgets. Use for an exact "
+                        "value with no float rounding. Mutually exclusive "
+                        "with total_amount."
+                    ),
+                },
             },
             "required": ["budget_id"],
             "anyOf": [
                 {"required": ["amount"]},
                 {"required": ["amount_micros"]},
+                {"required": ["total_amount"]},
+                {"required": ["total_amount_micros"]},
             ],
         },
     ),
@@ -782,7 +811,12 @@ TOOLS: list[Tool] = [
             "back. Typical flow: "
             "budget.create → campaigns.create with the returned budget_id. "
             "To edit an existing budget's amount use "
-            "google_ads_budget_update instead of creating a second budget."
+            "google_ads_budget_update instead of creating a second budget. "
+            "Budget type is fixed at creation: the period (DAILY / "
+            "CUSTOM_PERIOD) is immutable in the Google Ads API. For a "
+            "campaign-lifetime total budget pass period='CUSTOM_PERIOD' "
+            "with total_amount or total_amount_micros; otherwise supply "
+            "the daily amount."
         ),
         inputSchema={
             "type": "object",
@@ -804,8 +838,42 @@ TOOLS: list[Tool] = [
                         "for ¥5,000 / day."
                     ),
                 },
+                "period": {
+                    "type": "string",
+                    "enum": ["DAILY", "CUSTOM_PERIOD"],
+                    "description": (
+                        "Budget period. Default DAILY. CUSTOM_PERIOD makes "
+                        "this a campaign-lifetime total budget (requires "
+                        "total_amount or total_amount_micros, and the "
+                        "attached campaign must have start/end dates). "
+                        "Immutable after creation."
+                    ),
+                },
+                "total_amount": {
+                    "type": "number",
+                    "minimum": 1,
+                    "description": (
+                        "Total (lifetime) amount in the account's currency. "
+                        "Only valid with period='CUSTOM_PERIOD'. Mutually "
+                        "exclusive with total_amount_micros."
+                    ),
+                },
+                "total_amount_micros": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": (
+                        "Total (lifetime) amount in micros. Only valid "
+                        "with period='CUSTOM_PERIOD'. Mutually exclusive "
+                        "with total_amount."
+                    ),
+                },
             },
-            "required": ["name", "amount"],
+            "required": ["name"],
+            "anyOf": [
+                {"required": ["amount"]},
+                {"required": ["total_amount"]},
+                {"required": ["total_amount_micros"]},
+            ],
         },
     ),
     # === Account ===

--- a/mureo/mcp/_tools_meta_ads_campaigns.py
+++ b/mureo/mcp/_tools_meta_ads_campaigns.py
@@ -421,7 +421,30 @@ TOOLS: list[Tool] = [
                     "minimum": 1,
                     "description": (
                         "New daily budget in account currency minor units. "
-                        "Only valid when the campaign is not using CBO."
+                        "Only valid when the campaign is not using CBO. "
+                        "Mutually exclusive with lifetime_budget."
+                    ),
+                },
+                "lifetime_budget": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": (
+                        "New lifetime budget in account currency minor units "
+                        "(cents for USD, yen for JPY). Mutually exclusive "
+                        "with daily_budget. Requires the ad set to have an "
+                        "end_time — supply one in the same call if it is "
+                        "not already set."
+                    ),
+                },
+                "end_time": {
+                    "type": ["string", "integer"],
+                    "description": (
+                        "New schedule end. Accepts an ISO 8601 datetime "
+                        "string (e.g. '2026-08-01T00:00:00+0900') or a UTC "
+                        "UNIX timestamp integer. Pass 0 to clear the end "
+                        "date so the ad set runs continuously (Meta API "
+                        "convention; only valid with a daily budget — a "
+                        "lifetime budget requires an end date)."
                     ),
                 },
                 "targeting": {

--- a/mureo/policy/strategy_gate.py
+++ b/mureo/policy/strategy_gate.py
@@ -52,6 +52,7 @@ class Guardrails:
     max_daily_budget_per_campaign: float | None = None
     max_daily_budget_increase_pct: float | None = None
     max_total_daily_budget: float | None = None
+    max_lifetime_budget_per_campaign: float | None = None
     blocked_operations: frozenset[str] = field(default_factory=frozenset)
 
     def is_empty(self) -> bool:
@@ -59,6 +60,7 @@ class Guardrails:
             self.max_daily_budget_per_campaign is None
             and self.max_daily_budget_increase_pct is None
             and self.max_total_daily_budget is None
+            and self.max_lifetime_budget_per_campaign is None
             and not self.blocked_operations
         )
 
@@ -80,6 +82,7 @@ def parse_guardrails(content: str) -> Guardrails:
     max_per_campaign: float | None = None
     max_increase_pct: float | None = None
     max_total: float | None = None
+    max_lifetime: float | None = None
     blocked: set[str] = set()
 
     for line in content.splitlines():
@@ -94,6 +97,8 @@ def parse_guardrails(content: str) -> Guardrails:
             max_increase_pct = _to_float(raw)
         elif key == "max_total_daily_budget":
             max_total = _to_float(raw)
+        elif key == "max_lifetime_budget_per_campaign":
+            max_lifetime = _to_float(raw)
         elif key == "blocked_operations":
             blocked = {op.strip() for op in raw.split(",") if op.strip()}
 
@@ -101,6 +106,7 @@ def parse_guardrails(content: str) -> Guardrails:
         max_daily_budget_per_campaign=max_per_campaign,
         max_daily_budget_increase_pct=max_increase_pct,
         max_total_daily_budget=max_total,
+        max_lifetime_budget_per_campaign=max_lifetime,
         blocked_operations=frozenset(blocked),
     )
 
@@ -186,6 +192,27 @@ def evaluate_guardrails(
                         f"(max_daily_budget_increase_pct)."
                     ),
                 )
+
+    # Lifetime (period-total) budgets have distinct semantics from daily
+    # budgets, so they get their own cap rather than reusing the daily one.
+    # Without this, a lifetime-budget mutation would sidestep every budget
+    # guardrail the operator wrote (#367).
+    lifetime = arguments.get("lifetime_budget")
+    lifetime_cap = guardrails.max_lifetime_budget_per_campaign
+    if (
+        lifetime_cap is not None
+        and isinstance(lifetime, (int, float))
+        and not isinstance(lifetime, bool)
+        and float(lifetime) > lifetime_cap
+    ):
+        return PolicyDecision(
+            allowed=False,
+            reason=(
+                f"Proposed lifetime budget {float(lifetime):,.0f} exceeds the "
+                f"STRATEGY.md Guardrails cap of {lifetime_cap:,.0f} "
+                f"(max_lifetime_budget_per_campaign)."
+            ),
+        )
 
     total = arguments.get("projected_total_daily_budget")
     total_cap = guardrails.max_total_daily_budget

--- a/mureo/policy/strategy_gate.py
+++ b/mureo/policy/strategy_gate.py
@@ -128,8 +128,27 @@ def _proposed_budget(arguments: dict[str, Any]) -> float | None:
             v = arguments[key]
             if isinstance(v, (int, float)) and not isinstance(v, bool):
                 return float(v)
-    # Google Ads budgets are sometimes expressed in micros.
-    micros = arguments.get("budget_amount_micros")
+    # Google Ads budgets are sometimes expressed in micros —
+    # budget_amount_micros on campaign tools, amount_micros on budget tools.
+    for micros_key in ("budget_amount_micros", "amount_micros"):
+        micros = arguments.get(micros_key)
+        if isinstance(micros, (int, float)) and not isinstance(micros, bool):
+            return float(micros) / 1_000_000
+    return None
+
+
+def _proposed_lifetime_budget(arguments: dict[str, Any]) -> float | None:
+    """Extract a proposed lifetime / period-total budget in currency units.
+
+    Both spellings of a Google total budget are covered — ``total_amount``
+    (currency units) and ``total_amount_micros`` — so the cap cannot be
+    sidestepped by picking the other parameter form.
+    """
+    for key in ("lifetime_budget", "total_amount"):
+        v = arguments.get(key)
+        if isinstance(v, (int, float)) and not isinstance(v, bool):
+            return float(v)
+    micros = arguments.get("total_amount_micros")
     if isinstance(micros, (int, float)) and not isinstance(micros, bool):
         return float(micros) / 1_000_000
     return None
@@ -196,19 +215,16 @@ def evaluate_guardrails(
     # Lifetime (period-total) budgets have distinct semantics from daily
     # budgets, so they get their own cap rather than reusing the daily one.
     # Without this, a lifetime-budget mutation would sidestep every budget
-    # guardrail the operator wrote (#367).
-    lifetime = arguments.get("lifetime_budget")
+    # guardrail the operator wrote (#367). Covers Meta's ``lifetime_budget``
+    # (minor units) and Google's CUSTOM_PERIOD ``total_amount_micros``
+    # (micros → currency units), mirroring the daily micros handling (#366).
+    lifetime = _proposed_lifetime_budget(arguments)
     lifetime_cap = guardrails.max_lifetime_budget_per_campaign
-    if (
-        lifetime_cap is not None
-        and isinstance(lifetime, (int, float))
-        and not isinstance(lifetime, bool)
-        and float(lifetime) > lifetime_cap
-    ):
+    if lifetime_cap is not None and lifetime is not None and lifetime > lifetime_cap:
         return PolicyDecision(
             allowed=False,
             reason=(
-                f"Proposed lifetime budget {float(lifetime):,.0f} exceeds the "
+                f"Proposed lifetime budget {lifetime:,.0f} exceeds the "
                 f"STRATEGY.md Guardrails cap of {lifetime_cap:,.0f} "
                 f"(max_lifetime_budget_per_campaign)."
             ),

--- a/skills/_mureo-google-ads/SKILL.md
+++ b/skills/_mureo-google-ads/SKILL.md
@@ -310,19 +310,20 @@ immediate request but is not remembered.
 
 ### budget
 
-- `get` -- Get the daily budget for a campaign.
+- `get` -- Get the budget attached to a campaign, including its type. Returns id, name, daily_budget(_micros), total_budget / total_amount_micros (null unless a CUSTOM_PERIOD total budget), period (DAILY / CUSTOM_PERIOD), delivery_method, status, reference_count.
   ```
   Required: customer_id, campaign_id (string)
   ```
 
-- `update` -- Update daily budget amount. **Requires user confirmation.** Always show current vs. new amount.
+- `update` -- Update the daily and/or total budget amount. **Requires user confirmation.** Always show current vs. new amount. The period is immutable -- total amounts only apply to CUSTOM_PERIOD budgets.
   ```
-  Required: customer_id, budget_id (string), amount (number)
+  Required: customer_id, budget_id (string), and one of amount / amount_micros / total_amount / total_amount_micros
   ```
 
-- `create` -- Create a new campaign budget. **Requires user confirmation.**
+- `create` -- Create a new campaign budget. **Requires user confirmation.** Pass period=CUSTOM_PERIOD with total_amount(_micros) for a campaign-lifetime total budget (immutable after creation); otherwise supply the daily amount.
   ```
-  Required: customer_id, name (string), amount (number)
+  Required: customer_id, name (string), and one of amount / total_amount / total_amount_micros
+  Optional: period (DAILY | CUSTOM_PERIOD)
   ```
 
 ### accounts

--- a/skills/_mureo-strategy/SKILL.md
+++ b/skills/_mureo-strategy/SKILL.md
@@ -191,10 +191,12 @@ keys (all optional):
   `current_daily_budget`).
 - `max_total_daily_budget` — refused when a caller supplies
   `projected_total_daily_budget` above this.
-- `max_lifetime_budget_per_campaign` — a mutation proposing a `lifetime_budget`
-  (period-total, account currency) above this is refused. Lifetime and daily
-  budgets have distinct semantics, so declare this cap separately — a daily
-  cap alone does not constrain lifetime-budget mutations.
+- `max_lifetime_budget_per_campaign` — a mutation proposing a lifetime /
+  period-total budget (Meta `lifetime_budget` in account currency, or a
+  Google Ads CUSTOM_PERIOD `total_amount_micros`, converted from micros)
+  above this is refused. Lifetime and daily budgets have distinct semantics,
+  so declare this cap separately — a daily cap alone does not constrain
+  lifetime-budget mutations.
 - `blocked_operations` — comma-separated tool names that are always refused.
 
 Absent section (or an unparseable value) ⇒ no enforcement for that rule

--- a/skills/_mureo-strategy/SKILL.md
+++ b/skills/_mureo-strategy/SKILL.md
@@ -180,6 +180,7 @@ keys (all optional):
 - max_daily_budget_per_campaign: 50000
 - max_daily_budget_increase_pct: 20
 - max_total_daily_budget: 300000
+- max_lifetime_budget_per_campaign: 900000
 - blocked_operations: google_ads_campaigns_remove, meta_ads_campaigns_delete
 ```
 
@@ -190,6 +191,10 @@ keys (all optional):
   `current_daily_budget`).
 - `max_total_daily_budget` — refused when a caller supplies
   `projected_total_daily_budget` above this.
+- `max_lifetime_budget_per_campaign` — a mutation proposing a `lifetime_budget`
+  (period-total, account currency) above this is refused. Lifetime and daily
+  budgets have distinct semantics, so declare this cap separately — a daily
+  cap alone does not constrain lifetime-budget mutations.
 - `blocked_operations` — comma-separated tool names that are always refused.
 
 Absent section (or an unparseable value) ⇒ no enforcement for that rule

--- a/tests/test_google_ads_client.py
+++ b/tests/test_google_ads_client.py
@@ -941,6 +941,202 @@ class TestBudget:
         with pytest.raises(ValueError, match="finite"):
             await client.update_budget({"budget_id": "100", "amount": float("inf")})
 
+    # --- Budget type (daily vs total/CUSTOM_PERIOD) — #366 task 3 ---
+
+    @pytest.mark.asyncio
+    async def test_get_budget_exposes_period_and_total(self) -> None:
+        """get_budget surfaces period / delivery_method / total / name (#366)."""
+        client = _make_client()
+        row = MagicMock()
+        row.campaign_budget.id = 100
+        row.campaign_budget.name = "Q3 total budget"
+        row.campaign_budget.amount_micros = 10000_000_000
+        row.campaign_budget.total_amount_micros = 900_000_000_000
+        row.campaign_budget.status = 2  # ENABLED
+        row.campaign_budget.period = 5  # CUSTOM_PERIOD
+        row.campaign_budget.delivery_method = 2  # STANDARD
+        row.campaign_budget.reference_count = 2
+
+        with patch.object(client, "_search", return_value=[row]):
+            result = await client.get_budget("111")
+
+        assert result is not None
+        assert result["name"] == "Q3 total budget"
+        assert result["period"] == "CUSTOM_PERIOD"
+        assert result["delivery_method"] == "STANDARD"
+        assert result["status"] == "ENABLED"
+        assert result["total_amount_micros"] == 900_000_000_000
+        assert result["total_budget"] == 900_000.0
+        assert result["reference_count"] == 2
+
+    @pytest.mark.asyncio
+    async def test_get_budget_daily_has_no_total(self) -> None:
+        """A DAILY budget reports period=DAILY and null total fields."""
+        client = _make_client()
+        row = MagicMock()
+        row.campaign_budget.id = 100
+        row.campaign_budget.name = "daily"
+        row.campaign_budget.amount_micros = 10000_000_000
+        row.campaign_budget.total_amount_micros = 0  # proto default = unset
+        row.campaign_budget.status = 2
+        row.campaign_budget.period = 2  # DAILY
+        row.campaign_budget.delivery_method = 2
+        row.campaign_budget.reference_count = 1
+
+        with patch.object(client, "_search", return_value=[row]):
+            result = await client.get_budget("111")
+
+        assert result is not None
+        assert result["period"] == "DAILY"
+        assert result["total_amount_micros"] is None
+        assert result["total_budget"] is None
+
+    @pytest.mark.asyncio
+    async def test_update_budget_total_amount_micros_exact(self) -> None:
+        """total_amount_micros is sent verbatim on a CUSTOM_PERIOD budget."""
+        client = _make_client()
+        mock_result = MagicMock()
+        mock_result.resource_name = "customers/123/budgets/100"
+        mock_response = MagicMock()
+        mock_response.results = [mock_result]
+        mock_service = MagicMock()
+        mock_service.mutate_campaign_budgets.return_value = mock_response
+        client._client.get_service.return_value = mock_service
+        budget_op = MagicMock()
+        client._client.get_type.return_value = budget_op
+
+        await client.update_budget(
+            {"budget_id": "100", "total_amount_micros": 900_000_000_000}
+        )
+
+        assert budget_op.update.total_amount_micros == 900_000_000_000
+
+    @pytest.mark.asyncio
+    async def test_update_budget_total_amount_units_converted(self) -> None:
+        client = _make_client()
+        mock_response = MagicMock()
+        mock_response.results = [MagicMock()]
+        mock_service = MagicMock()
+        mock_service.mutate_campaign_budgets.return_value = mock_response
+        client._client.get_service.return_value = mock_service
+        budget_op = MagicMock()
+        client._client.get_type.return_value = budget_op
+
+        await client.update_budget({"budget_id": "100", "total_amount": 900_000})
+
+        assert budget_op.update.total_amount_micros == 900_000_000_000
+
+    @pytest.mark.asyncio
+    async def test_update_budget_total_両方指定(self) -> None:
+        client = _make_client()
+        with pytest.raises(ValueError, match="not both"):
+            await client.update_budget(
+                {
+                    "budget_id": "100",
+                    "total_amount": 900_000,
+                    "total_amount_micros": 900_000_000_000,
+                }
+            )
+
+    @pytest.mark.asyncio
+    async def test_update_budget_total_金額0以下(self) -> None:
+        client = _make_client()
+        with pytest.raises(ValueError, match="positive number"):
+            await client.update_budget({"budget_id": "100", "total_amount_micros": 0})
+
+    @pytest.mark.asyncio
+    async def test_update_budget_total_上限超過(self) -> None:
+        client = _make_client()
+        with pytest.raises(ValueError, match="ceiling"):
+            await client.update_budget(
+                {"budget_id": "100", "total_amount": 2_000_000_000}
+            )
+
+    @pytest.mark.asyncio
+    async def test_update_budget_daily_and_total_together(self) -> None:
+        """Daily and total amounts may be updated in a single mutate."""
+        client = _make_client()
+        mock_response = MagicMock()
+        mock_response.results = [MagicMock()]
+        mock_service = MagicMock()
+        mock_service.mutate_campaign_budgets.return_value = mock_response
+        client._client.get_service.return_value = mock_service
+        budget_op = MagicMock()
+        client._client.get_type.return_value = budget_op
+
+        await client.update_budget(
+            {
+                "budget_id": "100",
+                "amount_micros": 5_000_000,
+                "total_amount_micros": 900_000_000_000,
+            }
+        )
+
+        assert budget_op.update.amount_micros == 5_000_000
+        assert budget_op.update.total_amount_micros == 900_000_000_000
+
+    @pytest.mark.asyncio
+    async def test_create_budget_custom_period_total(self) -> None:
+        """create_budget sets period=CUSTOM_PERIOD and total_amount_micros."""
+        client = _make_client()
+        mock_result = MagicMock()
+        mock_result.resource_name = "customers/123/budgets/200"
+        mock_response = MagicMock()
+        mock_response.results = [mock_result]
+        mock_service = MagicMock()
+        mock_service.mutate_campaign_budgets.return_value = mock_response
+        client._client.get_service.return_value = mock_service
+        budget_op = MagicMock()
+        client._client.get_type.return_value = budget_op
+        client._client.enums = MagicMock()
+
+        result = await client.create_budget(
+            {
+                "name": "Q3 total",
+                "period": "CUSTOM_PERIOD",
+                "total_amount_micros": 900_000_000_000,
+            }
+        )
+
+        assert result["resource_name"] == "customers/123/budgets/200"
+        assert budget_op.create.total_amount_micros == 900_000_000_000
+        assert (
+            budget_op.create.period
+            == client._client.enums.BudgetPeriodEnum.CUSTOM_PERIOD
+        )
+
+    @pytest.mark.asyncio
+    async def test_create_budget_total_requires_custom_period(self) -> None:
+        """A total amount without period=CUSTOM_PERIOD is contradictory."""
+        client = _make_client()
+        with pytest.raises(ValueError, match="CUSTOM_PERIOD"):
+            await client.create_budget(
+                {"name": "bad", "total_amount_micros": 900_000_000_000}
+            )
+
+    @pytest.mark.asyncio
+    async def test_create_budget_custom_period_requires_total(self) -> None:
+        """CUSTOM_PERIOD without a total fails fast, before any API call."""
+        client = _make_client()
+        with pytest.raises(ValueError, match="total_amount"):
+            await client.create_budget(
+                {"name": "bad", "amount": 1000, "period": "CUSTOM_PERIOD"}
+            )
+
+    @pytest.mark.asyncio
+    async def test_create_budget_invalid_period(self) -> None:
+        client = _make_client()
+        with pytest.raises(ValueError, match="period"):
+            await client.create_budget(
+                {"name": "bad", "amount": 1000, "period": "WEEKLY"}
+            )
+
+    @pytest.mark.asyncio
+    async def test_create_budget_requires_some_amount(self) -> None:
+        client = _make_client()
+        with pytest.raises(ValueError, match="required"):
+            await client.create_budget({"name": "empty"})
+
     @pytest.mark.asyncio
     async def test_create_budget_正常(self) -> None:
         client = _make_client()

--- a/tests/test_mcp_tools_google_ads.py
+++ b/tests/test_mcp_tools_google_ads.py
@@ -158,6 +158,112 @@ def _mock_google_ads_context():
 
 
 # ---------------------------------------------------------------------------
+# Handler tests — budget type (daily vs total / CUSTOM_PERIOD) (#366)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGoogleAdsBudgetPeriodHandlers:
+    """Total-budget / period parameters on the budget tools."""
+
+    def test_budget_update_schema_exposes_total(self) -> None:
+        mod = _import_google_ads_tools()
+        tool = next(t for t in mod.TOOLS if t.name == "google_ads_budget_update")
+        props = tool.inputSchema["properties"]
+        assert "total_amount" in props
+        assert "total_amount_micros" in props
+        assert {"required": ["total_amount_micros"]} in tool.inputSchema["anyOf"]
+
+    def test_budget_create_schema_exposes_period_and_total(self) -> None:
+        mod = _import_google_ads_tools()
+        tool = next(t for t in mod.TOOLS if t.name == "google_ads_budget_create")
+        props = tool.inputSchema["properties"]
+        assert props["period"]["enum"] == ["DAILY", "CUSTOM_PERIOD"]
+        assert "total_amount_micros" in props
+        assert tool.inputSchema["required"] == ["name"]
+
+    async def test_budget_update_forwards_total(self) -> None:
+        mod = _import_google_ads_tools()
+        creds, client = _mock_google_ads_context()
+        client.update_budget.return_value = {"resource_name": "x"}
+
+        h = _import_handlers()
+        with (
+            patch.object(h, "load_google_ads_credentials", return_value=creds),
+            patch.object(h, "create_google_ads_client", return_value=client),
+        ):
+            await mod.handle_tool(
+                "google_ads_budget_update",
+                {
+                    "customer_id": "123",
+                    "budget_id": "100",
+                    "total_amount_micros": 900_000_000_000,
+                },
+            )
+
+        params = client.update_budget.await_args.args[0]
+        assert params["total_amount_micros"] == 900_000_000_000
+        assert "amount" not in params and "amount_micros" not in params
+
+    async def test_budget_update_still_requires_some_amount(self) -> None:
+        mod = _import_google_ads_tools()
+        creds, client = _mock_google_ads_context()
+        h = _import_handlers()
+        with (
+            patch.object(h, "load_google_ads_credentials", return_value=creds),
+            patch.object(h, "create_google_ads_client", return_value=client),
+            pytest.raises(ValueError, match="required"),
+        ):
+            await mod.handle_tool(
+                "google_ads_budget_update",
+                {"customer_id": "123", "budget_id": "100"},
+            )
+
+    async def test_budget_create_forwards_period_and_total(self) -> None:
+        mod = _import_google_ads_tools()
+        creds, client = _mock_google_ads_context()
+        client.create_budget.return_value = {"resource_name": "y"}
+
+        h = _import_handlers()
+        with (
+            patch.object(h, "load_google_ads_credentials", return_value=creds),
+            patch.object(h, "create_google_ads_client", return_value=client),
+        ):
+            await mod.handle_tool(
+                "google_ads_budget_create",
+                {
+                    "customer_id": "123",
+                    "name": "Q3 total",
+                    "period": "CUSTOM_PERIOD",
+                    "total_amount_micros": 900_000_000_000,
+                },
+            )
+
+        params = client.create_budget.await_args.args[0]
+        assert params["period"] == "CUSTOM_PERIOD"
+        assert params["total_amount_micros"] == 900_000_000_000
+        assert "amount" not in params
+
+    async def test_budget_create_daily_unchanged(self) -> None:
+        mod = _import_google_ads_tools()
+        creds, client = _mock_google_ads_context()
+        client.create_budget.return_value = {"resource_name": "z"}
+
+        h = _import_handlers()
+        with (
+            patch.object(h, "load_google_ads_credentials", return_value=creds),
+            patch.object(h, "create_google_ads_client", return_value=client),
+        ):
+            await mod.handle_tool(
+                "google_ads_budget_create",
+                {"customer_id": "123", "name": "daily", "amount": 3000},
+            )
+
+        params = client.create_budget.await_args.args[0]
+        assert params == {"name": "daily", "amount": 3000}
+
+
+# ---------------------------------------------------------------------------
 # Handler tests — read-only criteria / asset retrievals (#366)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_mcp_tools_meta_ads.py
+++ b/tests/test_mcp_tools_meta_ads.py
@@ -93,6 +93,15 @@ class TestMetaAdsToolDefinitions:
         assert tool is not None, f"Tool {tool_name} not found"
         assert set(tool.inputSchema["required"]) == set(expected_required)
 
+    def test_ad_sets_update_exposes_schedule_and_lifetime_budget(self) -> None:
+        """meta_ads_ad_sets_update exposes end_time and lifetime_budget (#367)."""
+        mod = _import_meta_ads_tools()
+        tool = next(t for t in mod.TOOLS if t.name == "meta_ads_ad_sets_update")
+        props = tool.inputSchema["properties"]
+        assert "end_time" in props
+        assert "lifetime_budget" in props
+        assert props["lifetime_budget"]["type"] == "integer"
+
 
 # ---------------------------------------------------------------------------
 # Handler tests — helpers
@@ -274,6 +283,139 @@ class TestMetaAdsAdSetHandlers:
             )
 
         client.update_ad_set.assert_awaited_once()
+
+    async def test_ad_sets_update_forwards_lifetime_budget(self) -> None:
+        """lifetime_budget reaches update_ad_set unchanged (#367)."""
+        mod = _import_meta_ads_tools()
+        handlers = _import_handlers()
+        creds, client = _mock_meta_ads_context()
+        client.update_ad_set.return_value = {"success": True}
+
+        with (
+            patch.object(handlers, "load_meta_ads_credentials", return_value=creds),
+            patch.object(handlers, "create_meta_ads_client", return_value=client),
+        ):
+            await mod.handle_tool(
+                "meta_ads_ad_sets_update",
+                {"account_id": "act_123", "ad_set_id": "20", "lifetime_budget": 90000},
+            )
+
+        kwargs = client.update_ad_set.await_args.kwargs
+        assert kwargs["lifetime_budget"] == 90000
+
+    async def test_ad_sets_update_forwards_end_time_string(self) -> None:
+        """An ISO 8601 end_time string reaches update_ad_set unchanged (#367)."""
+        mod = _import_meta_ads_tools()
+        handlers = _import_handlers()
+        creds, client = _mock_meta_ads_context()
+        client.update_ad_set.return_value = {"success": True}
+
+        with (
+            patch.object(handlers, "load_meta_ads_credentials", return_value=creds),
+            patch.object(handlers, "create_meta_ads_client", return_value=client),
+        ):
+            await mod.handle_tool(
+                "meta_ads_ad_sets_update",
+                {
+                    "account_id": "act_123",
+                    "ad_set_id": "20",
+                    "end_time": "2026-08-01T00:00:00+09:00",
+                },
+            )
+
+        kwargs = client.update_ad_set.await_args.kwargs
+        assert kwargs["end_time"] == "2026-08-01T00:00:00+09:00"
+
+    async def test_ad_sets_update_end_time_zero_clears_end_date(self) -> None:
+        """end_time=0 (Meta convention: no end date) is forwarded, not dropped (#367)."""
+        mod = _import_meta_ads_tools()
+        handlers = _import_handlers()
+        creds, client = _mock_meta_ads_context()
+        client.update_ad_set.return_value = {"success": True}
+
+        with (
+            patch.object(handlers, "load_meta_ads_credentials", return_value=creds),
+            patch.object(handlers, "create_meta_ads_client", return_value=client),
+        ):
+            await mod.handle_tool(
+                "meta_ads_ad_sets_update",
+                {"account_id": "act_123", "ad_set_id": "20", "end_time": 0},
+            )
+
+        kwargs = client.update_ad_set.await_args.kwargs
+        assert kwargs["end_time"] == 0
+
+    async def test_ad_sets_update_rejects_both_budgets(self) -> None:
+        """daily_budget and lifetime_budget are mutually exclusive on Meta (#367)."""
+        mod = _import_meta_ads_tools()
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            await mod.handle_tool(
+                "meta_ads_ad_sets_update",
+                {
+                    "account_id": "act_123",
+                    "ad_set_id": "20",
+                    "daily_budget": 5000,
+                    "lifetime_budget": 90000,
+                },
+            )
+
+    @pytest.mark.parametrize("no_end", [0, "0", " 0 "])
+    async def test_ad_sets_update_rejects_lifetime_budget_with_no_end(
+        self, no_end: Any
+    ) -> None:
+        """A lifetime budget requires an end date — end_time=0 contradicts it,
+        including the string form "0" which is wire-identical to 0 (#367)."""
+        mod = _import_meta_ads_tools()
+        with pytest.raises(ValueError, match="end_time"):
+            await mod.handle_tool(
+                "meta_ads_ad_sets_update",
+                {
+                    "account_id": "act_123",
+                    "ad_set_id": "20",
+                    "lifetime_budget": 90000,
+                    "end_time": no_end,
+                },
+            )
+
+    async def test_ad_sets_update_normalizes_string_zero_end_time(self) -> None:
+        """end_time="0" is normalized to the integer 0 before forwarding (#367)."""
+        mod = _import_meta_ads_tools()
+        handlers = _import_handlers()
+        creds, client = _mock_meta_ads_context()
+        client.update_ad_set.return_value = {"success": True}
+
+        with (
+            patch.object(handlers, "load_meta_ads_credentials", return_value=creds),
+            patch.object(handlers, "create_meta_ads_client", return_value=client),
+        ):
+            await mod.handle_tool(
+                "meta_ads_ad_sets_update",
+                {"account_id": "act_123", "ad_set_id": "20", "end_time": "0"},
+            )
+
+        kwargs = client.update_ad_set.await_args.kwargs
+        assert kwargs["end_time"] == 0
+
+    async def test_ad_sets_update_rejects_zero_lifetime_budget(self) -> None:
+        """A 0 lifetime budget halts delivery — refuse before any API call (#367)."""
+        mod = _import_meta_ads_tools()
+        with pytest.raises(ValueError, match="greater than 0"):
+            await mod.handle_tool(
+                "meta_ads_ad_sets_update",
+                {"account_id": "act_123", "ad_set_id": "20", "lifetime_budget": 0},
+            )
+
+    @pytest.mark.parametrize("bad_end_time", [-1, True, "", "  "])
+    async def test_ad_sets_update_rejects_invalid_end_time(
+        self, bad_end_time: Any
+    ) -> None:
+        """Negative / boolean / blank end_time values are rejected (#367)."""
+        mod = _import_meta_ads_tools()
+        with pytest.raises(ValueError, match="end_time"):
+            await mod.handle_tool(
+                "meta_ads_ad_sets_update",
+                {"account_id": "act_123", "ad_set_id": "20", "end_time": bad_end_time},
+            )
 
     async def test_pages_upload_photo(self) -> None:
         """meta_ads_pages_upload_photo returns the PAGE photo_id (cover_photo_id)."""

--- a/tests/test_strategy_gate.py
+++ b/tests/test_strategy_gate.py
@@ -133,6 +133,47 @@ class TestEvaluateGuardrails:
         )
         assert d.allowed is True
 
+    def test_total_amount_micros_hits_lifetime_cap(self) -> None:
+        """Google total (CUSTOM_PERIOD) budgets are lifetime-capped too (#366)."""
+        g = Guardrails(max_lifetime_budget_per_campaign=900000)
+        d = evaluate_guardrails(
+            "google_ads_budget_update",
+            {"budget_id": "1", "total_amount_micros": 1_000_000_000_000},
+            g,
+        )
+        assert d.allowed is False
+        assert "max_lifetime_budget_per_campaign" in d.reason
+
+    def test_total_amount_units_hits_lifetime_cap(self) -> None:
+        """The currency-unit form total_amount cannot sidestep the cap."""
+        g = Guardrails(max_lifetime_budget_per_campaign=900000)
+        d = evaluate_guardrails(
+            "google_ads_budget_update",
+            {"budget_id": "1", "total_amount": 1_000_000},
+            g,
+        )
+        assert d.allowed is False
+        assert "max_lifetime_budget_per_campaign" in d.reason
+
+    def test_amount_micros_hits_daily_cap(self) -> None:
+        """The micros form amount_micros cannot sidestep the daily cap."""
+        g = Guardrails(max_daily_budget_per_campaign=50000)
+        d = evaluate_guardrails(
+            "google_ads_budget_update",
+            {"budget_id": "1", "amount_micros": 80_000_000_000},
+            g,
+        )
+        assert d.allowed is False
+
+    def test_total_amount_micros_under_lifetime_cap_allows(self) -> None:
+        g = Guardrails(max_lifetime_budget_per_campaign=900000)
+        d = evaluate_guardrails(
+            "google_ads_budget_update",
+            {"budget_id": "1", "total_amount_micros": 500_000_000_000},
+            g,
+        )
+        assert d.allowed is True
+
     def test_lifetime_budget_ignores_daily_cap(self) -> None:
         """Daily and lifetime caps have distinct semantics — no cross-check."""
         g = Guardrails(max_daily_budget_per_campaign=50000)

--- a/tests/test_strategy_gate.py
+++ b/tests/test_strategy_gate.py
@@ -21,11 +21,13 @@ class TestParseGuardrails:
             "- max_daily_budget_per_campaign: 50,000\n"
             "- max_daily_budget_increase_pct: 20\n"
             "- max_total_daily_budget: 300000\n"
+            "- max_lifetime_budget_per_campaign: 900000\n"
             "- blocked_operations: google_ads_campaigns_remove, meta_ads_x\n"
         )
         assert g.max_daily_budget_per_campaign == 50000
         assert g.max_daily_budget_increase_pct == 20
         assert g.max_total_daily_budget == 300000
+        assert g.max_lifetime_budget_per_campaign == 900000
         assert g.blocked_operations == frozenset(
             {"google_ads_campaigns_remove", "meta_ads_x"}
         )
@@ -110,6 +112,36 @@ class TestEvaluateGuardrails:
             g,
         )
         assert d.allowed is False
+
+    def test_lifetime_cap_denies(self) -> None:
+        """lifetime_budget is gate-covered so it cannot sidestep caps (#367)."""
+        g = Guardrails(max_lifetime_budget_per_campaign=900000)
+        d = evaluate_guardrails(
+            "meta_ads_ad_sets_update",
+            {"ad_set_id": "1", "lifetime_budget": 1_000_000},
+            g,
+        )
+        assert d.allowed is False
+        assert "max_lifetime_budget_per_campaign" in d.reason
+
+    def test_lifetime_under_cap_allows(self) -> None:
+        g = Guardrails(max_lifetime_budget_per_campaign=900000)
+        d = evaluate_guardrails(
+            "meta_ads_ad_sets_update",
+            {"ad_set_id": "1", "lifetime_budget": 500000},
+            g,
+        )
+        assert d.allowed is True
+
+    def test_lifetime_budget_ignores_daily_cap(self) -> None:
+        """Daily and lifetime caps have distinct semantics — no cross-check."""
+        g = Guardrails(max_daily_budget_per_campaign=50000)
+        d = evaluate_guardrails(
+            "meta_ads_ad_sets_update",
+            {"ad_set_id": "1", "lifetime_budget": 80000},
+            g,
+        )
+        assert d.allowed is True
 
     def test_non_budget_tool_with_budget_cap_allows(self) -> None:
         # A status change carries no budget → the budget cap does not apply.


### PR DESCRIPTION
Part of #366 (task 3 — budget type get/set). **Stacked on #369** (which stacks on #368): merge #368 → #369 first, then retarget this PR's base to `main`. Closes #366 together with #369.

## Summary

Google Ads budgets come in two types — DAILY and CUSTOM_PERIOD (campaign-lifetime total). mureo previously read/wrote only the daily amount. This PR:

| Surface | Change |
|---|---|
| `google_ads_budget_get` | Now returns `name`, `period` (DAILY / CUSTOM_PERIOD), `delivery_method`, enum-mapped `status`, `total_budget` / `total_amount_micros` (null unless CUSTOM_PERIOD), `reference_count` — fixing the long-standing drift where the description promised these fields |
| `google_ads_budget_update` | Accepts `total_amount` / `total_amount_micros` alongside (or instead of) the daily amount, with a dynamic update mask |
| `google_ads_budget_create` | Accepts `period` + total amounts; `required` relaxed to `["name"]` + anyOf so a pure total budget needs no daily amount |

## Design notes

- **`period` is create-only**: the Google Ads API marks `CampaignBudget.period` Immutable (verified from the proto docstrings), so `update_budget` deliberately does not accept it, despite the issue text suggesting both. Symmetric fail-fast guards: a total without `period='CUSTOM_PERIOD'` and CUSTOM_PERIOD without a total are both `ValueError`s before any API call.
- **Catastrophe guard composition**: every amount path (daily + total, create + update) routes through the shared `_resolve_amount_micros` — positive, `_MAX_BUDGET_AMOUNT_MICROS` ceiling, bool/inf rejection, pair mutual exclusion. The create path's legacy bare `int(amount_micros)` (no ceiling) is gone.
- **Guardrail gate composition (#360/#367)**: `max_lifetime_budget_per_campaign` now catches Google totals in **both** spellings (`total_amount` currency units, `total_amount_micros` ÷1e6), and the daily cap additionally reads `amount_micros` — closing parameter-form bypasses found in security review.
- **BYOD**: `get_budget` shape parity (period=DAILY, null totals).
- Docs: `_mureo-google-ads` + `_mureo-strategy` skills (canonical + packaged byte-identical).

## Test plan

- [x] Client: get_budget field mapping (CUSTOM_PERIOD + DAILY/null-total), total update exact micros / unit conversion / mutual exclusion / zero / ceiling, daily+total combined mask, create with period+total, contradictory combinations, invalid period, no-amount rejection — plus all 16 pre-existing budget tests unchanged
- [x] Gate: total_amount_micros and total_amount deny over cap / allow under; amount_micros hits the daily cap; no daily↔lifetime cross-application
- [x] MCP: schemas (anyOf), handler forwarding (total-only update, period+total create, legacy daily create unchanged)
- [x] ruff / black / mypy (CI flags) clean; full suite green except known local plugin-env noise

TDD (tests first). Reviews: security-reviewer (HIGH `total_amount` gate bypass → fixed → CONFIRMED) + python-reviewer (MEDIUM schema wording + 2 LOW → fixed → CONFIRM).

https://claude.ai/code/session_0195WBK6YopTveq9RAQE2xMz
