### PR TITLE
feat(mcp): add meta_ads_pixels_create tool for Meta Pixel creation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,7 +186,7 @@ docs/integrations.md          # Platform discovery + external MCP integration gu
 | Insights | `insights.report`, `insights.breakdown` |
 | Audiences | `audiences.list`, `audiences.create`, `audiences.get`, `audiences.delete`, `audiences.create_lookalike` |
 | Conversions API | `conversions.send`, `conversions.send_purchase`, `conversions.send_lead` |
-| Pixels | `pixels.list`, `pixels.get`, `pixels.stats`, `pixels.events` |
+| Pixels | `pixels.list`, `pixels.get`, `pixels.stats`, `pixels.events`, `pixels.create` |
 | Analysis | `analysis.performance`, `analysis.audience`, `analysis.placements`, `analysis.cost`, `analysis.compare_ads`, `analysis.suggest_creative` |
 | Product Catalog | `catalogs.list`, `catalogs.create`, `catalogs.get`, `catalogs.delete`, `products.list`, `products.add`, `products.get`, `products.update`, `products.delete`, `feeds.list`, `feeds.create` |
 | Lead Ads | `lead_forms.list`, `lead_forms.get`, `lead_forms.create`, `leads.get`, `leads.get_by_ad` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`meta_ads_pixels_create` MCP tool.** Creates a Meta Pixel on an ad
+  account via Graph API `POST /act_{ad_account_id}/adspixels` with a required
+  `name`. Returns the created pixel id. Mutating and not automatically
+  reversible — pixels cannot be deleted through the Graph API — so the tool
+  description recommends calling `meta_ads_pixels_list` first (ad accounts
+  have a pixel limit) and recording the change with
+  `mureo_state_action_log_append`. Backed by a new `PixelsMixin.create_ad_pixel`
+  client method (previously the mixin was read-only).
+
 ## [0.10.29] - 2026-07-19
 
 ### Fixed

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -418,7 +418,7 @@ When loading Meta Ads credentials, `mureo/auth.py` checks the `token_obtained_at
 
 ## Command-Based Workflow System
 
-In addition to the 199 individual MCP tools, mureo provides **workflow commands** as Claude Code native slash skills (deployed to `~/.claude/skills/`). These commands are **platform-agnostic orchestration instructions** that guide the AI agent to discover platforms, select tools, and synthesize cross-platform insights — all driven by the strategy context in `STRATEGY.md`.
+In addition to the 200 individual MCP tools, mureo provides **workflow commands** as Claude Code native slash skills (deployed to `~/.claude/skills/`). These commands are **platform-agnostic orchestration instructions** that guide the AI agent to discover platforms, select tools, and synthesize cross-platform insights — all driven by the strategy context in `STRATEGY.md`.
 
 ### How It Works
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -1,6 +1,6 @@
 # MCP Server Guide
 
-mureo exposes 199 tools via the [Model Context Protocol](https://modelcontextprotocol.io/) (MCP): 178 advertising and SEO operation tools across Google Ads (86), Meta Ads (82), and Search Console (10), 2 rollback tools, 1 cross-platform anomaly-detection tool, 9 mureo-context tools (strategy / state / reports / outcome evaluation), 2 analytics-registry tools, 2 learning tools (`mureo_learning_insights_get` for the operator's local `/learn` history and `mureo_consult_advisor` for federated retrieval against external advisor MCP servers — see [`docs/insight-federation.md`](insight-federation.md)), and 5 Creative Studio tools (text-free key-visual generation + banner composition). Any MCP-compatible client can connect and call these tools over stdio. Re-check this count when MCP tools are added or removed (`test_list_tools_returns_all_tools` pins the exact number).
+mureo exposes 200 tools via the [Model Context Protocol](https://modelcontextprotocol.io/) (MCP): 179 advertising and SEO operation tools across Google Ads (86), Meta Ads (83), and Search Console (10), 2 rollback tools, 1 cross-platform anomaly-detection tool, 9 mureo-context tools (strategy / state / reports / outcome evaluation), 2 analytics-registry tools, 2 learning tools (`mureo_learning_insights_get` for the operator's local `/learn` history and `mureo_consult_advisor` for federated retrieval against external advisor MCP servers — see [`docs/insight-federation.md`](insight-federation.md)), and 5 Creative Studio tools (text-free key-visual generation + banner composition). Any MCP-compatible client can connect and call these tools over stdio. Re-check this count when MCP tools are added or removed (`test_list_tools_returns_all_tools` pins the exact number).
 
 ## Starting the Server
 
@@ -358,6 +358,7 @@ Or use `uv` to run it:
 | `meta_ads_pixels_get` | Get pixel details | `account_id`, `pixel_id` |
 | `meta_ads_pixels_stats` | Get pixel firing statistics | `account_id`, `pixel_id` |
 | `meta_ads_pixels_events` | List pixel events | `account_id`, `pixel_id` |
+| `meta_ads_pixels_create` | Create a pixel | `account_id`, `name` |
 
 #### Analysis
 

--- a/docs/native-vs-official.md
+++ b/docs/native-vs-official.md
@@ -105,7 +105,7 @@ from mureo native.
   assets (copy, images, carousels, collections, dynamic ads); Instagram-specific
   actions.
 
-### mureo native — Meta Ads (82 tools)
+### mureo native — Meta Ads (83 tools)
 
 Covers the same operational class as the official MCP **plus** every documented
 gap above:
@@ -114,7 +114,7 @@ gap above:
 - Audiences + **lookalikes**
 - Creatives — single / carousel / collection / dynamic / lead — + image/video upload
 - Insights + breakdowns; analysis (performance / audience / placements / cost / compare / suggest creative)
-- Pixels (list / get / stats / events) and **Conversions API send** (purchase / lead)
+- Pixels (list / get / stats / events / **create**) and **Conversions API send** (purchase / lead)
 - Catalogs / products / feeds
 - **Lead forms + lead retrieval + CSV export**
 - **Split tests**, **automated rules**, page-post boost, **Instagram** (accounts / media / boost)

--- a/mureo/mcp/_handlers_meta_ads_extended.py
+++ b/mureo/mcp/_handlers_meta_ads_extended.py
@@ -323,6 +323,16 @@ async def handle_pixels_events(args: dict[str, Any]) -> list[TextContent]:
     return _json_result(result)
 
 
+@api_error_handler
+async def handle_pixels_create(args: dict[str, Any]) -> list[TextContent]:
+    client = await _get_client(args)
+    if client is None:
+        return _no_meta_creds()
+    name = _require(args, "name")
+    result = await client.create_ad_pixel(name)
+    return _json_result(result)
+
+
 # ---------------------------------------------------------------------------
 # Analysis handlers
 # ---------------------------------------------------------------------------

--- a/mureo/mcp/_tools_meta_ads_audiences.py
+++ b/mureo/mcp/_tools_meta_ads_audiences.py
@@ -372,4 +372,34 @@ TOOLS: list[Tool] = [
             "required": ["pixel_id"],
         },
     ),
+    Tool(
+        name="meta_ads_pixels_create",
+        description=(
+            "Creates a new Meta Pixel on the ad account. Returns the new "
+            "pixel id. Mutating — not automatically reversible; pixels "
+            "cannot be deleted via the Graph API once created, so record "
+            "before-state with mureo_state_action_log_append if you may "
+            "need to audit the change. Call meta_ads_pixels_list first to "
+            "check for an existing pixel — ad accounts have a pixel limit, "
+            "and reusing an existing pixel is almost always preferable to "
+            "creating a duplicate. After creation, install the pixel's "
+            "code on the site and use meta_ads_pixels_stats / events to "
+            "confirm it is firing."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "name": {
+                    "type": "string",
+                    "description": (
+                        "Pixel name shown in Events Manager. Pick "
+                        "something descriptive (e.g. the site or brand) "
+                        "so it is easy to identify later."
+                    ),
+                },
+            },
+            "required": ["name"],
+        },
+    ),
 ]

--- a/mureo/mcp/tools_meta_ads.py
+++ b/mureo/mcp/tools_meta_ads.py
@@ -90,6 +90,7 @@ from mureo.mcp._handlers_meta_ads_extended import (
     handle_creatives_create_lead,
     handle_creatives_list,
     handle_creatives_upload_image,
+    handle_pixels_create,
     handle_pixels_events,
     handle_pixels_get,
     handle_pixels_list,
@@ -245,6 +246,7 @@ _HANDLERS: dict[str, Any] = {
     "meta_ads_pixels_get": handle_pixels_get,
     "meta_ads_pixels_stats": handle_pixels_stats,
     "meta_ads_pixels_events": handle_pixels_events,
+    "meta_ads_pixels_create": handle_pixels_create,
     # Analysis
     "meta_ads_analysis_performance": handle_analysis_performance,
     "meta_ads_analysis_audience": handle_analysis_audience,

--- a/mureo/meta_ads/_pixels.py
+++ b/mureo/meta_ads/_pixels.py
@@ -1,6 +1,7 @@
 """Meta Ads pixel operations mixin.
 
-Pixel listing, details, statistics, and event checking (read-only).
+Pixel listing, details, statistics, event checking, and creation.
+Read paths are read-only; ``create_ad_pixel`` is the sole write.
 """
 
 from __future__ import annotations
@@ -28,7 +29,10 @@ _PERIOD_DAYS: dict[str, int] = {
 
 
 class PixelsMixin:
-    """Meta Ads pixel operations mixin (read-only)
+    """Meta Ads pixel operations mixin
+
+    Read paths (list / get / stats / events) are read-only;
+    ``create_ad_pixel`` is the single write method.
 
     Used via multiple inheritance with MetaAdsApiClient.
     """
@@ -37,6 +41,10 @@ class PixelsMixin:
 
     async def _get(  # type: ignore[empty-body]
         self, path: str, params: dict[str, Any] | None = None
+    ) -> dict[str, Any]: ...
+
+    async def _post(  # type: ignore[empty-body]
+        self, path: str, data: dict[str, Any] | None = None
     ) -> dict[str, Any]: ...
 
     async def list_ad_pixels(
@@ -111,3 +119,24 @@ class PixelsMixin:
         }
         result = await self._get(f"/{pixel_id}/stats", params)
         return result.get("data", [])  # type: ignore[no-any-return]
+
+    async def create_ad_pixel(self, name: str) -> dict[str, Any]:
+        """Create a Meta Pixel on the ad account.
+
+        Args:
+            name: Pixel name shown in Events Manager. Must be
+                non-empty (leading / trailing whitespace is stripped).
+
+        Returns:
+            Created pixel info dict — Meta returns ``{"id": "..."}``.
+
+        Raises:
+            ValueError: ``name`` is empty or whitespace-only.
+        """
+        clean_name = name.strip()
+        if not clean_name:
+            raise ValueError("name must be a non-empty string")
+        logger.info("Pixel creation: name=%s", clean_name)
+        return await self._post(
+            f"/{self._ad_account_id}/adspixels", {"name": clean_name}
+        )

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -47,12 +47,15 @@ def _standalone_account_scoping():
     such a plugin would break these standalone assertions. Neutralize both
     seams; scoped behavior lives in test_account_id_tenant_scope.py.
     """
-    with patch(
-        "mureo.mcp._handlers_google_ads.runtime_google_ads_customer_ids",
-        return_value=None,
-    ), patch(
-        "mureo.mcp._handlers_meta_ads.runtime_meta_account_ids",
-        return_value=None,
+    with (
+        patch(
+            "mureo.mcp._handlers_google_ads.runtime_google_ads_customer_ids",
+            return_value=None,
+        ),
+        patch(
+            "mureo.mcp._handlers_meta_ads.runtime_meta_account_ids",
+            return_value=None,
+        ),
     ):
         yield
 
@@ -62,15 +65,15 @@ class TestListTools:
     """Verify list_tools returns the correct tool definitions."""
 
     async def test_list_tools_returns_all_tools(self) -> None:
-        """list_tools returns all tools (Google Ads 86 + Meta Ads 82 + Search Console 10
+        """list_tools returns all tools (Google Ads 86 + Meta Ads 83 + Search Console 10
         + Rollback 2 + Analysis 1 + Mureo Context 9 + Analytics Registry 2
-        + Learning 2 + Creative Studio 5 = 199).
+        + Learning 2 + Creative Studio 5 = 200).
 
         Analytics Registry is 2: mureo_analytics_modules_list +
         mureo_analytics_run (#440)."""
         mod = _import_server_module()
         tools = await mod.handle_list_tools()
-        assert len(tools) == 199
+        assert len(tools) == 200
 
     async def test_list_tools_contains_google_and_meta(self) -> None:
         """Google Ads and Meta Ads tools are included."""

--- a/tests/test_mcp_tools_meta_ads.py
+++ b/tests/test_mcp_tools_meta_ads.py
@@ -54,9 +54,9 @@ class TestMetaAdsToolDefinitions:
     """Verify the Meta Ads tool list is defined correctly."""
 
     def test_tool_count(self) -> None:
-        """All 82 tools are defined (81 + meta_ads_pages_upload_photo, #151)."""
+        """All 83 tools are defined (82 + meta_ads_pixels_create)."""
         mod = _import_meta_ads_tools()
-        assert len(mod.TOOLS) == 82
+        assert len(mod.TOOLS) == 83
 
     def test_all_tool_names(self) -> None:
         """Every tool name starts with meta_ads_ (underscore-separated, per MCP spec)."""
@@ -101,6 +101,7 @@ class TestMetaAdsToolDefinitions:
             ),
             ("meta_ads_audiences_list", []),
             ("meta_ads_audiences_create", ["name"]),
+            ("meta_ads_pixels_create", ["name"]),
         ],
     )
     def test_required_fields(

--- a/tests/test_mcp_tools_meta_ads_extended.py
+++ b/tests/test_mcp_tools_meta_ads_extended.py
@@ -549,3 +549,74 @@ class TestPixelHandlers:
         client.get_pixel_events.assert_awaited_once_with("px_1")
         parsed = json.loads(result[0].text)
         assert parsed[0]["event"] == "PageView"
+
+    async def test_pixels_create(self) -> None:
+        mod = _import_meta_ads_tools()
+        handlers = _import_handlers()
+        creds, client = _mock_meta_ads_context()
+        client.create_ad_pixel.return_value = {"id": "px_new"}
+
+        with (
+            patch.object(handlers, "load_meta_ads_credentials", return_value=creds),
+            patch.object(handlers, "create_meta_ads_client", return_value=client),
+        ):
+            result = await mod.handle_tool(
+                "meta_ads_pixels_create",
+                {"account_id": "act_123", "name": "Main Pixel"},
+            )
+
+        client.create_ad_pixel.assert_awaited_once_with("Main Pixel")
+        parsed = json.loads(result[0].text)
+        assert parsed["id"] == "px_new"
+
+    async def test_pixels_create_requires_name(self) -> None:
+        """name is the sole required parameter — omit it and the handler
+        must raise rather than POST a malformed payload."""
+        mod = _import_meta_ads_tools()
+        handlers = _import_handlers()
+        creds, client = _mock_meta_ads_context()
+
+        with (
+            patch.object(handlers, "load_meta_ads_credentials", return_value=creds),
+            patch.object(handlers, "create_meta_ads_client", return_value=client),
+            pytest.raises(ValueError, match="name"),
+        ):
+            await mod.handle_tool(
+                "meta_ads_pixels_create",
+                {"account_id": "act_123"},
+            )
+        client.create_ad_pixel.assert_not_called()
+
+    async def test_pixels_create_no_credentials(self) -> None:
+        """Returns error text when no credentials are present."""
+        mod = _import_meta_ads_tools()
+        handlers = _import_handlers()
+        with patch.object(handlers, "load_meta_ads_credentials", return_value=None):
+            result = await mod.handle_tool(
+                "meta_ads_pixels_create",
+                {"account_id": "act_123", "name": "Main Pixel"},
+            )
+        assert len(result) == 1
+        assert "Credentials not found" in result[0].text
+
+    async def test_pixels_create_api_error(self) -> None:
+        """A non-ValueError raised by the client (e.g. a Graph API
+        failure) round-trips through @api_error_handler into the
+        API_ERROR_PREFIX envelope rather than propagating."""
+        mod = _import_meta_ads_tools()
+        handlers = _import_handlers()
+        creds, client = _mock_meta_ads_context()
+        client.create_ad_pixel.side_effect = RuntimeError("Meta API request failed")
+
+        with (
+            patch.object(handlers, "load_meta_ads_credentials", return_value=creds),
+            patch.object(handlers, "create_meta_ads_client", return_value=client),
+        ):
+            result = await mod.handle_tool(
+                "meta_ads_pixels_create",
+                {"account_id": "act_123", "name": "Main Pixel"},
+            )
+
+        assert len(result) == 1
+        assert "API error" in result[0].text
+        assert "Meta API request failed" in result[0].text

--- a/tests/test_meta_ads_operations.py
+++ b/tests/test_meta_ads_operations.py
@@ -755,6 +755,28 @@ class TestPixelsMixin:
         result = await client.get_pixel_events("px1")
         assert len(result) == 1
 
+    @pytest.mark.asyncio
+    async def test_create_ad_pixel(self, client) -> None:
+        client._post = AsyncMock(return_value={"id": "px_new"})
+        result = await client.create_ad_pixel("Main Pixel")
+        client._post.assert_awaited_once()
+        call_args = client._post.call_args
+        assert "/act_123/adspixels" in call_args[0][0]
+        assert call_args[0][1] == {"name": "Main Pixel"}
+        assert result["id"] == "px_new"
+
+    @pytest.mark.asyncio
+    async def test_create_ad_pixel_strips_whitespace(self, client) -> None:
+        client._post = AsyncMock(return_value={"id": "px_new"})
+        await client.create_ad_pixel("  Main Pixel  ")
+        assert client._post.call_args[0][1] == {"name": "Main Pixel"}
+
+    @pytest.mark.asyncio
+    async def test_create_ad_pixel_rejects_empty_name(self, client) -> None:
+        with pytest.raises(ValueError, match="name"):
+            await client.create_ad_pixel("   ")
+        client._post.assert_not_called()
+
 
 # ===========================================================================
 # InsightsMixin tests

--- a/tests/test_strategy_reminder.py
+++ b/tests/test_strategy_reminder.py
@@ -191,6 +191,7 @@ _MUTATING_CATALOGUE: frozenset[str] = frozenset(
         "meta_ads_lead_forms_duplicate",  # CRITICAL round-2 fix
         "meta_ads_lead_forms_update",
         "meta_ads_page_posts_boost",
+        "meta_ads_pixels_create",
         "meta_ads_products_add",
         "meta_ads_products_delete",
         "meta_ads_products_update",


### PR DESCRIPTION
## Summary
- New mutating MCP tool `meta_ads_pixels_create`: creates a Meta Pixel on the ad account via Graph API `POST /act_{ad_account_id}/adspixels` (`name` required)
- `PixelsMixin.create_ad_pixel(name)` with input validation; mixin docstring updated since it is no longer read-only
- Handler / schema / dispatch registration follow the `meta_ads_lead_forms_create` pattern exactly
- Tool description declares the operation mutating and **not reversible via the Graph API** (pixels cannot be deleted), recommends checking `meta_ads_pixels_list` first (account pixel limit) and logging via `mureo_state_action_log_append`
- Aggregate tool count bumped 199 → 200 (Meta Ads 82 → 83) across `tests/test_mcp_server.py`, `docs/mcp-server.md`, `docs/architecture.md`, `docs/native-vs-official.md`

## Test plan
- TDD: tests written first (8 failed on red), then implementation
- Client tests assert the exact POST path/body; handler tests cover success, missing `name`, missing credentials, and API-error round-trip through `@api_error_handler`
- Meta-related suites: 174 passed; full suite green apart from known environment-only failures (local plugins inflate the absolute tool count; builtin registry sum verified = 200)

## Coordination
mureo-pro must merge its follow-up `TOOL_SPECS` entry (branch `feat/meta-pixels-create-toolspec`) immediately after this lands — its parity test binds to OSS main HEAD, so keep the two merges back-to-back.