### PR TITLE
fix(security): scope Meta account_id / Google customer_id to the active workspace (#411)

### DIFF
--- a/mureo/analytics/builtin/_live_clients.py
+++ b/mureo/analytics/builtin/_live_clients.py
@@ -104,6 +104,12 @@ def _aggregate_google_metrics(
 def _open_google_ads_client(account_id: str) -> object:
     """Resolve credentials + open a Google Ads client (live or BYOD).
 
+    WARNING (#411/#413): this helper does NOT enforce the workspace
+    account allow-list — ``account_id`` is used verbatim. Every wired MCP
+    tool today derives the id from workspace state, never from a caller
+    argument. If a future tool passes a caller-supplied id into the
+    AnalyticsModule Protocol, route it through the #411 resolvers first.
+
     Raises :class:`NoCredentialsError` in live mode when credentials
     are missing. BYOD mode is detected by the client factory itself
     (``mureo.mcp._client_factory``), so this helper does not re-check
@@ -439,7 +445,14 @@ def _aggregate_meta_metrics(
 
 
 def _open_meta_ads_client(account_id: str) -> object:
-    """Parallel to :func:`_open_google_ads_client` for Meta Ads."""
+    """Parallel to :func:`_open_google_ads_client` for Meta Ads.
+
+    WARNING (#411/#413): this helper does NOT enforce the workspace
+    account allow-list — ``account_id`` is used verbatim. Every wired MCP
+    tool today derives the id from workspace state, never from a caller
+    argument. If a future tool passes a caller-supplied id into the
+    AnalyticsModule Protocol, route it through the #411 resolvers first.
+    """
     from mureo.auth import load_meta_ads_credentials
     from mureo.byod.runtime import byod_has
     from mureo.mcp._client_factory import get_meta_ads_client

--- a/mureo/core/runtime_context.py
+++ b/mureo/core/runtime_context.py
@@ -391,23 +391,68 @@ def runtime_search_console_sites() -> frozenset[str] | None:
       cross-client risk, so it keeps the unrestricted behavior; a usable
       allow-list still scopes it if one is declared.
     """
+    return _runtime_account_allow_list("search_console_sites")
+
+
+def runtime_meta_account_ids() -> frozenset[str] | None:
+    """The Meta Ads ``account_id`` allow-list for the ACTIVE client, or
+    ``None`` when Meta Ads is not tenant-scoped (#411).
+
+    Same shape and rationale as :func:`runtime_search_console_sites`: the
+    Meta MCP tools take ``account_id`` as a free caller argument while the
+    shared credentials can reach every managed ad account, so a
+    multi-account backend declares the active client's accounts as
+    ``meta_account_ids`` on its ``SecretStore`` and the handler choke point
+    enforces the effective id against it — fail-closed when a multi-account
+    backend declares nothing. Entries may be ``act_``-prefixed or bare
+    numeric; the handler compares prefix-insensitively.
+    """
+    return _runtime_account_allow_list("meta_account_ids")
+
+
+def runtime_google_ads_customer_ids() -> frozenset[str] | None:
+    """The Google Ads ``customer_id`` allow-list for the ACTIVE client, or
+    ``None`` when Google Ads is not tenant-scoped (#411).
+
+    Same shape and rationale as :func:`runtime_search_console_sites`; the
+    store attribute is ``google_ads_customer_ids``. Entries may carry
+    hyphens or not; the handler compares hyphen-insensitively.
+    """
+    return _runtime_account_allow_list("google_ads_customer_ids")
+
+
+def _runtime_account_allow_list(attribute: str) -> frozenset[str] | None:
+    """Shared resolver behind the per-provider account allow-lists.
+
+    Resolution (identical for every member — the #375 contract; see
+    :func:`runtime_search_console_sites` for the full rationale):
+
+    - **No factory registered** → ``None`` (standalone OSS unrestricted;
+      the gate is on entry-point presence so the default store is never
+      consulted).
+    - **Store declares a usable collection** under ``attribute`` → a
+      ``frozenset`` of its non-blank string entries (possibly empty —
+      declaring the attribute opts INTO scoping).
+    - **Attribute absent/unusable on a multi-account backend** → an EMPTY
+      ``frozenset``: shared auth reaches every client's account, so a
+      forgotten or mistyped allow-list must fail CLOSED, not silently
+      reopen the cross-client leak.
+    - **Attribute absent/unusable on a single-account backend** → ``None``
+      (no shared-auth cross-client risk; unrestricted).
+    """
     if not list(entry_points(group=RUNTIME_CONTEXT_FACTORY_ENTRY_POINT_GROUP)):
         return None
     store = get_runtime_context().secret_store
-    scoped = _coerce_site_allow_list(getattr(store, "search_console_sites", None))
+    scoped = _coerce_site_allow_list(getattr(store, attribute, None))
     if scoped is not None:
         return scoped
-    # No usable allow-list. Fail CLOSED for a shared-OAuth (multi-account)
-    # backend — it can reach every client's property, so an un-declared or
-    # mistyped list must scope to nothing, not everything. A single-account
-    # backend has no such cross-client reach, so it stays unrestricted.
     if getattr(store, "multi_account_auth", False) is True:
         return frozenset()
     return None
 
 
 def _coerce_site_allow_list(declared: object) -> frozenset[str] | None:
-    """Normalize a declared ``search_console_sites`` value, or ``None``.
+    """Normalize a declared allow-list value, or ``None``.
 
     ``None`` means "no usable declaration" (absent, or a non-collection /
     bare ``str`` / ``bytes`` — a mistyped scalar must never become a

--- a/mureo/mcp/_handlers_google_ads.py
+++ b/mureo/mcp/_handlers_google_ads.py
@@ -17,6 +17,7 @@ from mureo.auth import (
     load_google_ads_credentials,
 )
 from mureo.byod.runtime import byod_has
+from mureo.core.runtime_context import runtime_google_ads_customer_ids
 from mureo.mcp._client_factory import get_google_ads_client
 from mureo.mcp._helpers import (
     _json_result,
@@ -37,6 +38,65 @@ _NO_CREDS_MSG = (
 )
 
 _throttler = Throttler(GOOGLE_ADS_THROTTLE)
+
+
+def _normalize_customer_id(value: str) -> str:
+    """Strip hyphens so membership checks are format-insensitive."""
+    return value.replace("-", "")
+
+
+def _resolve_customer_id(requested: str | None, default: str | None) -> str:
+    """Resolve and workspace-enforce the Google Ads ``customer_id`` (#411).
+
+    Every Google Ads tool funnels through ``_get_client``, which takes
+    ``customer_id`` as a free caller argument while the (possibly shared)
+    developer token + OAuth can reach every managed account. This binds
+    the EFFECTIVE id — explicit argument or credentials default alike —
+    to the active client's allow-list, mirroring Search Console's
+    ``site_url`` enforcement (#375):
+
+    - **Not tenant-scoped** (:func:`runtime_google_ads_customer_ids` →
+      ``None``): unchanged — argument wins, credentials default
+      (``customer_id`` then ``login_customer_id``) second, missing both is
+      an error.
+    - **Tenant-scoped**: an out-of-set value is refused (fail-closed,
+      hyphen-insensitive). No usable value — including a credentials
+      default that is not in the set, the common case when only the
+      operator's MCC ``login_customer_id`` is present — resolves to the
+      single configured account, or is refused when several are configured
+      (ambiguous) or none are (fail-fast).
+    """
+    allowed = runtime_google_ads_customer_ids()
+    if allowed is None:
+        customer_id = requested or default
+        if not customer_id:
+            raise ValueError(
+                "customer_id is required. Provide it as a parameter or "
+                "configure it in ~/.mureo/credentials.json via mureo auth "
+                "setup."
+            )
+        return str(customer_id)
+    if not allowed:
+        raise ValueError(
+            "Google Ads is not configured for this client. Configure the "
+            "client's account before querying it."
+        )
+    normalized_allowed = {_normalize_customer_id(entry) for entry in allowed}
+    if requested:
+        if _normalize_customer_id(str(requested)) not in normalized_allowed:
+            raise ValueError(
+                f"customer_id {requested!r} is not one of this client's "
+                "configured accounts and was refused."
+            )
+        return str(requested)
+    if default and _normalize_customer_id(str(default)) in normalized_allowed:
+        return str(default)
+    if len(allowed) == 1:
+        return next(iter(allowed))
+    raise ValueError(
+        "customer_id is required: this client has multiple configured "
+        "accounts — pass one of them explicitly."
+    )
 
 
 def _get_client(arguments: dict[str, Any]) -> Any:
@@ -63,14 +123,14 @@ def _get_client(arguments: dict[str, Any]) -> Any:
     if creds is None:
         return None
 
-    customer_id = (
-        _opt(arguments, "customer_id") or creds.customer_id or creds.login_customer_id
+    # getattr, not attribute access: the default must not be evaluated
+    # eagerly against credential objects that lack the field (the old
+    # ``or``-chain short-circuited when an explicit id was passed).
+    customer_id = _resolve_customer_id(
+        _opt(arguments, "customer_id"),
+        getattr(creds, "customer_id", None)
+        or getattr(creds, "login_customer_id", None),
     )
-    if not customer_id:
-        raise ValueError(
-            "customer_id is required. Provide it as a parameter or configure it "
-            "in ~/.mureo/credentials.json via mureo auth setup."
-        )
     if not str(customer_id).replace("-", "").isdigit():
         raise ValueError(
             f"Invalid customer_id format: {customer_id} (must be numeric, hyphens allowed)"

--- a/mureo/mcp/_handlers_google_ads_analysis.py
+++ b/mureo/mcp/_handlers_google_ads_analysis.py
@@ -14,7 +14,12 @@ from urllib.parse import urlparse
 if TYPE_CHECKING:
     from mcp.types import TextContent
 
-from mureo.mcp._handlers_google_ads import _get_client, _no_google_creds
+from mureo.core.runtime_context import runtime_google_ads_customer_ids
+from mureo.mcp._handlers_google_ads import (
+    _get_client,
+    _no_google_creds,
+    _normalize_customer_id,
+)
 from mureo.mcp._helpers import (
     _json_result,
     _opt,
@@ -62,14 +67,26 @@ async def handle_accounts_list(args: dict[str, Any]) -> list[TextContent]:
     An explicit ``customer_id`` (or BYOD mode) still routes through the
     customer-scoped client; only the real-mode, no-customer_id case uses the
     id-free :func:`mureo.google_ads.list_accessible_accounts` primitive.
+
+    Workspace scoping (#411): discovery enumerates every account the
+    (possibly operator-shared) auth can reach — on a multi-account backend
+    that is every sibling client's id and name. When the workspace is
+    scoped (:func:`runtime_google_ads_customer_ids` is not ``None``), both
+    real-mode branches filter the response to the allowed set, mirroring
+    the Search Console sites-list filtering (#375). BYOD rows are local
+    CSV labels with no shared-auth reach and stay unfiltered.
     """
     from mureo.byod.runtime import byod_has
 
-    if byod_has("google_ads") or _opt(args, "customer_id"):
+    byod = byod_has("google_ads")
+    if byod or _opt(args, "customer_id"):
         client = _get_client(args)
         if client is None:
             return _no_google_creds()
-        return _json_result(await client.list_accounts())
+        result = await client.list_accounts()
+        if not byod:
+            result = _filter_accounts_to_allowed(result)
+        return _json_result(result)
 
     from mureo.auth import load_google_ads_credentials
     from mureo.google_ads import list_accessible_accounts
@@ -78,7 +95,44 @@ async def handle_accounts_list(args: dict[str, Any]) -> list[TextContent]:
     if creds is None:
         return _no_google_creds()
     accounts = await list_accessible_accounts(creds)
-    return _json_result(accounts)
+    return _json_result(_filter_accounts_to_allowed(accounts))
+
+
+def _filter_accounts_to_allowed(accounts: Any) -> Any:
+    """Drop account rows outside the workspace allow-list (#411).
+
+    Unscoped (:func:`runtime_google_ads_customer_ids` → ``None``) returns
+    the payload untouched. Scoped keeps only ``dict`` rows whose account id
+    matches an allowed entry (hyphen-insensitive) — an unconfigured
+    workspace (empty set) therefore yields an empty roster, erring closed
+    like every other member of the #375 family.
+
+    The two branches feeding this filter use different row schemas:
+    :func:`mureo.google_ads.list_accessible_accounts` emits ``{"id": ...}``
+    rows, while ``client.list_accounts()`` emits ``{"customer_id":
+    "customers/<digits>"}`` resource names — both are handled.
+    """
+    allowed = runtime_google_ads_customer_ids()
+    if allowed is None:
+        return accounts
+    normalized = {_normalize_customer_id(str(entry)) for entry in allowed}
+    if not isinstance(accounts, list):
+        return []
+    return [
+        row
+        for row in accounts
+        if isinstance(row, dict) and _account_row_id(row) in normalized
+    ]
+
+
+def _account_row_id(row: dict[str, Any]) -> str:
+    """The normalized account id of one roster row, tolerant of both the
+    ``id`` and the resource-name ``customer_id`` schema."""
+    raw = str(row.get("id") or row.get("customer_id") or "")
+    prefix = "customers/"
+    if raw.startswith(prefix):
+        raw = raw[len(prefix) :]
+    return _normalize_customer_id(raw)
 
 
 @api_error_handler

--- a/mureo/mcp/_handlers_meta_ads.py
+++ b/mureo/mcp/_handlers_meta_ads.py
@@ -19,6 +19,7 @@ from mureo.auth import (
     refresh_meta_token_if_needed,
 )
 from mureo.byod.runtime import byod_has
+from mureo.core.runtime_context import runtime_meta_account_ids
 from mureo.mcp._client_factory import get_meta_ads_client
 from mureo.mcp._helpers import (
     _json_result,
@@ -40,6 +41,67 @@ _NO_CREDS_MSG = (
 )
 
 _throttler = Throttler(META_ADS_THROTTLE)
+
+
+def _normalize_meta_account_id(value: str) -> str:
+    """Strip the ``act_`` prefix so membership checks are prefix-insensitive."""
+    return value[4:] if value.startswith("act_") else value
+
+
+def _canonical_meta_account_id(value: str) -> str:
+    """Ensure the ``act_`` prefix the Meta client factory requires."""
+    return value if value.startswith("act_") else f"act_{value}"
+
+
+def _resolve_account_id(requested: str | None, default: str | None) -> str:
+    """Resolve and workspace-enforce the Meta ``account_id`` (#411).
+
+    Every Meta tool funnels through ``_get_client``, which takes
+    ``account_id`` as a free caller argument while the (possibly shared)
+    credentials can reach every managed ad account. This binds the
+    EFFECTIVE id — explicit argument or credentials default alike — to the
+    active client's allow-list, mirroring Search Console's ``site_url``
+    enforcement (#375):
+
+    - **Not tenant-scoped** (:func:`runtime_meta_account_ids` → ``None``):
+      unchanged — argument wins, credentials default second, missing both
+      is an error.
+    - **Tenant-scoped**: an out-of-set value is refused (fail-closed,
+      prefix-insensitive); no usable value resolves to the single
+      configured account, or is refused when several are configured
+      (ambiguous) or none are (fail-fast).
+    """
+    allowed = runtime_meta_account_ids()
+    if allowed is None:
+        account_id = requested or default
+        if not account_id:
+            raise ValueError(
+                "account_id is required. Provide it as a parameter or "
+                "configure it in ~/.mureo/credentials.json via mureo auth "
+                "setup."
+            )
+        return str(account_id)
+    if not allowed:
+        raise ValueError(
+            "Meta Ads is not configured for this client. Configure the "
+            "client's ad account before querying it."
+        )
+    normalized_allowed = {_normalize_meta_account_id(entry) for entry in allowed}
+    if requested:
+        if _normalize_meta_account_id(str(requested)) not in normalized_allowed:
+            raise ValueError(
+                f"account_id {requested!r} is not one of this client's "
+                "configured ad accounts and was refused."
+            )
+        return _canonical_meta_account_id(str(requested))
+    if default and _normalize_meta_account_id(str(default)) in normalized_allowed:
+        return _canonical_meta_account_id(str(default))
+    if len(allowed) == 1:
+        return _canonical_meta_account_id(next(iter(allowed)))
+    raise ValueError(
+        "account_id is required: this client has multiple configured ad "
+        "accounts — pass one of them explicitly."
+    )
 
 
 async def _get_client(arguments: dict[str, Any]) -> Any:
@@ -64,12 +126,12 @@ async def _get_client(arguments: dict[str, Any]) -> Any:
     if creds is None:
         return None
 
-    account_id = _opt(arguments, "account_id") or creds.account_id
-    if not account_id:
-        raise ValueError(
-            "account_id is required. Provide it as a parameter or configure it "
-            "in ~/.mureo/credentials.json via mureo auth setup."
-        )
+    # getattr, not attribute access: the default must not be evaluated
+    # eagerly against credential objects that lack the field (the old
+    # ``or``-chain short-circuited when an explicit id was passed).
+    account_id = _resolve_account_id(
+        _opt(arguments, "account_id"), getattr(creds, "account_id", None)
+    )
     if not str(account_id).startswith("act_"):
         raise ValueError(
             f"Invalid account_id format: {account_id} (must start with 'act_')"

--- a/tests/test_account_id_tenant_scope.py
+++ b/tests/test_account_id_tenant_scope.py
@@ -1,0 +1,473 @@
+"""Workspace scoping for Meta ``account_id`` / Google Ads ``customer_id`` (#411).
+
+Most Meta Ads and Google Ads MCP tools accept the per-account id as a free
+caller argument, and the shared handler choke point (``_get_client``) used
+it with the operator-shared credentials without validating it against the
+active workspace's bound account. On a multi-account backend the shared
+token reaches EVERY managed account, so a conversation bound to workspace A
+could read — and with write tools, mutate — workspace B's account simply by
+passing B's id. #375 closed the identical hole for Search Console
+(``site_url``); this generalizes that seam.
+
+Two halves are tested here, mirroring test_search_console_tenant_scope.py:
+
+1. ``runtime_meta_account_ids`` / ``runtime_google_ads_customer_ids`` — the
+   store-capability resolvers (fail-closed on a multi-account backend that
+   declares nothing).
+2. The handlers' ``_resolve_account_id`` / ``_resolve_customer_id`` and the
+   ``_get_client`` wiring — out-of-set ids refused, unconfigured fails
+   fast, single-entry default, id normalization (``act_`` prefix, hyphens).
+
+Standalone OSS (no ``mureo.runtime_context_factory`` registered) is
+unaffected: the resolvers return ``None`` and the ids behave exactly as
+before.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mureo.core.runtime_context import (
+    default_runtime_context,
+    reset_runtime_context,
+    runtime_google_ads_customer_ids,
+    runtime_meta_account_ids,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+_GROUP = "mureo.runtime_context_factory"
+
+
+class _FakeEP:
+    def __init__(self, name: str, target: Any) -> None:
+        self.name = name
+        self._target = target
+
+    def load(self) -> Any:
+        return self._target
+
+
+def _patch_eps(monkeypatch: pytest.MonkeyPatch, eps: list[_FakeEP]) -> None:
+    def fake_entry_points(*, group: str) -> list[_FakeEP]:
+        assert group == _GROUP
+        return eps
+
+    monkeypatch.setattr("mureo.core.runtime_context.entry_points", fake_entry_points)
+
+
+def _ctx_with_store(store: Any) -> Any:
+    return dataclasses.replace(default_runtime_context(), secret_store=store)
+
+
+@pytest.fixture(autouse=True)
+def _reset_ctx() -> Iterator[None]:
+    reset_runtime_context()
+    yield
+    reset_runtime_context()
+
+
+# ---------------------------------------------------------------------------
+# Resolvers — same contract as runtime_search_console_sites (#375)
+# ---------------------------------------------------------------------------
+
+_RESOLVERS = [
+    (runtime_meta_account_ids, "meta_account_ids", "act_111"),
+    (runtime_google_ads_customer_ids, "google_ads_customer_ids", "111-222-3333"),
+]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("resolver", "attribute", "sample"), _RESOLVERS, ids=["meta", "google"]
+)
+class TestAccountIdResolvers:
+    def test_none_when_no_factory_registered(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        resolver: Any,
+        attribute: str,
+        sample: str,
+    ) -> None:
+        _patch_eps(monkeypatch, [])
+        assert resolver() is None
+
+    def test_none_when_store_silent_on_single_account(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        resolver: Any,
+        attribute: str,
+        sample: str,
+    ) -> None:
+        _patch_eps(monkeypatch, [_FakeEP("x", default_runtime_context)])
+        assert resolver() is None
+
+    def test_fail_closed_when_store_silent_on_multi_account(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        resolver: Any,
+        attribute: str,
+        sample: str,
+    ) -> None:
+        """A shared-auth backend that forgets the allow-list must scope to
+        NOTHING, not everything."""
+
+        class _Store:
+            multi_account_auth = True
+
+        ctx = _ctx_with_store(_Store())
+        _patch_eps(monkeypatch, [_FakeEP("x", lambda: ctx)])
+        assert resolver() == frozenset()
+
+    def test_returns_declared_ids(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        resolver: Any,
+        attribute: str,
+        sample: str,
+    ) -> None:
+        store = MagicMock(spec=[])
+        setattr(store, attribute, [sample, "  ", 123])
+        ctx = _ctx_with_store(store)
+        _patch_eps(monkeypatch, [_FakeEP("x", lambda: ctx)])
+        assert resolver() == frozenset({sample})
+
+    def test_bare_str_declaration_is_not_an_allow_list(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        resolver: Any,
+        attribute: str,
+        sample: str,
+    ) -> None:
+        """A mistyped scalar on a multi-account backend fails CLOSED."""
+        store = MagicMock(spec=[])
+        setattr(store, attribute, sample)  # bare str, not a collection
+        store.multi_account_auth = True
+        ctx = _ctx_with_store(store)
+        _patch_eps(monkeypatch, [_FakeEP("x", lambda: ctx)])
+        assert resolver() == frozenset()
+
+
+# ---------------------------------------------------------------------------
+# Meta handler — _resolve_account_id + _get_client wiring
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestMetaAccountIdScoping:
+    def _resolve(self, requested: str | None, default: str | None) -> str:
+        from mureo.mcp._handlers_meta_ads import _resolve_account_id
+
+        return _resolve_account_id(requested, default)
+
+    def test_unscoped_keeps_existing_behavior(self) -> None:
+        with patch(
+            "mureo.mcp._handlers_meta_ads.runtime_meta_account_ids",
+            return_value=None,
+        ):
+            assert self._resolve("act_222", "act_111") == "act_222"
+            assert self._resolve(None, "act_111") == "act_111"
+            with pytest.raises(ValueError, match="account_id is required"):
+                self._resolve(None, None)
+
+    def test_unconfigured_client_fails_fast(self) -> None:
+        with (
+            patch(
+                "mureo.mcp._handlers_meta_ads.runtime_meta_account_ids",
+                return_value=frozenset(),
+            ),
+            pytest.raises(ValueError, match="not configured"),
+        ):
+            self._resolve("act_222", "act_111")
+
+    def test_out_of_set_explicit_id_is_refused(self) -> None:
+        with (
+            patch(
+                "mureo.mcp._handlers_meta_ads.runtime_meta_account_ids",
+                return_value=frozenset({"act_111"}),
+            ),
+            pytest.raises(ValueError, match="refused"),
+        ):
+            self._resolve("act_999", "act_111")
+
+    def test_out_of_set_credentials_default_is_refused(self) -> None:
+        """The workspace default from shared credentials is enforced too —
+        it may be an operator-level value that does not belong here."""
+        with (
+            patch(
+                "mureo.mcp._handlers_meta_ads.runtime_meta_account_ids",
+                return_value=frozenset({"act_111", "act_222"}),
+            ),
+            pytest.raises(ValueError, match="refused|required"),
+        ):
+            self._resolve(None, "act_999")
+
+    def test_multi_entry_default_in_set_is_used(self) -> None:
+        """The common production path: creds default already one of several
+        configured accounts, no explicit argument."""
+        with patch(
+            "mureo.mcp._handlers_meta_ads.runtime_meta_account_ids",
+            return_value=frozenset({"act_111", "act_222"}),
+        ):
+            assert self._resolve(None, "act_111") == "act_111"
+
+    def test_in_set_explicit_id_allowed(self) -> None:
+        with patch(
+            "mureo.mcp._handlers_meta_ads.runtime_meta_account_ids",
+            return_value=frozenset({"act_111", "act_222"}),
+        ):
+            assert self._resolve("act_222", "act_111") == "act_222"
+
+    def test_single_entry_defaults_and_gains_prefix(self) -> None:
+        """One configured account: omitted id resolves to it, and a bare
+        numeric allow-list entry is canonicalized to the act_ form the
+        client factory requires."""
+        with patch(
+            "mureo.mcp._handlers_meta_ads.runtime_meta_account_ids",
+            return_value=frozenset({"123456"}),
+        ):
+            assert self._resolve(None, None) == "act_123456"
+
+    def test_prefix_insensitive_membership(self) -> None:
+        """act_-prefixed argument matches a bare-numeric allow-list entry."""
+        with patch(
+            "mureo.mcp._handlers_meta_ads.runtime_meta_account_ids",
+            return_value=frozenset({"123456"}),
+        ):
+            assert self._resolve("act_123456", None) == "act_123456"
+
+    @pytest.mark.asyncio
+    async def test_get_client_refuses_out_of_set_argument(self) -> None:
+        """The wiring: every Meta tool goes through _get_client, which must
+        raise before any API client is constructed."""
+        from mureo.mcp import _handlers_meta_ads as handlers
+
+        creds = MagicMock(account_id="act_111")
+        with (
+            patch.object(handlers, "byod_has", return_value=False),
+            patch.object(handlers, "load_meta_ads_credentials", return_value=creds),
+            patch.object(
+                handlers,
+                "runtime_meta_account_ids",
+                return_value=frozenset({"act_111"}),
+            ),
+            patch.object(handlers, "refresh_meta_token_if_needed", new=AsyncMock()),
+            patch.object(handlers, "create_meta_ads_client") as factory,
+        ):
+            with pytest.raises(ValueError, match="refused"):
+                await handlers._get_client({"account_id": "act_999"})
+            factory.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_get_client_builds_client_for_allowed_argument(self) -> None:
+        from mureo.mcp import _handlers_meta_ads as handlers
+
+        creds = MagicMock(account_id=None)
+        with (
+            patch.object(handlers, "byod_has", return_value=False),
+            patch.object(handlers, "load_meta_ads_credentials", return_value=creds),
+            patch.object(
+                handlers, "runtime_meta_account_ids", return_value=frozenset({"111"})
+            ),
+            patch.object(
+                handlers,
+                "refresh_meta_token_if_needed",
+                new=AsyncMock(return_value=creds),
+            ),
+            patch.object(handlers, "register_client_for_cleanup"),
+            patch.object(handlers, "create_meta_ads_client") as factory,
+        ):
+            await handlers._get_client({"account_id": "act_111"})
+        factory.assert_called_once()
+        assert factory.call_args.args[1] == "act_111"
+
+
+# ---------------------------------------------------------------------------
+# Google Ads handler — _resolve_customer_id + _get_client wiring
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGoogleCustomerIdScoping:
+    def _resolve(self, requested: str | None, default: str | None) -> str:
+        from mureo.mcp._handlers_google_ads import _resolve_customer_id
+
+        return _resolve_customer_id(requested, default)
+
+    def test_unscoped_keeps_existing_behavior(self) -> None:
+        with patch(
+            "mureo.mcp._handlers_google_ads.runtime_google_ads_customer_ids",
+            return_value=None,
+        ):
+            assert self._resolve("222", "111") == "222"
+            assert self._resolve(None, "111") == "111"
+            with pytest.raises(ValueError, match="customer_id is required"):
+                self._resolve(None, None)
+
+    def test_unconfigured_client_fails_fast(self) -> None:
+        with (
+            patch(
+                "mureo.mcp._handlers_google_ads.runtime_google_ads_customer_ids",
+                return_value=frozenset(),
+            ),
+            pytest.raises(ValueError, match="not configured"),
+        ):
+            self._resolve("222", "111")
+
+    def test_out_of_set_explicit_id_is_refused(self) -> None:
+        with (
+            patch(
+                "mureo.mcp._handlers_google_ads.runtime_google_ads_customer_ids",
+                return_value=frozenset({"111-222-3333"}),
+            ),
+            pytest.raises(ValueError, match="refused"),
+        ):
+            self._resolve("999-888-7777", None)
+
+    def test_hyphen_insensitive_membership(self) -> None:
+        """1112223333 matches the configured 111-222-3333 and vice versa."""
+        with patch(
+            "mureo.mcp._handlers_google_ads.runtime_google_ads_customer_ids",
+            return_value=frozenset({"111-222-3333"}),
+        ):
+            assert self._resolve("1112223333", None) == "1112223333"
+
+    def test_multi_entry_default_in_set_is_used(self) -> None:
+        with patch(
+            "mureo.mcp._handlers_google_ads.runtime_google_ads_customer_ids",
+            return_value=frozenset({"111", "222"}),
+        ):
+            assert self._resolve(None, "111") == "111"
+
+    def test_single_entry_defaults_when_omitted(self) -> None:
+        with patch(
+            "mureo.mcp._handlers_google_ads.runtime_google_ads_customer_ids",
+            return_value=frozenset({"111-222-3333"}),
+        ):
+            assert self._resolve(None, None) == "111-222-3333"
+
+    def test_out_of_set_mcc_default_falls_back_to_single_entry(self) -> None:
+        """The shared login_customer_id (MCC) is usually NOT the client's
+        account — with one configured id, resolution lands there instead."""
+        with patch(
+            "mureo.mcp._handlers_google_ads.runtime_google_ads_customer_ids",
+            return_value=frozenset({"111-222-3333"}),
+        ):
+            assert self._resolve(None, "999-000-1111") == "111-222-3333"
+
+    def test_get_client_refuses_out_of_set_argument(self) -> None:
+        from mureo.mcp import _handlers_google_ads as handlers
+
+        creds = MagicMock(customer_id="111", login_customer_id="999")
+        with (
+            patch.object(handlers, "byod_has", return_value=False),
+            patch.object(handlers, "load_google_ads_credentials", return_value=creds),
+            patch.object(
+                handlers,
+                "runtime_google_ads_customer_ids",
+                return_value=frozenset({"111"}),
+            ),
+            patch.object(handlers, "create_google_ads_client") as factory,
+        ):
+            with pytest.raises(ValueError, match="refused"):
+                handlers._get_client({"customer_id": "222"})
+            factory.assert_not_called()
+
+    def test_get_client_builds_client_for_allowed_argument(self) -> None:
+        from mureo.mcp import _handlers_google_ads as handlers
+
+        creds = MagicMock(customer_id=None, login_customer_id=None)
+        with (
+            patch.object(handlers, "byod_has", return_value=False),
+            patch.object(handlers, "load_google_ads_credentials", return_value=creds),
+            patch.object(
+                handlers,
+                "runtime_google_ads_customer_ids",
+                return_value=frozenset({"111-222-3333"}),
+            ),
+            patch.object(handlers, "create_google_ads_client") as factory,
+        ):
+            handlers._get_client({"customer_id": "1112223333"})
+        factory.assert_called_once()
+        assert factory.call_args.args[1] == "1112223333"
+
+
+# ---------------------------------------------------------------------------
+# google_ads_accounts_list — the id-free discovery tool must not enumerate
+# sibling clients' accounts under shared auth (#411 review CRITICAL).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGoogleAccountsListScoping:
+    _ROWS = [
+        {"id": "1112223333", "name": "Mine"},
+        {"id": "9990001111", "name": "Sibling client"},
+    ]
+
+    async def _call(self, allowed: frozenset[str] | None) -> list[dict[str, Any]]:
+        import json as _json
+
+        from mureo.mcp import _handlers_google_ads_analysis as mod
+
+        with (
+            patch("mureo.byod.runtime.byod_has", return_value=False),
+            patch("mureo.auth.load_google_ads_credentials", return_value=MagicMock()),
+            patch(
+                "mureo.google_ads.list_accessible_accounts",
+                new=AsyncMock(return_value=list(self._ROWS)),
+            ),
+            patch.object(mod, "runtime_google_ads_customer_ids", return_value=allowed),
+        ):
+            result = await mod.handle_accounts_list({})
+        payload: list[dict[str, Any]] = _json.loads(result[0].text)
+        return payload
+
+    @pytest.mark.asyncio
+    async def test_recovery_path_filters_to_allowed(self) -> None:
+        rows = await self._call(frozenset({"111-222-3333"}))
+        assert [row["id"] for row in rows] == ["1112223333"]
+
+    @pytest.mark.asyncio
+    async def test_recovery_path_unscoped_is_unchanged(self) -> None:
+        rows = await self._call(None)
+        assert [row["id"] for row in rows] == ["1112223333", "9990001111"]
+
+    @pytest.mark.asyncio
+    async def test_recovery_path_fail_closed_when_unconfigured(self) -> None:
+        rows = await self._call(frozenset())
+        assert rows == []
+
+    @pytest.mark.asyncio
+    async def test_explicit_customer_id_branch_filters_response(self) -> None:
+        """The customer-scoped client's list_accounts() enumerates the same
+        shared-auth reachable set — its response is filtered too."""
+        import json as _json
+
+        from mureo.mcp import _handlers_google_ads_analysis as mod
+
+        # Real shape from mureo/google_ads/client.py list_accounts():
+        # {"customer_id": "<resource_name>"} with a "customers/" prefix.
+        rows = [
+            {"customer_id": "customers/1112223333"},
+            {"customer_id": "customers/9990001111"},
+        ]
+        client = MagicMock()
+        client.list_accounts = AsyncMock(return_value=rows)
+        with (
+            patch("mureo.byod.runtime.byod_has", return_value=False),
+            patch.object(mod, "_get_client", return_value=client),
+            patch.object(
+                mod,
+                "runtime_google_ads_customer_ids",
+                return_value=frozenset({"111-222-3333"}),
+            ),
+        ):
+            result = await mod.handle_accounts_list({"customer_id": "111-222-3333"})
+        payload = _json.loads(result[0].text)
+        assert payload == [{"customer_id": "customers/1112223333"}]

--- a/tests/test_image_upload.py
+++ b/tests/test_image_upload.py
@@ -19,6 +19,26 @@ import pytest
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture(autouse=True)
+def _standalone_account_scoping():
+    """Pin these tests to STANDALONE (untenanted) Google/Meta handlers.
+
+    #411 added workspace scoping: with a ``mureo.runtime_context_factory``
+    installed whose store is a shared-auth multi-account backend, an
+    undeclared allow-list fail-closes every account id. A dev box carrying
+    such a plugin would break these standalone assertions. Neutralize both
+    seams; scoped behavior lives in test_account_id_tenant_scope.py.
+    """
+    with patch(
+        "mureo.mcp._handlers_google_ads.runtime_google_ads_customer_ids",
+        return_value=None,
+    ), patch(
+        "mureo.mcp._handlers_meta_ads.runtime_meta_account_ids",
+        return_value=None,
+    ):
+        yield
+
+
 @pytest.fixture()
 def meta_client() -> Any:
     """Create a MetaAdsApiClient for tests."""

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -37,6 +37,26 @@ def _import_google_ads_handlers():
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture(autouse=True)
+def _standalone_account_scoping():
+    """Pin these tests to STANDALONE (untenanted) Google/Meta handlers.
+
+    #411 added workspace scoping: with a ``mureo.runtime_context_factory``
+    installed whose store is a shared-auth multi-account backend, an
+    undeclared allow-list fail-closes every account id. A dev box carrying
+    such a plugin would break these standalone assertions. Neutralize both
+    seams; scoped behavior lives in test_account_id_tenant_scope.py.
+    """
+    with patch(
+        "mureo.mcp._handlers_google_ads.runtime_google_ads_customer_ids",
+        return_value=None,
+    ), patch(
+        "mureo.mcp._handlers_meta_ads.runtime_meta_account_ids",
+        return_value=None,
+    ):
+        yield
+
+
 @pytest.mark.unit
 class TestListTools:
     """Verify list_tools returns the correct tool definitions."""

--- a/tests/test_mcp_tools_google_ads.py
+++ b/tests/test_mcp_tools_google_ads.py
@@ -30,6 +30,25 @@ def _import_handlers():
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture(autouse=True)
+def _standalone_google_ads():
+    """Pin these handler tests to STANDALONE (untenanted) Google Ads.
+
+    Google Ads gained workspace scoping (#411, mirroring Search Console's
+    #375): when a ``mureo.runtime_context_factory`` is installed AND its
+    store is a shared-auth multi-account backend, an undeclared
+    ``google_ads_customer_ids`` fail-closes every customer_id. A dev box carrying such a
+    plugin would therefore break these standalone assertions. Neutralize
+    the scoping seam so this module always exercises the unrestricted
+    path; the scoped behavior lives in test_account_id_tenant_scope.py.
+    """
+    with patch(
+        "mureo.mcp._handlers_google_ads.runtime_google_ads_customer_ids",
+        return_value=None,
+    ):
+        yield
+
+
 @pytest.mark.unit
 class TestGoogleAdsToolDefinitions:
     """Verify the Google Ads tool list is defined correctly."""

--- a/tests/test_mcp_tools_google_ads_analysis.py
+++ b/tests/test_mcp_tools_google_ads_analysis.py
@@ -37,6 +37,28 @@ def _mock_google_ads_context():
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture(autouse=True)
+def _standalone_google_ads():
+    """Pin these handler tests to STANDALONE (untenanted) Google Ads.
+
+    Google Ads gained workspace scoping (#411, mirroring Search Console's
+    #375): when a ``mureo.runtime_context_factory`` is installed AND its
+    store is a shared-auth multi-account backend, an undeclared
+    ``google_ads_customer_ids`` fail-closes every customer_id. A dev box carrying such a
+    plugin would therefore break these standalone assertions. Neutralize
+    the scoping seam so this module always exercises the unrestricted
+    path; the scoped behavior lives in test_account_id_tenant_scope.py.
+    """
+    with patch(
+        "mureo.mcp._handlers_google_ads.runtime_google_ads_customer_ids",
+        return_value=None,
+    ), patch(
+        "mureo.mcp._handlers_google_ads_analysis.runtime_google_ads_customer_ids",
+        return_value=None,
+    ):
+        yield
+
+
 @pytest.mark.unit
 class TestGoogleAdsBudgetCreateAndAccountsHandlers:
     """Tests for budget creation, account listing, and network/ad performance reports."""

--- a/tests/test_mcp_tools_google_ads_extensions.py
+++ b/tests/test_mcp_tools_google_ads_extensions.py
@@ -36,6 +36,25 @@ def _mock_google_ads_context():
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture(autouse=True)
+def _standalone_google_ads():
+    """Pin these handler tests to STANDALONE (untenanted) Google Ads.
+
+    Google Ads gained workspace scoping (#411, mirroring Search Console's
+    #375): when a ``mureo.runtime_context_factory`` is installed AND its
+    store is a shared-auth multi-account backend, an undeclared
+    ``google_ads_customer_ids`` fail-closes every customer_id. A dev box carrying such a
+    plugin would therefore break these standalone assertions. Neutralize
+    the scoping seam so this module always exercises the unrestricted
+    path; the scoped behavior lives in test_account_id_tenant_scope.py.
+    """
+    with patch(
+        "mureo.mcp._handlers_google_ads.runtime_google_ads_customer_ids",
+        return_value=None,
+    ):
+        yield
+
+
 @pytest.mark.unit
 class TestGoogleAdsSitelinkHandlers:
     """Sitelink-related handler tests."""

--- a/tests/test_mcp_tools_meta_ads.py
+++ b/tests/test_mcp_tools_meta_ads.py
@@ -30,6 +30,25 @@ def _import_handlers():
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture(autouse=True)
+def _standalone_meta_ads():
+    """Pin these handler tests to STANDALONE (untenanted) Meta Ads.
+
+    Meta Ads gained workspace scoping (#411, mirroring Search Console's
+    #375): when a ``mureo.runtime_context_factory`` is installed AND its
+    store is a shared-auth multi-account backend, an undeclared
+    ``meta_account_ids`` fail-closes every account_id. A dev box carrying such a
+    plugin would therefore break these standalone assertions. Neutralize
+    the scoping seam so this module always exercises the unrestricted
+    path; the scoped behavior lives in test_account_id_tenant_scope.py.
+    """
+    with patch(
+        "mureo.mcp._handlers_meta_ads.runtime_meta_account_ids",
+        return_value=None,
+    ):
+        yield
+
+
 @pytest.mark.unit
 class TestMetaAdsToolDefinitions:
     """Verify the Meta Ads tool list is defined correctly."""

--- a/tests/test_mcp_tools_meta_ads_analysis.py
+++ b/tests/test_mcp_tools_meta_ads_analysis.py
@@ -40,6 +40,25 @@ def _mock_meta_ads_context():
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture(autouse=True)
+def _standalone_meta_ads():
+    """Pin these handler tests to STANDALONE (untenanted) Meta Ads.
+
+    Meta Ads gained workspace scoping (#411, mirroring Search Console's
+    #375): when a ``mureo.runtime_context_factory`` is installed AND its
+    store is a shared-auth multi-account backend, an undeclared
+    ``meta_account_ids`` fail-closes every account_id. A dev box carrying such a
+    plugin would therefore break these standalone assertions. Neutralize
+    the scoping seam so this module always exercises the unrestricted
+    path; the scoped behavior lives in test_account_id_tenant_scope.py.
+    """
+    with patch(
+        "mureo.mcp._handlers_meta_ads.runtime_meta_account_ids",
+        return_value=None,
+    ):
+        yield
+
+
 @pytest.mark.unit
 class TestAnalysisHandlers:
     """Analysis handler tests."""

--- a/tests/test_mcp_tools_meta_ads_extended.py
+++ b/tests/test_mcp_tools_meta_ads_extended.py
@@ -41,6 +41,25 @@ def _mock_meta_ads_context():
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture(autouse=True)
+def _standalone_meta_ads():
+    """Pin these handler tests to STANDALONE (untenanted) Meta Ads.
+
+    Meta Ads gained workspace scoping (#411, mirroring Search Console's
+    #375): when a ``mureo.runtime_context_factory`` is installed AND its
+    store is a shared-auth multi-account backend, an undeclared
+    ``meta_account_ids`` fail-closes every account_id. A dev box carrying such a
+    plugin would therefore break these standalone assertions. Neutralize
+    the scoping seam so this module always exercises the unrestricted
+    path; the scoped behavior lives in test_account_id_tenant_scope.py.
+    """
+    with patch(
+        "mureo.mcp._handlers_meta_ads.runtime_meta_account_ids",
+        return_value=None,
+    ):
+        yield
+
+
 @pytest.mark.unit
 class TestCampaignPauseEnableHandlers:
     """Campaign pause/enable handler tests."""

--- a/tests/test_mcp_tools_meta_ads_other.py
+++ b/tests/test_mcp_tools_meta_ads_other.py
@@ -40,6 +40,25 @@ def _mock_meta_ads_context():
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture(autouse=True)
+def _standalone_meta_ads():
+    """Pin these handler tests to STANDALONE (untenanted) Meta Ads.
+
+    Meta Ads gained workspace scoping (#411, mirroring Search Console's
+    #375): when a ``mureo.runtime_context_factory`` is installed AND its
+    store is a shared-auth multi-account backend, an undeclared
+    ``meta_account_ids`` fail-closes every account_id. A dev box carrying such a
+    plugin would therefore break these standalone assertions. Neutralize
+    the scoping seam so this module always exercises the unrestricted
+    path; the scoped behavior lives in test_account_id_tenant_scope.py.
+    """
+    with patch(
+        "mureo.mcp._handlers_meta_ads.runtime_meta_account_ids",
+        return_value=None,
+    ):
+        yield
+
+
 @pytest.mark.unit
 class TestPagePostsHandlers:
     """Page post handler tests."""

--- a/tests/test_meta_ads_leads.py
+++ b/tests/test_meta_ads_leads.py
@@ -36,6 +36,25 @@ def _make_mock_client() -> LeadsMixin:
 # ===========================================================================
 
 
+@pytest.fixture(autouse=True)
+def _standalone_meta_ads():
+    """Pin these handler tests to STANDALONE (untenanted) Meta Ads.
+
+    Meta Ads gained workspace scoping (#411, mirroring Search Console's
+    #375): when a ``mureo.runtime_context_factory`` is installed AND its
+    store is a shared-auth multi-account backend, an undeclared
+    ``meta_account_ids`` fail-closes every account_id. A dev box carrying such a
+    plugin would therefore break these standalone assertions. Neutralize
+    the scoping seam so this module always exercises the unrestricted
+    path; the scoped behavior lives in test_account_id_tenant_scope.py.
+    """
+    with patch(
+        "mureo.mcp._handlers_meta_ads.runtime_meta_account_ids",
+        return_value=None,
+    ):
+        yield
+
+
 @pytest.mark.unit
 class TestListLeadForms:
     @pytest.fixture()

--- a/tests/test_meta_ads_media.py
+++ b/tests/test_meta_ads_media.py
@@ -20,6 +20,25 @@ from mureo.auth import MetaAdsCredentials
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture(autouse=True)
+def _standalone_meta_ads():
+    """Pin these handler tests to STANDALONE (untenanted) Meta Ads.
+
+    Meta Ads gained workspace scoping (#411, mirroring Search Console's
+    #375): when a ``mureo.runtime_context_factory`` is installed AND its
+    store is a shared-auth multi-account backend, an undeclared
+    ``meta_account_ids`` fail-closes every account_id. A dev box carrying such a
+    plugin would therefore break these standalone assertions. Neutralize
+    the scoping seam so this module always exercises the unrestricted
+    path; the scoped behavior lives in test_account_id_tenant_scope.py.
+    """
+    with patch(
+        "mureo.mcp._handlers_meta_ads.runtime_meta_account_ids",
+        return_value=None,
+    ):
+        yield
+
+
 @pytest.fixture()
 def meta_client() -> Any:
     """Create a MetaAdsApiClient for tests."""


### PR DESCRIPTION
## Summary

Closes #411 (security). Reported by a plugin/agency author.

Meta Ads and Google Ads MCP tools take the per-account id (`account_id` / `customer_id`) as a **free caller argument**, and the shared handler choke point (`_get_client` — every tool funnels through it) used it with the operator-shared credentials **without validating it against the active workspace's bound account**. On a multi-account backend the shared auth reaches every managed account, so a conversation bound to workspace A could read — and with write tools, **mutate** — workspace B's account by passing B's id. The workspace binding controlled only the *default*, not the *reachable set*.

#375 closed the identical hole for Search Console (`site_url`); this generalizes that seam.

## Changes

- **New resolvers** `runtime_meta_account_ids()` / `runtime_google_ads_customer_ids()`, sharing one `_runtime_account_allow_list()` with the (refactored, behavior-identical) `runtime_search_console_sites()`. Contract: no factory → `None` (standalone OSS unrestricted, byte-identical); declared collection → `frozenset`; **absent/unusable on a multi-account backend → empty `frozenset`, i.e. fail CLOSED**.
- **Enforcement at the choke point**: `_resolve_account_id` / `_resolve_customer_id` validate the *effective* id — explicit argument **and** credentials default alike — before any API client is constructed. Out-of-set refused; unconfigured fails fast; a single configured account resolves an omitted id (the common case where only the operator's MCC `login_customer_id` is present). Prefix- (`act_`) and hyphen-insensitive membership.
- **`google_ads_accounts_list` enumeration leak** (found in review): the id-free discovery/recovery branch bypassed `_get_client` and listed **every account the shared auth can reach** — sibling clients' ids and names. Both real-mode branches now filter through the allow-list (both row schemas handled), mirroring Search Console's sites-list filtering. BYOD stays unfiltered (local CSV labels, no shared-auth reach).

Standalone OSS installs are unaffected.

## Test plan

- [x] TDD (red first): resolver contract for both providers; resolution rules (unscoped parity, unconfigured fail-fast, out-of-set refusal of both the argument **and** the credentials default, normalization, single-entry default); `_get_client` wiring in both directions (refused id never reaches the client factory, allowed id does); accounts-list filtering across both row schemas
- [x] 11 existing suites gain the standalone-pin fixture #375 established, so a dev box carrying a multi-account plugin does not fail-close their unscoped assertions
- [x] Full suite 5427 passed (3 failures = known local plugin-env noise, identical on main); ruff/black/mypy clean
- [x] code-reviewer (2 rounds): CRITICAL (accounts-list enumeration) + HIGH (filter key-name mismatch) + 2 MEDIUM + LOW — all fixed and independently re-verified with the reviewer's own PoCs; approved

## Follow-up

- #413 — dormant `AnalyticsModule` live-client helpers bypass these resolvers (unreachable from any wired tool today; warning docstrings added)

https://claude.ai/code/session_0115NBUphwqsL1isTV8R7NHg
