### PR TITLE
feat(skills): structured report flags in weekly-report and goal-review

### DIFF
--- a/mureo/_data/skills/goal-review/SKILL.md
+++ b/mureo/_data/skills/goal-review/SKILL.md
@@ -67,7 +67,12 @@ Review progress toward all marketing goals across all platforms.
    - `generated_at`: ISO 8601 timestamp of this run
    - `period`: the assessment window or "as of" date
    - `kpis`: per-Goal headline numbers (target, current, % of target achieved)
-   - `flags`: a list of notable items (e.g. `["goal_cpa_off_track"]`)
+   - `flags`: a list of **structured** flags — each a small object `{code, severity, params}` so the dashboard renders a coarse, localizable chip with the numbers on drill-down:
+       - `code`: a canonical vocabulary key — one of `goals_met`, `cpa_over_target`, `cpa_under_target`, `cv_below_target`, `cv_above_target`, `spend_spike`, `cpa_spike`, `invalid_traffic_suspected`, `zero_cv_adspots`, `budget_overspend`, `budget_drift`, `tracking_suspect`, `zero_conversions`, `supply_tools_unconfigured`, `anomaly_baseline_insufficient`, `pending_observations`, `search_console_no_property`, `ga4_not_configured`.
+       - `severity`: one of `action`/`watch`/`info`/`positive` (omit to take the code's default — `info`/`positive` keep informational and good-news flags visually distinct from alarms).
+       - `params`: an object holding the DETAIL (target, current, % of target). Keep detail in `params`, **NOT baked into the code** — write `{"code":"cpa_over_target","params":{"cpa":15200}}`, never a slug like `goal_cpa_off_track`.
+       - For a finding outside the vocabulary use `{code:"custom", severity, label}` where `label` is a string or a `{"ja":…,"en":…}` map. Unknown non-`custom` codes are rejected. (A legacy bare-string flag still works but renders without the drill-down — prefer the object form.)
+       - Example: `[{"code":"cpa_over_target","params":{"cpa":15200}}, {"code":"cv_below_target","params":{"cv":18}}]`
    - `narrative`: a short text summary of overall Goal health (on-track / at-risk / off-track)
 
    This is best-effort: if `mureo_state_report_set` is unavailable (e.g. a pure file-mode host without the context MCP), skip it silently — the rest of this skill still works.

--- a/mureo/_data/skills/weekly-report/SKILL.md
+++ b/mureo/_data/skills/weekly-report/SKILL.md
@@ -71,7 +71,12 @@ Generate a weekly marketing operations report.
     - `generated_at`: ISO 8601 timestamp of this run
     - `period`: the reporting window (e.g. `"LAST_7_DAYS"` or an explicit date range)
     - `kpis`: per-platform and/or totals headline numbers (spend, conversions, cpa, week-over-week change)
-    - `flags`: a list of notable items (e.g. `["meta_ads_cpa_up_15pct"]`)
+    - `flags`: a list of **structured** flags — each a small object `{code, severity, params}` so the dashboard renders a coarse, localizable chip with the numbers on drill-down:
+        - `code`: a canonical vocabulary key — one of `goals_met`, `cpa_over_target`, `cpa_under_target`, `cv_below_target`, `cv_above_target`, `spend_spike`, `cpa_spike`, `invalid_traffic_suspected`, `zero_cv_adspots`, `budget_overspend`, `budget_drift`, `tracking_suspect`, `zero_conversions`, `supply_tools_unconfigured`, `anomaly_baseline_insufficient`, `pending_observations`, `search_console_no_property`, `ga4_not_configured`.
+        - `severity`: one of `action`/`watch`/`info`/`positive` (omit to take the code's default — `info`/`positive` keep informational and good-news flags visually distinct from alarms).
+        - `params`: an object holding the DETAIL (platform, yen, cpa, week-over-week change). Keep detail in `params`, **NOT baked into the code** — write `{"code":"cpa_over_target","params":{"cpa":15200}}`, never a slug like `meta_ads_cpa_up_15pct`.
+        - For a finding outside the vocabulary use `{code:"custom", severity, label}` where `label` is a string or a `{"ja":…,"en":…}` map. Unknown non-`custom` codes are rejected. (A legacy bare-string flag still works but renders without the drill-down — prefer the object form.)
+        - Example: `[{"code":"cpa_over_target","params":{"cpa":15200}}, {"code":"goals_met"}]`
     - `narrative`: the 2-3 sentence executive summary
 
     This is best-effort: if `mureo_state_report_set` is unavailable (e.g. a pure file-mode host without the context MCP), skip it silently — the rest of this skill still works.

--- a/skills/goal-review/SKILL.md
+++ b/skills/goal-review/SKILL.md
@@ -67,7 +67,12 @@ Review progress toward all marketing goals across all platforms.
    - `generated_at`: ISO 8601 timestamp of this run
    - `period`: the assessment window or "as of" date
    - `kpis`: per-Goal headline numbers (target, current, % of target achieved)
-   - `flags`: a list of notable items (e.g. `["goal_cpa_off_track"]`)
+   - `flags`: a list of **structured** flags — each a small object `{code, severity, params}` so the dashboard renders a coarse, localizable chip with the numbers on drill-down:
+       - `code`: a canonical vocabulary key — one of `goals_met`, `cpa_over_target`, `cpa_under_target`, `cv_below_target`, `cv_above_target`, `spend_spike`, `cpa_spike`, `invalid_traffic_suspected`, `zero_cv_adspots`, `budget_overspend`, `budget_drift`, `tracking_suspect`, `zero_conversions`, `supply_tools_unconfigured`, `anomaly_baseline_insufficient`, `pending_observations`, `search_console_no_property`, `ga4_not_configured`.
+       - `severity`: one of `action`/`watch`/`info`/`positive` (omit to take the code's default — `info`/`positive` keep informational and good-news flags visually distinct from alarms).
+       - `params`: an object holding the DETAIL (target, current, % of target). Keep detail in `params`, **NOT baked into the code** — write `{"code":"cpa_over_target","params":{"cpa":15200}}`, never a slug like `goal_cpa_off_track`.
+       - For a finding outside the vocabulary use `{code:"custom", severity, label}` where `label` is a string or a `{"ja":…,"en":…}` map. Unknown non-`custom` codes are rejected. (A legacy bare-string flag still works but renders without the drill-down — prefer the object form.)
+       - Example: `[{"code":"cpa_over_target","params":{"cpa":15200}}, {"code":"cv_below_target","params":{"cv":18}}]`
    - `narrative`: a short text summary of overall Goal health (on-track / at-risk / off-track)
 
    This is best-effort: if `mureo_state_report_set` is unavailable (e.g. a pure file-mode host without the context MCP), skip it silently — the rest of this skill still works.

--- a/skills/weekly-report/SKILL.md
+++ b/skills/weekly-report/SKILL.md
@@ -71,7 +71,12 @@ Generate a weekly marketing operations report.
     - `generated_at`: ISO 8601 timestamp of this run
     - `period`: the reporting window (e.g. `"LAST_7_DAYS"` or an explicit date range)
     - `kpis`: per-platform and/or totals headline numbers (spend, conversions, cpa, week-over-week change)
-    - `flags`: a list of notable items (e.g. `["meta_ads_cpa_up_15pct"]`)
+    - `flags`: a list of **structured** flags — each a small object `{code, severity, params}` so the dashboard renders a coarse, localizable chip with the numbers on drill-down:
+        - `code`: a canonical vocabulary key — one of `goals_met`, `cpa_over_target`, `cpa_under_target`, `cv_below_target`, `cv_above_target`, `spend_spike`, `cpa_spike`, `invalid_traffic_suspected`, `zero_cv_adspots`, `budget_overspend`, `budget_drift`, `tracking_suspect`, `zero_conversions`, `supply_tools_unconfigured`, `anomaly_baseline_insufficient`, `pending_observations`, `search_console_no_property`, `ga4_not_configured`.
+        - `severity`: one of `action`/`watch`/`info`/`positive` (omit to take the code's default — `info`/`positive` keep informational and good-news flags visually distinct from alarms).
+        - `params`: an object holding the DETAIL (platform, yen, cpa, week-over-week change). Keep detail in `params`, **NOT baked into the code** — write `{"code":"cpa_over_target","params":{"cpa":15200}}`, never a slug like `meta_ads_cpa_up_15pct`.
+        - For a finding outside the vocabulary use `{code:"custom", severity, label}` where `label` is a string or a `{"ja":…,"en":…}` map. Unknown non-`custom` codes are rejected. (A legacy bare-string flag still works but renders without the drill-down — prefer the object form.)
+        - Example: `[{"code":"cpa_over_target","params":{"cpa":15200}}, {"code":"goals_met"}]`
     - `narrative`: the 2-3 sentence executive summary
 
     This is best-effort: if `mureo_state_report_set` is unavailable (e.g. a pure file-mode host without the context MCP), skip it silently — the rest of this skill still works.

--- a/tests/test_weekly_goal_structured_flags.py
+++ b/tests/test_weekly_goal_structured_flags.py
@@ -1,0 +1,54 @@
+"""weekly-report and goal-review must author STRUCTURED report flags.
+
+Follow-up to the daily-check migration: the same canonical
+``{code, severity, params}`` vocabulary now drives the weekly and goal reports
+too (see ``tests/test_daily_check_structured_flags.py``). This pins that both
+SKILL.md files instruct the structured shape — not the old detail-in-the-slug
+string — in BOTH the packaged copy and the repo-root mirror, byte-identical.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_ROOT = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture(params=["weekly-report", "goal-review"])
+def skill(request):
+    name = request.param
+    packaged = _ROOT / "mureo" / "_data" / "skills" / name / "SKILL.md"
+    mirror = _ROOT / "skills" / name / "SKILL.md"
+    return name, packaged, mirror
+
+
+def test_copies_byte_identical(skill) -> None:
+    _name, packaged, mirror = skill
+    assert packaged.read_bytes() == mirror.read_bytes()
+
+
+def test_documents_structured_flag_shape(skill) -> None:
+    _name, packaged, _mirror = skill
+    body = packaged.read_text(encoding="utf-8")
+    assert "{code, severity, params}" in body
+    assert "NOT baked into the code" in body
+    assert "`action`/`watch`/`info`/`positive`" in body
+    assert '{code:"custom", severity, label}' in body
+    assert "goals_met" in body
+
+
+def test_legacy_slug_example_is_gone(skill) -> None:
+    """The old detail-in-the-slug example strings must be replaced."""
+    name, packaged, _mirror = skill
+    body = packaged.read_text(encoding="utf-8")
+    stale = {
+        "weekly-report": "meta_ads_cpa_up_15pct",
+        "goal-review": "goal_cpa_off_track",
+    }[name]
+    # It may still be referenced as the "never write a slug like …" counter-
+    # example, but must not be the promoted `flags` value any more.
+    assert f'["{stale}"]' not in body


### PR DESCRIPTION
Follow-up to the daily-check structured-flag migration (#428/#429/#430). Brings `weekly-report` and `goal-review` onto the canonical `{code, severity, params}` vocabulary (both copies each, byte-identical), keeping detail in `params` (not baked into the code) with the `custom` escape hatch. Completes the report-flag migration across the three report-persisting skills.

Tests: `tests/test_weekly_goal_structured_flags.py` (parametrized over both skills: byte-identical copies + structured guidance + legacy slug removed). Verified the documented example flags pass `normalize_flags`.

https://claude.ai/code/session_01X3WKmku93ucAR8DsatzLpG