### PR TITLE
fix(web): capture host + host_paths as one atomic snapshot (#407)

### DIFF
--- a/mureo/web/handlers.py
+++ b/mureo/web/handlers.py
@@ -598,9 +598,12 @@ class ConfigureHandler(BaseHTTPRequestHandler):
         send_bytes(self, body, content_type=_static_content_type(filename))
 
     def _serve_status(self) -> None:
+        # One atomic snapshot: pairing self.wizard.session.host with a separate
+        # self.wizard.host_paths read could cross a concurrent set_host (#407).
+        snap = self.wizard.host_snapshot()
         snapshot = collect_status(
-            self.wizard.session.host,
-            paths=self.wizard.host_paths,
+            snap.host,
+            paths=snap.paths,
             multi_account_auth=self._multi_account_active(),
         )
         send_json(self, snapshot.as_dict())
@@ -943,11 +946,14 @@ class ConfigureHandler(BaseHTTPRequestHandler):
         if not provider_id:
             send_error_json(self, 400, "provider_id_required")
             return
+        # One atomic snapshot: host and credentials_path must come from the
+        # same host, not two reads a concurrent set_host could split (#407).
+        snap = self.wizard.host_snapshot()
         result = install_provider(
             provider_id,
             home=self.wizard.home,
-            host=self.wizard.session.host,
-            credentials_path=self.wizard.host_paths.credentials_path,
+            host=snap.host,
+            credentials_path=snap.paths.credentials_path,
         )
         send_json(self, result.as_dict())
 

--- a/mureo/web/server.py
+++ b/mureo/web/server.py
@@ -34,7 +34,7 @@ from mureo.web.handlers import ConfigureHandler
 from mureo.web.host_paths import HostPaths, get_host_paths
 from mureo.web.instance import probe_mureo_instance, write_state_file
 from mureo.web.oauth_bridge import OAuthBridge
-from mureo.web.session import ConfigureSession
+from mureo.web.session import SUPPORTED_HOSTS, ConfigureSession
 from mureo.web.version_check import (
     start_periodic_update_check,
     stop_periodic_update_check,
@@ -85,6 +85,21 @@ class _ConfigureServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
     wizard: ConfigureWizard
 
 
+@dataclasses.dataclass(frozen=True)
+class HostSnapshot:
+    """An atomically-captured ``(host, paths)`` pair (#407).
+
+    Reading :attr:`ConfigureWizard.session`'s ``host`` and
+    :attr:`ConfigureWizard.host_paths` as two separate accesses lets a
+    concurrent :meth:`ConfigureWizard.set_host` land between them and pair one
+    host with another host's bundle. :meth:`ConfigureWizard.host_snapshot`
+    returns both captured under one lock, so the pair is always consistent.
+    """
+
+    host: str
+    paths: HostPaths
+
+
 class ConfigureWizard:
     """Configure-UI lifecycle owner."""
 
@@ -121,6 +136,10 @@ class ConfigureWizard:
         self._ready = threading.Event()
         self._stop = threading.Event()
         self._lock = threading.Lock()
+        # Guards the (session.host, _host_paths) pair so set_host publishes both
+        # together and host_snapshot() reads both together (#407). Separate from
+        # _lock (server lifecycle) to avoid coupling the two concerns.
+        self._host_lock = threading.Lock()
 
     @staticmethod
     def _discover_providers_safely() -> None:
@@ -172,21 +191,35 @@ class ConfigureWizard:
     def set_host(self, host: str) -> None:
         """Switch the Claude host and recompute path resolution.
 
-        No-op when ``host`` is already the session host: ``_resolve_host``
-        relays the client's host on every host-carrying POST, and the
-        rebuild is not free — the credentials override may resolve a
-        runtime-context factory (#406).
+        No-op when ``host`` is already the session host (``_resolve_host``
+        relays the client's host on every host-carrying POST) or when it is
+        not an allow-listed host — the rebuild is not free (the credentials
+        override may resolve a runtime-context factory).
 
-        The rebuilt bundle is published in a single assignment AFTER every
-        override has been applied. The configure server is threaded, and
-        publishing the base bundle first opened a window in which
-        concurrent requests read — or wrote — the unresolved host-default
-        credentials path instead of the runtime-resolved one (#406).
+        The new bundle is built OUTSIDE the lock (a single, fully-resolved
+        ``HostPaths`` — publishing a half-built bundle let concurrent requests
+        read the unresolved host-default credentials path, #406), then the host
+        and the bundle are published TOGETHER under ``_host_lock`` so a
+        concurrent :meth:`host_snapshot` never pairs one host with another
+        host's bundle (#407).
         """
-        if host == self.session.host:
+        if host == self.session.host or host not in SUPPORTED_HOSTS:
             return
-        self.session.set_host(host)
-        self._host_paths = self._build_host_paths()
+        new_paths = self._build_host_paths(host)
+        with self._host_lock:
+            self.session.set_host(host)
+            self._host_paths = new_paths
+
+    def host_snapshot(self) -> HostSnapshot:
+        """Atomically capture the current ``(host, host_paths)`` pair (#407).
+
+        Both fields are read under the lock :meth:`set_host` publishes them
+        under, so a concurrent switch can never expose a host paired with
+        another host's bundle. A handler that needs BOTH values in one request
+        takes a single snapshot instead of two separate ``self.wizard`` reads.
+        """
+        with self._host_lock:
+            return HostSnapshot(host=self.session.host, paths=self._host_paths)
 
     def mark_oauth_complete(
         self, provider: str, *, success: bool, error: str | None = None
@@ -281,8 +314,12 @@ class ConfigureWizard:
     # ------------------------------------------------------------------
     # Internals
     # ------------------------------------------------------------------
-    def _build_host_paths(self) -> HostPaths:
-        """Resolve the FULL paths bundle for the current session host.
+    def _build_host_paths(self, host: str | None = None) -> HostPaths:
+        """Resolve the FULL paths bundle for ``host`` (default: session host).
+
+        ``host`` is passed by :meth:`set_host` so the target bundle is built
+        BEFORE the session host is switched — keeping the potentially slow
+        build off the ``_host_lock`` critical section (#407).
 
         Base resolution plus the commands-path pin plus the credentials
         override are all applied to a local value; the caller publishes
@@ -292,7 +329,9 @@ class ConfigureWizard:
         credentials path (#406) — with a slow runtime-context factory the
         window spanned most of a dashboard page load.
         """
-        paths = get_host_paths(self.session.host, home=self.home)
+        paths = get_host_paths(
+            host if host is not None else self.session.host, home=self.home
+        )
         if self._commands_path_override is not None:
             paths = dataclasses.replace(
                 paths, commands_dir=self._commands_path_override

--- a/mureo/web/session.py
+++ b/mureo/web/session.py
@@ -48,7 +48,15 @@ class ConfigureSession:
             self.locale = locale
 
     def set_host(self, host: str) -> None:
-        """Set the Claude application host. Allow-list only."""
+        """Set the Claude application host. Allow-list only.
+
+        Not self-synchronizing: the sole production caller
+        (:meth:`mureo.web.server.ConfigureWizard.set_host`) serializes this
+        under ``_host_lock`` and publishes ``host`` together with the rebuilt
+        ``host_paths`` bundle, so readers never observe a torn (host, paths)
+        pair (#407). A new caller that mutates ``host`` outside that lock would
+        reintroduce the race.
+        """
         if host in SUPPORTED_HOSTS:
             self.host = host
 

--- a/tests/test_configure_wizard_host_paths.py
+++ b/tests/test_configure_wizard_host_paths.py
@@ -77,3 +77,87 @@ def test_set_host_never_publishes_unresolved_credentials_path(
     assert not switcher.is_alive()
     assert wizard.host_paths.credentials_path == resolved_path
     assert wizard.host_paths.host == "claude-desktop"
+
+
+# ---------------------------------------------------------------------------
+# #407 — host + host_paths must be captured as one atomic, consistent pair.
+# Reading ``session.host`` and ``host_paths`` as two separate accesses lets a
+# concurrent ``set_host`` land between them and pair one host with another
+# host's paths bundle. ``host_snapshot()`` captures both under one lock.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_host_snapshot_pairs_host_with_its_own_paths(tmp_path: Path) -> None:
+    wizard = server_mod.ConfigureWizard(home=tmp_path)
+    snap = wizard.host_snapshot()
+    assert snap.host == wizard.session.host
+    assert snap.paths is wizard.host_paths
+    # The bundle was built for that same host — never a cross-host mismatch.
+    assert snap.paths.host == snap.host
+
+
+@pytest.mark.unit
+def test_host_snapshot_reflects_a_host_switch(tmp_path: Path) -> None:
+    wizard = server_mod.ConfigureWizard(home=tmp_path)
+    assert wizard.host_snapshot().host == "claude-code"
+    wizard.set_host("codex")
+    snap = wizard.host_snapshot()
+    assert snap.host == "codex"
+    assert snap.paths.host == "codex"
+
+
+@pytest.mark.unit
+def test_host_snapshot_is_immutable(tmp_path: Path) -> None:
+    import dataclasses
+
+    wizard = server_mod.ConfigureWizard(home=tmp_path)
+    snap = wizard.host_snapshot()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        snap.host = "codex"  # type: ignore[misc]
+    # A later switch must not mutate an already-captured snapshot.
+    wizard.set_host("codex")
+    assert snap.host == "claude-code"
+
+
+@pytest.mark.unit
+def test_concurrent_switch_keeps_snapshots_consistent(tmp_path: Path) -> None:
+    """Under a concurrent host switch, every snapshot pairs a host with ITS
+    OWN paths bundle — never host A with host B's paths (#407)."""
+    wizard = server_mod.ConfigureWizard(home=tmp_path)
+    hosts = ("claude-code", "codex")
+    stop = threading.Event()
+    errors: list[str] = []
+
+    def flip() -> None:
+        for i in range(400):
+            wizard.set_host(hosts[i % 2])
+        stop.set()
+
+    def observe() -> None:
+        while not stop.is_set():
+            snap = wizard.host_snapshot()
+            if snap.paths.host != snap.host:
+                errors.append(f"{snap.host} paired with {snap.paths.host}'s paths")
+
+    switcher = threading.Thread(target=flip)
+    observer = threading.Thread(target=observe)
+    switcher.start()
+    observer.start()
+    switcher.join(timeout=10)
+    observer.join(timeout=10)
+    assert not switcher.is_alive() and not observer.is_alive()
+    assert not errors, errors[:3]
+
+
+@pytest.mark.unit
+def test_pairing_handlers_use_the_atomic_snapshot() -> None:
+    """The two handlers that read BOTH host and host_paths in one request now
+    go through host_snapshot() rather than two separate wizard reads (#407)."""
+    src = (Path(server_mod.__file__).resolve().parent / "handlers.py").read_text(
+        encoding="utf-8"
+    )
+    assert src.count("host_snapshot()") >= 2
+    # The old torn pairing (a separate session.host read feeding collect_status
+    # alongside the live host_paths) is gone.
+    assert "paths=self.wizard.host_paths" not in src


### PR DESCRIPTION
Closes #407.

Several configure-UI handlers read `wizard.session.host` and `wizard.host_paths` as two separate accesses within one request, so a concurrent `set_host` landing between them could pair one host with another host's paths bundle (TOCTOU).

**Fix**
- `server.py`: frozen `HostSnapshot(host, paths)` + a dedicated `_host_lock`. `set_host` builds the new bundle **outside** the lock (preserving the #406 'never publish an unresolved bundle' guarantee) then publishes host + paths **together** under the lock; `host_snapshot()` reads both under the lock. Non-allow-listed host is now an early no-op. `_build_host_paths(host=None)` gains a target-host param.
- `handlers.py`: the two pair-reading handlers (`_serve_status`, `_post_providers_install`) take one `host_snapshot()`.
- `session.py`: note that `ConfigureSession.set_host` is not self-synchronizing (callers hold `_host_lock`).

**Tests**: 4 new in `test_configure_wizard_host_paths.py` (consistent pair / switch reflection / immutability / concurrent-switch invariant / handler conversion); the #406 tests still pass. black + ruff-check + mypy clean on changed files; 372 web/server/handlers regression tests pass.

https://claude.ai/code/session_01X3WKmku93ucAR8DsatzLpG