### PR TITLE
feat(onboard): proactively offer to set STRATEGY.md ## Guardrails (#364)

### DIFF
--- a/mureo/_data/skills/onboard/SKILL.md
+++ b/mureo/_data/skills/onboard/SKILL.md
@@ -101,13 +101,24 @@ Guide me through setting up mureo for a new marketing account.
    - For goals involving organic search, note Search Console as the data source
    - Create `## Goal: <title>` sections in STRATEGY.md with Target, Deadline, Current (TBD), Platform, and Priority fields
 
-7. **Initial diagnosis**: Run health checks on each configured ad platform:
+7. **Offer budget guardrails** (optional but recommended): mureo can enforce **hard** budget limits deterministically — the built-in `StrategyPolicyGate` refuses any native `google_ads_*` / `meta_ads_*` budget mutation that violates a `## Guardrails` section in STRATEGY.md, *before* dispatch, regardless of what the AI decides. Without the section the gate is fail-open (no enforcement), so most operators never get guardrails unless they know to ask — offer them here.
+   - Explain in one line: "hard limits mureo enforces before any budget change, regardless of the AI."
+   - Offer to set the machine-readable keys, seeding defaults from what you already discovered (the Target Audience **Budget Range**, and the current per-campaign budgets from step 5) — but **let me confirm every number**, never auto-decide:
+     - `max_daily_budget_per_campaign` — suggest from the current max campaign daily budget (e.g. current max × 1.5) or the Budget Range.
+     - `max_daily_budget_increase_pct` — suggest a conservative default (e.g. 20).
+     - `max_total_daily_budget` — suggest from the Budget Range upper bound.
+     - `blocked_operations` — offer common destructive ops opt-in (e.g. `google_ads_campaigns_remove`, `meta_ads_campaigns_delete`).
+   - On confirmation, write the `## Guardrails` section to STRATEGY.md (`Write` on Code / `mureo_strategy_set` on Desktop / Cowork) using the exact format in `../_mureo-strategy/SKILL.md` → *Guardrails (machine-enforced hard rules)*.
+   - **Skippable**: if I say "no guardrails for now", leave the section absent (fail-open, unchanged behaviour) and note I can add them later just by asking.
+   - **Honest scope**: hard enforcement only covers mureo-dispatched native `google_ads` / `meta_ads`. Hosted / official MCPs (TikTok `tt-ads-*`, `google-ads-official`, `meta-ads-official`) go client→platform and bypass the gate, so for those guardrails stay best-effort until the MCP gateway (#359) lands — say so.
+
+8. **Initial diagnosis**: Run health checks on each configured ad platform:
    - **Google Ads**: prefer mureo native — `google_ads_performance_report` (LAST_30_DAYS), `google_ads_campaigns_list`, `google_ads_health_check_all`. Iterate the campaigns and call `google_ads_monitoring_zero_conversions` per campaign_id for any with conv = 0. If mureo's Google Ads tools are unavailable (e.g. `MUREO_DISABLE_GOOGLE_ADS=1` after `mureo providers add google-ads-official`), fall back to the official `google-ads-official` MCP's equivalent campaign-list and performance-report tools, then **skip the mureo-only anomaly-detection tools** (`google_ads_health_check_all`, `google_ads_monitoring_zero_conversions`) and identify zero-conversion campaigns manually from the raw conv numbers; note: "anomaly detection requires mureo's native MCP — install or re-enable via `mureo setup claude-code` for full onboarding coverage."
    - **Meta Ads**: prefer mureo native — `meta_ads_insights_report` (LAST_30_DAYS) — surface `result_indicator` per campaign so the operator sees up front whether any campaigns are optimizing for `link_click` instead of true leads. If mureo's Meta Ads tools are unavailable, fall back to the official `meta-ads-official` hosted MCP for raw insights; note that the `result_indicator` field is mureo-specific — inspect each campaign's optimization goal / actions list yourself and warn the operator about any `link_click`-optimized campaigns where the user expects real leads.
    - **TikTok Ads (hosted connector, `tiktok_ads`)**: call the connector's own reporting tools (e.g. `tt-ads-*`) for LAST_30_DAYS and record baseline per-campaign spend/conversions. mureo-only anomaly detection / RSA audit do not apply — report `analytics_not_available_for_tiktok_ads` and keep the diagnosis to the raw numbers. See `../_mureo-shared/SKILL.md` → *Hosted-connector platforms*.
    - mureo BYOD data is centralized in the workspace `byod/` directory (or `~/.mureo/byod/` for legacy CLI users) and is only accessible through mureo MCP tools — do **not** look for raw CSVs in the project directory.
    - If Search Console is available, run a top-queries check to establish an organic baseline. If GA4 is available, check overall site conversion metrics.
 
-8. **Summary**: Show what was set up — platforms discovered, data sources available, goals defined — and recommend next steps.
+9. **Summary**: Show what was set up — platforms discovered, data sources available, goals defined, guardrails offered — and recommend next steps.
 
 IMPORTANT: Ask me questions interactively — don't assume answers. Each STRATEGY.md section should reflect MY actual business, not generic examples.

--- a/skills/onboard/SKILL.md
+++ b/skills/onboard/SKILL.md
@@ -101,13 +101,24 @@ Guide me through setting up mureo for a new marketing account.
    - For goals involving organic search, note Search Console as the data source
    - Create `## Goal: <title>` sections in STRATEGY.md with Target, Deadline, Current (TBD), Platform, and Priority fields
 
-7. **Initial diagnosis**: Run health checks on each configured ad platform:
+7. **Offer budget guardrails** (optional but recommended): mureo can enforce **hard** budget limits deterministically — the built-in `StrategyPolicyGate` refuses any native `google_ads_*` / `meta_ads_*` budget mutation that violates a `## Guardrails` section in STRATEGY.md, *before* dispatch, regardless of what the AI decides. Without the section the gate is fail-open (no enforcement), so most operators never get guardrails unless they know to ask — offer them here.
+   - Explain in one line: "hard limits mureo enforces before any budget change, regardless of the AI."
+   - Offer to set the machine-readable keys, seeding defaults from what you already discovered (the Target Audience **Budget Range**, and the current per-campaign budgets from step 5) — but **let me confirm every number**, never auto-decide:
+     - `max_daily_budget_per_campaign` — suggest from the current max campaign daily budget (e.g. current max × 1.5) or the Budget Range.
+     - `max_daily_budget_increase_pct` — suggest a conservative default (e.g. 20).
+     - `max_total_daily_budget` — suggest from the Budget Range upper bound.
+     - `blocked_operations` — offer common destructive ops opt-in (e.g. `google_ads_campaigns_remove`, `meta_ads_campaigns_delete`).
+   - On confirmation, write the `## Guardrails` section to STRATEGY.md (`Write` on Code / `mureo_strategy_set` on Desktop / Cowork) using the exact format in `../_mureo-strategy/SKILL.md` → *Guardrails (machine-enforced hard rules)*.
+   - **Skippable**: if I say "no guardrails for now", leave the section absent (fail-open, unchanged behaviour) and note I can add them later just by asking.
+   - **Honest scope**: hard enforcement only covers mureo-dispatched native `google_ads` / `meta_ads`. Hosted / official MCPs (TikTok `tt-ads-*`, `google-ads-official`, `meta-ads-official`) go client→platform and bypass the gate, so for those guardrails stay best-effort until the MCP gateway (#359) lands — say so.
+
+8. **Initial diagnosis**: Run health checks on each configured ad platform:
    - **Google Ads**: prefer mureo native — `google_ads_performance_report` (LAST_30_DAYS), `google_ads_campaigns_list`, `google_ads_health_check_all`. Iterate the campaigns and call `google_ads_monitoring_zero_conversions` per campaign_id for any with conv = 0. If mureo's Google Ads tools are unavailable (e.g. `MUREO_DISABLE_GOOGLE_ADS=1` after `mureo providers add google-ads-official`), fall back to the official `google-ads-official` MCP's equivalent campaign-list and performance-report tools, then **skip the mureo-only anomaly-detection tools** (`google_ads_health_check_all`, `google_ads_monitoring_zero_conversions`) and identify zero-conversion campaigns manually from the raw conv numbers; note: "anomaly detection requires mureo's native MCP — install or re-enable via `mureo setup claude-code` for full onboarding coverage."
    - **Meta Ads**: prefer mureo native — `meta_ads_insights_report` (LAST_30_DAYS) — surface `result_indicator` per campaign so the operator sees up front whether any campaigns are optimizing for `link_click` instead of true leads. If mureo's Meta Ads tools are unavailable, fall back to the official `meta-ads-official` hosted MCP for raw insights; note that the `result_indicator` field is mureo-specific — inspect each campaign's optimization goal / actions list yourself and warn the operator about any `link_click`-optimized campaigns where the user expects real leads.
    - **TikTok Ads (hosted connector, `tiktok_ads`)**: call the connector's own reporting tools (e.g. `tt-ads-*`) for LAST_30_DAYS and record baseline per-campaign spend/conversions. mureo-only anomaly detection / RSA audit do not apply — report `analytics_not_available_for_tiktok_ads` and keep the diagnosis to the raw numbers. See `../_mureo-shared/SKILL.md` → *Hosted-connector platforms*.
    - mureo BYOD data is centralized in the workspace `byod/` directory (or `~/.mureo/byod/` for legacy CLI users) and is only accessible through mureo MCP tools — do **not** look for raw CSVs in the project directory.
    - If Search Console is available, run a top-queries check to establish an organic baseline. If GA4 is available, check overall site conversion metrics.
 
-8. **Summary**: Show what was set up — platforms discovered, data sources available, goals defined — and recommend next steps.
+9. **Summary**: Show what was set up — platforms discovered, data sources available, goals defined, guardrails offered — and recommend next steps.
 
 IMPORTANT: Ask me questions interactively — don't assume answers. Each STRATEGY.md section should reflect MY actual business, not generic examples.

--- a/tests/test_onboard_guardrails.py
+++ b/tests/test_onboard_guardrails.py
@@ -1,0 +1,57 @@
+"""onboard must proactively offer budget guardrails (#364).
+
+v0.10.18 shipped hard budget-guardrail enforcement (``StrategyPolicyGate``
+refuses native ``google_ads_*`` / ``meta_ads_*`` budget mutations that violate
+a ``## Guardrails`` section in STRATEGY.md), but the gate is fail-open and there
+was no onboarding prompt — so the safety feature stayed dormant for operators
+who did not know to ask. onboard now offers to set the section during setup.
+This pins that the step is present (with the machine-readable keys), skippable,
+and honest about its native-only scope, in BOTH copies kept byte-identical.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_ROOT = Path(__file__).resolve().parent.parent
+_PACKAGED = _ROOT / "mureo" / "_data" / "skills" / "onboard" / "SKILL.md"
+_MIRROR = _ROOT / "skills" / "onboard" / "SKILL.md"
+
+
+def _body() -> str:
+    return _PACKAGED.read_text(encoding="utf-8")
+
+
+def test_onboard_copies_are_byte_identical() -> None:
+    assert _PACKAGED.read_bytes() == _MIRROR.read_bytes()
+
+
+def test_offers_the_guardrails_section_with_the_machine_keys() -> None:
+    body = _body()
+    assert "## Guardrails" in body
+    for key in (
+        "max_daily_budget_per_campaign",
+        "max_daily_budget_increase_pct",
+        "max_total_daily_budget",
+        "blocked_operations",
+    ):
+        assert key in body, f"onboard does not seed {key}"
+    # References the enforcement mechanism / its format source of truth.
+    assert "StrategyPolicyGate" in body
+
+
+def test_guardrails_offer_is_skippable() -> None:
+    """Declining leaves the section absent (fail-open, unchanged behaviour)."""
+    body = _body()
+    assert "no guardrails for now" in body.lower()
+
+
+def test_guardrails_scope_is_honest() -> None:
+    """The copy states hard enforcement covers only mureo-dispatched native
+    google_ads/meta_ads — hosted/official MCPs bypass the gate (#359)."""
+    body = _body()
+    assert "#359" in body


### PR DESCRIPTION
Closes #364.

v0.10.18 shipped hard budget-guardrail enforcement (`StrategyPolicyGate` refuses native `google_ads_*` / `meta_ads_*` budget mutations that violate a `## Guardrails` section), but the gate is **fail-open** and there was no onboarding prompt — so the safety feature stayed dormant for operators who didn't know to ask.

**Change (skill-only, `onboard`)**: a new step (after Goals) offers to set the `## Guardrails` section, seeding the machine-readable keys (`max_daily_budget_per_campaign`, `max_daily_budget_increase_pct`, `max_total_daily_budget`, `blocked_operations`) from the operator's own inputs, **confirming every number** (operator owns them), then writing the section. Skippable (declining leaves it absent = fail-open, unchanged). Honest scope note: hard enforcement covers only mureo-dispatched native google_ads/meta_ads; hosted/official MCPs bypass the gate (#359). Both SKILL.md copies updated byte-identical.

**Deferred** (issue's "also consider"): the one-time daily-check nudge — needs run-state tracking to fire once; follow-up candidate.

Tests: `tests/test_onboard_guardrails.py` (byte-identical + keys + skippable + scope). Format matches `_mureo-strategy`.

https://claude.ai/code/session_01X3WKmku93ucAR8DsatzLpG