### PR TITLE
feat(context): canonical report-flag vocabulary + validation

### DIFF
--- a/mureo/analysis/report_flags.py
+++ b/mureo/analysis/report_flags.py
@@ -1,0 +1,167 @@
+"""Canonical vocabulary and normalization for structured report flags.
+
+A daily / weekly / goal report's ``flags`` list drives the coloured chips on
+the read-only Reports dashboard. Historically each flag was a free-form
+snake_case string with its detail baked in
+(``adspot_4311492_invalid_traffic_spike_115740yen_0cv_ctr4.66pct``), which the
+frontend could only render verbatim — cramming per-adspot detail into what is
+meant to be a coarse, at-a-glance tag, and never localizing it.
+
+A STRUCTURED flag fixes both problems::
+
+    {"code": "invalid_traffic_suspected",
+     "severity": "action",
+     "params": {"adspot": "4311492", "spend": 115740, "ctr": 0.0466}}
+
+* ``code`` is drawn from the fixed :data:`FLAG_SEVERITY` vocabulary, so the
+  chip renders a coarse, localizable label (``MUREO.t`` on the frontend)
+  instead of a de-slugged sentence.
+* ``severity`` is one of the four visual buckets in :data:`SEVERITIES`
+  (action / watch / info / positive → danger / warn / neutral / success). It
+  defaults from the code, so most authors omit it.
+* ``params`` carries the detail (adspot ids, yen, ctr) the dashboard shows on
+  drill-down and the narrative — never on the chip face.
+
+The ``custom`` code is an explicit escape hatch for a novel finding that does
+not fit the vocabulary: it carries an author-written ``label`` (a string, or a
+``{locale: text}`` map) and a required ``severity``.
+
+Backward compatibility is a hard requirement: a bare STRING flag is passed
+through untouched (the frontend still humanizes it), so existing STATE.json
+documents and skills keep working. Only object flags are validated.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+#: The severity axis — exactly the four visual buckets the dashboard colours:
+#: ``action`` (danger / red), ``watch`` (warn / amber), ``info`` (neutral /
+#: grey), ``positive`` (success / green). Kept separate from the alarm levels
+#: so a positive ("goals met") or informational ("baseline not yet
+#: established") flag is never mistaken for something needing action.
+SEVERITIES: tuple[str, ...] = ("action", "watch", "info", "positive")
+
+#: Canonical flag code → default severity. The keys ARE the allowed vocabulary
+#: for a non-``custom`` structured flag; the value is the severity stamped when
+#: the author omits one. ``custom`` is deliberately absent — it has no default
+#: and must supply its own label + severity.
+FLAG_SEVERITY: dict[str, str] = {
+    # Goal / target status
+    "cpa_over_target": "watch",
+    "cpa_under_target": "positive",
+    "cv_below_target": "watch",
+    "cv_above_target": "positive",
+    "goals_met": "positive",
+    # Spend / efficiency anomalies
+    "spend_spike": "watch",
+    "cpa_spike": "watch",
+    "invalid_traffic_suspected": "action",
+    "zero_cv_adspots": "watch",
+    "budget_overspend": "action",
+    "budget_drift": "watch",
+    # Measurement / data integrity
+    "tracking_suspect": "action",
+    "zero_conversions": "action",
+    # Setup / operational context
+    "supply_tools_unconfigured": "info",
+    "anomaly_baseline_insufficient": "info",
+    "pending_observations": "info",
+    "search_console_no_property": "info",
+    "ga4_not_configured": "info",
+}
+
+#: The escape-hatch code for a finding outside the vocabulary. It requires an
+#: author-written ``label`` and an explicit ``severity``.
+CUSTOM_CODE = "custom"
+
+
+def normalize_flags(flags: Any) -> list[Any] | None:
+    """Validate and normalize a report's ``flags`` list.
+
+    Returns a NEW list (never mutates the input) where:
+
+    * ``None`` → ``None`` (no flags section).
+    * each bare string is passed through unchanged (legacy flag).
+    * each object flag is validated against the vocabulary and returned with
+      its ``severity`` filled from :data:`FLAG_SEVERITY` when omitted.
+
+    Raises:
+        ValueError: if ``flags`` is not a list, or any element is neither a
+            string nor a valid flag object (unknown code, bad severity,
+            non-object ``params``, or a ``custom`` flag missing its label /
+            severity). The MCP handler surfaces this as a clean tool error.
+    """
+    if flags is None:
+        return None
+    if not isinstance(flags, list):
+        raise ValueError("flags must be a list")
+    return [_normalize_flag(flag) for flag in flags]
+
+
+def _normalize_flag(flag: Any) -> Any:
+    """Normalize one flag element (see :func:`normalize_flags`)."""
+    # Legacy bare-string flag: preserved verbatim for backward compatibility.
+    if isinstance(flag, str):
+        return flag
+    if not isinstance(flag, dict):
+        raise ValueError("each flag must be a string or an object")
+
+    code = flag.get("code")
+    if not isinstance(code, str) or not code:
+        raise ValueError("flag object must carry a non-empty string 'code'")
+
+    severity = flag.get("severity")
+    if code == CUSTOM_CODE:
+        if not _is_valid_label(flag.get("label")):
+            raise ValueError(
+                "custom flag requires a 'label' (a non-empty string or a "
+                "{locale: text} map)"
+            )
+        if severity is None:
+            raise ValueError("custom flag requires an explicit 'severity'")
+    else:
+        if code not in FLAG_SEVERITY:
+            raise ValueError(
+                f"unknown flag code {code!r}; use a canonical code "
+                f"({', '.join(sorted(FLAG_SEVERITY))}) or {CUSTOM_CODE!r}"
+            )
+        if severity is None:
+            severity = FLAG_SEVERITY[code]
+
+    if severity not in SEVERITIES:
+        raise ValueError(
+            f"flag 'severity' must be one of {SEVERITIES}; got {severity!r}"
+        )
+
+    params = flag.get("params")
+    if params is not None and not isinstance(params, dict):
+        raise ValueError("flag 'params' must be an object")
+
+    # Shallow-copy so author extras (e.g. a pre-rendered note) survive, then
+    # stamp the validated / defaulted fields. A new dict — the caller's flag
+    # is never mutated.
+    normalized = dict(flag)
+    normalized["code"] = code
+    normalized["severity"] = severity
+    return normalized
+
+
+def _is_valid_label(label: Any) -> bool:
+    """A ``custom`` flag's label: a non-empty string or a ``{locale: text}``
+    map of non-empty strings.
+
+    Locale keys are intentionally unconstrained at this layer (any non-empty
+    string is accepted, not a BCP-47 shape check): this is trusted-writer
+    content, and the frontend picks the key matching the active configure-UI
+    locale, falling back to a sensible default for anything it does not
+    recognize.
+    """
+    if isinstance(label, str):
+        return bool(label.strip())
+    if isinstance(label, dict):
+        return bool(label) and all(
+            isinstance(k, str) and isinstance(v, str) and bool(v.strip())
+            for k, v in label.items()
+        )
+    return False

--- a/mureo/mcp/_handlers_mureo_context.py
+++ b/mureo/mcp/_handlers_mureo_context.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from mureo.analysis.report_flags import normalize_flags
 from mureo.context.errors import ContextFileError
 from mureo.context.models import ActionLogEntry, CampaignSnapshot, StateDocument
 from mureo.context.state import (
@@ -240,6 +241,11 @@ async def handle_state_report_set(
     # (string / list / number) before it reaches the file.
     if not isinstance(summary, dict):
         raise ValueError("summary must be an object")
+    # Validate + normalize the structured flags (fills default severities,
+    # rejects unknown codes) before they reach STATE.json. Bare-string flags
+    # pass through untouched; a ``summary`` without ``flags`` is left as-is.
+    if "flags" in summary:
+        summary = {**summary, "flags": normalize_flags(summary.get("flags"))}
     path = _resolve_path(arguments, "STATE.json", store_attr="state_path")
     doc = set_report(path, report, summary)
     return _json_result(_state_to_dict(doc))

--- a/mureo/mcp/tools_mureo_context.py
+++ b/mureo/mcp/tools_mureo_context.py
@@ -238,8 +238,19 @@ TOOLS: list[Tool] = [
                     "description": (
                         "Free-form summary object. Convention: generated_at "
                         "(ISO 8601), period, kpis (per-platform / totals "
-                        "headline numbers), flags (list of notable items), "
-                        "narrative (short text)."
+                        "headline numbers), flags, narrative (short text). "
+                        "Each flag is either a legacy snake_case string OR a "
+                        "structured object {code, severity, params}: code is a "
+                        "canonical vocabulary key (e.g. goals_met, "
+                        "invalid_traffic_suspected, budget_drift, "
+                        "zero_cv_adspots, spend_spike, anomaly_baseline_"
+                        "insufficient), severity is action|watch|info|positive "
+                        "(defaulted from code if omitted), and params holds the "
+                        "detail (adspot ids, yen, ctr) — keep detail in params "
+                        "/ narrative, NOT in the code. For a finding outside "
+                        "the vocabulary use {code:'custom', severity, label} "
+                        "where label is a string or {locale: text} map. Unknown "
+                        "non-custom codes are rejected."
                     ),
                 },
                 "path": _PATH_PROPERTY,

--- a/tests/test_mcp_tools_mureo_context.py
+++ b/tests/test_mcp_tools_mureo_context.py
@@ -175,7 +175,7 @@ async def test_strategy_set_backs_up_before_overwrite(cwd_to_tmp) -> None:
 async def test_strategy_set_preserves_unknown_heading(cwd_to_tmp) -> None:
     """An unrecognized heading round-trips and is reported, not dropped."""
     mod = _import_tools()
-    md = "# Strategy\n\n" "## Persona\n30s\n\n" "## Quarterly Notes\nlaunch in Q3\n"
+    md = "# Strategy\n\n## Persona\n30s\n\n## Quarterly Notes\nlaunch in Q3\n"
     result = await mod.handle_tool("mureo_strategy_set", {"markdown": md})
     payload = json.loads(result[0].text)
 
@@ -477,6 +477,66 @@ def test_report_set_schema_enum_constrains_report() -> None:
     assert props["report"]["enum"] == ["daily", "weekly", "goal"]
     assert props["summary"]["type"] == "object"
     assert set(tool.inputSchema["required"]) == {"report", "summary"}
+
+
+async def test_report_set_normalizes_structured_flags(cwd_to_tmp) -> None:
+    """A structured object flag with a known code but no explicit severity is
+    persisted with the vocabulary's default severity filled in."""
+    initial = {"version": "2", "platforms": {}, "action_log": []}
+    (cwd_to_tmp / "STATE.json").write_text(json.dumps(initial), encoding="utf-8")
+    mod = _import_tools()
+    summary = {
+        "narrative": "One adspot spiking.",
+        "flags": [
+            {
+                "code": "invalid_traffic_suspected",
+                "params": {"adspot": "4311492", "spend": 115740, "ctr": 0.0466},
+            }
+        ],
+    }
+    result = await mod.handle_tool(
+        "mureo_state_report_set", {"report": "daily", "summary": summary}
+    )
+    payload = json.loads(result[0].text)
+    flag = payload["reports"]["daily"]["flags"][0]
+    assert flag["code"] == "invalid_traffic_suspected"
+    assert flag["severity"] == "action"
+    assert flag["params"]["adspot"] == "4311492"
+
+
+async def test_report_set_rejects_unknown_flag_code(cwd_to_tmp) -> None:
+    """A non-``custom`` object flag whose code is outside the vocabulary is
+    refused BEFORE it reaches STATE.json — validation is fail-closed, so a
+    rejected write leaves the document byte-for-byte untouched (no partial
+    write). Pinning the on-disk bytes guards the validate-before-write ordering
+    against a future refactor."""
+    initial = {"version": "2", "platforms": {}, "action_log": []}
+    state_path = cwd_to_tmp / "STATE.json"
+    state_path.write_text(json.dumps(initial), encoding="utf-8")
+    before = state_path.read_text(encoding="utf-8")
+    mod = _import_tools()
+    with pytest.raises(ValueError):
+        await mod.handle_tool(
+            "mureo_state_report_set",
+            {
+                "report": "daily",
+                "summary": {"flags": [{"code": "totally_made_up"}]},
+            },
+        )
+    assert state_path.read_text(encoding="utf-8") == before
+
+
+async def test_report_set_preserves_legacy_string_flags(cwd_to_tmp) -> None:
+    """Legacy bare-string flags round-trip unchanged (no normalization)."""
+    initial = {"version": "2", "platforms": {}, "action_log": []}
+    (cwd_to_tmp / "STATE.json").write_text(json.dumps(initial), encoding="utf-8")
+    mod = _import_tools()
+    result = await mod.handle_tool(
+        "mureo_state_report_set",
+        {"report": "daily", "summary": {"flags": ["cpa_over_target"]}},
+    )
+    payload = json.loads(result[0].text)
+    assert payload["reports"]["daily"]["flags"] == ["cpa_over_target"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_report_flags.py
+++ b/tests/test_report_flags.py
@@ -1,0 +1,224 @@
+"""Tests for the canonical report-flag vocabulary and normalization.
+
+A daily / weekly / goal report's ``flags`` list drives the coloured chips on
+the read-only Reports dashboard. Historically each flag was a free-form
+snake_case string with its detail baked in
+(``adspot_4311492_invalid_traffic_spike_115740yen_0cv_ctr4.66pct``), which the
+frontend could only render verbatim — cramming detail into a tag and never
+localizing it. :func:`normalize_flags` lets a skill author a STRUCTURED flag
+(``{code, severity, params}``) drawn from a fixed vocabulary so the chip shows a
+coarse, localizable label while the detail moves into ``params`` (rendered on
+drill-down) and the narrative.
+
+Backward compatibility is a hard requirement: a bare string flag is passed
+through untouched so existing STATE.json / skills keep working.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mureo.analysis.report_flags import FLAG_SEVERITY, SEVERITIES, normalize_flags
+
+pytestmark = pytest.mark.unit
+
+# ---------------------------------------------------------------------------
+# Vocabulary contract
+# ---------------------------------------------------------------------------
+
+
+def test_severities_are_the_four_buckets() -> None:
+    """The severity axis is exactly action / watch / info / positive — the
+    four visual buckets the dashboard colours (danger / warn / neutral /
+    success). Nothing else is a valid severity."""
+    assert set(SEVERITIES) == {"action", "watch", "info", "positive"}
+
+
+def test_vocabulary_covers_the_v1_codes() -> None:
+    """The v1 vocabulary includes the newly-introduced codes plus the ones the
+    dashboard already understood, each mapped to a default severity that is a
+    member of :data:`SEVERITIES`."""
+    expected = {
+        "cpa_over_target": "watch",
+        "cpa_under_target": "positive",
+        "cv_below_target": "watch",
+        "cv_above_target": "positive",
+        "goals_met": "positive",
+        "spend_spike": "watch",
+        "cpa_spike": "watch",
+        "invalid_traffic_suspected": "action",
+        "zero_cv_adspots": "watch",
+        "budget_overspend": "action",
+        "budget_drift": "watch",
+        "tracking_suspect": "action",
+        "zero_conversions": "action",
+        "supply_tools_unconfigured": "info",
+        "anomaly_baseline_insufficient": "info",
+        "pending_observations": "info",
+        "search_console_no_property": "info",
+        "ga4_not_configured": "info",
+    }
+    assert expected == FLAG_SEVERITY
+    assert set(FLAG_SEVERITY.values()) <= set(SEVERITIES)
+    # ``custom`` is the escape hatch — deliberately NOT a canonical code (it
+    # requires an author-supplied label + severity instead of a default).
+    assert "custom" not in FLAG_SEVERITY
+
+
+# ---------------------------------------------------------------------------
+# None / list shape
+# ---------------------------------------------------------------------------
+
+
+def test_none_passes_through() -> None:
+    assert normalize_flags(None) is None
+
+
+def test_empty_list_is_empty_list() -> None:
+    assert normalize_flags([]) == []
+
+
+def test_non_list_is_rejected() -> None:
+    with pytest.raises(ValueError):
+        normalize_flags({"code": "goals_met"})  # a bare object, not a list
+    with pytest.raises(ValueError):
+        normalize_flags("goals_met")
+
+
+# ---------------------------------------------------------------------------
+# Legacy string flags (backward compatibility)
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_string_flag_passes_through_unchanged() -> None:
+    """A bare snake_case string is preserved verbatim — the frontend still
+    humanizes it. This is what keeps existing STATE.json / skills working."""
+    assert normalize_flags(["cpa_over_target"]) == ["cpa_over_target"]
+    # Even an unknown/detail-laden legacy string is preserved (not rejected):
+    raw = "adspot_4311492_invalid_traffic_spike_115740yen_0cv_ctr4.66pct"
+    assert normalize_flags([raw]) == [raw]
+
+
+def test_mixed_legacy_and_structured_flags() -> None:
+    out = normalize_flags(["cpa_over_target", {"code": "goals_met"}])
+    assert out[0] == "cpa_over_target"
+    assert out[1] == {"code": "goals_met", "severity": "positive"}
+
+
+# ---------------------------------------------------------------------------
+# Structured object flags — canonical codes
+# ---------------------------------------------------------------------------
+
+
+def test_known_code_fills_default_severity() -> None:
+    """A known code with no explicit severity is stamped with the vocabulary's
+    default severity for that code."""
+    out = normalize_flags([{"code": "invalid_traffic_suspected"}])
+    assert out == [{"code": "invalid_traffic_suspected", "severity": "action"}]
+
+
+def test_known_code_keeps_explicit_severity_override() -> None:
+    """An author may override the default severity with any valid one."""
+    out = normalize_flags([{"code": "budget_drift", "severity": "action"}])
+    assert out == [{"code": "budget_drift", "severity": "action"}]
+
+
+def test_params_object_is_preserved() -> None:
+    """``params`` carries the detail (adspot / yen / ctr) rendered on
+    drill-down, and is preserved as-is."""
+    params = {"adspot": "4311492", "spend": 115740, "cv": 0, "ctr": 0.0466}
+    out = normalize_flags([{"code": "invalid_traffic_suspected", "params": params}])
+    assert out[0]["params"] == params
+    assert out[0]["severity"] == "action"
+
+
+def test_author_extra_fields_are_preserved() -> None:
+    """Unknown author fields survive normalization (trusted-writer content);
+    only code / severity / params are validated."""
+    out = normalize_flags([{"code": "goals_met", "note": "both goals on trailing 30d"}])
+    assert out[0]["note"] == "both goals on trailing 30d"
+
+
+def test_input_is_not_mutated() -> None:
+    """Normalization returns new objects and never mutates the caller's dict
+    (immutability — no hidden side effects)."""
+    original = {"code": "goals_met"}
+    normalize_flags([original])
+    assert original == {"code": "goals_met"}  # no severity injected in place
+
+
+def test_unknown_code_is_rejected() -> None:
+    """A non-``custom`` code outside the vocabulary is an error — this is what
+    keeps the vocabulary honest and forces authors to either use a canonical
+    code or the explicit ``custom`` escape hatch."""
+    with pytest.raises(ValueError):
+        normalize_flags([{"code": "totally_made_up"}])
+
+
+def test_missing_code_is_rejected() -> None:
+    with pytest.raises(ValueError):
+        normalize_flags([{"severity": "watch"}])
+    with pytest.raises(ValueError):
+        normalize_flags([{"code": ""}])
+
+
+def test_invalid_severity_is_rejected() -> None:
+    with pytest.raises(ValueError):
+        normalize_flags([{"code": "goals_met", "severity": "purple"}])
+
+
+def test_non_dict_params_is_rejected() -> None:
+    with pytest.raises(ValueError):
+        normalize_flags([{"code": "goals_met", "params": "not-an-object"}])
+
+
+def test_flag_that_is_neither_string_nor_object_is_rejected() -> None:
+    with pytest.raises(ValueError):
+        normalize_flags([123])
+    with pytest.raises(ValueError):
+        normalize_flags([None])
+
+
+# ---------------------------------------------------------------------------
+# Structured object flags — the ``custom`` escape hatch
+# ---------------------------------------------------------------------------
+
+
+def test_custom_flag_with_string_label() -> None:
+    out = normalize_flags(
+        [{"code": "custom", "severity": "watch", "label": "Novel finding"}]
+    )
+    assert out == [{"code": "custom", "severity": "watch", "label": "Novel finding"}]
+
+
+def test_custom_flag_with_localized_label_map() -> None:
+    out = normalize_flags(
+        [
+            {
+                "code": "custom",
+                "severity": "info",
+                "label": {"ja": "新種の所見", "en": "Novel finding"},
+            }
+        ]
+    )
+    assert out[0]["label"] == {"ja": "新種の所見", "en": "Novel finding"}
+
+
+def test_custom_flag_requires_label() -> None:
+    with pytest.raises(ValueError):
+        normalize_flags([{"code": "custom", "severity": "watch"}])
+
+
+def test_custom_flag_requires_severity() -> None:
+    """``custom`` has no default severity, so it must be supplied."""
+    with pytest.raises(ValueError):
+        normalize_flags([{"code": "custom", "label": "x"}])
+
+
+def test_custom_flag_rejects_empty_or_bad_label() -> None:
+    with pytest.raises(ValueError):
+        normalize_flags([{"code": "custom", "severity": "watch", "label": "  "}])
+    with pytest.raises(ValueError):
+        normalize_flags([{"code": "custom", "severity": "watch", "label": 42}])
+    with pytest.raises(ValueError):
+        normalize_flags([{"code": "custom", "severity": "watch", "label": {"ja": 1}}])


### PR DESCRIPTION
## Problem

Report-flag chips on the Reports dashboard were free-form snake_case strings
with their detail baked in, e.g. `adspot_4311492_invalid_traffic_spike_115740yen_0cv_ctr4.66pct`.
Read as bare chips they were too detailed for an at-a-glance tag, could not be
localized (English-only in the Japanese UI), and mixed positive/informational
flags in with alarms so a coherent report read as self-contradictory.

## This PR (backend contract — base of a 3-PR stack)

Introduce a **canonical flag vocabulary** and validate/normalize a report's
`flags` at the `mureo_state_report_set` boundary:

- `mureo/analysis/report_flags.py` — `FLAG_SEVERITY` (18 canonical codes →
  default severity), `SEVERITIES` (`action`/`watch`/`info`/`positive`), and
  `normalize_flags()`.
- A structured flag is `{code, severity, params}`: `code` from the vocabulary,
  `severity` defaulted from the code, `params` carrying the detail (adspot ids,
  yen, ctr) — so the chip stays coarse and the numbers move to a drill-down.
- `code: "custom"` is an explicit escape hatch (author-supplied `label` +
  `severity`) for a finding outside the vocabulary. Unknown non-custom codes
  are rejected.
- **Backward compatible**: legacy bare-string flags pass through untouched.
- Fail-closed: validation runs before the STATE.json write (a rejected flag
  never reaches disk).

## Tests

`tests/test_report_flags.py` (vocabulary contract, legacy passthrough, custom
hatch, immutability, boundaries) + handler integration tests in
`tests/test_mcp_tools_mureo_context.py`. ruff/format clean, new code mypy-clean.

## Stack

- **This PR (A)** → `main` — backend vocabulary + validation.
- **PR C** → renders structured flags as coarse, localized chips (frontend/i18n).
- **PR B** → teaches the daily-check skill to author structured flags.

PR B and PR C both depend only on this PR. **Merge order:** merge this PR first;
the children retarget to `main` (retarget before deleting this branch).
