### PR TITLE
fix(policy): a budget declaration must not switch off max_daily_budget_increase_pct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,20 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **A budget declaration no longer switches off `max_daily_budget_increase_pct`.**
-  The declaration seam (#414) replaced the built-in key scan for *every*
-  channel, including `current` — so a plugin that declared `daily` (the
-  expected, documented shape) had the percentage-increase cap silently stop
-  firing for its tools, on both the built-in gate and its own. That is the same
-  silent underenforcement the seam exists to remove, reintroduced through the
-  seam itself. It could not be worked around by declaring `current` either: the
-  `unit` flag covers all declared keys, while mureo's `current_daily_budget`
-  convention is currency units, so a micros tool ended up dividing the baseline
-  by 1e6 (a ¥10,000 → ¥15,000 raise was reported as "149,999,900% (0 →
-  15,000)"). A tool that does not declare `current` now keeps mureo's own
-  `current_daily_budget` convention key for that channel — the proposed budgets
-  (`daily` / `lifetime`) still belong wholly to the plugin's vocabulary. Docs
-  updated accordingly.
+- **A budget declaration no longer switches off `max_daily_budget_increase_pct`
+  or `max_total_daily_budget` (#418).** The declaration seam (#414) replaced the
+  built-in key scan for *every* channel — including the two figures the *caller*
+  supplies rather than the tool. So a plugin that declared `daily` (the expected,
+  documented shape) had both of those caps silently stop firing for its tools, on
+  the built-in gate and on its own gate delegating to it. That is the same silent
+  underenforcement the seam exists to remove, reintroduced through the seam
+  itself, landing on the plugins that adopted it. Neither was work-around-able:
+  the `unit` flag covers all declared keys while mureo's `current_daily_budget`
+  convention is currency units, so a micros tool that declared `current` divided
+  the baseline by 1e6 (a ¥10,000 → ¥15,000 raise reported as "149,999,900% (0 →
+  15,000)"), and `projected_total_daily_budget` has no declaration key at all.
+  Both channels now keep mureo's own convention keys, which a declaration does
+  not replace — the proposed budgets (`daily` / `lifetime`) still belong wholly
+  to the plugin's vocabulary. They are held to the same fail-closed standard as
+  every other budget channel (#419): a non-finite or oversized figure there
+  refuses the call instead of taking the cap dark. Docs updated accordingly.
 
 ## [0.10.24] - 2026-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A budget declaration no longer switches off `max_daily_budget_increase_pct`.**
+  The declaration seam (#414) replaced the built-in key scan for *every*
+  channel, including `current` — so a plugin that declared `daily` (the
+  expected, documented shape) had the percentage-increase cap silently stop
+  firing for its tools, on both the built-in gate and its own. That is the same
+  silent underenforcement the seam exists to remove, reintroduced through the
+  seam itself. It could not be worked around by declaring `current` either: the
+  `unit` flag covers all declared keys, while mureo's `current_daily_budget`
+  convention is currency units, so a micros tool ended up dividing the baseline
+  by 1e6 (a ¥10,000 → ¥15,000 raise was reported as "149,999,900% (0 →
+  15,000)"). A tool that does not declare `current` now keeps mureo's own
+  `current_daily_budget` convention key for that channel — the proposed budgets
+  (`daily` / `lifetime`) still belong wholly to the plugin's vocabulary. Docs
+  updated accordingly.
+
 ## [0.10.24] - 2026-07-14
 
 ### Security

--- a/docs/plugin-authoring.md
+++ b/docs/plugin-authoring.md
@@ -692,9 +692,12 @@ Tool(
   mutation — so `max_daily_budget_increase_pct` keeps working.
 - `unit` — `"currency"` (default) or `"micros"` (the value is divided by
   1,000,000). Stringified numbers (`"20000"`) are accepted. Note this
-  describes **your declared keys**; the built-in `current_daily_budget`
-  fallback is always currency units, so a micros tool does not have to
-  restate it.
+  describes **your declared keys** only. The convention keys mureo reads
+  for itself (`current_daily_budget`, `projected_total_daily_budget`) are
+  always currency units, so a micros tool does not restate them — and
+  should not declare `current: "current_daily_budget"` alongside
+  `unit: "micros"`, which would divide that baseline by 1e6 and report a
+  ¥10,000 → ¥15,000 raise as a 149,999,900% one.
 
 Semantics worth knowing before you declare:
 
@@ -705,10 +708,13 @@ Semantics worth knowing before you declare:
   also carries a *lifetime* budget, declare `lifetime` — declaring only
   `daily` opts the tool out of the built-in `lifetime_budget` /
   `total_amount` scan as well.
-- **`current` is the exception.** It is not a budget your tool proposes;
-  it is context the caller supplies. Leaving it undeclared keeps the
-  built-in `current_daily_budget` scan for that channel, so declaring
-  `daily` never silently switches `max_daily_budget_increase_pct` off.
+- **What the *caller* supplies is the exception.** The existing daily
+  budget (`current_daily_budget`) and the account-wide projected total
+  (`projected_total_daily_budget`) are not budgets your tool proposes —
+  they are context the skills compute and pass. A declaration does not
+  replace them, so declaring `daily` never silently switches
+  `max_daily_budget_increase_pct` or `max_total_daily_budget` off. The
+  projected total has no declaration key at all, by design.
 - **A declared key that is present but unreadable makes the gate deny.**
   `inf`, `nan`, a bool, a non-numeric string, a nested object under your
   declared key ⇒ the cap cannot be verified, so the call is refused with

--- a/docs/plugin-authoring.md
+++ b/docs/plugin-authoring.md
@@ -684,20 +684,31 @@ Tool(
 
 - `daily` / `lifetime` — the argument key carrying the proposed daily /
   lifetime (period-total) budget. At least one is required.
-- `current` — optional; the key carrying the *existing* daily budget.
-  Supply it to make `max_daily_budget_increase_pct` enforceable on your
-  tool (without it, a percentage cap has no baseline to compare against).
+- `current` — optional, and usually unnecessary: the key carrying the
+  *existing* daily budget. You only need it if your **tool itself** takes
+  the current budget as an argument under some other name. Leave it out
+  and mureo keeps reading its own `current_daily_budget` convention (in
+  currency units), which is what the skills pass on every budget
+  mutation — so `max_daily_budget_increase_pct` keeps working.
 - `unit` — `"currency"` (default) or `"micros"` (the value is divided by
-  1,000,000). Stringified numbers (`"20000"`) are accepted.
+  1,000,000). Stringified numbers (`"20000"`) are accepted. Note this
+  describes **your declared keys**; the built-in `current_daily_budget`
+  fallback is always currency units, so a micros tool does not have to
+  restate it.
 
 Semantics worth knowing before you declare:
 
-- **A declaration replaces the built-in key scan for that tool — for
-  *every* channel, not only the ones you name.** Your vocabulary is
-  authoritative, so an unrelated field spelled `amount` cannot false-trip
-  a cap. The corollary: if your tool also carries a *lifetime* budget,
-  declare `lifetime` — declaring only `daily` opts the tool out of the
-  built-in `lifetime_budget` / `total_amount` scan as well.
+- **A declaration replaces the built-in key scan for the budgets your tool
+  proposes (`daily`, `lifetime`) — for *every* one of them, not only the
+  ones you name.** Your vocabulary is authoritative, so an unrelated field
+  spelled `amount` cannot false-trip a cap. The corollary: if your tool
+  also carries a *lifetime* budget, declare `lifetime` — declaring only
+  `daily` opts the tool out of the built-in `lifetime_budget` /
+  `total_amount` scan as well.
+- **`current` is the exception.** It is not a budget your tool proposes;
+  it is context the caller supplies. Leaving it undeclared keeps the
+  built-in `current_daily_budget` scan for that channel, so declaring
+  `daily` never silently switches `max_daily_budget_increase_pct` off.
 - **A declared key that is present but unreadable makes the gate deny.**
   `inf`, `nan`, a bool, a non-numeric string, a nested object under your
   declared key ⇒ the cap cannot be verified, so the call is refused with

--- a/mureo/policy/strategy_gate.py
+++ b/mureo/policy/strategy_gate.py
@@ -68,14 +68,22 @@ class BudgetDeclaration:
 
     ``unit`` is ``"currency"`` (default) or ``"micros"`` (value / 1e6).
 
-    A declaration REPLACES the built-in key scan for that tool — **for every
-    channel, not just the ones it names**. The plugin owns its argument
-    vocabulary, so an unrelated field that happens to be spelled ``amount``
-    must not false-trip a cap. The corollary: declaring only ``daily`` also
-    opts the tool out of the built-in ``lifetime_budget`` / ``total_amount``
-    scan, so a tool that carries a lifetime budget must declare
-    ``lifetime`` too (a coincidental built-in spelling stops being honored
-    the moment you declare anything).
+    A declaration REPLACES the built-in key scan for the budgets the tool
+    **proposes** — ``daily`` and ``lifetime`` — for every one of them, not just
+    the ones it names. The plugin owns its argument vocabulary, so an unrelated
+    field that happens to be spelled ``amount`` must not false-trip a cap. The
+    corollary: declaring only ``daily`` also opts the tool out of the built-in
+    ``lifetime_budget`` / ``total_amount`` scan, so a tool that carries a
+    lifetime budget must declare ``lifetime`` too (a coincidental built-in
+    spelling stops being honored the moment you declare anything).
+
+    ``current`` is the exception, and deliberately so: the *existing* budget is
+    not something the tool carries — it is context the caller supplies, under
+    mureo's own cross-provider convention (``current_daily_budget``, in
+    currency units, passed by the skills on every budget mutation). A tool that
+    does not declare ``current`` therefore keeps the built-in scan for that one
+    channel, so ``max_daily_budget_increase_pct`` goes on working. Declaring it
+    still wins where a plugin really does carry the current budget itself.
 
     A declared key that is present but unreadable (``inf``, ``nan``, a
     bool, a non-numeric string) makes the gate DENY — see
@@ -261,6 +269,16 @@ def _budget_inputs(
             return _BudgetInputs(unreadable_key=key)
         resolved.append(declared)
     proposed, current, lifetime = resolved
+    if declaration.current_key is None:
+        # The *current* budget is not part of the plugin's argument vocabulary
+        # — it is context the caller supplies, under mureo's own cross-provider
+        # convention (``current_daily_budget``, in currency units; the skills
+        # pass it on every budget mutation). Replacing that channel too would
+        # silently disable max_daily_budget_increase_pct for every plugin that
+        # adopted the seam, which is the exact underenforcement it exists to
+        # remove. Note it is read in currency units even when the DECLARED keys
+        # are micros: ``micros`` describes what the tool carries, not this.
+        current = _current_budget(arguments)
     return _BudgetInputs(proposed=proposed, current=current, lifetime=lifetime)
 
 

--- a/mureo/policy/strategy_gate.py
+++ b/mureo/policy/strategy_gate.py
@@ -44,6 +44,10 @@ GUARDRAILS_HEADING = "guardrails"
 # different vocabulary declares its own keys instead — see BudgetDeclaration.
 _BUDGET_KEYS = ("daily_budget", "proposed_daily_budget", "amount")
 _CURRENT_BUDGET_KEYS = ("current_daily_budget", "current")
+#: The cross-provider convention key for the *existing* daily budget (currency
+#: units), which the skills pass on every budget mutation. This is the only one
+#: honored for a tool that declared its budget: see :func:`_budget_inputs`.
+_CONVENTION_CURRENT_KEY = "current_daily_budget"
 
 _BULLET_RE = re.compile(r"^\s*[-*]\s*([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(.+?)\s*$")
 
@@ -269,7 +273,7 @@ def _budget_inputs(
             return _BudgetInputs(unreadable_key=key)
         resolved.append(declared)
     proposed, current, lifetime = resolved
-    if declaration.current_key is None:
+    if not declaration.current_key:
         # The *current* budget is not part of the plugin's argument vocabulary
         # — it is context the caller supplies, under mureo's own cross-provider
         # convention (``current_daily_budget``, in currency units; the skills
@@ -278,7 +282,16 @@ def _budget_inputs(
         # adopted the seam, which is the exact underenforcement it exists to
         # remove. Note it is read in currency units even when the DECLARED keys
         # are micros: ``micros`` describes what the tool carries, not this.
-        current = _current_budget(arguments)
+        #
+        # Only the namespaced convention key, never the bare ``current`` alias
+        # the built-in scan also accepts: a declaring plugin owns its argument
+        # vocabulary, and ``current`` is a plausible name for something else
+        # entirely (an index, a status). Misreading one as the baseline would
+        # compute a nonsense increase — and a LARGE stray value yields a small
+        # percentage, i.e. it would ALLOW a raise that should have been refused.
+        value = arguments.get(_CONVENTION_CURRENT_KEY)
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            current = float(value)
     return _BudgetInputs(proposed=proposed, current=current, lifetime=lifetime)
 
 
@@ -413,8 +426,13 @@ def evaluate_guardrails(
 
     ``budget_declaration`` (#414) names the argument keys carrying this
     tool's budget. When given it REPLACES the built-in Google/Meta key scan
-    — the tool's own vocabulary is authoritative. Omitted (every built-in
-    tool, and any plugin that has not declared) ⇒ unchanged behavior.
+    for the budgets the tool *proposes* — the tool's own vocabulary is
+    authoritative there. The one exception is ``current``, which is caller
+    context rather than a tool argument: undeclared, it still comes from the
+    ``current_daily_budget`` convention, so declaring a budget cannot switch
+    ``max_daily_budget_increase_pct`` off (see :class:`BudgetDeclaration`).
+    Omitted (every built-in tool, and any plugin that has not declared) ⇒
+    unchanged behavior.
     """
     if guardrails.is_empty():
         return PolicyDecision(allowed=True)

--- a/mureo/policy/strategy_gate.py
+++ b/mureo/policy/strategy_gate.py
@@ -44,10 +44,13 @@ GUARDRAILS_HEADING = "guardrails"
 # different vocabulary declares its own keys instead — see BudgetDeclaration.
 _BUDGET_KEYS = ("daily_budget", "proposed_daily_budget", "amount")
 _CURRENT_BUDGET_KEYS = ("current_daily_budget", "current")
-#: The cross-provider convention key for the *existing* daily budget (currency
-#: units), which the skills pass on every budget mutation. This is the only one
-#: honored for a tool that declared its budget: see :func:`_budget_inputs`.
+#: The cross-provider convention keys for the two budget figures the CALLER
+#: supplies rather than the tool: the *existing* daily budget and the
+#: account-wide projected total (both in currency units), which the skills pass
+#: on a budget mutation. A declaration cannot replace these — see
+#: :func:`_budget_inputs`.
 _CONVENTION_CURRENT_KEY = "current_daily_budget"
+_CONVENTION_TOTAL_KEY = "projected_total_daily_budget"
 
 _BULLET_RE = re.compile(r"^\s*[-*]\s*([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(.+?)\s*$")
 
@@ -81,17 +84,22 @@ class BudgetDeclaration:
     lifetime budget must declare ``lifetime`` too (a coincidental built-in
     spelling stops being honored the moment you declare anything).
 
-    ``current`` is the exception, and deliberately so: the *existing* budget is
-    not something the tool carries — it is context the caller supplies, under
-    mureo's own cross-provider convention (``current_daily_budget``, in
-    currency units, passed by the skills on every budget mutation). A tool that
-    does not declare ``current`` therefore keeps the built-in scan for that one
-    channel, so ``max_daily_budget_increase_pct`` goes on working. Declaring it
-    still wins where a plugin really does carry the current budget itself.
+    The two CALLER-supplied figures are the exception, and deliberately so.
+    Neither is something the tool carries: the *existing* daily budget
+    (``current_daily_budget``) and the account-wide *projected total*
+    (``projected_total_daily_budget``) are context the skills compute and pass
+    on a budget mutation, under mureo's own cross-provider convention, in
+    currency units. A declaration does not replace them, so
+    ``max_daily_budget_increase_pct`` and ``max_total_daily_budget`` go on
+    working for a declaring tool. ``current`` may still be declared where a
+    plugin really does carry the current budget itself, and that declaration
+    wins; the projected total has no key at all, because it is never a tool
+    argument.
 
     A declared key that is present but unreadable (``inf``, ``nan``, a
     bool, a non-numeric string) makes the gate DENY — see
-    :func:`_declared_amount`.
+    :func:`_declared_amount`. The convention keys are held to the same
+    standard (#419).
     """
 
     daily_key: str | None = None
@@ -193,11 +201,13 @@ def _declared_amount(
 def _projected_total(arguments: dict[str, Any]) -> float | None:
     """The account-wide projected daily total a skill passes for the total cap.
 
-    Built-in key only (there is no declared equivalent); routed through
-    ``_saturate`` like every other budget channel so an oversized int denies
-    instead of raising.
+    Convention key only, on the declared path as much as the built-in one:
+    there is no declared equivalent because this figure is not a budget the
+    TOOL proposes — like ``current_daily_budget`` it is context the CALLER
+    computes. Routed through ``_saturate`` like every other budget channel so
+    an oversized int denies instead of raising.
     """
-    total = arguments.get("projected_total_daily_budget")
+    total = arguments.get(_CONVENTION_TOTAL_KEY)
     if isinstance(total, (int, float)) and not isinstance(total, bool):
         return _saturate(total)
     return None
@@ -273,26 +283,41 @@ def _budget_inputs(
             return _BudgetInputs(unreadable_key=key)
         resolved.append(declared)
     proposed, current, lifetime = resolved
+    # The two CALLER-supplied channels survive a declaration. Neither is part of
+    # the plugin's argument vocabulary: the existing daily budget and the
+    # account-wide projected total are context the skills compute and pass under
+    # mureo's own cross-provider convention (currency units, on every budget
+    # mutation). A declaration replaces the built-in scan for the budgets the
+    # tool PROPOSES; replacing these too silently disabled
+    # max_daily_budget_increase_pct and max_total_daily_budget for every plugin
+    # that adopted the seam — the exact underenforcement it exists to remove,
+    # and for the total cap not even opt-out-able, since a declaration has no
+    # key to name it with. Both are read in currency units even when the DECLARED
+    # keys are micros: ``micros`` describes what the tool carries, not these.
+    #
+    # They are budget channels like any other, so they fail closed on a
+    # non-finite figure exactly as the built-in scan does (#419): a ``nan``
+    # baseline makes ``current > 0`` False and takes the percentage cap dark,
+    # while a bare oversized int raises out of ``float()`` into the gate's
+    # blanket ``except`` — an abstain, i.e. an allow.
     if not declaration.current_key:
-        # The *current* budget is not part of the plugin's argument vocabulary
-        # — it is context the caller supplies, under mureo's own cross-provider
-        # convention (``current_daily_budget``, in currency units; the skills
-        # pass it on every budget mutation). Replacing that channel too would
-        # silently disable max_daily_budget_increase_pct for every plugin that
-        # adopted the seam, which is the exact underenforcement it exists to
-        # remove. Note it is read in currency units even when the DECLARED keys
-        # are micros: ``micros`` describes what the tool carries, not this.
-        #
-        # Only the namespaced convention key, never the bare ``current`` alias
-        # the built-in scan also accepts: a declaring plugin owns its argument
-        # vocabulary, and ``current`` is a plausible name for something else
-        # entirely (an index, a status). Misreading one as the baseline would
-        # compute a nonsense increase — and a LARGE stray value yields a small
-        # percentage, i.e. it would ALLOW a raise that should have been refused.
-        value = arguments.get(_CONVENTION_CURRENT_KEY)
-        if isinstance(value, (int, float)) and not isinstance(value, bool):
-            current = float(value)
-    return _BudgetInputs(proposed=proposed, current=current, lifetime=lifetime)
+        # Only the namespaced convention key here, never the bare ``current``
+        # alias the built-in scan also accepts: a declaring plugin owns its
+        # argument vocabulary, and ``current`` is a plausible name for something
+        # else entirely (an index, a status). Misreading one as the baseline
+        # would compute a nonsense increase — and a LARGE stray value yields a
+        # SMALL percentage, i.e. it would allow a raise that should be refused.
+        raw = arguments.get(_CONVENTION_CURRENT_KEY)
+        if isinstance(raw, (int, float)) and not isinstance(raw, bool):
+            current = _saturate(raw)
+            if not math.isfinite(current):
+                return _BudgetInputs(unreadable_key=_CONVENTION_CURRENT_KEY)
+    total = _projected_total(arguments)
+    if total is not None and not math.isfinite(total):
+        return _BudgetInputs(unreadable_key=_CONVENTION_TOTAL_KEY)
+    return _BudgetInputs(
+        proposed=proposed, current=current, lifetime=lifetime, total=total
+    )
 
 
 @dataclass(frozen=True)
@@ -427,12 +452,13 @@ def evaluate_guardrails(
     ``budget_declaration`` (#414) names the argument keys carrying this
     tool's budget. When given it REPLACES the built-in Google/Meta key scan
     for the budgets the tool *proposes* — the tool's own vocabulary is
-    authoritative there. The one exception is ``current``, which is caller
-    context rather than a tool argument: undeclared, it still comes from the
-    ``current_daily_budget`` convention, so declaring a budget cannot switch
-    ``max_daily_budget_increase_pct`` off (see :class:`BudgetDeclaration`).
-    Omitted (every built-in tool, and any plugin that has not declared) ⇒
-    unchanged behavior.
+    authoritative there. The exceptions are the two figures the CALLER supplies
+    rather than the tool: the current daily budget (undeclared, it still comes
+    from the ``current_daily_budget`` convention) and the projected account
+    total (always ``projected_total_daily_budget``). So declaring a budget
+    cannot switch ``max_daily_budget_increase_pct`` or ``max_total_daily_budget``
+    off (see :class:`BudgetDeclaration`). Omitted (every built-in tool, and any
+    plugin that has not declared) ⇒ unchanged behavior.
     """
     if guardrails.is_empty():
         return PolicyDecision(allowed=True)

--- a/tests/test_plugin_budget_declaration.py
+++ b/tests/test_plugin_budget_declaration.py
@@ -198,6 +198,65 @@ class TestDeclaredBudgetExtraction:
         assert decision.allowed is False
         assert "max_daily_budget_increase_pct" in (decision.reason or "")
 
+    def test_undeclared_current_falls_back_to_the_built_in_key(self) -> None:
+        """A plugin declares where ITS OWN arguments carry a budget. The
+        *current* budget is not one of them: it is context the caller supplies,
+        under mureo's own cross-provider convention (``current_daily_budget``;
+        see the _mureo-strategy skill). Dropping it because the tool declared
+        `daily` would silently disable max_daily_budget_increase_pct for every
+        plugin that adopts the seam — the same silent underenforcement #414
+        exists to remove.
+        """
+        decl = BudgetDeclaration(daily_key="daily_budget_micros", micros=True)
+        caps = Guardrails(max_daily_budget_increase_pct=20.0)
+        decision = evaluate_guardrails(
+            "t",
+            {"daily_budget_micros": 15_000_000_000, "current_daily_budget": 10_000},
+            caps,
+            budget_declaration=decl,
+        )
+        assert decision.allowed is False  # 10,000 -> 15,000 is +50%
+        assert "50%" in (decision.reason or "")
+
+    def test_the_fallback_current_is_currency_not_micros(self) -> None:
+        """The built-in ``current_daily_budget`` is currency units even when the
+        tool's own budget is micros — ``micros`` describes the DECLARED keys.
+        Dividing it by 1e6 would read ¥10,000 as ¥0.01 and report a 149,999,900%
+        increase.
+        """
+        decl = BudgetDeclaration(daily_key="daily_budget_micros", micros=True)
+        caps = Guardrails(max_daily_budget_increase_pct=20.0)
+        reason = (
+            evaluate_guardrails(
+                "t",
+                {
+                    "daily_budget_micros": 15_000_000_000,
+                    "current_daily_budget": 10_000,
+                },
+                caps,
+                budget_declaration=decl,
+            ).reason
+            or ""
+        )
+        assert "10,000 → 15,000" in reason
+
+    def test_a_declared_current_key_still_wins(self) -> None:
+        """The fallback only fills a gap; an explicit declaration still owns
+        the channel."""
+        decl = BudgetDeclaration(
+            daily_key="new_budget", current_key="old_budget", micros=False
+        )
+        caps = Guardrails(max_daily_budget_increase_pct=20.0)
+        decision = evaluate_guardrails(
+            "t",
+            # The declared key says +10% (allowed); the built-in key would say
+            # +900% if it were consulted. The declaration must win.
+            {"new_budget": 1_100, "old_budget": 1_000, "current_daily_budget": 110},
+            caps,
+            budget_declaration=decl,
+        )
+        assert decision.allowed is True
+
     def test_declared_lifetime_key_is_enforced(self) -> None:
         decl = BudgetDeclaration(lifetime_key="package_total")
         caps = Guardrails(max_lifetime_budget_per_campaign=50_000.0)

--- a/tests/test_plugin_budget_declaration.py
+++ b/tests/test_plugin_budget_declaration.py
@@ -240,6 +240,27 @@ class TestDeclaredBudgetExtraction:
         )
         assert "10,000 → 15,000" in reason
 
+    def test_the_fallback_ignores_the_bare_current_alias(self) -> None:
+        """The built-in scan also accepts a bare ``current``, but a DECLARING
+        plugin owns its vocabulary, and ``current`` is a plausible name for
+        something else entirely (an index, a status). Misreading one as the
+        baseline is the dangerous direction: a large stray value yields a small
+        percentage, i.e. it would ALLOW a raise that should have been refused.
+        """
+        decl = BudgetDeclaration(daily_key="daily_budget_micros", micros=True)
+        caps = Guardrails(max_daily_budget_increase_pct=20.0)
+        decision = evaluate_guardrails(
+            "t",
+            # `current` here is the plugin's own field, not a budget baseline.
+            # Read as one it would say "+50% of 1,000,000" — comfortably under
+            # the cap — and wave the ¥15,000 raise through.
+            {"daily_budget_micros": 15_000_000_000, "current": 1_000_000},
+            caps,
+            budget_declaration=decl,
+        )
+        assert decision.allowed is True  # no baseline ⇒ the pct rule abstains
+        assert "increase" not in (decision.reason or "")
+
     def test_a_declared_current_key_still_wins(self) -> None:
         """The fallback only fills a gap; an explicit declaration still owns
         the channel."""

--- a/tests/test_plugin_budget_declaration.py
+++ b/tests/test_plugin_budget_declaration.py
@@ -429,3 +429,115 @@ class TestUnreadableDeclaredBudget:
             "t", {"spend_limit": "inf"}, Guardrails(), budget_declaration=self._DECL
         )
         assert decision.allowed is True
+
+
+@pytest.mark.unit
+class TestDeclarationKeepsTheTotalCap:
+    """``max_total_daily_budget`` is the same story as the percentage cap.
+
+    ``projected_total_daily_budget`` is not a budget the tool proposes either —
+    it is the account-wide figure the *skills* compute and pass, under the same
+    cross-provider convention as ``current_daily_budget``. And a declaration
+    cannot even name it: ``BudgetDeclaration`` has no total key, so a declaring
+    plugin had NO way to keep ``max_total_daily_budget`` alive. Replacing that
+    channel therefore switched the cap off outright, for every plugin that
+    adopted the seam — the same silent underenforcement, one cap over.
+    """
+
+    _DECL = BudgetDeclaration(daily_key="daily_budget_micros", micros=True)
+    _CAPS_TOTAL = Guardrails(max_total_daily_budget=50_000.0)
+
+    def test_the_total_cap_still_fires_for_a_declaring_tool(self) -> None:
+        decision = evaluate_guardrails(
+            "t",
+            {
+                "daily_budget_micros": 15_000_000_000,
+                "projected_total_daily_budget": 120_000,
+            },
+            self._CAPS_TOTAL,
+            budget_declaration=self._DECL,
+        )
+        assert decision.allowed is False
+        assert "max_total_daily_budget" in (decision.reason or "")
+
+    def test_under_the_total_cap_is_allowed(self) -> None:
+        decision = evaluate_guardrails(
+            "t",
+            {
+                "daily_budget_micros": 15_000_000_000,
+                "projected_total_daily_budget": 40_000,
+            },
+            self._CAPS_TOTAL,
+            budget_declaration=self._DECL,
+        )
+        assert decision.allowed is True
+
+    @pytest.mark.parametrize(
+        "value", [float("nan"), float("inf"), float("-inf"), int("9" * 309)]
+    )
+    def test_a_non_finite_total_is_denied(self, value: Any) -> None:
+        """Held to #419's fail-closed standard like every other channel."""
+        decision = evaluate_guardrails(
+            "t",
+            {
+                "daily_budget_micros": 15_000_000_000,
+                "projected_total_daily_budget": value,
+            },
+            self._CAPS_TOTAL,
+            budget_declaration=self._DECL,
+        )
+        assert decision.allowed is False
+        assert "projected_total_daily_budget" in (decision.reason or "")
+
+
+@pytest.mark.unit
+class TestUnreadableFallbackCurrent:
+    """The fallback ``current`` is a budget channel, so #419 governs it too.
+
+    Every budget channel funnels through one choke point that saturates an
+    oversized int and refuses a non-finite figure (#419). The fallback reaches
+    ``current_daily_budget`` on a path the built-in scan does not walk, so it
+    has to be held to the same standard — otherwise a declaring plugin gets a
+    baseline the built-in gate would have refused, and in the dangerous
+    direction: ``nan > 0`` is False, which takes the percentage cap dark, and a
+    bare oversized int raises ``OverflowError`` into
+    ``StrategyPolicyGate.evaluate``'s blanket ``except`` — an abstain, i.e. an
+    allow. Both are the exact bypasses #419 closed on the built-in path.
+    """
+
+    _DECL = BudgetDeclaration(daily_key="daily_budget_micros", micros=True)
+    _CAPS_PCT = Guardrails(max_daily_budget_increase_pct=20.0)
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            float("nan"),
+            float("inf"),
+            float("-inf"),
+            int("9" * 309),  # bare int: float() raises OverflowError, not inf
+        ],
+    )
+    def test_a_non_finite_fallback_current_is_denied(self, value: Any) -> None:
+        decision = evaluate_guardrails(
+            "t",
+            {"daily_budget_micros": 15_000_000_000, "current_daily_budget": value},
+            self._CAPS_PCT,
+            budget_declaration=self._DECL,
+        )
+        assert decision.allowed is False
+        assert "current_daily_budget" in (decision.reason or "")
+
+    def test_it_matches_the_built_in_scan(self) -> None:
+        """Same garbage baseline, same verdict, declared or not — the seam must
+        not be a weaker gate than the one it replaces."""
+        args = {"current_daily_budget": float("nan")}
+        declared = evaluate_guardrails(
+            "t",
+            {**args, "daily_budget_micros": 15_000_000_000},
+            self._CAPS_PCT,
+            budget_declaration=self._DECL,
+        )
+        built_in = evaluate_guardrails(
+            "t", {**args, "daily_budget": 15_000}, self._CAPS_PCT
+        )
+        assert declared.allowed == built_in.allowed is False


### PR DESCRIPTION
## Problem

The declaration seam from #414 / #416 replaces the built-in key scan **for every channel, including `current`** (`_budget_inputs`, `strategy_gate.py`). `current_key` defaults to `None`, so for any tool that declares its budget the *current* budget resolves to `None`, and this branch of `evaluate_guardrails` can never fire:

```python
if pct_cap is not None and current is not None and current > 0:
```

A plugin that declares the expected, documented shape — just `daily` — therefore has **`max_daily_budget_increase_pct` silently switched off** for its tools. Not only on the built-in gate: declarations are registered process-globally at import from the entry points, so a plugin's own gate delegating to `StrategyPolicyGate` gets the same answer. There is no way for the plugin to opt out.

That is the same silent underenforcement #414 exists to remove, reintroduced through the seam itself — and it lands on precisely the plugins that did the right thing and adopted it.

**Declaring `current` does not work around it.** `unit` is one flag covering every declared key, while mureo's own convention (`current_daily_budget`, passed by the skills — see `_mureo-strategy/SKILL.md`) is **currency units**. A micros tool that declares `current` divides the baseline by 1e6:

```
Guardrails(max_daily_budget_increase_pct=20)
{"daily_budget_micros": 15_000_000_000, "current_daily_budget": 10_000}   # ¥10,000 → ¥15,000, +50%

daily only        → allowed=True                                    # cap silently dead
daily + current   → "raises spend 149999900% (0 → 15,000)"          # baseline destroyed
```

## Fix

`current` falls back to the built-in scan unless the plugin declares it.

The distinction is principled, not a special case: `daily` / `lifetime` are budgets **the tool proposes**, so the plugin's vocabulary is authoritative and replacing the scan wholesale is right (an unrelated field spelled `amount` must not false-trip a cap). The *current* budget is not something the tool carries at all — it is context the caller supplies, under mureo's own cross-provider convention. A plugin that genuinely does take the current budget as an argument can still declare `current`, and that declaration still wins.

## Tests

TDD, red first, in `tests/test_plugin_budget_declaration.py`:

- `test_undeclared_current_falls_back_to_the_built_in_key` — a micros `daily` declaration + `current_daily_budget` → the +50% raise is refused (was allowed).
- `test_the_fallback_current_is_currency_not_micros` — the reason reads `10,000 → 15,000`, not `0 → 15,000`.
- `test_a_declared_current_key_still_wins` — an explicit `current` declaration is not overridden by the fallback.

63 passed across `test_plugin_budget_declaration.py` + `test_strategy_gate.py`; ruff / black / mypy clean.

`docs/plugin-authoring.md` and the `BudgetDeclaration` docstring updated: they both stated the "replaces every channel" rule that this changes.

## Found by

Adopting the seam in a provider plugin: declaring `daily` made the plugin's own percentage-cap regression test start passing calls it used to refuse.
