### PR TITLE
fix(policy): fail closed on non-finite budgets so oversized/NaN cannot bypass caps

### DIFF
--- a/mureo/policy/strategy_gate.py
+++ b/mureo/policy/strategy_gate.py
@@ -116,6 +116,24 @@ class _Unreadable:
 _UNREADABLE = _Unreadable()
 
 
+def _saturate(value: int | float) -> float:
+    """``float(value)``, saturating an out-of-range ``int`` to infinity.
+
+    Python ints are arbitrary precision but floats are not, so ``float(10**400)``
+    raises ``OverflowError`` — and the downstream handler forwards the bare int
+    happily. Every budget path here funnels through this helper so an oversized
+    integer becomes ``inf`` (which exceeds any finite cap and denies) rather than
+    an exception that bubbles up to ``StrategyPolicyGate.evaluate``'s blanket
+    ``except`` and silently abstains — the exact bypass the guardrail exists to
+    prevent. A string budget never reaches here (``float("9"*309)`` already
+    saturates to ``inf`` without raising).
+    """
+    try:
+        return float(value)
+    except OverflowError:
+        return math.inf if value > 0 else -math.inf
+
+
 def _declared_amount(
     arguments: dict[str, Any], key: str | None, *, micros: bool
 ) -> float | _Unreadable | None:
@@ -144,7 +162,7 @@ def _declared_amount(
     if isinstance(raw, bool):
         return _UNREADABLE
     if isinstance(raw, (int, float)):
-        value = float(raw)
+        value = _saturate(raw)
     elif isinstance(raw, str):
         stripped = raw.strip()
         if not stripped:
@@ -160,26 +178,77 @@ def _declared_amount(
     return value / 1_000_000 if micros else value
 
 
+def _projected_total(arguments: dict[str, Any]) -> float | None:
+    """The account-wide projected daily total a skill passes for the total cap.
+
+    Built-in key only (there is no declared equivalent); routed through
+    ``_saturate`` like every other budget channel so an oversized int denies
+    instead of raising.
+    """
+    total = arguments.get("projected_total_daily_budget")
+    if isinstance(total, (int, float)) and not isinstance(total, bool):
+        return _saturate(total)
+    return None
+
+
 @dataclass(frozen=True)
 class _BudgetInputs:
-    """The three budget channels one evaluation needs, already resolved."""
+    """The budget channels one evaluation needs, already resolved.
+
+    Every value here is either ``None`` (no budget on that channel) or a
+    FINITE float. A present-but-non-finite value (``inf``/``nan``, from an
+    oversized int that saturated, a bare ``NaN`` on the wire, or garbage on a
+    declared key) is collapsed into :attr:`unreadable_key` so the caller fails
+    closed once — no downstream comparison ever sees ``inf``/``nan``. This is
+    the single choke point that keeps ``nan > cap`` (always False) and
+    ``finite/inf = nan`` from silently defeating a cap.
+    """
 
     proposed: float | None = None
     current: float | None = None
     lifetime: float | None = None
-    #: The first declared key that was present but unreadable (⇒ deny).
+    total: float | None = None
+    #: The first budget key that was present but unreadable (⇒ deny).
     unreadable_key: str | None = None
 
 
 def _budget_inputs(
     arguments: dict[str, Any], declaration: BudgetDeclaration | None
 ) -> _BudgetInputs:
-    """Resolve the budget channels from declared keys, else the built-in scan."""
+    """Resolve the budget channels from declared keys, else the built-in scan.
+
+    A non-finite value on ANY channel — declared or built-in — fails closed:
+    the whole call is refused. The declared path already did this via
+    ``_declared_amount`` returning ``_UNREADABLE``; the built-in scan is held to
+    the same standard here so an oversized int (``inf``) or a bare ``NaN``
+    cannot slip past a comparison.
+
+    Deliberately BROAD, and fail-safe: a non-finite value on a budget channel
+    denies even when the specific cap that reads that channel is not the one
+    configured (e.g. garbage in ``current_daily_budget`` with only an absolute
+    cap set). This is only reachable once the operator has written *some*
+    guardrail (``evaluate_guardrails`` returns early on an empty ``Guardrails``),
+    so the fail-open default is preserved; past that point a non-finite figure
+    in any recognized budget argument is malformed input, and refusing it is the
+    safe direction. It also keeps this the single choke point — scoping the
+    check per-active-cap would re-introduce the "which comparison did we forget"
+    surface that let the overflow/NaN bypass exist in the first place. Mirrors
+    the already-shipped declared path (#414), which denies on any unreadable
+    declared key regardless of which cap reads it.
+    """
     if declaration is None:
+        channels: list[tuple[str, float | None]] = [
+            ("daily budget", _proposed_budget(arguments)),
+            ("current budget", _current_budget(arguments)),
+            ("lifetime budget", _proposed_lifetime_budget(arguments)),
+            ("projected total daily budget", _projected_total(arguments)),
+        ]
+        for label, value in channels:
+            if value is not None and not math.isfinite(value):
+                return _BudgetInputs(unreadable_key=label)
+        proposed, current, lifetime, total = (v for _, v in channels)
         return _BudgetInputs(
-            proposed=_proposed_budget(arguments),
-            current=_current_budget(arguments),
-            lifetime=_proposed_lifetime_budget(arguments),
+            proposed=proposed, current=current, lifetime=lifetime, total=total
         )
     resolved: list[float | None] = []
     for key in (
@@ -187,10 +256,10 @@ def _budget_inputs(
         declaration.current_key,
         declaration.lifetime_key,
     ):
-        value = _declared_amount(arguments, key, micros=declaration.micros)
-        if isinstance(value, _Unreadable):
+        declared = _declared_amount(arguments, key, micros=declaration.micros)
+        if isinstance(declared, _Unreadable):
             return _BudgetInputs(unreadable_key=key)
-        resolved.append(value)
+        resolved.append(declared)
     proposed, current, lifetime = resolved
     return _BudgetInputs(proposed=proposed, current=current, lifetime=lifetime)
 
@@ -277,13 +346,13 @@ def _proposed_budget(arguments: dict[str, Any]) -> float | None:
         if key in arguments:
             v = arguments[key]
             if isinstance(v, (int, float)) and not isinstance(v, bool):
-                return float(v)
+                return _saturate(v)
     # Google Ads budgets are sometimes expressed in micros —
     # budget_amount_micros on campaign tools, amount_micros on budget tools.
     for micros_key in ("budget_amount_micros", "amount_micros"):
         micros = arguments.get(micros_key)
         if isinstance(micros, (int, float)) and not isinstance(micros, bool):
-            return float(micros) / 1_000_000
+            return _saturate(micros) / 1_000_000
     return None
 
 
@@ -297,10 +366,10 @@ def _proposed_lifetime_budget(arguments: dict[str, Any]) -> float | None:
     for key in ("lifetime_budget", "total_amount"):
         v = arguments.get(key)
         if isinstance(v, (int, float)) and not isinstance(v, bool):
-            return float(v)
+            return _saturate(v)
     micros = arguments.get("total_amount_micros")
     if isinstance(micros, (int, float)) and not isinstance(micros, bool):
-        return float(micros) / 1_000_000
+        return _saturate(micros) / 1_000_000
     return None
 
 
@@ -308,7 +377,7 @@ def _current_budget(arguments: dict[str, Any]) -> float | None:
     for key in _CURRENT_BUDGET_KEYS:
         v = arguments.get(key)
         if isinstance(v, (int, float)) and not isinstance(v, bool):
-            return float(v)
+            return _saturate(v)
     return None
 
 
@@ -401,18 +470,13 @@ def evaluate_guardrails(
             ),
         )
 
-    total = arguments.get("projected_total_daily_budget")
+    total = inputs.total
     total_cap = guardrails.max_total_daily_budget
-    if (
-        total_cap is not None
-        and isinstance(total, (int, float))
-        and not isinstance(total, bool)
-        and float(total) > total_cap
-    ):
+    if total_cap is not None and total is not None and total > total_cap:
         return PolicyDecision(
             allowed=False,
             reason=(
-                f"Projected total daily budget {float(total):,.0f} exceeds the "
+                f"Projected total daily budget {total:,.0f} exceeds the "
                 f"STRATEGY.md Guardrails cap of {total_cap:,.0f} "
                 f"(max_total_daily_budget)."
             ),

--- a/tests/test_plugin_budget_declaration.py
+++ b/tests/test_plugin_budget_declaration.py
@@ -303,6 +303,8 @@ class TestUnreadableDeclaredBudget:
             "Infinity",
             "nan",
             "not-a-number",
+            "9" * 309,  # too large for float64 as a string — saturates to inf
+            int("9" * 309),  # bare int: float() raises OverflowError, not inf
             True,  # bool is an int subclass — never a budget
             {"amount": 1},
             [],

--- a/tests/test_strategy_gate.py
+++ b/tests/test_strategy_gate.py
@@ -144,6 +144,106 @@ class TestEvaluateGuardrails:
         assert d.allowed is False
         assert "max_lifetime_budget_per_campaign" in d.reason
 
+    # A budget too large for a float64. Python ints are arbitrary precision, so
+    # ``float(10**400)`` raises OverflowError, not a value the extractor floors —
+    # and the handler downstream forwards the bare int happily. The gate must
+    # saturate to inf (which exceeds any finite cap and denies), never let the
+    # OverflowError bubble to StrategyPolicyGate.evaluate's blanket except, which
+    # would abstain and wave the call through.
+    _OVERSIZED_INT = int("9" * 309)
+
+    def test_oversized_daily_budget_denies_not_abstains(self) -> None:
+        g = Guardrails(max_daily_budget_per_campaign=50000)
+        d = evaluate_guardrails(
+            "meta_ads_ad_sets_update", {"daily_budget": self._OVERSIZED_INT}, g
+        )
+        assert d.allowed is False
+
+    def test_oversized_micros_budget_denies(self) -> None:
+        g = Guardrails(max_daily_budget_per_campaign=50000)
+        d = evaluate_guardrails(
+            "google_ads_budget_update",
+            {"budget_amount_micros": self._OVERSIZED_INT},
+            g,
+        )
+        assert d.allowed is False
+
+    def test_oversized_lifetime_budget_denies(self) -> None:
+        g = Guardrails(max_lifetime_budget_per_campaign=900000)
+        d = evaluate_guardrails(
+            "meta_ads_ad_sets_update",
+            {"lifetime_budget": self._OVERSIZED_INT},
+            g,
+        )
+        assert d.allowed is False
+
+    def test_oversized_int_reaches_the_gate_without_raising(self) -> None:
+        """End-to-end: the bare-int overflow must not fall through evaluate()'s
+        blanket except into a silent abstain."""
+        g = Guardrails(max_daily_budget_per_campaign=50000)
+        d = evaluate_guardrails(
+            "google_ads_budget_update", {"daily_budget": self._OVERSIZED_INT}, g
+        )
+        assert d.allowed is False
+
+    def test_oversized_projected_total_denies(self) -> None:
+        """The account-wide total cap funnels through the same saturation —
+        a bare-int projected total must deny, not raise-then-abstain."""
+        g = Guardrails(max_total_daily_budget=300000)
+        d = evaluate_guardrails(
+            "google_ads_budget_update",
+            {
+                "daily_budget": 10000,
+                "projected_total_daily_budget": self._OVERSIZED_INT,
+            },
+            g,
+        )
+        assert d.allowed is False
+
+    def test_oversized_current_does_not_neutralize_increase_pct(self) -> None:
+        """An oversized ``current`` makes ``(proposed-current)/current`` a NaN
+        that ``> cap`` reads as False. With only the pct cap configured, that
+        would let an arbitrarily large proposed budget through — so a
+        non-finite ``current`` must fail closed."""
+        g = Guardrails(max_daily_budget_increase_pct=20)  # NO absolute cap
+        d = evaluate_guardrails(
+            "meta_ads_ad_sets_update",
+            {"daily_budget": 5_000_000, "current_daily_budget": self._OVERSIZED_INT},
+            g,
+        )
+        assert d.allowed is False
+
+    @pytest.mark.parametrize(
+        ("key", "guardrails"),
+        [
+            ("daily_budget", Guardrails(max_daily_budget_per_campaign=50000)),
+            ("lifetime_budget", Guardrails(max_lifetime_budget_per_campaign=900000)),
+            (
+                "projected_total_daily_budget",
+                Guardrails(max_total_daily_budget=300000),
+            ),
+        ],
+    )
+    def test_nan_budget_denies_not_abstains(
+        self, key: str, guardrails: Guardrails
+    ) -> None:
+        """A bare ``NaN`` needs no overflow: ``nan > cap`` is always False, so
+        without a guard it silently defeats the cap. ``json.loads`` accepts the
+        ``NaN`` token, so this is wire-reachable. Non-finite ⇒ deny."""
+        d = evaluate_guardrails(
+            "meta_ads_ad_sets_update", {key: float("nan")}, guardrails
+        )
+        assert d.allowed is False
+
+    def test_nan_current_denies_not_abstains(self) -> None:
+        g = Guardrails(max_daily_budget_increase_pct=20)
+        d = evaluate_guardrails(
+            "meta_ads_ad_sets_update",
+            {"daily_budget": 11000, "current_daily_budget": float("nan")},
+            g,
+        )
+        assert d.allowed is False
+
     def test_total_amount_units_hits_lifetime_cap(self) -> None:
         """The currency-unit form total_amount cannot sidestep the cap."""
         g = Guardrails(max_lifetime_budget_per_campaign=900000)


### PR DESCRIPTION
## なぜ

`StrategyPolicyGate`(STRATEGY.md `## Guardrails` を dispatch 前に強制する built-in gate)の予算抽出が、提案予算を素の `float()` で読んでいた。これが **予算キャップの回避経路** を生んでいた。#414(plugin の予算キー宣言)を実装したブリッジ側から辿って発見。

### 3 つの回避経路(すべて再現確認済み・pre-fix で RED になるテストを追加)

1. **桁あふれ** — Python の `int` は無限精度だが `float` は違う。`int("9"*309)` / `10**400` を渡すと `float()` が **`OverflowError`**。これが未捕捉で `StrategyPolicyGate.evaluate` の blanket `except Exception: return PolicyDecision(allowed=True)` まで上がり、**キャップが無言で abstain**。handler は任意精度の `int()` で coerce してそのまま実支出として送る。**全経路** で成立: Google(`budget_amount_micros`)・Meta(`daily_budget` / `lifetime_budget`)・総額キャップ(`projected_total_daily_budget`)・#414 宣言経路。

2. **NaN**(overflow 不要) — `nan > cap` は常に `False`。任意の capped キーに `NaN` を入れると built-in scan の全比較を無効化する。**`json.loads` は `NaN` / `Infinity` トークンを許容** するので、JSON-RPC 引数として **wire から到達可能**。

3. **増加率キャップの無効化** — `current` を巨大化 / NaN 化すると `(proposed - current)/current` が `NaN` になり `> pct_cap` が `False`。`max_daily_budget_increase_pct` を単独設定しているとき、任意に大きい提案予算が通る。

## どう直したか

**個別の比較を叩くのではなく、単一の choke point で塞ぐ。**

- `_saturate(value)`: 範囲外の `int` を `±inf` に飽和(raise しない)。`inf` は任意の有限キャップを超えるので deny になる。5 箇所の `float()` 呼び出しをこれ経由に。
- `_budget_inputs()`: 全チャネル(daily / current / lifetime / projected-total)を `math.isfinite()` で検査し、**present-but-non-finite なら `unreadable_key` に落として fail-closed**。`evaluate_guardrails` は既に `unreadable_key` で deny する。これで下流の比較が `inf` / `nan` を二度と見ない。宣言経路(`_declared_amount` が非有限を `_UNREADABLE` にする)と同じ基準。
- 総額キャップも生の `arguments.get(...) + float()` をやめ、`inputs.total` 経由に統一。

集約したのは、比較を1つずつ守る方式が「どの比較を守り忘れたか」という **まさに本バグを生んだ穴** を再導入するため。

### fail-safe な設計判断(docstring に明記)

非有限 deny は **意図的に広い**(どのキャップがそのチャネルを読むかに関わらず deny)。ただし `evaluate_guardrails` は空の `Guardrails` で早期 return するため、**operator が何らかのガードレールを書いたときのみ** ここに到達する = fail-open の既定は保たれる。その先で予算引数に非有限値が入るのは malformed 入力であり、拒否が安全側。#414 で既にマージ済みの宣言経路の挙動と一致。

## テスト

red-first(pre-fix ファイルで失敗を確認):

- 桁あふれ int: daily / micros / lifetime / current / projected-total、built-in + 宣言経路
- bare NaN: 全 capped チャネル(daily / lifetime / projected-total / current)
- 増加率キャップ単独 + 巨大 current
- 正当な大きい有限予算(1e12 等)と「予算提案なし」は従来どおり pass

## 検証

- `pytest tests/` → **5474 passed**, 7 skipped(除外した 3 件はこのセッションで bridge を editable install したことによる tool-count 汚染で、本変更と無関係・CI クリーン環境では発生しない)
- black / ruff / mypy(strict)clean
- python-reviewer: 初回 **BLOCK(CRITICAL 3)** → 修正 → **APPROVE**

## Breaking change

なし。fail-safe な enforcement 強化のみ(regression なし)。既存の正当な呼び出しの挙動は不変。

https://claude.ai/code/session_01UFvgHU2TbFPPu4qckkLhNM
