### PR TITLE
fix(creative-studio): review follow-ups — async-safe fonts, parse hardening, format dedupe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `~/.mureo/fonts` with checksum-locked provenance and a system-font fallback
   when offline. `creative_studio_edit_visual` refines a visual through a
   provider's edit path for the art-direction loop. Composition dependencies
-  (jinja2, playwright, pillow) install via the new `mureo[creative]` extra and
+  (jinja2, playwright) install via the new `mureo[creative]` extra and
   are lazily imported, so the core install stays lean.
 - **Creative Studio guided workflow (`/creative-generate`) + documentation.** A
   new bundled skill encodes the 6-step, quality-first workflow — brief (Persona /
@@ -56,6 +56,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `creative_studio` credentials section — reusing the existing env-var write
   and section-remove endpoints, so keys no longer have to be hand-exported or
   entered through the generic advanced env form.
+
+### Fixed
+
+- **Creative Studio review follow-ups.** Font resolution during `compose` runs
+  off the event loop (`asyncio.to_thread`) and a failed download is
+  negative-cached for 24h, so an offline / egress-filtered host no longer
+  re-blocks on every compose call. Malformed provider `200` bodies now surface
+  as normalized, redacted provider errors instead of raw `KeyError` /
+  `binascii.Error`. `creative_studio_compose` deduplicates requested `formats`
+  (and the schema declares `uniqueItems`). Dropped the unused `pillow`
+  dependency from the `creative` extra.
 
 ## [0.10.20] - 2026-07-12
 

--- a/docs/creative-studio.ja.md
+++ b/docs/creative-studio.ja.md
@@ -43,7 +43,7 @@ Creative Studio がプロ品質で勝てるのは、**3 つのレイヤーを分
 extra と Chromium ブラウザが必要です。
 
 ```bash
-pip install 'mureo[creative]'     # jinja2 / playwright / pillow を追加
+pip install 'mureo[creative]'     # jinja2 / playwright を追加
 playwright install chromium       # Playwright 用の Chromium を初回のみダウンロード
 ```
 

--- a/docs/creative-studio.md
+++ b/docs/creative-studio.md
@@ -43,7 +43,7 @@ Visual **generation** (steps 1-4 of the workflow) works with the core install.
 `creative` extra and a Chromium browser:
 
 ```bash
-pip install 'mureo[creative]'     # adds jinja2, playwright, pillow
+pip install 'mureo[creative]'     # adds jinja2, playwright
 playwright install chromium       # one-time browser download for Playwright
 ```
 

--- a/mureo/creative_studio/composer.py
+++ b/mureo/creative_studio/composer.py
@@ -20,6 +20,7 @@ Two entry points:
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import importlib
 import logging
@@ -292,7 +293,9 @@ async def compose(
 
     visual_uri = _data_uri(Path(visual_path))
     logo_uri = _data_uri(brand.logo_path) if brand.logo_path is not None else None
-    font_css = _embedded_font_css()
+    # Font resolution may hit the network (synchronous httpx). Offload it to a
+    # worker thread so it never blocks the event loop this coroutine runs on.
+    font_css = await asyncio.to_thread(_embedded_font_css)
 
     factory = browser_factory or _default_browser_factory
     results: list[dict[str, Any]] = []

--- a/mureo/creative_studio/fonts.py
+++ b/mureo/creative_studio/fonts.py
@@ -37,6 +37,13 @@ _TIMEOUT = 30.0
 _LOCKFILE = "manifest.lock.json"
 _FILE_MODE = 0o644
 
+# Negative cache: after a failed download, a ``<filename>.unavailable`` marker
+# is written next to where the font would live. A fresh marker (younger than
+# the TTL) short-circuits :func:`ensure_font` so an offline / egress-filtered
+# host does not re-attempt (and re-block up to 2x30s) on EVERY compose call.
+_NEGATIVE_CACHE_TTL_SECONDS = 86400
+_UNAVAILABLE_SUFFIX = ".unavailable"
+
 # Font byte-size sanity bounds. Below the floor is almost certainly an error
 # page; above the ceiling is not a web font we would ship.
 _MIN_FONT_BYTES = 10 * 1024
@@ -142,6 +149,51 @@ def _record_lock(dest_dir: Path, spec: FontSpec, data: bytes) -> None:
         logger.debug("font lockfile update failed", exc_info=True)
 
 
+def _marker_path(dest: Path) -> Path:
+    """Return the negative-cache marker path sitting beside ``dest``."""
+    return dest.with_name(dest.name + _UNAVAILABLE_SUFFIX)
+
+
+def _unavailable_recently(dest: Path) -> bool:
+    """Return ``True`` when a fresh (< TTL) negative-cache marker exists.
+
+    A marker whose timestamp cannot be parsed, or that is older than the TTL,
+    is treated as absent so a genuine retry can proceed.
+    """
+    marker = _marker_path(dest)
+    try:
+        recorded = datetime.fromisoformat(marker.read_text(encoding="utf-8").strip())
+    except (OSError, ValueError):
+        return False
+    if recorded.tzinfo is None:
+        recorded = recorded.replace(tzinfo=timezone.utc)
+    age_seconds = (datetime.now(timezone.utc) - recorded).total_seconds()
+    return age_seconds < _NEGATIVE_CACHE_TTL_SECONDS
+
+
+def _write_unavailable_marker(dest: Path) -> None:
+    """Best-effort write of a timestamped negative-cache marker beside ``dest``.
+
+    Never raises: the marker is an optimisation, not a correctness requirement.
+    """
+    try:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        _marker_path(dest).write_text(
+            datetime.now(timezone.utc).isoformat(timespec="seconds"),
+            encoding="utf-8",
+        )
+    except OSError:
+        logger.debug("could not write font negative-cache marker", exc_info=True)
+
+
+def _clear_unavailable_marker(dest: Path) -> None:
+    """Best-effort removal of a (possibly stale) negative-cache marker."""
+    try:
+        _marker_path(dest).unlink(missing_ok=True)
+    except OSError:
+        logger.debug("could not clear font negative-cache marker", exc_info=True)
+
+
 def ensure_font(
     spec: FontSpec,
     dest_dir: Path | None = None,
@@ -154,25 +206,32 @@ def ensure_font(
     present. Otherwise downloads from the fixed manifest URL, verifies the
     magic bytes and size, writes it ``0o644``, and records a checksum in
     ``manifest.lock.json``. On ANY failure returns ``None`` with a
-    :class:`FontWarning` so the caller falls back to system fonts.
+    :class:`FontWarning` so the caller falls back to system fonts, and records
+    a negative-cache marker so the failing download is not re-attempted for
+    :data:`_NEGATIVE_CACHE_TTL_SECONDS`. A later successful download clears the
+    marker.
 
     Args:
         spec: The font to ensure.
         dest_dir: Directory to cache into (default ``~/.mureo/fonts``).
         client_factory: Injectable ``httpx.Client`` factory (tests / advanced).
     """
+    base = Path(dest_dir) if dest_dir is not None else Path.home() / ".mureo" / "fonts"
+    dest = base / spec.filename
+
+    if dest.is_file() and dest.stat().st_size > 0:
+        return dest
+
+    # A recent failed attempt short-circuits the download so an offline host
+    # does not re-block on every compose call. The HTTP client is not touched.
+    if _unavailable_recently(dest):
+        return None
+
+    if not spec.url.startswith("https://"):
+        _warn(f"font {spec.name!r}: refusing non-https url; skipped")
+        return None
+
     try:
-        base = (
-            Path(dest_dir) if dest_dir is not None else Path.home() / ".mureo" / "fonts"
-        )
-        dest = base / spec.filename
-        if dest.is_file() and dest.stat().st_size > 0:
-            return dest
-
-        if not spec.url.startswith("https://"):
-            _warn(f"font {spec.name!r}: refusing non-https url; skipped")
-            return None
-
         factory = client_factory or _default_client_factory
         with factory() as client:
             response = client.get(spec.url, follow_redirects=True)
@@ -180,9 +239,11 @@ def ensure_font(
             data = response.content
 
         if not _has_font_magic(data):
+            _write_unavailable_marker(dest)
             _warn(f"font {spec.name!r}: download failed magic-byte check; skipped")
             return None
         if not (_MIN_FONT_BYTES <= len(data) <= _MAX_FONT_BYTES):
+            _write_unavailable_marker(dest)
             _warn(
                 f"font {spec.name!r}: download size {len(data)} bytes out of "
                 f"bounds [{_MIN_FONT_BYTES}, {_MAX_FONT_BYTES}]; skipped"
@@ -192,9 +253,12 @@ def ensure_font(
         base.mkdir(parents=True, exist_ok=True)
         dest.write_bytes(data)
         os.chmod(dest, _FILE_MODE)
+        # Ignore/clear any stale marker now that the download has succeeded.
+        _clear_unavailable_marker(dest)
         _record_lock(base, spec, data)
         return dest
     except Exception as exc:  # noqa: BLE001 — never block composition on fonts
+        _write_unavailable_marker(dest)
         _warn(f"font {spec.name!r}: could not be resolved ({exc}); skipped")
         return None
 

--- a/mureo/creative_studio/providers/google_images.py
+++ b/mureo/creative_studio/providers/google_images.py
@@ -87,9 +87,11 @@ class GoogleImageProvider:
             resp = await client.post(_URL, params={"key": key}, json=body)
             resp.raise_for_status()
             payload = resp.json()
+            # Parse INSIDE the try so a malformed 200 body (missing inlineData
+            # / bad base64) surfaces as a normalized, redacted provider error.
+            return self._extract_image(payload)
         except Exception as exc:  # noqa: BLE001 — normalize + redact
             raise provider_error(self.name, exc, key) from exc
-        return self._extract_image(payload)
 
     async def generate(
         self, prompt: str, *, width: int, height: int, n: int = 1
@@ -122,9 +124,11 @@ class GoogleImageProvider:
                 resp = await client.post(_URL, params={"key": key}, json=body)
                 resp.raise_for_status()
                 payload = resp.json()
+                # Parse INSIDE the try (see _generate_one) so a malformed 200
+                # body is normalized + redacted rather than raising raw.
+                return self._extract_image(payload)
             except Exception as exc:  # noqa: BLE001 — normalize + redact
                 raise provider_error(self.name, exc, key) from exc
-        return self._extract_image(payload)
 
 
 #: Exposed for the shared provider test-suite.

--- a/mureo/creative_studio/providers/openai_images.py
+++ b/mureo/creative_studio/providers/openai_images.py
@@ -92,9 +92,14 @@ class OpenAIImageProvider:
                 resp = await client.post(_GENERATE_URL, json=payload, headers=headers)
                 resp.raise_for_status()
                 data = resp.json()
+                # Parse INSIDE the try so a malformed 200 body (missing
+                # b64_json / bad base64) surfaces as a normalized, redacted
+                # provider error rather than a raw KeyError / binascii.Error.
+                return [
+                    base64.b64decode(item["b64_json"]) for item in data.get("data", [])
+                ]
             except Exception as exc:  # noqa: BLE001 — normalize + redact
                 raise provider_error(self.name, exc, key) from exc
-        return [base64.b64decode(item["b64_json"]) for item in data.get("data", [])]
 
     async def edit(self, image: bytes, instruction: str) -> bytes:
         key = self._require_key()
@@ -108,9 +113,11 @@ class OpenAIImageProvider:
                 )
                 resp.raise_for_status()
                 data = resp.json()
+                # Parse INSIDE the try (see generate) so a malformed 200 body
+                # is normalized + redacted rather than raising a raw error.
+                return base64.b64decode(data["data"][0]["b64_json"])
             except Exception as exc:  # noqa: BLE001 — normalize + redact
                 raise provider_error(self.name, exc, key) from exc
-        return base64.b64decode(data["data"][0]["b64_json"])
 
 
 #: Exposed so the shared provider test-suite can instantiate without knowing

--- a/mureo/mcp/tools_creative_studio.py
+++ b/mureo/mcp/tools_creative_studio.py
@@ -237,6 +237,7 @@ TOOLS: list[Tool] = [
                         "type": "string",
                         "enum": sorted(FORMATS_BY_ID),
                     },
+                    "uniqueItems": True,
                     "default": ["meta_feed_1x1"],
                     "description": "Target format ids to render.",
                 },
@@ -560,6 +561,9 @@ async def _handle_compose(arguments: dict[str, Any]) -> list[TextContent]:
 
     if not isinstance(formats, list) or not formats:
         return _error("formats must be a non-empty array of format ids")
+    # Defensively dedupe (preserving order): the schema declares uniqueItems,
+    # but the handler can be called directly, so never render a format twice.
+    formats = list(dict.fromkeys(formats))
     unknown = [f for f in formats if f not in FORMATS_BY_ID]
     if unknown:
         valid = ", ".join(sorted(FORMATS_BY_ID))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,19 +60,18 @@ dependencies = [
 
 [project.optional-dependencies]
 # Creative Studio composition (PR-B). jinja2 renders the HTML/CSS banner
-# templates and playwright rasterises them with headless Chromium; pillow is
-# available for optional crop/resize helpers. All three are lazily imported
-# (mureo.creative_studio.composer) so a core install stays lean — the tools
-# raise a clear "pip install 'mureo[creative]'" message when the extra is
-# absent. PyYAML (brand kit) and httpx (font pipeline) are already core deps.
+# templates and playwright rasterises them with headless Chromium. Both are
+# lazily imported (mureo.creative_studio.composer) so a core install stays
+# lean — the tools raise a clear "pip install 'mureo[creative]'" message when
+# the extra is absent. PyYAML (brand kit) and httpx (font pipeline) are already
+# core deps.
 creative = [
     "jinja2>=3.1",
     "playwright>=1.40",
-    "pillow>=10.0",
 ]
 dev = [
     # jinja2 backs the composer template unit tests (the browser layer is
-    # mocked; playwright/pillow stay out of CI — they live in the "creative"
+    # mocked; playwright stays out of CI — it lives in the "creative"
     # runtime extra only).
     "jinja2>=3.1,<4",
     "pytest>=7.4,<9",

--- a/tests/creative_studio/test_composer.py
+++ b/tests/creative_studio/test_composer.py
@@ -374,6 +374,43 @@ async def test_compose_embeds_logo_when_present(
 
 
 @pytest.mark.unit
+async def test_compose_resolves_fonts_via_to_thread(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Fonts unavailable (offline): the resolver returns "" but compose still
+    # succeeds, and the (potentially blocking) resolution is offloaded to a
+    # worker thread so the event loop is never blocked.
+    monkeypatch.setattr(composer_mod, "_embedded_font_css", lambda: "")
+    recorded: list[object] = []
+    real_to_thread = composer_mod.asyncio.to_thread
+
+    async def recording_to_thread(func, /, *args, **kwargs):  # type: ignore[no-untyped-def]
+        recorded.append(func)
+        return await real_to_thread(func, *args, **kwargs)
+
+    monkeypatch.setattr(composer_mod.asyncio, "to_thread", recording_to_thread)
+
+    visual = tmp_path / "visual.png"
+    visual.write_bytes(b"\x89PNG visual")
+    out = tmp_path / "out"
+    out.mkdir()
+
+    browser = _FakeBrowser()
+    results = await compose(
+        visual,
+        _copy(),
+        "hero_overlay",
+        ["meta_feed_1x1"],
+        DEFAULT_BRAND_KIT,
+        out,
+        browser_factory=_fake_factory(browser),
+    )
+    assert len(results) == 1
+    # Font resolution was routed through asyncio.to_thread.
+    assert composer_mod._embedded_font_css in recorded
+
+
+@pytest.mark.unit
 async def test_compose_unknown_template_raises(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/creative_studio/test_fonts.py
+++ b/tests/creative_studio/test_fonts.py
@@ -159,6 +159,55 @@ def test_ensure_font_http_error_returns_none(tmp_path: Path) -> None:
 
 
 @pytest.mark.unit
+def test_ensure_font_failure_writes_negative_cache_and_skips_second_attempt(
+    tmp_path: Path,
+) -> None:
+    spec = FONT_MANIFEST[0]
+    calls = {"n": 0}
+
+    def boom(_request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("no network")
+
+    def counting_factory() -> httpx.Client:
+        calls["n"] += 1
+        return httpx.Client(transport=httpx.MockTransport(boom))
+
+    with pytest.warns(FontWarning):
+        assert (
+            ensure_font(spec, dest_dir=tmp_path, client_factory=counting_factory)
+            is None
+        )
+    assert calls["n"] == 1
+    # A negative-cache marker was written next to where the font would live.
+    assert (tmp_path / (spec.filename + ".unavailable")).exists()
+
+    # Second call within the TTL must NOT construct the HTTP client at all.
+    assert ensure_font(spec, dest_dir=tmp_path, client_factory=counting_factory) is None
+    assert calls["n"] == 1
+
+
+@pytest.mark.unit
+def test_ensure_font_negative_cache_expires_after_ttl(tmp_path: Path) -> None:
+    from datetime import datetime, timedelta, timezone
+
+    spec = FONT_MANIFEST[0]
+    marker = tmp_path / (spec.filename + ".unavailable")
+    stale = datetime.now(timezone.utc) - timedelta(
+        seconds=fonts_mod._NEGATIVE_CACHE_TTL_SECONDS + 60
+    )
+    marker.write_text(stale.isoformat(timespec="seconds"), encoding="utf-8")
+
+    # A marker older than the TTL must not block a retry; the now-successful
+    # download succeeds and clears the stale marker.
+    result = ensure_font(
+        spec, dest_dir=tmp_path, client_factory=_factory(_ok_handler(_VALID_TTF))
+    )
+    assert result is not None
+    assert result.read_bytes() == _VALID_TTF
+    assert not marker.exists()
+
+
+@pytest.mark.unit
 def test_font_face_css_embeds_data_uri_and_fallback(tmp_path: Path) -> None:
     spec = FONT_MANIFEST[0]
     font_file = tmp_path / spec.filename

--- a/tests/creative_studio/test_providers.py
+++ b/tests/creative_studio/test_providers.py
@@ -178,6 +178,81 @@ async def test_openai_edit_returns_bytes(monkeypatch: pytest.MonkeyPatch) -> Non
 
 
 @pytest.mark.unit
+async def test_openai_edit_sends_multipart_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(openai_mod, "_creative_studio_secret", lambda _f: "sk-KEY")
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["content_type"] = request.headers.get("content-type", "")
+        captured["body"] = request.read()
+        return httpx.Response(200, json={"data": [{"b64_json": _B64_PNG}]})
+
+    provider = openai_mod.OpenAIImageProvider(client_factory=_client_factory(handler))
+    out = await provider.edit(_PNG_BYTES, "brighten it")
+    assert out == _PNG_BYTES
+
+    assert "multipart/form-data" in str(captured["content_type"])
+    body = captured["body"]
+    assert isinstance(body, (bytes, bytearray))
+    # The image file part.
+    assert b'name="image"' in body
+    assert b"image.png" in body
+    assert _PNG_BYTES in body
+    # The model + prompt form fields.
+    assert b'name="model"' in body
+    assert b"gpt-image-1" in body
+    assert b'name="prompt"' in body
+    assert b"brighten it" in body
+
+
+@pytest.mark.unit
+async def test_openai_generate_malformed_body_wrapped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(openai_mod, "_creative_studio_secret", lambda _f: "sk-KEY")
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"data": [{}]})  # missing b64_json
+
+    provider = openai_mod.OpenAIImageProvider(client_factory=_client_factory(handler))
+    with pytest.raises(RuntimeError) as excinfo:
+        await provider.generate("x", width=1024, height=1024, n=1)
+    assert str(excinfo.value).startswith("openai image API error")
+
+
+@pytest.mark.unit
+async def test_openai_generate_invalid_base64_wrapped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(openai_mod, "_creative_studio_secret", lambda _f: "sk-KEY")
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"data": [{"b64_json": "a"}]})  # invalid b64
+
+    provider = openai_mod.OpenAIImageProvider(client_factory=_client_factory(handler))
+    with pytest.raises(RuntimeError) as excinfo:
+        await provider.generate("x", width=1024, height=1024, n=1)
+    assert str(excinfo.value).startswith("openai image API error")
+
+
+@pytest.mark.unit
+async def test_openai_edit_malformed_body_wrapped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(openai_mod, "_creative_studio_secret", lambda _f: "sk-KEY")
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"data": [{}]})  # missing b64_json
+
+    provider = openai_mod.OpenAIImageProvider(client_factory=_client_factory(handler))
+    with pytest.raises(RuntimeError) as excinfo:
+        await provider.edit(_PNG_BYTES, "x")
+    assert str(excinfo.value).startswith("openai image API error")
+
+
+@pytest.mark.unit
 async def test_openai_error_redacts_key(monkeypatch: pytest.MonkeyPatch) -> None:
     key = "sk-SUPER-SECRET-123"
     monkeypatch.setattr(openai_mod, "_creative_studio_secret", lambda _f: key)
@@ -224,6 +299,40 @@ async def test_google_generate_parses_inline_data(
     assert images == [_PNG_BYTES, _PNG_BYTES]
     assert len(calls) == 2  # n sequential calls
     assert "key=gm-KEY" in calls[0]
+
+
+@pytest.mark.unit
+async def test_google_generate_missing_inline_data_wrapped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(google_mod, "_creative_studio_secret", lambda _f: "gm-KEY")
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        # A 200 with candidates but no inlineData part.
+        return httpx.Response(
+            200,
+            json={"candidates": [{"content": {"parts": [{"text": "hi"}]}}]},
+        )
+
+    provider = google_mod.GoogleImageProvider(client_factory=_client_factory(handler))
+    with pytest.raises(RuntimeError) as excinfo:
+        await provider.generate("x", width=1024, height=1024, n=1)
+    assert str(excinfo.value).startswith("google image API error")
+
+
+@pytest.mark.unit
+async def test_google_edit_missing_inline_data_wrapped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(google_mod, "_creative_studio_secret", lambda _f: "gm-KEY")
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"candidates": []})  # no image data
+
+    provider = google_mod.GoogleImageProvider(client_factory=_client_factory(handler))
+    with pytest.raises(RuntimeError) as excinfo:
+        await provider.edit(_PNG_BYTES, "x")
+    assert str(excinfo.value).startswith("google image API error")
 
 
 @pytest.mark.unit

--- a/tests/test_mcp_tools_creative_studio.py
+++ b/tests/test_mcp_tools_creative_studio.py
@@ -268,6 +268,7 @@ def test_compose_schema_constraints() -> None:
     assert props["template"]["default"] == "hero_overlay"
     assert props["formats"]["type"] == "array"
     assert props["formats"]["default"] == ["meta_feed_1x1"]
+    assert props["formats"]["uniqueItems"] is True
     assert set(tool.inputSchema["required"]) == {"visual_path", "headline", "cta"}
 
 
@@ -371,6 +372,59 @@ async def test_compose_happy_path(
     assert manifest["copy"]["headline"] == "H"
     assert manifest["inputs"]["visual_sha256"]
     assert len(manifest["files"]) == 2
+
+
+@pytest.mark.unit
+async def test_compose_dedupes_duplicate_formats(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    recorded_formats: list[list[str]] = []
+
+    async def _recording_compose(
+        visual_path: Path,
+        copy: object,
+        template: str,
+        formats: list[str],
+        brand: object,
+        out_dir: Path,
+        **_kwargs: object,
+    ) -> list[dict]:
+        recorded_formats.append(list(formats))
+        files = []
+        for fid in formats:
+            p = Path(out_dir) / f"{fid}_{template}.png"
+            p.write_bytes(b"\x89PNG composed")
+            files.append(
+                {
+                    "format": fid,
+                    "path": str(p),
+                    "sha256": "deadbeef",
+                    "width": 1,
+                    "height": 1,
+                }
+            )
+        return files
+
+    monkeypatch.setattr(mod.composer, "compose", _recording_compose)
+    visual = tmp_path / "v.png"
+    visual.write_bytes(b"\x89PNG raw visual")
+
+    result = await mod.handle_tool(
+        "creative_studio_compose",
+        {
+            "visual_path": str(visual),
+            "headline": "H",
+            "cta": "C",
+            "formats": ["meta_feed_1x1", "meta_feed_1x1", "gdn_300x250"],
+        },
+    )
+    payload = _payload(result)
+    assert "error" not in payload
+    # compose was invoked exactly once, with duplicates removed (order kept).
+    assert len(recorded_formats) == 1
+    assert recorded_formats[0] == ["meta_feed_1x1", "gdn_300x250"]
+    assert len(payload["files"]) == 2
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

Follow-ups from the adversarial review of the Creative Studio feature (PRs #383–#386). Verdict there was release-safe; these harden the flagged non-blocking items:

- **M1**: font resolution now runs via `asyncio.to_thread` (never blocks the MCP event loop) + a 24h negative cache (`<font>.unavailable` marker) so offline hosts stop re-attempting downloads on every compose.
- **L1**: removed the dead `pillow` dependency from the `creative` extra (+ doc/changelog mentions).
- **L2**: provider response parsing/b64 decode moved inside the redacting try blocks — malformed 200 bodies now surface as normalized provider errors.
- **L5**: `uniqueItems` on compose `formats` + order-preserving handler dedupe (duplicate ids no longer double-render/overwrite).
- Test-gap fix: OpenAI edit test now pins the multipart request shape.

Both the original findings and this fix commit passed dedicated code-review agent passes (fix verdict: merge-ready, no CRITICAL/HIGH). 160 tests green on affected suites.

https://claude.ai/code/session_01AbvhGbHZoK8VqP3kR9nWWp