### PR TITLE
fix(configure): detect the basic-setup parts on disk instead of recalling a flag (#423)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The configure dashboard now detects the basic-setup components instead of
+  recalling them from a flag file (#423).** Every other row on the status
+  snapshot is read off the filesystem, but the three basic-setup rows (mureo
+  MCP, credential-guard hook, workflow skills) came from `setup_state.json` — a
+  record only the dashboard's own actions ever wrote. So skills installed with
+  `mureo setup`, or by hand, read as **not installed while present**; and, in
+  the dangerous direction, a component deleted after a dashboard install kept
+  reading as **installed while absent** — the UI asserting a guardrail-bearing
+  component is there when it is not, with nothing to prompt the operator to
+  look. The status now detects each part on every read: the hook by the
+  credential guard's own tag on the host's real hook surface, the skills by
+  presence in the host's skills directory, and the mureo MCP block by the same
+  registry read that already reports every other provider (which could
+  previously contradict the flag *within a single snapshot*). `setup_state.json`
+  is no longer written or read; one left behind by an older mureo is ignored.
+
 ## [0.10.25] - 2026-07-14
 
 ### Fixed

--- a/mureo/web/setup_actions.py
+++ b/mureo/web/setup_actions.py
@@ -51,13 +51,7 @@ from mureo.web.desktop_mcp import (
     unset_mureo_disable_env_desktop,
 )
 from mureo.web.legacy_commands import remove_legacy_commands
-from mureo.web.setup_state import (
-    PART_HOOK,
-    PART_MCP,
-    PART_SKILLS,
-    clear_part,
-    mark_part_installed,
-)
+from mureo.web.setup_state import PART_HOOK, PART_MCP, PART_SKILLS
 
 logger = logging.getLogger(__name__)
 
@@ -110,7 +104,6 @@ def _install_desktop_mcp(home: Path | None) -> ActionResult:
         logger.exception("install_mureo_mcp (desktop) failed")
         return ActionResult(status="error", detail=type(exc).__name__)
 
-    mark_part_installed(PART_MCP, home=home)
     if not wrote:
         return ActionResult(status="noop", detail="already_configured")
     return ActionResult(status="ok", detail=str(config_path))
@@ -139,7 +132,6 @@ def _install_codex_mcp(home: Path | None) -> ActionResult:
         logger.exception("install_mureo_mcp (codex) failed")
         return ActionResult(status="error", detail=type(exc).__name__)
 
-    mark_part_installed(PART_MCP, home=home)
     if not wrote:
         return ActionResult(status="noop", detail="already_configured")
     return ActionResult(status="ok", detail=str(config_path))
@@ -379,7 +371,6 @@ def install_mureo_mcp(home: Path | None = None, host: str = _HOST_CODE) -> Actio
             logger.exception("install_mureo_mcp failed")
             return ActionResult(status="error", detail=type(exc).__name__)
 
-        mark_part_installed(PART_MCP, home=home)
         result = (
             ActionResult(status="noop", detail="already_configured")
             if res is None
@@ -414,7 +405,6 @@ def install_auth_hook(home: Path | None = None, host: str = _HOST_CODE) -> Actio
         logger.exception("install_auth_hook failed")
         return ActionResult(status="error", detail=type(exc).__name__)
 
-    mark_part_installed(PART_HOOK, home=home)
     if result is None:
         return ActionResult(status="noop", detail="already_installed")
     return ActionResult(status="ok", detail=str(result))
@@ -438,7 +428,6 @@ def install_workflow_skills(
         logger.exception("install_workflow_skills failed")
         return ActionResult(status="error", detail=type(exc).__name__)
 
-    mark_part_installed(PART_SKILLS, home=home)
     return ActionResult(status="ok", detail=f"installed {count} skills at {dest}")
 
 
@@ -1093,7 +1082,6 @@ def _remove_desktop_mcp(home: Path | None) -> ActionResult:
 
     if not removed:
         return ActionResult(status="noop", detail="not_installed")
-    clear_part(PART_MCP, home=home)
     return ActionResult(status="ok")
 
 
@@ -1114,7 +1102,6 @@ def remove_mureo_mcp(home: Path | None = None, host: str = _HOST_CODE) -> Action
             return ActionResult(status="error", detail=type(exc).__name__)
         if not changed:
             return ActionResult(status="noop", detail="not_installed")
-        clear_part(PART_MCP, home=home)
         return ActionResult(status="ok")
 
     try:
@@ -1125,7 +1112,6 @@ def remove_mureo_mcp(home: Path | None = None, host: str = _HOST_CODE) -> Action
 
     if not result.changed:
         return ActionResult(status="noop", detail="not_installed")
-    clear_part(PART_MCP, home=home)
     return ActionResult(status="ok")
 
 
@@ -1145,7 +1131,6 @@ def remove_auth_hook(home: Path | None = None, host: str = _HOST_CODE) -> Action
             removed = remove_codex_credential_guard(_codex_hooks_path(home))
             if removed is None:
                 return ActionResult(status="noop", detail="not_installed")
-            clear_part(PART_HOOK, home=home)
             return ActionResult(status="ok")
         result = remove_credential_guard()
     except Exception as exc:  # noqa: BLE001
@@ -1154,7 +1139,6 @@ def remove_auth_hook(home: Path | None = None, host: str = _HOST_CODE) -> Action
 
     if not result.changed:
         return ActionResult(status="noop", detail="not_installed")
-    clear_part(PART_HOOK, home=home)
     return ActionResult(status="ok")
 
 
@@ -1173,10 +1157,6 @@ def remove_workflow_skills(
         logger.exception("remove_workflow_skills failed")
         return ActionResult(status="error", detail=type(exc).__name__)
 
-    # Clear the state flag on both success AND noop so the dashboard
-    # tri-state stays consistent (planner HANDOFF L137 — flag must reflect
-    # actual on-disk state).
-    clear_part(PART_SKILLS, home=home)
     if count == 0:
         return ActionResult(status="noop", detail=f"no skills found at {dest}")
     return ActionResult(status="ok", detail=f"removed {count} skills from {dest}")
@@ -1187,9 +1167,10 @@ def _installed_official_providers(
 ) -> list[str]:
     """Return the subset of ``_OFFICIAL_PROVIDER_IDS`` actually registered.
 
-    ``clear_all_setup`` needs to know which providers were installed
-    without depending on ``setup_state.json`` flags (those only track
-    basic-setup parts).
+    ``clear_all_setup`` needs to know which providers are actually
+    registered, so it probes the registry rather than trusting a record of
+    what was installed — the same rule the status snapshot now follows for
+    every row (#423).
 
     For ``host="claude-code"`` registration lives in ``~/.claude.json``
     (managed by ``claude mcp``) — NOT ``~/.claude/settings.json`` — so we

--- a/mureo/web/setup_state.py
+++ b/mureo/web/setup_state.py
@@ -1,14 +1,24 @@
-"""Persistent record of which basic-setup steps have been run."""
+"""Which basic-setup components are installed.
+
+Once a *record*: the configure UI wrote a flag file whenever one of its own
+actions ran, and read the status back out of it. That made the flag the only
+source of truth for three rows that every other row on the status snapshot
+detects from disk — so an install done any other way (``mureo setup``, by
+hand) read as absent, and a component deleted after a UI install read as
+present. The second is the dangerous direction: the UI asserts a
+guardrail-bearing component is there when it is not, and nothing prompts the
+operator to look (#423).
+
+So this is now just the shape. ``status_collector`` fills it by detecting each
+part on disk — the credential-guard hook by its tag, the skills by presence in
+the host's skills dir, the mureo MCP block by the same registry read that
+already reports every other provider. A ``setup_state.json`` left over from an
+older mureo is simply ignored.
+"""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from pathlib import Path
-from typing import Any
-
-from mureo.web._helpers import atomic_write_json, read_json_safe
-
-SETUP_STATE_FILENAME = "setup_state.json"
 
 PART_MCP = "mureo_mcp"
 PART_HOOK = "auth_hook"
@@ -19,7 +29,7 @@ KNOWN_PARTS: tuple[str, ...] = (PART_MCP, PART_HOOK, PART_SKILLS)
 
 @dataclass(frozen=True)
 class SetupParts:
-    """Whether each basic-setup component has been installed."""
+    """Whether each basic-setup component is installed, as found on disk."""
 
     mureo_mcp: bool = False
     auth_hook: bool = False
@@ -34,53 +44,3 @@ class SetupParts:
 
     def all_installed(self) -> bool:
         return self.mureo_mcp and self.auth_hook and self.skills
-
-
-def state_file_path(home: Path | None = None) -> Path:
-    """Return the canonical setup_state.json location."""
-    base = home if home is not None else Path.home()
-    return base / ".mureo" / SETUP_STATE_FILENAME
-
-
-def read_setup_state(home: Path | None = None) -> SetupParts:
-    """Load the persisted setup-parts record."""
-    payload = read_json_safe(state_file_path(home))
-    return SetupParts(
-        mureo_mcp=bool(payload.get(PART_MCP, False)),
-        auth_hook=bool(payload.get(PART_HOOK, False)),
-        skills=bool(payload.get(PART_SKILLS, False)),
-    )
-
-
-def write_setup_state(parts: SetupParts, home: Path | None = None) -> None:
-    """Persist ``parts`` to ``setup_state.json`` (atomic + 0o600)."""
-    payload: dict[str, Any] = parts.as_dict()
-    atomic_write_json(state_file_path(home), payload)
-
-
-def mark_part_installed(part: str, home: Path | None = None) -> SetupParts:
-    """Flip one part to True and persist."""
-    if part not in KNOWN_PARTS:
-        raise ValueError(f"unknown setup part: {part!r}")
-    current = read_setup_state(home)
-    updated = SetupParts(
-        mureo_mcp=current.mureo_mcp or part == PART_MCP,
-        auth_hook=current.auth_hook or part == PART_HOOK,
-        skills=current.skills or part == PART_SKILLS,
-    )
-    write_setup_state(updated, home)
-    return updated
-
-
-def clear_part(part: str, home: Path | None = None) -> SetupParts:
-    """Reset one part to False (used by uninstall flows)."""
-    if part not in KNOWN_PARTS:
-        raise ValueError(f"unknown setup part: {part!r}")
-    current = read_setup_state(home)
-    updated = SetupParts(
-        mureo_mcp=current.mureo_mcp and part != PART_MCP,
-        auth_hook=current.auth_hook and part != PART_HOOK,
-        skills=current.skills and part != PART_SKILLS,
-    )
-    write_setup_state(updated, home)
-    return updated

--- a/mureo/web/status_collector.py
+++ b/mureo/web/status_collector.py
@@ -22,7 +22,10 @@ from typing import TYPE_CHECKING, Any
 from mureo.web._helpers import read_json_safe
 from mureo.web.env_var_writer import allowed_env_var_names, get_env_var_target
 from mureo.web.host_paths import HostPaths, get_host_paths
-from mureo.web.setup_state import SetupParts, read_setup_state
+from mureo.web.setup_state import SetupParts
+
+_HOST_DESKTOP = "claude-desktop"
+_HOST_CODEX = "codex"
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -175,6 +178,71 @@ def _detect_legacy_commands(commands_dir: Path) -> bool:
     return bool(detect_legacy_commands(commands_dir))
 
 
+def _shipped_skill_names() -> frozenset[str]:
+    """The skills this mureo would install (``mureo/_data/skills``)."""
+    from mureo.cli.setup_cmd import _get_data_path
+
+    try:
+        src = _get_data_path("skills")
+        return frozenset(
+            d.name for d in src.iterdir() if d.is_dir() and (d / "SKILL.md").exists()
+        )
+    except OSError:  # unreadable package data — cannot claim anything is installed
+        return frozenset()
+
+
+def _detect_workflow_skills(skills_dir: Path) -> bool:
+    """Return True iff every skill mureo ships is present in ``skills_dir``.
+
+    Detected, never recalled (#423). The old status came from a flag file that
+    only the configure UI's own actions wrote, so a ``mureo setup`` install read
+    ✗ while present, and a hand-deleted skill read ✓ while absent — the UI
+    asserting a component is there when it is not.
+
+    A *missing* skill reads as not-installed rather than partially-installed:
+    the remedy is the same either way (re-run the install, which overwrites),
+    and a half-installed set reported as ✓ is how an operator ends up without
+    the workflow they think they have. Staleness (installed, but from an older
+    mureo) is version drift and belongs to the upgrade action, not here.
+    """
+    expected = _shipped_skill_names()
+    if not expected:
+        return False
+    return all((skills_dir / name / "SKILL.md").exists() for name in expected)
+
+
+def _detect_auth_hook(host: str, settings_path: Path) -> bool:
+    """Return True iff mureo's credential-guard PreToolUse hook is installed.
+
+    Identified with :func:`mureo.credential_guard.is_guard_entry` — the same
+    predicate the installer and the remover use. It is scoped to the entry's
+    inner ``command`` field, so a user's own hook is never claimed as ours, and
+    there is only ever one definition of "is this our guard" to keep correct.
+
+    The path comes from ``settings_path``, never from a separately-threaded
+    home: Codex keeps its hooks in ``hooks.json`` beside its config rather than
+    inside it, and deriving that from the resolved :class:`HostPaths` keeps this
+    reading the *same* tree the rest of the snapshot reads. (Taking a ``home``
+    of its own would let a caller that passes only ``paths`` — as the handler
+    does — silently read the operator's real ``~/.codex`` instead.)
+
+    Claude Desktop has no ``PreToolUse`` surface, so the installer no-ops there
+    and this is always False. A guard stranded in the *legacy* top-level
+    ``PreToolUse`` list by a much older mureo reads as absent; re-running the
+    install rewrites it into the nested shape, which is the safe direction.
+    """
+    if host == _HOST_DESKTOP:
+        return False
+    from mureo.credential_guard import is_guard_entry
+
+    path = settings_path.parent / "hooks.json" if host == _HOST_CODEX else settings_path
+    hooks = read_json_safe(path).get("hooks")
+    if not isinstance(hooks, dict):
+        return False
+    entries = hooks.get("PreToolUse")
+    return isinstance(entries, list) and any(is_guard_entry(e) for e in entries)
+
+
 def _mask_value(name: str, value: str) -> str:
     """Return a UI-safe preview for an env var value.
 
@@ -234,8 +302,15 @@ def collect_status(
     so this stays a pure filesystem read with no runtime-context coupling.
     """
     resolved = paths if paths is not None else get_host_paths(host, home)
-    setup_parts = read_setup_state(home)
     providers = _detect_installed_providers(resolved.mcp_registry_path)
+    # Detected from disk, like every other row here — never recalled from a
+    # flag file (#423). ``mureo_mcp`` reuses the provider detection above
+    # rather than keeping a second source of truth for the same fact.
+    setup_parts = SetupParts(
+        mureo_mcp=providers[MUREO_NATIVE_ID],
+        auth_hook=_detect_auth_hook(resolved.host, resolved.settings_path),
+        skills=_detect_workflow_skills(resolved.skills_dir),
+    )
     creds = _detect_credentials_present(resolved.credentials_path)
     creds_oauth = _detect_credentials_oauth(resolved.credentials_path)
     env_vars = _collect_env_vars(resolved.credentials_path)

--- a/tests/test_web_backfill_disable.py
+++ b/tests/test_web_backfill_disable.py
@@ -58,9 +58,7 @@ _GA_OFFICIAL = {"type": "stdio", "command": "pipx", "args": ["run", "x"]}
 
 @pytest.mark.unit
 class TestBackfillDisable:
-    def test_code_backfills_google_when_official_present(
-        self, tmp_path: Path
-    ) -> None:
+    def test_code_backfills_google_when_official_present(self, tmp_path: Path) -> None:
         from mureo.web.setup_actions import (
             backfill_disable_for_installed_providers,
         )
@@ -103,9 +101,7 @@ class TestBackfillDisable:
         # And the network probe is never even called from this path.
         probe.assert_not_called()
 
-    def test_code_meta_not_disabled_when_connector_absent(
-        self, tmp_path: Path
-    ) -> None:
+    def test_code_meta_not_disabled_when_connector_absent(self, tmp_path: Path) -> None:
         from mureo.web.setup_actions import (
             backfill_disable_for_installed_providers,
         )
@@ -184,9 +180,7 @@ class TestBackfillDisable:
                 return_value=False,
             ),
         ):
-            backfill_disable_for_installed_providers(
-                "claude-desktop", tmp_path
-            )
+            backfill_disable_for_installed_providers("claude-desktop", tmp_path)
 
         env = json.loads(cfg.read_text())["mcpServers"]["mureo"].get("env", {})
         assert env.get("MUREO_DISABLE_GOOGLE_ADS") == "1"
@@ -213,9 +207,9 @@ def test_install_mureo_mcp_triggers_backfill(tmp_path: Path) -> None:
             "mureo.auth_setup.install_mcp_config",
             side_effect=_fake_install_mcp_config,
         ),
-        patch(
-            "mureo.web.setup_actions.mark_part_installed"
-        ),
+        # (``mark_part_installed`` used to be patched here. The install no
+        # longer records a flag — the status is detected from disk, #423 — so
+        # there is nothing to stub out.)
         patch(
             "mureo.providers.config_writer.is_hosted_provider_connected",
             return_value=False,

--- a/tests/test_web_handlers.py
+++ b/tests/test_web_handlers.py
@@ -1263,9 +1263,7 @@ class TestPostSetupHookInstall:
 
     ROUTE = "/api/setup/hook/install"
 
-    def test_ok_dispatches_to_install_auth_hook(
-        self, wizard: ConfigureWizard
-    ) -> None:
+    def test_ok_dispatches_to_install_auth_hook(self, wizard: ConfigureWizard) -> None:
         fake = MagicMock()
         fake.as_dict.return_value = {"status": "ok", "detail": "written"}
         with patch(
@@ -1286,9 +1284,7 @@ class TestPostSetupHookInstall:
         body = json.loads(resp.read().decode("utf-8"))
         assert body == {"status": "noop"}
 
-    def test_error_envelope_surfaces_to_client(
-        self, wizard: ConfigureWizard
-    ) -> None:
+    def test_error_envelope_surfaces_to_client(self, wizard: ConfigureWizard) -> None:
         fake = MagicMock()
         fake.as_dict.return_value = {"status": "error", "detail": "OSError"}
         with patch("mureo.web.handlers.install_auth_hook", return_value=fake):
@@ -1346,9 +1342,7 @@ class TestPostSetupSkillsInstall:
         assert body == {"status": "ok", "detail": "installed 15 skills"}
         mock_install.assert_called_once()
 
-    def test_error_envelope_surfaces_to_client(
-        self, wizard: ConfigureWizard
-    ) -> None:
+    def test_error_envelope_surfaces_to_client(self, wizard: ConfigureWizard) -> None:
         fake = MagicMock()
         fake.as_dict.return_value = {"status": "error", "detail": "OSError"}
         with patch("mureo.web.handlers.install_workflow_skills", return_value=fake):
@@ -2056,7 +2050,8 @@ class TestPostSetupBasicClear:
 
     def test_passes_wizard_home_through(self, wizard: ConfigureWizard) -> None:
         """The handler propagates ``self.wizard.home`` to ``clear_all_setup``
-        so the per-step ``clear_part`` calls write to the same setup_state.json."""
+        so every per-step remove operates on the same tree (the tests sandbox
+        that home; in production it is ``None`` and the real one is used)."""
         with patch("mureo.web.handlers.clear_all_setup", return_value={}) as mock_clear:
             _post(wizard, self.ROUTE, {})
 
@@ -2298,9 +2293,7 @@ class TestReexecRunner:
 
         with (
             patch("mureo.web.handlers.time.sleep"),
-            patch.object(
-                handlers_mod.sys, "argv", ["mureo", "configure", "--serve"]
-            ),
+            patch.object(handlers_mod.sys, "argv", ["mureo", "configure", "--serve"]),
             patch.object(handlers_mod.sys, "executable", "/usr/bin/python3"),
             patch("mureo.web.handlers.os.execv") as mock_execv,
         ):
@@ -2335,9 +2328,7 @@ class TestRequestInteractiveReexec:
         import mureo.web.handlers as handlers_mod
 
         ran = threading.Event()
-        with patch(
-            "mureo.web.handlers._reexec_runner", side_effect=lambda: ran.set()
-        ):
+        with patch("mureo.web.handlers._reexec_runner", side_effect=lambda: ran.set()):
             handlers_mod._request_interactive_reexec()
             assert ran.wait(timeout=2.0), "reexec runner was not invoked"
 
@@ -2353,17 +2344,11 @@ class TestPostRestart:
 
     ROUTE = "/api/restart"
 
-    def test_managed_schedules_service_restart(
-        self, wizard: ConfigureWizard
-    ) -> None:
+    def test_managed_schedules_service_restart(self, wizard: ConfigureWizard) -> None:
         with (
             patch("mureo.web.service.is_managed_service", return_value=True),
-            patch(
-                "mureo.web.handlers._request_service_restart"
-            ) as mock_service,
-            patch(
-                "mureo.web.handlers._request_interactive_reexec"
-            ) as mock_reexec,
+            patch("mureo.web.handlers._request_service_restart") as mock_service,
+            patch("mureo.web.handlers._request_interactive_reexec") as mock_reexec,
         ):
             resp = _post(wizard, self.ROUTE, {})
         body = json.loads(resp.read().decode("utf-8"))
@@ -2374,12 +2359,8 @@ class TestPostRestart:
     def test_interactive_schedules_reexec(self, wizard: ConfigureWizard) -> None:
         with (
             patch("mureo.web.service.is_managed_service", return_value=False),
-            patch(
-                "mureo.web.handlers._request_service_restart"
-            ) as mock_service,
-            patch(
-                "mureo.web.handlers._request_interactive_reexec"
-            ) as mock_reexec,
+            patch("mureo.web.handlers._request_service_restart") as mock_service,
+            patch("mureo.web.handlers._request_interactive_reexec") as mock_reexec,
         ):
             resp = _post(wizard, self.ROUTE, {})
         body = json.loads(resp.read().decode("utf-8"))
@@ -2844,15 +2825,11 @@ class TestGetReportsSummary:
         assert body == fake
         mock_summary.assert_called_once_with(client=None, period=None)
 
-    def test_forwards_client_and_period_query(
-        self, wizard: ConfigureWizard
-    ) -> None:
+    def test_forwards_client_and_period_query(self, wizard: ConfigureWizard) -> None:
         with patch(
             "mureo.web.handlers.build_report_summary", return_value={}
         ) as mock_summary:
-            resp = _get(
-                wizard, self.ROUTE + "?client=acme&period=LAST_7_DAYS"
-            )
+            resp = _get(wizard, self.ROUTE + "?client=acme&period=LAST_7_DAYS")
         assert resp.status == 200
         mock_summary.assert_called_once_with(client="acme", period="LAST_7_DAYS")
 
@@ -2903,9 +2880,7 @@ class TestGetCreativeRuns:
 
     ROUTE = "/api/creative/runs"
 
-    def test_forwards_client_and_relays_payload(
-        self, wizard: ConfigureWizard
-    ) -> None:
+    def test_forwards_client_and_relays_payload(self, wizard: ConfigureWizard) -> None:
         fake = {"client": "acme", "runs": []}
         with patch(
             "mureo.web.handlers.list_creative_runs", return_value=fake
@@ -2930,9 +2905,7 @@ class TestGetCreativeImage:
 
     ROUTE = "/api/creative/image?client=default&run=r1&file=a.png"
 
-    def test_serves_png_bytes(
-        self, wizard: ConfigureWizard, tmp_path: Path
-    ) -> None:
+    def test_serves_png_bytes(self, wizard: ConfigureWizard, tmp_path: Path) -> None:
         png = tmp_path / "a.png"
         png.write_bytes(b"\x89PNG gallery bytes")
         with patch(
@@ -2945,9 +2918,10 @@ class TestGetCreativeImage:
         mock_resolve.assert_called_once_with("default", "r1", "a.png")
 
     def test_refusal_maps_to_404(self, wizard: ConfigureWizard) -> None:
-        with patch(
-            "mureo.web.handlers.resolve_gallery_image", return_value=None
-        ), pytest.raises(urllib.error.HTTPError) as exc:
+        with (
+            patch("mureo.web.handlers.resolve_gallery_image", return_value=None),
+            pytest.raises(urllib.error.HTTPError) as exc,
+        ):
             _get(wizard, self.ROUTE)
         assert exc.value.code == 404
 
@@ -2962,8 +2936,9 @@ class TestGetCreativeImage:
         """A file that disappears between resolution and read (TOCTOU on a
         live run dir) must map to the same uniform 404."""
         ghost = tmp_path / "gone.png"
-        with patch(
-            "mureo.web.handlers.resolve_gallery_image", return_value=ghost
-        ), pytest.raises(urllib.error.HTTPError) as exc:
+        with (
+            patch("mureo.web.handlers.resolve_gallery_image", return_value=ghost),
+            pytest.raises(urllib.error.HTTPError) as exc,
+        ):
             _get(wizard, self.ROUTE)
         assert exc.value.code == 404

--- a/tests/test_web_setup_actions_host.py
+++ b/tests/test_web_setup_actions_host.py
@@ -30,12 +30,15 @@ from __future__ import annotations
 
 import json
 import platform
-from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from mureo.web.setup_actions import ActionResult
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def _desktop_cfg(tmp_path: Path) -> Path:
@@ -76,17 +79,13 @@ class TestInstallMureoMcpHost:
         with patch(
             "mureo.auth_setup.install_mcp_config", return_value=None
         ) as mock_cfg:
-            result = setup_actions.install_mureo_mcp(
-                home=tmp_path, host="claude-code"
-            )
+            result = setup_actions.install_mureo_mcp(home=tmp_path, host="claude-code")
 
         assert result.status == "noop"
         assert result.detail == "already_configured"
         mock_cfg.assert_called_once_with(scope="global")
 
-    def test_desktop_host_writes_desktop_config_darwin(
-        self, tmp_path: Path
-    ) -> None:
+    def test_desktop_host_writes_desktop_config_darwin(self, tmp_path: Path) -> None:
         """``host="claude-desktop"`` on macOS writes the Desktop config
         (``mcpServers.mureo``), NOT ``settings.json``."""
         from mureo.web import setup_actions
@@ -109,9 +108,7 @@ class TestInstallMureoMcpHost:
         # The Code settings.json must NOT have been written.
         assert not (tmp_path / ".claude" / "settings.json").exists()
 
-    def test_desktop_host_already_configured_is_noop(
-        self, tmp_path: Path
-    ) -> None:
+    def test_desktop_host_already_configured_is_noop(self, tmp_path: Path) -> None:
         """An existing Desktop ``mureo`` entry → ``noop already_configured``;
         file unchanged."""
         from mureo.web import setup_actions
@@ -133,9 +130,7 @@ class TestInstallMureoMcpHost:
         assert result.detail == "already_configured"
         assert cfg.read_bytes() == before
 
-    def test_desktop_host_preserves_other_servers(
-        self, tmp_path: Path
-    ) -> None:
+    def test_desktop_host_preserves_other_servers(self, tmp_path: Path) -> None:
         """A pre-existing non-mureo Desktop server + unrelated top-level
         key survive the Desktop install."""
         from mureo.web import setup_actions
@@ -153,18 +148,14 @@ class TestInstallMureoMcpHost:
         )
 
         with patch.object(platform, "system", return_value="Darwin"):
-            setup_actions.install_mureo_mcp(
-                home=tmp_path, host="claude-desktop"
-            )
+            setup_actions.install_mureo_mcp(home=tmp_path, host="claude-desktop")
 
         payload = json.loads(cfg.read_text(encoding="utf-8"))
         assert payload["mcpServers"]["other"] == {"command": "node"}
         assert payload["theme"] == "dark"
         assert "mureo" in payload["mcpServers"]
 
-    def test_desktop_host_corrupt_config_returns_error(
-        self, tmp_path: Path
-    ) -> None:
+    def test_desktop_host_corrupt_config_returns_error(self, tmp_path: Path) -> None:
         """Corrupt Desktop config → ``status="error"`` (degrades, no
         500); original file untouched."""
         from mureo.web import setup_actions
@@ -182,9 +173,7 @@ class TestInstallMureoMcpHost:
         assert result.status == "error"
         assert cfg.read_bytes() == before
 
-    def test_desktop_host_non_darwin_falls_back_no_raise(
-        self, tmp_path: Path
-    ) -> None:
+    def test_desktop_host_non_darwin_falls_back_no_raise(self, tmp_path: Path) -> None:
         """Non-macOS + Desktop → host_paths fallback to
         ``<home>/.claude/settings.json``; no unsupported-platform error,
         mureo block present (acceptance criteria L23 / L118)."""
@@ -222,16 +211,12 @@ class TestInstallAuthHookHost:
         assert result.status == "ok"
         mock_guard.assert_called_once()
 
-    def test_desktop_host_returns_noop_unsupported(
-        self, tmp_path: Path
-    ) -> None:
+    def test_desktop_host_returns_noop_unsupported(self, tmp_path: Path) -> None:
         """``host="claude-desktop"`` → ``noop`` /
         ``detail="unsupported_on_desktop"``."""
         from mureo.web import setup_actions
 
-        with patch(
-            "mureo.auth_setup.install_credential_guard"
-        ) as mock_guard:
+        with patch("mureo.auth_setup.install_credential_guard") as mock_guard:
             result = setup_actions.install_auth_hook(
                 home=tmp_path, host="claude-desktop"
             )
@@ -250,18 +235,29 @@ class TestInstallAuthHookHost:
 
         assert before == after
 
-    def test_desktop_host_does_not_mark_part_hook(
+    def test_desktop_host_never_reports_the_hook_installed(
         self, tmp_path: Path
     ) -> None:
-        """Desktop hook is a no-op so ``PART_HOOK`` must NOT be marked
-        installed (dashboard must show "not applicable", not "installed").
-        Planner HANDOFF Q2 / risk L146."""
+        """Desktop has no ``PreToolUse`` surface, so the install is a no-op and
+        the dashboard must show "not applicable", not "installed" (planner
+        HANDOFF Q2 / risk L146).
+
+        Asserted against the *status*, which since #423 is detected rather than
+        recalled from a flag — so this now holds because there is no hook on
+        disk to find, not because an installer remembered to skip a write.
+        """
         from mureo.web import setup_actions
-        from mureo.web.setup_state import read_setup_state
+        from mureo.web.host_paths import get_host_paths
+        from mureo.web.status_collector import collect_status
 
         setup_actions.install_auth_hook(home=tmp_path, host="claude-desktop")
 
-        assert read_setup_state(home=tmp_path).auth_hook is False
+        snap = collect_status(
+            "claude-desktop",
+            home=tmp_path,
+            paths=get_host_paths("claude-desktop", tmp_path),
+        )
+        assert snap.setup_parts.auth_hook is False
 
 
 # ---------------------------------------------------------------------------
@@ -283,9 +279,7 @@ class TestInstallWorkflowSkillsHost:
         assert result.status == "ok"
         mock_skills.assert_called_once()
 
-    def test_desktop_host_same_dir_and_count_as_code(
-        self, tmp_path: Path
-    ) -> None:
+    def test_desktop_host_same_dir_and_count_as_code(self, tmp_path: Path) -> None:
         """Skills behaviour is identical for both hosts (shared
         ``~/.claude/skills`` — planner HANDOFF Q3)."""
         from mureo.web import setup_actions
@@ -367,9 +361,7 @@ class TestRemoveMureoMcpHost:
         assert "mureo" not in payload["mcpServers"]
         assert payload["mcpServers"]["other"] == {"command": "node"}
 
-    def test_desktop_host_idempotent_noop_when_absent(
-        self, tmp_path: Path
-    ) -> None:
+    def test_desktop_host_idempotent_noop_when_absent(self, tmp_path: Path) -> None:
         """Second Desktop remove (mureo already gone) → ``noop``."""
         from mureo.web import setup_actions
 
@@ -407,14 +399,10 @@ class TestRemoveAuthHookHost:
         assert result.status == "ok"
         mock_remove.assert_called_once()
 
-    def test_desktop_host_returns_noop_unsupported(
-        self, tmp_path: Path
-    ) -> None:
+    def test_desktop_host_returns_noop_unsupported(self, tmp_path: Path) -> None:
         from mureo.web import setup_actions
 
-        with patch(
-            "mureo.web.setup_actions.remove_credential_guard"
-        ) as mock_remove:
+        with patch("mureo.web.setup_actions.remove_credential_guard") as mock_remove:
             result = setup_actions.remove_auth_hook(
                 home=tmp_path, host="claude-desktop"
             )
@@ -470,9 +458,7 @@ class TestClearAllSetupHost:
         mock_mcp.assert_called_once()
         mock_hook.assert_called_once()
 
-    def test_desktop_host_propagates_host_to_mcp_and_hook(
-        self, tmp_path: Path
-    ) -> None:
+    def test_desktop_host_propagates_host_to_mcp_and_hook(self, tmp_path: Path) -> None:
         """``clear_all_setup(host="claude-desktop")`` passes
         ``host="claude-desktop"`` into the per-step mcp + hook removers."""
         from mureo.web import setup_actions
@@ -497,9 +483,7 @@ class TestClearAllSetupHost:
                 return_value=[],
             ),
         ):
-            setup_actions.clear_all_setup(
-                home=tmp_path, host="claude-desktop"
-            )
+            setup_actions.clear_all_setup(home=tmp_path, host="claude-desktop")
 
         for mock_fn in (mock_mcp, mock_hook):
             kwargs = mock_fn.call_args.kwargs
@@ -522,9 +506,7 @@ class TestClearAllSetupHost:
 
         with (
             patch.object(platform, "system", return_value="Darwin"),
-            patch(
-                "mureo.web.setup_actions.remove_credential_guard"
-            ) as mock_guard,
+            patch("mureo.web.setup_actions.remove_credential_guard") as mock_guard,
             patch(
                 "mureo.web.setup_actions.remove_skills",
                 return_value=(0, tmp_path / ".claude" / "skills"),
@@ -542,9 +524,7 @@ class TestClearAllSetupHost:
         assert envelope["auth_hook"]["detail"] == "unsupported_on_desktop"
         mock_guard.assert_not_called()
 
-    def test_desktop_host_never_touches_credentials_json(
-        self, tmp_path: Path
-    ) -> None:
+    def test_desktop_host_never_touches_credentials_json(self, tmp_path: Path) -> None:
         """CTO decision #3 holds on the Desktop bulk path too."""
         from mureo.web import setup_actions
 
@@ -562,9 +542,7 @@ class TestClearAllSetupHost:
 
         with (
             patch.object(platform, "system", return_value="Darwin"),
-            patch(
-                "mureo.web.setup_actions.remove_credential_guard"
-            ),
+            patch("mureo.web.setup_actions.remove_credential_guard"),
             patch(
                 "mureo.web.setup_actions.remove_skills",
                 return_value=(0, tmp_path / ".claude" / "skills"),
@@ -574,9 +552,7 @@ class TestClearAllSetupHost:
                 return_value=[],
             ),
         ):
-            setup_actions.clear_all_setup(
-                home=tmp_path, host="claude-desktop"
-            )
+            setup_actions.clear_all_setup(home=tmp_path, host="claude-desktop")
 
         assert creds.exists()
         assert creds.read_bytes() == before
@@ -589,40 +565,28 @@ class TestClearAllSetupHost:
 
 @pytest.mark.unit
 class TestHostParamSignatures:
-    def test_install_mureo_mcp_accepts_host_kwarg(
-        self, tmp_path: Path
-    ) -> None:
+    def test_install_mureo_mcp_accepts_host_kwarg(self, tmp_path: Path) -> None:
         from mureo.web import setup_actions
 
-        with patch(
-            "mureo.auth_setup.install_mcp_config", return_value=None
-        ):
+        with patch("mureo.auth_setup.install_mcp_config", return_value=None):
             r1 = setup_actions.install_mureo_mcp(home=tmp_path)
-            r2 = setup_actions.install_mureo_mcp(
-                home=tmp_path, host="claude-code"
-            )
+            r2 = setup_actions.install_mureo_mcp(home=tmp_path, host="claude-code")
 
         assert isinstance(r1, ActionResult)
         assert isinstance(r2, ActionResult)
 
-    def test_remove_mureo_mcp_accepts_host_kwarg(
-        self, tmp_path: Path
-    ) -> None:
+    def test_remove_mureo_mcp_accepts_host_kwarg(self, tmp_path: Path) -> None:
         from mureo.web import setup_actions
 
         with patch(
             "mureo.web.setup_actions.remove_mcp_config",
             return_value=MagicMock(changed=False),
         ):
-            r = setup_actions.remove_mureo_mcp(
-                home=tmp_path, host="claude-code"
-            )
+            r = setup_actions.remove_mureo_mcp(home=tmp_path, host="claude-code")
 
         assert isinstance(r, ActionResult)
 
-    def test_clear_all_setup_accepts_host_kwarg(
-        self, tmp_path: Path
-    ) -> None:
+    def test_clear_all_setup_accepts_host_kwarg(self, tmp_path: Path) -> None:
         from mureo.web import setup_actions
 
         with (
@@ -643,9 +607,7 @@ class TestHostParamSignatures:
                 return_value=[],
             ),
         ):
-            result = setup_actions.clear_all_setup(
-                home=tmp_path, host="claude-code"
-            )
+            result = setup_actions.clear_all_setup(home=tmp_path, host="claude-code")
 
         assert isinstance(result, dict)
 

--- a/tests/test_web_setup_actions_remove.py
+++ b/tests/test_web_setup_actions_remove.py
@@ -3,12 +3,12 @@
 Pins the symmetric uninstall wrappers added per planner HANDOFF
 ``feat-web-config-ui-phase1-uninstall.md``:
 
-- ``remove_mureo_mcp(home)``     → wraps ``settings_remove.remove_mcp_config``,
-                                   then ``clear_part(PART_MCP)``.
-- ``remove_auth_hook(home)``     → wraps ``settings_remove.remove_credential_guard``,
-                                   then ``clear_part(PART_HOOK)``.
-- ``remove_workflow_skills(home)``→ wraps ``setup_cmd.remove_skills``,
-                                   then ``clear_part(PART_SKILLS)``.
+- ``remove_mureo_mcp(home)``     → wraps ``settings_remove.remove_mcp_config``.
+- ``remove_auth_hook(home)``     → wraps ``settings_remove.remove_credential_guard``.
+- ``remove_workflow_skills(home)``→ wraps ``setup_cmd.remove_skills``.
+
+None of them records anything: the dashboard detects each part on disk on
+every status read (#423), so there is no flag to keep in sync.
 - ``clear_all_setup(home)``      → orchestrates the 4 individual removes
                                    + ``remove_legacy_commands`` + iterates
                                    ``mcpServers`` for installed official
@@ -22,14 +22,15 @@ The wrappers return ``ActionResult`` shaped envelopes (status: ok/noop/error).
 
 from __future__ import annotations
 
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from mureo.web.setup_actions import ActionResult
 
+if TYPE_CHECKING:
+    from pathlib import Path
 
 # ---------------------------------------------------------------------------
 # remove_mureo_mcp
@@ -59,9 +60,7 @@ class TestRemoveMureoMcp:
         from mureo.web import setup_actions
 
         fake = MagicMock(changed=False)
-        with patch(
-            "mureo.web.setup_actions.remove_mcp_config", return_value=fake
-        ):
+        with patch("mureo.web.setup_actions.remove_mcp_config", return_value=fake):
             result = setup_actions.remove_mureo_mcp(home=tmp_path)
 
         assert result.status == "noop"
@@ -81,51 +80,18 @@ class TestRemoveMureoMcp:
         # The detail should surface the exception type, not the raw message.
         assert result.detail == "RuntimeError"
 
-    def test_clears_part_state_on_success(self, tmp_path: Path) -> None:
-        """After a successful remove, ``setup_state.json``
-        ``mureo_mcp`` flips to False (acceptance criteria L135-L137).
-        Uses the real ``mark_part_installed`` + ``clear_part`` machinery."""
-        from mureo.web import setup_actions
-        from mureo.web.setup_state import (
-            PART_MCP,
-            mark_part_installed,
-            read_setup_state,
-        )
-
-        # Seed the state so we can observe the flip.
-        mark_part_installed(PART_MCP, home=tmp_path)
-        assert read_setup_state(home=tmp_path).mureo_mcp is True
-
-        fake = MagicMock(changed=True)
-        with patch(
-            "mureo.web.setup_actions.remove_mcp_config", return_value=fake
-        ):
-            setup_actions.remove_mureo_mcp(home=tmp_path)
-
-        assert read_setup_state(home=tmp_path).mureo_mcp is False
-
-    def test_does_not_clear_part_state_on_error(self, tmp_path: Path) -> None:
-        """A failed remove must NOT flip the setup-state flag. Otherwise
-        a transient failure would leave the dashboard reporting "not
-        installed" while the on-disk MCP block remains intact."""
-        from mureo.web import setup_actions
-        from mureo.web.setup_state import (
-            PART_MCP,
-            mark_part_installed,
-            read_setup_state,
-        )
-
-        mark_part_installed(PART_MCP, home=tmp_path)
-        assert read_setup_state(home=tmp_path).mureo_mcp is True
-
-        with patch(
-            "mureo.web.setup_actions.remove_mcp_config",
-            side_effect=RuntimeError("kaboom"),
-        ):
-            result = setup_actions.remove_mureo_mcp(home=tmp_path)
-
-        assert result.status == "error"
-        assert read_setup_state(home=tmp_path).mureo_mcp is True
+    # The two tests that lived here asserted that a remove flipped — and a
+    # FAILED remove did not flip — the ``setup_state.json`` flag the status
+    # used to be read from. The second one named the hazard exactly: "a
+    # transient failure would leave the dashboard reporting 'not installed'
+    # while the on-disk MCP block remains intact."
+    #
+    # That hazard is now structural rather than defended: the status is
+    # DETECTED from the MCP registry on every read (#423), so a remove that
+    # failed leaves the block on disk and the next status read simply finds it
+    # and says "installed". There is no flag left to flip, in either
+    # direction. What the status now reports off disk is covered by
+    # ``TestSetupPartsComeFromDisk`` in ``test_web_status_collector.py``.
 
     def test_as_dict_serializable(self, tmp_path: Path) -> None:
         """The returned ``ActionResult`` round-trips through ``as_dict``
@@ -133,9 +99,7 @@ class TestRemoveMureoMcp:
         from mureo.web import setup_actions
 
         fake = MagicMock(changed=True)
-        with patch(
-            "mureo.web.setup_actions.remove_mcp_config", return_value=fake
-        ):
+        with patch("mureo.web.setup_actions.remove_mcp_config", return_value=fake):
             result = setup_actions.remove_mureo_mcp(home=tmp_path)
 
         envelope = result.as_dict()
@@ -184,42 +148,9 @@ class TestRemoveAuthHook:
         assert result.status == "error"
         assert result.detail == "PermissionError"
 
-    def test_clears_part_state_on_success(self, tmp_path: Path) -> None:
-        """``auth_hook`` flag flips False after success."""
-        from mureo.web import setup_actions
-        from mureo.web.setup_state import (
-            PART_HOOK,
-            mark_part_installed,
-            read_setup_state,
-        )
-
-        mark_part_installed(PART_HOOK, home=tmp_path)
-        assert read_setup_state(home=tmp_path).auth_hook is True
-
-        fake = MagicMock(changed=True)
-        with patch(
-            "mureo.web.setup_actions.remove_credential_guard", return_value=fake
-        ):
-            setup_actions.remove_auth_hook(home=tmp_path)
-
-        assert read_setup_state(home=tmp_path).auth_hook is False
-
-    def test_does_not_clear_part_state_on_error(self, tmp_path: Path) -> None:
-        from mureo.web import setup_actions
-        from mureo.web.setup_state import (
-            PART_HOOK,
-            mark_part_installed,
-            read_setup_state,
-        )
-
-        mark_part_installed(PART_HOOK, home=tmp_path)
-        with patch(
-            "mureo.web.setup_actions.remove_credential_guard",
-            side_effect=RuntimeError("kaboom"),
-        ):
-            setup_actions.remove_auth_hook(home=tmp_path)
-
-        assert read_setup_state(home=tmp_path).auth_hook is True
+    # The flag-flip tests that lived here are gone with the flag (#423): the
+    # hook's status is now detected from the host's real hook surface, by the
+    # guard's tag, on every status read.
 
 
 # ---------------------------------------------------------------------------
@@ -269,43 +200,12 @@ class TestRemoveWorkflowSkills:
         assert result.status == "error"
         assert result.detail == "FileNotFoundError"
 
-    def test_clears_part_state_on_success(self, tmp_path: Path) -> None:
-        from mureo.web import setup_actions
-        from mureo.web.setup_state import (
-            PART_SKILLS,
-            mark_part_installed,
-            read_setup_state,
-        )
-
-        mark_part_installed(PART_SKILLS, home=tmp_path)
-        with patch(
-            "mureo.web.setup_actions.remove_skills",
-            return_value=(3, tmp_path / "skills"),
-        ):
-            setup_actions.remove_workflow_skills(home=tmp_path)
-
-        assert read_setup_state(home=tmp_path).skills is False
-
-    def test_clears_part_state_on_noop(self, tmp_path: Path) -> None:
-        """A noop on a previously-installed flag should still flip the
-        flag to False — there are no bundle skills on disk to remove,
-        so "installed" is already inaccurate. Pin this contract here so
-        the dashboard tri-state remains consistent."""
-        from mureo.web import setup_actions
-        from mureo.web.setup_state import (
-            PART_SKILLS,
-            mark_part_installed,
-            read_setup_state,
-        )
-
-        mark_part_installed(PART_SKILLS, home=tmp_path)
-        with patch(
-            "mureo.web.setup_actions.remove_skills",
-            return_value=(0, tmp_path / "skills"),
-        ):
-            setup_actions.remove_workflow_skills(home=tmp_path)
-
-        assert read_setup_state(home=tmp_path).skills is False
+    # The flag-flip tests that lived here are gone with the flag (#423). One of
+    # them existed only to paper over the flag drifting from disk: a *noop*
+    # remove (nothing on disk to delete) still had to force the flag to False
+    # because, as its docstring put it, "installed" was "already inaccurate".
+    # Detecting the skills on every status read removes the class of bug those
+    # tests were patching around — there is nothing left to keep in sync.
 
 
 # ---------------------------------------------------------------------------
@@ -408,9 +308,7 @@ class TestClearAllSetup:
         mock_skills.assert_called_once()
         mock_legacy.assert_called_once()
 
-    def test_uncaught_exception_in_step_is_isolated(
-        self, tmp_path: Path
-    ) -> None:
+    def test_uncaught_exception_in_step_is_isolated(self, tmp_path: Path) -> None:
         """If a wrapper itself raises (not returning an ActionResult),
         ``clear_all_setup`` still runs subsequent steps and reports the
         exception in the envelope. Acceptance criteria L132-L134."""
@@ -440,9 +338,7 @@ class TestClearAllSetup:
         mock_hook.assert_called_once()
         mock_skills.assert_called_once()
 
-    def test_iterates_installed_official_providers(
-        self, tmp_path: Path
-    ) -> None:
+    def test_iterates_installed_official_providers(self, tmp_path: Path) -> None:
         """Bulk path enumerates installed official providers from the
         real registry (``~/.claude.json`` for Claude Code, NOT
         settings.json) and calls ``remove_provider`` for each. CTO
@@ -597,9 +493,7 @@ class TestClearAllSetup:
 
         assert isinstance(result, dict)
 
-    def test_passes_home_through_to_individual_steps(
-        self, tmp_path: Path
-    ) -> None:
+    def test_passes_home_through_to_individual_steps(self, tmp_path: Path) -> None:
         """``home`` is propagated to each per-step wrapper so the
         per-step ``clear_part`` call hits the same state file."""
         from mureo.web import setup_actions
@@ -668,9 +562,7 @@ class TestRemoveActionsSignatures:
         for r in (r1, r2, r3):
             assert isinstance(r, ActionResult)
 
-    def test_remove_workflow_skills_accepts_optional_home(
-        self, tmp_path: Path
-    ) -> None:
+    def test_remove_workflow_skills_accepts_optional_home(self, tmp_path: Path) -> None:
         from mureo.web import setup_actions
 
         with patch(

--- a/tests/test_web_status_collector.py
+++ b/tests/test_web_status_collector.py
@@ -16,8 +16,10 @@ import pytest
 
 from mureo.web.host_paths import HostPaths
 from mureo.web.status_collector import (
+    MUREO_NATIVE_ID,
     StatusSnapshot,
     _mask_value,
+    _shipped_skill_names,
     collect_status,
 )
 
@@ -40,7 +42,7 @@ def _paths(tmp_path: Path) -> HostPaths:
 
 
 def _build_home(tmp_path: Path) -> Path:
-    """Return a clean fake home dir (so read_setup_state finds nothing)."""
+    """Return a clean fake home dir, so nothing leaks in from the real one."""
     home = tmp_path / "home"
     (home / ".mureo").mkdir(parents=True, exist_ok=True)
     (home / ".claude" / "commands").mkdir(parents=True, exist_ok=True)
@@ -275,9 +277,7 @@ class TestMureoDisableState:
             json.dumps({"mcpServers": {"mureo": {"command": "python"}}}),
             encoding="utf-8",
         )
-        snap = collect_status(
-            "claude-code", home=_build_home(tmp_path), paths=paths
-        )
+        snap = collect_status("claude-code", home=_build_home(tmp_path), paths=paths)
         assert snap.mureo_disable == {
             "google_ads": False,
             "meta_ads": False,
@@ -300,9 +300,7 @@ class TestMureoDisableState:
             ),
             encoding="utf-8",
         )
-        snap = collect_status(
-            "claude-code", home=_build_home(tmp_path), paths=paths
-        )
+        snap = collect_status("claude-code", home=_build_home(tmp_path), paths=paths)
         assert snap.mureo_disable["google_ads"] is True
         assert snap.mureo_disable["meta_ads"] is False
 
@@ -340,3 +338,229 @@ class TestMultiAccountAuthFlag:
         )
         assert snap.multi_account_auth is True
         assert snap.as_dict()["multi_account_auth"] is True
+
+
+def _install_all_skills(skills_dir: Path) -> None:
+    """Put every skill mureo ships into ``skills_dir``, as an install would."""
+    skills_dir.mkdir(parents=True, exist_ok=True)
+    for name in _shipped_skill_names():
+        (skills_dir / name).mkdir(parents=True, exist_ok=True)
+        (skills_dir / name / "SKILL.md").write_text(
+            "---\nname: x\n---\n", encoding="utf-8"
+        )
+
+
+def _state_file(home: Path) -> Path:
+    """The legacy flag file. Written by these tests only to prove it is now
+    IGNORED — the status comes from disk (#423)."""
+    return home / ".mureo" / "setup_state.json"
+
+
+@pytest.mark.unit
+class TestSetupPartsComeFromDisk:
+    """The three basic-setup rows must be DETECTED, not recalled (#423).
+
+    Every other row on the snapshot is read off the filesystem; these three
+    came from a flag file only the configure UI's own actions ever wrote. So
+    skills installed by ``mureo setup`` (or by hand) read ✗ while present, and
+    skills deleted after a UI install read ✓ while absent. The second is the
+    dangerous direction: the UI asserts a guardrail-bearing component is there
+    when it is not, and nothing prompts the operator to look.
+    """
+
+    def test_skills_on_disk_read_installed_even_with_no_flag(
+        self, tmp_path: Path
+    ) -> None:
+        paths = _paths(tmp_path)
+        home = _build_home(tmp_path)  # no flag file written at all
+        _install_all_skills(paths.skills_dir)
+
+        snap = collect_status("claude-code", home=home, paths=paths)
+
+        assert snap.setup_parts.skills is True
+
+    def test_skills_absent_read_not_installed_despite_the_flag(
+        self, tmp_path: Path
+    ) -> None:
+        """The false-POSITIVE direction: the flag says yes, the disk says no."""
+        paths = _paths(tmp_path)
+        home = _build_home(tmp_path)
+        _write_json(
+            _state_file(home),
+            {"mureo_mcp": True, "auth_hook": True, "skills": True},
+        )
+
+        snap = collect_status("claude-code", home=home, paths=paths)
+
+        assert snap.setup_parts.skills is False
+
+    def test_a_partial_install_reads_not_installed(self, tmp_path: Path) -> None:
+        """One skill missing means the install is incomplete — say so, so the
+        operator re-runs it, rather than reporting a half-installed set as ✓."""
+        import shutil
+
+        paths = _paths(tmp_path)
+        home = _build_home(tmp_path)
+        _install_all_skills(paths.skills_dir)
+        victim = sorted(p.name for p in paths.skills_dir.iterdir())[0]
+        shutil.rmtree(paths.skills_dir / victim)
+
+        snap = collect_status("claude-code", home=home, paths=paths)
+
+        assert snap.setup_parts.skills is False
+
+    def test_mureo_mcp_cannot_contradict_the_provider_detection(
+        self, tmp_path: Path
+    ) -> None:
+        """One snapshot could say ``setup_parts.mureo_mcp = True`` while
+        ``providers_installed["mureo"] = False`` — two sources of truth for one
+        fact, read in the same call."""
+        paths = _paths(tmp_path)
+        home = _build_home(tmp_path)
+        _write_json(_state_file(home), {"mureo_mcp": True})
+        _write_json(paths.mcp_registry_path, {"mcpServers": {}})  # mureo absent
+
+        snap = collect_status("claude-code", home=home, paths=paths)
+
+        assert snap.providers_installed[MUREO_NATIVE_ID] is False
+        assert snap.setup_parts.mureo_mcp is False
+
+    def test_auth_hook_is_read_from_the_settings_file(self, tmp_path: Path) -> None:
+        from mureo.credential_guard import GUARD_TAG
+
+        paths = _paths(tmp_path)
+        home = _build_home(tmp_path)
+        _write_json(
+            paths.settings_path,
+            {
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": f'python3 -c "..." # {GUARD_TAG}',
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+        )
+
+        snap = collect_status("claude-code", home=home, paths=paths)
+
+        assert snap.setup_parts.auth_hook is True
+
+    def test_auth_hook_absent_reads_not_installed_despite_the_flag(
+        self, tmp_path: Path
+    ) -> None:
+        paths = _paths(tmp_path)
+        home = _build_home(tmp_path)
+        _write_json(_state_file(home), {"auth_hook": True})
+        _write_json(paths.settings_path, {"hooks": {}})  # guard not installed
+
+        snap = collect_status("claude-code", home=home, paths=paths)
+
+        assert snap.setup_parts.auth_hook is False
+
+    def test_a_users_own_hook_is_not_claimed_as_ours(self, tmp_path: Path) -> None:
+        """Detection is scoped to the entry's own ``command``, via the same
+        ``is_guard_entry`` the installer and remover use — so an unrelated hook
+        never reads as mureo's guard."""
+        paths = _paths(tmp_path)
+        home = _build_home(tmp_path)
+        _write_json(
+            paths.settings_path,
+            {
+                "hooks": {
+                    "PreToolUse": [
+                        {"hooks": [{"type": "command", "command": "echo hi"}]}
+                    ]
+                }
+            },
+        )
+
+        snap = collect_status("claude-code", home=home, paths=paths)
+
+        assert snap.setup_parts.auth_hook is False
+
+
+@pytest.mark.unit
+class TestDetectorsAgreeWithTheRealInstallers:
+    """Round-trip the real installers through the detectors (#423).
+
+    The detectors read a shape somebody else writes. Hand-written fixtures pin
+    the reader against a shape that was true when the test was authored — they
+    would keep passing if the *writer* moved. These call the actual installers,
+    so the two cannot drift apart in silence.
+    """
+
+    def test_credential_guard_install_then_remove_round_trips(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from mureo.auth_setup import install_credential_guard
+        from mureo.cli.settings_remove import remove_credential_guard
+
+        home = _build_home(tmp_path)
+        monkeypatch.setattr("pathlib.Path.home", lambda: home)
+        paths = dataclasses.replace(
+            _paths(tmp_path), settings_path=home / ".claude" / "settings.json"
+        )
+
+        install_credential_guard()
+        assert (
+            collect_status("claude-code", home=home, paths=paths).setup_parts.auth_hook
+            is True
+        )
+
+        remove_credential_guard(settings_path=paths.settings_path)
+        assert (
+            collect_status("claude-code", home=home, paths=paths).setup_parts.auth_hook
+            is False
+        )
+
+    def test_codex_guard_is_found_beside_the_codex_config(self, tmp_path: Path) -> None:
+        """Codex keeps hooks in ``hooks.json`` next to ``config.toml``. The
+        detector derives that from the resolved HostPaths, so it reads the same
+        tree as the rest of the snapshot — never the operator's real ~/.codex.
+        """
+        from mureo.cli.setup_codex import install_codex_credential_guard
+        from mureo.web.host_paths import get_host_paths
+
+        home = _build_home(tmp_path)
+        paths = get_host_paths("codex", home)
+
+        assert collect_status(
+            "codex", home=home, paths=paths
+        ).setup_parts.auth_hook is (False)
+
+        install_codex_credential_guard(paths.settings_path.parent / "hooks.json")
+
+        assert (
+            collect_status("codex", home=home, paths=paths).setup_parts.auth_hook
+            is True
+        )
+
+    def test_skills_install_then_remove_round_trips(self, tmp_path: Path) -> None:
+        from mureo.cli.setup_cmd import install_skills, remove_skills
+
+        home = _build_home(tmp_path)
+        paths = _paths(tmp_path)
+
+        assert (
+            collect_status("claude-code", home=home, paths=paths).setup_parts.skills
+            is False
+        )
+
+        install_skills(target_dir=paths.skills_dir)
+        assert (
+            collect_status("claude-code", home=home, paths=paths).setup_parts.skills
+            is True
+        )
+
+        remove_skills(target_dir=paths.skills_dir)
+        assert (
+            collect_status("claude-code", home=home, paths=paths).setup_parts.skills
+            is False
+        )


### PR DESCRIPTION
Closes #423.

## The bug

Every row on the configure dashboard's status snapshot is read off the filesystem — except the three basic-setup rows (mureo MCP / credential-guard hook / workflow skills), which came from `~/.mureo/setup_state.json`: a record only the dashboard's own actions ever wrote.

```python
setup_parts = read_setup_state(home)                                   # ← a recorded bool
providers   = _detect_installed_providers(resolved.mcp_registry_path)  # ← the real file
creds       = _detect_credentials_present(resolved.credentials_path)   # ← the real file
legacy      = _detect_legacy_commands(resolved.commands_dir)           # ← the real dir
```

So the record drifted from reality the moment anything else touched the filesystem:

- Skills installed with `mureo setup`, or by hand → **✗ while present**. This is the reported symptom: `setup_state.json` reading `{"skills": false}` on a machine carrying all 26 skills.
- A component deleted after a dashboard install → **✓ while absent**. The dangerous direction: the UI asserts a guardrail-bearing component is there when it is not, and nothing prompts the operator to look.

It was not even the only source of truth. `_detect_installed_providers` already reports `providers_installed["mureo"]` from the host's real MCP registry, so a single `collect_status()` call could return `setup_parts.mureo_mcp = True` next to `providers_installed["mureo"] = False`.

## The fix

Detect each part on every read, from the paths `HostPaths` already resolves — no new plumbing.

- **`mureo_mcp`** — reuses the provider detection above. The second source of truth is *deleted*, not reconciled.
- **`auth_hook`** — the host's real hook surface, matched with `credential_guard.is_guard_entry`: the same predicate the installer and the remover use, scoped to the entry's inner `command`, so a user's own hook is never claimed as ours and there is only one definition of "is this our guard" to keep correct. Desktop has no `PreToolUse` surface, so it stays False there. Codex keeps hooks in `hooks.json` beside its config; that path is derived from the resolved `HostPaths` rather than a separately-threaded home, so it can never read a different tree than the rest of the snapshot.
- **`skills`** — presence in the host's skills dir. A *partial* install reads as not-installed: the remedy is the same either way (re-run the install, which overwrites), and a half-installed set reported as ✓ is how an operator ends up without the workflow they think they have. Staleness (installed, but from an older mureo) is version drift and stays with the upgrade action.

`setup_state.json` is no longer written or read — `mark_part_installed` / `clear_part` and the reader/writer go with it. A file left behind by an older mureo is simply ignored.

Two of the deleted tests existed only to paper over the drift. One forced the flag to False on a **noop** remove because, in its own docstring's words, "installed" was "already inaccurate". Detecting the parts removes the class of bug they were patching around, rather than defending against it.

## Tests

TDD, red first.

- `TestSetupPartsComeFromDisk` (7 cases) — pins both failure directions: present-but-flagless reads ✓, absent-but-flagged reads ✗, a partial skill install reads ✗, `mureo_mcp` can no longer contradict the provider detection within one snapshot, and a user's own hook is not claimed as mureo's.
- `TestDetectorsAgreeWithTheRealInstallers` (3 cases) — round-trips the **real** installers through the detectors (`install_credential_guard` / `install_codex_credential_guard` / `install_skills`, then the matching removers) instead of hand-written fixtures. A fixture pins the reader against a shape that was true when the test was written; it would keep passing if the *writer* moved. This cannot.

Full suite: **5493 passed, 7 skipped**. `ruff` / `black` clean.
