### PR TITLE
fix(policy): enforce budget guardrails on the provider ABI's own budget key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The budget guardrail now fires on provider plugins.** `StrategyPolicyGate`
+  matched a proposed budget against a fixed set of argument keys
+  (`daily_budget`, `amount`, `amount_micros`, …) — the spellings the
+  first-party `google_ads_*` / `meta_ads_*` tools use. It did
+  not match `daily_budget_micros`, which is the provider ABI's *own* budget
+  field (`CreateCampaignRequest.daily_budget_micros`) and the name
+  `docs/plugin-authoring.md` tells plugin authors to use. A provider plugin
+  that followed the ABI therefore had **every** budget rule silently skipped:
+  an operator's `max_daily_budget_per_campaign` was enforced on Google and Meta
+  while that plugin's budget writes went straight through — no error, no
+  warning, just an unenforced cap on a real-spend surface. `daily_budget_micros`
+  is now read alongside the other micros keys, so the caps
+  (`max_daily_budget_per_campaign`, `max_daily_budget_increase_pct`,
+  `max_total_daily_budget`) apply to any ABI-faithful plugin. Behaviour for
+  first-party tools is unchanged.
+
 ## [0.10.23] - 2026-07-13
 
 ### Fixed

--- a/mureo/policy/strategy_gate.py
+++ b/mureo/policy/strategy_gate.py
@@ -40,6 +40,13 @@ GUARDRAILS_HEADING = "guardrails"
 
 # Argument keys that carry a proposed daily budget, in priority order.
 _BUDGET_KEYS = ("daily_budget", "proposed_daily_budget", "amount")
+# The same, expressed in micros (1/1,000,000 of the account currency).
+# ``daily_budget_micros`` is the provider ABI's own budget field
+# (``CreateCampaignRequest.daily_budget_micros``) and the name
+# docs/plugin-authoring.md prescribes, so provider plugins surface it
+# verbatim on their MCP write tools. It belongs here, or every
+# ABI-faithful plugin's budget writes bypass the guardrails entirely.
+_BUDGET_MICROS_KEYS = ("daily_budget_micros", "budget_amount_micros", "amount_micros")
 _CURRENT_BUDGET_KEYS = ("current_daily_budget", "current")
 
 _BULLET_RE = re.compile(r"^\s*[-*]\s*([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(.+?)\s*$")
@@ -128,9 +135,10 @@ def _proposed_budget(arguments: dict[str, Any]) -> float | None:
             v = arguments[key]
             if isinstance(v, (int, float)) and not isinstance(v, bool):
                 return float(v)
-    # Google Ads budgets are sometimes expressed in micros —
-    # budget_amount_micros on campaign tools, amount_micros on budget tools.
-    for micros_key in ("budget_amount_micros", "amount_micros"):
+    # Budgets are often expressed in micros instead — amount_micros on the
+    # Google budget tools, daily_budget_micros on any provider plugin that
+    # follows the ABI (see _BUDGET_MICROS_KEYS).
+    for micros_key in _BUDGET_MICROS_KEYS:
         micros = arguments.get(micros_key)
         if isinstance(micros, (int, float)) and not isinstance(micros, bool):
             return float(micros) / 1_000_000

--- a/tests/test_strategy_gate.py
+++ b/tests/test_strategy_gate.py
@@ -81,6 +81,37 @@ class TestEvaluateGuardrails:
         )
         assert d.allowed is False  # 80,000 > 50,000
 
+    def test_canonical_abi_daily_budget_micros_denies(self) -> None:
+        """``daily_budget_micros`` is the provider ABI's budget field name
+        (``CreateCampaignRequest.daily_budget_micros``) and the one
+        docs/plugin-authoring.md tells plugin authors to use, so provider
+        plugins surface it verbatim on their MCP write tools. It must be
+        capped like any other budget — otherwise every ABI-faithful plugin
+        silently bypasses the guardrails.
+        """
+        g = Guardrails(max_daily_budget_per_campaign=50000)
+        d = evaluate_guardrails(
+            "example_ads_update_campaign", {"daily_budget_micros": 80_000_000_000}, g
+        )
+        assert d.allowed is False  # 80,000 > 50,000
+        assert "50,000" in d.reason and "80,000" in d.reason
+
+    def test_canonical_abi_daily_budget_micros_under_cap_allows(self) -> None:
+        g = Guardrails(max_daily_budget_per_campaign=50000)
+        d = evaluate_guardrails(
+            "example_ads_create_campaign", {"daily_budget_micros": 40_000_000_000}, g
+        )
+        assert d.allowed is True
+
+    def test_canonical_abi_daily_budget_micros_respects_increase_pct(self) -> None:
+        g = Guardrails(max_daily_budget_increase_pct=20)
+        d = evaluate_guardrails(
+            "example_ads_update_campaign",
+            {"daily_budget_micros": 15_000_000_000, "current_daily_budget": 10000},
+            g,
+        )
+        assert d.allowed is False  # 10,000 -> 15,000 is +50%
+
     def test_increase_pct_denies(self) -> None:
         g = Guardrails(max_daily_budget_increase_pct=20)
         d = evaluate_guardrails(


### PR DESCRIPTION
## Problem

`StrategyPolicyGate` (#360) hard-enforces the operator's STRATEGY.md `## Guardrails` budget caps before dispatch — but it finds the proposed budget by matching a fixed set of argument keys:

```python
_BUDGET_KEYS = ("daily_budget", "proposed_daily_budget", "amount")
...
for micros_key in ("budget_amount_micros", "amount_micros"):
```

Those are the spellings the first-party `google_ads_*` / `meta_ads_*` tools use. **`daily_budget_micros` is not among them** — yet that is the provider ABI's *own* budget field (`Campaign.daily_budget_micros`, `CreateCampaignRequest.daily_budget_micros`, `mureo/core/providers/models.py`) and the name `docs/plugin-authoring.md` explicitly tells plugin authors to use:

> integer micros … on every monetary field (`daily_budget_micros`, `cost_micros`, `cpc_bid_micros`)

The gate *does* run on plugin tools — `_evaluate_policy_gates` has no first-party allow-list — so the result is that **a provider plugin which follows the ABI has every budget rule silently skipped**. `_proposed_budget()` returns `None`, and `max_daily_budget_per_campaign`, `max_daily_budget_increase_pct` and `max_total_daily_budget` are all bypassed.

An operator's cap was enforced on Google and Meta while that plugin's budget writes went straight through — no error, no warning, just an unenforced cap on a real-spend surface. The gate's key list was a correct-but-incomplete union of *platform-native* names; it was never reconciled against the *ABI* name.

## Fix

Read `daily_budget_micros` alongside the other micros keys.

Deliberately an **explicit key**, not a generic `*_micros` suffix rule: a suffix rule would also match `cpc_bid_micros` / `cost_micros`, and treating a bid as a budget would misclassify bid-only mutations.

## Impact

- Any ABI-faithful provider plugin now has the budget caps applied to its writes.
- **First-party behaviour is unchanged.** No `_tools_*.py` inputSchema declares `daily_budget_micros` (the Google budget tools use `amount` / `amount_micros` / `total_amount*`; Meta uses `daily_budget` / `lifetime_budget`). `_BUDGET_KEYS` is still checked before the micros keys, so precedence is untouched.
- Fail-open contract is unchanged: no `## Guardrails` section ⇒ abstain.

## Tests

Three added to `tests/test_strategy_gate.py` (absolute cap, under-cap allow, % increase). Two of them fail without the one-line fix — verified by reverting it:

```
FAILED test_canonical_abi_daily_budget_micros_denies
FAILED test_canonical_abi_daily_budget_micros_respects_increase_pct
```

Full suite: 28 passed. ruff / black / mypy clean.
