### PR TITLE
docs: link commercial editions (mureo.jp) from READMEs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -7,6 +7,7 @@
 
 <p align="center">
   <a href="https://mureo.io">Webサイト</a> ·
+  <a href="https://mureo.jp">商用版</a> ·
   <a href="README.md">English</a>
 </p>
 
@@ -22,6 +23,8 @@
 _ローカルファースト・戦略準拠・セーフティゲート。_
 
 Claude Code、Cursor、Codex、Gemini に対応。mureo は各広告プラットフォームの公式 MCP の上に乗り、AI に守るべき戦略・測るべき成果・誰にでも見せられる監査証跡を与えます。**認証情報は端末の外に出ません。**
+
+> チーム・代理店向けの商用版（クラウド版／ローカルで動く Agency 版）もご用意しています。詳しくは **[mureo.jp](https://mureo.jp)** をご覧ください。
 
 <p align="center">
   <img src="docs/img/sample-search-term-cleanup.ja.svg" alt="mureo /search-term-cleanup の出力: ブランド自己カニバリゼーションを自動検出 — 同じブランド検索語が片方で CPA ¥4,550、もう片方で ¥31,800 が無駄、約 ¥250,000/30日 を再配分可能">

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 
 <p align="center">
   <a href="https://mureo.io">Website</a> ·
+  <a href="https://mureo.jp">Commercial edition</a> ·
   <a href="README.ja.md">日本語</a>
 </p>
 
@@ -22,6 +23,8 @@
 _Local-first. Strategy-grounded. Safety-gated._
 
 Works with Claude Code, Cursor, Codex & Gemini. mureo sits on top of the official ad-platform MCPs and gives your AI a strategy to follow, an outcome to be measured against, and an audit trail you can show to anyone — **credentials never leave your machine**.
+
+> Commercial editions are also available — including a cloud-hosted service and a local Agency edition for teams and agencies. See **[mureo.jp](https://mureo.jp)**.
 
 <p align="center">
   <img src="docs/img/sample-search-term-cleanup.svg" alt="mureo /search-term-cleanup output: brand self-cannibalization detected — same brand term converts at ¥4,550 CPA in one campaign vs ¥31,800 wasted in another, ~¥250,000/30d redirectable">


### PR DESCRIPTION
## Summary

Add a **Commercial edition** link (https://mureo.jp) to both READMEs:

- Header nav row: `Website · Commercial edition · 日本語` (JA: `Webサイト · 商用版 · English`)
- One-line note after the intro, mentioning both the cloud-hosted service and the local Agency edition

Docs-only change.

https://claude.ai/code/session_01AbvhGbHZoK8VqP3kR9nWWp