### PR TITLE
fix(mcp): make Search Console site_url optional so tenant auto-resolve works (H1)

### DIFF
--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -449,35 +449,37 @@ Or use `uv` to run it:
 
 Search Console tools reuse the same Google OAuth2 credentials as Google Ads -- no additional authentication is required.
 
+> **`site_url`** is an optional parameter on every tool below, not a schema-required one. It is resolved (and tenant-scoped) at runtime: in standalone use you pass it explicitly; under a multi-account backend it is bound to the active client's configured property (and a single-property client may omit it). The "Required Parameters" column lists only the schema-required fields.
+
 #### Sites
 
 | Tool | Description | Required Parameters |
 |------|-------------|-------------------|
 | `search_console_sites_list` | List verified sites | *(none)* |
-| `search_console_sites_get` | Get site details | `site_url` |
+| `search_console_sites_get` | Get site details | *(none; `site_url` optional)* |
 
 #### Analytics
 
 | Tool | Description | Required Parameters |
 |------|-------------|-------------------|
-| `search_console_analytics_query` | Query search analytics data | `site_url` |
-| `search_console_analytics_top_queries` | Get top search queries | `site_url` |
-| `search_console_analytics_top_pages` | Get top pages by clicks/impressions | `site_url` |
-| `search_console_analytics_device_breakdown` | Get performance breakdown by device | `site_url` |
-| `search_console_analytics_compare_periods` | Compare search performance across time periods | `site_url` |
+| `search_console_analytics_query` | Query search analytics data | `start_date`, `end_date` |
+| `search_console_analytics_top_queries` | Get top search queries | `start_date`, `end_date` |
+| `search_console_analytics_top_pages` | Get top pages by clicks/impressions | `start_date`, `end_date` |
+| `search_console_analytics_device_breakdown` | Get performance breakdown by device | `start_date`, `end_date` |
+| `search_console_analytics_compare_periods` | Compare search performance across time periods | `start_date_1`, `end_date_1`, `start_date_2`, `end_date_2` |
 
 #### Sitemaps
 
 | Tool | Description | Required Parameters |
 |------|-------------|-------------------|
-| `search_console_sitemaps_list` | List sitemaps for a site | `site_url` |
-| `search_console_sitemaps_submit` | Submit a sitemap | `site_url`, `feedpath` |
+| `search_console_sitemaps_list` | List sitemaps for a site | *(none; `site_url` optional)* |
+| `search_console_sitemaps_submit` | Submit a sitemap | `feedpath` |
 
 #### URL Inspection
 
 | Tool | Description | Required Parameters |
 |------|-------------|-------------------|
-| `search_console_url_inspection_inspect` | Inspect a URL for indexing status | `site_url`, `inspection_url` |
+| `search_console_url_inspection_inspect` | Inspect a URL for indexing status | `inspection_url` |
 
 ### Rollback
 

--- a/mureo/mcp/_tools_search_console.py
+++ b/mureo/mcp/_tools_search_console.py
@@ -90,7 +90,7 @@ TOOLS: list[Tool] = [
             "properties": {
                 "site_url": _SITE_URL_PARAM,
             },
-            "required": ["site_url"],
+            "required": [],
         },
     ),
     # === Search Analytics ===
@@ -154,7 +154,7 @@ TOOLS: list[Tool] = [
                     ),
                 },
             },
-            "required": ["site_url", "start_date", "end_date"],
+            "required": ["start_date", "end_date"],
         },
     ),
     Tool(
@@ -183,7 +183,7 @@ TOOLS: list[Tool] = [
                     "description": "Max rows (default: 100)",
                 },
             },
-            "required": ["site_url", "start_date", "end_date"],
+            "required": ["start_date", "end_date"],
         },
     ),
     Tool(
@@ -212,7 +212,7 @@ TOOLS: list[Tool] = [
                     "description": "Max rows (default: 100)",
                 },
             },
-            "required": ["site_url", "start_date", "end_date"],
+            "required": ["start_date", "end_date"],
         },
     ),
     Tool(
@@ -241,7 +241,7 @@ TOOLS: list[Tool] = [
                     "description": "Max rows (default: 100)",
                 },
             },
-            "required": ["site_url", "start_date", "end_date"],
+            "required": ["start_date", "end_date"],
         },
     ),
     Tool(
@@ -324,7 +324,6 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": [
-                "site_url",
                 "start_date_1",
                 "end_date_1",
                 "start_date_2",
@@ -352,7 +351,7 @@ TOOLS: list[Tool] = [
             "properties": {
                 "site_url": _SITE_URL_PARAM,
             },
-            "required": ["site_url"],
+            "required": [],
         },
     ),
     Tool(
@@ -399,7 +398,7 @@ TOOLS: list[Tool] = [
                     ),
                 },
             },
-            "required": ["site_url", "feedpath"],
+            "required": ["feedpath"],
         },
     ),
     # === URL Inspection ===
@@ -440,7 +439,7 @@ TOOLS: list[Tool] = [
                     ),
                 },
             },
-            "required": ["site_url", "inspection_url"],
+            "required": ["inspection_url"],
         },
     ),
 ]

--- a/tests/test_mcp_tools_search_console.py
+++ b/tests/test_mcp_tools_search_console.py
@@ -77,39 +77,42 @@ class TestSearchConsoleToolDefinitions:
     @pytest.mark.parametrize(
         "tool_name,expected_required",
         [
+            # site_url is intentionally NOT required at the schema level: it is
+            # resolved (and tenant-scoped) at runtime by _resolve_site_url, so a
+            # single-property multi-account client can omit it (H1). It stays an
+            # optional property on every tool that takes it.
             ("search_console_sites_list", []),
-            ("search_console_sites_get", ["site_url"]),
+            ("search_console_sites_get", []),
             (
                 "search_console_analytics_query",
-                ["site_url", "start_date", "end_date"],
+                ["start_date", "end_date"],
             ),
             (
                 "search_console_analytics_top_queries",
-                ["site_url", "start_date", "end_date"],
+                ["start_date", "end_date"],
             ),
             (
                 "search_console_analytics_top_pages",
-                ["site_url", "start_date", "end_date"],
+                ["start_date", "end_date"],
             ),
             (
                 "search_console_analytics_device_breakdown",
-                ["site_url", "start_date", "end_date"],
+                ["start_date", "end_date"],
             ),
             (
                 "search_console_analytics_compare_periods",
                 [
-                    "site_url",
                     "start_date_1",
                     "end_date_1",
                     "start_date_2",
                     "end_date_2",
                 ],
             ),
-            ("search_console_sitemaps_list", ["site_url"]),
-            ("search_console_sitemaps_submit", ["site_url", "feedpath"]),
+            ("search_console_sitemaps_list", []),
+            ("search_console_sitemaps_submit", ["feedpath"]),
             (
                 "search_console_url_inspection_inspect",
-                ["site_url", "inspection_url"],
+                ["inspection_url"],
             ),
         ],
     )

--- a/tests/test_search_console_site_url_optional.py
+++ b/tests/test_search_console_site_url_optional.py
@@ -1,0 +1,94 @@
+"""Regression: Search Console ``site_url`` must be OPTIONAL at the schema level.
+
+The tenant-scoped single-property auto-resolution in
+``_handlers_search_console._resolve_site_url`` is only reachable if the tool's
+``inputSchema`` does NOT list ``site_url`` in ``required`` — otherwise
+``server.handle_call_tool`` rejects an omitted ``site_url`` at
+``_validate_tool_input`` ("'site_url' is a required property") *before* the
+handler runs.
+
+This was review finding H1: every SC tool declared ``site_url`` as required, so
+the documented single-property auto-resolve was dead code on the real dispatch
+path. The existing tenant-scope tests call handlers directly (bypassing the
+schema), so they never caught it. These tests exercise the server dispatch
+path, where the schema is validated first.
+
+Standalone OSS is unaffected: ``_resolve_site_url`` still ``_require``s
+``site_url`` (a clear runtime error), so omitting it there still fails — just
+from the handler, not the schema.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mureo.mcp.tools_search_console import TOOLS
+
+
+@pytest.mark.unit
+def test_no_sc_tool_requires_site_url_in_schema() -> None:
+    """No Search Console tool may list ``site_url`` in its schema ``required``."""
+    offenders = [
+        tool.name
+        for tool in TOOLS
+        if "site_url" in tool.inputSchema.get("required", [])
+    ]
+    assert offenders == [], f"tools still require site_url in schema: {offenders}"
+
+
+@pytest.mark.unit
+def test_sc_tools_keep_site_url_as_a_property() -> None:
+    """``site_url`` stays an accepted (optional) property on every SC tool that
+    takes it — dropping it from ``required`` must not drop the property."""
+    for tool in TOOLS:
+        # Only the tools that take a site_url (all except sites_list).
+        if tool.name == "search_console_sites_list":
+            continue
+        assert "site_url" in tool.inputSchema.get("properties", {}), tool.name
+
+
+@pytest.mark.asyncio
+async def test_server_path_autoresolves_single_site_without_site_url() -> None:
+    """Through the schema-validated server dispatch, a tenant-scoped
+    single-property client resolves an omitted ``site_url`` instead of a schema
+    'required' rejection (the H1 bug)."""
+    from mureo.mcp import _handlers_search_console as h
+    from mureo.mcp import server
+
+    client = AsyncMock()
+    client.get_site.return_value = {"siteUrl": "https://only.example/"}
+    with (
+        patch.object(h, "load_google_ads_credentials", return_value=MagicMock()),
+        patch.object(h, "create_search_console_client", return_value=client),
+        patch.object(
+            h,
+            "runtime_search_console_sites",
+            return_value=frozenset({"https://only.example/"}),
+        ),
+    ):
+        result = await server.handle_call_tool("search_console_sites_get", {})
+
+    # Reached the handler and auto-resolved the single configured property.
+    client.get_site.assert_awaited_once_with("https://only.example/")
+    assert result  # a TextContent result, not a raised schema error
+
+
+@pytest.mark.asyncio
+async def test_server_path_standalone_still_errors_without_site_url() -> None:
+    """No regression for standalone OSS: with no tenant scope, an omitted
+    ``site_url`` still fails — now from the handler's ``_require`` rather than
+    the schema."""
+    from mureo.mcp import _handlers_search_console as h
+    from mureo.mcp import server
+
+    client = AsyncMock()
+    with (
+        patch.object(h, "load_google_ads_credentials", return_value=MagicMock()),
+        patch.object(h, "create_search_console_client", return_value=client),
+        patch.object(h, "runtime_search_console_sites", return_value=None),
+        pytest.raises(ValueError),
+    ):
+        await server.handle_call_tool("search_console_sites_get", {})
+    client.get_site.assert_not_awaited()


### PR DESCRIPTION
Fixes review finding **H1**, which slipped through un-applied in #441 (a dispatch miss — I reported it fixed when it wasn't; the docs audit surfaced it).

## The bug
Every Search Console tool declared `site_url` in its inputSchema `required`, so `server.handle_call_tool` rejected an omitted `site_url` at `_validate_tool_input` **before the handler ran** — making `_resolve_site_url`'s single-property auto-resolution (for a tenant-scoped multi-account client) unreachable. Fail-safe (rejects), so no security impact — but the documented feature was dead. The existing tenant-scope tests call handlers directly, bypassing the schema, so they never caught it.

## The fix
Drop `site_url` from `required` on all Search Console tools; it stays an optional **property**. Enforcement is unchanged and lives in `_resolve_site_url`:
- **Standalone OSS** (not tenant-scoped): still `_require`s `site_url` — omitting it errors from the handler.
- **Multi-account**: bound to the active client's allow-listed property — single → auto-resolve, multiple → refuse (no silent fallback), out-of-scope → refuse, unconfigured → fail-closed.

## Verification
- Security review verified end-to-end via `server.handle_call_tool` that no cross-tenant path opens (sibling property refused, single auto-resolves to the tenant's own property only, empty allow-list fail-closed, whitespace/non-string handled). **越境不可を確認**.
- New **schema-path** regression test (`test_search_console_site_url_optional.py`) — fails before the fix, passes after. Updated `test_required_fields` expectations. Synced `docs/mcp-server.md` required columns.
- `pytest -k search_console` → 83 passed; `ruff check mureo/` / `black --check mureo/` / `mypy` clean.

https://claude.ai/code/session_01X3WKmku93ucAR8DsatzLpG
