### PR TITLE
feat(mcp): announce the bound workspace in server instructions

### DIFF
--- a/mureo/mcp/server.py
+++ b/mureo/mcp/server.py
@@ -796,9 +796,52 @@ async def _dispatch_tool(name: str, arguments: dict[str, Any]) -> list[Any]:
 # ---------------------------------------------------------------------------
 
 
+def _server_instructions() -> str | None:
+    """Server-level instructions that name the workspace this server is bound to.
+
+    Some hosts expose *every* configured MCP server to *every* conversation at
+    once, with no way to scope a conversation to one of them. When more than one
+    mureo server is configured (one per workspace), the model has no signal about
+    which workspace a given server is bound to and can route a tool call to the
+    wrong one. Single-process, cwd-scoped hosts (e.g. Claude Code) are unaffected.
+
+    Naming the bound workspace in the server's ``instructions`` (part of the MCP
+    ``InitializeResult`` the client shows the model) gives the model the signal it
+    needs to pick the right server and to notice a mismatch instead of proceeding.
+
+    Returns ``None`` for the default single-workspace install so its
+    ``InitializeResult`` stays byte-identical — standalone OSS users see no change.
+    """
+    # Lazy import mirrors the throttle path above (``_acquire_plugin_throttle``):
+    # keeping it inside the function pre-empts a cycle should
+    # ``mureo.core.runtime_context`` ever reference MCP types.
+    from mureo.core.runtime_context import (
+        DEFAULT_WORKSPACE_ID,
+        RuntimeContextFactoryError,
+        get_runtime_context,
+    )
+
+    try:
+        workspace_id = get_runtime_context().workspace_id
+    except RuntimeContextFactoryError:
+        # A misconfigured factory is a real error, but it must surface where it
+        # already does (first tool call), not by refusing to start the server.
+        # Omit instructions and let startup proceed unchanged.
+        return None
+    if workspace_id == DEFAULT_WORKSPACE_ID:
+        return None
+    return (
+        f"This mureo server is bound to workspace {workspace_id!r}. Every tool "
+        f"here reads and writes ONLY that workspace's data. If the user is "
+        f"working on a different client/workspace, do NOT use this server — use "
+        f"the mureo server bound to that workspace instead. Never assume a tool "
+        f"call here acts on any workspace other than {workspace_id!r}."
+    )
+
+
 def _create_server() -> Server:
     """Create an MCP Server instance and register handlers."""
-    server = Server("mureo")
+    server = Server("mureo", instructions=_server_instructions())
 
     @server.list_tools()  # type: ignore[no-untyped-call, untyped-decorator, unused-ignore]
     async def list_tools() -> list[Any]:

--- a/tests/test_mcp_server_workspace_instructions.py
+++ b/tests/test_mcp_server_workspace_instructions.py
@@ -1,0 +1,83 @@
+"""MCP server ``instructions`` name the bound workspace.
+
+When several mureo servers are configured (one per workspace) in a host that
+exposes all of them to every conversation, each server must tell the model which
+workspace it is bound to. The default single-workspace install must stay
+byte-identical (no instructions).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from mureo.core.runtime_context import DEFAULT_WORKSPACE_ID, RuntimeContextFactoryError
+
+
+def _import_server_module():
+    from mureo.mcp import server as mcp_server_module
+
+    return mcp_server_module
+
+
+def _patch_workspace(monkeypatch: pytest.MonkeyPatch, workspace_id: str) -> None:
+    # ``_server_instructions`` re-imports ``get_runtime_context`` from the module
+    # on every call, so patching the module attribute is picked up at call time.
+    monkeypatch.setattr(
+        "mureo.core.runtime_context.get_runtime_context",
+        lambda: SimpleNamespace(workspace_id=workspace_id),
+    )
+
+
+@pytest.mark.unit
+def test_default_workspace_has_no_instructions(monkeypatch: pytest.MonkeyPatch) -> None:
+    server = _import_server_module()
+    _patch_workspace(monkeypatch, DEFAULT_WORKSPACE_ID)
+    assert server._server_instructions() is None
+
+
+@pytest.mark.unit
+def test_bound_workspace_is_named_and_scoped(monkeypatch: pytest.MonkeyPatch) -> None:
+    server = _import_server_module()
+    _patch_workspace(monkeypatch, "agency:acme")
+    text = server._server_instructions()
+    assert text is not None
+    # Names the exact workspace so the model can disambiguate sibling servers …
+    assert "agency:acme" in text
+    # … and states the hard scoping guarantee that prevents cross-client reads.
+    assert "ONLY" in text
+
+
+@pytest.mark.unit
+def test_factory_error_omits_instructions_without_failing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    server = _import_server_module()
+
+    def _boom() -> None:
+        raise RuntimeContextFactoryError("two factories registered")
+
+    monkeypatch.setattr("mureo.core.runtime_context.get_runtime_context", _boom)
+    # A broken factory must not stop the server from being created; the error
+    # surfaces on the first tool call as before, not at startup.
+    assert server._server_instructions() is None
+
+
+@pytest.mark.unit
+def test_create_server_propagates_instructions(monkeypatch: pytest.MonkeyPatch) -> None:
+    server = _import_server_module()
+    _patch_workspace(monkeypatch, "agency:globex")
+    created = server._create_server()
+    assert created.instructions is not None
+    assert "agency:globex" in created.instructions
+
+
+@pytest.mark.unit
+def test_create_server_default_has_no_instructions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    server = _import_server_module()
+    _patch_workspace(monkeypatch, DEFAULT_WORKSPACE_ID)
+    created = server._create_server()
+    assert created.instructions is None


### PR DESCRIPTION
## Problem

Some hosts expose *every* configured MCP server to *every* conversation at once, with no way to scope a conversation to one of them. When more than one mureo server is configured (one per workspace), the model has **no signal about which workspace a given server is bound to** and can route a tool call to the wrong one.

Single-process, cwd-scoped hosts (e.g. Claude Code — one MCP process per session, whose `cwd` fixes the workspace) are unaffected. The gap is specific to hosts that present all servers to all conversations.

## Change

Name the bound workspace in the MCP server's `instructions` — the field of the `InitializeResult` that the client presents to the model. It reuses the **existing** `RuntimeContext.workspace_id`; no new protocol surface.

- `_server_instructions()` returns a scoping instruction naming `workspace_id`, or `None` when the workspace is the default.
- `_create_server()` passes it through: `Server("mureo", instructions=_server_instructions())`.

When several servers are visible, each one now tells the model *this server is bound to workspace X; every tool here acts ONLY on that workspace* — so the model can pick the right server and notice a mismatch instead of proceeding.

## Backward compatibility

The default single-workspace install has `workspace_id == DEFAULT_WORKSPACE_ID` (`"default"`) → `_server_instructions()` returns `None` → `Server("mureo", instructions=None)` is identical to the previous `Server("mureo")`, and `create_initialization_options()` emits the same `instructions=None`. **Standalone users see a byte-identical InitializeResult.** Instructions appear only when an alternate backend declares a non-default `workspace_id`.

A misconfigured factory (`RuntimeContextFactoryError`) omits instructions rather than refusing to start; the error still surfaces on the first tool call, exactly as before.

## Tests

`tests/test_mcp_server_workspace_instructions.py` (5 tests): default→None, bound→named+scoped, factory-error→None-without-failing, and `_create_server` propagation for both bound and default. All pass; existing MCP server suites (`test_mcp_server*.py`, 53 tests) pass unchanged; `ruff` clean.
