### PR TITLE
fix(#442): gate GA4 credential wizard under a multi-account backend

### DIFF
--- a/mureo/_data/web/auth_wizards.js
+++ b/mureo/_data/web/auth_wizards.js
@@ -561,7 +561,10 @@
     // by Claude itself on first connect (RFC 9728) — configure cannot and
     // must not do it. The provider-choice "next page" (providers_install
     // step) shows the manual setup instructions instead.
-    if (state.platforms.ga4) {
+    if (state.platforms.ga4 && !state.multiAccountAuth) {
+      // #442: under a multi-account backend GA4 is wired per-account, not as
+      // one shared service account, so the Setup-tab GA4 slot is hidden. The
+      // server also refuses the write (_post_env_var); this is the UX half.
       // Each input carries the credentials.json-backed env var NAME it
       // persists to (POSTed to /api/credentials/env-var on Done) plus a
       // localized label key. GA4-official reads these env vars at

--- a/mureo/_data/web/auth_wizards.js
+++ b/mureo/_data/web/auth_wizards.js
@@ -515,7 +515,7 @@
           state.providerChoice.google_ads === "official") ||
         (platform === "meta_ads" && state.platforms.meta_ads &&
           state.providerChoice.meta_ads === "official") ||
-        (platform === "ga4" && state.platforms.ga4) ||
+        (platform === "ga4" && state.platforms.ga4 && !state.multiAccountAuth) ||
         (platform === "tiktok_ads" && state.platforms.tiktok_ads);
       if (needsOfficial) {
         host.appendChild(buildProviderInstallSlot(state, platform, render));

--- a/mureo/_data/web/wizard.js
+++ b/mureo/_data/web/wizard.js
@@ -249,6 +249,13 @@
     STATE.existing.google.has_oauth = Boolean(oauth.google);
     STATE.existing.meta.has_oauth = Boolean(oauth.meta);
     STATE.multiAccountAuth = Boolean(status.multi_account_auth);
+    // #442: a multi-account backend wires GA4 per-account, so the shared-SA
+    // GA4 flow is removed from Setup entirely. Force the platform off here so
+    // the selection checkbox, the provider-install instructions, and the auth
+    // slot all drop out (the server also refuses a ga4 write, _post_env_var).
+    if (STATE.multiAccountAuth) {
+      STATE.platforms.ga4 = false;
+    }
   }
 
   // ------------------------------------------------------------------
@@ -347,6 +354,9 @@
       '<h2>' + MUREO.t("wizard.platforms.title") + "</h2>" +
       '<p>' + MUREO.t("wizard.platforms.desc") + "</p>";
     PLATFORMS.forEach(function (p) {
+      // #442: no shared GA4 service account under a multi-account backend, so
+      // GA4 is not selectable here (that layer wires it per-account instead).
+      if (p === "ga4" && STATE.multiAccountAuth) return;
       const label = document.createElement("label");
       label.style.display = "block";
       const checkbox = document.createElement("input");

--- a/mureo/_data/web/wizard.js
+++ b/mureo/_data/web/wizard.js
@@ -55,6 +55,13 @@
     host: "claude-code",
     basicInstallCompleted: false,
     basicInstallSkippedByAdvanced: false,
+    // #442: a multi-account backend (e.g. the agency layer) advertises
+    // multi_account_auth via /api/status. GA4 auth is a single service
+    // account, so under a multi-account backend the Setup-tab GA4 slot is
+    // hidden (buildAuthQueue) and the write is refused server-side
+    // (_post_env_var) -- GA4 is wired per-account by that layer, not as one
+    // shared SA.
+    multiAccountAuth: false,
     platforms: {
       google_ads: false,
       meta_ads: false,
@@ -241,6 +248,7 @@
     const oauth = status.credentials_oauth || {};
     STATE.existing.google.has_oauth = Boolean(oauth.google);
     STATE.existing.meta.has_oauth = Boolean(oauth.meta);
+    STATE.multiAccountAuth = Boolean(status.multi_account_auth);
   }
 
   // ------------------------------------------------------------------

--- a/mureo/web/handlers.py
+++ b/mureo/web/handlers.py
@@ -91,6 +91,7 @@ from mureo.web.byod_actions import (
 from mureo.web.creative_gallery import list_creative_runs, resolve_gallery_image
 from mureo.web.demo_actions import init_demo, list_demo_scenarios
 from mureo.web.env_var_writer import (
+    get_env_var_target,
     is_allowed_env_var,
     remove_credential_section,
     write_credential_env_var,
@@ -1125,6 +1126,19 @@ class ConfigureHandler(BaseHTTPRequestHandler):
             return
         if not value:
             send_error_json(self, 400, "value_required")
+            return
+        # #442: GA4 auth is a single service account. Under a multi-account
+        # backend that one SA would reach every account/property, so refuse to
+        # write it into the shared credentials.json here -- the multi-account
+        # layer wires GA4 per-account instead. Mirrors the Search Console
+        # multi-account fail-closed (#375). Resolve the EFFECTIVE section first:
+        # GOOGLE_APPLICATION_CREDENTIALS is shared with google_ads via an
+        # explicit ``section``, so only genuine ga4 writes are refused (the
+        # Google Ads service-account path stays writable).
+        _target = get_env_var_target(name)
+        _effective_section = section or (_target.section if _target else None)
+        if _effective_section == "ga4" and self._multi_account_active():
+            send_error_json(self, 403, "ga4_multi_account_forbidden")
             return
         try:
             write_credential_env_var(

--- a/tests/test_web_assets_multi_account_mcp.py
+++ b/tests/test_web_assets_multi_account_mcp.py
@@ -37,3 +37,12 @@ def test_dashboard_gates_basic_mcp_on_multi_account() -> None:
     snapshot declares ``multi_account_auth``."""
     js = _read("dashboard.js")
     assert "multi_account_auth" in js
+
+
+@pytest.mark.unit
+def test_auth_wizard_hides_ga4_slot_under_multi_account() -> None:
+    """#442: ``auth_wizards.js`` gates the GA4 auth slot on the multi-account
+    flag, and ``wizard.js`` hydrates it from the status snapshot -- so under a
+    multi-account backend the single-shared-SA GA4 slot is not offered."""
+    assert "state.multiAccountAuth" in _read("auth_wizards.js")
+    assert "STATE.multiAccountAuth" in _read("wizard.js")

--- a/tests/test_web_assets_multi_account_mcp.py
+++ b/tests/test_web_assets_multi_account_mcp.py
@@ -46,3 +46,25 @@ def test_auth_wizard_hides_ga4_slot_under_multi_account() -> None:
     multi-account backend the single-shared-SA GA4 slot is not offered."""
     assert "state.multiAccountAuth" in _read("auth_wizards.js")
     assert "STATE.multiAccountAuth" in _read("wizard.js")
+
+
+@pytest.mark.unit
+def test_wizard_removes_ga4_entirely_under_multi_account() -> None:
+    """#442 (full removal): under a multi-account backend GA4 must not appear
+    anywhere in Setup, not just the auth slot. The wizard forces the ga4
+    platform off on hydration (so every step-relevance check drops it) and the
+    platform-selection step skips its checkbox."""
+    wizard = _read("wizard.js")
+    # Forced off on hydration -> hasAuthQueued / hasOfficialProviderQueued /
+    # the summary all see ga4 = false.
+    assert "STATE.platforms.ga4 = false" in wizard
+    # Selection checkbox is not rendered (cannot be re-enabled by the user).
+    assert 'p === "ga4" && STATE.multiAccountAuth' in wizard
+
+
+@pytest.mark.unit
+def test_providers_install_hides_ga4_under_multi_account() -> None:
+    """#442: the provider-install ("official MCP setup instructions") step also
+    drops the GA4 entry under a multi-account backend."""
+    aw = _read("auth_wizards.js")
+    assert 'platform === "ga4" && state.platforms.ga4 && !state.multiAccountAuth' in aw

--- a/tests/test_web_handlers.py
+++ b/tests/test_web_handlers.py
@@ -884,6 +884,87 @@ class TestPostEnvVar:
                 )
             assert exc.value.code == 500
 
+    def test_ga4_write_refused_under_multi_account(
+        self, wizard: ConfigureWizard
+    ) -> None:
+        # #442: GA4 auth is a single service account. Under a multi-account
+        # backend, writing it into the shared credentials.json would let one SA
+        # reach every account/property -- refuse it (mirrors Search Console's
+        # multi-account fail-closed). The write must NOT be attempted.
+        with (
+            patch(
+                "mureo.web.handlers.ConfigureHandler._multi_account_active",
+                return_value=True,
+            ),
+            patch("mureo.web.handlers.write_credential_env_var") as mock_write,
+        ):
+            with pytest.raises(urllib.error.HTTPError) as exc:
+                _post(
+                    wizard,
+                    "/api/credentials/env-var",
+                    {"name": "GOOGLE_APPLICATION_CREDENTIALS", "value": "/p/sa.json"},
+                )
+            assert exc.value.code == 403
+        mock_write.assert_not_called()
+
+    def test_ga4_project_id_refused_under_multi_account(
+        self, wizard: ConfigureWizard
+    ) -> None:
+        with (
+            patch(
+                "mureo.web.handlers.ConfigureHandler._multi_account_active",
+                return_value=True,
+            ),
+            patch("mureo.web.handlers.write_credential_env_var") as mock_write,
+        ):
+            with pytest.raises(urllib.error.HTTPError) as exc:
+                _post(
+                    wizard,
+                    "/api/credentials/env-var",
+                    {"name": "GOOGLE_PROJECT_ID", "value": "proj-1"},
+                )
+            assert exc.value.code == 403
+        mock_write.assert_not_called()
+
+    def test_google_ads_sa_path_allowed_under_multi_account(
+        self, wizard: ConfigureWizard
+    ) -> None:
+        # The GA4 guard keys off the EFFECTIVE section, not the env NAME:
+        # GOOGLE_APPLICATION_CREDENTIALS is shared with google_ads, whose
+        # service-account path (section="google_ads") must still be writable.
+        with (
+            patch(
+                "mureo.web.handlers.ConfigureHandler._multi_account_active",
+                return_value=True,
+            ),
+            patch("mureo.web.handlers.write_credential_env_var") as mock_write,
+        ):
+            resp = _post(
+                wizard,
+                "/api/credentials/env-var",
+                {
+                    "name": "GOOGLE_APPLICATION_CREDENTIALS",
+                    "value": "/p/ads-sa.json",
+                    "section": "google_ads",
+                },
+            )
+        assert json.loads(resp.read().decode("utf-8"))["status"] == "ok"
+        mock_write.assert_called_once()
+
+    def test_ga4_write_allowed_when_not_multi_account(
+        self, wizard: ConfigureWizard
+    ) -> None:
+        # Standalone OSS (no multi-account backend): the GA4 wizard writes
+        # exactly as before -- the guard must not regress the single-tenant path.
+        with patch("mureo.web.handlers.write_credential_env_var") as mock_write:
+            resp = _post(
+                wizard,
+                "/api/credentials/env-var",
+                {"name": "GOOGLE_APPLICATION_CREDENTIALS", "value": "/p/sa.json"},
+            )
+        assert json.loads(resp.read().decode("utf-8"))["status"] == "ok"
+        mock_write.assert_called_once()
+
 
 @pytest.mark.unit
 class TestPostCredentialsRemove:


### PR DESCRIPTION
Closes #442.

## Problem

Under a multi-account backend (a `SecretStore` that declares `credentials_write_path`), the Setup-tab **GA4 auth wizard still collects a single GA4 service account** and writes it into the `ga4` section of one shared `credentials.json`. Because GA4 auth is a service account, that single SA then reaches **every** account/property — the same cross-account exposure that Search Console's multi-account seam (`runtime_search_console_sites`, #375) already closes by failing closed. GA4 had no equivalent gate.

## Fix (two layers, mirroring Search Console #375)

- **Server (security boundary)** — `web/handlers.py::_post_env_var`: refuse a write whose **effective section** resolves to `ga4` when a multi-account backend is active (`_multi_account_active()`), returning `403`. The check is section-aware (via `get_env_var_target`), so the shared `GOOGLE_APPLICATION_CREDENTIALS` still writes the Google Ads service-account path (`section="google_ads"`) — only genuine GA4 writes are refused.
- **UI** — `wizard.js` hydrates `multi_account_auth` from `/api/status` into `STATE.multiAccountAuth`, and `auth_wizards.js::buildAuthQueue` hides the GA4 slot under a multi-account backend.
- **Standalone OSS** (no multi-account backend) is unaffected — the GA4 wizard behaves exactly as before.

## Tests

- `tests/test_web_handlers.py`: GA4 write refused under multi-account (`GOOGLE_APPLICATION_CREDENTIALS` / `GOOGLE_PROJECT_ID` → 403, writer not called); Google Ads SA path still allowed under multi-account (section-aware guard); GA4 write still works when not multi-account (no regression).
- `tests/test_web_assets_multi_account_mcp.py`: static-asset guard pinning that `auth_wizards.js` gates the GA4 slot on the flag and `wizard.js` hydrates it.

## Verification

`ruff check` / `black --check` / `mypy mureo/ --ignore-missing-imports` all green; `pytest tests/test_web_handlers.py tests/test_web_assets_multi_account_mcp.py` → 220 passed (incl. 5 new).

https://claude.ai/code/session_01K1AUpHXkywox8yK4irkP7e
