### PR TITLE
feat(web): allow a "reports" DashboardCard group so extensions can add Reports-tab actions (#425)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Extensions can contribute a `DashboardCard` to the Reports tab (#425).**
+  `BUILTIN_CARD_GROUPS` previously allowed only `"advanced"`, where operator
+  *settings* live; `"reports"` is now a second accepted group so an extension
+  can place an operator reporting action (e.g. "refresh every client's numbers
+  now") beside the built-in report cards rather than under Advanced or in a
+  whole separate tab. Purely additive — extensions using only `"advanced"` are
+  unaffected; a `DashboardCard(group="reports")` raises `ValueError` on an older
+  mureo, so a downstream extension version-gates on this release. Same safety
+  contract as before (no inline-executable HTML; behaviour ships as
+  `StaticAsset` scripts/styles).
+
 ### Fixed
 
 - **The configure dashboard now detects the basic-setup components instead of

--- a/docs/plugin-authoring.md
+++ b/docs/plugin-authoring.md
@@ -1900,11 +1900,15 @@ class MyExtension:
 
 Contract:
 
-- `group` must be one of `BUILTIN_CARD_GROUPS` (currently only
-  `"advanced"`) — a fixed allowlist, mirroring the
-  `hidden_builtin_tabs` discipline, so plugins never couple to
-  arbitrary internals of the app layout. An unknown group raises at
-  `DashboardCard` construction and skips the extension.
+- `group` must be one of `BUILTIN_CARD_GROUPS` (`"advanced"` for an
+  operator setting beside a built-in settings card, or `"reports"` for a
+  reporting action beside the built-in report cards) — a fixed allowlist,
+  mirroring the `hidden_builtin_tabs` discipline, so plugins never couple
+  to arbitrary internals of the app layout. An unknown group raises at
+  `DashboardCard` construction and skips the extension. A card in a group
+  a given mureo does not yet accept (e.g. `"reports"` before this release)
+  raises `ValueError`, so version-gate a new-group card on the mureo
+  release that added it.
 - The fragment obeys the same sanitisation as `view()` — no inline
   `<script>` / `<style>` / `on*=` / `javascript:`; ship behaviour and
   styling as `StaticAsset` `scripts` / `styles`, served from

--- a/mureo/_data/web/extensions.js
+++ b/mureo/_data/web/extensions.js
@@ -15,8 +15,8 @@
 // ``/static/ext/<name>/<filename>`` (same origin) so the loads pass.
 //
 // Extensions may additionally ship ``dashboard_cards`` — fragments
-// injected into BUILT-IN dashboard groups (allowlisted; currently the
-// "advanced" group only). Cards render eagerly at discovery time (the
+// injected into BUILT-IN dashboard groups (allowlisted: the "advanced"
+// and "reports" groups). Cards render eagerly at discovery time (the
 // built-in tab's click path belongs to dashboard.js, so there is no
 // lazy hook), and card assets load through the same
 // ``/static/ext/<name>/…`` URLs.
@@ -35,7 +35,7 @@
   // Mirrors BUILTIN_CARD_GROUPS in ``mureo/web/extensions.py`` — the
   // server already validates, but a client-side allowlist keeps a
   // malformed payload from writing into an arbitrary group node.
-  const CARD_GROUPS = ["advanced"];
+  const CARD_GROUPS = ["advanced", "reports"];
 
   const _populated = new Set();
   // Every discovered extension (including headless / route-only ones —

--- a/mureo/web/extensions.py
+++ b/mureo/web/extensions.py
@@ -115,7 +115,7 @@ BUILTIN_DASHBOARD_TABS: Final[tuple[str, ...]] = ("setup", "demo", "byod", "dang
 #: group that also appears in ``BUILTIN_DASHBOARD_TABS``, decide what
 #: a card inside a tab hidden via ``hidden_builtin_tabs`` should do —
 #: today the two sets are disjoint so a card can never be hidden.
-BUILTIN_CARD_GROUPS: Final[tuple[str, ...]] = ("advanced",)
+BUILTIN_CARD_GROUPS: Final[tuple[str, ...]] = ("advanced", "reports")
 
 #: Inline-executable patterns banned in ``html_fragment``. The
 #: configure-UI CSP forbids ``unsafe-inline`` so these would not
@@ -253,13 +253,15 @@ class ViewContribution:
 @dataclass(frozen=True)
 class DashboardCard:
     """One extension-supplied card rendered INSIDE a built-in dashboard
-    group (``group`` must be one of :data:`BUILTIN_CARD_GROUPS`,
-    currently only ``"advanced"``).
+    group (``group`` must be one of :data:`BUILTIN_CARD_GROUPS`:
+    ``"advanced"`` or ``"reports"``).
 
-    For small, operator-wide companion settings that belong next to an
-    existing built-in card — e.g. a plugin that pairs a write-side
-    setting with the built-in "External advisor MCP" (read-side) card —
-    where a whole extension tab would be disproportionate.
+    For a small companion that belongs next to an existing built-in card,
+    where a whole extension tab would be disproportionate — e.g. a plugin
+    that pairs a write-side setting with the built-in "External advisor
+    MCP" (read-side) card under ``"advanced"``, or an operator reporting
+    action (refresh every client's numbers now) beside the report cards
+    under ``"reports"`` (#425).
 
     Same safety contract as :class:`ViewContribution`: the fragment may
     not contain inline-executable content; behaviour ships as
@@ -357,9 +359,9 @@ class WebExtension(Protocol):
       (later claims are downgraded with a warning). Added in #189.
     * ``dashboard_cards() -> tuple[DashboardCard, ...]`` — cards the
       renderer injects into built-in dashboard groups (each card's
-      ``group`` must be in :data:`BUILTIN_CARD_GROUPS`; currently only
-      ``"advanced"``). Use for small operator-wide settings that pair
-      with a built-in card and do not warrant a whole extension tab;
+      ``group`` must be in :data:`BUILTIN_CARD_GROUPS`: ``"advanced"``
+      or ``"reports"``). Use for a small companion that pairs with a
+      built-in card and does not warrant a whole extension tab;
       an extension may ship cards with or without a ``view()``. Called
       exactly once during discovery, like ``view()``. A non-callable
       attribute, a non-tuple return, or a non-``DashboardCard``

--- a/tests/test_web_assets_extension_dashboard_cards.py
+++ b/tests/test_web_assets_extension_dashboard_cards.py
@@ -22,8 +22,25 @@ def _read(name: str) -> str:
 def test_extensions_js_declares_card_group_allowlist() -> None:
     js = _read("extensions.js")
     # Mirrors BUILTIN_CARD_GROUPS in mureo/web/extensions.py — widening
-    # one side without the other is a bug this assertion surfaces.
-    assert 'const CARD_GROUPS = ["advanced"];' in js
+    # one side without the other is a bug this assertion surfaces (#425
+    # added "reports").
+    assert 'const CARD_GROUPS = ["advanced", "reports"];' in js
+
+
+@pytest.mark.unit
+def test_extensions_js_card_group_allowlist_matches_python() -> None:
+    """The client allowlist must equal ``BUILTIN_CARD_GROUPS`` exactly — a
+    group accepted by the Python constructor but missing here would let a card
+    validate on the server and then silently never render (#425)."""
+    import re
+
+    from mureo.web.extensions import BUILTIN_CARD_GROUPS
+
+    js = _read("extensions.js")
+    match = re.search(r"const CARD_GROUPS = (\[[^\]]*\]);", js)
+    assert match is not None, "CARD_GROUPS declaration not found"
+    js_groups = re.findall(r'"([^"]+)"', match.group(1))
+    assert tuple(js_groups) == BUILTIN_CARD_GROUPS
 
 
 @pytest.mark.unit

--- a/tests/test_web_extensions.py
+++ b/tests/test_web_extensions.py
@@ -949,6 +949,29 @@ def test_dashboard_card_rejects_unknown_group() -> None:
 
 
 @pytest.mark.unit
+def test_reports_is_an_allowed_card_group() -> None:
+    """#425: an extension can contribute a card to the Reports tab, not only
+    Advanced — an operator reporting action (e.g. refresh every client now)
+    belongs beside the report cards, not under operator settings."""
+    from mureo.web.extensions import BUILTIN_CARD_GROUPS, DashboardCard
+
+    assert "reports" in BUILTIN_CARD_GROUPS
+    card = DashboardCard(group="reports", html_fragment="<p>hi</p>")
+    assert card.group == "reports"
+
+
+@pytest.mark.unit
+def test_advanced_is_still_an_allowed_card_group() -> None:
+    """The addition is purely additive — the existing group keeps working."""
+    from mureo.web.extensions import BUILTIN_CARD_GROUPS, DashboardCard
+
+    assert "advanced" in BUILTIN_CARD_GROUPS
+    assert (
+        DashboardCard(group="advanced", html_fragment="<p>hi</p>").group == "advanced"
+    )
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize(
     "html",
     [


### PR DESCRIPTION
Closes #425.

## Motivation

`BUILTIN_CARD_GROUPS` accepted only `"advanced"`, which is where operator **settings** live (the team-advisor write card, etc.). A multi-account layer built on the reporting seam wants to offer an operator-facing action — "refresh every client's numbers now", a cross-client daily-check — and its natural home is the **Reports** tab, beside the per-client report cards the seam already drives. Advanced is a poor fit for a reporting action, and a whole separate extension tab duplicates the Reports surface.

This is the exact companion case `DashboardCard`'s docstring already anticipates, just for a second built-in group.

## Change

- `mureo/web/extensions.py` — `BUILTIN_CARD_GROUPS = ("advanced", "reports")`; docstrings updated.
- `mureo/_data/web/extensions.js` — the client-side `CARD_GROUPS` mirror gains `"reports"` (a card whose group is not in the mirror is filtered out before render, so both sides must widen together).
- `docs/plugin-authoring.md` + `CHANGELOG.md`.

**No server schema change.** `handlers.py` already echoes `card.group`, and the only group gate is `DashboardCard.__post_init__`. The frontend already ships a `data-dashboard-group="reports"` anchor, and `dashboard.js`'s reports render only mutates `[data-reports-*]` descendants of `[data-dashboard-reports]` — never the group container — so a card appended to the group survives a period toggle / client switch / refresh (verified by reading the render path).

`"reports"` is not in `BUILTIN_DASHBOARD_TABS`, so the card-group and hideable-tab sets stay disjoint and a card still cannot land in a `hidden_builtin_tabs`-hidden tab.

## Compatibility

Purely additive. `"advanced"`-only extensions are unaffected. A `DashboardCard(group="reports")` raises `ValueError` on an older mureo, so a downstream extension version-gates on this release (documented in the authoring guide).

## Tests

- `reports` accepted / `advanced` still accepted / unknown group still rejected (`test_web_extensions.py`).
- **Python↔JS parity** (`test_web_assets_extension_dashboard_cards.py`): parses the real `extensions.js` `CARD_GROUPS` array and asserts it equals `BUILTIN_CARD_GROUPS` exactly — widening one side without the other fails red.

Full suite: **5496 passed, 7 skipped**. `ruff` / `black` clean. code-reviewer approved (no CRITICAL/HIGH).
