### PR TITLE
feat(policy): let plugin tools declare their budget keys so Guardrails reach them (#414)

### DIFF
--- a/docs/plugin-authoring.md
+++ b/docs/plugin-authoring.md
@@ -545,10 +545,14 @@ Rules the server enforces (a non-conforming provider is skipped with a
   name (e.g. `acme_ads_list_campaigns`). Built-in tool names are
   reserved — a colliding plugin tool is dropped (built-ins win), and a
   name already taken by an earlier plugin is dropped (first wins).
-- **Validate inbound arguments yourself.** `inputSchema` validation is
-  advisory on the client side and the dispatch path is not
-  fault-isolated; translate malformed arguments into your own error
-  type rather than letting a bare `KeyError`/`ValueError` escape.
+- **Keep `inputSchema` honest — mureo enforces it server-side.** Since
+  #324 the dispatcher validates every call against your declared
+  `inputSchema` *before* it reaches your handler and rejects a violation
+  with `ValueError`. Declare the types your handler actually accepts: a
+  tool that declares `{"type": "integer"}` but tolerates `"1000"` will
+  now have that call rejected before you see it. Beyond schema shape,
+  still translate malformed arguments into your own error type rather
+  than letting a bare `KeyError`/`ValueError` escape.
 
 Sync clients: run blocking work off the event loop with
 `asyncio.to_thread(...)` inside `handle_mcp_tool` so you do not block
@@ -585,11 +589,46 @@ mureo-specific Protocol method:
 - Optional `_meta={"mureo": {...}}` (the canonical alias; the
   intuitive `meta=` spelling is also accepted):
   - `"reversal": {"operation": "...", "params": {...}}` — recorded
-    verbatim into the entry's `reversible_params`. **Honest scope:**
-    `rollback_plan_get` only builds an *executable* reversal when
-    `operation` is in mureo's built-in rollback allow-list; an
-    arbitrary plugin operation is recorded for audit/visibility but
-    is **not** auto-reversible.
+    verbatim into the entry's `reversible_params`. Since #324 this is
+    **executable**, not audit-only: `rollback_plan_get` builds a real
+    reversal when `operation` names a *registered, non-destructive*
+    tool — a built-in from mureo's rollback allow-list, or one of your
+    own plugin tools. (An `operation` naming an unregistered or
+    destructive tool is still recorded for audit but is not applied.)
+    The reversal's params are bounded by the target tool's declared
+    `inputSchema` property names.
+  - **Runtime-correct reversal** (`MCPReversibleToolProvider`, #327/#328)
+    — a *static* `reversal` cannot know the entity id the platform will
+    mint, nor the prior state you are about to overwrite. Implement the
+    optional `capture_reversal` method on your provider and mureo calls
+    it **before** the mutation, recording what you return instead of the
+    static hint:
+
+    ```python
+    class AcmeAdsProvider:
+        async def capture_reversal(
+            self, name: str, arguments: dict[str, Any]
+        ) -> dict[str, Any] | None:
+            """Return the reversal for the call about to run, or None."""
+            if name != "acme_ads_set_campaign_status":
+                return None
+            prior = await self._client.get_campaign(arguments["campaign_id"])
+            return {
+                "operation": "acme_ads_set_campaign_status",
+                "params": {
+                    "campaign_id": arguments["campaign_id"],
+                    "status": prior["status"],  # the state we are replacing
+                },
+            }
+    ```
+
+    The method is `async`. Return `None` to fall back to the static hint.
+    It is best-effort: an exception is logged and the mutation proceeds
+    with the static hint (auditing must never break the call). For
+    `rollback_apply` to execute it, `operation` must name a registered,
+    non-destructive tool of the same plugin. A provider that does not
+    implement it keeps its static `meta["mureo"]["reversal"]` behavior
+    unchanged.
   - `"throttle": {"rate": <float>, "burst": <int>, "hourly_limit": <int|null>}`
     — a dedicated bucket for that tool; malformed/absent ⇒ shared
     default.
@@ -599,6 +638,77 @@ mureo-specific Protocol method:
     from this so daily-check's evidence step reviews the outcome like a
     built-in write (no `metrics_at_action` baseline ⇒ reviewed
     qualitatively).
+  - `"budget": {"daily": "<key>", "lifetime": "<key>",
+    "current": "<key>", "unit": "currency"|"micros"}` — **declare where
+    your tool carries its budget so `STRATEGY.md` `## Guardrails` caps
+    are enforced on your platform too** (#414). See the next section.
+
+##### Budget declarations — getting your platform under the Guardrails
+
+mureo's built-in `StrategyPolicyGate` blocks any mutation that violates
+the operator's `## Guardrails` (`max_daily_budget_per_campaign`,
+`max_daily_budget_increase_pct`, `max_lifetime_budget_per_campaign`,
+`blocked_operations`) **before dispatch**. To find the proposed budget it
+scans the argument keys the built-in Google/Meta tools use.
+
+If your tool spells its budget any other way, the gate finds nothing and
+treats the call as "no budget proposed" — it is **allowed through with no
+error and no warning**, and the operator who wrote a cap believes it is
+protecting your platform when it is not. Declare your keys and that
+silent gap closes:
+
+```python
+Tool(
+    name="acme_ads_update_budget",
+    description="Update a campaign's daily budget.",
+    inputSchema={
+        "type": "object",
+        "properties": {
+            "campaign_id": {"type": "string"},
+            "daily_budget_micros": {"type": "integer"},
+            "current_budget_micros": {"type": "integer"},
+        },
+        "required": ["campaign_id", "daily_budget_micros"],
+    },
+    _meta={
+        "mureo": {
+            "budget": {
+                "daily": "daily_budget_micros",
+                "current": "current_budget_micros",
+                "unit": "micros",
+            }
+        }
+    },
+)
+```
+
+- `daily` / `lifetime` — the argument key carrying the proposed daily /
+  lifetime (period-total) budget. At least one is required.
+- `current` — optional; the key carrying the *existing* daily budget.
+  Supply it to make `max_daily_budget_increase_pct` enforceable on your
+  tool (without it, a percentage cap has no baseline to compare against).
+- `unit` — `"currency"` (default) or `"micros"` (the value is divided by
+  1,000,000). Stringified numbers (`"20000"`) are accepted.
+
+Semantics worth knowing before you declare:
+
+- **A declaration replaces the built-in key scan for that tool — for
+  *every* channel, not only the ones you name.** Your vocabulary is
+  authoritative, so an unrelated field spelled `amount` cannot false-trip
+  a cap. The corollary: if your tool also carries a *lifetime* budget,
+  declare `lifetime` — declaring only `daily` opts the tool out of the
+  built-in `lifetime_budget` / `total_amount` scan as well.
+- **A declared key that is present but unreadable makes the gate deny.**
+  `inf`, `nan`, a bool, a non-numeric string, a nested object under your
+  declared key ⇒ the cap cannot be verified, so the call is refused with
+  a clear reason rather than waved through. (An *absent* key — or `null`
+  / a blank string — simply means "no budget proposed on that channel"
+  and is not a denial.)
+- **A malformed declaration is rejected whole**, never half-applied, and
+  undeclared tools keep today's behavior byte-identical.
+
+You do **not** need to register your own `mureo.policy_gates` entry for
+budget enforcement — declare the keys and the one built-in gate does it.
 
 **Structural strategy parity (mutating tools).** A mutating plugin
 call gets the same *structural* strategy handling as a built-in write:

--- a/mureo/mcp/plugin_semantics.py
+++ b/mureo/mcp/plugin_semantics.py
@@ -35,6 +35,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from mureo.policy.strategy_gate import BudgetDeclaration
 from mureo.throttle import ThrottleConfig
 
 if TYPE_CHECKING:
@@ -53,6 +54,10 @@ logger = logging.getLogger(__name__)
 _DEFAULT_OBSERVATION_DAYS = 14
 
 
+#: Accepted ``budget.unit`` spellings → whether the value is in micros.
+_BUDGET_UNITS = {"currency": False, "micros": True}
+
+
 @dataclass(frozen=True)
 class ToolSemantics:
     """Safety classification derived from a plugin tool's MCP metadata."""
@@ -61,6 +66,46 @@ class ToolSemantics:
     reversal: dict[str, Any] | None = None
     throttle: ThrottleConfig | None = None
     observation_days: int | None = None
+    budget: BudgetDeclaration | None = None
+
+
+def _parse_budget(raw: Any) -> BudgetDeclaration | None:
+    """Parse ``meta["mureo"]["budget"]``, or ``None`` when unusable (#414).
+
+    A malformed hint is rejected WHOLE rather than half-applied: a partial
+    declaration would re-create the exact silent-underenforcement the seam
+    exists to remove. Requires a dict carrying at least one of ``daily`` /
+    ``lifetime`` as a non-blank string key name; ``current`` is optional;
+    ``unit`` is ``currency`` (default) or ``micros``.
+    """
+    if not isinstance(raw, dict):
+        return None
+    unit = raw.get("unit", "currency")
+    if not isinstance(unit, str) or unit not in _BUDGET_UNITS:
+        return None
+
+    def _key(name: str) -> str | None:
+        value = raw.get(name)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+        return None
+
+    daily = _key("daily")
+    lifetime = _key("lifetime")
+    if daily is None and lifetime is None:
+        return None
+    # A declared-but-unusable key name (non-str) is a mistake, not an
+    # omission — refuse the whole declaration so it surfaces in testing
+    # rather than silently dropping one cap.
+    for name in ("daily", "lifetime", "current"):
+        if name in raw and _key(name) is None:
+            return None
+    return BudgetDeclaration(
+        daily_key=daily,
+        lifetime_key=lifetime,
+        current_key=_key("current"),
+        micros=_BUDGET_UNITS[unit],
+    )
 
 
 def _meta_mureo(tool: Tool) -> dict[str, Any]:
@@ -120,6 +165,7 @@ def derive_semantics(tool: Tool) -> ToolSemantics:
         reversal=reversal,
         throttle=throttle,
         observation_days=observation_days,
+        budget=_parse_budget(section.get("budget")),
     )
 
 

--- a/mureo/mcp/server.py
+++ b/mureo/mcp/server.py
@@ -264,6 +264,37 @@ _PLUGIN_TOOL_THROTTLERS: dict[str, Throttler] = {
 }
 
 
+def _register_plugin_budget_declarations(
+    semantics: dict[str, ToolSemantics],
+) -> None:
+    """Publish plugin budget declarations to the StrategyPolicyGate (#414).
+
+    The gate's built-in key scan only knows the Google/Meta argument
+    spellings, so a plugin tool's budget was invisible to it — every
+    ``## Guardrails`` cap was silently unenforced on that platform. A
+    plugin now declares its keys in standard MCP metadata and this wires
+    them into the gate's registry, so the ONE built-in gate enforces them
+    (no per-plugin hand-rolled gate). Best-effort: a registry failure must
+    not take the server down.
+    """
+    from mureo.policy.strategy_gate import register_budget_declaration
+
+    for name, sem in semantics.items():
+        if sem.budget is None:
+            continue
+        try:
+            register_budget_declaration(name, sem.budget)
+        except Exception:  # noqa: BLE001 — never break startup on a hint
+            logger.warning(
+                "could not register budget declaration for plugin tool '%s'",
+                name,
+                exc_info=True,
+            )
+
+
+_register_plugin_budget_declarations(_PLUGIN_SEMANTICS)
+
+
 # Guardrail parity (#114 follow-up): top-level ``inputSchema`` property names
 # per plugin tool. The rollback planner uses these to bound the params a
 # plugin-declared reversal may carry — the plugin counterpart of the static

--- a/mureo/policy/strategy_gate.py
+++ b/mureo/policy/strategy_gate.py
@@ -24,6 +24,7 @@ keeps mureo's default behaviour identical to "no enforcement".
 from __future__ import annotations
 
 import logging
+import math
 import re
 import time
 from dataclasses import dataclass, field
@@ -39,10 +40,159 @@ logger = logging.getLogger(__name__)
 GUARDRAILS_HEADING = "guardrails"
 
 # Argument keys that carry a proposed daily budget, in priority order.
+# These are the BUILT-IN (Google/Meta) spellings; a plugin whose tools use a
+# different vocabulary declares its own keys instead — see BudgetDeclaration.
 _BUDGET_KEYS = ("daily_budget", "proposed_daily_budget", "amount")
 _CURRENT_BUDGET_KEYS = ("current_daily_budget", "current")
 
 _BULLET_RE = re.compile(r"^\s*[-*]\s*([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(.+?)\s*$")
+
+
+@dataclass(frozen=True)
+class BudgetDeclaration:
+    """Where one tool carries its budget arguments (#414).
+
+    Built-in Google/Meta tools are covered by the hard-coded key scan above.
+    A plugin tool's arguments can be spelled anything, so the gate had no way
+    to find its budget and silently treated every plugin mutation as
+    "no budget proposed" — the operator's ``## Guardrails`` caps were
+    unenforced for that platform, with no error or warning. A plugin closes
+    that by declaring its keys in standard MCP metadata::
+
+        Tool(
+            name="acme_ads_update_budget",
+            _meta={"mureo": {"budget": {"daily": "daily_budget_micros",
+                                        "unit": "micros"}}},
+            ...
+        )
+
+    ``unit`` is ``"currency"`` (default) or ``"micros"`` (value / 1e6).
+
+    A declaration REPLACES the built-in key scan for that tool — **for every
+    channel, not just the ones it names**. The plugin owns its argument
+    vocabulary, so an unrelated field that happens to be spelled ``amount``
+    must not false-trip a cap. The corollary: declaring only ``daily`` also
+    opts the tool out of the built-in ``lifetime_budget`` / ``total_amount``
+    scan, so a tool that carries a lifetime budget must declare
+    ``lifetime`` too (a coincidental built-in spelling stops being honored
+    the moment you declare anything).
+
+    A declared key that is present but unreadable (``inf``, ``nan``, a
+    bool, a non-numeric string) makes the gate DENY — see
+    :func:`_declared_amount`.
+    """
+
+    daily_key: str | None = None
+    lifetime_key: str | None = None
+    current_key: str | None = None
+    micros: bool = False
+
+
+# Tool name → declaration. Populated by the MCP server from plugin tool
+# metadata at import (see ``mureo.mcp.server``), so the pure decision layer
+# stays I/O-free and the gate needs no plugin imports.
+_BUDGET_DECLARATIONS: dict[str, BudgetDeclaration] = {}
+
+
+def register_budget_declaration(tool_name: str, declaration: BudgetDeclaration) -> None:
+    """Bind ``tool_name``'s budget argument keys (last registration wins)."""
+    _BUDGET_DECLARATIONS[tool_name] = declaration
+
+
+def budget_declaration_for(tool_name: str) -> BudgetDeclaration | None:
+    """The declaration registered for ``tool_name``, or ``None``."""
+    return _BUDGET_DECLARATIONS.get(tool_name)
+
+
+def reset_budget_declarations() -> None:
+    """Drop every registration (tests; a re-discovery re-registers)."""
+    _BUDGET_DECLARATIONS.clear()
+
+
+class _Unreadable:
+    """Sentinel: a declared budget key is PRESENT but not a usable number."""
+
+
+_UNREADABLE = _Unreadable()
+
+
+def _declared_amount(
+    arguments: dict[str, Any], key: str | None, *, micros: bool
+) -> float | _Unreadable | None:
+    """Read one declared budget key as currency units.
+
+    Three outcomes, and the distinction is the whole point of #414:
+
+    - ``None`` — the key is absent (or ``null`` / blank, which mean the same
+      thing): this call proposes no budget on that channel.
+    - ``float`` — a usable amount (stringified numbers are accepted; plugins
+      hit them in the wild when a JSON body round-trips through a form
+      encoder).
+    - :data:`_UNREADABLE` — the key IS present but carries garbage (a
+      non-finite ``inf``/``nan``, a bool, a non-numeric string, a nested
+      object). The caller must **deny**: silently treating it as "no
+      proposal" would let ``{"spend_limit": "inf"}`` sail past every cap —
+      re-opening the exact silent bypass this seam exists to close, and
+      making the declared path weaker than the built-in scan (where a raw
+      ``inf`` simply exceeds any finite cap and denies).
+    """
+    if not key or key not in arguments:
+        return None
+    raw = arguments[key]
+    if raw is None:
+        return None
+    if isinstance(raw, bool):
+        return _UNREADABLE
+    if isinstance(raw, (int, float)):
+        value = float(raw)
+    elif isinstance(raw, str):
+        stripped = raw.strip()
+        if not stripped:
+            return None
+        try:
+            value = float(stripped)
+        except ValueError:
+            return _UNREADABLE
+    else:
+        return _UNREADABLE
+    if math.isnan(value) or math.isinf(value):
+        return _UNREADABLE
+    return value / 1_000_000 if micros else value
+
+
+@dataclass(frozen=True)
+class _BudgetInputs:
+    """The three budget channels one evaluation needs, already resolved."""
+
+    proposed: float | None = None
+    current: float | None = None
+    lifetime: float | None = None
+    #: The first declared key that was present but unreadable (⇒ deny).
+    unreadable_key: str | None = None
+
+
+def _budget_inputs(
+    arguments: dict[str, Any], declaration: BudgetDeclaration | None
+) -> _BudgetInputs:
+    """Resolve the budget channels from declared keys, else the built-in scan."""
+    if declaration is None:
+        return _BudgetInputs(
+            proposed=_proposed_budget(arguments),
+            current=_current_budget(arguments),
+            lifetime=_proposed_lifetime_budget(arguments),
+        )
+    resolved: list[float | None] = []
+    for key in (
+        declaration.daily_key,
+        declaration.current_key,
+        declaration.lifetime_key,
+    ):
+        value = _declared_amount(arguments, key, micros=declaration.micros)
+        if isinstance(value, _Unreadable):
+            return _BudgetInputs(unreadable_key=key)
+        resolved.append(value)
+    proposed, current, lifetime = resolved
+    return _BudgetInputs(proposed=proposed, current=current, lifetime=lifetime)
 
 
 @dataclass(frozen=True)
@@ -166,11 +316,18 @@ def evaluate_guardrails(
     tool_name: str,
     arguments: dict[str, Any],
     guardrails: Guardrails,
+    *,
+    budget_declaration: BudgetDeclaration | None = None,
 ) -> PolicyDecision:
     """Pure decision: does ``tool_name(arguments)`` violate ``guardrails``?
 
     Returns ``PolicyDecision(allowed=False, reason=...)`` on the first hard
     violation, else ``allowed=True``. No I/O.
+
+    ``budget_declaration`` (#414) names the argument keys carrying this
+    tool's budget. When given it REPLACES the built-in Google/Meta key scan
+    — the tool's own vocabulary is authoritative. Omitted (every built-in
+    tool, and any plugin that has not declared) ⇒ unchanged behavior.
     """
     if guardrails.is_empty():
         return PolicyDecision(allowed=True)
@@ -184,7 +341,21 @@ def evaluate_guardrails(
             ),
         )
 
-    proposed = _proposed_budget(arguments)
+    inputs = _budget_inputs(arguments, budget_declaration)
+    if inputs.unreadable_key is not None:
+        # Fail CLOSED: the operator wrote a cap and the tool's declared
+        # budget argument carries garbage, so the cap CANNOT be checked.
+        # Allowing here would be the #414 silent bypass with extra steps.
+        return PolicyDecision(
+            allowed=False,
+            reason=(
+                f"Budget argument '{inputs.unreadable_key}' is not a usable "
+                f"number, so the STRATEGY.md Guardrails caps cannot be "
+                f"verified for this call. Refusing it."
+            ),
+        )
+
+    proposed = inputs.proposed
     if proposed is not None:
         cap = guardrails.max_daily_budget_per_campaign
         if cap is not None and proposed > cap:
@@ -197,7 +368,7 @@ def evaluate_guardrails(
                 ),
             )
 
-        current = _current_budget(arguments)
+        current = inputs.current
         pct_cap = guardrails.max_daily_budget_increase_pct
         if pct_cap is not None and current is not None and current > 0:
             increase_pct = (proposed - current) / current * 100
@@ -218,7 +389,7 @@ def evaluate_guardrails(
     # guardrail the operator wrote (#367). Covers Meta's ``lifetime_budget``
     # (minor units) and Google's CUSTOM_PERIOD ``total_amount_micros``
     # (micros → currency units), mirroring the daily micros handling (#366).
-    lifetime = _proposed_lifetime_budget(arguments)
+    lifetime = inputs.lifetime
     lifetime_cap = guardrails.max_lifetime_budget_per_campaign
     if lifetime_cap is not None and lifetime is not None and lifetime > lifetime_cap:
         return PolicyDecision(
@@ -302,7 +473,14 @@ class StrategyPolicyGate:
 
     def evaluate(self, tool_name: str, arguments: dict[str, Any]) -> PolicyDecision:
         try:
-            return evaluate_guardrails(tool_name, arguments, _load_guardrails())
+            return evaluate_guardrails(
+                tool_name,
+                arguments,
+                _load_guardrails(),
+                # #414: a plugin tool that declared its budget keys is now
+                # enforced by THIS gate — no hand-rolled per-plugin gate.
+                budget_declaration=budget_declaration_for(tool_name),
+            )
         except Exception:  # noqa: BLE001 — abstain on any unexpected error
             logger.debug("StrategyPolicyGate: abstaining on error", exc_info=True)
             return PolicyDecision(allowed=True)

--- a/tests/test_plugin_budget_declaration.py
+++ b/tests/test_plugin_budget_declaration.py
@@ -1,0 +1,349 @@
+"""Plugin budget declarations for the StrategyPolicyGate (#414).
+
+The gate's budget extraction was hard-wired to the Google/Meta argument
+keys, so a plugin tool carrying its budget under any other name sailed
+past every ``## Guardrails`` cap — silently: no startup error, no
+warning, just an unenforced platform. Three known plugins each
+hand-rolled the same normalize-and-delegate workaround gate.
+
+This adds the declaration seam (issue option A): a plugin declares its
+budget argument keys in standard MCP metadata —
+
+    _meta={"mureo": {"budget": {"daily": "daily_budget_micros",
+                                 "unit": "micros"}}}
+
+— ``derive_semantics`` parses it, the server registers it, and
+``StrategyPolicyGate`` consults it for that tool ahead of the built-in
+key scan. Undeclared tools keep today's behavior byte-identical.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from mureo.policy.strategy_gate import (
+    BudgetDeclaration,
+    Guardrails,
+    budget_declaration_for,
+    evaluate_guardrails,
+    register_budget_declaration,
+    reset_budget_declarations,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry() -> Iterator[None]:
+    """Isolate the process-global registry WITHOUT destroying it.
+
+    ``mureo.mcp.server`` populates it once at import from real plugin
+    discovery; a destructive clear would drop those declarations for the
+    rest of the pytest session (inert only while no shipped plugin
+    declares a budget).
+
+    Also resets the process-cached RuntimeContext and the gate's TTL
+    guardrail cache around each test: the end-to-end gate test resolves
+    STRATEGY.md through the active state store, which a context cached by
+    an earlier test (pointing at ITS workspace) would otherwise win.
+    """
+    import mureo.policy.strategy_gate as sg
+    from mureo.core.runtime_context import reset_runtime_context
+    from mureo.policy.strategy_gate import _BUDGET_DECLARATIONS
+
+    saved = dict(_BUDGET_DECLARATIONS)
+    reset_budget_declarations()
+    reset_runtime_context()
+    sg._cache.clear()
+    yield
+    reset_budget_declarations()
+    _BUDGET_DECLARATIONS.update(saved)
+    reset_runtime_context()
+    sg._cache.clear()
+
+
+def _tool(meta_mureo: dict[str, Any]) -> Any:
+    from mcp.types import Tool
+
+    return Tool(
+        name="acme_ads_update_budget",
+        description="x",
+        inputSchema={"type": "object", "properties": {}},
+        _meta={"mureo": meta_mureo},
+    )
+
+
+# ---------------------------------------------------------------------------
+# derive_semantics — parsing the meta["mureo"]["budget"] declaration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDeriveSemanticsBudget:
+    def test_parses_full_declaration(self) -> None:
+        from mureo.mcp.plugin_semantics import derive_semantics
+
+        sem = derive_semantics(
+            _tool(
+                {
+                    "budget": {
+                        "daily": "daily_budget_micros",
+                        "lifetime": "total_micros",
+                        "current": "current_micros",
+                        "unit": "micros",
+                    }
+                }
+            )
+        )
+        assert sem.budget == BudgetDeclaration(
+            daily_key="daily_budget_micros",
+            lifetime_key="total_micros",
+            current_key="current_micros",
+            micros=True,
+        )
+
+    def test_defaults_to_currency_unit(self) -> None:
+        from mureo.mcp.plugin_semantics import derive_semantics
+
+        sem = derive_semantics(_tool({"budget": {"daily": "spend_limit"}}))
+        assert sem.budget == BudgetDeclaration(daily_key="spend_limit")
+        assert sem.budget.micros is False
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "daily_budget",  # bare string, not a dict
+            {"unit": "micros"},  # neither daily nor lifetime key
+            {"daily": 123},  # non-str key name
+            {"daily": "x", "unit": "yen"},  # unknown unit
+            {"current": "cur"},  # current alone declares no proposal
+            {"daily": "ok", "lifetime": 123},  # one good key, one malformed
+        ],
+    )
+    def test_malformed_declaration_is_rejected(self, raw: Any) -> None:
+        """A malformed hint must not half-apply — the whole point of #414
+        is that silent misconfiguration is the failure mode to avoid."""
+        from mureo.mcp.plugin_semantics import derive_semantics
+
+        sem = derive_semantics(_tool({"budget": raw}))
+        assert sem.budget is None
+
+    def test_absent_budget_is_none(self) -> None:
+        from mureo.mcp.plugin_semantics import derive_semantics
+
+        assert derive_semantics(_tool({})).budget is None
+
+
+# ---------------------------------------------------------------------------
+# evaluate_guardrails — declared extraction (pure)
+# ---------------------------------------------------------------------------
+
+_CAPS = Guardrails(max_daily_budget_per_campaign=10_000.0)
+
+
+@pytest.mark.unit
+class TestDeclaredBudgetExtraction:
+    def test_declared_daily_key_is_enforced(self) -> None:
+        decl = BudgetDeclaration(daily_key="spend_limit")
+        decision = evaluate_guardrails(
+            "acme_ads_update_budget",
+            {"spend_limit": 20_000},
+            _CAPS,
+            budget_declaration=decl,
+        )
+        assert decision.allowed is False
+        assert "max_daily_budget_per_campaign" in (decision.reason or "")
+
+    def test_under_cap_is_allowed(self) -> None:
+        decl = BudgetDeclaration(daily_key="spend_limit")
+        decision = evaluate_guardrails(
+            "acme_ads_update_budget",
+            {"spend_limit": 5_000},
+            _CAPS,
+            budget_declaration=decl,
+        )
+        assert decision.allowed is True
+
+    def test_micros_are_converted(self) -> None:
+        decl = BudgetDeclaration(daily_key="daily_micros", micros=True)
+        decision = evaluate_guardrails(
+            "t",
+            {"daily_micros": 20_000_000_000},  # 20,000 currency units
+            _CAPS,
+            budget_declaration=decl,
+        )
+        assert decision.allowed is False
+
+    def test_numeric_string_is_coerced(self) -> None:
+        """Plugins hit stringified numbers in the wild (issue report) — a
+        declared key accepts them rather than silently skipping the cap."""
+        decl = BudgetDeclaration(daily_key="spend_limit")
+        decision = evaluate_guardrails(
+            "t", {"spend_limit": "20000"}, _CAPS, budget_declaration=decl
+        )
+        assert decision.allowed is False
+
+    def test_declared_current_key_drives_increase_pct(self) -> None:
+        decl = BudgetDeclaration(daily_key="new_budget", current_key="old_budget")
+        caps = Guardrails(max_daily_budget_increase_pct=10.0)
+        decision = evaluate_guardrails(
+            "t",
+            {"new_budget": 2_000, "old_budget": 1_000},
+            caps,
+            budget_declaration=decl,
+        )
+        assert decision.allowed is False
+        assert "max_daily_budget_increase_pct" in (decision.reason or "")
+
+    def test_declared_lifetime_key_is_enforced(self) -> None:
+        decl = BudgetDeclaration(lifetime_key="package_total")
+        caps = Guardrails(max_lifetime_budget_per_campaign=50_000.0)
+        decision = evaluate_guardrails(
+            "t", {"package_total": 60_000}, caps, budget_declaration=decl
+        )
+        assert decision.allowed is False
+        assert "max_lifetime_budget_per_campaign" in (decision.reason or "")
+
+    def test_declaration_replaces_builtin_key_scan(self) -> None:
+        """With a declaration, the built-in Google/Meta keys are NOT
+        scanned — the plugin owns its argument vocabulary, so a stray
+        ``amount`` field (e.g. a non-budget amount) cannot false-trip."""
+        decl = BudgetDeclaration(daily_key="spend_limit")
+        decision = evaluate_guardrails(
+            "t",
+            {"amount": 99_999},  # built-in key; NOT the declared one
+            _CAPS,
+            budget_declaration=decl,
+        )
+        assert decision.allowed is True
+
+    def test_no_declaration_keeps_builtin_scan(self) -> None:
+        decision = evaluate_guardrails("t", {"daily_budget": 20_000}, _CAPS)
+        assert decision.allowed is False
+
+
+# ---------------------------------------------------------------------------
+# Registry + gate integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDeclarationRegistry:
+    def test_register_and_lookup(self) -> None:
+        decl = BudgetDeclaration(daily_key="spend_limit")
+        register_budget_declaration("acme_ads_update_budget", decl)
+        assert budget_declaration_for("acme_ads_update_budget") == decl
+        assert budget_declaration_for("unknown_tool") is None
+
+    def test_gate_consults_registry(self, tmp_path: Any, monkeypatch: Any) -> None:
+        """End to end: a registered plugin declaration makes the built-in
+        StrategyPolicyGate deny an over-cap plugin call."""
+        from mureo.policy.strategy_gate import StrategyPolicyGate
+
+        strategy = tmp_path / "STRATEGY.md"
+        strategy.write_text(
+            "## Guardrails\n- max_daily_budget_per_campaign: 10000\n",
+            encoding="utf-8",
+        )
+        monkeypatch.chdir(tmp_path)
+        register_budget_declaration(
+            "acme_ads_update_budget", BudgetDeclaration(daily_key="spend_limit")
+        )
+        gate = StrategyPolicyGate()
+        decision = gate.evaluate("acme_ads_update_budget", {"spend_limit": 20_000})
+        assert decision.allowed is False
+
+
+# ---------------------------------------------------------------------------
+# Server wiring — plugin semantics land in the registry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_server_registers_declared_plugin_budgets() -> None:
+    from mureo.mcp import server as server_mod
+    from mureo.mcp.plugin_semantics import ToolSemantics
+
+    semantics = {
+        "acme_ads_update_budget": ToolSemantics(
+            mutating=True,
+            budget=BudgetDeclaration(daily_key="spend_limit"),
+        ),
+        "acme_ads_list": ToolSemantics(mutating=False),
+    }
+    server_mod._register_plugin_budget_declarations(semantics)
+    assert budget_declaration_for("acme_ads_update_budget") == BudgetDeclaration(
+        daily_key="spend_limit"
+    )
+    assert budget_declaration_for("acme_ads_list") is None
+
+
+@pytest.mark.unit
+class TestUnreadableDeclaredBudget:
+    """A declared key that is PRESENT but unreadable must fail CLOSED.
+
+    Returning "no proposal" for garbage would re-open the exact silent
+    bypass #414 exists to close — worse, it would make the declared path
+    weaker than the built-in scan, where a raw ``inf`` simply exceeds any
+    finite cap and denies.
+    """
+
+    _DECL = BudgetDeclaration(daily_key="spend_limit")
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            float("inf"),
+            float("-inf"),
+            float("nan"),
+            "inf",
+            "Infinity",
+            "nan",
+            "not-a-number",
+            True,  # bool is an int subclass — never a budget
+            {"amount": 1},
+            [],
+        ],
+    )
+    def test_unreadable_value_is_denied(self, value: Any) -> None:
+        decision = evaluate_guardrails(
+            "acme_ads_update_budget",
+            {"spend_limit": value},
+            _CAPS,
+            budget_declaration=self._DECL,
+        )
+        assert decision.allowed is False
+        assert "spend_limit" in (decision.reason or "")
+
+    @pytest.mark.parametrize("value", [None, "", "   "])
+    def test_absent_like_value_carries_no_proposal(self, value: Any) -> None:
+        """JSON ``null`` / a blank string mean 'no budget here', not garbage —
+        they must not deny (the schema validator rejects a typed blank right
+        after the gate anyway)."""
+        decision = evaluate_guardrails(
+            "acme_ads_update_budget",
+            {"spend_limit": value},
+            _CAPS,
+            budget_declaration=self._DECL,
+        )
+        assert decision.allowed is True
+
+    def test_unreadable_lifetime_is_denied(self) -> None:
+        decision = evaluate_guardrails(
+            "t",
+            {"package_total": "inf"},
+            Guardrails(max_lifetime_budget_per_campaign=50_000.0),
+            budget_declaration=BudgetDeclaration(lifetime_key="package_total"),
+        )
+        assert decision.allowed is False
+
+    def test_no_guardrails_still_fails_open(self) -> None:
+        """Fail-closed only applies once the operator wrote a rule — an empty
+        Guardrails section keeps mureo's 'no enforcement' default."""
+        decision = evaluate_guardrails(
+            "t", {"spend_limit": "inf"}, Guardrails(), budget_declaration=self._DECL
+        )
+        assert decision.allowed is True


### PR DESCRIPTION
## Summary

Closes #414. Reported by a plugin author; three external plugins are affected.

`StrategyPolicyGate` (#360) enforces STRATEGY.md `## Guardrails` before dispatch, but its budget extraction is hard-wired to the built-in Google/Meta argument keys. A plugin tool carrying its budget under any other name is read as **"no budget proposed"** and sails past every cap — **silently**: no startup error, no warning. The operator who wrote `max_daily_budget_per_campaign` believes their platform is protected when it is not, on a surface where real money moves. Three plugins each hand-rolled the same normalize-and-delegate workaround gate.

Implements the issue's **option A**: declare the budget keys in tool metadata.

## The seam

```python
Tool(
    name="acme_ads_update_budget",
    _meta={"mureo": {"budget": {
        "daily": "daily_budget_micros",
        "current": "current_budget_micros",   # enables the increase-% cap
        "unit": "micros",                      # or "currency" (default)
    }}},
    ...
)
```

`derive_semantics` parses it, the server registers it at import, and the **one** built-in gate enforces it. No per-plugin `mureo.policy_gates` entry needed — the three plugins can delete their duplicate gates.

Semantics (all documented):
- A declaration **replaces** the built-in key scan for that tool, for **every** channel — the plugin owns its vocabulary, so an unrelated field spelled `amount` cannot false-trip a cap (corollary: a tool with a lifetime budget must declare `lifetime` too).
- A declared key that is **present but unreadable** (`inf`/`nan`, bool, non-numeric string, nested object) makes the gate **deny** — the cap cannot be verified, so the call is refused with a clear reason. Treating garbage as "no proposal" would be the same silent bypass with extra steps (this was a CRITICAL review finding). An **absent** key — or `null` / blank — still means "no budget on that channel". Fail-closed engages only once the operator wrote a rule.
- A malformed declaration is rejected **whole**, never half-applied. Stringified numbers are accepted (plugins hit them in the wild).

## docs/plugin-authoring.md — three stale statements fixed

The canon plugin authors read had drifted since #324/#327:

1. `inputSchema` validation is **server-side enforced before dispatch** (#324) — the docs said "advisory on the client side". A plugin that declared `{"type": "integer"}` while its handler tolerated strings breaks under #324; that's exactly what happened to one plugin.
2. A plugin-declared reversal **is executable** (#324) when it names a registered, non-destructive tool — the docs still said plugin operations are "not auto-reversible".
3. `capture_reversal` / `MCPReversibleToolProvider` (#327/#328) were **entirely absent**; now documented with an example verified against the real Protocol signature (`async def capture_reversal(self, name, arguments)`).

Plus a new section documenting the budget declaration.

## Test plan

- [x] TDD (red first, twice — initial build and the CRITICAL fix): parsing (full / defaults / every malformed shape / absent), pure extraction (declared daily/current/lifetime, micros, numeric strings, declaration-replaces-scan, undeclared-keeps-scan), deny-on-unreadable across value types and both channels, absent-vs-garbage, no-guardrails fail-open, the registry, an end-to-end gate denial against a real STRATEGY.md, and the server wiring
- [x] Full suite 5429 passed (3 failures = known local plugin-env noise, identical on main); ruff/black/mypy clean
- [x] code-reviewer (2 rounds): CRITICAL (`"inf"` under a declared key bypassed every cap) + 3 MEDIUM + LOW — all fixed and independently re-verified with the reviewer's own PoCs; approved

https://claude.ai/code/session_0115NBUphwqsL1isTV8R7NHg
