### PR TITLE
fix(web): publish host_paths atomically in set_host to close the credentials-path race (#406)

### DIFF
--- a/mureo/web/server.py
+++ b/mureo/web/server.py
@@ -102,10 +102,8 @@ class ConfigureWizard:
             static_dir if static_dir is not None else _resolve_static_dir()
         )
         self.session = ConfigureSession()
-        self._host_paths: HostPaths = get_host_paths(self.session.host, home=home)
         self._commands_path_override = commands_path
-        self._apply_commands_override()
-        self._apply_credentials_override()
+        self._host_paths: HostPaths = self._build_host_paths()
         self.oauth_bridge = OAuthBridge()
         # Discover third-party extensions once at wizard construction.
         # ``discover_web_extensions`` caches internally, so this call
@@ -172,11 +170,23 @@ class ConfigureWizard:
         return f"http://{self._bind_host}:{self.port}/"
 
     def set_host(self, host: str) -> None:
-        """Switch the Claude host and recompute path resolution."""
+        """Switch the Claude host and recompute path resolution.
+
+        No-op when ``host`` is already the session host: ``_resolve_host``
+        relays the client's host on every host-carrying POST, and the
+        rebuild is not free — the credentials override may resolve a
+        runtime-context factory (#406).
+
+        The rebuilt bundle is published in a single assignment AFTER every
+        override has been applied. The configure server is threaded, and
+        publishing the base bundle first opened a window in which
+        concurrent requests read — or wrote — the unresolved host-default
+        credentials path instead of the runtime-resolved one (#406).
+        """
+        if host == self.session.host:
+            return
         self.session.set_host(host)
-        self._host_paths = get_host_paths(self.session.host, home=self.home)
-        self._apply_commands_override()
-        self._apply_credentials_override()
+        self._host_paths = self._build_host_paths()
 
     def mark_oauth_complete(
         self, provider: str, *, success: bool, error: str | None = None
@@ -271,20 +281,25 @@ class ConfigureWizard:
     # ------------------------------------------------------------------
     # Internals
     # ------------------------------------------------------------------
-    def _apply_commands_override(self) -> None:
-        """If the caller pinned a commands path, swap it into the bundle."""
-        if self._commands_path_override is None:
-            return
-        self._host_paths = HostPaths(
-            host=self._host_paths.host,
-            settings_path=self._host_paths.settings_path,
-            skills_dir=self._host_paths.skills_dir,
-            commands_dir=self._commands_path_override,
-            credentials_path=self._host_paths.credentials_path,
-            mcp_registry_path=self._host_paths.mcp_registry_path,
-        )
+    def _build_host_paths(self) -> HostPaths:
+        """Resolve the FULL paths bundle for the current session host.
 
-    def _apply_credentials_override(self) -> None:
+        Base resolution plus the commands-path pin plus the credentials
+        override are all applied to a local value; the caller publishes
+        the result in one assignment. The configure server is threaded,
+        and mutating ``self._host_paths`` step-by-step opened a window in
+        which concurrent requests observed the unresolved host-default
+        credentials path (#406) — with a slow runtime-context factory the
+        window spanned most of a dashboard page load.
+        """
+        paths = get_host_paths(self.session.host, home=self.home)
+        if self._commands_path_override is not None:
+            paths = dataclasses.replace(
+                paths, commands_dir=self._commands_path_override
+            )
+        return self._with_credentials_override(paths)
+
+    def _with_credentials_override(self, paths: HostPaths) -> HostPaths:
         """Align the configure-UI credentials path with the active
         RuntimeContext when running against the real home (#194).
 
@@ -308,15 +323,17 @@ class ConfigureWizard:
         ``home=None`` and so still honors the factory. The factory's path
         is resolved by :func:`runtime_credentials_path`, unit-tested
         directly; this method only decides *whether* to apply it.
+
+        Pure: returns a new bundle instead of mutating ``self._host_paths``
+        so the caller can publish the fully-resolved result atomically
+        (#406).
         """
         if self.home is not None:
-            return
-        resolved = runtime_credentials_path(self._host_paths.credentials_path)
-        if resolved == self._host_paths.credentials_path:
-            return
-        self._host_paths = dataclasses.replace(
-            self._host_paths, credentials_path=resolved
-        )
+            return paths
+        resolved = runtime_credentials_path(paths.credentials_path)
+        if resolved == paths.credentials_path:
+            return paths
+        return dataclasses.replace(paths, credentials_path=resolved)
 
 
 def run_configure_wizard(

--- a/tests/test_configure_wizard_host_paths.py
+++ b/tests/test_configure_wizard_host_paths.py
@@ -1,0 +1,79 @@
+"""``ConfigureWizard`` host-path resolution must be atomic (#406).
+
+The configure server is threaded (``ThreadingMixIn``). ``set_host()``
+used to publish the freshly rebuilt base ``HostPaths`` FIRST and only
+then re-apply the credentials-path override (#194/#196), so any request
+handled during that window read — or worse, wrote — the unresolved
+host-default credentials path instead of the runtime-resolved one.
+With a registered runtime-context factory the override resolution takes
+long enough that a dashboard page load hit the window in 27/30 live
+attempts, rendering every saved credential as ✗.
+
+These tests pin the two halves of the fix: a no-op ``set_host`` (same
+host — sent by every dashboard POST) must not rebuild at all, and a real
+host switch must never expose a torn intermediate to other threads.
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+import pytest
+
+import mureo.web.server as server_mod
+
+
+@pytest.mark.unit
+def test_set_host_same_host_does_not_rebuild(tmp_path: Path) -> None:
+    """Every dashboard POST carries the current host; re-resolving the
+    bundle each time reopens the race window and repeats a potentially
+    slow runtime-context resolution for nothing."""
+    wizard = server_mod.ConfigureWizard(home=tmp_path)
+    before = wizard.host_paths
+    wizard.set_host(wizard.session.host)
+    assert wizard.host_paths is before
+
+
+@pytest.mark.unit
+def test_set_host_never_publishes_unresolved_credentials_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """While the credentials override is still resolving, concurrent
+    readers must keep seeing the previous fully-resolved bundle."""
+    resolved_path = Path("/resolved/credentials.json")
+    entered = threading.Event()
+    release = threading.Event()
+
+    def slow_resolve(default: Path) -> Path:
+        entered.set()
+        assert release.wait(timeout=10), "test deadlock: release never set"
+        return resolved_path
+
+    monkeypatch.setattr(server_mod, "runtime_credentials_path", slow_resolve)
+
+    # __init__ resolves once — let it through immediately.
+    release.set()
+    wizard = server_mod.ConfigureWizard(home=None)
+    assert wizard.host_paths.credentials_path == resolved_path
+
+    # Now block the resolver and switch hosts from another thread.
+    entered.clear()
+    release.clear()
+    switcher = threading.Thread(target=wizard.set_host, args=("claude-desktop",))
+    switcher.start()
+    try:
+        assert entered.wait(timeout=10), "set_host never reached the resolver"
+        # Mid-flight: the torn base bundle (host-default credentials path)
+        # must NOT be visible — readers see the old resolved value.
+        assert wizard.host_paths.credentials_path == resolved_path, (
+            "set_host published an unresolved credentials path mid-rebuild "
+            "(#406 race window)"
+        )
+    finally:
+        release.set()
+        switcher.join(timeout=10)
+
+    assert not switcher.is_alive()
+    assert wizard.host_paths.credentials_path == resolved_path
+    assert wizard.host_paths.host == "claude-desktop"


### PR DESCRIPTION
## Summary

Closes #406.

The configure server is threaded (`ThreadingMixIn`), but `ConfigureWizard.set_host()` mutated shared state non-atomically: the fresh base `HostPaths` was published **before** the credentials-path override (#194/#196) was re-applied. Concurrent requests reading `wizard.host_paths` in that window operated on the unresolved host-default credentials path — and since `_resolve_host` calls `set_host` on every host-carrying POST, a dashboard page load raced it almost every time.

**Live reproduction** (daemon with a registered runtime-context factory): `POST /api/host` concurrent with `GET /api/status` returned wrong `env_vars` in **27/30** attempts — every saved credential rendered ✗ after a reload. After the fix: **0/30**, and reloads render correctly. Credential writes racing the window landed in the wrong file (silent storage split).

## Changes

- `_build_host_paths()` resolves the full bundle (base → commands-dir pin via `dataclasses.replace` → credentials override) on a local value; `__init__` / `set_host` publish it in a **single assignment** (atomic under the GIL).
- `set_host()` **no-ops on an unchanged host** — eliminating the routine window reopening and the repeated (potentially slow) factory resolution per dashboard POST. Freshness is unaffected: `get_runtime_context()` is a process-wide cached singleton.
- The in-place mutators `_apply_commands_override` / `_apply_credentials_override` are replaced by the pure `_with_credentials_override` (docstring retained).

## Test plan

- [x] TDD (red first, independently re-verified red via a worktree at the pre-fix HEAD): same-host `set_host` preserves `host_paths` object identity; an Event-blocked resolver deterministically pins that a concurrent reader never observes the unresolved default mid-switch
- [x] Live verification: race hits 27/30 → 0/30; dashboard reload renders saved keys correctly
- [x] Full suite 5359 passed (7 pre-existing local plugin-env failures, identical on main); 328 configure/web-related tests green; ruff/black/mypy clean
- [x] code-reviewer: approved, no CRITICAL/HIGH/MEDIUM; behavior parity (override ordering, `home is None` gate, `session.set_host` skip safety) independently verified

## Follow-up

- #407 — pre-existing adjacent seam: handlers pair `session.host` and `host_paths` via two unsynchronized reads (not introduced or worsened here)

https://claude.ai/code/session_0115NBUphwqsL1isTV8R7NHg
