### PR TITLE
fix(analytics): graceful scope refusal + thread resolved account_id (#435)

### DIFF
--- a/mureo/analytics/builtin/_live_clients.py
+++ b/mureo/analytics/builtin/_live_clients.py
@@ -47,7 +47,22 @@ class NoCredentialsError(RuntimeError):
 
     Distinct subclass so the adapter can catch this case and return an
     honest empty result rather than surfacing a noisy error to the
-    workflow.
+    workflow. Subclasses signal other "cannot fetch this account, degrade
+    gracefully" conditions (see :class:`AccountNotAvailableError`) and are
+    caught by the same ``except NoCredentialsError`` in every adapter method.
+    """
+
+
+class AccountNotAvailableError(NoCredentialsError):
+    """The account cannot be fetched in the active workspace scope (#413/#435).
+
+    Raised when the #411 allow-list refuses the ``account_id`` (out-of-set,
+    empty allow-list, or an ambiguous multi-account default). A subclass of
+    :class:`NoCredentialsError` so every adapter's existing
+    ``except NoCredentialsError`` renders the same graceful "not available"
+    sentinel — a workspace-scope violation degrades like missing credentials
+    rather than propagating a raw ``ValueError`` out of the AnalyticsModule
+    Protocol method.
     """
 
 
@@ -101,8 +116,13 @@ def _aggregate_google_metrics(
     )
 
 
-def _open_google_ads_client(account_id: str) -> object:
+def _open_google_ads_client(account_id: str) -> tuple[object, str]:
     """Resolve credentials + open a Google Ads client (live or BYOD).
+
+    Returns ``(client, resolved_account_id)`` — the resolved id (possibly
+    canonicalized) so callers label / look up conversions with the same value
+    the client was opened with (#435). A workspace-scope refusal raises
+    :class:`AccountNotAvailableError`.
 
     Workspace scoping (#411/#413): ``account_id`` is bound to the active
     client's allow-list via ``_resolve_customer_id`` before use — a
@@ -128,16 +148,19 @@ def _open_google_ads_client(account_id: str) -> object:
     from mureo.mcp._handlers_google_ads import _resolve_customer_id
 
     # Bind the account to the workspace allow-list (#411/#413) before it
-    # reaches the client factory — see the workspace-scoping note above.
-    account_id = _resolve_customer_id(account_id, None)
+    # reaches the client factory; a refusal degrades gracefully (#435).
+    try:
+        account_id = _resolve_customer_id(account_id, None)
+    except ValueError as exc:
+        raise AccountNotAvailableError(str(exc)) from exc
 
     if byod_has("google_ads"):
-        return get_google_ads_client(creds=None, customer_id=account_id)
+        return get_google_ads_client(creds=None, customer_id=account_id), account_id
 
     creds = load_google_ads_credentials()
     if creds is None:
         raise NoCredentialsError("google_ads credentials not configured")
-    return get_google_ads_client(creds, account_id)
+    return get_google_ads_client(creds, account_id), account_id
 
 
 async def fetch_google_ads_metrics(
@@ -157,7 +180,7 @@ async def fetch_google_ads_metrics(
     fan-out is a follow-up; the trade-off is documented and tested
     in ``test_live_clients.py``.
     """
-    client = _open_google_ads_client(account_id)
+    client, account_id = _open_google_ads_client(account_id)
 
     # Local import defers the google_ads analysis module until first use (the
     # registry import must stay cheap; see the module docstring).
@@ -196,7 +219,7 @@ async def fetch_google_ads_performance_rows(
     :func:`fetch_google_ads_metrics` so the adapter renders a single
     sentinel headline rather than diverging on the same condition.
     """
-    client = _open_google_ads_client(account_id)
+    client, account_id = _open_google_ads_client(account_id)
     return await client.get_performance_report(period=period)  # type: ignore[attr-defined,no-any-return]
 
 
@@ -291,7 +314,7 @@ async def fetch_google_ads_per_campaign_metrics(
     Raises :class:`NoCredentialsError` uniformly with
     :func:`fetch_google_ads_metrics`.
     """
-    client = _open_google_ads_client(account_id)
+    client, account_id = _open_google_ads_client(account_id)
     from mureo.google_ads._analysis_constants import _get_comparison_date_ranges
 
     period_token = _GOOGLE_WINDOW_TO_PERIOD.get(window_days, "LAST_7_DAYS")
@@ -362,7 +385,7 @@ async def fetch_google_ads_list(
     Used by :meth:`GoogleAdsAnalyticsModule.audit_creative`. Raises
     :class:`NoCredentialsError` in live mode when creds are missing.
     """
-    client = _open_google_ads_client(account_id)
+    client, account_id = _open_google_ads_client(account_id)
     return await client.list_ads()  # type: ignore[attr-defined,no-any-return]
 
 
@@ -370,7 +393,7 @@ async def fetch_meta_ads_list(
     account_id: str,
 ) -> list[dict[str, object]]:
     """Return ``list_ads`` results for one Meta account."""
-    client = _open_meta_ads_client(account_id)
+    client, account_id = _open_meta_ads_client(account_id)
     return await client.list_ads()  # type: ignore[attr-defined,no-any-return]
 
 
@@ -382,7 +405,7 @@ async def fetch_meta_ads_per_campaign_metrics(
     """Per-campaign fan-out for Meta — parallel to
     :func:`fetch_google_ads_per_campaign_metrics`.
     """
-    client = _open_meta_ads_client(account_id)
+    client, account_id = _open_meta_ads_client(account_id)
     from mureo.meta_ads._period import previous_period
 
     current_period = _META_WINDOW_TO_PERIOD.get(window_days, "last_7d")
@@ -450,8 +473,13 @@ def _aggregate_meta_metrics(
     )
 
 
-def _open_meta_ads_client(account_id: str) -> object:
+def _open_meta_ads_client(account_id: str) -> tuple[object, str]:
     """Parallel to :func:`_open_google_ads_client` for Meta Ads.
+
+    Returns ``(client, resolved_account_id)`` — the resolved id is
+    canonicalized to the ``act_`` form when tenant-scoped, so callers use the
+    same value the client was opened with (#435). A workspace-scope refusal
+    raises :class:`AccountNotAvailableError`.
 
     Workspace scoping (#411/#413): ``account_id`` is bound to the active
     client's allow-list via ``_resolve_account_id`` before use — a
@@ -466,16 +494,19 @@ def _open_meta_ads_client(account_id: str) -> object:
     from mureo.mcp._handlers_meta_ads import _resolve_account_id
 
     # Bind the account to the workspace allow-list (#411/#413) before it
-    # reaches the client factory — see the workspace-scoping note above.
-    account_id = _resolve_account_id(account_id, None)
+    # reaches the client factory; a refusal degrades gracefully (#435).
+    try:
+        account_id = _resolve_account_id(account_id, None)
+    except ValueError as exc:
+        raise AccountNotAvailableError(str(exc)) from exc
 
     if byod_has("meta_ads"):
-        return get_meta_ads_client(creds=None, account_id=account_id)
+        return get_meta_ads_client(creds=None, account_id=account_id), account_id
 
     creds = load_meta_ads_credentials()
     if creds is None:
         raise NoCredentialsError("meta_ads credentials not configured")
-    return get_meta_ads_client(creds, account_id)
+    return get_meta_ads_client(creds, account_id), account_id
 
 
 async def fetch_meta_ads_metrics(
@@ -489,7 +520,7 @@ async def fetch_meta_ads_metrics(
     in live mode. Shares the per-campaign aggregation limitation
     documented on :func:`fetch_google_ads_metrics`.
     """
-    client = _open_meta_ads_client(account_id)
+    client, account_id = _open_meta_ads_client(account_id)
     from mureo.meta_ads._period import previous_period
 
     current_period = _META_WINDOW_TO_PERIOD.get(window_days, "last_7d")
@@ -513,11 +544,12 @@ async def fetch_meta_ads_performance_rows(
     period: str,
 ) -> list[dict[str, object]]:
     """Return raw performance rows for ``account_id`` over ``period``."""
-    client = _open_meta_ads_client(account_id)
+    client, account_id = _open_meta_ads_client(account_id)
     return await client.get_performance_report(period=period)  # type: ignore[attr-defined,no-any-return]
 
 
 __all__ = [
+    "AccountNotAvailableError",
     "NoCredentialsError",
     "fetch_google_ads_list",
     "fetch_google_ads_metrics",

--- a/tests/test_live_clients_account_scope.py
+++ b/tests/test_live_clients_account_scope.py
@@ -1,13 +1,14 @@
-"""The analytics live-client helpers must enforce the #411 allow-list (#413).
+"""The analytics live-client helpers must enforce the #411 allow-list (#413)
+and stay consistent after resolution (#435).
 
-``_open_google_ads_client`` / ``_open_meta_ads_client`` used to pass the caller
-``account_id`` verbatim to the client factory, bypassing the workspace account
-allow-list the MCP handlers enforce via ``_resolve_customer_id`` /
-``_resolve_account_id``. Dormant (no wired tool fed a caller id into the
-AnalyticsModule Protocol), but a future tool that did would silently escape
-#411 tenant scoping. The helpers now route the id through the same resolvers:
-a non-tenant-scoped run passes it through unchanged; a tenant-scoped run
-refuses an out-of-allow-list id (fail-closed).
+``_open_google_ads_client`` / ``_open_meta_ads_client`` route the caller
+``account_id`` through the same ``_resolve_customer_id`` / ``_resolve_account_id``
+the MCP handlers use: a non-tenant-scoped run passes it through unchanged; a
+tenant-scoped run refuses an out-of-allow-list id. Per #435 the helpers now
+(1) surface a refusal as :class:`AccountNotAvailableError`, a
+:class:`NoCredentialsError` subclass so adapters degrade gracefully instead of
+crashing, and (2) return the RESOLVED id so callers label / look up conversions
+with the same (possibly canonicalized) value the client was opened with.
 """
 
 from __future__ import annotations
@@ -15,6 +16,7 @@ from __future__ import annotations
 import pytest
 
 from mureo.analytics.builtin import _live_clients
+from mureo.analytics.builtin.google_ads import GoogleAdsAnalyticsModule
 
 pytestmark = pytest.mark.unit
 
@@ -52,47 +54,89 @@ def _scope_meta(monkeypatch: pytest.MonkeyPatch, allowed) -> None:
     monkeypatch.setattr(mh, "runtime_meta_account_ids", lambda: allowed)
 
 
-# --- Google Ads ------------------------------------------------------------
+# --- scope enforcement + resolved-id return (#413/#435) --------------------
 
 
 def test_google_refuses_out_of_allowlist(monkeypatch, stub_factories) -> None:
     _scope_google(monkeypatch, frozenset({"111"}))
-    with pytest.raises(ValueError):
+    with pytest.raises(_live_clients.AccountNotAvailableError):
         _live_clients._open_google_ads_client("999")
 
 
 def test_google_allows_in_allowlist(monkeypatch, stub_factories) -> None:
     sentinel_g, _sm, calls = stub_factories
     _scope_google(monkeypatch, frozenset({"111"}))
-    assert _live_clients._open_google_ads_client("111") is sentinel_g
+    client, resolved = _live_clients._open_google_ads_client("111")
+    assert client is sentinel_g
+    assert resolved == "111"
     assert calls["google"] == "111"
 
 
 def test_google_not_tenant_scoped_passes_through(monkeypatch, stub_factories) -> None:
     sentinel_g, _sm, calls = stub_factories
     _scope_google(monkeypatch, None)  # no allow-list active
-    assert _live_clients._open_google_ads_client("acct-x") is sentinel_g
+    client, resolved = _live_clients._open_google_ads_client("acct-x")
+    assert client is sentinel_g
+    assert resolved == "acct-x"
     assert calls["google"] == "acct-x"
-
-
-# --- Meta Ads --------------------------------------------------------------
 
 
 def test_meta_refuses_out_of_allowlist(monkeypatch, stub_factories) -> None:
     _scope_meta(monkeypatch, frozenset({"act_111"}))
-    with pytest.raises(ValueError):
+    with pytest.raises(_live_clients.AccountNotAvailableError):
         _live_clients._open_meta_ads_client("act_999")
 
 
 def test_meta_allows_in_allowlist(monkeypatch, stub_factories) -> None:
     _sg, sentinel_m, calls = stub_factories
     _scope_meta(monkeypatch, frozenset({"act_111"}))
-    assert _live_clients._open_meta_ads_client("act_111") is sentinel_m
+    client, resolved = _live_clients._open_meta_ads_client("act_111")
+    assert client is sentinel_m
+    assert resolved == "act_111"
     assert calls["meta"] == "act_111"
 
 
 def test_meta_not_tenant_scoped_passes_through(monkeypatch, stub_factories) -> None:
     _sg, sentinel_m, calls = stub_factories
     _scope_meta(monkeypatch, None)
-    assert _live_clients._open_meta_ads_client("act_x") is sentinel_m
+    client, resolved = _live_clients._open_meta_ads_client("act_x")
+    assert client is sentinel_m
+    assert resolved == "act_x"
     assert calls["meta"] == "act_x"
+
+
+# --- #435 WARNING 2: resolved id is returned AND used ----------------------
+
+
+def test_meta_returns_and_uses_canonical_resolved_id(
+    monkeypatch, stub_factories
+) -> None:
+    """A bare ``111`` matching allow-list ``act_111`` resolves to the canonical
+    ``act_111`` — the client is opened with it AND it is returned, so callers
+    label / look up conversions with the same id (no #435 format skew)."""
+    _sg, sentinel_m, calls = stub_factories
+    _scope_meta(monkeypatch, frozenset({"act_111"}))
+    client, resolved = _live_clients._open_meta_ads_client("111")
+    assert client is sentinel_m
+    assert resolved == "act_111"
+    assert calls["meta"] == "act_111"
+
+
+# --- #435 WARNING 1: a scope refusal degrades gracefully -------------------
+
+
+def test_scope_refusal_is_a_no_credentials_subclass() -> None:
+    """``AccountNotAvailableError`` subclasses ``NoCredentialsError`` so every
+    adapter's existing ``except NoCredentialsError`` renders the graceful
+    sentinel — a scope violation degrades like missing credentials."""
+    assert issubclass(
+        _live_clients.AccountNotAvailableError, _live_clients.NoCredentialsError
+    )
+
+
+async def test_module_detect_anomalies_empty_on_scope_refusal(monkeypatch) -> None:
+    """End-to-end: a workspace-scope refusal makes ``detect_anomalies`` return
+    the empty sentinel (config state), not raise (#435 WARNING 1)."""
+    _scope_google(monkeypatch, frozenset({"111"}))  # refuses "999"
+    module = GoogleAdsAnalyticsModule()
+    assert await module.detect_anomalies("999") == ()


### PR DESCRIPTION
Closes #435. Follow-up to #413 (both items raised in its review).

**WARNING 1 — resolver `ValueError` degrades gracefully.** New `AccountNotAvailableError(NoCredentialsError)`; `_open_google_ads_client` / `_open_meta_ads_client` catch the #411 resolver's `ValueError` and re-raise it as this subclass, so every AnalyticsModule adapter's existing `except NoCredentialsError` renders the graceful empty sentinel instead of letting a raw `ValueError` escape the Protocol method.

**WARNING 2 — resolved id is threaded through.** `_open_*_client` now returns `(client, resolved_account_id)`; all 8 fetch call sites do `client, account_id = _open_*_client(account_id)` as their first statement, so aggregation / labeling / `load_conversion_action_types` use the same (canonicalized, e.g. Meta `123`→`act_111`) id the client was opened with — no format skew.

**Tests**: `tests/test_live_clients_account_scope.py` (9) incl. an end-to-end `detect_anomalies` graceful-empty on refusal, Meta canonicalization, and the subclass invariant. CI-safe: with the local mureo-agency runtime-context factory disabled (= CI), `tests/analytics/` + the new tests = 149 passed. black + ruff + mypy clean.

https://claude.ai/code/session_01X3WKmku93ucAR8DsatzLpG