### PR TITLE
fix(analytics): scope live-client account_id through the #411 allow-list (#413)

### DIFF
--- a/mureo/analytics/builtin/_live_clients.py
+++ b/mureo/analytics/builtin/_live_clients.py
@@ -104,11 +104,12 @@ def _aggregate_google_metrics(
 def _open_google_ads_client(account_id: str) -> object:
     """Resolve credentials + open a Google Ads client (live or BYOD).
 
-    WARNING (#411/#413): this helper does NOT enforce the workspace
-    account allow-list — ``account_id`` is used verbatim. Every wired MCP
-    tool today derives the id from workspace state, never from a caller
-    argument. If a future tool passes a caller-supplied id into the
-    AnalyticsModule Protocol, route it through the #411 resolvers first.
+    Workspace scoping (#411/#413): ``account_id`` is bound to the active
+    client's allow-list via ``_resolve_customer_id`` before use — a
+    non-tenant-scoped run passes it through unchanged, a tenant-scoped run
+    refuses an out-of-allow-list id (fail-closed). Enforcing here means a
+    future tool that wires a caller-supplied id into the AnalyticsModule
+    Protocol cannot silently bypass #411 scoping.
 
     Raises :class:`NoCredentialsError` in live mode when credentials
     are missing. BYOD mode is detected by the client factory itself
@@ -124,6 +125,11 @@ def _open_google_ads_client(account_id: str) -> object:
     from mureo.auth import load_google_ads_credentials
     from mureo.byod.runtime import byod_has
     from mureo.mcp._client_factory import get_google_ads_client
+    from mureo.mcp._handlers_google_ads import _resolve_customer_id
+
+    # Bind the account to the workspace allow-list (#411/#413) before it
+    # reaches the client factory — see the workspace-scoping note above.
+    account_id = _resolve_customer_id(account_id, None)
 
     if byod_has("google_ads"):
         return get_google_ads_client(creds=None, customer_id=account_id)
@@ -447,15 +453,21 @@ def _aggregate_meta_metrics(
 def _open_meta_ads_client(account_id: str) -> object:
     """Parallel to :func:`_open_google_ads_client` for Meta Ads.
 
-    WARNING (#411/#413): this helper does NOT enforce the workspace
-    account allow-list — ``account_id`` is used verbatim. Every wired MCP
-    tool today derives the id from workspace state, never from a caller
-    argument. If a future tool passes a caller-supplied id into the
-    AnalyticsModule Protocol, route it through the #411 resolvers first.
+    Workspace scoping (#411/#413): ``account_id`` is bound to the active
+    client's allow-list via ``_resolve_account_id`` before use — a
+    non-tenant-scoped run passes it through unchanged, a tenant-scoped run
+    refuses an out-of-allow-list id (fail-closed). Enforcing here means a
+    future tool that wires a caller-supplied id into the AnalyticsModule
+    Protocol cannot silently bypass #411 scoping.
     """
     from mureo.auth import load_meta_ads_credentials
     from mureo.byod.runtime import byod_has
     from mureo.mcp._client_factory import get_meta_ads_client
+    from mureo.mcp._handlers_meta_ads import _resolve_account_id
+
+    # Bind the account to the workspace allow-list (#411/#413) before it
+    # reaches the client factory — see the workspace-scoping note above.
+    account_id = _resolve_account_id(account_id, None)
 
     if byod_has("meta_ads"):
         return get_meta_ads_client(creds=None, account_id=account_id)

--- a/tests/test_live_clients_account_scope.py
+++ b/tests/test_live_clients_account_scope.py
@@ -1,0 +1,98 @@
+"""The analytics live-client helpers must enforce the #411 allow-list (#413).
+
+``_open_google_ads_client`` / ``_open_meta_ads_client`` used to pass the caller
+``account_id`` verbatim to the client factory, bypassing the workspace account
+allow-list the MCP handlers enforce via ``_resolve_customer_id`` /
+``_resolve_account_id``. Dormant (no wired tool fed a caller id into the
+AnalyticsModule Protocol), but a future tool that did would silently escape
+#411 tenant scoping. The helpers now route the id through the same resolvers:
+a non-tenant-scoped run passes it through unchanged; a tenant-scoped run
+refuses an out-of-allow-list id (fail-closed).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mureo.analytics.builtin import _live_clients
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def stub_factories(monkeypatch: pytest.MonkeyPatch):
+    """Stub BYOD + the client factories so a test exercises only the scoping
+    step, never real credentials or the network. Returns (sentinels, calls)."""
+    monkeypatch.setattr("mureo.byod.runtime.byod_has", lambda platform: True)
+    sentinel_g, sentinel_m = object(), object()
+    calls: dict[str, str | None] = {}
+
+    def fake_google(creds=None, customer_id=None):
+        calls["google"] = customer_id
+        return sentinel_g
+
+    def fake_meta(creds=None, account_id=None):
+        calls["meta"] = account_id
+        return sentinel_m
+
+    monkeypatch.setattr("mureo.mcp._client_factory.get_google_ads_client", fake_google)
+    monkeypatch.setattr("mureo.mcp._client_factory.get_meta_ads_client", fake_meta)
+    return sentinel_g, sentinel_m, calls
+
+
+def _scope_google(monkeypatch: pytest.MonkeyPatch, allowed) -> None:
+    import mureo.mcp._handlers_google_ads as gh
+
+    monkeypatch.setattr(gh, "runtime_google_ads_customer_ids", lambda: allowed)
+
+
+def _scope_meta(monkeypatch: pytest.MonkeyPatch, allowed) -> None:
+    import mureo.mcp._handlers_meta_ads as mh
+
+    monkeypatch.setattr(mh, "runtime_meta_account_ids", lambda: allowed)
+
+
+# --- Google Ads ------------------------------------------------------------
+
+
+def test_google_refuses_out_of_allowlist(monkeypatch, stub_factories) -> None:
+    _scope_google(monkeypatch, frozenset({"111"}))
+    with pytest.raises(ValueError):
+        _live_clients._open_google_ads_client("999")
+
+
+def test_google_allows_in_allowlist(monkeypatch, stub_factories) -> None:
+    sentinel_g, _sm, calls = stub_factories
+    _scope_google(monkeypatch, frozenset({"111"}))
+    assert _live_clients._open_google_ads_client("111") is sentinel_g
+    assert calls["google"] == "111"
+
+
+def test_google_not_tenant_scoped_passes_through(monkeypatch, stub_factories) -> None:
+    sentinel_g, _sm, calls = stub_factories
+    _scope_google(monkeypatch, None)  # no allow-list active
+    assert _live_clients._open_google_ads_client("acct-x") is sentinel_g
+    assert calls["google"] == "acct-x"
+
+
+# --- Meta Ads --------------------------------------------------------------
+
+
+def test_meta_refuses_out_of_allowlist(monkeypatch, stub_factories) -> None:
+    _scope_meta(monkeypatch, frozenset({"act_111"}))
+    with pytest.raises(ValueError):
+        _live_clients._open_meta_ads_client("act_999")
+
+
+def test_meta_allows_in_allowlist(monkeypatch, stub_factories) -> None:
+    _sg, sentinel_m, calls = stub_factories
+    _scope_meta(monkeypatch, frozenset({"act_111"}))
+    assert _live_clients._open_meta_ads_client("act_111") is sentinel_m
+    assert calls["meta"] == "act_111"
+
+
+def test_meta_not_tenant_scoped_passes_through(monkeypatch, stub_factories) -> None:
+    _sg, sentinel_m, calls = stub_factories
+    _scope_meta(monkeypatch, None)
+    assert _live_clients._open_meta_ads_client("act_x") is sentinel_m
+    assert calls["meta"] == "act_x"


### PR DESCRIPTION
Closes #413.

The built-in analytics live-client helpers (`_open_google_ads_client` / `_open_meta_ads_client` in `mureo/analytics/builtin/_live_clients.py`) passed the caller `account_id` verbatim to the client factory, bypassing the #411 workspace account allow-list the MCP handlers enforce via `_resolve_customer_id` / `_resolve_account_id`. Dormant (no wired tool feeds a caller id into the AnalyticsModule Protocol) but a future one would silently escape tenant scoping.

**Fix**: route both helpers through the same resolvers, applied before the BYOD/live branch (so BYOD reads are scoped too). A non-tenant-scoped run passes the id through unchanged; a tenant-scoped run refuses an out-of-allow-list id (fail-closed).

**Tests**: `tests/test_live_clients_account_scope.py` (refuse out-of-allowlist / allow in-allowlist / non-scoped passthrough, ×google+meta). CI-safe: with the local mureo-agency runtime-context factory disabled (= CI), all 91 analytics/builtin tests pass. black + ruff + mypy clean.

Follow-ups tracked in a separate issue (deferred while the path is dormant): AnalyticsModule methods catch only `NoCredentialsError` (not the resolver's `ValueError`); and the resolved/canonicalized id isn't threaded back to aggregation/labeling.

https://claude.ai/code/session_01X3WKmku93ucAR8DsatzLpG