### PR TITLE
fix(analytics): canonicalize Meta account_id to act_ on the unscoped path (#435)

### DIFF
--- a/mureo/analytics/builtin/_live_clients.py
+++ b/mureo/analytics/builtin/_live_clients.py
@@ -477,8 +477,8 @@ def _open_meta_ads_client(account_id: str) -> tuple[object, str]:
     """Parallel to :func:`_open_google_ads_client` for Meta Ads.
 
     Returns ``(client, resolved_account_id)`` — the resolved id is
-    canonicalized to the ``act_`` form when tenant-scoped, so callers use the
-    same value the client was opened with (#435). A workspace-scope refusal
+    canonicalized to the ``act_`` form (tenant-scoped or not), so callers use
+    the same value the client was opened with (#435). A workspace-scope refusal
     raises :class:`AccountNotAvailableError`.
 
     Workspace scoping (#411/#413): ``account_id`` is bound to the active
@@ -491,7 +491,10 @@ def _open_meta_ads_client(account_id: str) -> tuple[object, str]:
     from mureo.auth import load_meta_ads_credentials
     from mureo.byod.runtime import byod_has
     from mureo.mcp._client_factory import get_meta_ads_client
-    from mureo.mcp._handlers_meta_ads import _resolve_account_id
+    from mureo.mcp._handlers_meta_ads import (
+        _canonical_meta_account_id,
+        _resolve_account_id,
+    )
 
     # Bind the account to the workspace allow-list (#411/#413) before it
     # reaches the client factory; a refusal degrades gracefully (#435).
@@ -499,6 +502,12 @@ def _open_meta_ads_client(account_id: str) -> tuple[object, str]:
         account_id = _resolve_account_id(account_id, None)
     except ValueError as exc:
         raise AccountNotAvailableError(str(exc)) from exc
+
+    # Canonicalize to the ``act_`` form the Meta client requires. The
+    # tenant-scoped resolver already does this, but the non-scoped path returns
+    # the id verbatim — a bare id would otherwise raise a raw ValueError from
+    # the client factory, escaping the adapters' graceful handler (#435).
+    account_id = _canonical_meta_account_id(account_id)
 
     if byod_has("meta_ads"):
         return get_meta_ads_client(creds=None, account_id=account_id), account_id

--- a/tests/test_live_clients_account_scope.py
+++ b/tests/test_live_clients_account_scope.py
@@ -122,6 +122,20 @@ def test_meta_returns_and_uses_canonical_resolved_id(
     assert calls["meta"] == "act_111"
 
 
+def test_meta_bare_id_canonicalized_even_when_unscoped(
+    monkeypatch, stub_factories
+) -> None:
+    """A bare numeric id is canonicalized to the ``act_`` form even when NOT
+    tenant-scoped, so it never reaches ``MetaAdsApiClient`` (which requires the
+    prefix) as a raw id that would raise past the adapters' graceful handler."""
+    _sg, sentinel_m, calls = stub_factories
+    _scope_meta(monkeypatch, None)  # not tenant-scoped
+    client, resolved = _live_clients._open_meta_ads_client("111")
+    assert client is sentinel_m
+    assert resolved == "act_111"
+    assert calls["meta"] == "act_111"
+
+
 # --- #435 WARNING 1: a scope refusal degrades gracefully -------------------
 
 


### PR DESCRIPTION
Follow-up to #435 (LOW-2 from its review). `_open_meta_ads_client` resolves `account_id` via the #411 resolver, but the NON-tenant-scoped path returned it verbatim; a bare (non-`act_`) id then raised a raw `ValueError` from `MetaAdsApiClient.__init__`, escaping the adapters' graceful `except NoCredentialsError`. Fix: apply the idempotent `_canonical_meta_account_id` after resolution, so both scoped and unscoped paths pass — and thread downstream — the `act_`-prefixed id. No-op for already-prefixed ids; `load_conversion_action_types` compares prefix-insensitively so CV overrides still match.

Test: `test_meta_bare_id_canonicalized_even_when_unscoped`. CI-safe (agency factory disabled = 150 analytics tests pass); black/ruff/mypy clean.

https://claude.ai/code/session_01X3WKmku93ucAR8DsatzLpG