### PR TITLE
feat(mcp): Meta bidding controls — bid_strategy, ad-set budgets, promoted_object, pages_list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,6 +193,7 @@ docs/integrations.md          # Platform discovery + external MCP integration gu
 | Videos | `videos.upload`, `videos.upload_file` |
 | Split Tests | `split_tests.list`, `split_tests.get`, `split_tests.create`, `split_tests.end` |
 | Ad Rules | `ad_rules.list`, `ad_rules.get`, `ad_rules.create`, `ad_rules.update`, `ad_rules.delete` |
+| Pages | `pages.list` |
 | Page Posts | `page_posts.list`, `page_posts.boost` |
 | Instagram | `instagram.accounts`, `instagram.media`, `instagram.boost` |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Meta Ads bidding controls on campaign / ad-set write tools.**
+  `meta_ads_campaigns_create` and `meta_ads_campaigns_update` gain
+  `bid_strategy` (`LOWEST_COST_WITHOUT_CAP`, `LOWEST_COST_WITH_BID_CAP`,
+  `COST_CAP`, `LOWEST_COST_WITH_MIN_ROAS`); `campaigns_create` also gains
+  `is_adset_budget_sharing_enabled` (required by Meta when creating a
+  campaign without campaign budget optimization). `meta_ads_ad_sets_create`
+  and `meta_ads_ad_sets_update` gain `bid_strategy`, `bid_constraints`
+  (carrying `roas_average_floor` for the min-ROAS strategy), and
+  `promoted_object` (the pixel/event conversion target); `ad_sets_update`
+  additionally exposes `bid_amount` (previously create-only, needed when
+  switching to a capped strategy). Combinations are passed through to Graph
+  rather than pre-validated, with the tool descriptions documenting the
+  cross-field requirements. Read paths now surface
+  `is_adset_budget_sharing_enabled` (campaigns) and `promoted_object`
+  (ad sets).
+- **`meta_ads_pages_list` MCP tool.** Read-only listing of the Facebook
+  Pages the current token can manage, aggregating personal
+  (`/me/accounts`) and business-owned (`/me/businesses` → `owned_pages`)
+  Pages. Backed by a new `MetaAdsApiClient.list_pages` method that shares
+  the two-step page-discovery logic with `get_page_access_token`.
+
+### Changed
+
+- **Stricter input validation on the four Meta Ads campaign / ad-set write
+  tools.** `meta_ads_campaigns_create`, `meta_ads_campaigns_update`,
+  `meta_ads_ad_sets_create`, and `meta_ads_ad_sets_update` now declare
+  `additionalProperties: false`, so an unknown / misspelled parameter is
+  rejected with a clear schema error instead of being silently dropped.
+
 - **`meta_ads_pixels_create` MCP tool.** Creates a Meta Pixel on an ad
   account via Graph API `POST /act_{ad_account_id}/adspixels` with a required
   `name`. Returns the created pixel id. Mutating and not automatically

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -418,7 +418,7 @@ When loading Meta Ads credentials, `mureo/auth.py` checks the `token_obtained_at
 
 ## Command-Based Workflow System
 
-In addition to the 200 individual MCP tools, mureo provides **workflow commands** as Claude Code native slash skills (deployed to `~/.claude/skills/`). These commands are **platform-agnostic orchestration instructions** that guide the AI agent to discover platforms, select tools, and synthesize cross-platform insights — all driven by the strategy context in `STRATEGY.md`.
+In addition to the 201 individual MCP tools, mureo provides **workflow commands** as Claude Code native slash skills (deployed to `~/.claude/skills/`). These commands are **platform-agnostic orchestration instructions** that guide the AI agent to discover platforms, select tools, and synthesize cross-platform insights — all driven by the strategy context in `STRATEGY.md`.
 
 ### How It Works
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -1,6 +1,6 @@
 # MCP Server Guide
 
-mureo exposes 200 tools via the [Model Context Protocol](https://modelcontextprotocol.io/) (MCP): 179 advertising and SEO operation tools across Google Ads (86), Meta Ads (83), and Search Console (10), 2 rollback tools, 1 cross-platform anomaly-detection tool, 9 mureo-context tools (strategy / state / reports / outcome evaluation), 2 analytics-registry tools, 2 learning tools (`mureo_learning_insights_get` for the operator's local `/learn` history and `mureo_consult_advisor` for federated retrieval against external advisor MCP servers — see [`docs/insight-federation.md`](insight-federation.md)), and 5 Creative Studio tools (text-free key-visual generation + banner composition). Any MCP-compatible client can connect and call these tools over stdio. Re-check this count when MCP tools are added or removed (`test_list_tools_returns_all_tools` pins the exact number).
+mureo exposes 201 tools via the [Model Context Protocol](https://modelcontextprotocol.io/) (MCP): 180 advertising and SEO operation tools across Google Ads (86), Meta Ads (84), and Search Console (10), 2 rollback tools, 1 cross-platform anomaly-detection tool, 9 mureo-context tools (strategy / state / reports / outcome evaluation), 2 analytics-registry tools, 2 learning tools (`mureo_learning_insights_get` for the operator's local `/learn` history and `mureo_consult_advisor` for federated retrieval against external advisor MCP servers — see [`docs/insight-federation.md`](insight-federation.md)), and 5 Creative Studio tools (text-free key-visual generation + banner composition). Any MCP-compatible client can connect and call these tools over stdio. Re-check this count when MCP tools are added or removed (`test_list_tools_returns_all_tools` pins the exact number).
 
 ## Starting the Server
 
@@ -400,6 +400,12 @@ Or use `uv` to run it:
 | `meta_ads_leads_get` | Get lead data (per form) | `account_id`, `form_id` |
 | `meta_ads_leads_get_by_ad` | Get lead data (per ad) | `account_id`, `ad_id` |
 | `meta_ads_pages_upload_photo` | Upload a Page photo, returns the `photo_id` for an Instant Form intro `context_card.cover_photo_id` (needs `pages_manage_posts`) | `account_id`, `page_id`, `file_path` \| `image_url` |
+
+#### Pages
+
+| Tool | Description | Required Parameters |
+|------|-------------|-------------------|
+| `meta_ads_pages_list` | List manageable Facebook Pages (personal + business-owned) | `account_id` |
 
 #### Videos
 

--- a/docs/native-vs-official.md
+++ b/docs/native-vs-official.md
@@ -105,12 +105,13 @@ from mureo native.
   assets (copy, images, carousels, collections, dynamic ads); Instagram-specific
   actions.
 
-### mureo native — Meta Ads (83 tools)
+### mureo native — Meta Ads (84 tools)
 
 Covers the same operational class as the official MCP **plus** every documented
 gap above:
 
-- Campaigns, ad sets, ads (CRUD + pause / enable)
+- Campaigns, ad sets, ads (CRUD + pause / enable) — including **bid strategy**, **bid constraints (min-ROAS)**, and **promoted_object** (conversion optimization)
+- **Page discovery** (`pages_list`)
 - Audiences + **lookalikes**
 - Creatives — single / carousel / collection / dynamic / lead — + image/video upload
 - Insights + breakdowns; analysis (performance / audience / placements / cost / compare / suggest creative)

--- a/mureo/mcp/_handlers_meta_ads.py
+++ b/mureo/mcp/_handlers_meta_ads.py
@@ -188,7 +188,13 @@ async def handle_campaigns_create(args: dict[str, Any]) -> list[TextContent]:
         "name": _require(args, "name"),
         "objective": _require(args, "objective"),
     }
-    for key in ("status", "daily_budget", "lifetime_budget"):
+    for key in (
+        "status",
+        "daily_budget",
+        "lifetime_budget",
+        "bid_strategy",
+        "is_adset_budget_sharing_enabled",
+    ):
         val = _opt(args, key)
         if val is not None:
             kwargs[key] = val
@@ -204,7 +210,7 @@ async def handle_campaigns_update(args: dict[str, Any]) -> list[TextContent]:
         return _no_meta_creds()
     campaign_id = _require(args, "campaign_id")
     update_kwargs: dict[str, Any] = {}
-    for key in ("name", "status", "daily_budget"):
+    for key in ("name", "status", "daily_budget", "bid_strategy"):
         val = _opt(args, key)
         if val is not None:
             update_kwargs[key] = val
@@ -246,6 +252,9 @@ async def handle_ad_sets_create(args: dict[str, Any]) -> list[TextContent]:
         "targeting",
         "status",
         "bid_amount",
+        "bid_strategy",
+        "bid_constraints",
+        "promoted_object",
     ):
         val = _opt(args, key)
         if val is not None:
@@ -305,14 +314,24 @@ def _validate_ad_set_schedule_and_budget(args: dict[str, Any]) -> int | str | No
 
 @api_error_handler
 async def handle_ad_sets_update(args: dict[str, Any]) -> list[TextContent]:
-    _validate_positive_money(args, "daily_budget", "lifetime_budget")
+    _validate_positive_money(args, "daily_budget", "lifetime_budget", "bid_amount")
     end_time = _validate_ad_set_schedule_and_budget(args)
     client = await _get_client(args)
     if client is None:
         return _no_meta_creds()
     ad_set_id = _require(args, "ad_set_id")
     update_kwargs: dict[str, Any] = {}
-    for key in ("name", "status", "daily_budget", "lifetime_budget", "targeting"):
+    for key in (
+        "name",
+        "status",
+        "daily_budget",
+        "lifetime_budget",
+        "targeting",
+        "bid_strategy",
+        "bid_amount",
+        "bid_constraints",
+        "promoted_object",
+    ):
         val = _opt(args, key)
         if val is not None:
             update_kwargs[key] = val
@@ -902,6 +921,7 @@ from mureo.mcp._handlers_meta_ads_other import (  # noqa: E402, F401
     handle_instagram_media,
     handle_page_posts_boost,
     handle_page_posts_list,
+    handle_pages_list,
     handle_split_tests_create,
     handle_split_tests_end,
     handle_split_tests_get,

--- a/mureo/mcp/_handlers_meta_ads_other.py
+++ b/mureo/mcp/_handlers_meta_ads_other.py
@@ -49,6 +49,21 @@ async def handle_page_posts_boost(args: dict[str, Any]) -> list[TextContent]:
 
 
 # ---------------------------------------------------------------------------
+# Page handlers
+# ---------------------------------------------------------------------------
+
+
+@api_error_handler
+async def handle_pages_list(args: dict[str, Any]) -> list[TextContent]:
+    """List Facebook Pages the current token can manage (read-only)."""
+    client = await _get_client(args)
+    if client is None:
+        return _no_meta_creds()
+    result = await client.list_pages()
+    return _json_result(result)
+
+
+# ---------------------------------------------------------------------------
 # Instagram handlers
 # ---------------------------------------------------------------------------
 

--- a/mureo/mcp/_tools_meta_ads_campaigns.py
+++ b/mureo/mcp/_tools_meta_ads_campaigns.py
@@ -33,6 +33,94 @@ _LIMIT_PARAM = {
     ),
 }
 
+# Bid strategy enum shared by campaign and ad-set write tools. The
+# description documents the cross-field requirements each strategy
+# imposes; combinations are NOT pre-validated in handlers — invalid
+# pairings surface as Graph's own error (consistent tool philosophy).
+_BID_STRATEGY_PARAM = {
+    "type": "string",
+    "enum": [
+        "LOWEST_COST_WITHOUT_CAP",
+        "LOWEST_COST_WITH_BID_CAP",
+        "COST_CAP",
+        "LOWEST_COST_WITH_MIN_ROAS",
+    ],
+    "description": (
+        "Bid strategy for automatic auction bidding. "
+        "LOWEST_COST_WITHOUT_CAP is fully automatic (do NOT set "
+        "bid_amount). LOWEST_COST_WITH_BID_CAP and COST_CAP both require "
+        "a bid_amount on the ad set (the cap). LOWEST_COST_WITH_MIN_ROAS "
+        "requires bid_constraints.roas_average_floor on the ad set. When "
+        "set on the campaign, budgets typically live at the campaign (CBO) "
+        "level; when set on the ad set, at the ad-set level."
+    ),
+}
+
+# Ad-set bid constraints. roas_average_floor is the minimum-ROAS floor
+# scaled x10000 (e.g. 1.2x ROAS -> 12000), used with
+# LOWEST_COST_WITH_MIN_ROAS.
+_BID_CONSTRAINTS_PARAM = {
+    "type": "object",
+    "properties": {
+        "roas_average_floor": {
+            "type": "integer",
+            "minimum": 1,
+            "description": (
+                "Minimum average ROAS floor, scaled x10000 (e.g. a 1.2x "
+                "ROAS target is 12000). Required when bid_strategy is "
+                "LOWEST_COST_WITH_MIN_ROAS."
+            ),
+        },
+    },
+    "description": (
+        "Bid constraints object. Currently carries roas_average_floor "
+        "for the LOWEST_COST_WITH_MIN_ROAS strategy."
+    ),
+}
+
+# Ad-set promoted_object: the conversion target for conversion
+# optimization. All members are standard Graph promoted_object fields.
+_PROMOTED_OBJECT_PARAM = {
+    "type": "object",
+    "properties": {
+        "pixel_id": {
+            "type": "string",
+            "description": "Meta Pixel ID to optimize conversions toward.",
+        },
+        "custom_event_type": {
+            "type": "string",
+            "description": (
+                "Standard conversion event to optimize for. Common values: "
+                "LEAD, PURCHASE, COMPLETE_REGISTRATION, ADD_TO_CART, "
+                "INITIATED_CHECKOUT, CONTENT_VIEW. Graph accepts many "
+                "values — passed through unchanged."
+            ),
+        },
+        "page_id": {
+            "type": "string",
+            "description": "Facebook Page ID (for page-based optimization goals).",
+        },
+        "application_id": {
+            "type": "string",
+            "description": "App ID (for app-install / app-event optimization).",
+        },
+        "object_store_url": {
+            "type": "string",
+            "description": "App store URL (paired with application_id).",
+        },
+        "custom_conversion_id": {
+            "type": "string",
+            "description": "Custom Conversion ID to optimize toward.",
+        },
+    },
+    "description": (
+        "Conversion target for conversion optimization, e.g. "
+        '{"pixel_id": "123", "custom_event_type": "LEAD"}. Required for '
+        "conversion optimization (e.g. OUTCOME_LEADS + optimization_goal "
+        "OFFSITE_CONVERSIONS optimizing to a pixel event)."
+    ),
+}
+
 TOOLS: list[Tool] = [
     # === Campaigns ===
     Tool(
@@ -164,8 +252,19 @@ TOOLS: list[Tool] = [
                         "Mutually exclusive with daily_budget."
                     ),
                 },
+                "bid_strategy": _BID_STRATEGY_PARAM,
+                "is_adset_budget_sharing_enabled": {
+                    "type": "boolean",
+                    "description": (
+                        "Required by Meta when creating a campaign WITHOUT "
+                        "campaign budget optimization (i.e. budgets live on "
+                        "the ad sets). Set false for per-ad-set budgets; set "
+                        "true to let ad sets share a campaign-level budget."
+                    ),
+                },
             },
             "required": ["name", "objective"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -211,8 +310,10 @@ TOOLS: list[Tool] = [
                         "budgets must be edited via meta_ads_ad_sets_update."
                     ),
                 },
+                "bid_strategy": _BID_STRATEGY_PARAM,
             },
             "required": ["campaign_id"],
+            "additionalProperties": False,
         },
     ),
     # === Campaign pause / enable ===
@@ -373,13 +474,17 @@ TOOLS: list[Tool] = [
                     "minimum": 1,
                     "description": (
                         "Bid cap in account currency minor units. Required "
-                        "for bid-strategy optimization goals such as "
-                        "LINK_CLICKS with TARGET_COST. Omit for automatic "
-                        "bidding."
+                        "when bid_strategy is LOWEST_COST_WITH_BID_CAP or "
+                        "COST_CAP. Omit for LOWEST_COST_WITHOUT_CAP "
+                        "(automatic bidding)."
                     ),
                 },
+                "bid_strategy": _BID_STRATEGY_PARAM,
+                "bid_constraints": _BID_CONSTRAINTS_PARAM,
+                "promoted_object": _PROMOTED_OBJECT_PARAM,
             },
             "required": ["campaign_id", "name"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -466,8 +571,21 @@ TOOLS: list[Tool] = [
                         "false (safe merge)."
                     ),
                 },
+                "bid_strategy": _BID_STRATEGY_PARAM,
+                "bid_amount": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": (
+                        "Bid cap in account currency minor units. Set when "
+                        "switching to a capped strategy "
+                        "(LOWEST_COST_WITH_BID_CAP or COST_CAP)."
+                    ),
+                },
+                "bid_constraints": _BID_CONSTRAINTS_PARAM,
+                "promoted_object": _PROMOTED_OBJECT_PARAM,
             },
             "required": ["ad_set_id"],
+            "additionalProperties": False,
         },
     ),
     # === Ad set get / pause / enable ===

--- a/mureo/mcp/_tools_meta_ads_other.py
+++ b/mureo/mcp/_tools_meta_ads_other.py
@@ -485,6 +485,25 @@ TOOLS: list[Tool] = [
             "required": ["page_id", "post_id", "ad_set_id"],
         },
     ),
+    # === Pages ===
+    Tool(
+        name="meta_ads_pages_list",
+        description=(
+            "Lists Facebook Pages the current access token can manage, "
+            "aggregating personal Pages (/me/accounts) and business-owned "
+            "Pages (/me/businesses -> owned_pages). Returns id, name, and "
+            "category (when present) per Page. Read-only. Use this to find "
+            "a page_id before creating lead forms, boosting posts, or "
+            "attaching a Page to an ad set's promoted_object."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "account_id": _ACCOUNT_ID_PARAM,
+            },
+            "required": [],
+        },
+    ),
     # === Instagram ===
     Tool(
         name="meta_ads_instagram_accounts",

--- a/mureo/mcp/tools_meta_ads.py
+++ b/mureo/mcp/tools_meta_ads.py
@@ -107,6 +107,7 @@ from mureo.mcp._handlers_meta_ads_other import (
     handle_instagram_media,
     handle_page_posts_boost,
     handle_page_posts_list,
+    handle_pages_list,
     handle_split_tests_create,
     handle_split_tests_end,
     handle_split_tests_get,
@@ -265,6 +266,8 @@ _HANDLERS: dict[str, Any] = {
     "meta_ads_ad_rules_create": handle_ad_rules_create,
     "meta_ads_ad_rules_update": handle_ad_rules_update,
     "meta_ads_ad_rules_delete": handle_ad_rules_delete,
+    # Pages
+    "meta_ads_pages_list": handle_pages_list,
     # Page posts
     "meta_ads_page_posts_list": handle_page_posts_list,
     "meta_ads_page_posts_boost": handle_page_posts_boost,

--- a/mureo/meta_ads/_ad_sets.py
+++ b/mureo/meta_ads/_ad_sets.py
@@ -6,6 +6,11 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+# Dict-valued update kwargs that Meta requires form-encoded as JSON
+# (like ``targeting``). ``targeting`` itself is handled separately
+# because it also carries the read-modify-write merge.
+_JSON_DICT_KWARGS: frozenset[str] = frozenset({"bid_constraints", "promoted_object"})
+
 
 class AdSetsMixin:
     """Meta Ads ad set operations mixin
@@ -27,7 +32,7 @@ class AdSetsMixin:
     _AD_SET_FIELDS = (
         "id,name,status,campaign_id,daily_budget,lifetime_budget,"
         "billing_event,optimization_goal,targeting,start_time,end_time,"
-        "created_time,updated_time,bid_amount,bid_strategy"
+        "created_time,updated_time,bid_amount,bid_strategy,promoted_object"
     )
 
     async def list_ad_sets(
@@ -82,6 +87,9 @@ class AdSetsMixin:
         status: str = "PAUSED",
         use_dynamic_creative: bool = False,
         bid_amount: int | None = None,
+        bid_strategy: str | None = None,
+        bid_constraints: dict[str, Any] | None = None,
+        promoted_object: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Create an ad set
 
@@ -97,6 +105,15 @@ class AdSetsMixin:
             use_dynamic_creative: Enable dynamic creative
             bid_amount: Bid amount in the currency's minor units (cents for
                 USD, whole yen for JPY; required for some optimization goals)
+            bid_strategy: Ad-set bid strategy. One of
+                LOWEST_COST_WITHOUT_CAP, LOWEST_COST_WITH_BID_CAP,
+                COST_CAP, LOWEST_COST_WITH_MIN_ROAS.
+            bid_constraints: Bid constraints dict, e.g.
+                ``{"roas_average_floor": 12000}`` for
+                LOWEST_COST_WITH_MIN_ROAS. Form-encoded via json.dumps.
+            promoted_object: Conversion target dict, e.g.
+                ``{"pixel_id": "123", "custom_event_type": "LEAD"}``.
+                Required for conversion optimization. json.dumps-encoded.
 
         Returns:
             Created ad set information.
@@ -114,6 +131,12 @@ class AdSetsMixin:
             data["daily_budget"] = daily_budget
         if bid_amount is not None:
             data["bid_amount"] = bid_amount
+        if bid_strategy is not None:
+            data["bid_strategy"] = bid_strategy
+        if bid_constraints is not None:
+            data["bid_constraints"] = json.dumps(bid_constraints)
+        if promoted_object is not None:
+            data["promoted_object"] = json.dumps(promoted_object)
         if targeting is not None:
             data["targeting"] = json.dumps(targeting)
         else:
@@ -160,6 +183,10 @@ class AdSetsMixin:
                 if not replace_targeting:
                     targeting = await self._merge_targeting(ad_set_id, value)
                 data[key] = json.dumps(targeting)
+            elif key in _JSON_DICT_KWARGS and isinstance(value, dict):
+                # Nested dict fields must be form-encoded via json.dumps,
+                # same as targeting (Meta rejects a bare Python-repr dict).
+                data[key] = json.dumps(value)
             else:
                 data[key] = value
 

--- a/mureo/meta_ads/_campaigns.py
+++ b/mureo/meta_ads/_campaigns.py
@@ -27,7 +27,8 @@ class CampaignsMixin:
     _CAMPAIGN_FIELDS = (
         "id,name,status,objective,daily_budget,lifetime_budget,"
         "created_time,updated_time,start_time,stop_time,"
-        "special_ad_categories,bid_strategy,budget_remaining"
+        "special_ad_categories,bid_strategy,budget_remaining,"
+        "is_adset_budget_sharing_enabled"
     )
 
     async def list_campaigns(
@@ -79,6 +80,8 @@ class CampaignsMixin:
         daily_budget: int | None = None,
         lifetime_budget: int | None = None,
         special_ad_categories: list[str] | None = None,
+        bid_strategy: str | None = None,
+        is_adset_budget_sharing_enabled: bool | None = None,
     ) -> dict[str, Any]:
         """Create a campaign.
 
@@ -91,6 +94,14 @@ class CampaignsMixin:
             lifetime_budget: Lifetime budget in the currency's minor units
                 (cents for USD, whole yen for JPY)
             special_ad_categories: Special ad categories (HOUSING, CREDIT, etc.)
+            bid_strategy: Campaign-level bid strategy. One of
+                LOWEST_COST_WITHOUT_CAP, LOWEST_COST_WITH_BID_CAP,
+                COST_CAP, LOWEST_COST_WITH_MIN_ROAS. Forwarded only when
+                set; Graph validates it against the objective.
+            is_adset_budget_sharing_enabled: Meta requires this flag when
+                creating a campaign WITHOUT campaign budget optimization
+                (ad-set-level budgets). Set False for per-ad-set budgets.
+                Forwarded only when not None (False is a meaningful value).
 
         Returns:
             Created campaign information
@@ -105,6 +116,12 @@ class CampaignsMixin:
             data["daily_budget"] = daily_budget
         if lifetime_budget is not None:
             data["lifetime_budget"] = lifetime_budget
+        if bid_strategy is not None:
+            data["bid_strategy"] = bid_strategy
+        if is_adset_budget_sharing_enabled is not None:
+            # httpx form-encodes Python bools to "true"/"false" (Graph's
+            # expected wire form), so forward the bool as-is.
+            data["is_adset_budget_sharing_enabled"] = is_adset_budget_sharing_enabled
         if special_ad_categories is not None:
             data["special_ad_categories"] = json.dumps(special_ad_categories)
         else:

--- a/mureo/meta_ads/client.py
+++ b/mureo/meta_ads/client.py
@@ -24,6 +24,8 @@ from mureo.meta_ads._pixels import PixelsMixin
 from mureo.meta_ads._split_test import SplitTestMixin
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
     from mureo.throttle import Throttler
 
 logger = logging.getLogger(__name__)
@@ -277,6 +279,32 @@ class MetaAdsApiClient(
                 usage_header[:200],
             )
 
+    async def _iter_page_batches(
+        self, fields: str
+    ) -> AsyncIterator[list[dict[str, Any]]]:
+        """Yield batches of accessible pages, personal source first.
+
+        Shared two-step page discovery used by both
+        :meth:`get_page_access_token` (which short-circuits once it finds
+        its target) and :meth:`list_pages` (which consumes every batch):
+        ``/me/accounts`` (personal pages) then ``/me/businesses`` ->
+        ``/{business_id}/owned_pages`` (business-owned pages). Lazy so the
+        token lookup can stop before the business calls are made.
+
+        Args:
+            fields: Comma-separated Graph field list to request per page.
+        """
+        result = await self._get("/me/accounts", {"fields": fields})
+        yield result.get("data", [])
+
+        biz_result = await self._get("/me/businesses", {"fields": "id"})
+        for biz in biz_result.get("data", []):
+            pages_result = await self._get(
+                f"/{biz['id']}/owned_pages",
+                {"fields": fields},
+            )
+            yield pages_result.get("data", [])
+
     async def get_page_access_token(self, page_id: str) -> str:
         """Get a Page Access Token for the given page.
 
@@ -295,31 +323,44 @@ class MetaAdsApiClient(
         if page_id in self._page_tokens:
             return self._page_tokens[page_id]
 
-        # Try personal pages first
-        result = await self._get("/me/accounts", {"fields": "id,access_token"})
-        for page in result.get("data", []):
-            self._page_tokens[page["id"]] = page["access_token"]
-
-        if page_id in self._page_tokens:
-            return self._page_tokens[page_id]
-
-        # Fall back to business-owned pages
-        biz_result = await self._get("/me/businesses", {"fields": "id"})
-        for biz in biz_result.get("data", []):
-            pages_result = await self._get(
-                f"/{biz['id']}/owned_pages",
-                {"fields": "id,access_token"},
-            )
-            for page in pages_result.get("data", []):
+        async for batch in self._iter_page_batches("id,access_token"):
+            for page in batch:
                 self._page_tokens[page["id"]] = page["access_token"]
+            # Short-circuit: stop before the business calls if we already
+            # have the token from the personal-pages batch.
+            if page_id in self._page_tokens:
+                return self._page_tokens[page_id]
 
-        if page_id not in self._page_tokens:
-            raise RuntimeError(
-                f"Page {page_id} not accessible with current token. "
-                f"Ensure the user has admin access to this page "
-                f"and the page is owned by a connected business portfolio."
-            )
-        return self._page_tokens[page_id]
+        raise RuntimeError(
+            f"Page {page_id} not accessible with current token. "
+            f"Ensure the user has admin access to this page "
+            f"and the page is owned by a connected business portfolio."
+        )
+
+    async def list_pages(self) -> list[dict[str, Any]]:
+        """List Facebook Pages the current token can manage.
+
+        Aggregates personal (``/me/accounts``) and business-owned
+        (``/me/businesses`` -> ``/{business_id}/owned_pages``) pages via
+        the shared :meth:`_iter_page_batches` helper. Read-only.
+
+        Returns:
+            A list of ``{"id", "name", "category"?}`` dicts (``category``
+            is included only when Graph returns it for that page). A Page
+            that appears in both sources (a common overlap when the user
+            has a role on a Page that a Business Portfolio also owns) is
+            listed once, keyed on id, preserving first-seen order.
+        """
+        pages: dict[str, dict[str, Any]] = {}
+        async for batch in self._iter_page_batches("id,name,category"):
+            for page in batch:
+                entry: dict[str, Any] = {"id": page["id"], "name": page.get("name")}
+                if "category" in page:
+                    entry["category"] = page["category"]
+                # setdefault keeps the first-seen entry (personal batch
+                # wins) and dedupes ids shared across both sources.
+                pages.setdefault(page["id"], entry)
+        return list(pages.values())
 
     async def _get_as_page(
         self, page_id: str, path: str, params: dict[str, Any] | None = None

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -65,15 +65,15 @@ class TestListTools:
     """Verify list_tools returns the correct tool definitions."""
 
     async def test_list_tools_returns_all_tools(self) -> None:
-        """list_tools returns all tools (Google Ads 86 + Meta Ads 83 + Search Console 10
+        """list_tools returns all tools (Google Ads 86 + Meta Ads 84 + Search Console 10
         + Rollback 2 + Analysis 1 + Mureo Context 9 + Analytics Registry 2
-        + Learning 2 + Creative Studio 5 = 200).
+        + Learning 2 + Creative Studio 5 = 201).
 
         Analytics Registry is 2: mureo_analytics_modules_list +
         mureo_analytics_run (#440)."""
         mod = _import_server_module()
         tools = await mod.handle_list_tools()
-        assert len(tools) == 200
+        assert len(tools) == 201
 
     async def test_list_tools_contains_google_and_meta(self) -> None:
         """Google Ads and Meta Ads tools are included."""

--- a/tests/test_mcp_tools_meta_ads.py
+++ b/tests/test_mcp_tools_meta_ads.py
@@ -54,9 +54,46 @@ class TestMetaAdsToolDefinitions:
     """Verify the Meta Ads tool list is defined correctly."""
 
     def test_tool_count(self) -> None:
-        """All 83 tools are defined (82 + meta_ads_pixels_create)."""
+        """All 84 tools are defined (83 + meta_ads_pages_list)."""
         mod = _import_meta_ads_tools()
-        assert len(mod.TOOLS) == 83
+        assert len(mod.TOOLS) == 84
+
+    def test_bidding_control_schema_properties(self) -> None:
+        """The four touched write tools expose the new bidding-control
+        properties and are strict (additionalProperties: false)."""
+        mod = _import_meta_ads_tools()
+        by_name = {t.name: t for t in mod.TOOLS}
+
+        cc = by_name["meta_ads_campaigns_create"].inputSchema
+        assert cc["additionalProperties"] is False
+        assert set(cc["properties"]["bid_strategy"]["enum"]) == {
+            "LOWEST_COST_WITHOUT_CAP",
+            "LOWEST_COST_WITH_BID_CAP",
+            "COST_CAP",
+            "LOWEST_COST_WITH_MIN_ROAS",
+        }
+        assert cc["properties"]["is_adset_budget_sharing_enabled"]["type"] == "boolean"
+
+        cu = by_name["meta_ads_campaigns_update"].inputSchema
+        assert cu["additionalProperties"] is False
+        assert "bid_strategy" in cu["properties"]
+
+        ac = by_name["meta_ads_ad_sets_create"].inputSchema
+        assert ac["additionalProperties"] is False
+        assert "bid_strategy" in ac["properties"]
+        assert ac["properties"]["bid_constraints"]["type"] == "object"
+        assert ac["properties"]["promoted_object"]["type"] == "object"
+
+        au = by_name["meta_ads_ad_sets_update"].inputSchema
+        assert au["additionalProperties"] is False
+        for key in ("bid_strategy", "bid_amount", "bid_constraints", "promoted_object"):
+            assert key in au["properties"], key
+
+    def test_pages_list_tool_registered(self) -> None:
+        mod = _import_meta_ads_tools()
+        names = {t.name for t in mod.TOOLS}
+        assert "meta_ads_pages_list" in names
+        assert "meta_ads_pages_list" in mod._HANDLERS
 
     def test_all_tool_names(self) -> None:
         """Every tool name starts with meta_ads_ (underscore-separated, per MCP spec)."""
@@ -216,6 +253,92 @@ class TestMetaAdsCampaignHandlers:
             )
 
         client.update_campaign.assert_awaited_once()
+
+    async def test_campaigns_create_forwards_bid_strategy(self) -> None:
+        mod = _import_meta_ads_tools()
+        handlers = _import_handlers()
+        creds, client = _mock_meta_ads_context()
+        client.create_campaign.return_value = {"id": "789"}
+
+        with (
+            patch.object(handlers, "load_meta_ads_credentials", return_value=creds),
+            patch.object(handlers, "create_meta_ads_client", return_value=client),
+        ):
+            await mod.handle_tool(
+                "meta_ads_campaigns_create",
+                {
+                    "account_id": "act_123",
+                    "name": "New Camp",
+                    "objective": "OUTCOME_SALES",
+                    "bid_strategy": "COST_CAP",
+                },
+            )
+
+        kwargs = client.create_campaign.await_args.kwargs
+        assert kwargs["bid_strategy"] == "COST_CAP"
+
+    async def test_campaigns_create_forwards_budget_sharing_false(self) -> None:
+        """is_adset_budget_sharing_enabled=False must reach the client, not be
+        dropped by a falsy check."""
+        mod = _import_meta_ads_tools()
+        handlers = _import_handlers()
+        creds, client = _mock_meta_ads_context()
+        client.create_campaign.return_value = {"id": "789"}
+
+        with (
+            patch.object(handlers, "load_meta_ads_credentials", return_value=creds),
+            patch.object(handlers, "create_meta_ads_client", return_value=client),
+        ):
+            await mod.handle_tool(
+                "meta_ads_campaigns_create",
+                {
+                    "account_id": "act_123",
+                    "name": "New Camp",
+                    "objective": "OUTCOME_SALES",
+                    "is_adset_budget_sharing_enabled": False,
+                },
+            )
+
+        kwargs = client.create_campaign.await_args.kwargs
+        assert kwargs["is_adset_budget_sharing_enabled"] is False
+
+    async def test_campaigns_update_forwards_bid_strategy(self) -> None:
+        mod = _import_meta_ads_tools()
+        handlers = _import_handlers()
+        creds, client = _mock_meta_ads_context()
+        client.update_campaign.return_value = {"success": True}
+
+        with (
+            patch.object(handlers, "load_meta_ads_credentials", return_value=creds),
+            patch.object(handlers, "create_meta_ads_client", return_value=client),
+        ):
+            await mod.handle_tool(
+                "meta_ads_campaigns_update",
+                {
+                    "account_id": "act_123",
+                    "campaign_id": "456",
+                    "bid_strategy": "LOWEST_COST_WITH_MIN_ROAS",
+                },
+            )
+
+        kwargs = client.update_campaign.await_args.kwargs
+        assert kwargs["bid_strategy"] == "LOWEST_COST_WITH_MIN_ROAS"
+
+    async def test_campaigns_create_rejects_unknown_param(self) -> None:
+        """additionalProperties:false makes an undeclared param a schema
+        validation error (via the real dispatcher path)."""
+        from mureo.mcp import server as mcp_server
+
+        with pytest.raises(ValueError, match="not_a_real_param|additional"):
+            await mcp_server.handle_call_tool(
+                "meta_ads_campaigns_create",
+                {
+                    "account_id": "act_123",
+                    "name": "C",
+                    "objective": "OUTCOME_SALES",
+                    "not_a_real_param": "x",
+                },
+            )
 
     async def test_campaigns_create_rejects_zero_daily_budget(self) -> None:
         """A 0 daily budget halts delivery — refuse before any API call (#277)."""
@@ -473,6 +596,64 @@ class TestMetaAdsAdSetHandlers:
                 },
             )
 
+    async def test_ad_sets_create_forwards_bidding_and_promoted_object(self) -> None:
+        mod = _import_meta_ads_tools()
+        handlers = _import_handlers()
+        creds, client = _mock_meta_ads_context()
+        client.create_ad_set.return_value = {"id": "20"}
+
+        with (
+            patch.object(handlers, "load_meta_ads_credentials", return_value=creds),
+            patch.object(handlers, "create_meta_ads_client", return_value=client),
+        ):
+            await mod.handle_tool(
+                "meta_ads_ad_sets_create",
+                {
+                    "account_id": "act_123",
+                    "campaign_id": "456",
+                    "name": "AS",
+                    "bid_strategy": "LOWEST_COST_WITH_MIN_ROAS",
+                    "bid_constraints": {"roas_average_floor": 12000},
+                    "promoted_object": {"pixel_id": "1", "custom_event_type": "LEAD"},
+                },
+            )
+
+        kwargs = client.create_ad_set.await_args.kwargs
+        assert kwargs["bid_strategy"] == "LOWEST_COST_WITH_MIN_ROAS"
+        assert kwargs["bid_constraints"] == {"roas_average_floor": 12000}
+        assert kwargs["promoted_object"] == {
+            "pixel_id": "1",
+            "custom_event_type": "LEAD",
+        }
+
+    async def test_ad_sets_update_forwards_bidding_and_promoted_object(self) -> None:
+        mod = _import_meta_ads_tools()
+        handlers = _import_handlers()
+        creds, client = _mock_meta_ads_context()
+        client.update_ad_set.return_value = {"success": True}
+
+        with (
+            patch.object(handlers, "load_meta_ads_credentials", return_value=creds),
+            patch.object(handlers, "create_meta_ads_client", return_value=client),
+        ):
+            await mod.handle_tool(
+                "meta_ads_ad_sets_update",
+                {
+                    "account_id": "act_123",
+                    "ad_set_id": "20",
+                    "bid_strategy": "LOWEST_COST_WITH_BID_CAP",
+                    "bid_amount": 500,
+                    "bid_constraints": {"roas_average_floor": 15000},
+                    "promoted_object": {"pixel_id": "9"},
+                },
+            )
+
+        kwargs = client.update_ad_set.await_args.kwargs
+        assert kwargs["bid_strategy"] == "LOWEST_COST_WITH_BID_CAP"
+        assert kwargs["bid_amount"] == 500
+        assert kwargs["bid_constraints"] == {"roas_average_floor": 15000}
+        assert kwargs["promoted_object"] == {"pixel_id": "9"}
+
 
 # ---------------------------------------------------------------------------
 # Handler tests — ads
@@ -627,6 +808,45 @@ class TestMetaAdsAudienceHandlers:
             )
 
         client.create_custom_audience.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Handler tests — pages
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestMetaAdsPageHandlers:
+    """Page-listing handler tests."""
+
+    async def test_pages_list_success(self) -> None:
+        mod = _import_meta_ads_tools()
+        handlers = _import_handlers()
+        creds, client = _mock_meta_ads_context()
+        client.list_pages.return_value = [
+            {"id": "p1", "name": "Page One", "category": "Business"}
+        ]
+
+        with (
+            patch.object(handlers, "load_meta_ads_credentials", return_value=creds),
+            patch.object(handlers, "create_meta_ads_client", return_value=client),
+        ):
+            result = await mod.handle_tool(
+                "meta_ads_pages_list", {"account_id": "act_123"}
+            )
+
+        client.list_pages.assert_awaited_once()
+        parsed = json.loads(result[0].text)
+        assert parsed[0]["id"] == "p1"
+
+    async def test_pages_list_no_credentials(self) -> None:
+        mod = _import_meta_ads_tools()
+        handlers = _import_handlers()
+        with patch.object(handlers, "load_meta_ads_credentials", return_value=None):
+            result = await mod.handle_tool(
+                "meta_ads_pages_list", {"account_id": "act_123"}
+            )
+        assert "Credentials not found" in result[0].text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_meta_ads_operations.py
+++ b/tests/test_meta_ads_operations.py
@@ -127,6 +127,47 @@ class TestCampaignsMixin:
         data = client._post.call_args[0][1]
         assert data["status"] == "ACTIVE"
 
+    @pytest.mark.asyncio
+    async def test_create_campaign_with_bid_strategy(self, client) -> None:
+        await client.create_campaign("Test", "OUTCOME_SALES", bid_strategy="COST_CAP")
+        data = client._post.call_args[0][1]
+        assert data["bid_strategy"] == "COST_CAP"
+
+    @pytest.mark.asyncio
+    async def test_create_campaign_omits_bid_strategy_when_none(self, client) -> None:
+        await client.create_campaign("Test", "OUTCOME_SALES")
+        data = client._post.call_args[0][1]
+        assert "bid_strategy" not in data
+
+    @pytest.mark.asyncio
+    async def test_create_campaign_budget_sharing_false_serialized(
+        self, client
+    ) -> None:
+        # A False value is meaningful (per-ad-set budgets) and must be
+        # forwarded, not dropped by a falsy check.
+        await client.create_campaign(
+            "Test", "OUTCOME_SALES", is_adset_budget_sharing_enabled=False
+        )
+        data = client._post.call_args[0][1]
+        assert data["is_adset_budget_sharing_enabled"] is False
+
+    @pytest.mark.asyncio
+    async def test_create_campaign_budget_sharing_true_serialized(self, client) -> None:
+        await client.create_campaign(
+            "Test", "OUTCOME_SALES", is_adset_budget_sharing_enabled=True
+        )
+        data = client._post.call_args[0][1]
+        assert data["is_adset_budget_sharing_enabled"] is True
+
+    @pytest.mark.asyncio
+    async def test_create_campaign_omits_budget_sharing_when_none(self, client) -> None:
+        await client.create_campaign("Test", "OUTCOME_SALES")
+        data = client._post.call_args[0][1]
+        assert "is_adset_budget_sharing_enabled" not in data
+
+    def test_campaign_fields_include_budget_sharing(self, client) -> None:
+        assert "is_adset_budget_sharing_enabled" in client._CAMPAIGN_FIELDS
+
 
 # ===========================================================================
 # AdSetsMixin tests
@@ -266,6 +307,176 @@ class TestAdSetsMixin:
         await client.enable_ad_set("1")
         data = client._post.call_args[0][1]
         assert data["status"] == "ACTIVE"
+
+    @pytest.mark.asyncio
+    async def test_create_ad_set_with_bid_strategy(self, client) -> None:
+        await client.create_ad_set(
+            "camp1", "AS", 3000, bid_strategy="LOWEST_COST_WITH_BID_CAP"
+        )
+        data = client._post.call_args[0][1]
+        assert data["bid_strategy"] == "LOWEST_COST_WITH_BID_CAP"
+
+    @pytest.mark.asyncio
+    async def test_create_ad_set_bid_constraints_json_serialized(self, client) -> None:
+        constraints = {"roas_average_floor": 12000}
+        await client.create_ad_set("camp1", "AS", 3000, bid_constraints=constraints)
+        data = client._post.call_args[0][1]
+        # Nested dicts are form-encoded via json.dumps (same idiom as targeting).
+        assert json.loads(data["bid_constraints"]) == constraints
+
+    @pytest.mark.asyncio
+    async def test_create_ad_set_promoted_object_json_serialized(self, client) -> None:
+        promoted = {"pixel_id": "123", "custom_event_type": "LEAD"}
+        await client.create_ad_set("camp1", "AS", 3000, promoted_object=promoted)
+        data = client._post.call_args[0][1]
+        assert json.loads(data["promoted_object"]) == promoted
+
+    @pytest.mark.asyncio
+    async def test_create_ad_set_omits_new_fields_when_none(self, client) -> None:
+        await client.create_ad_set("camp1", "AS", 3000)
+        data = client._post.call_args[0][1]
+        assert "bid_strategy" not in data
+        assert "bid_constraints" not in data
+        assert "promoted_object" not in data
+
+    @pytest.mark.asyncio
+    async def test_update_ad_set_serializes_bid_constraints(self, client) -> None:
+        constraints = {"roas_average_floor": 15000}
+        await client.update_ad_set("1", bid_constraints=constraints)
+        data = client._post.call_args[0][1]
+        assert json.loads(data["bid_constraints"]) == constraints
+
+    @pytest.mark.asyncio
+    async def test_update_ad_set_serializes_promoted_object(self, client) -> None:
+        promoted = {"pixel_id": "999", "custom_event_type": "PURCHASE"}
+        await client.update_ad_set("1", promoted_object=promoted)
+        data = client._post.call_args[0][1]
+        assert json.loads(data["promoted_object"]) == promoted
+
+    @pytest.mark.asyncio
+    async def test_update_ad_set_forwards_bid_strategy_and_amount(self, client) -> None:
+        await client.update_ad_set("1", bid_strategy="COST_CAP", bid_amount=500)
+        data = client._post.call_args[0][1]
+        assert data["bid_strategy"] == "COST_CAP"
+        assert data["bid_amount"] == 500
+
+    def test_ad_set_fields_include_promoted_object(self, client) -> None:
+        assert "promoted_object" in client._AD_SET_FIELDS
+
+
+# ===========================================================================
+# Client-level page listing tests
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestClientListPages:
+    """list_pages lives on MetaAdsApiClient (not a mixin) — it shares the
+    two-step /me/accounts -> /me/businesses page-fetch with
+    get_page_access_token."""
+
+    def _make_client(self):
+        from mureo.meta_ads.client import MetaAdsApiClient
+
+        return MetaAdsApiClient("token", "act_123")
+
+    @pytest.mark.asyncio
+    async def test_list_pages_happy_path(self) -> None:
+        client = self._make_client()
+
+        async def fake_get(path, params=None):
+            if path == "/me/accounts":
+                return {
+                    "data": [
+                        {"id": "p1", "name": "Page One", "category": "Business"},
+                        {"id": "p2", "name": "Page Two"},
+                    ]
+                }
+            if path == "/me/businesses":
+                return {"data": []}
+            return {"data": []}
+
+        client._get = AsyncMock(side_effect=fake_get)
+        pages = await client.list_pages()
+        ids = {p["id"] for p in pages}
+        assert ids == {"p1", "p2"}
+        assert pages[0]["name"] == "Page One"
+        assert pages[0]["category"] == "Business"
+
+    @pytest.mark.asyncio
+    async def test_list_pages_business_fallback(self) -> None:
+        client = self._make_client()
+
+        async def fake_get(path, params=None):
+            if path == "/me/accounts":
+                return {"data": []}
+            if path == "/me/businesses":
+                return {"data": [{"id": "biz1"}]}
+            if path == "/biz1/owned_pages":
+                return {"data": [{"id": "p3", "name": "Owned Page"}]}
+            return {"data": []}
+
+        client._get = AsyncMock(side_effect=fake_get)
+        pages = await client.list_pages()
+        assert [p["id"] for p in pages] == ["p3"]
+        assert pages[0]["name"] == "Owned Page"
+
+    @pytest.mark.asyncio
+    async def test_list_pages_dedupes_overlap(self) -> None:
+        # A Page the user has a role on AND that a Business Portfolio owns
+        # appears in both /me/accounts and owned_pages. It must be listed
+        # once, keyed on id, preserving first-seen (personal) order.
+        client = self._make_client()
+
+        async def fake_get(path, params=None):
+            if path == "/me/accounts":
+                return {
+                    "data": [
+                        {"id": "p1", "name": "Shared Page", "category": "Business"},
+                        {"id": "p2", "name": "Personal Only"},
+                    ]
+                }
+            if path == "/me/businesses":
+                return {"data": [{"id": "biz1"}]}
+            if path == "/biz1/owned_pages":
+                return {
+                    "data": [
+                        # Same id as p1 — the overlap the reviewer flagged.
+                        {"id": "p1", "name": "Shared Page", "category": "Business"},
+                        {"id": "p3", "name": "Business Only"},
+                    ]
+                }
+            return {"data": []}
+
+        client._get = AsyncMock(side_effect=fake_get)
+        pages = await client.list_pages()
+        ids = [p["id"] for p in pages]
+        assert ids.count("p1") == 1
+        # First-seen (personal-batch) order is preserved.
+        assert ids == ["p1", "p2", "p3"]
+
+    @pytest.mark.asyncio
+    async def test_get_page_access_token_short_circuits_on_personal_page(self) -> None:
+        # When the target page resolves from the first /me/accounts batch,
+        # the business-portfolio calls must NOT be made.
+        client = self._make_client()
+
+        async def fake_get(path, params=None):
+            if path == "/me/accounts":
+                return {"data": [{"id": "p1", "access_token": "tok-p1"}]}
+            if path == "/me/businesses":
+                raise AssertionError(
+                    "/me/businesses must not be queried when the page "
+                    "resolves from /me/accounts (short-circuit broken)"
+                )
+            return {"data": []}
+
+        get_mock = AsyncMock(side_effect=fake_get)
+        client._get = get_mock
+        token = await client.get_page_access_token("p1")
+        assert token == "tok-p1"
+        called_paths = [call.args[0] for call in get_mock.call_args_list]
+        assert "/me/businesses" not in called_paths
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

Answers a field report from a real advertiser account where automated bidding could not be configured and non-CBO campaigns could not be created.

**P0 — bidding strategy**
- `bid_strategy` (`LOWEST_COST_WITHOUT_CAP` / `LOWEST_COST_WITH_BID_CAP` / `COST_CAP` / `LOWEST_COST_WITH_MIN_ROAS`) on `meta_ads_campaigns_create/update` and `meta_ads_ad_sets_create/update`
- `bid_constraints` (`roas_average_floor`) for MIN_ROAS; `bid_amount` newly exposed on `ad_sets_update` (needed when switching to a capped strategy)
- Tool descriptions document the required combinations (capped strategies need `bid_amount`; MIN_ROAS needs `bid_constraints`); invalid combinations surface Graph's own error

**P0 — ad-set-level budgets**
- `is_adset_budget_sharing_enabled` (bool) on `campaigns_create` — required by Meta when creating a campaign without campaign budget optimization. `False` is forwarded explicitly (`is not None` guard; httpx form-encodes to `false`)

**P0 — no more silent parameter drops**
- The four touched write tools now declare `additionalProperties: false`, so unknown parameters fail schema validation with a clear error instead of being silently discarded (repo-wide rollout tracked separately)

**P1**
- `promoted_object` (`pixel_id`, `custom_event_type`, …) on `ad_sets_create/update` for conversion optimization
- New read-only tool `meta_ads_pages_list`: enumerates Facebook Pages from `/me/accounts` with `/me/businesses` → `owned_pages` fallback, deduplicated by page id; shared pagination refactored out of `get_page_access_token` (short-circuit pinned by a regression test)

**P2**
- Read side now returns `is_adset_budget_sharing_enabled` (campaigns) and `promoted_object` (ad sets); `bid_strategy` was already returned

Tool counts 200 → 201 (Meta Ads 83 → 84) across tests and docs.

## Test plan
- Strict TDD: 23 new/updated tests written first (red), then implemented; 232 passing in the touched suites
- Full suite: 5740 passed; only known environment-only failures (local plugins inflate absolute tool count — builtin registry arithmetic verified = 201; live-client tests need network)
- Code review: no CRITICAL/HIGH; the one MEDIUM (pages_list dedup) fixed with a red/green test

## Coordination
mureo-pro must merge its follow-up (`feat/meta-bidding-controls-toolspec`: TOOL_SPECS updates + pages_list spec) immediately after this lands — parity tests bind to OSS main HEAD.
