### PR TITLE
fix(skills): add Japanese trigger phrases to operational skill descriptions (#396)

### DIFF
--- a/mureo/_data/skills/budget-rebalance/SKILL.md
+++ b/mureo/_data/skills/budget-rebalance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: budget-rebalance
-description: "Rebalance campaign budgets across all configured platforms based on strategy and performance signals. Use when the user asks to optimize budgets, redistribute spend, scale efficient campaigns, or cap overspending ones. Reads STRATEGY.md goals, analyzes campaign efficiency, and proposes budget changes with rationale."
+description: "Rebalance campaign budgets across all configured platforms based on strategy and performance signals. Use when the user asks to optimize budgets, redistribute spend, scale efficient campaigns, or cap overspending ones. Reads STRATEGY.md goals, analyzes campaign efficiency, and proposes budget changes with rationale. Also use when the user asks in Japanese (予算を最適化して / 予算の再配分 / 好調なキャンペーンに予算を寄せて / 予算リバランス)."
 metadata:
   version: 0.10.23
 ---

--- a/mureo/_data/skills/competitive-scan/SKILL.md
+++ b/mureo/_data/skills/competitive-scan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: competitive-scan
-description: "Scan competitor activity using auction insights and market signals. Use when the user asks about competitors, market dynamics, impression share changes, competitor moves, or competitive positioning."
+description: "Scan competitor activity using auction insights and market signals. Use when the user asks about competitors, market dynamics, impression share changes, competitor moves, or competitive positioning. Also use when the user asks in Japanese (競合の動きを調べて / 競合分析 / インプレッションシェアの変化を確認 / 競合にシェアを取られていないか)."
 metadata:
   version: 0.10.23
 ---

--- a/mureo/_data/skills/creative-refresh/SKILL.md
+++ b/mureo/_data/skills/creative-refresh/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: creative-refresh
-description: "Refresh ad copy and creative assets based on performance signals and brand voice. Use when the user asks to refresh creative, propose new ad copy, A/B test creatives, update RSA assets, rotate underperformers, or visually evaluate / compare banner (image) creatives."
+description: "Refresh ad copy and creative assets based on performance signals and brand voice. Use when the user asks to refresh creative, propose new ad copy, A/B test creatives, update RSA assets, rotate underperformers, or visually evaluate / compare banner (image) creatives. Also use when the user asks in Japanese (クリエイティブを刷新して / 広告文の改善案がほしい / RSAアセットの入れ替え / バナーを比較評価して)."
 metadata:
   version: 0.10.23
 ---

--- a/mureo/_data/skills/daily-check/SKILL.md
+++ b/mureo/_data/skills/daily-check/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: daily-check
-description: "Run a daily health check on all configured ad accounts (Google Ads, Meta Ads, Search Console, GA4). Use when the user asks for a daily review, health check, status update, anomaly detection, or 'how are my campaigns doing today'. Reads STRATEGY.md and STATE.json, runs platform-specific health diagnostics, checks goal progress, evaluates pending action_log observations, and reports findings as Healthy / Watch / Action-needed."
+description: "Run a daily health check on all configured ad accounts (Google Ads, Meta Ads, Search Console, GA4). Use when the user asks for a daily review, health check, status update, anomaly detection, or 'how are my campaigns doing today'. Reads STRATEGY.md and STATE.json, runs platform-specific health diagnostics, checks goal progress, evaluates pending action_log observations, and reports findings as Healthy / Watch / Action-needed. Also use when the user asks in Japanese (デイリーチェック / 今日のアカウント状況は / 異常がないか確認して / 日次ヘルスチェック)."
 metadata:
   version: 0.10.23
 ---

--- a/mureo/_data/skills/goal-review/SKILL.md
+++ b/mureo/_data/skills/goal-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: goal-review
-description: "Review Goal progress against STRATEGY.md targets. Use when the user asks to evaluate goal achievement, review KPI progress, assess strategy performance, or check if targets are being met."
+description: "Review Goal progress against STRATEGY.md targets. Use when the user asks to evaluate goal achievement, review KPI progress, assess strategy performance, or check if targets are being met. Also use when the user asks in Japanese (目標の進捗を確認 / KPIレビュー / ゴール達成状況は / 目標に届きそうか)."
 metadata:
   version: 0.10.23
 ---

--- a/mureo/_data/skills/lead-form-create/SKILL.md
+++ b/mureo/_data/skills/lead-form-create/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lead-form-create
-description: "Create a Meta Instant Form (Lead Ad form) through a one-question-at-a-time interview. Use when the user asks to create a lead form, Instant Form, CV form, or similar. The agent collects required parameters via a guided dialogue, confirms, then calls meta_ads_lead_forms_create."
+description: "Create a Meta Instant Form (Lead Ad form) through a one-question-at-a-time interview. Use when the user asks to create a lead form, Instant Form, CV form, or similar. The agent collects required parameters via a guided dialogue, confirms, then calls meta_ads_lead_forms_create. Also use when the user asks in Japanese (リードフォームを作成 / インスタントフォームを作って / CVフォーム作成)."
 metadata:
   version: 0.10.23
 ---

--- a/mureo/_data/skills/learn/SKILL.md
+++ b/mureo/_data/skills/learn/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: learn
-description: "Save a marketing diagnosis insight to the pro-diagnosis knowledge base so it is applied in future operations across all platforms. Use when the user runs /learn, explicitly teaches the agent a marketing insight, corrects the agent's analysis, or asks to remember/record an operational learning for next time."
+description: "Save a marketing diagnosis insight to the pro-diagnosis knowledge base so it is applied in future operations across all platforms. Use when the user runs /learn, explicitly teaches the agent a marketing insight, corrects the agent's analysis, or asks to remember/record an operational learning for next time. Also use when the user asks in Japanese (この学びを記録して / 次回から反映して / 運用の気づきを覚えておいて)."
 metadata:
   version: 0.10.23
 ---

--- a/mureo/_data/skills/onboard/SKILL.md
+++ b/mureo/_data/skills/onboard/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: onboard
-description: "Initial account setup — create STRATEGY.md and STATE.json from scratch, import platform data, and establish baseline metrics. Use when the user is starting fresh with mureo, has no STRATEGY.md yet, or asks to set up a new account."
+description: "Initial account setup — create STRATEGY.md and STATE.json from scratch, import platform data, and establish baseline metrics. Use when the user is starting fresh with mureo, has no STRATEGY.md yet, or asks to set up a new account. Also use when the user asks in Japanese (初期セットアップ / STRATEGY.mdを作成して / mureoを使い始めたい / アカウントの立ち上げ)."
 metadata:
   version: 0.10.23
 ---

--- a/mureo/_data/skills/rescue/SKILL.md
+++ b/mureo/_data/skills/rescue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rescue
-description: "Emergency performance fix when an ad account is in trouble. Use when the user reports a sudden CPA spike, conversion drop, runaway spend, or asks for an urgent performance rescue. Sets Operation Mode to TURNAROUND_RESCUE and applies stabilization actions."
+description: "Emergency performance fix when an ad account is in trouble. Use when the user reports a sudden CPA spike, conversion drop, runaway spend, or asks for an urgent performance rescue. Sets Operation Mode to TURNAROUND_RESCUE and applies stabilization actions. Also use when the user asks in Japanese (CPAが急に悪化した / CVが激減した / 広告費が暴走している / 緊急で立て直して)."
 metadata:
   version: 0.10.23
 ---

--- a/mureo/_data/skills/search-term-cleanup/SKILL.md
+++ b/mureo/_data/skills/search-term-cleanup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: search-term-cleanup
-description: "Audit and clean up search terms (negative keywords, intent classification, query hygiene). Use when the user asks to clean up search queries, add negative keywords, review search term reports, or improve match quality. Cross-references Search Console, GA4, and ad platform data."
+description: "Audit and clean up search terms (negative keywords, intent classification, query hygiene). Use when the user asks to clean up search queries, add negative keywords, review search term reports, or improve match quality. Cross-references Search Console, GA4, and ad platform data. Also use when the user asks in Japanese (検索語句のクリーンアップ / 除外キーワードを追加して / 無駄な検索クエリを止めたい)."
 metadata:
   version: 0.10.23
 ---

--- a/mureo/_data/skills/sync-state/SKILL.md
+++ b/mureo/_data/skills/sync-state/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sync-state
-description: "Sync STATE.json with current campaign data from all platforms. Use when the user asks to refresh state, sync campaigns, update STATE.json from live data, or pull latest campaign snapshots."
+description: "Sync STATE.json with current campaign data from all platforms. Use when the user asks to refresh state, sync campaigns, update STATE.json from live data, or pull latest campaign snapshots. Also use when the user asks in Japanese (STATE.jsonを更新 / 最新データに同期して / キャンペーン情報を取り込み直して)."
 metadata:
   version: 0.10.23
 ---

--- a/mureo/_data/skills/weekly-report/SKILL.md
+++ b/mureo/_data/skills/weekly-report/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: weekly-report
-description: "Generate a weekly summary report across all platforms. Use when the user asks for a weekly report, summary, recap, end-of-week review, or weekly digest."
+description: "Generate a weekly summary report across all platforms. Use when the user asks for a weekly report, summary, recap, end-of-week review, or weekly digest. Also use when the user asks in Japanese (週次レポート / 今週のまとめ / 週報を作成して)."
 metadata:
   version: 0.10.23
 ---

--- a/skills/budget-rebalance/SKILL.md
+++ b/skills/budget-rebalance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: budget-rebalance
-description: "Rebalance campaign budgets across all configured platforms based on strategy and performance signals. Use when the user asks to optimize budgets, redistribute spend, scale efficient campaigns, or cap overspending ones. Reads STRATEGY.md goals, analyzes campaign efficiency, and proposes budget changes with rationale."
+description: "Rebalance campaign budgets across all configured platforms based on strategy and performance signals. Use when the user asks to optimize budgets, redistribute spend, scale efficient campaigns, or cap overspending ones. Reads STRATEGY.md goals, analyzes campaign efficiency, and proposes budget changes with rationale. Also use when the user asks in Japanese (予算を最適化して / 予算の再配分 / 好調なキャンペーンに予算を寄せて / 予算リバランス)."
 metadata:
   version: 0.10.23
 ---

--- a/skills/competitive-scan/SKILL.md
+++ b/skills/competitive-scan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: competitive-scan
-description: "Scan competitor activity using auction insights and market signals. Use when the user asks about competitors, market dynamics, impression share changes, competitor moves, or competitive positioning."
+description: "Scan competitor activity using auction insights and market signals. Use when the user asks about competitors, market dynamics, impression share changes, competitor moves, or competitive positioning. Also use when the user asks in Japanese (競合の動きを調べて / 競合分析 / インプレッションシェアの変化を確認 / 競合にシェアを取られていないか)."
 metadata:
   version: 0.10.23
 ---

--- a/skills/creative-refresh/SKILL.md
+++ b/skills/creative-refresh/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: creative-refresh
-description: "Refresh ad copy and creative assets based on performance signals and brand voice. Use when the user asks to refresh creative, propose new ad copy, A/B test creatives, update RSA assets, rotate underperformers, or visually evaluate / compare banner (image) creatives."
+description: "Refresh ad copy and creative assets based on performance signals and brand voice. Use when the user asks to refresh creative, propose new ad copy, A/B test creatives, update RSA assets, rotate underperformers, or visually evaluate / compare banner (image) creatives. Also use when the user asks in Japanese (クリエイティブを刷新して / 広告文の改善案がほしい / RSAアセットの入れ替え / バナーを比較評価して)."
 metadata:
   version: 0.10.23
 ---

--- a/skills/daily-check/SKILL.md
+++ b/skills/daily-check/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: daily-check
-description: "Run a daily health check on all configured ad accounts (Google Ads, Meta Ads, Search Console, GA4). Use when the user asks for a daily review, health check, status update, anomaly detection, or 'how are my campaigns doing today'. Reads STRATEGY.md and STATE.json, runs platform-specific health diagnostics, checks goal progress, evaluates pending action_log observations, and reports findings as Healthy / Watch / Action-needed."
+description: "Run a daily health check on all configured ad accounts (Google Ads, Meta Ads, Search Console, GA4). Use when the user asks for a daily review, health check, status update, anomaly detection, or 'how are my campaigns doing today'. Reads STRATEGY.md and STATE.json, runs platform-specific health diagnostics, checks goal progress, evaluates pending action_log observations, and reports findings as Healthy / Watch / Action-needed. Also use when the user asks in Japanese (デイリーチェック / 今日のアカウント状況は / 異常がないか確認して / 日次ヘルスチェック)."
 metadata:
   version: 0.10.23
 ---

--- a/skills/goal-review/SKILL.md
+++ b/skills/goal-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: goal-review
-description: "Review Goal progress against STRATEGY.md targets. Use when the user asks to evaluate goal achievement, review KPI progress, assess strategy performance, or check if targets are being met."
+description: "Review Goal progress against STRATEGY.md targets. Use when the user asks to evaluate goal achievement, review KPI progress, assess strategy performance, or check if targets are being met. Also use when the user asks in Japanese (目標の進捗を確認 / KPIレビュー / ゴール達成状況は / 目標に届きそうか)."
 metadata:
   version: 0.10.23
 ---

--- a/skills/lead-form-create/SKILL.md
+++ b/skills/lead-form-create/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lead-form-create
-description: "Create a Meta Instant Form (Lead Ad form) through a one-question-at-a-time interview. Use when the user asks to create a lead form, Instant Form, CV form, or similar. The agent collects required parameters via a guided dialogue, confirms, then calls meta_ads_lead_forms_create."
+description: "Create a Meta Instant Form (Lead Ad form) through a one-question-at-a-time interview. Use when the user asks to create a lead form, Instant Form, CV form, or similar. The agent collects required parameters via a guided dialogue, confirms, then calls meta_ads_lead_forms_create. Also use when the user asks in Japanese (リードフォームを作成 / インスタントフォームを作って / CVフォーム作成)."
 metadata:
   version: 0.10.23
 ---

--- a/skills/learn/SKILL.md
+++ b/skills/learn/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: learn
-description: "Save a marketing diagnosis insight to the pro-diagnosis knowledge base so it is applied in future operations across all platforms. Use when the user runs /learn, explicitly teaches the agent a marketing insight, corrects the agent's analysis, or asks to remember/record an operational learning for next time."
+description: "Save a marketing diagnosis insight to the pro-diagnosis knowledge base so it is applied in future operations across all platforms. Use when the user runs /learn, explicitly teaches the agent a marketing insight, corrects the agent's analysis, or asks to remember/record an operational learning for next time. Also use when the user asks in Japanese (この学びを記録して / 次回から反映して / 運用の気づきを覚えておいて)."
 metadata:
   version: 0.10.23
 ---

--- a/skills/onboard/SKILL.md
+++ b/skills/onboard/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: onboard
-description: "Initial account setup — create STRATEGY.md and STATE.json from scratch, import platform data, and establish baseline metrics. Use when the user is starting fresh with mureo, has no STRATEGY.md yet, or asks to set up a new account."
+description: "Initial account setup — create STRATEGY.md and STATE.json from scratch, import platform data, and establish baseline metrics. Use when the user is starting fresh with mureo, has no STRATEGY.md yet, or asks to set up a new account. Also use when the user asks in Japanese (初期セットアップ / STRATEGY.mdを作成して / mureoを使い始めたい / アカウントの立ち上げ)."
 metadata:
   version: 0.10.23
 ---

--- a/skills/rescue/SKILL.md
+++ b/skills/rescue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rescue
-description: "Emergency performance fix when an ad account is in trouble. Use when the user reports a sudden CPA spike, conversion drop, runaway spend, or asks for an urgent performance rescue. Sets Operation Mode to TURNAROUND_RESCUE and applies stabilization actions."
+description: "Emergency performance fix when an ad account is in trouble. Use when the user reports a sudden CPA spike, conversion drop, runaway spend, or asks for an urgent performance rescue. Sets Operation Mode to TURNAROUND_RESCUE and applies stabilization actions. Also use when the user asks in Japanese (CPAが急に悪化した / CVが激減した / 広告費が暴走している / 緊急で立て直して)."
 metadata:
   version: 0.10.23
 ---

--- a/skills/search-term-cleanup/SKILL.md
+++ b/skills/search-term-cleanup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: search-term-cleanup
-description: "Audit and clean up search terms (negative keywords, intent classification, query hygiene). Use when the user asks to clean up search queries, add negative keywords, review search term reports, or improve match quality. Cross-references Search Console, GA4, and ad platform data."
+description: "Audit and clean up search terms (negative keywords, intent classification, query hygiene). Use when the user asks to clean up search queries, add negative keywords, review search term reports, or improve match quality. Cross-references Search Console, GA4, and ad platform data. Also use when the user asks in Japanese (検索語句のクリーンアップ / 除外キーワードを追加して / 無駄な検索クエリを止めたい)."
 metadata:
   version: 0.10.23
 ---

--- a/skills/sync-state/SKILL.md
+++ b/skills/sync-state/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sync-state
-description: "Sync STATE.json with current campaign data from all platforms. Use when the user asks to refresh state, sync campaigns, update STATE.json from live data, or pull latest campaign snapshots."
+description: "Sync STATE.json with current campaign data from all platforms. Use when the user asks to refresh state, sync campaigns, update STATE.json from live data, or pull latest campaign snapshots. Also use when the user asks in Japanese (STATE.jsonを更新 / 最新データに同期して / キャンペーン情報を取り込み直して)."
 metadata:
   version: 0.10.23
 ---

--- a/skills/weekly-report/SKILL.md
+++ b/skills/weekly-report/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: weekly-report
-description: "Generate a weekly summary report across all platforms. Use when the user asks for a weekly report, summary, recap, end-of-week review, or weekly digest."
+description: "Generate a weekly summary report across all platforms. Use when the user asks for a weekly report, summary, recap, end-of-week review, or weekly digest. Also use when the user asks in Japanese (週次レポート / 今週のまとめ / 週報を作成して)."
 metadata:
   version: 0.10.23
 ---

--- a/tests/test_skill_ja_triggers.py
+++ b/tests/test_skill_ja_triggers.py
@@ -1,0 +1,77 @@
+"""Japanese trigger coverage for the bundled operational skills (#396).
+
+Operators phrase requests in Japanese, but skill firing is driven by the
+``description`` frontmatter. Descriptions written only in English lower
+the match confidence for natural Japanese asks ("CPAが急に悪化した" vs
+"Use when the user reports a sudden CPA spike"), which showed up as
+near-zero real-world usage for several workflow skills. The newer skills
+(ad-fatigue-check, audience-review, ...) already enumerate Japanese
+trigger phrases; this suite pins that EVERY user-triggered operational
+skill does.
+
+Foundation skills (``_mureo-*`` prefix) are exempt: they are loaded as
+PREREQUISITEs by other skills, never fired from a user utterance.
+
+Marks: unit — pure on-disk file inspection, no network.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from mureo.core.skills.parser import parse_skill_md
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+_PACKAGED = REPO_ROOT / "mureo" / "_data" / "skills"
+_MIRROR = REPO_ROOT / "skills"
+
+# Hiragana, katakana, and CJK unified ideographs — any hit means the
+# description carries at least one Japanese trigger phrase.
+_JAPANESE = re.compile(r"[぀-ヿ一-鿿]")
+
+
+def _operational_skill_dirs() -> list[Path]:
+    return sorted(
+        p
+        for p in _PACKAGED.iterdir()
+        if p.is_dir() and not p.name.startswith("_") and (p / "SKILL.md").exists()
+    )
+
+
+def _skill_ids() -> list[str]:
+    return [p.name for p in _operational_skill_dirs()]
+
+
+@pytest.mark.unit
+class TestOperationalSkillJapaneseTriggers:
+    def test_discovers_a_plausible_skill_population(self) -> None:
+        """Structural anchor: the packaged tree holds the operational
+        skills (20 at the time of writing) — an empty glob must fail
+        loudly instead of vacuously passing the suite."""
+        assert len(_operational_skill_dirs()) >= 15
+
+    @pytest.mark.parametrize("skill_dir", _operational_skill_dirs(), ids=_skill_ids())
+    def test_description_contains_japanese_trigger(self, skill_dir: Path) -> None:
+        parsed = parse_skill_md(skill_dir / "SKILL.md")
+        description = parsed.description
+        assert description
+        assert _JAPANESE.search(description), (
+            f"{skill_dir.name}: description has no Japanese trigger phrases — "
+            "operators ask in Japanese, so English-only descriptions risk the "
+            "skill never firing (#396). Follow the enumeration style of "
+            "ad-fatigue-check / audience-review."
+        )
+
+    @pytest.mark.parametrize("skill_dir", _operational_skill_dirs(), ids=_skill_ids())
+    def test_packaged_and_mirror_copies_stay_identical(self, skill_dir: Path) -> None:
+        """The repo-root ``skills/`` mirror must match the packaged copy
+        byte-for-byte, so a trigger edit cannot land on one side only."""
+        mirror = _MIRROR / skill_dir.name / "SKILL.md"
+        assert mirror.exists(), f"missing mirror for {skill_dir.name}"
+        packaged_text = (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+        assert (
+            mirror.read_text(encoding="utf-8") == packaged_text
+        ), f"{skill_dir.name}: skills/ mirror differs from mureo/_data/skills/"


### PR DESCRIPTION
Closes #396 (proposal 2; proposal 1 — references/ split — deferred with a decision comment on the issue).

## Summary

12 older operational skills had English-only `description` frontmatter, lowering skill-fire match confidence for natural Japanese asks (the newer 8 skills already enumerate Japanese triggers). Each gets one appended sentence: "Also use when the user asks in Japanese (トリガー / ...)" — in both the packaged copy and the byte-identical repo-root mirror. Foundation `_mureo-*` skills excluded (PREREQUISITE-loaded). `metadata.version` untouched.

## Test plan

- [x] TDD: new `tests/test_skill_ja_triggers.py` failed red on exactly the 12 targets, green after
- [x] Invariants pinned for ALL current and future operational skills: Japanese present in parsed description + packaged/mirror byte-parity
- [x] 332 skill-related tests pass; ruff/black clean
- [x] code-reviewer: approved (no CRITICAL/HIGH/MEDIUM; YAML integrity, version drift, and cross-skill misfire risk independently verified)

https://claude.ai/code/session_0115NBUphwqsL1isTV8R7NHg