### PR TITLE
fix(upgrade): refresh stale credential-guard hooks on mureo upgrade (#398)

### DIFF
--- a/mureo/cli/upgrade_cmd.py
+++ b/mureo/cli/upgrade_cmd.py
@@ -33,12 +33,18 @@ Design contract
 
 from __future__ import annotations
 
+import json
 import re
 import shlex
 import subprocess
 import sys
 from importlib import metadata
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from typing import Any
 
 import typer
 
@@ -264,14 +270,79 @@ def _restart_managed_service() -> None:
         )
 
 
+def _has_installed_guard(config: Path) -> bool:
+    """True when ``config`` actually carries a tagged guard hook entry.
+
+    Deliberately stricter than a whole-file substring search: the tag
+    literal appearing anywhere else (a comment field, an unrelated key)
+    must not count as "installed", because the refresh below would then
+    re-append a guard the user deliberately removed. Checks the nested
+    ``hooks.PreToolUse`` list (Claude settings.json / current Codex
+    hooks.json) and the legacy Codex top-level ``PreToolUse`` list.
+    Unreadable or malformed files count as "not installed" — the refresh
+    then skips them instead of poking an installer at a file it would
+    refuse anyway.
+    """
+    from mureo.credential_guard import is_guard_entry
+
+    try:
+        data = json.loads(config.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError, OSError):
+        return False
+    if not isinstance(data, dict):
+        return False
+    candidates: list[Any] = []
+    hooks = data.get("hooks")
+    if isinstance(hooks, dict) and isinstance(hooks.get("PreToolUse"), list):
+        candidates.extend(hooks["PreToolUse"])
+    if isinstance(data.get("PreToolUse"), list):
+        candidates.extend(data["PreToolUse"])
+    return any(is_guard_entry(entry) for entry in candidates)
+
+
+def _refresh_credential_guard() -> None:
+    """Upgrade previously installed credential-guard hooks after an upgrade.
+
+    #393 shipped guard hooks whose ``sys.exit(1)`` never blocked anything.
+    The installers are upgrade-aware, but they only run from setup — an
+    upgrade alone leaves the stale hooks in ``~/.claude/settings.json`` /
+    ``~/.codex/hooks.json`` forever (#398). Refresh here, but only on
+    surfaces where a tagged hook already exists, so an upgrade never
+    (re)installs the guard someone deliberately removed. Best-effort: a
+    failure is reported but never fails the upgrade.
+    """
+    from mureo.auth_setup import install_credential_guard
+    from mureo.cli.setup_codex import install_codex_credential_guard
+
+    surfaces: list[tuple[Path, Callable[[], Path | None]]] = [
+        (Path.home() / ".claude" / "settings.json", install_credential_guard),
+        (Path.home() / ".codex" / "hooks.json", install_codex_credential_guard),
+    ]
+    for config, installer in surfaces:
+        try:
+            if not _has_installed_guard(config):
+                continue
+            if installer() is not None:
+                typer.echo(f"Refreshed credential-guard hooks at {config}.")
+        except Exception as exc:  # noqa: BLE001 — refresh is best-effort
+            typer.echo(
+                f"Credential-guard refresh skipped for {config} "
+                f"({type(exc).__name__}); re-run `mureo configure` to update it.",
+                err=True,
+            )
+
+
 def _post_upgrade_refresh() -> None:
     """Make a successful upgrade actually take effect.
 
-    Both the deployed skills and any always-on daemon otherwise keep the
-    pre-upgrade version: skills are not re-copied, and the daemon holds old code
-    in memory. Refresh both so ``mureo upgrade`` is a single, reliable step.
+    The deployed skills, the installed credential-guard hooks, and any
+    always-on daemon otherwise keep the pre-upgrade version: skills are not
+    re-copied, stale hooks stay in the host configs, and the daemon holds
+    old code in memory. Refresh all three so ``mureo upgrade`` is a single,
+    reliable step.
     """
     _refresh_deployed_skills()
+    _refresh_credential_guard()
     _restart_managed_service()
 
 
@@ -304,9 +375,10 @@ def upgrade(
         False,
         "--no-refresh",
         help=(
-            "Skip the post-upgrade refresh (re-deploying skills + restarting "
-            "the always-on service). By default a successful upgrade refreshes "
-            "both so the new version actually takes effect."
+            "Skip the post-upgrade refresh (re-deploying skills, upgrading "
+            "installed credential-guard hooks, and restarting the always-on "
+            "service). By default a successful upgrade refreshes all three "
+            "so the new version actually takes effect."
         ),
     ),
 ) -> None:

--- a/tests/test_cli_upgrade.py
+++ b/tests/test_cli_upgrade.py
@@ -34,6 +34,13 @@ from unittest.mock import MagicMock
 import pytest
 from typer.testing import CliRunner
 
+# Captured at import time — before the autouse ``_no_real_post_upgrade``
+# fixture replaces the module attribute — so the wiring test can exercise
+# the real function.
+from mureo.cli.upgrade_cmd import (  # noqa: N812 — deliberate constant casing
+    _post_upgrade_refresh as _REAL_POST_UPGRADE_REFRESH,
+)
+
 if TYPE_CHECKING:
     from collections.abc import Iterable
     from pathlib import Path
@@ -567,6 +574,200 @@ def test_refresh_deployed_skills_recopies_when_dir_exists(
     monkeypatch.setattr("mureo.cli.setup_cmd.install_skills", install)
     upgrade_cmd._refresh_deployed_skills()
     install.assert_called_once()
+
+
+_STALE_GUARD_SETTINGS = {
+    "hooks": {
+        "PreToolUse": [
+            {
+                "matcher": "Read",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": (
+                            'python3 -c "import sys; sys.exit(1)"'
+                            " # [mureo-credential-guard]"
+                        ),
+                    }
+                ],
+            }
+        ]
+    }
+}
+
+
+def test_refresh_credential_guard_upgrades_stale_claude_hooks(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Tagged hooks in ~/.claude/settings.json are upgraded on `mureo upgrade`
+    — the #393 sys.exit(1) form never blocked and must not survive an
+    upgrade (issue #398)."""
+    import json
+
+    from mureo.cli import upgrade_cmd
+
+    settings = tmp_path / ".claude" / "settings.json"
+    settings.parent.mkdir(parents=True)
+    settings.write_text(json.dumps(_STALE_GUARD_SETTINGS), encoding="utf-8")
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+
+    upgrade_cmd._refresh_credential_guard()
+
+    text = settings.read_text(encoding="utf-8")
+    assert "[mureo-credential-guard]" in text
+    assert "sys.exit(1)" not in text
+    assert "permissionDecision" in text
+    assert "Refreshed credential-guard hooks" in capsys.readouterr().out
+
+
+def test_refresh_credential_guard_upgrades_stale_codex_hooks(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Tagged hooks in ~/.codex/hooks.json are upgraded too, including the
+    legacy top-level schema migration."""
+    import json
+
+    from mureo.cli import upgrade_cmd
+
+    hooks_file = tmp_path / ".codex" / "hooks.json"
+    hooks_file.parent.mkdir(parents=True)
+    hooks_file.write_text(
+        json.dumps({"PreToolUse": _STALE_GUARD_SETTINGS["hooks"]["PreToolUse"]}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+
+    upgrade_cmd._refresh_credential_guard()
+
+    data = json.loads(hooks_file.read_text(encoding="utf-8"))
+    flat = json.dumps(data)
+    assert "sys.exit(1)" not in flat
+    assert "permissionDecision" in flat
+    # Migrated to the nested schema Codex actually loads.
+    assert "PreToolUse" not in data
+    assert data["hooks"]["PreToolUse"]
+
+
+def test_refresh_credential_guard_never_force_installs(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """No tagged hook → the guard was deliberately removed (or never
+    installed); an upgrade must not (re)install it."""
+    import json
+
+    from mureo.cli import upgrade_cmd
+
+    settings = tmp_path / ".claude" / "settings.json"
+    settings.parent.mkdir(parents=True)
+    original = json.dumps({"hooks": {"PreToolUse": []}})
+    settings.write_text(original, encoding="utf-8")
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+
+    upgrade_cmd._refresh_credential_guard()
+
+    assert settings.read_text(encoding="utf-8") == original
+    assert not (tmp_path / ".codex").exists()
+
+
+def test_refresh_credential_guard_never_force_installs_codex(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An untagged ~/.codex/hooks.json is left untouched too."""
+    import json
+
+    from mureo.cli import upgrade_cmd
+
+    hooks_file = tmp_path / ".codex" / "hooks.json"
+    hooks_file.parent.mkdir(parents=True)
+    original = json.dumps({"hooks": {"PreToolUse": []}})
+    hooks_file.write_text(original, encoding="utf-8")
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+
+    upgrade_cmd._refresh_credential_guard()
+
+    assert hooks_file.read_text(encoding="utf-8") == original
+
+
+def test_refresh_credential_guard_ignores_tag_outside_hook_entries(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The tag literal appearing outside a real hook entry (e.g. a stray
+    note key) must not trigger a (re)install — "installed" means an actual
+    tagged PreToolUse entry, matching credential_guard.is_guard_entry."""
+    import json
+
+    from mureo.cli import upgrade_cmd
+
+    settings = tmp_path / ".claude" / "settings.json"
+    settings.parent.mkdir(parents=True)
+    original = json.dumps(
+        {
+            "note": "removed [mureo-credential-guard] on purpose",
+            "hooks": {"PreToolUse": []},
+        }
+    )
+    settings.write_text(original, encoding="utf-8")
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+
+    upgrade_cmd._refresh_credential_guard()
+
+    assert settings.read_text(encoding="utf-8") == original
+
+
+def test_refresh_credential_guard_noop_when_files_absent(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from mureo.cli import upgrade_cmd
+
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    upgrade_cmd._refresh_credential_guard()
+    assert not (tmp_path / ".claude").exists()
+    assert not (tmp_path / ".codex").exists()
+
+
+def test_refresh_credential_guard_swallows_errors(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A failing installer must never fail the upgrade (best-effort)."""
+    import json
+
+    from mureo.cli import upgrade_cmd
+
+    settings = tmp_path / ".claude" / "settings.json"
+    settings.parent.mkdir(parents=True)
+    settings.write_text(json.dumps(_STALE_GUARD_SETTINGS), encoding="utf-8")
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+
+    def _boom() -> None:
+        raise RuntimeError("disk full")
+
+    monkeypatch.setattr("mureo.auth_setup.install_credential_guard", _boom)
+    # Must not raise.
+    upgrade_cmd._refresh_credential_guard()
+    assert "Credential-guard refresh skipped" in capsys.readouterr().err
+
+
+def test_post_upgrade_refresh_includes_credential_guard(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The wiring: _post_upgrade_refresh runs skills, guard, and service.
+
+    Uses ``_REAL_POST_UPGRADE_REFRESH`` (captured at module import) because
+    the autouse ``_no_real_post_upgrade`` fixture replaces the module
+    attribute with a mock for every test.
+    """
+    skills = MagicMock()
+    guard = MagicMock()
+    service = MagicMock()
+    monkeypatch.setattr("mureo.cli.upgrade_cmd._refresh_deployed_skills", skills)
+    monkeypatch.setattr("mureo.cli.upgrade_cmd._refresh_credential_guard", guard)
+    monkeypatch.setattr("mureo.cli.upgrade_cmd._restart_managed_service", service)
+
+    _REAL_POST_UPGRADE_REFRESH()
+
+    skills.assert_called_once()
+    guard.assert_called_once()
+    service.assert_called_once()
 
 
 def test_restart_managed_service_noop_when_not_installed(


### PR DESCRIPTION
## Summary

Closes #398 (follow-up to #393 / #397).

`mureo upgrade` now upgrades previously installed credential-guard hooks. Without this, users who upgrade via pip only would keep the old non-blocking `sys.exit(1)` hooks in `~/.claude/settings.json` / `~/.codex/hooks.json` forever — #397's upgrade-aware installers only run from setup.

## Changes

`_refresh_credential_guard()` added to the post-upgrade refresh in `mureo/cli/upgrade_cmd.py`, mirroring the established `_refresh_deployed_skills()` pattern:

- **Never force-installs**: a new `_has_installed_guard()` helper parses the config and checks `credential_guard.is_guard_entry` over the actual entry lists (nested `hooks.PreToolUse` plus Codex's legacy top-level list). A stray tag literal elsewhere in the file does not count as "installed", so a deliberately removed guard stays removed.
- **Both surfaces**: Claude Code `settings.json` and Codex `hooks.json` (the latter also picks up #397's legacy→nested schema migration).
- **Best-effort**: per-surface `try/except`; a failure is reported to stderr and never fails the upgrade. Malformed/unreadable configs are skipped.
- `--no-refresh` keeps skipping everything; help text updated to mention the guard.

## Test plan

- [x] TDD: 6 red tests first, then implementation
- [x] Integration-style tests run the **real** installers against a monkeypatched home: stale-hook upgrade on both surfaces, never-force-install (both surfaces + tag-outside-entries case), absent-file no-op, error swallowing (stderr message asserted), `_post_upgrade_refresh` wiring
- [x] `tests/test_cli_upgrade.py`: 43 passed; related guard/installer suites unaffected
- [x] `ruff` / `black` / `mypy` (strict) clean
- [x] code-reviewer agent: 1 MEDIUM (substring pre-check could re-install on a stray tag literal) + 3 LOW — all fixed and re-verified, approved

https://claude.ai/code/session_0115NBUphwqsL1isTV8R7NHg
