### PR TITLE
fix(credential-guard): actually block credential access with deny JSON (#393)

### DIFF
--- a/mureo/auth_setup.py
+++ b/mureo/auth_setup.py
@@ -32,6 +32,7 @@ from typing import Any
 import httpx
 from google_auth_oauthlib.flow import Flow, InstalledAppFlow
 
+from mureo import credential_guard
 from mureo.auth import GoogleAdsCredentials, MetaAdsCredentials
 
 # Private alias so existing call sites and test monkeypatches of
@@ -668,55 +669,22 @@ def setup_mcp_config() -> None:
 # Credential guard hook
 # ---------------------------------------------------------------------------
 
-# Unique identifier to detect mureo-installed hooks
-_MUREO_HOOK_TAG = "[mureo-credential-guard]"
-
-_CREDENTIAL_GUARD_HOOK_READ = {
-    "matcher": "Read",
-    "hooks": [
-        {
-            "type": "command",
-            "command": (
-                f'python3 -c "'
-                f"import sys,json; "
-                f"d=json.loads(sys.stdin.read()); "
-                f"p=d.get('tool_input',{{}}).get('file_path',''); "
-                f"sys.exit(1) if 'credentials' in p and '.mureo' in p else sys.exit(0)"
-                f'" # {_MUREO_HOOK_TAG}'
-            ),
-        }
-    ],
-}
-
-_CREDENTIAL_GUARD_HOOK_BASH = {
-    "matcher": "Bash",
-    "hooks": [
-        {
-            "type": "command",
-            "command": (
-                f'python3 -c "'
-                f"import sys,json; "
-                f"d=json.loads(sys.stdin.read()); "
-                f"c=d.get('tool_input',{{}}).get('command',''); "
-                f"sys.exit(1) if '.mureo/credentials' in c or "
-                f"('.mureo' in c and 'credentials' in c) else sys.exit(0)"
-                f'" # {_MUREO_HOOK_TAG}'
-            ),
-        }
-    ],
-}
+# Unique identifier to detect mureo-installed hooks (re-exported for callers
+# that predate the shared mureo.credential_guard module).
+_MUREO_HOOK_TAG = credential_guard.GUARD_TAG
 
 
 def install_credential_guard() -> Path | None:
     """Add PreToolUse hooks to block AI agents from reading credentials.
 
-    Safely merges into ~/.claude/settings.json without overwriting
-    existing hooks. Uses a tag comment to detect previously installed
-    mureo hooks and avoid duplicates.
+    Safely merges into ~/.claude/settings.json without overwriting existing
+    hooks. Tagged entries from an older mureo are replaced in place so
+    re-running setup upgrades a stale guard (#393: the old ``sys.exit(1)``
+    form never blocked anything); everything else is preserved.
 
     Returns:
-        Path to settings file if hooks were added. None if skipped
-        (already installed or file could not be parsed).
+        Path to settings file if hooks were added or upgraded. None if
+        skipped (already current or file could not be parsed).
     """
     settings_path = Path.home() / ".claude" / "settings.json"
 
@@ -732,28 +700,36 @@ def install_credential_guard() -> Path | None:
             )
             return None
 
-    # Get or create hooks.PreToolUse
+    # Get or create hooks.PreToolUse, refusing unexpected shapes
     hooks = existing.setdefault("hooks", {})
-    pre_tool_use: list[dict[str, Any]] = hooks.setdefault("PreToolUse", [])
+    if not isinstance(hooks, dict):
+        logger.warning(
+            "settings.json 'hooks' is not an object — skipping credential guard",
+        )
+        return None
+    pre_tool_use = hooks.setdefault("PreToolUse", [])
+    if not isinstance(pre_tool_use, list):
+        logger.warning(
+            "settings.json 'hooks.PreToolUse' is not a list — "
+            "skipping credential guard",
+        )
+        return None
 
-    # Check if mureo hooks are already installed (by tag)
-    for entry in pre_tool_use:
-        for h in entry.get("hooks", []):
-            cmd = h.get("command", "")
-            if _MUREO_HOOK_TAG in cmd:
-                logger.info("Credential guard already installed: %s", settings_path)
-                return None
+    # Drop any previously installed mureo entries (tag-scoped), then append
+    # the current templates. Identical content means nothing to do.
+    kept = [e for e in pre_tool_use if not credential_guard.is_guard_entry(e)]
+    desired = kept + credential_guard.guard_entries()
+    if desired == pre_tool_use:
+        logger.info("Credential guard already installed: %s", settings_path)
+        return None
+    hooks["PreToolUse"] = desired
 
-    # Append mureo hooks (do NOT replace existing hooks)
-    pre_tool_use.append(_CREDENTIAL_GUARD_HOOK_READ)
-    pre_tool_use.append(_CREDENTIAL_GUARD_HOOK_BASH)
+    # Write back (preserve all existing content). Same atomic writer the
+    # removal path uses on this file — upgrades now rewrite a populated
+    # settings.json, so a crash mid-write must not truncate it.
+    from mureo.cli.settings_remove import _atomic_write_json
 
-    # Write back (preserve all existing content)
-    settings_path.parent.mkdir(parents=True, exist_ok=True)
-    settings_path.write_text(
-        json.dumps(existing, indent=2, ensure_ascii=False) + "\n",
-        encoding="utf-8",
-    )
+    _atomic_write_json(existing, settings_path)
 
     logger.info("Credential guard hooks installed: %s", settings_path)
     return settings_path

--- a/mureo/cli/settings_remove.py
+++ b/mureo/cli/settings_remove.py
@@ -30,15 +30,10 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from mureo.credential_guard import GUARD_TAG as _MUREO_HOOK_TAG
 from mureo.fsutil import secure_fchmod
 
 logger = logging.getLogger(__name__)
-
-
-# Unique identifier the credential-guard hooks carry in their ``command``
-# field. Must match the literal used by ``mureo.auth_setup`` so removal is
-# tag-driven (not heuristic).
-_MUREO_HOOK_TAG = "[mureo-credential-guard]"
 
 
 class ConfigWriteError(Exception):

--- a/mureo/cli/setup_codex.py
+++ b/mureo/cli/setup_codex.py
@@ -14,16 +14,18 @@ Idempotency is enforced via tag markers (``[mureo-mcp-config]`` /
 ``[mureo-credential-guard]``) so re-running ``mureo setup codex`` is
 safe and never duplicates entries.
 
-The credential guard is defense-in-depth, not the primary control for
-credential protection — the same substring-matching limitations as the
-Claude Code guard apply (symlinks, indirect paths, encoded forms, and
-shell indirection can all evade the match). Real safety comes from
-filesystem permissions on ``~/.mureo/credentials.json`` itself.
+The credential guard templates are shared with the Claude Code installer
+via :mod:`mureo.credential_guard` (see that module for the blocking
+contract and evasion limitations). The guard is defense-in-depth, not the
+primary control — real safety comes from filesystem permissions on
+``~/.mureo`` itself.
 
-The ``hooks.json`` schema (top-level ``PreToolUse`` list) follows the
-Codex CLI hook format documented at
-https://developers.openai.com/codex/hooks and is compatible with the
-matcher / hooks structure reused by ``hatayama/codex-hooks``.
+The ``hooks.json`` schema nests the event lists under a top-level
+``hooks`` key (``{"hooks": {"PreToolUse": [...]}}``), matching the Codex
+CLI hook format documented at https://developers.openai.com/codex/hooks
+(same shape as Claude's settings.json). Earlier mureo versions wrote a
+top-level ``PreToolUse`` list that Codex never loads; install/remove
+migrate mureo's own tagged entries out of that legacy location (#393).
 """
 
 from __future__ import annotations
@@ -38,6 +40,7 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
+from mureo import credential_guard
 from mureo.cli.setup_cmd import _get_data_path
 
 logger = logging.getLogger(__name__)
@@ -83,7 +86,7 @@ def _atomic_write_text(path: Path, content: str) -> None:
 
 
 _MCP_TAG = "[mureo-mcp-config]"
-_GUARD_TAG = "[mureo-credential-guard]"
+_GUARD_TAG = credential_guard.GUARD_TAG
 
 # Use the interpreter running `mureo setup codex` (sys.executable), the env
 # where mureo IS installed — a bare "python" resolves to a system Python that
@@ -100,38 +103,13 @@ args = ["-m", "mureo.mcp"]
 
 
 def _credential_guard_hooks() -> list[dict[str, Any]]:
-    """Two PreToolUse entries (Read + Bash) that block credential reads.
+    """The shared PreToolUse guard entries (path tools + Bash).
 
-    Structurally mirrors ``mureo.auth_setup._CREDENTIAL_GUARD_HOOK_*`` but
-    written here to keep the Codex install surface self-contained.
+    Identical to the Claude Code install — the templates live in
+    :mod:`mureo.credential_guard` so a blocking-behavior fix can never
+    again land on one host and miss the other (#393).
     """
-    read_cmd = (
-        'python3 -c "'
-        "import sys,json; "
-        "d=json.loads(sys.stdin.read()); "
-        "p=d.get('tool_input',{}).get('file_path',''); "
-        "sys.exit(1) if 'credentials' in p and '.mureo' in p else sys.exit(0)"
-        f'" # {_GUARD_TAG}'
-    )
-    bash_cmd = (
-        'python3 -c "'
-        "import sys,json; "
-        "d=json.loads(sys.stdin.read()); "
-        "c=d.get('tool_input',{}).get('command',''); "
-        "sys.exit(1) if '.mureo/credentials' in c or "
-        "('.mureo' in c and 'credentials' in c) else sys.exit(0)"
-        f'" # {_GUARD_TAG}'
-    )
-    return [
-        {
-            "matcher": "Read",
-            "hooks": [{"type": "command", "command": read_cmd}],
-        },
-        {
-            "matcher": "Bash",
-            "hooks": [{"type": "command", "command": bash_cmd}],
-        },
-    ]
+    return credential_guard.guard_entries()
 
 
 # ---------------------------------------------------------------------------
@@ -184,10 +162,14 @@ def install_codex_mcp_config() -> Path | None:
 
 
 def install_codex_credential_guard(hooks_file: Path | None = None) -> Path | None:
-    """Append PreToolUse hooks to ``~/.codex/hooks.json``.
+    """Install the PreToolUse guard into ``~/.codex/hooks.json``.
 
-    Existing hook entries are preserved. Returns the path on first
-    install or ``None`` if the mureo tag is already present.
+    Entries land under the nested ``{"hooks": {"PreToolUse": [...]}}``
+    location Codex actually loads. Foreign hook entries are preserved
+    everywhere; mureo's own tagged entries are upgraded in place, including
+    any stranded in the legacy top-level ``PreToolUse`` list an older mureo
+    wrote (#393). Returns the path when the file changed or ``None`` when
+    the guard is already current (or the file could not be parsed).
 
     ``hooks_file`` overrides the target (the home-aware configure-UI flow
     passes ``<home>/.codex/hooks.json``); it defaults to the real
@@ -206,25 +188,53 @@ def install_codex_credential_guard(hooks_file: Path | None = None) -> Path | Non
             logger.warning("Could not parse %s — refusing to overwrite", hooks_file)
             return None
 
-    pre_tool_use_raw = existing.get("PreToolUse", [])
-    if not isinstance(pre_tool_use_raw, list):
+    changed = False
+
+    # Legacy top-level list: strip mureo's own tagged entries (they migrate
+    # to the nested location below); foreign entries stay where they are.
+    legacy = existing.get("PreToolUse")
+    legacy_kept: list[Any] = []
+    if legacy is not None:
+        if not isinstance(legacy, list):
+            logger.warning(
+                "hooks.json 'PreToolUse' is not a list (got %s) — "
+                "refusing to overwrite",
+                type(legacy).__name__,
+            )
+            return None
+        legacy_kept = [e for e in legacy if not credential_guard.is_guard_entry(e)]
+        changed = changed or len(legacy_kept) != len(legacy)
+
+    hooks_obj = existing.get("hooks", {})
+    if not isinstance(hooks_obj, dict):
         logger.warning(
-            "hooks.json 'PreToolUse' is not a list (got %s) — refusing to overwrite",
-            type(pre_tool_use_raw).__name__,
+            "hooks.json 'hooks' is not an object (got %s) — refusing to overwrite",
+            type(hooks_obj).__name__,
         )
         return None
-    pre_tool_use: list[dict[str, Any]] = pre_tool_use_raw
-    existing["PreToolUse"] = pre_tool_use
+    pre_tool_use = hooks_obj.get("PreToolUse", [])
+    if not isinstance(pre_tool_use, list):
+        logger.warning(
+            "hooks.json 'hooks.PreToolUse' is not a list (got %s) — "
+            "refusing to overwrite",
+            type(pre_tool_use).__name__,
+        )
+        return None
 
-    for entry in pre_tool_use:
-        if not isinstance(entry, dict):
-            continue
-        for hook in entry.get("hooks", []):
-            if _GUARD_TAG in hook.get("command", ""):
-                logger.info("Codex credential guard already installed: %s", hooks_file)
-                return None
+    kept = [e for e in pre_tool_use if not credential_guard.is_guard_entry(e)]
+    desired = kept + _credential_guard_hooks()
+    changed = changed or desired != pre_tool_use
+    if not changed:
+        logger.info("Codex credential guard already installed: %s", hooks_file)
+        return None
 
-    pre_tool_use.extend(_credential_guard_hooks())
+    if legacy is not None:
+        if legacy_kept:
+            existing["PreToolUse"] = legacy_kept
+        else:
+            existing.pop("PreToolUse", None)
+    existing["hooks"] = hooks_obj
+    hooks_obj["PreToolUse"] = desired
 
     _atomic_write_text(
         hooks_file,
@@ -238,10 +248,12 @@ def remove_codex_credential_guard(hooks_file: Path | None = None) -> Path | None
     """Drop the mureo-tagged PreToolUse hooks from ``~/.codex/hooks.json``.
 
     The inverse of :func:`install_codex_credential_guard`: removes only the
-    entries whose command carries the ``[mureo-credential-guard]`` tag, and
-    preserves every other hook. Returns the path when something was removed,
-    or ``None`` when the file is absent/unparseable or no tagged entry was
-    present (idempotent). ``hooks_file`` mirrors the install override.
+    entries whose command carries the ``[mureo-credential-guard]`` tag —
+    from both the nested ``hooks.PreToolUse`` location and the legacy
+    top-level list — and preserves every other hook. Returns the path when
+    something was removed, or ``None`` when the file is absent/unparseable
+    or no tagged entry was present (idempotent). ``hooks_file`` mirrors the
+    install override.
     """
     if hooks_file is None:
         hooks_file = Path.home() / ".codex" / "hooks.json"
@@ -254,23 +266,27 @@ def remove_codex_credential_guard(hooks_file: Path | None = None) -> Path | None
         return None
     if not isinstance(parsed, dict):
         return None
-    pre_tool_use = parsed.get("PreToolUse")
-    if not isinstance(pre_tool_use, list):
-        return None
 
-    def _is_mureo_entry(entry: Any) -> bool:
-        if not isinstance(entry, dict):
-            return False
-        return any(
-            _GUARD_TAG in hook.get("command", "")
-            for hook in entry.get("hooks", [])
-            if isinstance(hook, dict)
-        )
+    changed = False
 
-    kept = [entry for entry in pre_tool_use if not _is_mureo_entry(entry)]
-    if len(kept) == len(pre_tool_use):
+    legacy = parsed.get("PreToolUse")
+    if isinstance(legacy, list):
+        legacy_kept = [e for e in legacy if not credential_guard.is_guard_entry(e)]
+        if len(legacy_kept) != len(legacy):
+            parsed["PreToolUse"] = legacy_kept
+            changed = True
+
+    hooks_obj = parsed.get("hooks")
+    if isinstance(hooks_obj, dict):
+        nested = hooks_obj.get("PreToolUse")
+        if isinstance(nested, list):
+            nested_kept = [e for e in nested if not credential_guard.is_guard_entry(e)]
+            if len(nested_kept) != len(nested):
+                hooks_obj["PreToolUse"] = nested_kept
+                changed = True
+
+    if not changed:
         return None  # nothing tagged — idempotent no-op
-    parsed["PreToolUse"] = kept
     _atomic_write_text(
         hooks_file,
         json.dumps(parsed, indent=2, ensure_ascii=False) + "\n",

--- a/mureo/credential_guard.py
+++ b/mureo/credential_guard.py
@@ -1,0 +1,154 @@
+"""Shared PreToolUse credential-guard hook templates (#393).
+
+Single source of truth for the guard hooks installed into Claude Code's
+``~/.claude/settings.json`` and Codex's ``~/.codex/hooks.json``.  The two
+installers previously carried copy-pasted templates, which is how the
+non-blocking ``sys.exit(1)`` bug shipped to both hosts.
+
+Blocking contract (identical for Claude Code and Codex): a PreToolUse hook
+blocks by printing ``{"hookSpecificOutput": {"permissionDecision": "deny",
+...}}`` to stdout and exiting 0, or by exiting 2 with the reason on stderr.
+Any other non-zero exit — including 1 — is a *non-blocking* hook error and
+the tool call proceeds.  The deny-JSON form is used here because an
+interpreter crash (exit 1) can never be mistaken for an intentional block.
+
+Two guards are installed:
+
+* Path guard (``Read|Edit|Write|Grep|Glob|NotebookEdit``): resolves the
+  tool's target path with ``os.path.realpath`` (after ``expanduser``) and
+  denies when it lands inside ``~/.mureo`` — covering every file in the
+  directory and closing the symlink/relative-path evasions of the old
+  substring check.
+* Bash guard: denies any command whose text references ``.mureo``.  A
+  substring check is all a command string allows, but anchoring on the
+  directory name (not ``credentials``) also catches wildcard forms like
+  ``cat ~/.mureo/cred*``.
+
+Both comparisons are case-folded: macOS and Windows filesystems are
+case-insensitive by default, so ``~/.MUREO/credentials.json`` opens the
+real file.  On case-sensitive filesystems this can only over-block (a
+genuinely distinct ``~/.MUREO`` directory), never under-block — the right
+direction for a guard.
+
+The guard remains defense-in-depth, not the primary control: shell
+indirection and encoded forms can still evade the Bash guard.  Real safety
+comes from filesystem permissions on ``~/.mureo`` itself.
+
+NOTE: the python payloads run inside double quotes on a shell command line
+(``python3 -c "..."``), so they must not contain double quotes, ``$``,
+backticks, backslashes, or newlines.  ``tests/test_credential_guard.py``
+enforces this along with the blocking behavior.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Unique identifier used to detect (and upgrade/remove) mureo-installed hooks.
+GUARD_TAG = "[mureo-credential-guard]"
+
+# Matchers are regexes over the tool name. PATH_TOOLS_MATCHER lists the
+# Claude Code tools that receive a filesystem path; entries for tools a host
+# does not expose (e.g. Codex has no Read tool) simply never fire.
+PATH_TOOLS_MATCHER = "Read|Edit|Write|Grep|Glob|NotebookEdit"
+BASH_MATCHER = "Bash"
+
+# Characters allowed in a deny reason. The reason is interpolated into a
+# single-quoted python literal inside a double-quoted shell command; anything
+# outside this set (quotes, $, backticks, backslashes, braces, newlines...)
+# could break parsing and turn the block into a fail-open exit-1 error —
+# exactly the #393 failure mode.
+_SAFE_REASON_CHARS = frozenset(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 .,:;~/-_"
+)
+
+
+def _deny_expr(reason: str) -> str:
+    """A python expression that prints the PreToolUse deny JSON."""
+    unsafe = set(reason) - _SAFE_REASON_CHARS
+    if unsafe:
+        raise ValueError(f"deny reason contains unsafe characters: {unsafe!r}")
+    return (
+        "print(json.dumps({'hookSpecificOutput':{'hookEventName':'PreToolUse',"
+        "'permissionDecision':'deny','permissionDecisionReason':"
+        f"'{reason}'}}}}))"
+    )
+
+
+_PATH_GUARD_CODE = (
+    "import sys,json,os; "
+    "d=json.loads(sys.stdin.read() or '{}'); "
+    "i=d.get('tool_input') or {}; "
+    "p=str(i.get('file_path') or i.get('path') or i.get('notebook_path') or ''); "
+    "b=os.path.realpath(os.path.expanduser('~/.mureo')).lower(); "
+    "r=os.path.realpath(os.path.expanduser(p)).lower() if p else ''; "
+    + _deny_expr("mureo credential guard: files under ~/.mureo are protected")
+    + " if r==b or r.startswith(b+os.sep) else None"
+)
+
+_BASH_GUARD_CODE = (
+    "import sys,json; "
+    "d=json.loads(sys.stdin.read() or '{}'); "
+    "c=str((d.get('tool_input') or {}).get('command') or ''); "
+    + _deny_expr("mureo credential guard: commands referencing .mureo are blocked")
+    + " if '.mureo' in c.lower() else None"
+)
+
+
+def path_guard_command() -> str:
+    """The shell command for the path-based guard (Read/Edit/Write/Grep/Glob)."""
+    return f'python3 -c "{_PATH_GUARD_CODE}" # {GUARD_TAG}'
+
+
+def bash_guard_command() -> str:
+    """The shell command for the Bash command-text guard."""
+    return f'python3 -c "{_BASH_GUARD_CODE}" # {GUARD_TAG}'
+
+
+def path_guard_entry() -> dict[str, Any]:
+    """A fresh PreToolUse entry for the path guard."""
+    return {
+        "matcher": PATH_TOOLS_MATCHER,
+        "hooks": [{"type": "command", "command": path_guard_command()}],
+    }
+
+
+def bash_guard_entry() -> dict[str, Any]:
+    """A fresh PreToolUse entry for the Bash guard."""
+    return {
+        "matcher": BASH_MATCHER,
+        "hooks": [{"type": "command", "command": bash_guard_command()}],
+    }
+
+
+def guard_entries() -> list[dict[str, Any]]:
+    """Fresh copies of both guard entries, in install order.
+
+    Fresh so that callers merging them into parsed user config never alias
+    dicts across two install targets.
+    """
+    return [path_guard_entry(), bash_guard_entry()]
+
+
+def is_guard_entry(entry: Any) -> bool:
+    """True when ``entry`` is a mureo-tagged PreToolUse entry.
+
+    Detection is scoped to the inner ``command`` field so a user's own entry
+    whose matcher happens to contain the tag literal is never claimed.
+
+    Matching is entry-level: installers drop the whole entry when any inner
+    hook carries the tag. mureo only ever writes single-hook entries, so
+    this is equivalent to the finer hook-level stripping that
+    ``mureo.cli.settings_remove`` performs — it differs only on a
+    hand-merged config where a user appended their own hook to a mureo
+    entry.
+    """
+    if not isinstance(entry, dict):
+        return False
+    hooks = entry.get("hooks")
+    if not isinstance(hooks, list):
+        return False
+    return any(
+        isinstance(hook, dict) and GUARD_TAG in str(hook.get("command", ""))
+        for hook in hooks
+    )

--- a/tests/hook_guard_runner.py
+++ b/tests/hook_guard_runner.py
@@ -1,0 +1,75 @@
+"""Test helper: execute a credential-guard hook command like the agent harness.
+
+Claude Code / Codex run PreToolUse hook commands through a shell with the
+tool-call JSON on stdin.  The guard commands mureo installs have the shape::
+
+    python3 -c "<single-line python>" # [mureo-credential-guard]
+
+Re-running the embedded payload through ``sys.executable`` keeps these tests
+portable (no bash dependency on the Windows CI job) while exercising the
+exact code a shell would hand to ``python3 -c``.  ``extract_python_code``
+also asserts the payload is shell-safe: because the code sits inside double
+quotes on the command line, any ``"``, ``$``, backtick, or backslash would
+change meaning under a POSIX shell.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+_COMMAND_RE = re.compile(r'^python3 -c "(?P<code>[^"]*)" # \[mureo-credential-guard\]$')
+
+_SHELL_HAZARDS = ("$", "`", "\\", "\n")
+
+
+def extract_python_code(command: str) -> str:
+    """Return the python payload from a guard command, refusing unsafe shapes."""
+    match = _COMMAND_RE.match(command)
+    if match is None:
+        raise AssertionError(f"unexpected guard command shape: {command!r}")
+    code = match.group("code")
+    for hazard in _SHELL_HAZARDS:
+        if hazard in code:
+            raise AssertionError(
+                f"guard payload contains shell-unsafe character {hazard!r}: {code!r}"
+            )
+    return code
+
+
+def run_guard(
+    command: str,
+    tool_input: dict[str, Any],
+    home: Path,
+    tool_name: str = "Read",
+) -> subprocess.CompletedProcess[str]:
+    """Run a guard command with ``tool_input`` on stdin and ``home`` as $HOME.
+
+    ``HOME`` (POSIX) and ``USERPROFILE`` (Windows) are both overridden so the
+    guard's ``os.path.expanduser('~/.mureo')`` resolves inside the test tree.
+    """
+    code = extract_python_code(command)
+    payload = json.dumps({"tool_name": tool_name, "tool_input": tool_input})
+    env = dict(os.environ, HOME=str(home), USERPROFILE=str(home))
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        input=payload,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+
+
+def deny_decision(proc: subprocess.CompletedProcess[str]) -> str | None:
+    """Return the ``permissionDecision`` emitted by a guard run, if any."""
+    if not proc.stdout.strip():
+        return None
+    output = json.loads(proc.stdout)
+    decision = output.get("hookSpecificOutput", {}).get("permissionDecision")
+    return str(decision) if decision is not None else None

--- a/tests/test_auth_setup.py
+++ b/tests/test_auth_setup.py
@@ -1021,7 +1021,7 @@ def test_install_credential_guard_new(tmp_path: Path) -> None:
     settings = json.loads(result.read_text(encoding="utf-8"))
     pre_tool_use = settings["hooks"]["PreToolUse"]
     assert len(pre_tool_use) == 2
-    assert pre_tool_use[0]["matcher"] == "Read"
+    assert pre_tool_use[0]["matcher"] == "Read|Edit|Write|Grep|Glob|NotebookEdit"
     assert pre_tool_use[1]["matcher"] == "Bash"
     assert "[mureo-credential-guard]" in pre_tool_use[0]["hooks"][0]["command"]
 
@@ -1062,7 +1062,7 @@ def test_install_credential_guard_preserves_existing_hooks(tmp_path: Path) -> No
     pre_tool_use = settings["hooks"]["PreToolUse"]
     assert len(pre_tool_use) == 3
     assert pre_tool_use[0]["matcher"] == "Write"  # original
-    assert pre_tool_use[1]["matcher"] == "Read"  # mureo
+    assert pre_tool_use[1]["matcher"] == "Read|Edit|Write|Grep|Glob|NotebookEdit"  # mureo
     assert pre_tool_use[2]["matcher"] == "Bash"  # mureo
 
 
@@ -1088,6 +1088,61 @@ def test_install_credential_guard_skip_if_already_installed(tmp_path: Path) -> N
     settings = json.loads(settings_path.read_text(encoding="utf-8"))
     # Still only 2 mureo hooks (no duplicates)
     assert len(settings["hooks"]["PreToolUse"]) == 2
+
+
+@pytest.mark.unit
+def test_install_credential_guard_upgrades_stale_hooks(tmp_path: Path) -> None:
+    """Tagged hooks from an older mureo (non-blocking ``sys.exit(1)`` form)
+    are replaced on re-install instead of being skipped (#393)."""
+    from mureo.auth_setup import install_credential_guard
+
+    claude_dir = tmp_path / ".claude"
+    claude_dir.mkdir()
+    settings_path = claude_dir / "settings.json"
+    stale_cmd = (
+        'python3 -c "import sys,json; sys.exit(1)" # [mureo-credential-guard]'
+    )
+    settings_path.write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "matcher": "Write",
+                            "hooks": [{"type": "command", "command": "echo check"}],
+                        },
+                        {
+                            "matcher": "Read",
+                            "hooks": [{"type": "command", "command": stale_cmd}],
+                        },
+                        {
+                            "matcher": "Bash",
+                            "hooks": [{"type": "command", "command": stale_cmd}],
+                        },
+                    ]
+                }
+            }
+        )
+    )
+
+    with patch("mureo.auth_setup.Path.home", return_value=tmp_path):
+        result = install_credential_guard()
+
+    assert result is not None  # upgrade happened, not a skip
+    settings = json.loads(settings_path.read_text(encoding="utf-8"))
+    pre_tool_use = settings["hooks"]["PreToolUse"]
+    # Foreign hook survives; the 2 stale mureo entries became 2 current ones.
+    assert len(pre_tool_use) == 3
+    assert pre_tool_use[0]["matcher"] == "Write"
+    tagged = [
+        h["command"]
+        for e in pre_tool_use
+        for h in e["hooks"]
+        if "[mureo-credential-guard]" in h["command"]
+    ]
+    assert len(tagged) == 2
+    assert all("sys.exit(1)" not in c for c in tagged)
+    assert all("permissionDecision" in c for c in tagged)
 
 
 @pytest.mark.unit

--- a/tests/test_credential_guard.py
+++ b/tests/test_credential_guard.py
@@ -1,0 +1,247 @@
+"""Behavioral tests for the shared credential-guard hook templates (#393).
+
+The guard must actually BLOCK.  Claude Code and Codex PreToolUse hooks treat
+a plain exit code 1 as a *non-blocking* error — the tool call proceeds — so
+the old ``sys.exit(1)`` templates never protected anything.  Blocking
+requires exit code 2 or a ``permissionDecision: "deny"`` JSON on stdout;
+mureo uses the deny-JSON form because an interpreter crash (exit 1) can
+never be mistaken for an intentional block.
+
+These tests execute the generated hook payloads in a subprocess with a fake
+``$HOME``, mirroring how the agent harness invokes them.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests.hook_guard_runner import deny_decision, run_guard
+
+_PROTECTED_FILES = (
+    "credentials.json",
+    "agency.json",
+    "config.json",
+    "setup_state.json",
+    os.path.join("shared", "credentials.json.bak"),
+)
+
+
+@pytest.fixture
+def fake_home(tmp_path: Path) -> Path:
+    """A home directory with a populated ``~/.mureo``."""
+    mureo_dir = tmp_path / ".mureo"
+    (mureo_dir / "shared").mkdir(parents=True)
+    for name in _PROTECTED_FILES:
+        (mureo_dir / name).write_text("{}", encoding="utf-8")
+    return tmp_path
+
+
+def _path_guard_command() -> str:
+    from mureo.credential_guard import path_guard_entry
+
+    return path_guard_entry()["hooks"][0]["command"]
+
+
+def _bash_guard_command() -> str:
+    from mureo.credential_guard import bash_guard_entry
+
+    return bash_guard_entry()["hooks"][0]["command"]
+
+
+# ---------------------------------------------------------------------------
+# Path guard (Read / Edit / Write / Grep / Glob)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestPathGuardBehavior:
+    def test_denies_read_of_credentials(self, fake_home: Path) -> None:
+        proc = run_guard(
+            _path_guard_command(),
+            {"file_path": str(fake_home / ".mureo" / "credentials.json")},
+            fake_home,
+        )
+        assert proc.returncode == 0
+        assert deny_decision(proc) == "deny"
+
+    @pytest.mark.parametrize("name", _PROTECTED_FILES)
+    def test_denies_every_file_under_mureo_dir(
+        self, fake_home: Path, name: str
+    ) -> None:
+        """The whole ``~/.mureo`` tree is protected, not just credentials.json."""
+        proc = run_guard(
+            _path_guard_command(),
+            {"file_path": str(fake_home / ".mureo" / name)},
+            fake_home,
+        )
+        assert deny_decision(proc) == "deny"
+
+    def test_denies_tilde_path(self, fake_home: Path) -> None:
+        proc = run_guard(
+            _path_guard_command(),
+            {"file_path": "~/.mureo/credentials.json"},
+            fake_home,
+        )
+        assert deny_decision(proc) == "deny"
+
+    def test_denies_grep_path_field(self, fake_home: Path) -> None:
+        """Grep/Glob send ``path`` instead of ``file_path``."""
+        proc = run_guard(
+            _path_guard_command(),
+            {"path": str(fake_home / ".mureo"), "pattern": "token"},
+            fake_home,
+            tool_name="Grep",
+        )
+        assert deny_decision(proc) == "deny"
+
+    @pytest.mark.skipif(
+        sys.platform == "win32", reason="symlink creation needs privileges"
+    )
+    def test_denies_symlink_evasion(self, fake_home: Path, tmp_path: Path) -> None:
+        """A symlink outside ~/.mureo resolving into it is still blocked."""
+        link = tmp_path / "innocent.json"
+        link.symlink_to(fake_home / ".mureo" / "credentials.json")
+        proc = run_guard(_path_guard_command(), {"file_path": str(link)}, fake_home)
+        assert deny_decision(proc) == "deny"
+
+    def test_allows_files_outside_mureo(self, fake_home: Path) -> None:
+        project_file = fake_home / "project" / "main.py"
+        project_file.parent.mkdir()
+        project_file.write_text("print('ok')\n", encoding="utf-8")
+        proc = run_guard(
+            _path_guard_command(), {"file_path": str(project_file)}, fake_home
+        )
+        assert proc.returncode == 0
+        assert proc.stdout.strip() == ""
+
+    def test_allows_similarly_named_sibling_dir(self, fake_home: Path) -> None:
+        """Prefix matching must not spill over to ``~/.mureo-backup`` etc."""
+        sibling = fake_home / ".mureo-backup" / "credentials.json"
+        sibling.parent.mkdir()
+        sibling.write_text("{}", encoding="utf-8")
+        proc = run_guard(_path_guard_command(), {"file_path": str(sibling)}, fake_home)
+        assert proc.returncode == 0
+        assert proc.stdout.strip() == ""
+
+    def test_denies_uppercase_path_evasion(self, fake_home: Path) -> None:
+        """macOS/Windows filesystems are case-insensitive by default, so
+        ``~/.MUREO/credentials.json`` opens the real file — must be denied."""
+        proc = run_guard(
+            _path_guard_command(),
+            {"file_path": str(fake_home / ".MUREO" / "credentials.json")},
+            fake_home,
+        )
+        assert deny_decision(proc) == "deny"
+
+    def test_allows_empty_tool_input(self, fake_home: Path) -> None:
+        proc = run_guard(_path_guard_command(), {}, fake_home)
+        assert proc.returncode == 0
+        assert proc.stdout.strip() == ""
+
+
+# ---------------------------------------------------------------------------
+# Bash guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestBashGuardBehavior:
+    def test_denies_wildcard_read(self, fake_home: Path) -> None:
+        """``cat ~/.mureo/cred*`` evaded the old 'credentials' substring check."""
+        proc = run_guard(
+            _bash_guard_command(),
+            {"command": "cat ~/.mureo/cred*"},
+            fake_home,
+            tool_name="Bash",
+        )
+        assert proc.returncode == 0
+        assert deny_decision(proc) == "deny"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "cat ~/.mureo/credentials.json",
+            "cat $HOME/.mureo/config.json",
+            "cp -r ~/.mureo /tmp/exfil",
+            "python3 -c 'print(open(\"/Users/x/.mureo/agency.json\").read())'",
+            "cat ~/.MUREO/credentials.json",  # case-insensitive filesystems
+        ],
+    )
+    def test_denies_mureo_dir_references(self, fake_home: Path, command: str) -> None:
+        proc = run_guard(
+            _bash_guard_command(), {"command": command}, fake_home, tool_name="Bash"
+        )
+        assert deny_decision(proc) == "deny"
+
+    @pytest.mark.parametrize("command", ["echo hello", "ls -la", "git status"])
+    def test_allows_unrelated_commands(self, fake_home: Path, command: str) -> None:
+        proc = run_guard(
+            _bash_guard_command(), {"command": command}, fake_home, tool_name="Bash"
+        )
+        assert proc.returncode == 0
+        assert proc.stdout.strip() == ""
+
+
+# ---------------------------------------------------------------------------
+# Template structure
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGuardTemplates:
+    def test_no_nonblocking_exit1(self) -> None:
+        """exit(1) is a non-blocking hook error — it must never come back."""
+        for command in (_path_guard_command(), _bash_guard_command()):
+            assert "sys.exit(1)" not in command
+            assert "permissionDecision" in command
+
+    def test_deny_json_shape(self, fake_home: Path) -> None:
+        import json
+
+        proc = run_guard(
+            _path_guard_command(),
+            {"file_path": str(fake_home / ".mureo" / "credentials.json")},
+            fake_home,
+        )
+        output = json.loads(proc.stdout)["hookSpecificOutput"]
+        assert output["hookEventName"] == "PreToolUse"
+        assert output["permissionDecision"] == "deny"
+        assert output["permissionDecisionReason"]
+
+    def test_commands_are_tagged(self) -> None:
+        from mureo.credential_guard import GUARD_TAG
+
+        for command in (_path_guard_command(), _bash_guard_command()):
+            assert command.endswith(f"# {GUARD_TAG}")
+
+    def test_path_matcher_covers_file_tools(self) -> None:
+        from mureo.credential_guard import bash_guard_entry, path_guard_entry
+
+        matcher = path_guard_entry()["matcher"]
+        for tool in ("Read", "Edit", "Write", "Grep", "Glob", "NotebookEdit"):
+            assert re.fullmatch(matcher, tool), f"matcher must cover {tool}"
+        assert bash_guard_entry()["matcher"] == "Bash"
+
+    def test_unsafe_deny_reason_is_rejected(self) -> None:
+        """A reason with quoting hazards would fail open (exit 1) at hook
+        runtime — it must be refused at build time instead."""
+        from mureo.credential_guard import _deny_expr
+
+        for bad in ("it's blocked", 'say "no"', "a\\b", "cost $5", "x`y`"):
+            with pytest.raises(ValueError, match="unsafe"):
+                _deny_expr(bad)
+
+    def test_guard_entries_returns_fresh_copies(self) -> None:
+        """Installers merge these into user config — aliasing would let one
+        install mutate another's already-written structure."""
+        from mureo.credential_guard import guard_entries
+
+        first, second = guard_entries(), guard_entries()
+        assert first == second
+        assert first[0] is not second[0]
+        assert first[0]["hooks"] is not second[0]["hooks"]

--- a/tests/test_setup_codex.py
+++ b/tests/test_setup_codex.py
@@ -87,8 +87,20 @@ class TestInstallCodexMcpConfig:
         assert 'command = "legacy-mureo"' in config.read_text(encoding="utf-8")
 
 
+_STALE_GUARD_CMD = (
+    'python3 -c "import sys,json; sys.exit(1)" # [mureo-credential-guard]'
+)
+
+
 class TestInstallCodexCredentialGuard:
-    """PreToolUse hook in ~/.codex/hooks.json blocks credential reads."""
+    """PreToolUse hook in ~/.codex/hooks.json blocks credential reads.
+
+    Codex reads hooks from the nested ``{"hooks": {"PreToolUse": [...]}}``
+    shape (same as Claude's settings.json).  Earlier mureo versions wrote a
+    top-level ``PreToolUse`` list that Codex never loads, so the install
+    must both target the nested location and migrate its own stale entries
+    out of the legacy one (#393).
+    """
 
     def test_creates_hooks_json_when_missing(self, home: Path) -> None:
         result = install_codex_credential_guard()
@@ -96,24 +108,31 @@ class TestInstallCodexCredentialGuard:
         hooks_file = home / ".codex" / "hooks.json"
         assert hooks_file.exists()
         data = json.loads(hooks_file.read_text(encoding="utf-8"))
-        pre = data.get("PreToolUse", [])
+        # Nested shape only — the legacy top-level list is never created.
+        assert "PreToolUse" not in data
+        pre = data["hooks"]["PreToolUse"]
         assert len(pre) >= 1
-        # At least one entry targets Bash and mentions the mureo guard tag
         matchers = [entry.get("matcher") for entry in pre]
         assert "Bash" in matchers
         flat = json.dumps(data)
         assert "[mureo-credential-guard]" in flat
+        assert "sys.exit(1)" not in flat
+        assert "permissionDecision" in flat
 
     def test_preserves_existing_hooks(self, home: Path) -> None:
         hooks_file = home / ".codex" / "hooks.json"
         hooks_file.parent.mkdir(parents=True)
         existing = {
-            "PreToolUse": [
-                {
-                    "matcher": "Bash",
-                    "hooks": [{"type": "command", "command": "echo 'existing guard'"}],
-                }
-            ]
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "Bash",
+                        "hooks": [
+                            {"type": "command", "command": "echo 'existing guard'"}
+                        ],
+                    }
+                ]
+            }
         }
         hooks_file.write_text(json.dumps(existing), encoding="utf-8")
 
@@ -124,13 +143,100 @@ class TestInstallCodexCredentialGuard:
         assert "existing guard" in flat
         assert "[mureo-credential-guard]" in flat
 
+    def test_migrates_legacy_top_level_entries(self, home: Path) -> None:
+        """Stale tagged entries under the legacy top-level ``PreToolUse``
+        move to the nested location; foreign legacy entries stay put."""
+        hooks_file = home / ".codex" / "hooks.json"
+        hooks_file.parent.mkdir(parents=True)
+        foreign = {
+            "matcher": "Bash",
+            "hooks": [{"type": "command", "command": "echo mine"}],
+        }
+        stale = {
+            "matcher": "Read",
+            "hooks": [{"type": "command", "command": _STALE_GUARD_CMD}],
+        }
+        hooks_file.write_text(
+            json.dumps({"PreToolUse": [foreign, stale]}), encoding="utf-8"
+        )
+
+        result = install_codex_credential_guard()
+
+        assert result is not None
+        data = json.loads(hooks_file.read_text(encoding="utf-8"))
+        # Foreign legacy entry untouched, stale mureo entry migrated out.
+        assert data["PreToolUse"] == [foreign]
+        flat = json.dumps(data["hooks"]["PreToolUse"])
+        assert flat.count("[mureo-credential-guard]") == 2
+        assert "sys.exit(1)" not in flat
+
+    def test_migrates_legacy_when_only_tagged(self, home: Path) -> None:
+        """A legacy list holding only mureo entries is dropped entirely."""
+        hooks_file = home / ".codex" / "hooks.json"
+        hooks_file.parent.mkdir(parents=True)
+        stale = {
+            "matcher": "Bash",
+            "hooks": [{"type": "command", "command": _STALE_GUARD_CMD}],
+        }
+        hooks_file.write_text(json.dumps({"PreToolUse": [stale]}), encoding="utf-8")
+
+        result = install_codex_credential_guard()
+
+        assert result is not None
+        data = json.loads(hooks_file.read_text(encoding="utf-8"))
+        assert "PreToolUse" not in data
+        assert json.dumps(data["hooks"]).count("[mureo-credential-guard]") == 2
+
+    def test_upgrades_stale_nested_entries(self, home: Path) -> None:
+        """Tagged nested entries from an older mureo are replaced, not kept."""
+        hooks_file = home / ".codex" / "hooks.json"
+        hooks_file.parent.mkdir(parents=True)
+        stale = {
+            "matcher": "Read",
+            "hooks": [{"type": "command", "command": _STALE_GUARD_CMD}],
+        }
+        hooks_file.write_text(
+            json.dumps({"hooks": {"PreToolUse": [stale]}}), encoding="utf-8"
+        )
+
+        result = install_codex_credential_guard()
+
+        assert result is not None
+        data = json.loads(hooks_file.read_text(encoding="utf-8"))
+        flat = json.dumps(data)
+        assert "sys.exit(1)" not in flat
+        assert "permissionDecision" in flat
+        assert flat.count("[mureo-credential-guard]") == 2
+
+    def test_installed_guard_blocks_credential_read(self, home: Path) -> None:
+        """The installed Codex commands share the blocking templates."""
+        from tests.hook_guard_runner import deny_decision, run_guard
+
+        install_codex_credential_guard()
+        data = json.loads(
+            (home / ".codex" / "hooks.json").read_text(encoding="utf-8")
+        )
+        commands = [
+            h["command"]
+            for entry in data["hooks"]["PreToolUse"]
+            for h in entry["hooks"]
+        ]
+        cred = str(home / ".mureo" / "credentials.json")
+        decisions = [
+            deny_decision(
+                run_guard(cmd, {"file_path": cred, "command": f"cat {cred}"}, home)
+            )
+            for cmd in commands
+        ]
+        assert "deny" in decisions
+
     def test_idempotent_skip_when_already_installed(self, home: Path) -> None:
         install_codex_credential_guard()
         result = install_codex_credential_guard()
         assert result is None
         data = json.loads((home / ".codex" / "hooks.json").read_text(encoding="utf-8"))
         flat = json.dumps(data)
-        # Two mureo entries (Read + Bash) persist; no duplicates are added.
+        # Two mureo entries (path tools + Bash) persist; no duplicates.
         assert flat.count("[mureo-credential-guard]") == 2
 
     def test_corrupt_hooks_json_returns_none_without_clobber(self, home: Path) -> None:
@@ -144,12 +250,24 @@ class TestInstallCodexCredentialGuard:
         # Corrupt content left intact for the operator to inspect.
         assert hooks_file.read_text(encoding="utf-8") == "{not valid json"
 
-    def test_pretooluse_wrong_type_refused(self, home: Path) -> None:
-        """PreToolUse must be a list; a dict (or other type) is refused."""
+    def test_legacy_pretooluse_wrong_type_refused(self, home: Path) -> None:
+        """Legacy top-level PreToolUse must be a list; a dict is refused."""
         hooks_file = home / ".codex" / "hooks.json"
         hooks_file.parent.mkdir(parents=True)
         hooks_file.write_text(
             json.dumps({"PreToolUse": {"matcher": "Bash"}}),
+            encoding="utf-8",
+        )
+
+        result = install_codex_credential_guard()
+        assert result is None
+
+    def test_nested_pretooluse_wrong_type_refused(self, home: Path) -> None:
+        """Nested hooks.PreToolUse must be a list; a dict is refused."""
+        hooks_file = home / ".codex" / "hooks.json"
+        hooks_file.parent.mkdir(parents=True)
+        hooks_file.write_text(
+            json.dumps({"hooks": {"PreToolUse": {"matcher": "Bash"}}}),
             encoding="utf-8",
         )
 
@@ -252,7 +370,13 @@ class TestRemoveCredentialGuard:
         # A user's own unrelated hook must survive.
         hooks_file.write_text(
             json.dumps(
-                {"PreToolUse": [{"matcher": "Read", "hooks": [{"command": "echo hi"}]}]}
+                {
+                    "hooks": {
+                        "PreToolUse": [
+                            {"matcher": "Read", "hooks": [{"command": "echo hi"}]}
+                        ]
+                    }
+                }
             ),
             encoding="utf-8",
         )
@@ -262,11 +386,28 @@ class TestRemoveCredentialGuard:
         data = json.loads(hooks_file.read_text(encoding="utf-8"))
         remaining = [
             h.get("command", "")
-            for e in data["PreToolUse"]
+            for e in data["hooks"]["PreToolUse"]
             for h in e.get("hooks", [])
         ]
         assert remaining == ["echo hi"]  # only the user's hook kept
-        assert not any("mureo-credential-guard" in c for c in remaining)
+        assert "mureo-credential-guard" not in json.dumps(data)
+
+    def test_removes_legacy_top_level_tagged_entries(self, home: Path) -> None:
+        """Entries an older mureo wrote to the legacy top-level list are
+        removed too (they carry the same tag)."""
+        from mureo.cli.setup_codex import remove_codex_credential_guard
+
+        hooks_file = home / ".codex" / "hooks.json"
+        hooks_file.parent.mkdir(parents=True)
+        stale = {
+            "matcher": "Bash",
+            "hooks": [{"type": "command", "command": _STALE_GUARD_CMD}],
+        }
+        hooks_file.write_text(json.dumps({"PreToolUse": [stale]}), encoding="utf-8")
+
+        assert remove_codex_credential_guard() == hooks_file
+        data = json.loads(hooks_file.read_text(encoding="utf-8"))
+        assert "mureo-credential-guard" not in json.dumps(data)
 
     def test_idempotent_when_absent(self, home: Path) -> None:
         from mureo.cli.setup_codex import remove_codex_credential_guard
@@ -282,4 +423,4 @@ class TestRemoveCredentialGuard:
         assert target.exists()
         assert remove_codex_credential_guard(target) == target
         data = json.loads(target.read_text(encoding="utf-8"))
-        assert data["PreToolUse"] == []
+        assert data["hooks"]["PreToolUse"] == []


### PR DESCRIPTION
## Summary

Fixes #393 — the credential-guard PreToolUse hooks never actually blocked anything.

Both Claude Code and Codex treat a hook's exit code 1 as a **non-blocking** error (the tool call proceeds); blocking requires exit code 2 or a `permissionDecision: "deny"` JSON on stdout. The installed templates used `sys.exit(1)`, so reading `~/.mureo/credentials.json` sailed through (reproduced on a live host).

## Changes

**New single-source module `mureo/credential_guard.py`** — the templates were copy-pasted across `auth_setup.py`, `setup_codex.py` (and the tag constant again in `settings_remove.py`), which is exactly how the bug shipped to both hosts. All three now import from one place.

**Blocking mechanism** — deny-JSON on stdout (exit 0). Both hosts honor it, and unlike exit 2 it can never be confused with an interpreter crash (exit 1), which would fail open.

**Hardened matching** (the issue's companion weaknesses):
- Path guard (`Read|Edit|Write|Grep|Glob|NotebookEdit`): `realpath` + `expanduser` + case-folded comparison protects the **entire** `~/.mureo` tree (`agency.json`, `config.json`, `setup_state.json`, `shared/…`), closing symlink, tilde, relative-path, and case-insensitive-filesystem (`~/.MUREO`) evasions.
- Bash guard: denies any command referencing `.mureo` (case-folded), catching wildcard forms like `cat ~/.mureo/cred*` that the old `'credentials'` substring missed. Known trade-off: dev commands mentioning `.mureo` now hit the guard too — deny-more is the right direction for a guard, and file-scoped tools on non-protected paths still work.

**Codex schema fix** — `~/.codex/hooks.json` was written as a top-level `{"PreToolUse": [...]}` list, a shape Codex never loads (verified against the official hooks docs); entries now land under the nested `{"hooks": {"PreToolUse": [...]}}` location. Install migrates mureo's tagged entries out of the legacy spot; remove strips both. Foreign entries are preserved everywhere.

**Upgrade-aware installers** — previously the tag check skipped reinstall, so existing users would have kept the broken hooks forever. Tagged entries are now replaced in place on re-run (`mureo setup` / configure UI), and identical content still returns the idempotent skip.

**Robustness** — `~/.claude/settings.json` writes now use the same atomic writer (tmp + fsync + `os.replace`, 0600) as the removal path; deny reasons are validated against a safe-character set at build time so a future quoting hazard fails fast instead of failing open.

## Test plan

- [x] TDD: 10 red tests first (blocking behavior, schema, migration), then implementation
- [x] `tests/test_credential_guard.py` executes the generated payloads in a subprocess with overridden `HOME`/`USERPROFILE` (bash-free — Windows CI safe) and pins the contract: deny JSON at exit 0, silent allow, symlink/uppercase/wildcard evasions, `.mureo-backup` sibling false-positive guard, fresh-copy aliasing
- [x] Installer tests: upgrade of stale `sys.exit(1)` entries, legacy→nested Codex migration, both-location removal, foreign-entry preservation, corrupt/wrong-type refusal
- [x] Full suite: 5305 passed (7 pre-existing local plugin-env failures, identical on main)
- [x] `ruff` / `black` / `mypy` (CI parity on `mureo/`) clean
- [x] code-reviewer agent: 2 MEDIUM + 3 LOW findings all fixed and re-verified empirically, including end-to-end blocking on a live Claude Code host
- [x] `mureo-agency` `readonly_install.py` uses its own tag (`[mureo-agency-readonly-hook]`) — unaffected by the tag-scoped upgrade/removal

## Follow-ups (out of scope)

- Codex `apply_patch` matcher (path-field shape undocumented; substring-checking patch content would false-positive on mureo's own source)
- `Grep`/`Glob` over a *parent* directory of `~/.mureo` is not blocked (documented defense-in-depth limitation; primary control remains filesystem permissions)

https://claude.ai/code/session_0115NBUphwqsL1isTV8R7NHg
