### PR TITLE
fix(search-console): bind site_url to tenant allow-list to stop cross-client leakage

### DIFF
--- a/mureo/core/runtime_context.py
+++ b/mureo/core/runtime_context.py
@@ -345,3 +345,79 @@ def runtime_ui_plugin_credential_fields() -> dict[str, frozenset[str]] | None:
             continue
         scoped[provider] = frozenset(str(k) for k in keys)
     return scoped or None
+
+
+def runtime_search_console_sites() -> frozenset[str] | None:
+    """Return the Search Console ``site_url`` allow-list for the ACTIVE
+    client, or ``None`` when Search Console is not tenant-scoped.
+
+    Search Console reuses the operator-shared Google OAuth — one identity
+    that may see MANY clients' properties — and its MCP tools take
+    ``site_url`` as a free caller argument. In a multi-account (agency)
+    deployment nothing otherwise stops one client's workspace from querying a
+    sibling client's property (cross-client data leak). A multi-account
+    backend closes this by declaring, on its ``SecretStore``, the set of
+    ``site_url``s that belong to the active client as ``search_console_sites``
+    (a non-``str`` collection of strings). The Search Console handlers then
+    resolve/enforce ``site_url`` against this set — fail-closed for an
+    out-of-set value, fail-fast when none is configured — mirroring how
+    Google Ads binds ``customer_id`` from per-client config. Joins the
+    store-capability family of :func:`runtime_credentials_path` (#196),
+    :func:`runtime_multi_account_auth` (#198), and
+    :func:`runtime_ui_plugin_credential_fields` (#202).
+
+    Resolution:
+
+    - **No factory registered** → ``None``. Standalone OSS keeps the
+      unrestricted behavior — the gate is on entry-point *presence* so the
+      default store is never consulted and existing single-workspace use is
+      byte-identical.
+    - **Store declares a usable ``search_console_sites``** (a non-``str`` /
+      non-``bytes`` :class:`~collections.abc.Collection`) → a ``frozenset`` of
+      its non-blank string entries. An empty / all-blank / all-non-str
+      collection resolves to an EMPTY ``frozenset`` (scoping ON, zero sites),
+      which the handlers turn into a fail-fast — a security control errs
+      CLOSED once engaged.
+    - **Attribute absent or NOT a usable collection (bare ``str`` / ``bytes``
+      / generator / other), on a multi-account backend** (``multi_account_auth
+      is True``) → an EMPTY ``frozenset``, NOT ``None``. A shared-OAuth
+      backend that reaches many clients' properties MUST scope Search Console;
+      forgetting (or mistyping) the allow-list must fail CLOSED (a loud
+      "not configured for this client") rather than silently reopen the
+      cross-client leak. This is the key difference from the permissive
+      members of the family: absence defaults to the SAFE side here.
+    - **Attribute absent / not usable on a single-account backend** → ``None``
+      (not scoped). A single-account factory carries no shared-OAuth
+      cross-client risk, so it keeps the unrestricted behavior; a usable
+      allow-list still scopes it if one is declared.
+    """
+    if not list(entry_points(group=RUNTIME_CONTEXT_FACTORY_ENTRY_POINT_GROUP)):
+        return None
+    store = get_runtime_context().secret_store
+    scoped = _coerce_site_allow_list(getattr(store, "search_console_sites", None))
+    if scoped is not None:
+        return scoped
+    # No usable allow-list. Fail CLOSED for a shared-OAuth (multi-account)
+    # backend — it can reach every client's property, so an un-declared or
+    # mistyped list must scope to nothing, not everything. A single-account
+    # backend has no such cross-client reach, so it stays unrestricted.
+    if getattr(store, "multi_account_auth", False) is True:
+        return frozenset()
+    return None
+
+
+def _coerce_site_allow_list(declared: object) -> frozenset[str] | None:
+    """Normalize a declared ``search_console_sites`` value, or ``None``.
+
+    ``None`` means "no usable declaration" (absent, or a non-collection /
+    bare ``str`` / ``bytes`` — a mistyped scalar must never become a
+    one-element allow-list). A usable collection yields a ``frozenset`` of its
+    non-blank string entries (possibly empty).
+    """
+    if declared is None:
+        return None
+    if isinstance(declared, (str, bytes)) or not isinstance(declared, Collection):
+        return None
+    return frozenset(
+        site.strip() for site in declared if isinstance(site, str) and site.strip()
+    )

--- a/mureo/mcp/_handlers_search_console.py
+++ b/mureo/mcp/_handlers_search_console.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from mcp.types import TextContent
 
 from mureo.auth import create_search_console_client, load_google_ads_credentials
+from mureo.core.runtime_context import runtime_search_console_sites
 from mureo.mcp._helpers import (
     _json_result,
     _no_creds_result,
@@ -54,6 +55,75 @@ def _no_sc_creds() -> list[TextContent]:
     return _no_creds_result(_NO_CREDS_MSG)
 
 
+def _resolve_site_url(args: dict[str, Any]) -> str:
+    """Resolve and tenant-enforce the ``site_url`` for a Search Console call.
+
+    Search Console reuses the operator-shared Google OAuth, so in a
+    multi-account (agency) deployment the shared identity can reach EVERY
+    client's property — and every Search Console tool takes ``site_url`` as a
+    free argument. Left unchecked, one client's workspace can query a sibling
+    client's property (cross-client leak). This binds ``site_url`` to the
+    active client the same way Google Ads binds ``customer_id`` from
+    per-client config.
+
+    - **Not tenant-scoped** (:func:`runtime_search_console_sites` → ``None`` —
+      standalone OSS, no multi-account backend): unchanged. ``site_url`` is a
+      required caller argument, used verbatim.
+    - **Tenant-scoped**: the value MUST be one of the active client's
+      configured properties. An out-of-scope value is refused (fail-closed);
+      an omitted value resolves to the single configured site, or is refused
+      when the client has several (ambiguous) or none configured (fail-fast).
+    """
+    allowed = runtime_search_console_sites()
+    if allowed is None:
+        return _require(args, "site_url")
+    if not allowed:
+        raise ValueError(
+            "Search Console is not configured for this client. Configure the "
+            "client's Search Console property before querying it."
+        )
+    requested = _opt(args, "site_url")
+    if not isinstance(requested, str) or not requested.strip():
+        if len(allowed) == 1:
+            return next(iter(allowed))
+        raise ValueError(
+            "site_url is required: this client has multiple configured Search "
+            "Console properties — pass one of them explicitly. Use "
+            "search_console_sites_list to see the allowed properties."
+        )
+    requested = requested.strip()
+    if requested not in allowed:
+        raise ValueError(
+            f"site_url {requested!r} is not one of this client's configured "
+            "Search Console properties and was refused. Use "
+            "search_console_sites_list to see the allowed properties."
+        )
+    return requested
+
+
+def _filter_sites_to_allowed(
+    sites: Any, allowed: frozenset[str]
+) -> list[dict[str, Any]]:
+    """Keep only the ``siteEntry`` rows whose ``siteUrl`` is tenant-allowed.
+
+    ``search_console_sites_list`` returns EVERY property the shared OAuth can
+    access — including sibling clients' — so when Search Console is
+    tenant-scoped the list is filtered to the active client's properties
+    before it ever reaches the agent. An empty ``allowed`` set yields ``[]``
+    (client scoped but no site configured). Defensive against a malformed
+    payload (non-list / non-dict rows / missing ``siteUrl``).
+    """
+    if not isinstance(sites, list):
+        return []
+    return [
+        row
+        for row in sites
+        if isinstance(row, dict)
+        and isinstance(row.get("siteUrl"), str)
+        and row["siteUrl"].strip() in allowed
+    ]
+
+
 # ---------------------------------------------------------------------------
 # Sites handlers
 # ---------------------------------------------------------------------------
@@ -66,6 +136,12 @@ async def handle_sites_list(args: dict[str, Any]) -> list[TextContent]:
     if client is None:
         return _no_sc_creds()
     result = await client.list_sites()
+    # Tenant scoping: never expose sibling clients' properties. When the
+    # active client is scoped, filter the shared-OAuth site list down to its
+    # own properties before returning it to the agent.
+    allowed = runtime_search_console_sites()
+    if allowed is not None:
+        result = _filter_sites_to_allowed(result, allowed)
     return _json_result(result)
 
 
@@ -75,7 +151,7 @@ async def handle_sites_get(args: dict[str, Any]) -> list[TextContent]:
     client = await _get_client(args)
     if client is None:
         return _no_sc_creds()
-    site_url = _require(args, "site_url")
+    site_url = _resolve_site_url(args)
     result = await client.get_site(site_url)
     return _json_result(result)
 
@@ -92,7 +168,7 @@ async def handle_analytics_query(args: dict[str, Any]) -> list[TextContent]:
     if client is None:
         return _no_sc_creds()
     result = await client.query_analytics(
-        site_url=_require(args, "site_url"),
+        site_url=_resolve_site_url(args),
         start_date=_require(args, "start_date"),
         end_date=_require(args, "end_date"),
         dimensions=_opt(args, "dimensions"),
@@ -111,7 +187,7 @@ async def handle_analytics_top_queries(
     if client is None:
         return _no_sc_creds()
     result = await client.query_analytics(
-        site_url=_require(args, "site_url"),
+        site_url=_resolve_site_url(args),
         start_date=_require(args, "start_date"),
         end_date=_require(args, "end_date"),
         dimensions=["query"],
@@ -129,7 +205,7 @@ async def handle_analytics_top_pages(
     if client is None:
         return _no_sc_creds()
     result = await client.query_analytics(
-        site_url=_require(args, "site_url"),
+        site_url=_resolve_site_url(args),
         start_date=_require(args, "start_date"),
         end_date=_require(args, "end_date"),
         dimensions=["page"],
@@ -147,7 +223,7 @@ async def handle_analytics_device_breakdown(
     if client is None:
         return _no_sc_creds()
     result = await client.query_analytics(
-        site_url=_require(args, "site_url"),
+        site_url=_resolve_site_url(args),
         start_date=_require(args, "start_date"),
         end_date=_require(args, "end_date"),
         dimensions=["device"],
@@ -165,7 +241,7 @@ async def handle_analytics_compare_periods(
     if client is None:
         return _no_sc_creds()
 
-    site_url = _require(args, "site_url")
+    site_url = _resolve_site_url(args)
     dimensions = _opt(args, "dimensions", ["query"])
     row_limit = _opt(args, "row_limit", 100)
 
@@ -198,7 +274,7 @@ async def handle_sitemaps_list(args: dict[str, Any]) -> list[TextContent]:
     client = await _get_client(args)
     if client is None:
         return _no_sc_creds()
-    site_url = _require(args, "site_url")
+    site_url = _resolve_site_url(args)
     result = await client.list_sitemaps(site_url)
     return _json_result(result)
 
@@ -209,7 +285,7 @@ async def handle_sitemaps_submit(args: dict[str, Any]) -> list[TextContent]:
     client = await _get_client(args)
     if client is None:
         return _no_sc_creds()
-    site_url = _require(args, "site_url")
+    site_url = _resolve_site_url(args)
     feedpath = _require(args, "feedpath")
     result = await client.submit_sitemap(site_url, feedpath)
     return _json_result(result)
@@ -228,7 +304,7 @@ async def handle_url_inspection_inspect(
     client = await _get_client(args)
     if client is None:
         return _no_sc_creds()
-    site_url = _require(args, "site_url")
+    site_url = _resolve_site_url(args)
     inspection_url = _require(args, "inspection_url")
     result = await client.inspect_url(site_url, inspection_url)
     return _json_result(result)

--- a/mureo/mcp/_handlers_search_console.py
+++ b/mureo/mcp/_handlers_search_console.py
@@ -76,7 +76,10 @@ def _resolve_site_url(args: dict[str, Any]) -> str:
     """
     allowed = runtime_search_console_sites()
     if allowed is None:
-        return _require(args, "site_url")
+        # Standalone: unchanged. Annotate the Any from _require so the
+        # str-typed return is honest to mypy (no-any-return).
+        site_url: str = _require(args, "site_url")
+        return site_url
     if not allowed:
         raise ValueError(
             "Search Console is not configured for this client. Configure the "

--- a/mureo/web/about.py
+++ b/mureo/web/about.py
@@ -1,40 +1,66 @@
 """Version/package payload for the configure UI's "About mureo" tab (#229).
 
-Resolves the installed mureo version plus every distribution that
-contributes to mureo's plugin entry-point groups (providers, runtime-
-context factories, web extensions). Discovery is entry-point based, so
-a freshly installed plugin appears automatically — no per-plugin wiring.
+Resolves the installed mureo version plus every installed mureo plugin,
+discovered along TWO axes that together match what ``mureo upgrade`` /
+the update-check consider an installed mureo package (#365):
+
+1. **Entry-point** — any distribution contributing to one of mureo's
+   plugin extension groups (providers, skills, runtime-context factories,
+   web extensions, policy gates, analytics). Catches a plugin whose
+   distribution is NOT named ``mureo-*`` (e.g. a third-party ``acme-ads``
+   that registers ``mureo.providers``).
+2. **Name-prefix** — every installed ``mureo`` / ``mureo-*`` distribution,
+   using the SAME discovery the updater uses
+   (:func:`mureo.cli.upgrade_cmd._discover_all_mureo_packages`). Catches a
+   plugin that registers only, say, ``mureo.skills`` and would otherwise be
+   flagged "update available" yet never listed here (#365).
+
+The two are unioned and deduplicated by PEP 503 canonical name (which is
+also the display name, matching the update banner's labelling), so the
+"Installed packages" list and the "Update available" banner agree —
+whenever both observe the same installed metadata — about what is
+installed and how it is named.
 
 Only :mod:`importlib.metadata` (stdlib) is consulted. The payload
 carries nothing environment-specific: no secrets, no file paths — only
 distribution names and versions.
 
 Fault isolation mirrors :mod:`mureo.web.extensions`: one broken
-plugin's metadata (a raising ``dist`` lookup, a corrupted group) skips
-just that item, never the endpoint.
+plugin's metadata (a raising ``dist`` lookup, a corrupted group) — or a
+failing name-prefix walk — skips just that item, never the endpoint.
 """
 
 from __future__ import annotations
 
 from importlib.metadata import (
-    PackageNotFoundError,
     entry_points,
     packages_distributions,
     version,
 )
 from typing import Any, Final
 
-from mureo.core.providers.registry import PROVIDERS_ENTRY_POINT_GROUP
+from mureo.analytics.registry import ANALYTICS_ENTRY_POINT_GROUP
+from mureo.cli.upgrade_cmd import _canonicalise, _discover_all_mureo_packages
+from mureo.core.policy import POLICY_GATES_ENTRY_POINT_GROUP
+from mureo.core.providers.registry import (
+    PROVIDERS_ENTRY_POINT_GROUP,
+    SKILLS_ENTRY_POINT_GROUP,
+)
 from mureo.core.runtime_context import RUNTIME_CONTEXT_FACTORY_ENTRY_POINT_GROUP
 from mureo.web.extensions import WEB_EXTENSIONS_ENTRY_POINT_GROUP
 
 #: Entry-point groups scanned for contributing distributions. Reuses the
 #: group-name constants owned by each consuming module so a future
-#: rename flows through here automatically.
+#: rename flows through here automatically. Covers EVERY mureo extension
+#: surface (#365) — a ``mureo.skills`` / ``mureo.policy_gates`` /
+#: ``mureo.analytics`` plugin is as "installed" as a provider one.
 ABOUT_ENTRY_POINT_GROUPS: Final[tuple[str, ...]] = (
     PROVIDERS_ENTRY_POINT_GROUP,
+    SKILLS_ENTRY_POINT_GROUP,
     RUNTIME_CONTEXT_FACTORY_ENTRY_POINT_GROUP,
     WEB_EXTENSIONS_ENTRY_POINT_GROUP,
+    POLICY_GATES_ENTRY_POINT_GROUP,
+    ANALYTICS_ENTRY_POINT_GROUP,
 )
 
 #: Placeholder shown when a version cannot be resolved (e.g. a dev tree
@@ -49,10 +75,27 @@ def _mureo_version() -> str:
     distribution — :class:`PackageNotFoundError` then must not break the
     About endpoint.
     """
+    return _safe_version("mureo")
+
+
+def _safe_version(name: str) -> str:
+    """Installed version of ``name``, or the placeholder when unresolvable.
+
+    Always returns a non-empty ``str`` so the payload's documented
+    ``{"name": str, "version": str}`` shape holds. ``version()`` can:
+    - raise :class:`PackageNotFoundError` (vanished between the walk and here),
+    - raise anything else on a corrupted ``METADATA`` (e.g. a non-UTF-8 decode),
+    - return ``None`` when the ``Version`` header is absent (malformed dist-info
+      — ``version()`` does NOT raise for this).
+    Every one of these degrades to the placeholder rather than dropping the row
+    or escaping to a 500 — mirroring axis 1's per-item guard in
+    :func:`_resolve_distribution`.
+    """
     try:
-        return version("mureo")
-    except PackageNotFoundError:
+        resolved = version(name)
+    except Exception:  # noqa: BLE001 — never 500 the About tab on bad metadata
         return UNKNOWN_VERSION
+    return resolved if isinstance(resolved, str) and resolved else UNKNOWN_VERSION
 
 
 def _resolve_distribution(ep: Any) -> tuple[str, str] | None:
@@ -81,10 +124,11 @@ def _resolve_distribution(ep: Any) -> tuple[str, str] | None:
     if not candidates:
         return None
     fallback_name = candidates[0]
-    try:
-        return fallback_name, version(fallback_name)
-    except PackageNotFoundError:
-        return fallback_name, UNKNOWN_VERSION
+    # Route through _safe_version (not version() directly) so a malformed
+    # dist-info — Version header absent, so version() returns None rather than
+    # raising — degrades to the placeholder here too, matching the dist-present
+    # branch above and never emitting a non-string version.
+    return fallback_name, _safe_version(fallback_name)
 
 
 def collect_about_info() -> dict[str, Any]:
@@ -97,14 +141,27 @@ def collect_about_info() -> dict[str, Any]:
           "packages": [{"name": str, "version": str}, ...]
         }
 
-    ``packages`` lists every distribution contributing to
-    :data:`ABOUT_ENTRY_POINT_GROUPS`, deduplicated by distribution name
-    and sorted by name, with mureo itself always present. The seeded
-    mureo version wins over any entry-point-derived duplicate so the
-    headline version and the table row never disagree.
+    ``packages`` unions the two discovery axes described in the module
+    docstring — entry-point contributors across :data:`ABOUT_ENTRY_POINT_GROUPS`
+    AND every installed ``mureo`` / ``mureo-*`` distribution the updater sees —
+    deduplicated by PEP 503 canonical name and sorted by display name, with
+    mureo itself always present. The seeded mureo version wins over any
+    discovered duplicate so the headline version and the table row never
+    disagree.
     """
     mureo_version = _mureo_version()
-    by_name: dict[str, str] = {"mureo": mureo_version}
+    # Canonical distribution name -> {"name": <display>, "version": <ver>}.
+    # Keying on the canonical name is what makes this list AGREE with the
+    # update checker (#365): the updater discovers packages by canonical
+    # name-prefix, so deduping here on the same key guarantees a package the
+    # updater flags is listed here exactly once and never keyed differently.
+    by_canonical: dict[str, dict[str, str]] = {}
+
+    # Axis 1 — entry-point contributors across every mureo extension group.
+    # Runs first so that for a plugin present on both axes, its entry-point
+    # ``dist.version`` is the one kept (via ``setdefault``) over axis 2's
+    # separate lookup. Display name is canonical on both axes, so ordering no
+    # longer affects the label.
     for group in ABOUT_ENTRY_POINT_GROUPS:
         try:
             group_eps = entry_points(group=group)
@@ -116,13 +173,47 @@ def collect_about_info() -> dict[str, Any]:
             except Exception:  # noqa: BLE001 — per-entry-point fault isolation
                 continue
             if resolved is not None:
-                by_name.setdefault(resolved[0], resolved[1])
+                name, dist_version = resolved
+                canonical = _canonicalise(name)
+                # Display the CANONICAL name (not the raw ``dist.name``) so a
+                # mixed-case / underscored distribution reads identically to the
+                # update-check banner, which always shows the canonical form
+                # (#365). Keeps the two surfaces labelled the same, not just
+                # scoped the same.
+                by_canonical.setdefault(
+                    canonical, {"name": canonical, "version": dist_version}
+                )
+
+    # Axis 2 — every installed ``mureo`` / ``mureo-*`` distribution, by the
+    # SAME name-prefix rule the update checker uses (#365). Closes the gap
+    # where a name-prefixed plugin registering none of the scanned groups was
+    # flagged "update available" yet never listed here.
+    for canonical in _name_prefixed_packages():
+        by_canonical.setdefault(
+            canonical, {"name": canonical, "version": _safe_version(canonical)}
+        )
+
+    # mureo itself: the seeded headline version always wins over any
+    # discovered duplicate (name-prefix discovery includes ``mureo``).
+    by_canonical["mureo"] = {"name": "mureo", "version": mureo_version}
+
     return {
         "mureo": {"name": "mureo", "version": mureo_version},
-        "packages": [
-            {"name": name, "version": by_name[name]} for name in sorted(by_name)
-        ],
+        "packages": sorted(by_canonical.values(), key=lambda pkg: pkg["name"]),
     }
+
+
+def _name_prefixed_packages() -> list[str]:
+    """Canonical names of installed ``mureo`` / ``mureo-*`` distributions.
+
+    Delegates to the updater's own discovery so the two features stay in
+    lock-step (#365). A failing walk degrades to an empty list — the About
+    endpoint must never 500 on a corrupted metadata index.
+    """
+    try:
+        return _discover_all_mureo_packages()
+    except Exception:  # noqa: BLE001 — discovery must never 500 the About tab
+        return []
 
 
 __all__ = [

--- a/tests/test_mcp_tools_search_console.py
+++ b/tests/test_mcp_tools_search_console.py
@@ -13,6 +13,26 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _standalone_search_console():
+    """Pin these handler tests to STANDALONE (untenanted) Search Console.
+
+    Search Console gained tenant scoping (:func:`runtime_search_console_sites`):
+    when a ``mureo.runtime_context_factory`` is installed AND its store is a
+    shared-OAuth multi-account backend, an undeclared ``search_console_sites``
+    fail-closes every ``site_url``. A dev box carrying the agency plugin would
+    therefore break these standalone assertions. Neutralize the scoping seam so
+    the module always exercises the unrestricted path regardless of what is
+    installed; the scoped behavior lives in
+    ``test_search_console_tenant_scope.py``.
+    """
+    with patch(
+        "mureo.mcp._handlers_search_console.runtime_search_console_sites",
+        return_value=None,
+    ):
+        yield
+
+
 def _import_tools():
     from mureo.mcp import tools_search_console
 

--- a/tests/test_search_console_tenant_scope.py
+++ b/tests/test_search_console_tenant_scope.py
@@ -1,0 +1,426 @@
+"""Tenant scoping for Search Console (#365-adjacent multi-tenancy fix).
+
+Search Console reuses the operator-shared Google OAuth, and its MCP tools
+take ``site_url`` as a free caller argument. In a multi-account (agency)
+deployment the shared identity can reach EVERY client's property, so nothing
+otherwise stops one client's workspace from querying a sibling's property —
+a cross-client data leak.
+
+Two halves are tested here:
+
+1. ``runtime_search_console_sites`` — the store-capability resolver that a
+   multi-account backend uses to declare the active client's allowed
+   ``site_url``s (mirrors ``runtime_multi_account_auth`` #198).
+2. The Search Console handlers' ``_resolve_site_url`` / ``list_sites``
+   filtering — which fail-close an out-of-scope ``site_url`` and hide
+   sibling properties.
+
+Standalone OSS (no ``mureo.runtime_context_factory`` registered) is
+unaffected: the resolver returns ``None`` and ``site_url`` stays a plain
+required argument used verbatim.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mureo.core.runtime_context import (
+    RuntimeContextFactoryError,
+    default_runtime_context,
+    reset_runtime_context,
+    runtime_search_console_sites,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+_GROUP = "mureo.runtime_context_factory"
+
+
+class _FakeEP:
+    def __init__(self, name: str, target: Any) -> None:
+        self.name = name
+        self._target = target
+
+    def load(self) -> Any:
+        return self._target
+
+
+def _patch_eps(monkeypatch: pytest.MonkeyPatch, eps: list[_FakeEP]) -> None:
+    def fake_entry_points(*, group: str) -> list[_FakeEP]:
+        assert group == _GROUP
+        return eps
+
+    monkeypatch.setattr("mureo.core.runtime_context.entry_points", fake_entry_points)
+
+
+def _ctx_with_store(store: Any) -> Any:
+    """A default RuntimeContext whose secret_store is ``store``."""
+    return dataclasses.replace(default_runtime_context(), secret_store=store)
+
+
+@pytest.fixture(autouse=True)
+def _reset_ctx() -> Iterator[None]:
+    reset_runtime_context()
+    yield
+    reset_runtime_context()
+
+
+# ---------------------------------------------------------------------------
+# runtime_search_console_sites resolver
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRuntimeSearchConsoleSites:
+    def test_none_when_no_factory_registered(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Standalone OSS: no factory → not scoped (byte-identical to today)."""
+        _patch_eps(monkeypatch, [])
+        assert runtime_search_console_sites() is None
+
+    def test_none_when_store_silent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Factory present but the store never declares the attribute → not
+        scoped (no opt-in)."""
+        _patch_eps(monkeypatch, [_FakeEP("agency", default_runtime_context)])
+        assert runtime_search_console_sites() is None
+
+    def test_returns_declared_sites(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        class _Store:
+            search_console_sites = [
+                "https://a.example/",
+                "sc-domain:b.example",
+            ]
+
+        ctx = _ctx_with_store(_Store())
+        _patch_eps(monkeypatch, [_FakeEP("agency", lambda: ctx)])
+        assert runtime_search_console_sites() == frozenset(
+            {"https://a.example/", "sc-domain:b.example"}
+        )
+
+    def test_blank_and_non_str_entries_dropped(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        class _Store:
+            search_console_sites = ["https://a.example/", "  ", "", 123, None]
+
+        ctx = _ctx_with_store(_Store())
+        _patch_eps(monkeypatch, [_FakeEP("agency", lambda: ctx)])
+        assert runtime_search_console_sites() == frozenset({"https://a.example/"})
+
+    def test_empty_declared_collection_is_empty_frozenset_not_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Declaring the attribute opts INTO scoping — an empty collection is
+        'scoped with zero sites' (→ handlers fail-fast), NOT 'no scoping'."""
+
+        class _Store:
+            search_console_sites: list[str] = []
+
+        ctx = _ctx_with_store(_Store())
+        _patch_eps(monkeypatch, [_FakeEP("agency", lambda: ctx)])
+        result = runtime_search_console_sites()
+        assert result == frozenset()
+        assert result is not None
+
+    def test_bare_str_declaration_on_single_account_is_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A mistyped scalar must NOT become a one-element allow-list. On a
+        single-account backend (no shared-OAuth risk) an unusable declaration
+        stays 'not scoped'."""
+
+        class _Store:
+            search_console_sites = "https://a.example/"
+
+        ctx = _ctx_with_store(_Store())
+        _patch_eps(monkeypatch, [_FakeEP("agency", lambda: ctx)])
+        assert runtime_search_console_sites() is None
+
+    def test_all_invalid_entries_is_empty_frozenset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A usable-but-all-junk collection is 'scoped, zero sites' (errs
+        CLOSED → handlers fail-fast), never 'not scoped'."""
+
+        class _Store:
+            search_console_sites = ["", "  ", 123, None]
+
+        ctx = _ctx_with_store(_Store())
+        _patch_eps(monkeypatch, [_FakeEP("agency", lambda: ctx)])
+        result = runtime_search_console_sites()
+        assert result == frozenset()
+        assert result is not None
+
+    # -- Fail-closed coupling to multi_account_auth (shared-OAuth backends) --
+    #
+    # The whole cross-client leak lives in a shared-OAuth (multi-account)
+    # deployment. Such a backend that FORGETS or MISTYPES search_console_sites
+    # must scope to NOTHING (fail-fast), never silently reopen the leak.
+
+    def test_multi_account_without_sites_fails_closed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        class _Store:
+            multi_account_auth = True
+
+        ctx = _ctx_with_store(_Store())
+        _patch_eps(monkeypatch, [_FakeEP("agency", lambda: ctx)])
+        result = runtime_search_console_sites()
+        assert result == frozenset()
+        assert result is not None
+
+    def test_multi_account_with_bare_str_fails_closed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        class _Store:
+            multi_account_auth = True
+            search_console_sites = "https://a.example/"
+
+        ctx = _ctx_with_store(_Store())
+        _patch_eps(monkeypatch, [_FakeEP("agency", lambda: ctx)])
+        assert runtime_search_console_sites() == frozenset()
+
+    def test_multi_account_with_generator_fails_closed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A lazy/generator declaration is not a Collection → unusable → a
+        multi-account backend still scopes to nothing (not unrestricted)."""
+
+        class _Store:
+            multi_account_auth = True
+            search_console_sites = (s for s in ["https://a.example/"])
+
+        ctx = _ctx_with_store(_Store())
+        _patch_eps(monkeypatch, [_FakeEP("agency", lambda: ctx)])
+        assert runtime_search_console_sites() == frozenset()
+
+    def test_multi_account_with_usable_sites_returns_them(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A properly-declared multi-account backend scopes to its own list."""
+
+        class _Store:
+            multi_account_auth = True
+            search_console_sites = ["https://a.example/"]
+
+        ctx = _ctx_with_store(_Store())
+        _patch_eps(monkeypatch, [_FakeEP("agency", lambda: ctx)])
+        assert runtime_search_console_sites() == frozenset({"https://a.example/"})
+
+    def test_multiple_factories_propagate_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A misconfigured (>1) factory surfaces its error rather than
+        silently resolving to unrestricted — fail-closed at the seam."""
+        _patch_eps(
+            monkeypatch,
+            [
+                _FakeEP("a", default_runtime_context),
+                _FakeEP("b", default_runtime_context),
+            ],
+        )
+        with pytest.raises(RuntimeContextFactoryError):
+            runtime_search_console_sites()
+
+
+# ---------------------------------------------------------------------------
+# Handler enforcement — _resolve_site_url + list_sites filtering
+# ---------------------------------------------------------------------------
+
+
+def _handlers() -> Any:
+    from mureo.mcp import _handlers_search_console
+
+    return _handlers_search_console
+
+
+def _mock_client_ctx(h: Any, client: AsyncMock) -> Any:
+    """Patch creds + client factory so a handler reaches the mock client."""
+    return (
+        patch.object(h, "load_google_ads_credentials", return_value=MagicMock()),
+        patch.object(h, "create_search_console_client", return_value=client),
+    )
+
+
+def _scoped(h: Any, sites: frozenset[str] | None) -> Any:
+    """Patch the handler-module's scoping resolver to ``sites``."""
+    return patch.object(h, "runtime_search_console_sites", return_value=sites)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestSiteUrlEnforcement:
+    async def test_standalone_requires_site_url(self) -> None:
+        """Not scoped (None) + no site_url arg → the usual required-param error."""
+        h = _handlers()
+        client = AsyncMock()
+        p_creds, p_client = _mock_client_ctx(h, client)
+        with p_creds, p_client, _scoped(h, None), pytest.raises(ValueError):
+            await h.handle_sites_get({})
+        client.get_site.assert_not_awaited()
+
+    async def test_standalone_uses_site_url_verbatim(self) -> None:
+        h = _handlers()
+        client = AsyncMock()
+        client.get_site.return_value = {"siteUrl": "https://x.example/"}
+        p_creds, p_client = _mock_client_ctx(h, client)
+        with p_creds, p_client, _scoped(h, None):
+            await h.handle_sites_get({"site_url": "https://x.example/"})
+        client.get_site.assert_awaited_once_with("https://x.example/")
+
+    async def test_scoped_in_set_is_allowed(self) -> None:
+        h = _handlers()
+        client = AsyncMock()
+        client.get_site.return_value = {"siteUrl": "https://a.example/"}
+        p_creds, p_client = _mock_client_ctx(h, client)
+        allowed = frozenset({"https://a.example/", "https://b.example/"})
+        with p_creds, p_client, _scoped(h, allowed):
+            await h.handle_sites_get({"site_url": "https://a.example/"})
+        client.get_site.assert_awaited_once_with("https://a.example/")
+
+    async def test_scoped_out_of_set_is_refused(self) -> None:
+        """Fail-closed: a sibling client's property is refused before any API
+        call."""
+        h = _handlers()
+        client = AsyncMock()
+        p_creds, p_client = _mock_client_ctx(h, client)
+        allowed = frozenset({"https://a.example/"})
+        with p_creds, p_client, _scoped(h, allowed), pytest.raises(ValueError):
+            await h.handle_sites_get({"site_url": "https://sibling.example/"})
+        client.get_site.assert_not_awaited()
+
+    async def test_scoped_omitted_single_site_resolves(self) -> None:
+        h = _handlers()
+        client = AsyncMock()
+        client.get_site.return_value = {"siteUrl": "https://only.example/"}
+        p_creds, p_client = _mock_client_ctx(h, client)
+        with p_creds, p_client, _scoped(h, frozenset({"https://only.example/"})):
+            await h.handle_sites_get({})
+        client.get_site.assert_awaited_once_with("https://only.example/")
+
+    async def test_scoped_omitted_multiple_sites_is_ambiguous(self) -> None:
+        h = _handlers()
+        client = AsyncMock()
+        p_creds, p_client = _mock_client_ctx(h, client)
+        allowed = frozenset({"https://a.example/", "https://b.example/"})
+        with p_creds, p_client, _scoped(h, allowed), pytest.raises(ValueError):
+            await h.handle_sites_get({})
+        client.get_site.assert_not_awaited()
+
+    async def test_scoped_empty_set_fails_fast(self) -> None:
+        """Scoped with zero configured sites → fail-fast, even with a site_url."""
+        h = _handlers()
+        client = AsyncMock()
+        p_creds, p_client = _mock_client_ctx(h, client)
+        with p_creds, p_client, _scoped(h, frozenset()), pytest.raises(ValueError):
+            await h.handle_sites_get({"site_url": "https://a.example/"})
+        client.get_site.assert_not_awaited()
+
+    async def test_analytics_query_enforces_site_url(self) -> None:
+        """Enforcement is centralized: an analytics tool refuses an
+        out-of-scope site_url too."""
+        h = _handlers()
+        client = AsyncMock()
+        p_creds, p_client = _mock_client_ctx(h, client)
+        args = {
+            "site_url": "https://sibling.example/",
+            "start_date": "2026-01-01",
+            "end_date": "2026-01-31",
+        }
+        with (
+            p_creds,
+            p_client,
+            _scoped(h, frozenset({"https://a.example/"})),
+            pytest.raises(ValueError),
+        ):
+            await h.handle_analytics_top_queries(args)
+        client.query_analytics.assert_not_awaited()
+
+    async def test_sitemaps_submit_write_path_enforces_site_url(self) -> None:
+        """The WRITE path is gated too: submitting a sitemap to a sibling's
+        property is refused before any mutation."""
+        h = _handlers()
+        client = AsyncMock()
+        p_creds, p_client = _mock_client_ctx(h, client)
+        args = {
+            "site_url": "https://sibling.example/",
+            "feedpath": "https://sibling.example/sitemap.xml",
+        }
+        with (
+            p_creds,
+            p_client,
+            _scoped(h, frozenset({"https://a.example/"})),
+            pytest.raises(ValueError),
+        ):
+            await h.handle_sitemaps_submit(args)
+        client.submit_sitemap.assert_not_awaited()
+
+    async def test_compare_periods_enforces_site_url(self) -> None:
+        """The structurally-distinct compare-periods handler (one resolve
+        reused across two queries) enforces the allow-list too."""
+        h = _handlers()
+        client = AsyncMock()
+        p_creds, p_client = _mock_client_ctx(h, client)
+        args = {
+            "site_url": "https://sibling.example/",
+            "start_date_1": "2026-01-01",
+            "end_date_1": "2026-01-31",
+            "start_date_2": "2026-02-01",
+            "end_date_2": "2026-02-28",
+        }
+        with (
+            p_creds,
+            p_client,
+            _scoped(h, frozenset({"https://a.example/"})),
+            pytest.raises(ValueError),
+        ):
+            await h.handle_analytics_compare_periods(args)
+        client.query_analytics.assert_not_awaited()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestSitesListFiltering:
+    async def test_scoped_list_hides_sibling_properties(self) -> None:
+        h = _handlers()
+        client = AsyncMock()
+        client.list_sites.return_value = [
+            {"siteUrl": "https://a.example/", "permissionLevel": "siteOwner"},
+            {"siteUrl": "https://sibling.example/", "permissionLevel": "siteOwner"},
+        ]
+        p_creds, p_client = _mock_client_ctx(h, client)
+        with p_creds, p_client, _scoped(h, frozenset({"https://a.example/"})):
+            result = await h.handle_sites_list({})
+        parsed = json.loads(result[0].text)
+        urls = [row["siteUrl"] for row in parsed]
+        assert urls == ["https://a.example/"]
+
+    async def test_scoped_empty_set_lists_nothing(self) -> None:
+        h = _handlers()
+        client = AsyncMock()
+        client.list_sites.return_value = [{"siteUrl": "https://sibling.example/"}]
+        p_creds, p_client = _mock_client_ctx(h, client)
+        with p_creds, p_client, _scoped(h, frozenset()):
+            result = await h.handle_sites_list({})
+        assert json.loads(result[0].text) == []
+
+    async def test_standalone_list_is_unfiltered(self) -> None:
+        h = _handlers()
+        client = AsyncMock()
+        client.list_sites.return_value = [
+            {"siteUrl": "https://a.example/"},
+            {"siteUrl": "https://b.example/"},
+        ]
+        p_creds, p_client = _mock_client_ctx(h, client)
+        with p_creds, p_client, _scoped(h, None):
+            result = await h.handle_sites_list({})
+        urls = [row["siteUrl"] for row in json.loads(result[0].text)]
+        assert urls == ["https://a.example/", "https://b.example/"]

--- a/tests/test_web_about.py
+++ b/tests/test_web_about.py
@@ -1,10 +1,11 @@
 """Version/extension-package discovery for ``mureo.web.about``.
 
 ``collect_about_info`` resolves the installed mureo version plus every
-distribution contributing to mureo's plugin entry-point groups via
-:mod:`importlib.metadata`. These tests mock that surface entirely —
-the machine running them may carry real mureo plugins (dev boxes do),
-so nothing here depends on what is actually installed.
+installed mureo plugin, discovered along two axes (#365): the plugin
+entry-point groups AND the ``mureo`` / ``mureo-*`` name prefix (the same
+set the updater sees). These tests mock both surfaces entirely — the
+machine running them may carry real mureo plugins (dev boxes do), so
+nothing here depends on what is actually installed.
 """
 
 from __future__ import annotations
@@ -86,11 +87,28 @@ def _version_for(versions: dict[str, str]) -> Any:
 
 @pytest.mark.unit
 class TestCollectAboutInfo:
-    def test_groups_constant_covers_all_three_plugin_surfaces(self) -> None:
+    @pytest.fixture(autouse=True)
+    def _no_name_prefixed_dists(self) -> Any:
+        """Neutralise the real name-prefix distribution walk (#365).
+
+        ``collect_about_info`` now also lists every installed ``mureo`` /
+        ``mureo-*`` distribution (the same set the updater discovers). That
+        walk hits real installed metadata, so on a dev box carrying real
+        ``mureo-*`` plugins it would break these hermetic entry-point cases.
+        Default it to "no name-prefixed dists"; the cases that exercise the
+        name-prefix axis re-patch it inside their own ``with`` block.
+        """
+        with patch("mureo.web.about._discover_all_mureo_packages", return_value=[]):
+            yield
+
+    def test_groups_constant_covers_all_mureo_plugin_surfaces(self) -> None:
         assert ABOUT_ENTRY_POINT_GROUPS == (
             "mureo.providers",
+            "mureo.skills",
             "mureo.runtime_context_factory",
             "mureo.web_extensions",
+            "mureo.policy_gates",
+            "mureo.analytics",
         )
 
     def test_mureo_always_present_with_no_entry_points(self) -> None:
@@ -209,6 +227,30 @@ class TestCollectAboutInfo:
             info = collect_about_info()
         assert {"name": "acme-plugin", "version": "2.0.0"} in info["packages"]
 
+    def test_dist_none_fallback_version_none_uses_placeholder(self) -> None:
+        """The ``dist is None`` fallback path also normalizes a ``None``
+        version (malformed dist-info) to the placeholder — matching the
+        dist-present branch and never emitting a non-string version."""
+
+        def version_returns_none(name: str) -> str | None:
+            return "1.0.0" if name == "mureo" else None
+
+        by_group = {
+            "mureo.providers": (
+                _FakeEntryPoint(dist=None, module="acme_plugin.providers"),
+            ),
+        }
+        with (
+            patch("mureo.web.about.entry_points", _entry_points_for(by_group)),
+            patch("mureo.web.about.version", version_returns_none),
+            patch(
+                "mureo.web.about.packages_distributions",
+                return_value={"acme_plugin": ["acme-plugin"]},
+            ),
+        ):
+            info = collect_about_info()
+        assert {"name": "acme-plugin", "version": UNKNOWN_VERSION} in info["packages"]
+
     def test_dist_none_without_mapping_is_skipped(self) -> None:
         by_group = {
             "mureo.providers": (
@@ -255,6 +297,195 @@ class TestCollectAboutInfo:
         assert set(info["mureo"].keys()) == {"name", "version"}
         for pkg in info["packages"]:
             assert set(pkg.keys()) == {"name", "version"}
+
+    # -- #365: consistency with the update checker ------------------------
+    #
+    # The "Installed packages" list and the "Update available" banner must
+    # agree on what counts as an installed mureo package. The updater keys
+    # off the ``mureo`` / ``mureo-*`` name prefix; About must list that same
+    # set so a package can never be flagged "update available" while absent
+    # from "Installed packages".
+
+    def test_name_prefixed_package_without_entry_points_is_listed(self) -> None:
+        """A ``mureo-*`` plugin registering NONE of the scanned entry-point
+        groups (e.g. ``mureo-logly-tools`` — ``mureo.skills`` only, but here
+        with no entry point at all) is still listed, matching the updater."""
+        with (
+            patch("mureo.web.about.entry_points", _entry_points_for({})),
+            patch(
+                "mureo.web.about.version",
+                _version_for({"mureo": "1.0.0", "mureo-logly-tools": "0.3.0"}),
+            ),
+            patch(
+                "mureo.web.about._discover_all_mureo_packages",
+                return_value=["mureo", "mureo-logly-tools"],
+            ),
+        ):
+            info = collect_about_info()
+        assert {"name": "mureo-logly-tools", "version": "0.3.0"} in info["packages"]
+        names = [pkg["name"] for pkg in info["packages"]]
+        assert names == ["mureo", "mureo-logly-tools"]
+
+    def test_name_prefixed_package_missing_version_uses_placeholder(self) -> None:
+        """A name-prefix-discovered dist whose version cannot be resolved
+        degrades to the placeholder rather than dropping the row."""
+        with (
+            patch("mureo.web.about.entry_points", _entry_points_for({})),
+            patch("mureo.web.about.version", _version_for({"mureo": "1.0.0"})),
+            patch(
+                "mureo.web.about._discover_all_mureo_packages",
+                return_value=["mureo", "mureo-ghost"],
+            ),
+        ):
+            info = collect_about_info()
+        assert {"name": "mureo-ghost", "version": UNKNOWN_VERSION} in info["packages"]
+
+    def test_name_prefix_and_entry_point_dedupe_by_canonical(self) -> None:
+        """A package surfaced by BOTH axes (a skills entry point AND the
+        name prefix) appears exactly once."""
+        by_group = {
+            "mureo.skills": (
+                _FakeEntryPoint(dist=_FakeDist("mureo-logly-tools", "0.3.0")),
+            ),
+        }
+        with (
+            patch("mureo.web.about.entry_points", _entry_points_for(by_group)),
+            patch(
+                "mureo.web.about.version",
+                _version_for({"mureo": "1.0.0", "mureo-logly-tools": "0.3.0"}),
+            ),
+            patch(
+                "mureo.web.about._discover_all_mureo_packages",
+                return_value=["mureo", "mureo-logly-tools"],
+            ),
+        ):
+            info = collect_about_info()
+        names = [pkg["name"] for pkg in info["packages"]]
+        assert names == ["mureo", "mureo-logly-tools"]
+
+    def test_skills_only_entry_point_plugin_is_listed(self) -> None:
+        """A skills plugin NOT named ``mureo-*`` (so invisible to the
+        name-prefix axis) is surfaced via the now-scanned skills group."""
+        by_group = {
+            "mureo.skills": (_FakeEntryPoint(dist=_FakeDist("acme-skills", "1.1.0")),),
+        }
+        with (
+            patch("mureo.web.about.entry_points", _entry_points_for(by_group)),
+            patch("mureo.web.about.version", _version_for({"mureo": "1.0.0"})),
+        ):
+            info = collect_about_info()
+        names = [pkg["name"] for pkg in info["packages"]]
+        assert names == ["acme-skills", "mureo"]
+
+    def test_policy_gate_and_analytics_groups_are_scanned(self) -> None:
+        """The policy-gate and analytics extension surfaces are scanned too,
+        so a plugin contributing only those still appears."""
+        by_group = {
+            "mureo.policy_gates": (
+                _FakeEntryPoint(dist=_FakeDist("gate-plugin", "2.0.0")),
+            ),
+            "mureo.analytics": (
+                _FakeEntryPoint(dist=_FakeDist("analytics-plugin", "3.0.0")),
+            ),
+        }
+        with (
+            patch("mureo.web.about.entry_points", _entry_points_for(by_group)),
+            patch("mureo.web.about.version", _version_for({"mureo": "1.0.0"})),
+        ):
+            info = collect_about_info()
+        names = [pkg["name"] for pkg in info["packages"]]
+        assert names == ["analytics-plugin", "gate-plugin", "mureo"]
+
+    def test_name_prefix_discovery_failure_is_isolated(self) -> None:
+        """If the name-prefix walk blows up, the endpoint still returns the
+        entry-point-derived rows rather than 500-ing."""
+        by_group = {
+            "mureo.providers": (_FakeEntryPoint(dist=_FakeDist("ep-plugin", "1.0.0")),),
+        }
+        with (
+            patch("mureo.web.about.entry_points", _entry_points_for(by_group)),
+            patch("mureo.web.about.version", _version_for({"mureo": "1.0.0"})),
+            patch(
+                "mureo.web.about._discover_all_mureo_packages",
+                side_effect=RuntimeError("metadata index corrupted"),
+            ),
+        ):
+            info = collect_about_info()
+        names = [pkg["name"] for pkg in info["packages"]]
+        assert names == ["ep-plugin", "mureo"]
+
+    def test_name_prefixed_version_none_uses_placeholder(self) -> None:
+        """``importlib.metadata.version`` returns ``None`` (not raises) for a
+        dist whose ``METADATA`` has a Name but no Version header. The row must
+        still carry a string version (payload shape ``{"name","version"}``)."""
+
+        def version_returns_none(name: str) -> str | None:
+            if name == "mureo":
+                return "1.0.0"
+            return None  # malformed dist-info: Version header absent
+
+        with (
+            patch("mureo.web.about.entry_points", _entry_points_for({})),
+            patch("mureo.web.about.version", version_returns_none),
+            patch(
+                "mureo.web.about._discover_all_mureo_packages",
+                return_value=["mureo", "mureo-malformed"],
+            ),
+        ):
+            info = collect_about_info()
+        row = next(p for p in info["packages"] if p["name"] == "mureo-malformed")
+        assert row == {"name": "mureo-malformed", "version": UNKNOWN_VERSION}
+        assert isinstance(row["version"], str)
+
+    def test_mixed_case_name_dedupes_and_displays_canonical(self) -> None:
+        """A distribution whose raw entry-point name is mixed-case / underscored
+        is deduped against its name-prefix canonical form AND displayed in the
+        canonical form — so About labels it identically to the update banner."""
+        by_group = {
+            "mureo.skills": (
+                _FakeEntryPoint(dist=_FakeDist("Mureo_Logly_Tools", "0.3.0")),
+            ),
+        }
+        with (
+            patch("mureo.web.about.entry_points", _entry_points_for(by_group)),
+            patch(
+                "mureo.web.about.version",
+                _version_for({"mureo": "1.0.0", "mureo-logly-tools": "0.3.0"}),
+            ),
+            patch(
+                "mureo.web.about._discover_all_mureo_packages",
+                return_value=["mureo", "mureo-logly-tools"],
+            ),
+        ):
+            info = collect_about_info()
+        names = [pkg["name"] for pkg in info["packages"]]
+        assert names == ["mureo", "mureo-logly-tools"]
+        assert "Mureo_Logly_Tools" not in names
+
+    def test_every_updater_package_appears_exactly_once(self) -> None:
+        """Property of #365: every name the updater discovers is listed here
+        exactly once (⊆ guarantee), regardless of entry-point registration."""
+        updater_set = ["mureo", "mureo-agency", "mureo-logly-tools", "mureo-x"]
+        by_group = {
+            # Only one of them also registers an entry point — the rest are
+            # name-prefix-only, exactly the #365 gap.
+            "mureo.providers": (
+                _FakeEntryPoint(dist=_FakeDist("mureo-agency", "0.1.0")),
+            ),
+        }
+        versions = {name: "1.0.0" for name in updater_set}
+        with (
+            patch("mureo.web.about.entry_points", _entry_points_for(by_group)),
+            patch("mureo.web.about.version", _version_for(versions)),
+            patch(
+                "mureo.web.about._discover_all_mureo_packages",
+                return_value=updater_set,
+            ),
+        ):
+            info = collect_about_info()
+        names = [pkg["name"] for pkg in info["packages"]]
+        for canonical in updater_set:
+            assert names.count(canonical) == 1, f"{canonical} not listed exactly once"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

Fixes a **cross-client data leak** in Search Console for the multi-account (agency) deployment.

Search Console reuses one operator-shared Google OAuth, and every SC MCP tool took `site_url` as a **free, unvalidated required argument**. In an agency deployment that single identity can reach MANY clients' properties, so one client's workspace could query a **sibling client's** Search Console data. Unlike Google Ads (`customer_id`) and Meta (`account_id`), Search Console had no per-request tenant binding, and `search_console_sites_list` returns *every* property the shared OAuth can see.

## Fix

A tenant-scoping seam mirroring the existing store-capability family (#196 / #198 / #202):

- **`runtime_search_console_sites()`** (`mureo/core/runtime_context.py`) — resolves the active client's allowed `site_url` set from a `search_console_sites` capability a multi-account backend declares on its `SecretStore`.
  - No `mureo.runtime_context_factory` registered (**standalone OSS**) → `None` → unchanged, unrestricted (byte-identical).
  - **Coupled to `multi_account_auth`**: a shared-OAuth backend that omits or mistypes the allow-list resolves to an **empty set (fail-closed)**, never silently unrestricted — closes the "fail-open by omission" hole.
- **`_resolve_site_url()`** (`mureo/mcp/_handlers_search_console.py`) — every `site_url`-bearing handler (reads **and** writes: `sitemaps_submit`, `url_inspection_inspect`, `analytics_compare_periods` included) enforces the value against the allow-list **before any API call**: out-of-set refused (fail-closed); omitted resolves to the single configured site, or errors (ambiguous / fail-fast).
- **`handle_sites_list`** filters the shared-OAuth site list down to the client's own properties, so sibling properties (and their permission metadata) never reach the agent.

## Test plan

- [x] New `tests/test_search_console_tenant_scope.py` — resolver (standalone/None, declared set, empty→fail-closed, `multi_account_auth` coupling, bare-str/generator mistypes, multiple-factory error) + handler enforcement across reads/writes with **`assert_not_awaited` proving no API call precedes refusal**; `sites_list` filtering hides sibling rows.
- [x] Existing `tests/test_mcp_tools_search_console.py` pinned to standalone via an autouse fixture so an installed agency plugin can't break them.
- [x] `ruff check mureo/` (CI lint) + `black` clean. Related SC/runtime/web suite green (395 passed). The only local failures are pre-existing `test_mcp_server_env_gating` "plugin-env noise" that reproduce on `main` and don't occur in a clean CI venv.
- [x] Two rounds of security-review; all HIGH/MEDIUM findings addressed.

## Scope / follow-up

OSS provides the **seam only**. The agency backend (private repo) must declare `search_console_sites` per active client on its secret store to populate the allow-list; until it does, Search Console now **fail-closes safely** for the multi-account backend rather than leaking.
