### PR TITLE
chore(release): 0.10.22

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mureo",
-  "version": "0.10.20",
+  "version": "0.10.22",
   "description": "Your local-first AI ad ops crew for Google Ads, Meta Ads, Search Console & GA4. mureo sits on top of the official ad-platform MCPs, gates every change against your strategy, correlates outcomes locally, and keeps an auditable decision log — credentials never leave your machine.",
   "author": {
     "name": "Logly Inc.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.22] - 2026-07-12
+
 ### Added
 
 - **Creative Studio image generation (visual layer).** A new
@@ -65,6 +67,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `creative_studio` credentials section — reusing the existing env-var write
   and section-remove endpoints, so keys no longer have to be hand-exported or
   entered through the generic advanced env form.
+
+### Fixed
+
+- **Creative Studio review follow-ups.** Font resolution during `compose` runs
+  off the event loop (`asyncio.to_thread`) and a failed download is
+  negative-cached for 24h, so an offline / egress-filtered host no longer
+  re-blocks on every compose call. Malformed provider `200` bodies now surface
+  as normalized, redacted provider errors instead of raw `KeyError` /
+  `binascii.Error`. `creative_studio_compose` deduplicates requested `formats`
+  (and the schema declares `uniqueItems`). Dropped the unused `pillow`
+  dependency from the `creative` extra.
+
+## [0.10.21] - 2026-07-12
+
+### Added
+
 - **Three workflow skills — `/tracking-health`, `/budget-pacing`,
   `/monthly-report`.** `tracking-health` is a preventive conversion-tracking
   audit: Meta pixel inventory + health (`meta_ads_pixels_list` / `_get` /
@@ -113,7 +131,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (derived from `meta_ads_insights_report` impressions ÷ reach, since no
   `frequency` field is exposed), week-over-week CTR decline, and CPM drift
   — with a minimum-impressions noise guard — and hands fatigued ads to
-  `/creative-generate` or `/creative-refresh` (persists `report="fatigue"`).
+  `/creative-refresh` (persists `report="fatigue"`).
   `incident-postmortem` closes the learning loop after a `/rescue`:
   reconstructs the timeline from `action_log`, runs platform/site/measurement/
   external root-cause analysis, writes a structured postmortem document,
@@ -125,24 +143,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Skills polish.** Deduplicated the ~20-line learning-insights + advisor
   diagnostic preamble into a single canonical *Diagnostic preamble* section in
-  `_mureo-shared/SKILL.md` (nine workflow skills now carry a two-line pointer;
+  `_mureo-shared/SKILL.md` (eight workflow skills now carry a two-line pointer;
   `weekly-report` gains the preamble, `sync-state` documents why it is
   intentionally exempt); normalized every bundled skill's `metadata.version` to
   `0.10.20`; corrected the Google Ads skill title from `v18` to `v23` to match
   the shipped `google-ads` client; and documented OpenAI Codex tool-selection
   behaviour (`~/.codex/skills`, `$<name>` / `/skills` invocation) in the shared
   Tool Selection guidance.
-
-### Fixed
-
-- **Creative Studio review follow-ups.** Font resolution during `compose` runs
-  off the event loop (`asyncio.to_thread`) and a failed download is
-  negative-cached for 24h, so an offline / egress-filtered host no longer
-  re-blocks on every compose call. Malformed provider `200` bodies now surface
-  as normalized, redacted provider errors instead of raw `KeyError` /
-  `binascii.Error`. `creative_studio_compose` deduplicates requested `formats`
-  (and the schema declares `uniqueItems`). Dropped the unused `pillow`
-  dependency from the `creative` extra.
 
 ## [0.10.20] - 2026-07-12
 

--- a/mureo/__init__.py
+++ b/mureo/__init__.py
@@ -1,3 +1,3 @@
 """mureo — your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."""
 
-__version__ = "0.10.20"
+__version__ = "0.10.22"

--- a/mureo/_data/skills/_mureo-google-ads/SKILL.md
+++ b/mureo/_data/skills/_mureo-google-ads/SKILL.md
@@ -2,7 +2,7 @@
 name: _mureo-google-ads
 description: "Google Ads: Manage campaigns, ad groups, ads, keywords, budgets, and performance analysis."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
   openclaw:
     category: "advertising"
     requires:

--- a/mureo/_data/skills/_mureo-learning/SKILL.md
+++ b/mureo/_data/skills/_mureo-learning/SKILL.md
@@ -2,7 +2,7 @@
 name: _mureo-learning
 description: "Evidence-based marketing decision framework: statistical thinking for AI agents operating ad accounts."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
   openclaw:
     category: "marketing"
     requires:

--- a/mureo/_data/skills/_mureo-meta-ads/SKILL.md
+++ b/mureo/_data/skills/_mureo-meta-ads/SKILL.md
@@ -2,7 +2,7 @@
 name: _mureo-meta-ads
 description: "Meta Ads: Manage campaigns, ad sets, ads, insights, and audiences on Facebook/Instagram."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
   openclaw:
     category: "advertising"
     requires:

--- a/mureo/_data/skills/_mureo-shared/SKILL.md
+++ b/mureo/_data/skills/_mureo-shared/SKILL.md
@@ -2,7 +2,7 @@
 name: _mureo-shared
 description: "mureo: Shared patterns for authentication, security rules, and output formatting."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
   openclaw:
     category: "advertising"
     requires:

--- a/mureo/_data/skills/_mureo-strategy/SKILL.md
+++ b/mureo/_data/skills/_mureo-strategy/SKILL.md
@@ -2,7 +2,7 @@
 name: _mureo-strategy
 description: "Strategy Context: Manage business strategy files (STRATEGY.md, STATE.json) for strategy-driven ad operations."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
   openclaw:
     category: "advertising"
     requires:

--- a/mureo/_data/skills/ad-fatigue-check/SKILL.md
+++ b/mureo/_data/skills/ad-fatigue-check/SKILL.md
@@ -2,7 +2,7 @@
 name: ad-fatigue-check
 description: "Detect creative fatigue across active ads — rising frequency, declining CTR week-over-week, and CPM drift — score each ad FATIGUED / WATCH / FRESH, and hand the evidence to a creative refresh. Use when the user asks whether creatives are worn out, why CTR is falling, if frequency is too high, when to rotate or refresh ads, or requests クリエイティブ疲弊チェック / 広告の疲弊を確認 / フリークエンシーが高い / CTRが落ちてきた / そろそろ差し替え時か. Reads active ads per platform, applies documented fatigue thresholds with noise guards, and routes fatigued ads to /creative-generate or /creative-refresh."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
 ---
 
 # Ad Fatigue Check

--- a/mureo/_data/skills/audience-review/SKILL.md
+++ b/mureo/_data/skills/audience-review/SKILL.md
@@ -2,7 +2,7 @@
 name: audience-review
 description: "Audit who your ads actually target and where they run, compare it against the STRATEGY.md Persona, and surface exclusions, bid adjustments, lookalikes, and placement pruning tied to that Persona. Use when the user asks to review targeting, audiences, demographics, placements, or device performance, to check whether spend matches the Persona, to find wasted placements (e.g. Audience Network with no conversions), or requests オーディエンスレビュー / 配置レビュー / ターゲティング見直し / ペルソナと配信のズレを確認 / 除外設定を提案して. Reads Persona + Target Audience from STRATEGY.md and drives the read-only targeting tools."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
 ---
 
 # Audience Review

--- a/mureo/_data/skills/budget-pacing/SKILL.md
+++ b/mureo/_data/skills/budget-pacing/SKILL.md
@@ -2,7 +2,7 @@
 name: budget-pacing
 description: "Month-to-date spend vs the monthly budget target, projected month-end landing, and pace alerts across all configured platforms. Use when the user asks about pacing, burn rate, whether they will overspend or underspend this month, monthly-budget tracking, landing/forecast, 'are we on budget', or requests 予算ペーシング / 着地予測 / 予算消化ペース. DISTINCT from /budget-rebalance (which reallocates budget between campaigns) — this manages total-spend trajectory toward a monthly target. Reads STRATEGY.md Guardrails / a Monthly Budget section and STATE.json."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
 ---
 
 # Budget Pacing

--- a/mureo/_data/skills/budget-rebalance/SKILL.md
+++ b/mureo/_data/skills/budget-rebalance/SKILL.md
@@ -2,7 +2,7 @@
 name: budget-rebalance
 description: "Rebalance campaign budgets across all configured platforms based on strategy and performance signals. Use when the user asks to optimize budgets, redistribute spend, scale efficient campaigns, or cap overspending ones. Reads STRATEGY.md goals, analyzes campaign efficiency, and proposes budget changes with rationale."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
 ---
 
 # Budget Rebalance

--- a/mureo/_data/skills/competitive-scan/SKILL.md
+++ b/mureo/_data/skills/competitive-scan/SKILL.md
@@ -2,7 +2,7 @@
 name: competitive-scan
 description: "Scan competitor activity using auction insights and market signals. Use when the user asks about competitors, market dynamics, impression share changes, competitor moves, or competitive positioning."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
 ---
 
 # Competitive Scan

--- a/mureo/_data/skills/creative-generate/SKILL.md
+++ b/mureo/_data/skills/creative-generate/SKILL.md
@@ -2,7 +2,7 @@
 name: creative-generate
 description: "Generate creator-quality ad creatives — text-free key visuals plus composed banners — from a strategy-grounded brief. Use when the user asks to create ad creatives, generate ad images or banners, make banner variations, design display / social ad creatives, or asks in Japanese (クリエイティブ作成 / バナー作成 / 広告画像を生成 / バナーのバリエーションを作って). Runs a 6-step workflow (brief → copy → visuals → art-direction scoring loop → HTML/CSS composition → delivery) via the creative_studio_* MCP tools, then hands approved banners to the existing upload tools."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
 ---
 
 # Creative Generate

--- a/mureo/_data/skills/creative-refresh/SKILL.md
+++ b/mureo/_data/skills/creative-refresh/SKILL.md
@@ -2,7 +2,7 @@
 name: creative-refresh
 description: "Refresh ad copy and creative assets based on performance signals and brand voice. Use when the user asks to refresh creative, propose new ad copy, A/B test creatives, update RSA assets, rotate underperformers, or visually evaluate / compare banner (image) creatives."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
 ---
 
 # Creative Refresh

--- a/mureo/_data/skills/daily-check/SKILL.md
+++ b/mureo/_data/skills/daily-check/SKILL.md
@@ -2,7 +2,7 @@
 name: daily-check
 description: "Run a daily health check on all configured ad accounts (Google Ads, Meta Ads, Search Console, GA4). Use when the user asks for a daily review, health check, status update, anomaly detection, or 'how are my campaigns doing today'. Reads STRATEGY.md and STATE.json, runs platform-specific health diagnostics, checks goal progress, evaluates pending action_log observations, and reports findings as Healthy / Watch / Action-needed."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
 ---
 
 # Daily Check

--- a/mureo/_data/skills/experiment/SKILL.md
+++ b/mureo/_data/skills/experiment/SKILL.md
@@ -2,7 +2,7 @@
 name: experiment
 description: "Design, run, and evaluate a controlled A/B test (split test) on your ad accounts with evidence discipline — one variable, a falsifiable hypothesis, a fixed window, and a per-variant outcome verdict. Use when the user asks to run an A/B test, split test, or experiment, to 'test whether X beats Y', to validate a creative-refresh or learning hunch properly, or requests A/Bテスト / スプリットテスト設計 / 実験を回したい / どちらが勝ったか評価して / 仮説を検証したい. Forces a designed experiment instead of an ad-hoc change, records the baseline in action_log, and forbids peeking-based decisions before the window closes."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
 ---
 
 # Experiment

--- a/mureo/_data/skills/goal-review/SKILL.md
+++ b/mureo/_data/skills/goal-review/SKILL.md
@@ -2,7 +2,7 @@
 name: goal-review
 description: "Review Goal progress against STRATEGY.md targets. Use when the user asks to evaluate goal achievement, review KPI progress, assess strategy performance, or check if targets are being met."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
 ---
 
 # Goal Review

--- a/mureo/_data/skills/incident-postmortem/SKILL.md
+++ b/mureo/_data/skills/incident-postmortem/SKILL.md
@@ -2,7 +2,7 @@
 name: incident-postmortem
 description: "Close the learning loop after a rescue or incident — reconstruct the timeline from action_log, run root-cause analysis (platform / site / measurement / external), produce a structured postmortem document, distill reusable insights via /learn, and propose preventive guardrails. Use after a /rescue, a CPA spike, a conversion drop, or a runaway-spend event has been handled, or when the user asks for a postmortem, retrospective, root-cause writeup, or requests インシデント振り返り / ポストモーテム / 事後分析 / なぜ起きたのか / 再発防止策. Read-and-document only — makes no ad-platform writes."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
 ---
 
 # Incident Postmortem

--- a/mureo/_data/skills/lead-form-create/SKILL.md
+++ b/mureo/_data/skills/lead-form-create/SKILL.md
@@ -2,7 +2,7 @@
 name: lead-form-create
 description: "Create a Meta Instant Form (Lead Ad form) through a one-question-at-a-time interview. Use when the user asks to create a lead form, Instant Form, CV form, or similar. The agent collects required parameters via a guided dialogue, confirms, then calls meta_ads_lead_forms_create."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
 ---
 
 # Lead Form Create

--- a/mureo/_data/skills/learn/SKILL.md
+++ b/mureo/_data/skills/learn/SKILL.md
@@ -2,7 +2,7 @@
 name: learn
 description: "Save a marketing diagnosis insight to the pro-diagnosis knowledge base so it is applied in future operations across all platforms. Use when the user runs /learn, explicitly teaches the agent a marketing insight, corrects the agent's analysis, or asks to remember/record an operational learning for next time."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
 ---
 
 # Learn

--- a/mureo/_data/skills/monthly-report/SKILL.md
+++ b/mureo/_data/skills/monthly-report/SKILL.md
@@ -2,7 +2,7 @@
 name: monthly-report
 description: "Stakeholder / client-facing monthly digest across all configured platforms: the previous full calendar month with month-over-month comparison, per-Goal attainment, an action-log recap grouped by command with outcome verdicts, budget utilization, and next-month recommendations. Use when the user asks for a monthly report, month-end summary, client report, monthly recap / digest, or requests 月次レポート / 月次まとめ / クライアント向けレポート. Written in plain language for a client audience."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
 ---
 
 # Monthly Report

--- a/mureo/_data/skills/onboard/SKILL.md
+++ b/mureo/_data/skills/onboard/SKILL.md
@@ -2,7 +2,7 @@
 name: onboard
 description: "Initial account setup — create STRATEGY.md and STATE.json from scratch, import platform data, and establish baseline metrics. Use when the user is starting fresh with mureo, has no STRATEGY.md yet, or asks to set up a new account."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
 ---
 
 # Onboard

--- a/mureo/_data/skills/rescue/SKILL.md
+++ b/mureo/_data/skills/rescue/SKILL.md
@@ -2,7 +2,7 @@
 name: rescue
 description: "Emergency performance fix when an ad account is in trouble. Use when the user reports a sudden CPA spike, conversion drop, runaway spend, or asks for an urgent performance rescue. Sets Operation Mode to TURNAROUND_RESCUE and applies stabilization actions."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
 ---
 
 # Rescue

--- a/mureo/_data/skills/search-term-cleanup/SKILL.md
+++ b/mureo/_data/skills/search-term-cleanup/SKILL.md
@@ -2,7 +2,7 @@
 name: search-term-cleanup
 description: "Audit and clean up search terms (negative keywords, intent classification, query hygiene). Use when the user asks to clean up search queries, add negative keywords, review search term reports, or improve match quality. Cross-references Search Console, GA4, and ad platform data."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
 ---
 
 # Search Term Cleanup

--- a/mureo/_data/skills/sync-state/SKILL.md
+++ b/mureo/_data/skills/sync-state/SKILL.md
@@ -2,7 +2,7 @@
 name: sync-state
 description: "Sync STATE.json with current campaign data from all platforms. Use when the user asks to refresh state, sync campaigns, update STATE.json from live data, or pull latest campaign snapshots."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
 ---
 
 # Sync State

--- a/mureo/_data/skills/tracking-health/SKILL.md
+++ b/mureo/_data/skills/tracking-health/SKILL.md
@@ -2,7 +2,7 @@
 name: tracking-health
 description: "Preventive audit of conversion tracking across all configured ad platforms — Meta pixels + CAPI, Google Ads conversion actions — with a GA4 cross-check. Use when the user asks to check tracking, audit conversion measurement, verify pixels / tags, diagnose why conversions stopped or look wrong, sanity-check CV counting, or requests a 計測ヘルスチェック / タグ・計測監査 / 計測が壊れていないか確認. Reads STRATEGY.md and STATE.json, produces a per-platform tracking scorecard (OK / Watch / Broken per check) and a fix list ranked by revenue risk."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
 ---
 
 # Tracking Health

--- a/mureo/_data/skills/weekly-report/SKILL.md
+++ b/mureo/_data/skills/weekly-report/SKILL.md
@@ -2,7 +2,7 @@
 name: weekly-report
 description: "Generate a weekly summary report across all platforms. Use when the user asks for a weekly report, summary, recap, end-of-week review, or weekly digest."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
 ---
 
 # Weekly Report

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mureo"
-version = "0.10.20"
+version = "0.10.22"
 description = "Your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/skills/_mureo-google-ads/SKILL.md
+++ b/skills/_mureo-google-ads/SKILL.md
@@ -2,7 +2,7 @@
 name: _mureo-google-ads
 description: "Google Ads: Manage campaigns, ad groups, ads, keywords, budgets, and performance analysis."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
   openclaw:
     category: "advertising"
     requires:

--- a/skills/_mureo-learning/SKILL.md
+++ b/skills/_mureo-learning/SKILL.md
@@ -2,7 +2,7 @@
 name: _mureo-learning
 description: "Evidence-based marketing decision framework: statistical thinking for AI agents operating ad accounts."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
   openclaw:
     category: "marketing"
     requires:

--- a/skills/_mureo-meta-ads/SKILL.md
+++ b/skills/_mureo-meta-ads/SKILL.md
@@ -2,7 +2,7 @@
 name: _mureo-meta-ads
 description: "Meta Ads: Manage campaigns, ad sets, ads, insights, and audiences on Facebook/Instagram."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
   openclaw:
     category: "advertising"
     requires:

--- a/skills/_mureo-pro-diagnosis/SKILL.md
+++ b/skills/_mureo-pro-diagnosis/SKILL.md
@@ -2,7 +2,7 @@
 name: _mureo-pro-diagnosis
 description: "Professional marketing diagnostic frameworks: expert-level campaign analysis that grows with your experience."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
   openclaw:
     category: "marketing"
     requires:

--- a/skills/_mureo-shared/SKILL.md
+++ b/skills/_mureo-shared/SKILL.md
@@ -2,7 +2,7 @@
 name: _mureo-shared
 description: "mureo: Shared patterns for authentication, security rules, and output formatting."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
   openclaw:
     category: "advertising"
     requires:

--- a/skills/_mureo-strategy/SKILL.md
+++ b/skills/_mureo-strategy/SKILL.md
@@ -2,7 +2,7 @@
 name: _mureo-strategy
 description: "Strategy Context: Manage business strategy files (STRATEGY.md, STATE.json) for strategy-driven ad operations."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
   openclaw:
     category: "advertising"
     requires:

--- a/skills/ad-fatigue-check/SKILL.md
+++ b/skills/ad-fatigue-check/SKILL.md
@@ -2,7 +2,7 @@
 name: ad-fatigue-check
 description: "Detect creative fatigue across active ads — rising frequency, declining CTR week-over-week, and CPM drift — score each ad FATIGUED / WATCH / FRESH, and hand the evidence to a creative refresh. Use when the user asks whether creatives are worn out, why CTR is falling, if frequency is too high, when to rotate or refresh ads, or requests クリエイティブ疲弊チェック / 広告の疲弊を確認 / フリークエンシーが高い / CTRが落ちてきた / そろそろ差し替え時か. Reads active ads per platform, applies documented fatigue thresholds with noise guards, and routes fatigued ads to /creative-generate or /creative-refresh."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
 ---
 
 # Ad Fatigue Check

--- a/skills/audience-review/SKILL.md
+++ b/skills/audience-review/SKILL.md
@@ -2,7 +2,7 @@
 name: audience-review
 description: "Audit who your ads actually target and where they run, compare it against the STRATEGY.md Persona, and surface exclusions, bid adjustments, lookalikes, and placement pruning tied to that Persona. Use when the user asks to review targeting, audiences, demographics, placements, or device performance, to check whether spend matches the Persona, to find wasted placements (e.g. Audience Network with no conversions), or requests オーディエンスレビュー / 配置レビュー / ターゲティング見直し / ペルソナと配信のズレを確認 / 除外設定を提案して. Reads Persona + Target Audience from STRATEGY.md and drives the read-only targeting tools."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
 ---
 
 # Audience Review

--- a/skills/budget-pacing/SKILL.md
+++ b/skills/budget-pacing/SKILL.md
@@ -2,7 +2,7 @@
 name: budget-pacing
 description: "Month-to-date spend vs the monthly budget target, projected month-end landing, and pace alerts across all configured platforms. Use when the user asks about pacing, burn rate, whether they will overspend or underspend this month, monthly-budget tracking, landing/forecast, 'are we on budget', or requests 予算ペーシング / 着地予測 / 予算消化ペース. DISTINCT from /budget-rebalance (which reallocates budget between campaigns) — this manages total-spend trajectory toward a monthly target. Reads STRATEGY.md Guardrails / a Monthly Budget section and STATE.json."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
 ---
 
 # Budget Pacing

--- a/skills/budget-rebalance/SKILL.md
+++ b/skills/budget-rebalance/SKILL.md
@@ -2,7 +2,7 @@
 name: budget-rebalance
 description: "Rebalance campaign budgets across all configured platforms based on strategy and performance signals. Use when the user asks to optimize budgets, redistribute spend, scale efficient campaigns, or cap overspending ones. Reads STRATEGY.md goals, analyzes campaign efficiency, and proposes budget changes with rationale."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
 ---
 
 # Budget Rebalance

--- a/skills/competitive-scan/SKILL.md
+++ b/skills/competitive-scan/SKILL.md
@@ -2,7 +2,7 @@
 name: competitive-scan
 description: "Scan competitor activity using auction insights and market signals. Use when the user asks about competitors, market dynamics, impression share changes, competitor moves, or competitive positioning."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
 ---
 
 # Competitive Scan

--- a/skills/creative-generate/SKILL.md
+++ b/skills/creative-generate/SKILL.md
@@ -2,7 +2,7 @@
 name: creative-generate
 description: "Generate creator-quality ad creatives — text-free key visuals plus composed banners — from a strategy-grounded brief. Use when the user asks to create ad creatives, generate ad images or banners, make banner variations, design display / social ad creatives, or asks in Japanese (クリエイティブ作成 / バナー作成 / 広告画像を生成 / バナーのバリエーションを作って). Runs a 6-step workflow (brief → copy → visuals → art-direction scoring loop → HTML/CSS composition → delivery) via the creative_studio_* MCP tools, then hands approved banners to the existing upload tools."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
 ---
 
 # Creative Generate

--- a/skills/creative-refresh/SKILL.md
+++ b/skills/creative-refresh/SKILL.md
@@ -2,7 +2,7 @@
 name: creative-refresh
 description: "Refresh ad copy and creative assets based on performance signals and brand voice. Use when the user asks to refresh creative, propose new ad copy, A/B test creatives, update RSA assets, rotate underperformers, or visually evaluate / compare banner (image) creatives."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
 ---
 
 # Creative Refresh

--- a/skills/daily-check/SKILL.md
+++ b/skills/daily-check/SKILL.md
@@ -2,7 +2,7 @@
 name: daily-check
 description: "Run a daily health check on all configured ad accounts (Google Ads, Meta Ads, Search Console, GA4). Use when the user asks for a daily review, health check, status update, anomaly detection, or 'how are my campaigns doing today'. Reads STRATEGY.md and STATE.json, runs platform-specific health diagnostics, checks goal progress, evaluates pending action_log observations, and reports findings as Healthy / Watch / Action-needed."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
 ---
 
 # Daily Check

--- a/skills/experiment/SKILL.md
+++ b/skills/experiment/SKILL.md
@@ -2,7 +2,7 @@
 name: experiment
 description: "Design, run, and evaluate a controlled A/B test (split test) on your ad accounts with evidence discipline — one variable, a falsifiable hypothesis, a fixed window, and a per-variant outcome verdict. Use when the user asks to run an A/B test, split test, or experiment, to 'test whether X beats Y', to validate a creative-refresh or learning hunch properly, or requests A/Bテスト / スプリットテスト設計 / 実験を回したい / どちらが勝ったか評価して / 仮説を検証したい. Forces a designed experiment instead of an ad-hoc change, records the baseline in action_log, and forbids peeking-based decisions before the window closes."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
 ---
 
 # Experiment

--- a/skills/goal-review/SKILL.md
+++ b/skills/goal-review/SKILL.md
@@ -2,7 +2,7 @@
 name: goal-review
 description: "Review Goal progress against STRATEGY.md targets. Use when the user asks to evaluate goal achievement, review KPI progress, assess strategy performance, or check if targets are being met."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
 ---
 
 # Goal Review

--- a/skills/incident-postmortem/SKILL.md
+++ b/skills/incident-postmortem/SKILL.md
@@ -2,7 +2,7 @@
 name: incident-postmortem
 description: "Close the learning loop after a rescue or incident — reconstruct the timeline from action_log, run root-cause analysis (platform / site / measurement / external), produce a structured postmortem document, distill reusable insights via /learn, and propose preventive guardrails. Use after a /rescue, a CPA spike, a conversion drop, or a runaway-spend event has been handled, or when the user asks for a postmortem, retrospective, root-cause writeup, or requests インシデント振り返り / ポストモーテム / 事後分析 / なぜ起きたのか / 再発防止策. Read-and-document only — makes no ad-platform writes."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
 ---
 
 # Incident Postmortem

--- a/skills/lead-form-create/SKILL.md
+++ b/skills/lead-form-create/SKILL.md
@@ -2,7 +2,7 @@
 name: lead-form-create
 description: "Create a Meta Instant Form (Lead Ad form) through a one-question-at-a-time interview. Use when the user asks to create a lead form, Instant Form, CV form, or similar. The agent collects required parameters via a guided dialogue, confirms, then calls meta_ads_lead_forms_create."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
 ---
 
 # Lead Form Create

--- a/skills/learn/SKILL.md
+++ b/skills/learn/SKILL.md
@@ -2,7 +2,7 @@
 name: learn
 description: "Save a marketing diagnosis insight to the pro-diagnosis knowledge base so it is applied in future operations across all platforms. Use when the user runs /learn, explicitly teaches the agent a marketing insight, corrects the agent's analysis, or asks to remember/record an operational learning for next time."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
 ---
 
 # Learn

--- a/skills/monthly-report/SKILL.md
+++ b/skills/monthly-report/SKILL.md
@@ -2,7 +2,7 @@
 name: monthly-report
 description: "Stakeholder / client-facing monthly digest across all configured platforms: the previous full calendar month with month-over-month comparison, per-Goal attainment, an action-log recap grouped by command with outcome verdicts, budget utilization, and next-month recommendations. Use when the user asks for a monthly report, month-end summary, client report, monthly recap / digest, or requests 月次レポート / 月次まとめ / クライアント向けレポート. Written in plain language for a client audience."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
 ---
 
 # Monthly Report

--- a/skills/onboard/SKILL.md
+++ b/skills/onboard/SKILL.md
@@ -2,7 +2,7 @@
 name: onboard
 description: "Initial account setup — create STRATEGY.md and STATE.json from scratch, import platform data, and establish baseline metrics. Use when the user is starting fresh with mureo, has no STRATEGY.md yet, or asks to set up a new account."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
 ---
 
 # Onboard

--- a/skills/rescue/SKILL.md
+++ b/skills/rescue/SKILL.md
@@ -2,7 +2,7 @@
 name: rescue
 description: "Emergency performance fix when an ad account is in trouble. Use when the user reports a sudden CPA spike, conversion drop, runaway spend, or asks for an urgent performance rescue. Sets Operation Mode to TURNAROUND_RESCUE and applies stabilization actions."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
 ---
 
 # Rescue

--- a/skills/search-term-cleanup/SKILL.md
+++ b/skills/search-term-cleanup/SKILL.md
@@ -2,7 +2,7 @@
 name: search-term-cleanup
 description: "Audit and clean up search terms (negative keywords, intent classification, query hygiene). Use when the user asks to clean up search queries, add negative keywords, review search term reports, or improve match quality. Cross-references Search Console, GA4, and ad platform data."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
 ---
 
 # Search Term Cleanup

--- a/skills/sync-state/SKILL.md
+++ b/skills/sync-state/SKILL.md
@@ -2,7 +2,7 @@
 name: sync-state
 description: "Sync STATE.json with current campaign data from all platforms. Use when the user asks to refresh state, sync campaigns, update STATE.json from live data, or pull latest campaign snapshots."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
 ---
 
 # Sync State

--- a/skills/tracking-health/SKILL.md
+++ b/skills/tracking-health/SKILL.md
@@ -2,7 +2,7 @@
 name: tracking-health
 description: "Preventive audit of conversion tracking across all configured ad platforms — Meta pixels + CAPI, Google Ads conversion actions — with a GA4 cross-check. Use when the user asks to check tracking, audit conversion measurement, verify pixels / tags, diagnose why conversions stopped or look wrong, sanity-check CV counting, or requests a 計測ヘルスチェック / タグ・計測監査 / 計測が壊れていないか確認. Reads STRATEGY.md and STATE.json, produces a per-platform tracking scorecard (OK / Watch / Broken per check) and a fix list ranked by revenue risk."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
 ---
 
 # Tracking Health

--- a/skills/weekly-report/SKILL.md
+++ b/skills/weekly-report/SKILL.md
@@ -2,7 +2,7 @@
 name: weekly-report
 description: "Generate a weekly summary report across all platforms. Use when the user asks for a weekly report, summary, recap, end-of-week review, or weekly digest."
 metadata:
-  version: 0.10.20
+  version: 0.10.22
 ---
 
 # Weekly Report

--- a/tests/test_creative_generate_skill.py
+++ b/tests/test_creative_generate_skill.py
@@ -53,7 +53,10 @@ class TestCreativeGenerateSkillLoadable:
         assert "クリエイティブ作成" in entry.description
         # metadata block is preserved verbatim in extra (forward-compat).
         assert "metadata" in entry.extra
-        assert entry.extra["metadata"]["version"] == "0.10.20"
+        # Pinned to the package version so release bumps can't drift.
+        from mureo import __version__
+
+        assert entry.extra["metadata"]["version"] == __version__
 
     def test_copies_are_byte_identical(self) -> None:
         """The packaged copy and the repo-root mirror must not drift."""


### PR DESCRIPTION
## Summary
- Bump version 0.10.20 → 0.10.22 (pyproject / __init__ / plugin.json / all 51 SKILL.md frontmatters)
- CHANGELOG: record the shipped skills-only **[0.10.21]** section (verbatim from `release/0.10.21`) and cut **[0.10.22]** with the Creative Studio feature set (#384 #385 #386 #387 #388) — visual layer, typography composition, `/creative-generate` skill + docs, visual prompt engineering, dashboard credentials section
- Test: derive creative-generate frontmatter version pin from `mureo.__version__` (was hardcoded)

## Context
0.10.21 was a skills-only release cut from a branch off v0.10.20 (Creative Studio excluded). This release ships Creative Studio from main and resolves the main(0.10.20) < PyPI(0.10.21) version inversion.

## Test plan
- [x] Full suite locally: 5270 passed (7 known local-only failures from the agency plugin injecting extra tools into this editable env; clean CI unaffected)
- [ ] CI green
- [ ] After merge: tag v0.10.22 → GitHub Release → PyPI trusted publishing → wheel inspection (creative_studio present, 25 bundled skills)

https://claude.ai/code/session_01DjF1BFWDKrZYTN6YWMM8Tt