### PR TITLE
fix(web): schedule upgrade restart before flushing the response

### DIFF
--- a/mureo/web/handlers.py
+++ b/mureo/web/handlers.py
@@ -733,11 +733,16 @@ class ConfigureHandler(BaseHTTPRequestHandler):
             request_update_refresh()
             restarting = is_managed_service()
         result = {**result, "restarting": restarting}
-        send_json(self, result)
-        # Schedule the restart AFTER the response is flushed so the client
-        # receives ``restarting=True`` and can poll for the daemon's return.
+        # Schedule the restart FIRST (same ordering as ``_post_restart``): the
+        # scheduler only SPAWNS a daemon thread that waits out
+        # ``_RESTART_RESPONSE_GRACE_SECONDS`` before touching the process, so
+        # the response below still flushes long before the server goes down.
+        # Scheduling before ``send_json`` also removes the send-then-schedule
+        # race that made the route test flaky (the assertion could run before
+        # the handler thread reached the scheduling line).
         if restarting:
             _request_service_restart(self.wizard)
+        send_json(self, result)
 
     def _post_restart(self, payload: dict[str, Any]) -> None:  # noqa: ARG002
         """Restart the running configure server (About tab button).


### PR DESCRIPTION
Deflakes `TestPostUpgrade::test_managed_service_upgrade_auto_restarts` (failed on 3 CI jobs in the #379 update run): the route scheduled the exit-to-restart AFTER `send_json`, so the test's mock assertion raced the handler thread.

Fix: schedule BEFORE `send_json` — identical to the ordering shipped and code-reviewed for `/api/restart` in #378 (the scheduler only spawns a daemon thread that waits out `_RESTART_RESPONSE_GRACE_SECONDS`, so the response still flushes long before the process exits). No behavior change.

Verified: `TestPostUpgrade` 5x consecutive green locally; full `test_web_handlers.py` green.

https://claude.ai/code/session_01AbvhGbHZoK8VqP3kR9nWWp