### PR TITLE
chore(release): 0.10.20

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mureo",
-  "version": "0.10.19",
+  "version": "0.10.20",
   "description": "Your local-first AI ad ops crew for Google Ads, Meta Ads, Search Console & GA4. mureo sits on top of the official ad-platform MCPs, gates every change against your strategy, correlates outcomes locally, and keeps an auditable decision log — credentials never leave your machine.",
   "author": {
     "name": "Logly Inc.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.20] - 2026-07-12
+
+### Added
+
+- **Per-row reinstall buttons for the basic setup.** The configure dashboard's
+  Setup section gains Install / Reinstall buttons next to the existing Remove
+  buttons for the credential-guard hook and the workflow skills, so either can
+  be restored without re-running the wizard (new `/api/setup/hook/install` and
+  `/api/setup/skills/install` routes). Both install and remove buttons now
+  surface error envelopes instead of treating HTTP 200 as success. (#377)
+- **"Restart configure" button on the About tab.** Restart the running
+  configure server from the browser: a managed service (launchd/systemd)
+  restarts via its supervisor, while an interactive `mureo configure`
+  re-execs itself in place. The page waits for the server to come back and
+  reloads automatically. (#378)
+- **Workspace-scoped MCP server instructions.** When bound to a non-default
+  workspace, the MCP server names that workspace in its `InitializeResult`
+  instructions so hosts that expose several mureo servers to one conversation
+  can route tool calls to the right workspace. The default single-workspace
+  install is unchanged. (#379)
+
+### Fixed
+
+- Deflaked the managed-upgrade route by scheduling the exit-to-restart before
+  flushing the HTTP response (no behavior change). (#381)
+
+### Documentation
+
+- READMEs now link the commercial editions (mureo.jp): the cloud-hosted
+  service and the local Agency edition. (#380)
+
+
 ## [0.10.19] - 2026-07-09
 
 ### Added

--- a/mureo/__init__.py
+++ b/mureo/__init__.py
@@ -1,3 +1,3 @@
 """mureo — your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."""
 
-__version__ = "0.10.19"
+__version__ = "0.10.20"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mureo"
-version = "0.10.19"
+version = "0.10.20"
 description = "Your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."
 requires-python = ">=3.10"
 license = "Apache-2.0"


### PR DESCRIPTION
Release 0.10.20: reinstall buttons (#377), About-tab restart (#378), workspace-scoped MCP instructions (#379), upgrade-route deflake (#381), commercial-edition README links (#380). Version parity across pyproject / __init__ / .claude-plugin verified (parity tests green).

https://claude.ai/code/session_01AbvhGbHZoK8VqP3kR9nWWp