### PR TITLE
fix(web): list name-prefixed mureo-* packages in About to match update-check (#365)

### DIFF
--- a/mureo/web/about.py
+++ b/mureo/web/about.py
@@ -1,40 +1,66 @@
 """Version/package payload for the configure UI's "About mureo" tab (#229).
 
-Resolves the installed mureo version plus every distribution that
-contributes to mureo's plugin entry-point groups (providers, runtime-
-context factories, web extensions). Discovery is entry-point based, so
-a freshly installed plugin appears automatically — no per-plugin wiring.
+Resolves the installed mureo version plus every installed mureo plugin,
+discovered along TWO axes that together match what ``mureo upgrade`` /
+the update-check consider an installed mureo package (#365):
+
+1. **Entry-point** — any distribution contributing to one of mureo's
+   plugin extension groups (providers, skills, runtime-context factories,
+   web extensions, policy gates, analytics). Catches a plugin whose
+   distribution is NOT named ``mureo-*`` (e.g. a third-party ``acme-ads``
+   that registers ``mureo.providers``).
+2. **Name-prefix** — every installed ``mureo`` / ``mureo-*`` distribution,
+   using the SAME discovery the updater uses
+   (:func:`mureo.cli.upgrade_cmd._discover_all_mureo_packages`). Catches a
+   plugin that registers only, say, ``mureo.skills`` and would otherwise be
+   flagged "update available" yet never listed here (#365).
+
+The two are unioned and deduplicated by PEP 503 canonical name (which is
+also the display name, matching the update banner's labelling), so the
+"Installed packages" list and the "Update available" banner agree —
+whenever both observe the same installed metadata — about what is
+installed and how it is named.
 
 Only :mod:`importlib.metadata` (stdlib) is consulted. The payload
 carries nothing environment-specific: no secrets, no file paths — only
 distribution names and versions.
 
 Fault isolation mirrors :mod:`mureo.web.extensions`: one broken
-plugin's metadata (a raising ``dist`` lookup, a corrupted group) skips
-just that item, never the endpoint.
+plugin's metadata (a raising ``dist`` lookup, a corrupted group) — or a
+failing name-prefix walk — skips just that item, never the endpoint.
 """
 
 from __future__ import annotations
 
 from importlib.metadata import (
-    PackageNotFoundError,
     entry_points,
     packages_distributions,
     version,
 )
 from typing import Any, Final
 
-from mureo.core.providers.registry import PROVIDERS_ENTRY_POINT_GROUP
+from mureo.analytics.registry import ANALYTICS_ENTRY_POINT_GROUP
+from mureo.cli.upgrade_cmd import _canonicalise, _discover_all_mureo_packages
+from mureo.core.policy import POLICY_GATES_ENTRY_POINT_GROUP
+from mureo.core.providers.registry import (
+    PROVIDERS_ENTRY_POINT_GROUP,
+    SKILLS_ENTRY_POINT_GROUP,
+)
 from mureo.core.runtime_context import RUNTIME_CONTEXT_FACTORY_ENTRY_POINT_GROUP
 from mureo.web.extensions import WEB_EXTENSIONS_ENTRY_POINT_GROUP
 
 #: Entry-point groups scanned for contributing distributions. Reuses the
 #: group-name constants owned by each consuming module so a future
-#: rename flows through here automatically.
+#: rename flows through here automatically. Covers EVERY mureo extension
+#: surface (#365) — a ``mureo.skills`` / ``mureo.policy_gates`` /
+#: ``mureo.analytics`` plugin is as "installed" as a provider one.
 ABOUT_ENTRY_POINT_GROUPS: Final[tuple[str, ...]] = (
     PROVIDERS_ENTRY_POINT_GROUP,
+    SKILLS_ENTRY_POINT_GROUP,
     RUNTIME_CONTEXT_FACTORY_ENTRY_POINT_GROUP,
     WEB_EXTENSIONS_ENTRY_POINT_GROUP,
+    POLICY_GATES_ENTRY_POINT_GROUP,
+    ANALYTICS_ENTRY_POINT_GROUP,
 )
 
 #: Placeholder shown when a version cannot be resolved (e.g. a dev tree
@@ -49,10 +75,27 @@ def _mureo_version() -> str:
     distribution — :class:`PackageNotFoundError` then must not break the
     About endpoint.
     """
+    return _safe_version("mureo")
+
+
+def _safe_version(name: str) -> str:
+    """Installed version of ``name``, or the placeholder when unresolvable.
+
+    Always returns a non-empty ``str`` so the payload's documented
+    ``{"name": str, "version": str}`` shape holds. ``version()`` can:
+    - raise :class:`PackageNotFoundError` (vanished between the walk and here),
+    - raise anything else on a corrupted ``METADATA`` (e.g. a non-UTF-8 decode),
+    - return ``None`` when the ``Version`` header is absent (malformed dist-info
+      — ``version()`` does NOT raise for this).
+    Every one of these degrades to the placeholder rather than dropping the row
+    or escaping to a 500 — mirroring axis 1's per-item guard in
+    :func:`_resolve_distribution`.
+    """
     try:
-        return version("mureo")
-    except PackageNotFoundError:
+        resolved = version(name)
+    except Exception:  # noqa: BLE001 — never 500 the About tab on bad metadata
         return UNKNOWN_VERSION
+    return resolved if isinstance(resolved, str) and resolved else UNKNOWN_VERSION
 
 
 def _resolve_distribution(ep: Any) -> tuple[str, str] | None:
@@ -81,10 +124,11 @@ def _resolve_distribution(ep: Any) -> tuple[str, str] | None:
     if not candidates:
         return None
     fallback_name = candidates[0]
-    try:
-        return fallback_name, version(fallback_name)
-    except PackageNotFoundError:
-        return fallback_name, UNKNOWN_VERSION
+    # Route through _safe_version (not version() directly) so a malformed
+    # dist-info — Version header absent, so version() returns None rather than
+    # raising — degrades to the placeholder here too, matching the dist-present
+    # branch above and never emitting a non-string version.
+    return fallback_name, _safe_version(fallback_name)
 
 
 def collect_about_info() -> dict[str, Any]:
@@ -97,14 +141,27 @@ def collect_about_info() -> dict[str, Any]:
           "packages": [{"name": str, "version": str}, ...]
         }
 
-    ``packages`` lists every distribution contributing to
-    :data:`ABOUT_ENTRY_POINT_GROUPS`, deduplicated by distribution name
-    and sorted by name, with mureo itself always present. The seeded
-    mureo version wins over any entry-point-derived duplicate so the
-    headline version and the table row never disagree.
+    ``packages`` unions the two discovery axes described in the module
+    docstring — entry-point contributors across :data:`ABOUT_ENTRY_POINT_GROUPS`
+    AND every installed ``mureo`` / ``mureo-*`` distribution the updater sees —
+    deduplicated by PEP 503 canonical name and sorted by display name, with
+    mureo itself always present. The seeded mureo version wins over any
+    discovered duplicate so the headline version and the table row never
+    disagree.
     """
     mureo_version = _mureo_version()
-    by_name: dict[str, str] = {"mureo": mureo_version}
+    # Canonical distribution name -> {"name": <display>, "version": <ver>}.
+    # Keying on the canonical name is what makes this list AGREE with the
+    # update checker (#365): the updater discovers packages by canonical
+    # name-prefix, so deduping here on the same key guarantees a package the
+    # updater flags is listed here exactly once and never keyed differently.
+    by_canonical: dict[str, dict[str, str]] = {}
+
+    # Axis 1 — entry-point contributors across every mureo extension group.
+    # Runs first so that for a plugin present on both axes, its entry-point
+    # ``dist.version`` is the one kept (via ``setdefault``) over axis 2's
+    # separate lookup. Display name is canonical on both axes, so ordering no
+    # longer affects the label.
     for group in ABOUT_ENTRY_POINT_GROUPS:
         try:
             group_eps = entry_points(group=group)
@@ -116,13 +173,47 @@ def collect_about_info() -> dict[str, Any]:
             except Exception:  # noqa: BLE001 — per-entry-point fault isolation
                 continue
             if resolved is not None:
-                by_name.setdefault(resolved[0], resolved[1])
+                name, dist_version = resolved
+                canonical = _canonicalise(name)
+                # Display the CANONICAL name (not the raw ``dist.name``) so a
+                # mixed-case / underscored distribution reads identically to the
+                # update-check banner, which always shows the canonical form
+                # (#365). Keeps the two surfaces labelled the same, not just
+                # scoped the same.
+                by_canonical.setdefault(
+                    canonical, {"name": canonical, "version": dist_version}
+                )
+
+    # Axis 2 — every installed ``mureo`` / ``mureo-*`` distribution, by the
+    # SAME name-prefix rule the update checker uses (#365). Closes the gap
+    # where a name-prefixed plugin registering none of the scanned groups was
+    # flagged "update available" yet never listed here.
+    for canonical in _name_prefixed_packages():
+        by_canonical.setdefault(
+            canonical, {"name": canonical, "version": _safe_version(canonical)}
+        )
+
+    # mureo itself: the seeded headline version always wins over any
+    # discovered duplicate (name-prefix discovery includes ``mureo``).
+    by_canonical["mureo"] = {"name": "mureo", "version": mureo_version}
+
     return {
         "mureo": {"name": "mureo", "version": mureo_version},
-        "packages": [
-            {"name": name, "version": by_name[name]} for name in sorted(by_name)
-        ],
+        "packages": sorted(by_canonical.values(), key=lambda pkg: pkg["name"]),
     }
+
+
+def _name_prefixed_packages() -> list[str]:
+    """Canonical names of installed ``mureo`` / ``mureo-*`` distributions.
+
+    Delegates to the updater's own discovery so the two features stay in
+    lock-step (#365). A failing walk degrades to an empty list — the About
+    endpoint must never 500 on a corrupted metadata index.
+    """
+    try:
+        return _discover_all_mureo_packages()
+    except Exception:  # noqa: BLE001 — discovery must never 500 the About tab
+        return []
 
 
 __all__ = [

--- a/tests/test_web_about.py
+++ b/tests/test_web_about.py
@@ -1,10 +1,11 @@
 """Version/extension-package discovery for ``mureo.web.about``.
 
 ``collect_about_info`` resolves the installed mureo version plus every
-distribution contributing to mureo's plugin entry-point groups via
-:mod:`importlib.metadata`. These tests mock that surface entirely —
-the machine running them may carry real mureo plugins (dev boxes do),
-so nothing here depends on what is actually installed.
+installed mureo plugin, discovered along two axes (#365): the plugin
+entry-point groups AND the ``mureo`` / ``mureo-*`` name prefix (the same
+set the updater sees). These tests mock both surfaces entirely — the
+machine running them may carry real mureo plugins (dev boxes do), so
+nothing here depends on what is actually installed.
 """
 
 from __future__ import annotations
@@ -86,11 +87,28 @@ def _version_for(versions: dict[str, str]) -> Any:
 
 @pytest.mark.unit
 class TestCollectAboutInfo:
-    def test_groups_constant_covers_all_three_plugin_surfaces(self) -> None:
+    @pytest.fixture(autouse=True)
+    def _no_name_prefixed_dists(self) -> Any:
+        """Neutralise the real name-prefix distribution walk (#365).
+
+        ``collect_about_info`` now also lists every installed ``mureo`` /
+        ``mureo-*`` distribution (the same set the updater discovers). That
+        walk hits real installed metadata, so on a dev box carrying real
+        ``mureo-*`` plugins it would break these hermetic entry-point cases.
+        Default it to "no name-prefixed dists"; the cases that exercise the
+        name-prefix axis re-patch it inside their own ``with`` block.
+        """
+        with patch("mureo.web.about._discover_all_mureo_packages", return_value=[]):
+            yield
+
+    def test_groups_constant_covers_all_mureo_plugin_surfaces(self) -> None:
         assert ABOUT_ENTRY_POINT_GROUPS == (
             "mureo.providers",
+            "mureo.skills",
             "mureo.runtime_context_factory",
             "mureo.web_extensions",
+            "mureo.policy_gates",
+            "mureo.analytics",
         )
 
     def test_mureo_always_present_with_no_entry_points(self) -> None:
@@ -209,6 +227,30 @@ class TestCollectAboutInfo:
             info = collect_about_info()
         assert {"name": "acme-plugin", "version": "2.0.0"} in info["packages"]
 
+    def test_dist_none_fallback_version_none_uses_placeholder(self) -> None:
+        """The ``dist is None`` fallback path also normalizes a ``None``
+        version (malformed dist-info) to the placeholder — matching the
+        dist-present branch and never emitting a non-string version."""
+
+        def version_returns_none(name: str) -> str | None:
+            return "1.0.0" if name == "mureo" else None
+
+        by_group = {
+            "mureo.providers": (
+                _FakeEntryPoint(dist=None, module="acme_plugin.providers"),
+            ),
+        }
+        with (
+            patch("mureo.web.about.entry_points", _entry_points_for(by_group)),
+            patch("mureo.web.about.version", version_returns_none),
+            patch(
+                "mureo.web.about.packages_distributions",
+                return_value={"acme_plugin": ["acme-plugin"]},
+            ),
+        ):
+            info = collect_about_info()
+        assert {"name": "acme-plugin", "version": UNKNOWN_VERSION} in info["packages"]
+
     def test_dist_none_without_mapping_is_skipped(self) -> None:
         by_group = {
             "mureo.providers": (
@@ -255,6 +297,195 @@ class TestCollectAboutInfo:
         assert set(info["mureo"].keys()) == {"name", "version"}
         for pkg in info["packages"]:
             assert set(pkg.keys()) == {"name", "version"}
+
+    # -- #365: consistency with the update checker ------------------------
+    #
+    # The "Installed packages" list and the "Update available" banner must
+    # agree on what counts as an installed mureo package. The updater keys
+    # off the ``mureo`` / ``mureo-*`` name prefix; About must list that same
+    # set so a package can never be flagged "update available" while absent
+    # from "Installed packages".
+
+    def test_name_prefixed_package_without_entry_points_is_listed(self) -> None:
+        """A ``mureo-*`` plugin registering NONE of the scanned entry-point
+        groups (e.g. ``mureo-logly-tools`` — ``mureo.skills`` only, but here
+        with no entry point at all) is still listed, matching the updater."""
+        with (
+            patch("mureo.web.about.entry_points", _entry_points_for({})),
+            patch(
+                "mureo.web.about.version",
+                _version_for({"mureo": "1.0.0", "mureo-logly-tools": "0.3.0"}),
+            ),
+            patch(
+                "mureo.web.about._discover_all_mureo_packages",
+                return_value=["mureo", "mureo-logly-tools"],
+            ),
+        ):
+            info = collect_about_info()
+        assert {"name": "mureo-logly-tools", "version": "0.3.0"} in info["packages"]
+        names = [pkg["name"] for pkg in info["packages"]]
+        assert names == ["mureo", "mureo-logly-tools"]
+
+    def test_name_prefixed_package_missing_version_uses_placeholder(self) -> None:
+        """A name-prefix-discovered dist whose version cannot be resolved
+        degrades to the placeholder rather than dropping the row."""
+        with (
+            patch("mureo.web.about.entry_points", _entry_points_for({})),
+            patch("mureo.web.about.version", _version_for({"mureo": "1.0.0"})),
+            patch(
+                "mureo.web.about._discover_all_mureo_packages",
+                return_value=["mureo", "mureo-ghost"],
+            ),
+        ):
+            info = collect_about_info()
+        assert {"name": "mureo-ghost", "version": UNKNOWN_VERSION} in info["packages"]
+
+    def test_name_prefix_and_entry_point_dedupe_by_canonical(self) -> None:
+        """A package surfaced by BOTH axes (a skills entry point AND the
+        name prefix) appears exactly once."""
+        by_group = {
+            "mureo.skills": (
+                _FakeEntryPoint(dist=_FakeDist("mureo-logly-tools", "0.3.0")),
+            ),
+        }
+        with (
+            patch("mureo.web.about.entry_points", _entry_points_for(by_group)),
+            patch(
+                "mureo.web.about.version",
+                _version_for({"mureo": "1.0.0", "mureo-logly-tools": "0.3.0"}),
+            ),
+            patch(
+                "mureo.web.about._discover_all_mureo_packages",
+                return_value=["mureo", "mureo-logly-tools"],
+            ),
+        ):
+            info = collect_about_info()
+        names = [pkg["name"] for pkg in info["packages"]]
+        assert names == ["mureo", "mureo-logly-tools"]
+
+    def test_skills_only_entry_point_plugin_is_listed(self) -> None:
+        """A skills plugin NOT named ``mureo-*`` (so invisible to the
+        name-prefix axis) is surfaced via the now-scanned skills group."""
+        by_group = {
+            "mureo.skills": (_FakeEntryPoint(dist=_FakeDist("acme-skills", "1.1.0")),),
+        }
+        with (
+            patch("mureo.web.about.entry_points", _entry_points_for(by_group)),
+            patch("mureo.web.about.version", _version_for({"mureo": "1.0.0"})),
+        ):
+            info = collect_about_info()
+        names = [pkg["name"] for pkg in info["packages"]]
+        assert names == ["acme-skills", "mureo"]
+
+    def test_policy_gate_and_analytics_groups_are_scanned(self) -> None:
+        """The policy-gate and analytics extension surfaces are scanned too,
+        so a plugin contributing only those still appears."""
+        by_group = {
+            "mureo.policy_gates": (
+                _FakeEntryPoint(dist=_FakeDist("gate-plugin", "2.0.0")),
+            ),
+            "mureo.analytics": (
+                _FakeEntryPoint(dist=_FakeDist("analytics-plugin", "3.0.0")),
+            ),
+        }
+        with (
+            patch("mureo.web.about.entry_points", _entry_points_for(by_group)),
+            patch("mureo.web.about.version", _version_for({"mureo": "1.0.0"})),
+        ):
+            info = collect_about_info()
+        names = [pkg["name"] for pkg in info["packages"]]
+        assert names == ["analytics-plugin", "gate-plugin", "mureo"]
+
+    def test_name_prefix_discovery_failure_is_isolated(self) -> None:
+        """If the name-prefix walk blows up, the endpoint still returns the
+        entry-point-derived rows rather than 500-ing."""
+        by_group = {
+            "mureo.providers": (_FakeEntryPoint(dist=_FakeDist("ep-plugin", "1.0.0")),),
+        }
+        with (
+            patch("mureo.web.about.entry_points", _entry_points_for(by_group)),
+            patch("mureo.web.about.version", _version_for({"mureo": "1.0.0"})),
+            patch(
+                "mureo.web.about._discover_all_mureo_packages",
+                side_effect=RuntimeError("metadata index corrupted"),
+            ),
+        ):
+            info = collect_about_info()
+        names = [pkg["name"] for pkg in info["packages"]]
+        assert names == ["ep-plugin", "mureo"]
+
+    def test_name_prefixed_version_none_uses_placeholder(self) -> None:
+        """``importlib.metadata.version`` returns ``None`` (not raises) for a
+        dist whose ``METADATA`` has a Name but no Version header. The row must
+        still carry a string version (payload shape ``{"name","version"}``)."""
+
+        def version_returns_none(name: str) -> str | None:
+            if name == "mureo":
+                return "1.0.0"
+            return None  # malformed dist-info: Version header absent
+
+        with (
+            patch("mureo.web.about.entry_points", _entry_points_for({})),
+            patch("mureo.web.about.version", version_returns_none),
+            patch(
+                "mureo.web.about._discover_all_mureo_packages",
+                return_value=["mureo", "mureo-malformed"],
+            ),
+        ):
+            info = collect_about_info()
+        row = next(p for p in info["packages"] if p["name"] == "mureo-malformed")
+        assert row == {"name": "mureo-malformed", "version": UNKNOWN_VERSION}
+        assert isinstance(row["version"], str)
+
+    def test_mixed_case_name_dedupes_and_displays_canonical(self) -> None:
+        """A distribution whose raw entry-point name is mixed-case / underscored
+        is deduped against its name-prefix canonical form AND displayed in the
+        canonical form — so About labels it identically to the update banner."""
+        by_group = {
+            "mureo.skills": (
+                _FakeEntryPoint(dist=_FakeDist("Mureo_Logly_Tools", "0.3.0")),
+            ),
+        }
+        with (
+            patch("mureo.web.about.entry_points", _entry_points_for(by_group)),
+            patch(
+                "mureo.web.about.version",
+                _version_for({"mureo": "1.0.0", "mureo-logly-tools": "0.3.0"}),
+            ),
+            patch(
+                "mureo.web.about._discover_all_mureo_packages",
+                return_value=["mureo", "mureo-logly-tools"],
+            ),
+        ):
+            info = collect_about_info()
+        names = [pkg["name"] for pkg in info["packages"]]
+        assert names == ["mureo", "mureo-logly-tools"]
+        assert "Mureo_Logly_Tools" not in names
+
+    def test_every_updater_package_appears_exactly_once(self) -> None:
+        """Property of #365: every name the updater discovers is listed here
+        exactly once (⊆ guarantee), regardless of entry-point registration."""
+        updater_set = ["mureo", "mureo-agency", "mureo-logly-tools", "mureo-x"]
+        by_group = {
+            # Only one of them also registers an entry point — the rest are
+            # name-prefix-only, exactly the #365 gap.
+            "mureo.providers": (
+                _FakeEntryPoint(dist=_FakeDist("mureo-agency", "0.1.0")),
+            ),
+        }
+        versions = {name: "1.0.0" for name in updater_set}
+        with (
+            patch("mureo.web.about.entry_points", _entry_points_for(by_group)),
+            patch("mureo.web.about.version", _version_for(versions)),
+            patch(
+                "mureo.web.about._discover_all_mureo_packages",
+                return_value=updater_set,
+            ),
+        ):
+            info = collect_about_info()
+        names = [pkg["name"] for pkg in info["packages"]]
+        for canonical in updater_set:
+            assert names.count(canonical) == 1, f"{canonical} not listed exactly once"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

Fixes #365 — the "About mureo" Installed-packages list and the "Update available" banner used **inconsistent discovery criteria**, so a package could be flagged as "update available" while never appearing in "Installed packages".

- **About** (`collect_about_info`) listed only distributions registering an entry point in the providers / runtime_context_factory / web_extensions groups.
- **Update-check** (`_discover_all_mureo_packages`) flags **any** `mureo` / `mureo-*` distribution by PEP 503 name prefix — no entry-point requirement.

A `mureo.skills`-only plugin (e.g. `mureo-logly-tools`) was therefore reported as updatable yet shown as not installed.

## Fix

`collect_about_info()` now unions **two discovery axes**, deduplicated by PEP 503 canonical name (which is also the display name, matching the update banner's labelling):

1. **Entry-point** — contributors across **every** mureo extension group. Adds `mureo.skills`, `mureo.policy_gates`, `mureo.analytics` to `ABOUT_ENTRY_POINT_GROUPS` (previously only providers / rcf / web_extensions). Catches plugins **not** named `mureo-*` (e.g. a third-party `acme-ads` provider).
2. **Name-prefix** — every installed `mureo` / `mureo-*` distribution via the **same** `_discover_all_mureo_packages()` the updater uses. Closes the reported gap.

This guarantees **updater's set ⊆ Installed list**, and both surfaces now label a package identically (canonical form).

Also hardened `_safe_version`: a missing / `None` / broken-metadata version (e.g. `importlib.metadata.version()` returning `None` for a dist whose `METADATA` has a Name but no Version header — it does **not** raise) degrades to the `unknown` placeholder, so the payload's `{"name": str, "version": str}` shape always holds. The Python-3.10 `dist is None` fallback path in `_resolve_distribution` routes through it too. The About endpoint never 500s.

## Test plan

- [x] `tests/test_web_about.py` — updated `ABOUT_ENTRY_POINT_GROUPS` assertion; added cases: name-prefixed plugin w/o entry points is listed; dedupe across the two axes by canonical name; skills / policy_gates / analytics groups scanned; name-prefix discovery failure isolated; `version()==None` → placeholder (both name-prefix axis and the `dist is None` fallback); mixed-case name deduped + displayed canonical; ⊆ property (every updater package listed exactly once). **34 passed.**
- [x] Related suite (`-k "about or version_check or upgrade or handlers"`) — **517 passed**.
- [x] `ruff` + `black` clean.
- [x] Two rounds of `code-reviewer` review; all WARNING findings addressed.

## Scope

OSS `mureo` only — `mureo/web/about.py` + tests. No change to the updater, MCP server, or ad-platform clients.
