### PR TITLE
feat(creative-studio): HTML/CSS composition engine, brand kit, and JP font pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `creative_studio` credentials section (or the `OPENAI_API_KEY` /
   `GEMINI_API_KEY` / `FAL_KEY` env vars), calls are rate-limited, and the
   family can be disabled with `MUREO_DISABLE_CREATIVE_STUDIO=1`.
+- **Creative Studio composition (typography layer).** The `creative_studio_*`
+  family gains the layout half of the pipeline: `creative_studio_compose`
+  composites headline/body/CTA/badge/logo over a text-free key visual using
+  three professional Jinja2 HTML/CSS templates (`hero_overlay`, `split`,
+  `minimal_badge`) rendered by headless Chromium, so Japanese typography is
+  pixel-perfect across every banner format (per-format safe areas keep copy
+  clear of platform UI chrome). A lightweight brand kit
+  (`./BRAND_KIT/kit.yml`, surfaced by `creative_studio_brand_kit_get`) supplies
+  colours, fonts, and a logo — degrading field-by-field to tasteful defaults so
+  output quality never depends on config hygiene. A Japanese-font pipeline
+  bundles Noto Sans JP + Zen Kaku Gothic New, downloaded once into
+  `~/.mureo/fonts` with checksum-locked provenance and a system-font fallback
+  when offline. `creative_studio_edit_visual` refines a visual through a
+  provider's edit path for the art-direction loop. Composition dependencies
+  (jinja2, playwright, pillow) install via the new `mureo[creative]` extra and
+  are lazily imported, so the core install stays lean.
 
 ## [0.10.20] - 2026-07-12
 

--- a/mureo/creative_studio/brand_kit.py
+++ b/mureo/creative_studio/brand_kit.py
@@ -26,6 +26,12 @@ from mureo._image_validation import validate_image_file
 #: ``#rgb`` or ``#rrggbb`` (case-insensitive).
 _HEX_RE = re.compile(r"^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$")
 
+# Font-family names flow into template CSS marked ``| safe`` (autoescape is
+# for HTML, not CSS strings), so restrict them to a conservative charset: a
+# hostile BRAND_KIT (e.g. client-supplied in an agency workspace) must not be
+# able to break out of the CSS string context.
+_FONT_NAME_RE = re.compile(r"^[A-Za-z0-9 \-_+.]{1,64}$")
+
 #: Colour roles a kit may define. Unknown keys are ignored.
 _COLOR_KEYS: tuple[str, ...] = ("primary", "secondary", "accent", "text", "background")
 #: Font roles a kit may define.
@@ -124,11 +130,11 @@ def _resolve_fonts(raw: Any) -> dict[str, str]:
         if key not in raw:
             continue
         value = raw[key]
-        if isinstance(value, str) and value.strip():
+        if isinstance(value, str) and _FONT_NAME_RE.match(value.strip()):
             fonts[key] = value.strip()
         else:
             _warn(
-                f"brand kit font {key!r} is not a non-empty string "
+                f"brand kit font {key!r} is not a safe font-family name "
                 f"({value!r}); keeping the default {fonts[key]!r}"
             )
     return fonts

--- a/mureo/creative_studio/brand_kit.py
+++ b/mureo/creative_studio/brand_kit.py
@@ -1,0 +1,220 @@
+"""Brand-kit loading for Creative Studio.
+
+A brand kit gives the composer the colours, fonts, and logo that make a
+generated banner look like it belongs to a specific brand rather than a
+generic template. It is read from ``<cwd or base>/BRAND_KIT/kit.yml``.
+
+The loader is deliberately forgiving: **quality of output must not depend on
+config hygiene**, so a missing, malformed, or partially-invalid kit NEVER
+raises. Every field degrades to a tasteful default independently (a bad hex
+colour falls back only for that colour, an unreadable logo is treated as
+absent) and a :class:`BrandKitWarning` is emitted instead of an exception.
+"""
+
+from __future__ import annotations
+
+import re
+import warnings
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from mureo._image_validation import validate_image_file
+
+#: ``#rgb`` or ``#rrggbb`` (case-insensitive).
+_HEX_RE = re.compile(r"^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$")
+
+#: Colour roles a kit may define. Unknown keys are ignored.
+_COLOR_KEYS: tuple[str, ...] = ("primary", "secondary", "accent", "text", "background")
+#: Font roles a kit may define.
+_FONT_KEYS: tuple[str, ...] = ("heading", "body")
+
+# Logo validation bounds (mirrors the platform upload validators).
+_LOGO_MAX_BYTES = 10 * 1024 * 1024
+_LOGO_MAX_LABEL = "10MB"
+_LOGO_EXTENSIONS = frozenset({"png", "jpg", "jpeg", "webp"})
+
+_DEFAULT_LOGO_CLEAR_PX = 24
+
+# Tasteful neutral defaults: near-black primary, muted grey secondary, indigo
+# accent, near-black text on white, with Noto Sans JP for crisp Japanese text.
+_DEFAULT_COLORS: dict[str, str] = {
+    "primary": "#1a1d29",
+    "secondary": "#6b7280",
+    "accent": "#4f46e5",
+    "text": "#111827",
+    "background": "#ffffff",
+}
+_DEFAULT_FONTS: dict[str, str] = {
+    "heading": "Noto Sans JP",
+    "body": "Noto Sans JP",
+}
+
+
+class BrandKitWarning(UserWarning):
+    """Emitted when a brand kit is malformed and a field degrades to default.
+
+    A distinct subclass so strict deployments can opt into
+    ``warnings.filterwarnings("error", category=BrandKitWarning)``.
+    """
+
+
+@dataclass(frozen=True)
+class BrandKit:
+    """A resolved brand kit.
+
+    Attributes:
+        colors: Role -> hex string (``primary`` / ``secondary`` / ``accent`` /
+            ``text`` / ``background``); always fully populated.
+        fonts: Role -> font-family name (``heading`` / ``body``).
+        logo_path: Absolute path to a validated logo image, or ``None``.
+        logo_min_clear_px: Minimum clear-space padding around the logo, in px.
+    """
+
+    colors: dict[str, str] = field(default_factory=lambda: dict(_DEFAULT_COLORS))
+    fonts: dict[str, str] = field(default_factory=lambda: dict(_DEFAULT_FONTS))
+    logo_path: Path | None = None
+    logo_min_clear_px: int = _DEFAULT_LOGO_CLEAR_PX
+
+
+#: The kit used when no ``kit.yml`` exists or it cannot be parsed at all.
+DEFAULT_BRAND_KIT = BrandKit(
+    colors=dict(_DEFAULT_COLORS),
+    fonts=dict(_DEFAULT_FONTS),
+    logo_path=None,
+    logo_min_clear_px=_DEFAULT_LOGO_CLEAR_PX,
+)
+
+
+def _warn(message: str) -> None:
+    warnings.warn(message, BrandKitWarning, stacklevel=3)
+
+
+def _resolve_colors(raw: Any) -> dict[str, str]:
+    """Merge a raw ``colors`` mapping onto the defaults, per-field validated."""
+    colors = dict(_DEFAULT_COLORS)
+    if not isinstance(raw, dict):
+        if raw is not None:
+            _warn("brand kit 'colors' is not a mapping; using default colours")
+        return colors
+    for key in _COLOR_KEYS:
+        if key not in raw:
+            continue
+        value = raw[key]
+        if isinstance(value, str) and _HEX_RE.match(value.strip()):
+            colors[key] = value.strip()
+        else:
+            _warn(
+                f"brand kit colour {key!r} is not a valid hex value "
+                f"({value!r}); keeping the default {colors[key]}"
+            )
+    return colors
+
+
+def _resolve_fonts(raw: Any) -> dict[str, str]:
+    """Merge a raw ``fonts`` mapping onto the defaults, per-field validated."""
+    fonts = dict(_DEFAULT_FONTS)
+    if not isinstance(raw, dict):
+        if raw is not None:
+            _warn("brand kit 'fonts' is not a mapping; using default fonts")
+        return fonts
+    for key in _FONT_KEYS:
+        if key not in raw:
+            continue
+        value = raw[key]
+        if isinstance(value, str) and value.strip():
+            fonts[key] = value.strip()
+        else:
+            _warn(
+                f"brand kit font {key!r} is not a non-empty string "
+                f"({value!r}); keeping the default {fonts[key]!r}"
+            )
+    return fonts
+
+
+def _resolve_logo(raw: Any, kit_dir: Path) -> Path | None:
+    """Resolve + validate the logo path relative to the BRAND_KIT dir.
+
+    Returns ``None`` (with a warning) for anything that is not a valid,
+    supported, in-bounds image file.
+    """
+    if raw is None:
+        return None
+    if not isinstance(raw, str) or not raw.strip():
+        _warn(f"brand kit 'logo' is not a path string ({raw!r}); ignoring")
+        return None
+    candidate = kit_dir / raw.strip()
+    try:
+        validated = validate_image_file(
+            str(candidate),
+            max_size_bytes=_LOGO_MAX_BYTES,
+            max_size_label=_LOGO_MAX_LABEL,
+            allowed_extensions=_LOGO_EXTENSIONS,
+        )
+    except (ValueError, FileNotFoundError, OSError) as exc:
+        _warn(f"brand kit logo {raw!r} is unusable ({exc}); treating as absent")
+        return None
+    return validated.resolve()
+
+
+def _resolve_clear_px(raw: Any) -> int:
+    """Resolve ``logo_min_clear_px``; degrade to the default when invalid."""
+    if raw is None:
+        return _DEFAULT_LOGO_CLEAR_PX
+    if isinstance(raw, bool) or not isinstance(raw, int) or raw < 0:
+        _warn(
+            f"brand kit 'logo_min_clear_px' must be a non-negative integer "
+            f"({raw!r}); using {_DEFAULT_LOGO_CLEAR_PX}"
+        )
+        return _DEFAULT_LOGO_CLEAR_PX
+    return int(raw)
+
+
+def load_brand_kit(base: Path | None = None) -> BrandKit:
+    """Load the brand kit from ``<base or cwd>/BRAND_KIT/kit.yml``.
+
+    Never raises. A missing file returns :data:`DEFAULT_BRAND_KIT`; a
+    malformed file degrades field-by-field to defaults with a
+    :class:`BrandKitWarning`.
+
+    Args:
+        base: Directory containing the ``BRAND_KIT`` folder. Defaults to the
+            current working directory.
+    """
+    root = base if base is not None else Path.cwd()
+    kit_dir = root / "BRAND_KIT"
+    kit_file = kit_dir / "kit.yml"
+
+    if not kit_file.is_file():
+        return DEFAULT_BRAND_KIT
+
+    try:
+        text = kit_file.read_text(encoding="utf-8")
+        data = yaml.safe_load(text)
+    except (OSError, yaml.YAMLError, ValueError) as exc:
+        _warn(f"brand kit could not be parsed ({exc}); using defaults")
+        return DEFAULT_BRAND_KIT
+
+    if data is None:
+        # Empty file — nothing to override.
+        return DEFAULT_BRAND_KIT
+    if not isinstance(data, dict):
+        _warn("brand kit kit.yml is not a mapping; using defaults")
+        return DEFAULT_BRAND_KIT
+
+    return BrandKit(
+        colors=_resolve_colors(data.get("colors")),
+        fonts=_resolve_fonts(data.get("fonts")),
+        logo_path=_resolve_logo(data.get("logo"), kit_dir),
+        logo_min_clear_px=_resolve_clear_px(data.get("logo_min_clear_px")),
+    )
+
+
+__all__ = [
+    "DEFAULT_BRAND_KIT",
+    "BrandKit",
+    "BrandKitWarning",
+    "load_brand_kit",
+]

--- a/mureo/creative_studio/composer.py
+++ b/mureo/creative_studio/composer.py
@@ -1,0 +1,348 @@
+"""HTML/CSS composition engine for Creative Studio (PR-B).
+
+The typography & layout layer: it takes a text-free key visual (from the
+provider layer, PR-A) plus ad copy and a brand kit, renders a professional
+banner via Jinja2 HTML/CSS templates, and rasterises each target format with
+headless Chromium (Playwright) so Japanese text is pixel-perfect.
+
+Design mirrors :class:`mureo.google_ads._message_match.LPScreenshotter`:
+Playwright (and Jinja2) are imported lazily so the core install stays lean;
+when the optional extra is missing a clear :class:`RuntimeError` tells the
+operator to install ``mureo[creative]``.
+
+Two entry points:
+
+- :func:`render_html` — pure template rendering (no browser), so template
+  logic is unit-testable without Playwright.
+- :func:`compose` — the full pipeline; accepts an injectable
+  ``browser_factory`` so orchestration is testable with a fake browser.
+"""
+
+from __future__ import annotations
+
+import base64
+import importlib
+import logging
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from mureo._image_validation import validate_image_file
+from mureo.creative_studio.fonts import (
+    FALLBACK_STACK,
+    FONT_MANIFEST,
+    ensure_font,
+    font_face_css,
+)
+from mureo.creative_studio.formats import (
+    FORMATS_BY_ID as _FORMATS_BY_ID,
+)
+from mureo.creative_studio.formats import (
+    PORTRAIT,
+    VERTICAL,
+    CreativeFormat,
+    aspect_for,
+    safe_area_for,
+)
+from mureo.creative_studio.workspace import sha256_of, write_bytes
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Callable
+    from contextlib import AbstractAsyncContextManager
+
+    from mureo.creative_studio.brand_kit import BrandKit
+
+logger = logging.getLogger(__name__)
+
+#: The three shipped layout templates, chosen by the operator per compose call.
+TEMPLATES: tuple[str, ...] = ("hero_overlay", "split", "minimal_badge")
+
+#: Raised (as a RuntimeError) when the composition extra is not installed.
+_MISSING_EXTRA = (
+    "Creative Studio composition requires the 'creative' extra: "
+    "pip install 'mureo[creative]'"
+)
+
+_TEMPLATES_DIR = Path(__file__).parent / "templates"
+
+# Composed PNGs are validated before being returned downstream.
+_MAX_IMAGE_BYTES = 30 * 1024 * 1024
+_MAX_IMAGE_LABEL = "30MB"
+_ALLOWED_IMAGE_EXTENSIONS = frozenset({"png"})
+
+#: Panel proportion for the split layout.
+_SPLIT_PANEL_PCT = 42
+
+
+@dataclass(frozen=True)
+class CopySpec:
+    """The ad copy overlaid on a visual.
+
+    Attributes:
+        headline: The primary line (required).
+        body: An optional supporting line.
+        cta: The call-to-action button label (required).
+        badge: An optional short badge chip (e.g. a limited-offer flag).
+    """
+
+    headline: str
+    body: str | None
+    cta: str
+    badge: str | None
+
+
+# ---------------------------------------------------------------------------
+# Lazy dependency imports (mirrors LPScreenshotter's pattern)
+# ---------------------------------------------------------------------------
+
+
+def _import_jinja() -> Any:
+    try:
+        return importlib.import_module("jinja2")
+    except ImportError as exc:  # pragma: no cover - exercised via monkeypatch
+        raise RuntimeError(_MISSING_EXTRA) from exc
+
+
+def _import_playwright() -> Any:
+    try:
+        return importlib.import_module("playwright.async_api")
+    except ImportError as exc:  # pragma: no cover - requires the extra absent
+        raise RuntimeError(_MISSING_EXTRA) from exc
+
+
+def _build_environment() -> Any:
+    """Build a Jinja2 environment with autoescape + StrictUndefined."""
+    jinja2 = _import_jinja()
+    return jinja2.Environment(
+        loader=jinja2.FileSystemLoader(str(_TEMPLATES_DIR)),
+        autoescape=True,
+        undefined=jinja2.StrictUndefined,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Data-URI + template rendering
+# ---------------------------------------------------------------------------
+
+
+def _mime_for(suffix: str) -> str:
+    lowered = suffix.lower()
+    if lowered in (".jpg", ".jpeg"):
+        return "image/jpeg"
+    if lowered == ".webp":
+        return "image/webp"
+    return "image/png"
+
+
+def _data_uri(path: Path) -> str:
+    """Return a base64 ``data:`` URI for the image at ``path``."""
+    encoded = base64.b64encode(Path(path).read_bytes()).decode("ascii")
+    return f"data:{_mime_for(Path(path).suffix)};base64,{encoded}"
+
+
+def _pct(fraction: float) -> str:
+    """Format a fractional inset as a CSS percentage string (0.04 -> ``4%``)."""
+    return f"{fraction * 100:g}%"
+
+
+def render_html(
+    *,
+    template: str,
+    fmt: CreativeFormat,
+    copy: CopySpec,
+    brand: BrandKit,
+    visual_data_uri: str,
+    logo_data_uri: str | None = None,
+    font_css: str = "",
+) -> str:
+    """Render one format's banner HTML. Pure — no browser, no file writes.
+
+    Args:
+        template: One of :data:`TEMPLATES`.
+        fmt: The target :class:`CreativeFormat` (drives viewport + safe area).
+        copy: The ad copy to overlay.
+        brand: The resolved brand kit (colours / fonts / logo clear-space).
+        visual_data_uri: The background key visual as a ``data:`` URI.
+        logo_data_uri: The brand logo as a ``data:`` URI, or ``None``.
+        font_css: ``@font-face`` CSS to inline (empty falls back to system).
+
+    Raises:
+        ValueError: When ``template`` is not a known template.
+        RuntimeError: When Jinja2 (the ``creative`` extra) is not installed.
+    """
+    if template not in TEMPLATES:
+        raise ValueError(
+            f"unknown template {template!r}; valid templates: {', '.join(TEMPLATES)}"
+        )
+
+    env = _build_environment()
+    jinja_template = env.get_template(f"{template}.html.j2")
+
+    insets = safe_area_for(fmt.id)
+    stack_vertical = aspect_for(fmt.id) in (PORTRAIT, VERTICAL)
+
+    return str(
+        jinja_template.render(
+            width=fmt.width,
+            height=fmt.height,
+            pad_top=_pct(insets["top"]),
+            pad_right=_pct(insets["right"]),
+            pad_bottom=_pct(insets["bottom"]),
+            pad_left=_pct(insets["left"]),
+            colors=brand.colors,
+            fonts=brand.fonts,
+            font_css=font_css,
+            fallback_stack=FALLBACK_STACK,
+            visual_uri=visual_data_uri,
+            logo_uri=logo_data_uri,
+            logo_min_clear_px=brand.logo_min_clear_px,
+            headline=copy.headline,
+            body=copy.body,
+            cta=copy.cta,
+            badge=copy.badge,
+            stack_vertical=stack_vertical,
+            panel_pct=_SPLIT_PANEL_PCT,
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Font embedding
+# ---------------------------------------------------------------------------
+
+
+def _embedded_font_css() -> str:
+    """Resolve the manifest fonts and return inlined ``@font-face`` CSS.
+
+    Best-effort: any font that cannot be resolved is skipped; if none can be
+    resolved the composer falls back to the system font stack (empty string).
+    """
+    available: dict[str, Path] = {}
+    for spec in FONT_MANIFEST:
+        path = ensure_font(spec)
+        if path is not None:
+            available[spec.name] = path
+    if not available:
+        return ""
+    try:
+        return font_face_css(available)
+    except Exception:  # noqa: BLE001 — fonts must never block composition
+        logger.debug(
+            "font_face_css failed; falling back to system fonts", exc_info=True
+        )
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# Browser step
+# ---------------------------------------------------------------------------
+
+
+@asynccontextmanager
+async def _default_browser_factory() -> AsyncIterator[Any]:
+    """Launch one headless Chromium for the whole compose call."""
+    playwright_api = _import_playwright()
+    async with playwright_api.async_playwright() as pw:
+        browser = await pw.chromium.launch(
+            headless=True,
+            args=["--force-color-profile=srgb"],
+        )
+        try:
+            yield browser
+        finally:
+            await browser.close()
+
+
+async def compose(
+    visual_path: Path,
+    copy: CopySpec,
+    template: str,
+    formats: list[str],
+    brand: BrandKit,
+    out_dir: Path,
+    *,
+    browser_factory: Callable[[], AbstractAsyncContextManager[Any]] | None = None,
+) -> list[dict[str, Any]]:
+    """Render ``copy`` over ``visual_path`` into every requested format.
+
+    Launches a single Chromium instance for the whole call; per format it
+    opens a page at the exact viewport, sets the rendered HTML, waits for
+    fonts, screenshots to PNG, writes it via the workspace helpers, validates
+    it, and records ``{format, path, sha256, width, height}``.
+
+    Args:
+        visual_path: The text-free background key visual.
+        copy: The ad copy to overlay.
+        template: One of :data:`TEMPLATES`.
+        formats: Target format ids (must exist in the format matrix).
+        brand: The resolved brand kit.
+        out_dir: Directory to write composed PNGs into.
+        browser_factory: Injectable async-context-manager factory yielding a
+            browser (tests pass a fake; default launches Playwright Chromium).
+
+    Raises:
+        ValueError: When ``template`` is unknown.
+        RuntimeError: When the ``creative`` extra is not installed.
+    """
+    if template not in TEMPLATES:
+        raise ValueError(
+            f"unknown template {template!r}; valid templates: {', '.join(TEMPLATES)}"
+        )
+
+    visual_uri = _data_uri(Path(visual_path))
+    logo_uri = _data_uri(brand.logo_path) if brand.logo_path is not None else None
+    font_css = _embedded_font_css()
+
+    factory = browser_factory or _default_browser_factory
+    results: list[dict[str, Any]] = []
+
+    async with factory() as browser:
+        for format_id in formats:
+            fmt = _FORMATS_BY_ID[format_id]
+            html = render_html(
+                template=template,
+                fmt=fmt,
+                copy=copy,
+                brand=brand,
+                visual_data_uri=visual_uri,
+                logo_data_uri=logo_uri,
+                font_css=font_css,
+            )
+            page = await browser.new_page(
+                viewport={"width": fmt.width, "height": fmt.height}
+            )
+            try:
+                await page.set_content(html)
+                # Wait for embedded/system fonts to be ready before capture so
+                # Japanese glyphs render, not tofu boxes.
+                await page.evaluate("document.fonts.ready.then(() => true)")
+                png = await page.screenshot(type="png")
+            finally:
+                await page.close()
+
+            out_path = write_bytes(Path(out_dir) / f"{format_id}_{template}.png", png)
+            validate_image_file(
+                str(out_path),
+                max_size_bytes=_MAX_IMAGE_BYTES,
+                max_size_label=_MAX_IMAGE_LABEL,
+                allowed_extensions=_ALLOWED_IMAGE_EXTENSIONS,
+            )
+            results.append(
+                {
+                    "format": format_id,
+                    "path": str(out_path),
+                    "sha256": sha256_of(out_path),
+                    "width": fmt.width,
+                    "height": fmt.height,
+                }
+            )
+    return results
+
+
+__all__ = [
+    "TEMPLATES",
+    "CopySpec",
+    "compose",
+    "render_html",
+]

--- a/mureo/creative_studio/fonts.py
+++ b/mureo/creative_studio/fonts.py
@@ -1,0 +1,241 @@
+"""Japanese-font resolution for the Creative Studio composer.
+
+Headless-Chromium rendering needs the display font **available locally at
+render time** to guarantee crisp Japanese glyphs without a live network
+round-trip. This module keeps a small, fixed manifest of two faces (Noto
+Sans JP for body/most copy, Zen Kaku Gothic New Bold as a display face),
+downloads them once into ``~/.mureo/fonts`` on first use, verifies them, and
+records a lockfile of checksums.
+
+Robustness is the contract: a font download that fails for ANY reason
+(offline, bad bytes, wrong size) returns ``None`` with a warning so the
+composer falls back to the system font stack — a network hiccup must never
+block composition. Download URLs are fixed manifest constants (never
+caller-supplied), so there is no SSRF surface.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import logging
+import os
+import warnings
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING, NamedTuple
+
+import httpx
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+logger = logging.getLogger(__name__)
+
+_TIMEOUT = 30.0
+_LOCKFILE = "manifest.lock.json"
+_FILE_MODE = 0o644
+
+# Font byte-size sanity bounds. Below the floor is almost certainly an error
+# page; above the ceiling is not a web font we would ship.
+_MIN_FONT_BYTES = 10 * 1024
+_MAX_FONT_BYTES = 40 * 1024 * 1024
+
+# Accepted sfnt/WOFF2 magic numbers: TrueType (0x00010000), OpenType ('OTTO'),
+# and WOFF2 ('wOF2').
+_FONT_MAGIC: tuple[bytes, ...] = (b"\x00\x01\x00\x00", b"OTTO", b"wOF2")
+
+#: System-font fallback chain used when an embedded face is unavailable.
+FALLBACK_STACK = (
+    "'Noto Sans JP', 'Hiragino Kaku Gothic ProN', 'Yu Gothic', Meiryo, sans-serif"
+)
+
+
+class FontSpec(NamedTuple):
+    """One downloadable font face.
+
+    Attributes:
+        name: CSS ``font-family`` name (e.g. ``"Noto Sans JP"``).
+        filename: Local filename under the fonts directory.
+        url: Fixed https download URL (never caller-supplied).
+        format: CSS ``@font-face`` ``format()`` hint (e.g. ``"truetype"``).
+    """
+
+    name: str
+    filename: str
+    url: str
+    format: str
+
+
+#: The two faces the composer relies on. Both are variable/bold TrueType files
+#: served from the official Google Fonts GitHub mirror.
+FONT_MANIFEST: tuple[FontSpec, ...] = (
+    FontSpec(
+        name="Noto Sans JP",
+        filename="NotoSansJP-wght.ttf",
+        url=(
+            "https://github.com/google/fonts/raw/main/ofl/notosansjp/"
+            "NotoSansJP%5Bwght%5D.ttf"
+        ),
+        format="truetype",
+    ),
+    FontSpec(
+        name="Zen Kaku Gothic New",
+        filename="ZenKakuGothicNew-Bold.ttf",
+        url=(
+            "https://github.com/google/fonts/raw/main/ofl/zenkakugothicnew/"
+            "ZenKakuGothicNew-Bold.ttf"
+        ),
+        format="truetype",
+    ),
+)
+
+#: Fast name -> spec lookup for :func:`font_face_css`.
+_SPEC_BY_NAME: dict[str, FontSpec] = {spec.name: spec for spec in FONT_MANIFEST}
+
+
+def _default_client_factory() -> httpx.Client:
+    return httpx.Client(timeout=_TIMEOUT, follow_redirects=True)
+
+
+def _warn(message: str) -> None:
+    warnings.warn(message, FontWarning, stacklevel=3)
+
+
+class FontWarning(UserWarning):
+    """Emitted when a font cannot be resolved and the composer must fall back.
+
+    A distinct subclass so strict deployments can opt into
+    ``warnings.filterwarnings("error", category=FontWarning)``.
+    """
+
+
+def _has_font_magic(data: bytes) -> bool:
+    return data[:4] in _FONT_MAGIC
+
+
+def _record_lock(dest_dir: Path, spec: FontSpec, data: bytes) -> None:
+    """Best-effort append of a checksum entry to ``manifest.lock.json``.
+
+    Never raises: a lockfile write failure must not discard a font that was
+    downloaded and validated successfully.
+    """
+    try:
+        lock_path = dest_dir / _LOCKFILE
+        existing: dict[str, object] = {}
+        if lock_path.is_file():
+            loaded = json.loads(lock_path.read_text(encoding="utf-8"))
+            if isinstance(loaded, dict):
+                existing = loaded
+        existing[spec.filename] = {
+            "filename": spec.filename,
+            "sha256": hashlib.sha256(data).hexdigest(),
+            "source_url": spec.url,
+            "fetched_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        }
+        lock_path.write_text(
+            json.dumps(existing, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
+        os.chmod(lock_path, _FILE_MODE)
+    except Exception:  # noqa: BLE001 — lockfile bookkeeping is best-effort
+        logger.debug("font lockfile update failed", exc_info=True)
+
+
+def ensure_font(
+    spec: FontSpec,
+    dest_dir: Path | None = None,
+    *,
+    client_factory: Callable[[], httpx.Client] | None = None,
+) -> Path | None:
+    """Return a local path to ``spec``'s font, downloading it once if needed.
+
+    Returns the existing file without any network call when it is already
+    present. Otherwise downloads from the fixed manifest URL, verifies the
+    magic bytes and size, writes it ``0o644``, and records a checksum in
+    ``manifest.lock.json``. On ANY failure returns ``None`` with a
+    :class:`FontWarning` so the caller falls back to system fonts.
+
+    Args:
+        spec: The font to ensure.
+        dest_dir: Directory to cache into (default ``~/.mureo/fonts``).
+        client_factory: Injectable ``httpx.Client`` factory (tests / advanced).
+    """
+    try:
+        base = (
+            Path(dest_dir) if dest_dir is not None else Path.home() / ".mureo" / "fonts"
+        )
+        dest = base / spec.filename
+        if dest.is_file() and dest.stat().st_size > 0:
+            return dest
+
+        if not spec.url.startswith("https://"):
+            _warn(f"font {spec.name!r}: refusing non-https url; skipped")
+            return None
+
+        factory = client_factory or _default_client_factory
+        with factory() as client:
+            response = client.get(spec.url, follow_redirects=True)
+            response.raise_for_status()
+            data = response.content
+
+        if not _has_font_magic(data):
+            _warn(f"font {spec.name!r}: download failed magic-byte check; skipped")
+            return None
+        if not (_MIN_FONT_BYTES <= len(data) <= _MAX_FONT_BYTES):
+            _warn(
+                f"font {spec.name!r}: download size {len(data)} bytes out of "
+                f"bounds [{_MIN_FONT_BYTES}, {_MAX_FONT_BYTES}]; skipped"
+            )
+            return None
+
+        base.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(data)
+        os.chmod(dest, _FILE_MODE)
+        _record_lock(base, spec, data)
+        return dest
+    except Exception as exc:  # noqa: BLE001 — never block composition on fonts
+        _warn(f"font {spec.name!r}: could not be resolved ({exc}); skipped")
+        return None
+
+
+def font_face_css(available: dict[str, Path]) -> str:
+    """Return ``@font-face`` CSS embedding each available font as a data URI.
+
+    Base64 data-URI embedding lets Playwright's ``set_content`` render with
+    no file server. The returned CSS always ends with a ``:root`` custom
+    property carrying :data:`FALLBACK_STACK` so templates can reference the
+    same system fallback chain.
+
+    Args:
+        available: Mapping of font-family name to a local font file path.
+    """
+    blocks: list[str] = []
+    for name, path in available.items():
+        try:
+            encoded = base64.b64encode(Path(path).read_bytes()).decode("ascii")
+        except OSError:  # noqa: PERF203 — skip an unreadable face, keep the rest
+            _warn(f"font {name!r}: could not read {path} for embedding; skipped")
+            continue
+        spec = _SPEC_BY_NAME.get(name)
+        fmt = spec.format if spec is not None else "truetype"
+        blocks.append(
+            "@font-face {\n"
+            f"  font-family: '{name}';\n"
+            f"  src: url(data:font/ttf;base64,{encoded}) format('{fmt}');\n"
+            "  font-weight: 100 900;\n"
+            "  font-display: swap;\n"
+            "}"
+        )
+    blocks.append(f":root {{ --mureo-font-fallback: {FALLBACK_STACK}; }}")
+    return "\n".join(blocks)
+
+
+__all__ = [
+    "FALLBACK_STACK",
+    "FONT_MANIFEST",
+    "FontSpec",
+    "FontWarning",
+    "ensure_font",
+    "font_face_css",
+]

--- a/mureo/creative_studio/formats.py
+++ b/mureo/creative_studio/formats.py
@@ -7,8 +7,9 @@ display sizes, responsive display assets) as frozen
 recommended master-generation size a provider should render at before the
 composer (PR-B) crops per format.
 
-Safe-area definitions are a placeholder here; the composer consumes them
-fully in PR-B.
+Safe-area definitions are per-format keep-out margins (fractional insets)
+consumed by the composer (PR-B) to keep every headline / CTA / logo clear of
+the format's edges and any platform UI chrome.
 """
 
 from __future__ import annotations
@@ -71,16 +72,48 @@ _GENERATION_SIZE_BY_ASPECT: dict[str, tuple[int, int]] = {
 }
 
 
-# Placeholder safe-area (headline / CTA keep-out) definitions per aspect
-# class, expressed as fractional margins (top, right, bottom, left). Filled
-# in and consumed by the composer in PR-B; kept here so the matrix module is
-# the single source of truth for format geometry.
+# Per-format safe-area (headline / CTA / logo keep-out) definitions, expressed
+# as fractional margins (top, right, bottom, left) of the format's own
+# dimensions. These are per FORMAT id — not per aspect class — because two
+# formats sharing an aspect can need very different insets: a 9:16 story
+# reserves large top/bottom bands for platform UI chrome, whereas a 160x600
+# skyscraper (same "vertical" aspect) wants a tight 2% margin to use every
+# scarce pixel. The composer converts these fractions to CSS padding.
+#
+# Defaults: 4% each side. Overrides:
+#   - story_9x16: 14% top / 20% bottom (Instagram/Facebook story UI chrome).
+#   - gdn_728x90 & gdn_160x600: 2% (very small canvases, maximise usable area).
+_DEFAULT_INSET = 0.04
+
+
+def _uniform(value: float) -> dict[str, float]:
+    """Return an inset dict with the same margin on all four sides."""
+    return {"top": value, "right": value, "bottom": value, "left": value}
+
+
 SAFE_AREAS: dict[str, dict[str, float]] = {
-    SQUARE: {"top": 0.08, "right": 0.08, "bottom": 0.08, "left": 0.08},
-    PORTRAIT: {"top": 0.08, "right": 0.08, "bottom": 0.10, "left": 0.08},
-    LANDSCAPE: {"top": 0.08, "right": 0.08, "bottom": 0.08, "left": 0.08},
-    VERTICAL: {"top": 0.10, "right": 0.06, "bottom": 0.12, "left": 0.06},
+    "meta_feed_1x1": _uniform(_DEFAULT_INSET),
+    "meta_feed_4x5": _uniform(_DEFAULT_INSET),
+    "story_9x16": {"top": 0.14, "right": 0.04, "bottom": 0.20, "left": 0.04},
+    "gdn_300x250": _uniform(_DEFAULT_INSET),
+    "gdn_336x280": _uniform(_DEFAULT_INSET),
+    "gdn_728x90": _uniform(0.02),
+    "gdn_160x600": _uniform(0.02),
+    "rda_landscape": _uniform(_DEFAULT_INSET),
+    "rda_square": _uniform(_DEFAULT_INSET),
 }
+
+
+def safe_area_for(format_id: str) -> dict[str, float]:
+    """Return a fresh copy of the safe-area insets for ``format_id``.
+
+    A copy is returned so a caller mutating the result never corrupts the
+    shared table.
+
+    Raises:
+        KeyError: When ``format_id`` is not a known format.
+    """
+    return dict(SAFE_AREAS[format_id])
 
 
 def aspect_for(format_id: str) -> str:
@@ -118,4 +151,5 @@ __all__ = [
     "CreativeFormat",
     "aspect_for",
     "generation_size_for_aspect",
+    "safe_area_for",
 ]

--- a/mureo/creative_studio/templates/hero_overlay.html.j2
+++ b/mureo/creative_studio/templates/hero_overlay.html.j2
@@ -1,0 +1,116 @@
+{#
+  hero_overlay — full-bleed key visual with a bottom gradient scrim, headline,
+  optional body line, a pill CTA in the brand accent, and an optional top-left
+  logo with clear-space. All copy sits inside the format's safe area.
+
+  autoescape is ON: user copy ({{ headline }} etc.) is HTML-escaped; CSS values
+  (colours, fonts, data URIs, the injected @font-face block) are trusted and
+  marked | safe so they are not corrupted by HTML entity encoding.
+#}
+<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<style>
+{{ font_css | safe }}
+:root {
+  --u: calc(min(100vw, 100vh) / 100);
+  --accent: {{ colors.accent | safe }};
+  --bg: {{ colors.background | safe }};
+  --heading: '{{ fonts.heading | safe }}', {{ fallback_stack | safe }};
+  --body: '{{ fonts.body | safe }}', {{ fallback_stack | safe }};
+}
+* { margin: 0; padding: 0; box-sizing: border-box; }
+html, body {
+  width: {{ width }}px;
+  height: {{ height }}px;
+  overflow: hidden;
+}
+.stage {
+  position: relative;
+  width: {{ width }}px;
+  height: {{ height }}px;
+  background: var(--bg);
+  font-family: var(--body);
+}
+.bg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.scrim {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    to bottom,
+    rgba(0, 0, 0, 0) 42%,
+    rgba(0, 0, 0, 0.55) 100%
+  );
+}
+.logo-wrap {
+  position: absolute;
+  top: {{ pad_top }};
+  left: {{ pad_left }};
+  padding: {{ logo_min_clear_px }}px;
+}
+.logo {
+  display: block;
+  height: clamp(18px, calc(var(--u) * 9), 88px);
+  width: auto;
+}
+.content {
+  position: absolute;
+  left: {{ pad_left }};
+  right: {{ pad_right }};
+  bottom: {{ pad_bottom }};
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: calc(var(--u) * 2);
+}
+.headline {
+  font-family: var(--heading);
+  color: #ffffff;
+  font-weight: 700;
+  line-height: 1.12;
+  letter-spacing: 0.01em;
+  font-size: clamp(16px, calc(var(--u) * 7.6), 100px);
+  text-shadow: 0 calc(var(--u) * 0.3) calc(var(--u) * 1.6) rgba(0, 0, 0, 0.45);
+  overflow-wrap: anywhere;
+}
+.body {
+  color: rgba(255, 255, 255, 0.92);
+  font-size: clamp(11px, calc(var(--u) * 3.4), 34px);
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+.cta {
+  display: inline-block;
+  margin-top: calc(var(--u) * 1.5);
+  padding: calc(var(--u) * 2.2) calc(var(--u) * 4.5);
+  background: var(--accent);
+  color: #ffffff;
+  font-weight: 700;
+  border-radius: 999px;
+  font-size: clamp(11px, calc(var(--u) * 3.2), 30px);
+  overflow-wrap: anywhere;
+}
+</style>
+</head>
+<body>
+<div class="stage">
+  <img class="bg" src="{{ visual_uri | safe }}" alt="">
+  <div class="scrim"></div>
+  {% if logo_uri %}
+  <div class="logo-wrap"><img class="logo" src="{{ logo_uri | safe }}" alt=""></div>
+  {% endif %}
+  <div class="content">
+    <div class="headline">{{ headline }}</div>
+    {% if body %}<div class="body">{{ body }}</div>{% endif %}
+    <span class="cta">{{ cta }}</span>
+  </div>
+</div>
+</body>
+</html>

--- a/mureo/creative_studio/templates/minimal_badge.html.j2
+++ b/mureo/creative_studio/templates/minimal_badge.html.j2
@@ -1,0 +1,119 @@
+{#
+  minimal_badge — a slightly desaturated background visual behind a centred
+  white card holding the headline and pill CTA. A small accent badge chip sits
+  at the card's top-right (only when a badge is supplied); the logo sits at the
+  card's bottom-centre. The card is kept within the format's safe area.
+  autoescape ON: only CSS values are marked | safe.
+#}
+<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<style>
+{{ font_css | safe }}
+:root {
+  --u: calc(min(100vw, 100vh) / 100);
+  --accent: {{ colors.accent | safe }};
+  --bg: {{ colors.background | safe }};
+  --text: {{ colors.text | safe }};
+  --heading: '{{ fonts.heading | safe }}', {{ fallback_stack | safe }};
+  --body: '{{ fonts.body | safe }}', {{ fallback_stack | safe }};
+}
+* { margin: 0; padding: 0; box-sizing: border-box; }
+html, body {
+  width: {{ width }}px;
+  height: {{ height }}px;
+  overflow: hidden;
+}
+.stage {
+  position: relative;
+  width: {{ width }}px;
+  height: {{ height }}px;
+  background: var(--bg);
+  font-family: var(--body);
+}
+.bg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: saturate(0.7) brightness(0.96);
+}
+.safe {
+  position: absolute;
+  inset: 0;
+  padding: {{ pad_top }} {{ pad_right }} {{ pad_bottom }} {{ pad_left }};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.card {
+  position: relative;
+  max-width: 82%;
+  background: #ffffff;
+  border-radius: clamp(16px, calc(var(--u) * 2.2), 24px);
+  box-shadow: 0 calc(var(--u) * 2) calc(var(--u) * 5) rgba(0, 0, 0, 0.22);
+  padding: calc(var(--u) * 6) calc(var(--u) * 6) calc(var(--u) * 5);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: calc(var(--u) * 2.5);
+  text-align: center;
+}
+{% if badge %}
+.badge {
+  position: absolute;
+  top: calc(var(--u) * -2);
+  right: calc(var(--u) * -1);
+  background: var(--accent);
+  color: #ffffff;
+  font-weight: 700;
+  padding: calc(var(--u) * 1.2) calc(var(--u) * 2.6);
+  border-radius: 999px;
+  font-size: clamp(9px, calc(var(--u) * 2.6), 22px);
+  box-shadow: 0 calc(var(--u) * 0.6) calc(var(--u) * 1.8) rgba(0, 0, 0, 0.25);
+  overflow-wrap: anywhere;
+}
+{% endif %}
+.headline {
+  font-family: var(--heading);
+  font-weight: 700;
+  color: var(--text);
+  line-height: 1.16;
+  font-size: clamp(15px, calc(var(--u) * 6), 72px);
+  overflow-wrap: anywhere;
+}
+.cta {
+  display: inline-block;
+  padding: calc(var(--u) * 2.2) calc(var(--u) * 5);
+  background: var(--accent);
+  color: #ffffff;
+  font-weight: 700;
+  border-radius: 999px;
+  font-size: clamp(10px, calc(var(--u) * 3.1), 28px);
+  overflow-wrap: anywhere;
+}
+.logo {
+  display: block;
+  height: clamp(14px, calc(var(--u) * 6), 60px);
+  width: auto;
+  margin-top: calc(var(--u) * 1.5);
+}
+</style>
+</head>
+<body>
+<div class="stage">
+  <img class="bg" src="{{ visual_uri | safe }}" alt="">
+  <div class="safe">
+    <div class="card">
+      {% if badge %}<span class="badge">{{ badge }}</span>{% endif %}
+      <div class="headline">{{ headline }}</div>
+      {% if body %}<div class="body">{{ body }}</div>{% endif %}
+      <span class="cta">{{ cta }}</span>
+      {% if logo_uri %}<img class="logo" src="{{ logo_uri | safe }}" alt="">{% endif %}
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/mureo/creative_studio/templates/split.html.j2
+++ b/mureo/creative_studio/templates/split.html.j2
@@ -1,0 +1,104 @@
+{#
+  split — the key visual fills one half, a solid brand-background panel the
+  other (42% of the canvas). The visual is on the LEFT for landscape/square and
+  on TOP for portrait/vertical (driven by stack_vertical). The panel carries
+  the headline, optional body, pill CTA, and optional logo, all inside the safe
+  area. autoescape ON: only CSS values are marked | safe.
+#}
+<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<style>
+{{ font_css | safe }}
+:root {
+  --u: calc(min(100vw, 100vh) / 100);
+  --accent: {{ colors.accent | safe }};
+  --panel-bg: {{ colors.background | safe }};
+  --text: {{ colors.text | safe }};
+  --heading: '{{ fonts.heading | safe }}', {{ fallback_stack | safe }};
+  --body: '{{ fonts.body | safe }}', {{ fallback_stack | safe }};
+}
+* { margin: 0; padding: 0; box-sizing: border-box; }
+html, body {
+  width: {{ width }}px;
+  height: {{ height }}px;
+  overflow: hidden;
+}
+.stage {
+  display: flex;
+  flex-direction: {{ 'column' if stack_vertical else 'row' }};
+  width: {{ width }}px;
+  height: {{ height }}px;
+  background: var(--panel-bg);
+  font-family: var(--body);
+}
+.visual {
+  position: relative;
+  flex: 0 0 {{ 100 - panel_pct }}%;
+  overflow: hidden;
+}
+.visual img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+.panel {
+  flex: 0 0 {{ panel_pct }}%;
+  position: relative;
+  background: var(--panel-bg);
+  color: var(--text);
+  padding: {{ pad_top }} {{ pad_right }} {{ pad_bottom }} {{ pad_left }};
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: calc(var(--u) * 2);
+}
+.headline {
+  font-family: var(--heading);
+  font-weight: 700;
+  line-height: 1.14;
+  letter-spacing: 0.01em;
+  color: var(--text);
+  font-size: clamp(15px, calc(var(--u) * 6.2), 76px);
+  overflow-wrap: anywhere;
+}
+.body {
+  color: var(--text);
+  opacity: 0.82;
+  font-size: clamp(10px, calc(var(--u) * 3.1), 30px);
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+.cta {
+  align-self: flex-start;
+  margin-top: calc(var(--u) * 1.5);
+  padding: calc(var(--u) * 2.2) calc(var(--u) * 4.5);
+  background: var(--accent);
+  color: #ffffff;
+  font-weight: 700;
+  border-radius: 999px;
+  font-size: clamp(10px, calc(var(--u) * 3), 28px);
+  overflow-wrap: anywhere;
+}
+.logo {
+  display: block;
+  height: clamp(16px, calc(var(--u) * 7.5), 72px);
+  width: auto;
+  margin-top: calc(var(--u) * 2);
+}
+</style>
+</head>
+<body>
+<div class="stage">
+  <div class="visual"><img src="{{ visual_uri | safe }}" alt=""></div>
+  <div class="panel">
+    {% if logo_uri %}<img class="logo" src="{{ logo_uri | safe }}" alt="">{% endif %}
+    <div class="headline">{{ headline }}</div>
+    {% if body %}<div class="body">{{ body }}</div>{% endif %}
+    <span class="cta">{{ cta }}</span>
+  </div>
+</div>
+</body>
+</html>

--- a/mureo/mcp/tools_creative_studio.py
+++ b/mureo/mcp/tools_creative_studio.py
@@ -1,15 +1,18 @@
-"""MCP tool family for Creative Studio visual generation (PR-A).
+"""MCP tool family for Creative Studio (PR-A visual generation + PR-B compose).
 
-Two tools, self-contained in one module (mirroring
-``tools_analytics_registry``):
+Self-contained in one module (mirroring ``tools_analytics_registry``):
 
 - ``creative_studio_providers_list`` — enumerate configured image providers
   and their capabilities.
 - ``creative_studio_generate_visual`` — generate text-free key visuals with
   one or all configured providers, write them to a run directory with a
   provenance manifest, and return the paths.
-
-The composer / templates / brand-kit tools arrive in PR-B.
+- ``creative_studio_brand_kit_get`` — return the loaded brand kit (colours /
+  fonts / logo) so the agent can judge brand fit.
+- ``creative_studio_edit_visual`` — refine a visual through a provider's edit
+  path (for the art-direction loop).
+- ``creative_studio_compose`` — composite copy + brand over a visual into
+  per-format banner PNGs via the HTML/CSS composition engine.
 """
 
 from __future__ import annotations
@@ -22,8 +25,14 @@ from typing import Any
 from mcp.types import TextContent, Tool
 
 from mureo._image_validation import validate_image_file
-from mureo.creative_studio.formats import generation_size_for_aspect
-from mureo.creative_studio.providers import ImageProvider, available_providers
+from mureo.creative_studio import composer
+from mureo.creative_studio.brand_kit import DEFAULT_BRAND_KIT, BrandKit, load_brand_kit
+from mureo.creative_studio.formats import FORMATS_BY_ID, generation_size_for_aspect
+from mureo.creative_studio.providers import (
+    ImageProvider,
+    NotSupportedError,
+    available_providers,
+)
 from mureo.creative_studio.workspace import (
     create_run_dir,
     sha256_of,
@@ -43,6 +52,9 @@ _THROTTLER = Throttler(CREATIVE_STUDIO_THROTTLE)
 _MAX_IMAGE_BYTES = 30 * 1024 * 1024
 _MAX_IMAGE_LABEL = "30MB"
 _ALLOWED_IMAGE_EXTENSIONS = frozenset({"png"})
+
+# Compose accepts any raster the browser can decode as a background visual.
+_COMPOSE_INPUT_EXTENSIONS = frozenset({"png", "jpg", "jpeg", "webp"})
 
 # The hard constraint appended to every provider prompt: image models render
 # text (especially Japanese) poorly, so they generate the VISUAL only — the
@@ -122,6 +134,114 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["prompt"],
+        },
+    ),
+    Tool(
+        name="creative_studio_brand_kit_get",
+        description=(
+            "Return the loaded brand kit (colours, fonts, logo path, and logo "
+            "clear-space) read from ./BRAND_KIT/kit.yml. When no kit exists, "
+            "tasteful neutral defaults are returned and 'defaults_used' is "
+            "true. Use this to judge brand fit before composing banners."
+        ),
+        inputSchema={"type": "object", "properties": {}},
+    ),
+    Tool(
+        name="creative_studio_edit_visual",
+        description=(
+            "Refine an existing key visual through an image provider's edit "
+            "path (the art-direction loop: fix a weak visual, then re-score). "
+            "The instruction describes the imagery change ONLY — no text is "
+            "rendered by the model. The edited PNG is written next to the "
+            "input as '<stem>_edit_<k>.png' and validated; the tool returns "
+            "its path, SHA-256, and the provider used."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Path to the PNG visual to edit.",
+                },
+                "instruction": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": (
+                        "What to change about the imagery (e.g. 'brighten the "
+                        "sky, remove the clutter on the left')."
+                    ),
+                },
+                "provider": {
+                    "type": "string",
+                    "description": (
+                        "Provider name to use. Defaults to the first "
+                        "configured provider whose capabilities report edit "
+                        "support."
+                    ),
+                },
+            },
+            "required": ["path", "instruction"],
+        },
+    ),
+    Tool(
+        name="creative_studio_compose",
+        description=(
+            "Composite ad copy + brand kit over a key visual into per-format "
+            "banner PNGs. The typography layer: headline/body/CTA/badge/logo "
+            "are laid out in HTML/CSS and rendered by headless Chromium so "
+            "Japanese text is pixel-perfect. Pick a layout 'template', the "
+            "target 'formats', and pass the copy; the composed PNGs land in a "
+            "new run directory with a provenance manifest. Requires the "
+            "'creative' extra (pip install 'mureo[creative]')."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "visual_path": {
+                    "type": "string",
+                    "description": (
+                        "Path to the text-free background key visual "
+                        "(png/jpg/jpeg/webp)."
+                    ),
+                },
+                "headline": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "The primary headline copy.",
+                },
+                "cta": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "The call-to-action button label.",
+                },
+                "body": {
+                    "type": "string",
+                    "description": "Optional supporting body line.",
+                },
+                "badge": {
+                    "type": "string",
+                    "description": (
+                        "Optional short badge chip (e.g. a limited-offer flag; "
+                        "used by the minimal_badge template)."
+                    ),
+                },
+                "template": {
+                    "type": "string",
+                    "enum": list(composer.TEMPLATES),
+                    "default": "hero_overlay",
+                    "description": "Layout template to render.",
+                },
+                "formats": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": sorted(FORMATS_BY_ID),
+                    },
+                    "default": ["meta_feed_1x1"],
+                    "description": "Target format ids to render.",
+                },
+            },
+            "required": ["visual_path", "headline", "cta"],
         },
     ),
 ]
@@ -304,9 +424,233 @@ def _record_audit(run_id: str, manifest_path: Path) -> None:
         )
 
 
+def _brand_summary(brand: BrandKit) -> dict[str, Any]:
+    """Serialisable summary of a brand kit for a manifest / tool result."""
+    return {
+        "colors": dict(brand.colors),
+        "fonts": dict(brand.fonts),
+        "logo": str(brand.logo_path) if brand.logo_path is not None else None,
+        "logo_min_clear_px": brand.logo_min_clear_px,
+        "defaults_used": brand == DEFAULT_BRAND_KIT,
+    }
+
+
+async def _handle_brand_kit_get(_arguments: dict[str, Any]) -> list[TextContent]:
+    brand = load_brand_kit()
+    return _json_result(_brand_summary(brand))
+
+
+def _resolve_edit_provider(provider_arg: str | None) -> ImageProvider | None:
+    """Resolve the provider for an edit call.
+
+    A named provider must merely be configured (a non-edit provider then
+    surfaces a clear NotSupportedError envelope at call time). With no name,
+    the first configured provider advertising edit support is chosen.
+    """
+    configured = [p for p in available_providers() if _safe_is_configured(p)]
+    if provider_arg:
+        for provider in configured:
+            if provider.name == provider_arg:
+                return provider
+        return None
+    for provider in configured:
+        try:
+            if provider.capabilities().get("edit"):
+                return provider
+        except Exception:  # noqa: BLE001 — a broken provider is simply skipped
+            logger.debug("capabilities() failed for %r", provider, exc_info=True)
+    return None
+
+
+def _next_free_edit_path(input_path: Path) -> Path:
+    """Return ``<stem>_edit_<k>.png`` next to ``input_path`` for the next free k."""
+    parent = input_path.parent
+    stem = input_path.stem
+    k = 1
+    while True:
+        candidate = parent / f"{stem}_edit_{k}.png"
+        if not candidate.exists():
+            return candidate
+        k += 1
+
+
+async def _handle_edit_visual(arguments: dict[str, Any]) -> list[TextContent]:
+    path_arg = _require(arguments, "path")
+    instruction = _require(arguments, "instruction")
+    provider_arg = _opt(arguments, "provider")
+
+    try:
+        in_path = validate_image_file(
+            str(path_arg),
+            max_size_bytes=_MAX_IMAGE_BYTES,
+            max_size_label=_MAX_IMAGE_LABEL,
+            allowed_extensions=_ALLOWED_IMAGE_EXTENSIONS,
+        )
+    except (ValueError, FileNotFoundError) as exc:
+        return _error(f"invalid image path: {exc}")
+
+    provider = _resolve_edit_provider(provider_arg)
+    if provider is None:
+        if provider_arg:
+            return _error(
+                f"provider {provider_arg!r} is not configured. Configure it in "
+                "the dashboard 'creative_studio' credentials section first."
+            )
+        return _error(
+            "No image provider with edit capability is configured. Add an "
+            "edit-capable provider's API key (e.g. OPENAI_API_KEY) in the "
+            "'creative_studio' credentials section, then retry."
+        )
+
+    try:
+        await _THROTTLER.acquire()
+        edited = await provider.edit(in_path.read_bytes(), instruction)
+    except NotSupportedError as exc:
+        return _error(
+            f"provider {provider.name!r} does not support image editing: {exc}"
+        )
+    except Exception as exc:  # noqa: BLE001 — surface as an error envelope
+        logger.warning("creative_studio_edit_visual failed", exc_info=True)
+        return _error(f"image edit failed: {exc}")
+
+    out_path = write_bytes(_next_free_edit_path(in_path), edited)
+    try:
+        validate_image_file(
+            str(out_path),
+            max_size_bytes=_MAX_IMAGE_BYTES,
+            max_size_label=_MAX_IMAGE_LABEL,
+            allowed_extensions=_ALLOWED_IMAGE_EXTENSIONS,
+        )
+    except (ValueError, FileNotFoundError) as exc:
+        return _error(f"edited image failed validation: {exc}")
+
+    sha = sha256_of(out_path)
+    _studio_audit(
+        "creative_studio_edit_visual",
+        f"Edited visual {in_path.name} -> {out_path.name} via {provider.name}",
+        {"input": str(in_path), "output": str(out_path), "provider": provider.name},
+    )
+    return _json_result(
+        {"path": str(out_path), "sha256": sha, "provider": provider.name}
+    )
+
+
+async def _handle_compose(arguments: dict[str, Any]) -> list[TextContent]:
+    visual_path = _require(arguments, "visual_path")
+    headline = _require(arguments, "headline")
+    cta = _require(arguments, "cta")
+    body = _opt(arguments, "body")
+    badge = _opt(arguments, "badge")
+    template = _opt(arguments, "template", "hero_overlay")
+    formats = _opt(arguments, "formats") or ["meta_feed_1x1"]
+
+    try:
+        vpath = validate_image_file(
+            str(visual_path),
+            max_size_bytes=_MAX_IMAGE_BYTES,
+            max_size_label=_MAX_IMAGE_LABEL,
+            allowed_extensions=_COMPOSE_INPUT_EXTENSIONS,
+        )
+    except (ValueError, FileNotFoundError) as exc:
+        return _error(f"invalid visual path: {exc}")
+
+    if template not in composer.TEMPLATES:
+        valid = ", ".join(composer.TEMPLATES)
+        return _error(f"unknown template {template!r}. Valid templates: {valid}")
+
+    if not isinstance(formats, list) or not formats:
+        return _error("formats must be a non-empty array of format ids")
+    unknown = [f for f in formats if f not in FORMATS_BY_ID]
+    if unknown:
+        valid = ", ".join(sorted(FORMATS_BY_ID))
+        return _error(f"unknown format id(s): {unknown}. Valid format ids: {valid}")
+
+    brand = load_brand_kit()
+    copy = composer.CopySpec(headline=headline, body=body, cta=cta, badge=badge)
+
+    run_dir = create_run_dir()
+    run_id = run_dir.name
+
+    try:
+        files_meta = await composer.compose(
+            vpath, copy, template, formats, brand, run_dir
+        )
+    except RuntimeError as exc:
+        # Missing 'creative' extra — surface the pip hint verbatim.
+        return _error(str(exc))
+    except Exception as exc:  # noqa: BLE001 — surface as an error envelope
+        logger.warning("creative_studio_compose failed", exc_info=True)
+        return _error(f"composition failed: {exc}")
+
+    manifest_data: dict[str, Any] = {
+        "kind": "compose",
+        "run_id": run_id,
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "template": template,
+        "inputs": {
+            "visual_path": str(vpath),
+            "visual_sha256": sha256_of(vpath),
+        },
+        "copy": {"headline": headline, "body": body, "cta": cta, "badge": badge},
+        "brand": _brand_summary(brand),
+        "files": files_meta,
+    }
+    manifest_path = write_manifest(run_dir, manifest_data)
+    _studio_audit(
+        "creative_studio_compose",
+        f"Composed {len(files_meta)} banner(s) with '{template}' (run {run_id})",
+        {"run_id": run_id, "manifest_path": str(manifest_path)},
+    )
+
+    return _json_result(
+        {
+            "run_id": run_id,
+            "run_dir": str(run_dir),
+            "files": files_meta,
+            "manifest": str(manifest_path),
+        }
+    )
+
+
+def _studio_audit(action: str, summary: str, metrics: dict[str, Any]) -> None:
+    """Best-effort audit-only action_log entry. No-op without STATE.json.
+
+    Mirrors :func:`_record_audit`: wrapped in try/except so it never breaks
+    the tool call, and records nothing when there is no STATE.json in the
+    current working directory. ``reversible_params`` is ``None`` — composition
+    and edits write local files only and are not platform mutations to
+    reverse.
+    """
+    try:
+        state_path = Path.cwd() / "STATE.json"
+        if not state_path.is_file():
+            return
+        from mureo.context.models import ActionLogEntry
+        from mureo.context.state import append_action_log
+
+        now = datetime.now(timezone.utc)
+        entry = ActionLogEntry(
+            timestamp=now.isoformat(timespec="seconds"),
+            action=action,
+            platform="creative_studio",
+            summary=summary,
+            command=action,
+            metrics_at_action=metrics,
+            reversible_params=None,
+        )
+        append_action_log(state_path, entry)
+    except Exception:  # noqa: BLE001 — auditing must never break the tool call
+        logger.warning(
+            "creative_studio audit action_log promotion failed", exc_info=True
+        )
+
+
 _HANDLERS = {
     "creative_studio_providers_list": _handle_providers_list,
     "creative_studio_generate_visual": _handle_generate_visual,
+    "creative_studio_brand_kit_get": _handle_brand_kit_get,
+    "creative_studio_edit_visual": _handle_edit_visual,
+    "creative_studio_compose": _handle_compose,
 }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,10 @@ creative = [
     "pillow>=10.0",
 ]
 dev = [
+    # jinja2 backs the composer template unit tests (the browser layer is
+    # mocked; playwright/pillow stay out of CI — they live in the "creative"
+    # runtime extra only).
+    "jinja2>=3.1,<4",
     "pytest>=7.4,<9",
     "pytest-asyncio>=0.23,<1",
     "pytest-cov>=4.1,<7",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,17 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# Creative Studio composition (PR-B). jinja2 renders the HTML/CSS banner
+# templates and playwright rasterises them with headless Chromium; pillow is
+# available for optional crop/resize helpers. All three are lazily imported
+# (mureo.creative_studio.composer) so a core install stays lean — the tools
+# raise a clear "pip install 'mureo[creative]'" message when the extra is
+# absent. PyYAML (brand kit) and httpx (font pipeline) are already core deps.
+creative = [
+    "jinja2>=3.1",
+    "playwright>=1.40",
+    "pillow>=10.0",
+]
 dev = [
     "pytest>=7.4,<9",
     "pytest-asyncio>=0.23,<1",

--- a/tests/creative_studio/test_brand_kit.py
+++ b/tests/creative_studio/test_brand_kit.py
@@ -176,3 +176,21 @@ def test_empty_kit_yml_returns_defaults(tmp_path: Path) -> None:
     _write_kit(tmp_path, "")
     kit = load_brand_kit(base=tmp_path)
     assert kit == DEFAULT_BRAND_KIT
+
+
+@pytest.mark.unit
+def test_font_name_css_injection_rejected(tmp_path, recwarn):
+    """A font name that could break out of the CSS string context (templates
+    mark font names ``| safe``) is rejected and the default kept."""
+    kit_dir = tmp_path / "BRAND_KIT"
+    kit_dir.mkdir()
+    (kit_dir / "kit.yml").write_text(
+        "fonts:\n"
+        '  heading: "\'; } </style><script>alert(1)</script>"\n'
+        "  body: 'Zen Kaku Gothic New'\n",
+        encoding="utf-8",
+    )
+    kit = load_brand_kit(tmp_path)
+    assert kit.fonts["heading"] == DEFAULT_BRAND_KIT.fonts["heading"]
+    assert kit.fonts["body"] == "Zen Kaku Gothic New"
+    assert any("heading" in str(w.message) for w in recwarn.list)

--- a/tests/creative_studio/test_brand_kit.py
+++ b/tests/creative_studio/test_brand_kit.py
@@ -1,0 +1,178 @@
+"""Unit tests for the Creative Studio brand-kit loader.
+
+The loader must NEVER raise on a malformed kit: quality of output must not
+depend on config hygiene, so every field degrades to a tasteful default
+independently and a warning is emitted instead of an exception.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from mureo.creative_studio.brand_kit import (
+    DEFAULT_BRAND_KIT,
+    BrandKit,
+    BrandKitWarning,
+    load_brand_kit,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_kit(base: Path, text: str) -> None:
+    kit_dir = base / "BRAND_KIT"
+    kit_dir.mkdir(parents=True, exist_ok=True)
+    (kit_dir / "kit.yml").write_text(text, encoding="utf-8")
+
+
+def _write_logo(base: Path, name: str = "logo.png") -> Path:
+    kit_dir = base / "BRAND_KIT"
+    kit_dir.mkdir(parents=True, exist_ok=True)
+    logo = kit_dir / name
+    logo.write_bytes(b"\x89PNG\r\n\x1a\n fake logo bytes")
+    return logo
+
+
+@pytest.mark.unit
+def test_default_brand_kit_shape() -> None:
+    assert isinstance(DEFAULT_BRAND_KIT, BrandKit)
+    assert DEFAULT_BRAND_KIT.colors["primary"] == "#1a1d29"
+    assert DEFAULT_BRAND_KIT.colors["accent"] == "#4f46e5"
+    assert DEFAULT_BRAND_KIT.colors["text"] == "#111827"
+    assert DEFAULT_BRAND_KIT.colors["background"] == "#ffffff"
+    assert DEFAULT_BRAND_KIT.fonts["heading"] == "Noto Sans JP"
+    assert DEFAULT_BRAND_KIT.fonts["body"] == "Noto Sans JP"
+    assert DEFAULT_BRAND_KIT.logo_path is None
+    assert DEFAULT_BRAND_KIT.logo_min_clear_px == 24
+
+
+@pytest.mark.unit
+def test_brand_kit_is_frozen() -> None:
+    import dataclasses
+
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        DEFAULT_BRAND_KIT.logo_min_clear_px = 1  # type: ignore[misc]
+
+
+@pytest.mark.unit
+def test_missing_file_returns_defaults(tmp_path: Path) -> None:
+    kit = load_brand_kit(base=tmp_path)
+    assert kit == DEFAULT_BRAND_KIT
+
+
+@pytest.mark.unit
+def test_parses_kit_yml(tmp_path: Path) -> None:
+    _write_kit(
+        tmp_path,
+        """
+colors:
+  primary: "#0055ff"
+  accent: "#ff8800"
+fonts:
+  heading: "Zen Kaku Gothic New"
+  body: "Noto Sans JP"
+logo_min_clear_px: 40
+""",
+    )
+    kit = load_brand_kit(base=tmp_path)
+    assert kit.colors["primary"] == "#0055ff"
+    assert kit.colors["accent"] == "#ff8800"
+    # Unspecified colors keep defaults.
+    assert kit.colors["text"] == DEFAULT_BRAND_KIT.colors["text"]
+    assert kit.fonts["heading"] == "Zen Kaku Gothic New"
+    assert kit.fonts["body"] == "Noto Sans JP"
+    assert kit.logo_min_clear_px == 40
+
+
+@pytest.mark.unit
+def test_three_digit_hex_accepted(tmp_path: Path) -> None:
+    _write_kit(tmp_path, 'colors:\n  primary: "#fa0"\n')
+    kit = load_brand_kit(base=tmp_path)
+    assert kit.colors["primary"] == "#fa0"
+
+
+@pytest.mark.unit
+def test_invalid_hex_falls_back_per_field(tmp_path: Path) -> None:
+    _write_kit(
+        tmp_path,
+        'colors:\n  primary: "not-a-color"\n  accent: "#123456"\n',
+    )
+    with pytest.warns(BrandKitWarning):
+        kit = load_brand_kit(base=tmp_path)
+    # The bad field degrades to its default; the good field is applied.
+    assert kit.colors["primary"] == DEFAULT_BRAND_KIT.colors["primary"]
+    assert kit.colors["accent"] == "#123456"
+
+
+@pytest.mark.unit
+def test_valid_logo_resolved(tmp_path: Path) -> None:
+    logo = _write_logo(tmp_path)
+    _write_kit(tmp_path, 'logo: "logo.png"\n')
+    kit = load_brand_kit(base=tmp_path)
+    assert kit.logo_path is not None
+    assert kit.logo_path == logo.resolve()
+
+
+@pytest.mark.unit
+def test_invalid_logo_treated_as_absent(tmp_path: Path) -> None:
+    # A .txt logo fails the image-file validation -> absent + warning.
+    kit_dir = tmp_path / "BRAND_KIT"
+    kit_dir.mkdir(parents=True)
+    (kit_dir / "logo.txt").write_text("nope")
+    (kit_dir / "kit.yml").write_text('logo: "logo.txt"\n', encoding="utf-8")
+    with pytest.warns(BrandKitWarning):
+        kit = load_brand_kit(base=tmp_path)
+    assert kit.logo_path is None
+
+
+@pytest.mark.unit
+def test_missing_logo_file_treated_as_absent(tmp_path: Path) -> None:
+    _write_kit(tmp_path, 'logo: "does_not_exist.png"\n')
+    with pytest.warns(BrandKitWarning):
+        kit = load_brand_kit(base=tmp_path)
+    assert kit.logo_path is None
+
+
+@pytest.mark.unit
+def test_logo_traversal_rejected(tmp_path: Path) -> None:
+    _write_kit(tmp_path, 'logo: "../../etc/passwd"\n')
+    with pytest.warns(BrandKitWarning):
+        kit = load_brand_kit(base=tmp_path)
+    assert kit.logo_path is None
+
+
+@pytest.mark.unit
+def test_unknown_keys_ignored(tmp_path: Path) -> None:
+    _write_kit(
+        tmp_path,
+        'colors:\n  primary: "#010203"\n  bogus: "#ffffff"\nmystery: 42\n',
+    )
+    kit = load_brand_kit(base=tmp_path)
+    assert kit.colors["primary"] == "#010203"
+    assert "bogus" not in kit.colors
+
+
+@pytest.mark.unit
+def test_garbage_yaml_never_raises(tmp_path: Path) -> None:
+    _write_kit(tmp_path, "colors: [unclosed, list\n  primary: nope::")
+    with pytest.warns(BrandKitWarning):
+        kit = load_brand_kit(base=tmp_path)
+    assert kit == DEFAULT_BRAND_KIT
+
+
+@pytest.mark.unit
+def test_non_mapping_yaml_never_raises(tmp_path: Path) -> None:
+    _write_kit(tmp_path, "just a scalar string")
+    with pytest.warns(BrandKitWarning):
+        kit = load_brand_kit(base=tmp_path)
+    assert kit == DEFAULT_BRAND_KIT
+
+
+@pytest.mark.unit
+def test_empty_kit_yml_returns_defaults(tmp_path: Path) -> None:
+    _write_kit(tmp_path, "")
+    kit = load_brand_kit(base=tmp_path)
+    assert kit == DEFAULT_BRAND_KIT

--- a/tests/creative_studio/test_composer.py
+++ b/tests/creative_studio/test_composer.py
@@ -1,0 +1,411 @@
+"""Unit tests for the Creative Studio HTML/CSS composition engine.
+
+Template rendering (``render_html``) is pure and exercised directly. The
+browser step (``compose``) is driven with a FAKE ``browser_factory`` that
+records viewports and returns a constant PNG, so Playwright is never
+launched. Font embedding is stubbed so no network is touched.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import pytest
+
+from mureo.creative_studio import composer as composer_mod
+from mureo.creative_studio.brand_kit import DEFAULT_BRAND_KIT
+from mureo.creative_studio.composer import TEMPLATES, CopySpec, compose, render_html
+from mureo.creative_studio.formats import FORMATS_BY_ID
+
+_VISUAL_URI = "data:image/png;base64,QUJD"
+_LOGO_URI = "data:image/png;base64,TE9HTw=="
+# 1x1 transparent PNG — a constant the fake browser "screenshots".
+_ONE_PX_PNG = bytes.fromhex(
+    "89504e470d0a1a0a0000000d494844520000000100000001080600000"
+    "01f15c4890000000a49444154789c6300010000050001"
+    "0d0a2db40000000049454e44ae426082"
+)
+
+
+def _copy(**over: object) -> CopySpec:
+    base = {
+        "headline": "強力な見出し",
+        "body": "本文の説明",
+        "cta": "今すぐ購入",
+        "badge": None,
+    }
+    base.update(over)
+    return CopySpec(**base)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# render_html
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_templates_constant() -> None:
+    assert TEMPLATES == ("hero_overlay", "split", "minimal_badge")
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("template", TEMPLATES)
+def test_render_html_exact_viewport(template: str) -> None:
+    fmt = FORMATS_BY_ID["meta_feed_1x1"]
+    html = render_html(
+        template=template,
+        fmt=fmt,
+        copy=_copy(badge="限定"),
+        brand=DEFAULT_BRAND_KIT,
+        visual_data_uri=_VISUAL_URI,
+    )
+    assert "1080px" in html
+    # Body must not scroll: exact size + hidden overflow.
+    assert "overflow:hidden" in html.replace(" ", "")
+    assert "box-sizing:border-box" in html.replace(" ", "")
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("template", TEMPLATES)
+def test_render_html_small_format_dimensions(template: str) -> None:
+    fmt = FORMATS_BY_ID["gdn_728x90"]
+    html = render_html(
+        template=template,
+        fmt=fmt,
+        copy=_copy(badge="SALE"),
+        brand=DEFAULT_BRAND_KIT,
+        visual_data_uri=_VISUAL_URI,
+    )
+    assert "728px" in html
+    assert "90px" in html
+    assert "--u" in html  # clamp unit custom property present
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("template", TEMPLATES)
+def test_render_html_autoescapes_headline(template: str) -> None:
+    html = render_html(
+        template=template,
+        fmt=FORMATS_BY_ID["meta_feed_1x1"],
+        copy=_copy(headline="<script>alert(1)</script>", badge="限定"),
+        brand=DEFAULT_BRAND_KIT,
+        visual_data_uri=_VISUAL_URI,
+    )
+    assert "<script>alert(1)</script>" not in html
+    assert "&lt;script&gt;" in html
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("template", TEMPLATES)
+def test_render_html_default_safe_area_4pct(template: str) -> None:
+    html = render_html(
+        template=template,
+        fmt=FORMATS_BY_ID["meta_feed_1x1"],
+        copy=_copy(badge="限定"),
+        brand=DEFAULT_BRAND_KIT,
+        visual_data_uri=_VISUAL_URI,
+    )
+    assert "4%" in html
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("template", TEMPLATES)
+def test_render_html_story_safe_area(template: str) -> None:
+    html = render_html(
+        template=template,
+        fmt=FORMATS_BY_ID["story_9x16"],
+        copy=_copy(badge="限定"),
+        brand=DEFAULT_BRAND_KIT,
+        visual_data_uri=_VISUAL_URI,
+    )
+    # story_9x16 reserves extra chrome room top/bottom.
+    assert "14%" in html
+    assert "20%" in html
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("template", TEMPLATES)
+def test_render_html_embeds_visual_data_uri(template: str) -> None:
+    html = render_html(
+        template=template,
+        fmt=FORMATS_BY_ID["meta_feed_1x1"],
+        copy=_copy(badge="限定"),
+        brand=DEFAULT_BRAND_KIT,
+        visual_data_uri=_VISUAL_URI,
+    )
+    assert _VISUAL_URI in html
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("template", TEMPLATES)
+def test_render_html_cta_present(template: str) -> None:
+    html = render_html(
+        template=template,
+        fmt=FORMATS_BY_ID["meta_feed_1x1"],
+        copy=_copy(cta="ここをクリック", badge="限定"),
+        brand=DEFAULT_BRAND_KIT,
+        visual_data_uri=_VISUAL_URI,
+    )
+    assert "ここをクリック" in html
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("template", TEMPLATES)
+def test_render_html_body_conditional(template: str) -> None:
+    with_body = render_html(
+        template=template,
+        fmt=FORMATS_BY_ID["meta_feed_1x1"],
+        copy=_copy(body="ユニークな本文マーカー", badge="限定"),
+        brand=DEFAULT_BRAND_KIT,
+        visual_data_uri=_VISUAL_URI,
+    )
+    assert "ユニークな本文マーカー" in with_body
+
+    without_body = render_html(
+        template=template,
+        fmt=FORMATS_BY_ID["meta_feed_1x1"],
+        copy=_copy(body=None, badge="限定"),
+        brand=DEFAULT_BRAND_KIT,
+        visual_data_uri=_VISUAL_URI,
+    )
+    assert "ユニークな本文マーカー" not in without_body
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("template", TEMPLATES)
+def test_render_html_logo_conditional(template: str) -> None:
+    with_logo = render_html(
+        template=template,
+        fmt=FORMATS_BY_ID["meta_feed_1x1"],
+        copy=_copy(badge="限定"),
+        brand=DEFAULT_BRAND_KIT,
+        visual_data_uri=_VISUAL_URI,
+        logo_data_uri=_LOGO_URI,
+    )
+    assert _LOGO_URI in with_logo
+
+    without_logo = render_html(
+        template=template,
+        fmt=FORMATS_BY_ID["meta_feed_1x1"],
+        copy=_copy(badge="限定"),
+        brand=DEFAULT_BRAND_KIT,
+        visual_data_uri=_VISUAL_URI,
+        logo_data_uri=None,
+    )
+    assert _LOGO_URI not in without_logo
+
+
+@pytest.mark.unit
+def test_render_html_badge_on_minimal_badge() -> None:
+    html = render_html(
+        template="minimal_badge",
+        fmt=FORMATS_BY_ID["meta_feed_1x1"],
+        copy=_copy(badge="限定オファー"),
+        brand=DEFAULT_BRAND_KIT,
+        visual_data_uri=_VISUAL_URI,
+    )
+    assert "限定オファー" in html
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("template", TEMPLATES)
+def test_render_html_injects_font_css(template: str) -> None:
+    marker = "@font-face{font-family:'MARKERFONT'}"
+    html = render_html(
+        template=template,
+        fmt=FORMATS_BY_ID["meta_feed_1x1"],
+        copy=_copy(badge="限定"),
+        brand=DEFAULT_BRAND_KIT,
+        visual_data_uri=_VISUAL_URI,
+        font_css=marker,
+    )
+    assert marker in html
+
+
+@pytest.mark.unit
+def test_render_html_unknown_template_raises() -> None:
+    with pytest.raises(ValueError, match="template"):
+        render_html(
+            template="does_not_exist",
+            fmt=FORMATS_BY_ID["meta_feed_1x1"],
+            copy=_copy(),
+            brand=DEFAULT_BRAND_KIT,
+            visual_data_uri=_VISUAL_URI,
+        )
+
+
+@pytest.mark.unit
+def test_render_html_missing_jinja_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    real_import = importlib.import_module
+
+    def fake_import(name: str, *args: object, **kwargs: object):
+        if name == "jinja2":
+            raise ImportError("no jinja2")
+        return real_import(name, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(composer_mod.importlib, "import_module", fake_import)
+    with pytest.raises(RuntimeError, match=r"mureo\[creative\]"):
+        render_html(
+            template="hero_overlay",
+            fmt=FORMATS_BY_ID["meta_feed_1x1"],
+            copy=_copy(),
+            brand=DEFAULT_BRAND_KIT,
+            visual_data_uri=_VISUAL_URI,
+        )
+
+
+# ---------------------------------------------------------------------------
+# compose (orchestration) with a fake browser
+# ---------------------------------------------------------------------------
+
+
+class _FakePage:
+    def __init__(self, owner: _FakeBrowser) -> None:
+        self._owner = owner
+
+    async def set_content(self, html: str) -> None:
+        self._owner.htmls.append(html)
+
+    async def evaluate(self, script: str) -> bool:
+        self._owner.evaluated.append(script)
+        return True
+
+    async def screenshot(self, *, type: str = "png") -> bytes:  # noqa: A002
+        self._owner.screenshot_types.append(type)
+        return _ONE_PX_PNG
+
+    async def close(self) -> None:
+        return None
+
+
+class _FakeBrowser:
+    def __init__(self) -> None:
+        self.viewports: list[dict[str, int]] = []
+        self.htmls: list[str] = []
+        self.evaluated: list[str] = []
+        self.screenshot_types: list[str] = []
+
+    async def new_page(self, *, viewport: dict[str, int]) -> _FakePage:
+        self.viewports.append(viewport)
+        return _FakePage(self)
+
+
+def _fake_factory(browser: _FakeBrowser):
+    @asynccontextmanager
+    async def factory():
+        yield browser
+
+    return factory
+
+
+@pytest.mark.unit
+async def test_compose_writes_files_per_format(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(composer_mod, "_embedded_font_css", lambda: "")
+    visual = tmp_path / "visual.png"
+    visual.write_bytes(b"\x89PNG\r\n\x1a\n visual bytes")
+    out = tmp_path / "out"
+    out.mkdir()
+
+    browser = _FakeBrowser()
+    fmt_ids = ["meta_feed_1x1", "gdn_300x250"]
+    results = await compose(
+        visual,
+        _copy(),
+        "hero_overlay",
+        fmt_ids,
+        DEFAULT_BRAND_KIT,
+        out,
+        browser_factory=_fake_factory(browser),
+    )
+
+    assert [r["format"] for r in results] == fmt_ids
+    for entry, fid in zip(results, fmt_ids, strict=True):
+        path = Path(entry["path"])
+        assert path.exists()
+        assert path.name == f"{fid}_hero_overlay.png"
+        assert entry["sha256"]
+        fmt = FORMATS_BY_ID[fid]
+        assert entry["width"] == fmt.width
+        assert entry["height"] == fmt.height
+
+    # One page per format, with the exact viewport of that format.
+    assert browser.viewports == [
+        {"width": 1080, "height": 1080},
+        {"width": 300, "height": 250},
+    ]
+    # Fonts-ready gate is awaited once per format.
+    assert len(browser.evaluated) == 2
+
+
+@pytest.mark.unit
+async def test_compose_embeds_logo_when_present(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import dataclasses
+
+    monkeypatch.setattr(composer_mod, "_embedded_font_css", lambda: "")
+    visual = tmp_path / "visual.png"
+    visual.write_bytes(b"\x89PNG visual")
+    logo = tmp_path / "logo.png"
+    logo.write_bytes(b"\x89PNG logo")
+    brand = dataclasses.replace(DEFAULT_BRAND_KIT, logo_path=logo)
+    out = tmp_path / "out"
+    out.mkdir()
+
+    browser = _FakeBrowser()
+    await compose(
+        visual,
+        _copy(),
+        "hero_overlay",
+        ["meta_feed_1x1"],
+        brand,
+        out,
+        browser_factory=_fake_factory(browser),
+    )
+    # The composed HTML embeds a logo data URI.
+    assert "data:image/png;base64," in browser.htmls[0]
+    # Two data URIs at minimum: the visual and the logo.
+    assert browser.htmls[0].count("data:image/png;base64,") >= 2
+
+
+@pytest.mark.unit
+async def test_compose_unknown_template_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(composer_mod, "_embedded_font_css", lambda: "")
+    visual = tmp_path / "visual.png"
+    visual.write_bytes(b"\x89PNG visual")
+    out = tmp_path / "out"
+    out.mkdir()
+    with pytest.raises(ValueError, match="template"):
+        await compose(
+            visual,
+            _copy(),
+            "nope",
+            ["meta_feed_1x1"],
+            DEFAULT_BRAND_KIT,
+            out,
+            browser_factory=_fake_factory(_FakeBrowser()),
+        )
+
+
+@pytest.mark.unit
+def test_copy_spec_is_frozen() -> None:
+    import dataclasses
+
+    spec = _copy()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        spec.headline = "x"  # type: ignore[misc]
+
+
+@pytest.mark.unit
+def test_manifest_helper_round_trip(tmp_path: Path) -> None:
+    # Sanity guard that json metadata survives (used by the MCP compose tool).
+    data = {"kind": "compose", "template": "split", "files": []}
+    (tmp_path / "m.json").write_text(json.dumps(data), encoding="utf-8")
+    assert json.loads((tmp_path / "m.json").read_text())["kind"] == "compose"

--- a/tests/creative_studio/test_fonts.py
+++ b/tests/creative_studio/test_fonts.py
@@ -1,0 +1,184 @@
+"""Unit tests for the Creative Studio Japanese-font pipeline.
+
+No real network is used: an :class:`httpx.MockTransport` is injected via the
+``client_factory`` seam so the download path is exercised deterministically.
+``ensure_font`` must never raise — every failure degrades to ``None`` plus a
+warning so an offline machine still composes (falling back to system fonts).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from mureo.creative_studio import fonts as fonts_mod
+from mureo.creative_studio.fonts import (
+    FALLBACK_STACK,
+    FONT_MANIFEST,
+    FontSpec,
+    FontWarning,
+    ensure_font,
+    font_face_css,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+# A minimal valid TrueType header (magic 0x00010000) padded past the 10KB floor.
+_TTF_MAGIC = b"\x00\x01\x00\x00"
+_VALID_TTF = _TTF_MAGIC + b"\x00" * 11_000
+
+
+def _factory(handler: Callable[[httpx.Request], httpx.Response]):
+    transport = httpx.MockTransport(handler)
+
+    def make() -> httpx.Client:
+        return httpx.Client(transport=transport)
+
+    return make
+
+
+def _ok_handler(content: bytes) -> Callable[[httpx.Request], httpx.Response]:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=content)
+
+    return handler
+
+
+@pytest.mark.unit
+def test_manifest_has_two_faces() -> None:
+    names = {spec.name for spec in FONT_MANIFEST}
+    assert "Noto Sans JP" in names
+    assert "Zen Kaku Gothic New" in names
+    for spec in FONT_MANIFEST:
+        assert isinstance(spec, FontSpec)
+        assert spec.url.startswith("https://")
+        assert spec.filename
+        assert spec.format
+
+
+@pytest.mark.unit
+def test_ensure_font_returns_existing_without_download(tmp_path: Path) -> None:
+    spec = FONT_MANIFEST[0]
+    dest = tmp_path / spec.filename
+    dest.write_bytes(_VALID_TTF)
+
+    def exploding() -> httpx.Client:
+        raise AssertionError("should not download when the font already exists")
+
+    result = ensure_font(spec, dest_dir=tmp_path, client_factory=exploding)
+    assert result == dest
+
+
+@pytest.mark.unit
+def test_ensure_font_downloads_and_records_lockfile(tmp_path: Path) -> None:
+    import hashlib
+
+    spec = FONT_MANIFEST[0]
+    result = ensure_font(
+        spec, dest_dir=tmp_path, client_factory=_factory(_ok_handler(_VALID_TTF))
+    )
+    assert result is not None
+    assert result.exists()
+    assert result.read_bytes() == _VALID_TTF
+
+    lock = json.loads((tmp_path / "manifest.lock.json").read_text(encoding="utf-8"))
+    entry = lock[spec.filename]
+    assert entry["filename"] == spec.filename
+    assert entry["source_url"] == spec.url
+    assert entry["sha256"] == hashlib.sha256(_VALID_TTF).hexdigest()
+    assert entry["fetched_at"]
+
+
+@pytest.mark.unit
+def test_ensure_font_rejects_bad_magic(tmp_path: Path) -> None:
+    spec = FONT_MANIFEST[0]
+    garbage = b"NOT-A-FONT" + b"\x00" * 11_000
+    with pytest.warns(FontWarning):
+        result = ensure_font(
+            spec, dest_dir=tmp_path, client_factory=_factory(_ok_handler(garbage))
+        )
+    assert result is None
+    assert not (tmp_path / spec.filename).exists()
+
+
+@pytest.mark.unit
+def test_ensure_font_rejects_too_small(tmp_path: Path) -> None:
+    spec = FONT_MANIFEST[0]
+    tiny = _TTF_MAGIC + b"\x00" * 10  # valid magic but well under 10KB
+    with pytest.warns(FontWarning):
+        result = ensure_font(
+            spec, dest_dir=tmp_path, client_factory=_factory(_ok_handler(tiny))
+        )
+    assert result is None
+
+
+@pytest.mark.unit
+def test_ensure_font_rejects_too_large(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    spec = FONT_MANIFEST[0]
+    # Shrink the ceiling so the test needn't allocate 40MB.
+    monkeypatch.setattr(fonts_mod, "_MAX_FONT_BYTES", 12_000)
+    oversized = _TTF_MAGIC + b"\x00" * 20_000
+    with pytest.warns(FontWarning):
+        result = ensure_font(
+            spec, dest_dir=tmp_path, client_factory=_factory(_ok_handler(oversized))
+        )
+    assert result is None
+
+
+@pytest.mark.unit
+def test_ensure_font_network_failure_returns_none(tmp_path: Path) -> None:
+    spec = FONT_MANIFEST[0]
+
+    def boom(_request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("no network")
+
+    with pytest.warns(FontWarning):
+        result = ensure_font(spec, dest_dir=tmp_path, client_factory=_factory(boom))
+    assert result is None
+
+
+@pytest.mark.unit
+def test_ensure_font_http_error_returns_none(tmp_path: Path) -> None:
+    spec = FONT_MANIFEST[0]
+
+    def not_found(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, content=b"missing")
+
+    with pytest.warns(FontWarning):
+        result = ensure_font(
+            spec, dest_dir=tmp_path, client_factory=_factory(not_found)
+        )
+    assert result is None
+
+
+@pytest.mark.unit
+def test_font_face_css_embeds_data_uri_and_fallback(tmp_path: Path) -> None:
+    spec = FONT_MANIFEST[0]
+    font_file = tmp_path / spec.filename
+    font_file.write_bytes(_VALID_TTF)
+
+    css = font_face_css({spec.name: font_file})
+    assert "@font-face" in css
+    assert "data:font/ttf;base64," in css
+    assert spec.name in css
+    assert FALLBACK_STACK in css
+
+
+@pytest.mark.unit
+def test_font_face_css_empty_when_no_fonts() -> None:
+    css = font_face_css({})
+    # Still surfaces the fallback stack so callers can reference it.
+    assert FALLBACK_STACK in css
+
+
+@pytest.mark.unit
+def test_fallback_stack_contents() -> None:
+    assert "Noto Sans JP" in FALLBACK_STACK
+    assert "sans-serif" in FALLBACK_STACK

--- a/tests/creative_studio/test_formats.py
+++ b/tests/creative_studio/test_formats.py
@@ -9,9 +9,11 @@ import pytest
 from mureo.creative_studio.formats import (
     FORMATS,
     FORMATS_BY_ID,
+    SAFE_AREAS,
     CreativeFormat,
     aspect_for,
     generation_size_for_aspect,
+    safe_area_for,
 )
 
 _EXPECTED_IDS = {
@@ -121,3 +123,50 @@ def test_generation_size_for_aspect() -> None:
 def test_generation_size_for_aspect_unknown_raises() -> None:
     with pytest.raises(ValueError):
         generation_size_for_aspect("bogus")
+
+
+# ---------------------------------------------------------------------------
+# Per-format safe areas (PR-B)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_safe_areas_cover_every_format() -> None:
+    assert set(SAFE_AREAS) == _EXPECTED_IDS
+    for insets in SAFE_AREAS.values():
+        assert set(insets) == {"top", "right", "bottom", "left"}
+        for value in insets.values():
+            assert 0.0 <= value < 0.5
+
+
+@pytest.mark.unit
+def test_safe_area_for_default_is_four_percent() -> None:
+    insets = safe_area_for("meta_feed_1x1")
+    assert insets == {"top": 0.04, "right": 0.04, "bottom": 0.04, "left": 0.04}
+
+
+@pytest.mark.unit
+def test_safe_area_for_story_reserves_platform_chrome() -> None:
+    insets = safe_area_for("story_9x16")
+    assert insets["top"] == 0.14
+    assert insets["bottom"] == 0.20
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("format_id", ["gdn_728x90", "gdn_160x600"])
+def test_safe_area_for_small_gdn_units(format_id: str) -> None:
+    insets = safe_area_for(format_id)
+    assert insets == {"top": 0.02, "right": 0.02, "bottom": 0.02, "left": 0.02}
+
+
+@pytest.mark.unit
+def test_safe_area_for_returns_copy(format_id: str = "meta_feed_1x1") -> None:
+    a = safe_area_for(format_id)
+    a["top"] = 0.99
+    assert safe_area_for(format_id)["top"] == 0.04  # not mutated by caller
+
+
+@pytest.mark.unit
+def test_safe_area_for_unknown_raises() -> None:
+    with pytest.raises(KeyError):
+        safe_area_for("does_not_exist")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -44,10 +44,10 @@ class TestListTools:
     async def test_list_tools_returns_all_tools(self) -> None:
         """list_tools returns all tools (Google Ads 86 + Meta Ads 82 + Search Console 10
         + Rollback 2 + Analysis 1 + Mureo Context 9 + Analytics Registry 1
-        + Learning 2 + Creative Studio 2 = 195)."""
+        + Learning 2 + Creative Studio 5 = 198)."""
         mod = _import_server_module()
         tools = await mod.handle_list_tools()
-        assert len(tools) == 195
+        assert len(tools) == 198
 
     async def test_list_tools_contains_google_and_meta(self) -> None:
         """Google Ads and Meta Ads tools are included."""

--- a/tests/test_mcp_tools_creative_studio.py
+++ b/tests/test_mcp_tools_creative_studio.py
@@ -64,6 +64,9 @@ def test_tool_names_are_prefixed() -> None:
     assert names == {
         "creative_studio_providers_list",
         "creative_studio_generate_visual",
+        "creative_studio_brand_kit_get",
+        "creative_studio_edit_visual",
+        "creative_studio_compose",
     }
     for tool in mod.TOOLS:
         assert tool.name.startswith("creative_studio_")
@@ -247,3 +250,295 @@ async def test_generate_visual_named_unconfigured_provider_errors(
 async def test_handle_tool_unknown_name_raises() -> None:
     with pytest.raises(ValueError, match="Unknown tool"):
         await mod.handle_tool("creative_studio_nope", {})
+
+
+# ---------------------------------------------------------------------------
+# PR-B: schemas for the composer / brand-kit / edit tools
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_compose_schema_constraints() -> None:
+    tool = next(t for t in mod.TOOLS if t.name == "creative_studio_compose")
+    props = tool.inputSchema["properties"]
+    assert props["visual_path"]["type"] == "string"
+    assert props["headline"]["minLength"] == 1
+    assert props["cta"]["type"] == "string"
+    assert set(props["template"]["enum"]) == set(mod.composer.TEMPLATES)
+    assert props["template"]["default"] == "hero_overlay"
+    assert props["formats"]["type"] == "array"
+    assert props["formats"]["default"] == ["meta_feed_1x1"]
+    assert set(tool.inputSchema["required"]) == {"visual_path", "headline", "cta"}
+
+
+@pytest.mark.unit
+def test_edit_visual_schema_constraints() -> None:
+    tool = next(t for t in mod.TOOLS if t.name == "creative_studio_edit_visual")
+    props = tool.inputSchema["properties"]
+    assert props["path"]["type"] == "string"
+    assert props["instruction"]["minLength"] == 1
+    assert "provider" in props
+    assert set(tool.inputSchema["required"]) == {"path", "instruction"}
+
+
+@pytest.mark.unit
+def test_brand_kit_get_schema_takes_no_args() -> None:
+    tool = next(t for t in mod.TOOLS if t.name == "creative_studio_brand_kit_get")
+    assert tool.inputSchema.get("properties", {}) == {}
+
+
+# ---------------------------------------------------------------------------
+# brand_kit_get handler
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_brand_kit_get_shape(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    result = await mod.handle_tool("creative_studio_brand_kit_get", {})
+    payload = _payload(result)
+    assert set(payload["colors"]) >= {
+        "primary",
+        "secondary",
+        "accent",
+        "text",
+        "background",
+    }
+    assert set(payload["fonts"]) == {"heading", "body"}
+    assert payload["logo"] is None
+    assert payload["defaults_used"] is True
+
+
+# ---------------------------------------------------------------------------
+# compose handler (fake composer — no Playwright)
+# ---------------------------------------------------------------------------
+
+
+async def _fake_compose(
+    visual_path: Path,
+    copy: object,
+    template: str,
+    formats: list[str],
+    brand: object,
+    out_dir: Path,
+    **_kwargs: object,
+) -> list[dict]:
+    files = []
+    for fid in formats:
+        p = Path(out_dir) / f"{fid}_{template}.png"
+        p.write_bytes(b"\x89PNG composed")
+        files.append(
+            {
+                "format": fid,
+                "path": str(p),
+                "sha256": "deadbeef",
+                "width": 1,
+                "height": 1,
+            }
+        )
+    return files
+
+
+@pytest.mark.unit
+async def test_compose_happy_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(mod.composer, "compose", _fake_compose)
+    visual = tmp_path / "v.png"
+    visual.write_bytes(b"\x89PNG raw visual")
+
+    result = await mod.handle_tool(
+        "creative_studio_compose",
+        {
+            "visual_path": str(visual),
+            "headline": "H",
+            "cta": "C",
+            "body": "B",
+            "template": "split",
+            "formats": ["meta_feed_1x1", "gdn_300x250"],
+        },
+    )
+    payload = _payload(result)
+    assert "run_id" in payload
+    assert Path(payload["run_dir"]).is_dir()
+    assert len(payload["files"]) == 2
+    manifest = json.loads(Path(payload["manifest"]).read_text(encoding="utf-8"))
+    assert manifest["kind"] == "compose"
+    assert manifest["template"] == "split"
+    assert manifest["copy"]["headline"] == "H"
+    assert manifest["inputs"]["visual_sha256"]
+    assert len(manifest["files"]) == 2
+
+
+@pytest.mark.unit
+async def test_compose_unknown_format_lists_valid_ids(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(mod.composer, "compose", _fake_compose)
+    visual = tmp_path / "v.png"
+    visual.write_bytes(b"\x89PNG raw visual")
+
+    result = await mod.handle_tool(
+        "creative_studio_compose",
+        {"visual_path": str(visual), "headline": "H", "cta": "C", "formats": ["bogus"]},
+    )
+    payload = _payload(result)
+    assert "error" in payload
+    assert "bogus" in payload["error"]
+    assert "meta_feed_1x1" in payload["error"]  # valid ids are listed
+
+
+@pytest.mark.unit
+async def test_compose_missing_extra_envelope(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    async def _raise(*_a: object, **_k: object) -> list[dict]:
+        raise RuntimeError(
+            "Creative Studio composition requires the 'creative' extra: "
+            "pip install 'mureo[creative]'"
+        )
+
+    monkeypatch.setattr(mod.composer, "compose", _raise)
+    visual = tmp_path / "v.png"
+    visual.write_bytes(b"\x89PNG raw visual")
+
+    result = await mod.handle_tool(
+        "creative_studio_compose",
+        {"visual_path": str(visual), "headline": "H", "cta": "C"},
+    )
+    payload = _payload(result)
+    assert "error" in payload
+    assert "mureo[creative]" in payload["error"]
+
+
+@pytest.mark.unit
+async def test_compose_rejects_bad_visual_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(mod.composer, "compose", _fake_compose)
+    bad = tmp_path / "v.txt"
+    bad.write_text("not an image")
+    result = await mod.handle_tool(
+        "creative_studio_compose",
+        {"visual_path": str(bad), "headline": "H", "cta": "C"},
+    )
+    assert "error" in _payload(result)
+
+
+# ---------------------------------------------------------------------------
+# edit_visual handler
+# ---------------------------------------------------------------------------
+
+
+class _EditProvider(_FakeProvider):
+    """A configured, edit-capable provider that returns edited bytes."""
+
+    def capabilities(self) -> dict:
+        return {"edit": True, "max_size": [1024, 1024]}
+
+    async def edit(self, image: bytes, instruction: str) -> bytes:
+        self.calls.append({"edit": instruction})
+        return b"EDITED-BYTES"
+
+
+class _LyingProvider(_FakeProvider):
+    """Advertises edit support but raises NotSupportedError at call time."""
+
+    def capabilities(self) -> dict:
+        return {"edit": True, "max_size": [1024, 1024]}
+
+    async def edit(self, image: bytes, instruction: str) -> bytes:
+        raise NotSupportedError("edit not actually supported")
+
+
+@pytest.mark.unit
+async def test_edit_visual_happy_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    prov = _EditProvider()
+    monkeypatch.setattr(mod, "available_providers", lambda: [prov])
+    img = tmp_path / "pic.png"
+    img.write_bytes(b"\x89PNG original")
+
+    result = await mod.handle_tool(
+        "creative_studio_edit_visual",
+        {"path": str(img), "instruction": "brighten the sky"},
+    )
+    payload = _payload(result)
+    assert payload["provider"] == "fake"
+    out = Path(payload["path"])
+    assert out.exists()
+    assert out.name == "pic_edit_1.png"
+    assert out.read_bytes() == b"EDITED-BYTES"
+    assert payload["sha256"]
+
+
+@pytest.mark.unit
+async def test_edit_visual_increments_suffix(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(mod, "available_providers", lambda: [_EditProvider()])
+    img = tmp_path / "pic.png"
+    img.write_bytes(b"\x89PNG original")
+    (tmp_path / "pic_edit_1.png").write_bytes(b"existing")
+
+    result = await mod.handle_tool(
+        "creative_studio_edit_visual",
+        {"path": str(img), "instruction": "x"},
+    )
+    assert Path(_payload(result)["path"]).name == "pic_edit_2.png"
+
+
+@pytest.mark.unit
+async def test_edit_visual_no_edit_capable_provider(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    # _FakeProvider advertises edit=False.
+    monkeypatch.setattr(mod, "available_providers", lambda: [_FakeProvider()])
+    img = tmp_path / "pic.png"
+    img.write_bytes(b"\x89PNG original")
+    result = await mod.handle_tool(
+        "creative_studio_edit_visual",
+        {"path": str(img), "instruction": "x"},
+    )
+    assert "error" in _payload(result)
+
+
+@pytest.mark.unit
+async def test_edit_visual_not_supported_envelope(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(mod, "available_providers", lambda: [_LyingProvider()])
+    img = tmp_path / "pic.png"
+    img.write_bytes(b"\x89PNG original")
+    result = await mod.handle_tool(
+        "creative_studio_edit_visual",
+        {"path": str(img), "instruction": "x"},
+    )
+    assert "error" in _payload(result)
+
+
+@pytest.mark.unit
+async def test_edit_visual_rejects_bad_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(mod, "available_providers", lambda: [_EditProvider()])
+    bad = tmp_path / "pic.txt"
+    bad.write_text("not an image")
+    result = await mod.handle_tool(
+        "creative_studio_edit_visual",
+        {"path": str(bad), "instruction": "x"},
+    )
+    assert "error" in _payload(result)

--- a/tests/test_web_auth.py
+++ b/tests/test_web_auth.py
@@ -13,6 +13,7 @@ the network.
 from __future__ import annotations
 
 import threading
+import sys
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -486,9 +487,22 @@ class TestMetaAdsSubmitRoute:
             method="POST",
             headers={"Content-Type": "application/x-www-form-urlencoded"},
         )
-        with pytest.raises(urllib.error.HTTPError) as exc_info:
+        try:
             urllib.request.urlopen(req, timeout=2.0)
-        assert exc_info.value.code == 413
+            raise AssertionError("oversize body was not rejected")
+        except urllib.error.HTTPError as exc:
+            assert exc.code == 413
+        except (ConnectionError, urllib.error.URLError) as exc:
+            # Windows: the server tears down the socket while the client is
+            # still sending the oversize body, surfacing as
+            # ConnectionAbortedError (WinError 10053) before the 413 response
+            # can be read. The request was still rejected — accept that on
+            # win32 only; POSIX must still see a clean 413. Mirrors the
+            # spoofed-Host tests in test_web_handlers.py.
+            if sys.platform != "win32":
+                raise AssertionError(
+                    f"expected HTTP 413, got {type(exc).__name__}: {exc}"
+                ) from exc
 
     def test_refuses_non_facebook_redirect_origin(self, wizard: Any) -> None:
         """Even if build_meta_auth_url is somehow subverted to return a


### PR DESCRIPTION
## Summary

PR-B of the Creative Studio plan: the typography & layout layer.

- `composer.py` — Jinja2 (autoescape + StrictUndefined) → one headless Chromium per call → exact-viewport PNG per format; `document.fonts.ready` gate; pure `render_html` split out for browser-free unit tests; lazy imports with the `pip install 'mureo[creative]'` hint.
- 3 professional templates (hero_overlay / split / minimal_badge) scaling 160×600→1080×1920 via a `--u` clamp unit; per-format safe areas (story 14%/20%, skyscraper/leaderboard 2%).
- `brand_kit.py` — forgiving `BRAND_KIT/kit.yml` loader (per-field degradation, hex-validated colors, **CSS-safe-charset font names** — review hardening, traversal-safe logo).
- `fonts.py` — Noto Sans JP + Zen Kaku Gothic New: fixed-URL download → `~/.mureo/fonts`, magic-byte + size verify, lockfile; any failure falls back to the system JP font stack (composition never blocks on network).
- New tools: `creative_studio_compose` / `creative_studio_edit_visual` / `creative_studio_brand_kit_get`.
- `pyproject`: new `creative` extra (jinja2/playwright/pillow); zero new core deps.

## Review
Reviewed by maintainer session (design/review role): `| safe` audit (CSS values + internal data URIs only; copy is escaped — verified with an injection test), input validation on paths/template/format ids, plus a live smoke render visually inspected — crisp Japanese typography at 1080².

Tests: 150 passed (creative suites + MCP tool suite); known agency-plugin dev-machine failures unchanged.

https://claude.ai/code/session_01AbvhGbHZoK8VqP3kR9nWWp