### PR TITLE
feat(mcp): Meta targeting discovery — interest search and category catalogues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,6 +185,7 @@ docs/integrations.md          # Platform discovery + external MCP integration gu
 | Images | `images.upload_file` |
 | Insights | `insights.report`, `insights.breakdown` |
 | Audiences | `audiences.list`, `audiences.create`, `audiences.get`, `audiences.delete`, `audiences.create_lookalike` |
+| Targeting | `targeting.search`, `targeting.categories` |
 | Conversions API | `conversions.send`, `conversions.send_purchase`, `conversions.send_lead` |
 | Pixels | `pixels.list`, `pixels.get`, `pixels.stats`, `pixels.events`, `pixels.create` |
 | Analysis | `analysis.performance`, `analysis.audience`, `analysis.placements`, `analysis.cost`, `analysis.compare_ads`, `analysis.suggest_creative` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Meta Ads targeting-discovery tools (`meta_ads_targeting_search`,
+  `meta_ads_targeting_categories`).** Two read-only tools that resolve
+  Meta's internal targeting IDs needed to build an ad-set `targeting`
+  spec. `meta_ads_targeting_search` searches the interest catalogue by
+  keyword (`query`, optional `limit` / `locale`) and returns interest
+  ids with audience-size bounds and path, for use in
+  `targeting.flexible_spec` / `interests`. `meta_ads_targeting_categories`
+  lists a full category catalogue for one `category_class` (behaviors,
+  demographics, life_events, industries, income, family_statuses,
+  user_device, user_os — mapped to Graph's `class` param) for behavior /
+  demographic targeting where keyword search is unavailable. Both hit the
+  API-root `/search` endpoint (not account-scoped) via a new
+  `TargetingMixin`; the class name is validated at the boundary. Meta Ads
+  tool count 84 → 86 (aggregate 201 → 203).
+
 - **Meta Ads bidding controls on campaign / ad-set write tools.**
   `meta_ads_campaigns_create` and `meta_ads_campaigns_update` gain
   `bid_strategy` (`LOWEST_COST_WITHOUT_CAP`, `LOWEST_COST_WITH_BID_CAP`,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -286,7 +286,7 @@ The base class (`GoogleAdsApiClient`) provides:
 - Input validation: `_validate_id()`, `_validate_status()`, `_validate_match_type()`, `_validate_date()`
 - Error handling: `_wrap_mutate_error()` decorator that catches `GoogleAdsException` and returns user-friendly messages
 
-### Meta Ads Client -- 15 Mixins
+### Meta Ads Client -- 16 Mixins
 
 ```python
 class MetaAdsApiClient(
@@ -305,6 +305,7 @@ class MetaAdsApiClient(
     InstagramMixin,    # Instagram accounts, media, boosting
     SplitTestMixin,    # A/B test creation and management
     AdRulesMixin,      # Automated rules (alerts, auto-pause, etc.)
+    TargetingMixin,    # Interest / category targeting-ID discovery (read-only)
 ):
 ```
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -1,6 +1,6 @@
 # MCP Server Guide
 
-mureo exposes 201 tools via the [Model Context Protocol](https://modelcontextprotocol.io/) (MCP): 180 advertising and SEO operation tools across Google Ads (86), Meta Ads (84), and Search Console (10), 2 rollback tools, 1 cross-platform anomaly-detection tool, 9 mureo-context tools (strategy / state / reports / outcome evaluation), 2 analytics-registry tools, 2 learning tools (`mureo_learning_insights_get` for the operator's local `/learn` history and `mureo_consult_advisor` for federated retrieval against external advisor MCP servers — see [`docs/insight-federation.md`](insight-federation.md)), and 5 Creative Studio tools (text-free key-visual generation + banner composition). Any MCP-compatible client can connect and call these tools over stdio. Re-check this count when MCP tools are added or removed (`test_list_tools_returns_all_tools` pins the exact number).
+mureo exposes 203 tools via the [Model Context Protocol](https://modelcontextprotocol.io/) (MCP): 182 advertising and SEO operation tools across Google Ads (86), Meta Ads (86), and Search Console (10), 2 rollback tools, 1 cross-platform anomaly-detection tool, 9 mureo-context tools (strategy / state / reports / outcome evaluation), 2 analytics-registry tools, 2 learning tools (`mureo_learning_insights_get` for the operator's local `/learn` history and `mureo_consult_advisor` for federated retrieval against external advisor MCP servers — see [`docs/insight-federation.md`](insight-federation.md)), and 5 Creative Studio tools (text-free key-visual generation + banner composition). Any MCP-compatible client can connect and call these tools over stdio. Re-check this count when MCP tools are added or removed (`test_list_tools_returns_all_tools` pins the exact number).
 
 ## Starting the Server
 
@@ -341,6 +341,13 @@ Or use `uv` to run it:
 | `meta_ads_audiences_get` | Get audience details | `account_id`, `audience_id` |
 | `meta_ads_audiences_delete` | Delete a custom audience | `account_id`, `audience_id` |
 | `meta_ads_audiences_create_lookalike` | Create a lookalike audience | `account_id`, `source_audience_id`, `country` |
+
+#### Targeting Discovery
+
+| Tool | Description | Required Parameters |
+|------|-------------|-------------------|
+| `meta_ads_targeting_search` | Resolve interest names to internal targeting IDs (with audience-size bounds and path) | `query` |
+| `meta_ads_targeting_categories` | List a full targeting category catalogue (behaviors / demographics / etc.) with internal IDs | `category_class` |
 
 #### Conversions API (CAPI)
 

--- a/docs/native-vs-official.md
+++ b/docs/native-vs-official.md
@@ -105,7 +105,7 @@ from mureo native.
   assets (copy, images, carousels, collections, dynamic ads); Instagram-specific
   actions.
 
-### mureo native — Meta Ads (84 tools)
+### mureo native — Meta Ads (86 tools)
 
 Covers the same operational class as the official MCP **plus** every documented
 gap above:
@@ -113,6 +113,7 @@ gap above:
 - Campaigns, ad sets, ads (CRUD + pause / enable) — including **bid strategy**, **bid constraints (min-ROAS)**, and **promoted_object** (conversion optimization)
 - **Page discovery** (`pages_list`)
 - Audiences + **lookalikes**
+- **Targeting discovery** — interest search + category catalogues (behaviors / demographics / etc.) that resolve Meta's internal targeting IDs
 - Creatives — single / carousel / collection / dynamic / lead — + image/video upload
 - Insights + breakdowns; analysis (performance / audience / placements / cost / compare / suggest creative)
 - Pixels (list / get / stats / events / **create**) and **Conversions API send** (purchase / lead)

--- a/mureo/mcp/_handlers_meta_ads_extended.py
+++ b/mureo/mcp/_handlers_meta_ads_extended.py
@@ -334,6 +334,39 @@ async def handle_pixels_create(args: dict[str, Any]) -> list[TextContent]:
 
 
 # ---------------------------------------------------------------------------
+# Targeting discovery (interest search / category catalogues)
+# ---------------------------------------------------------------------------
+
+
+@api_error_handler
+async def handle_targeting_search(args: dict[str, Any]) -> list[TextContent]:
+    client = await _get_client(args)
+    if client is None:
+        return _no_meta_creds()
+    query = _require(args, "query")
+    kwargs: dict[str, Any] = {"limit": _opt(args, "limit", 25)}
+    locale = _opt(args, "locale")
+    if locale is not None:
+        kwargs["locale"] = locale
+    result = await client.search_targeting_interests(query, **kwargs)
+    return _json_result(result)
+
+
+@api_error_handler
+async def handle_targeting_categories(args: dict[str, Any]) -> list[TextContent]:
+    client = await _get_client(args)
+    if client is None:
+        return _no_meta_creds()
+    category_class = _require(args, "category_class")
+    kwargs: dict[str, Any] = {"limit": _opt(args, "limit", 200)}
+    locale = _opt(args, "locale")
+    if locale is not None:
+        kwargs["locale"] = locale
+    result = await client.list_targeting_categories(category_class, **kwargs)
+    return _json_result(result)
+
+
+# ---------------------------------------------------------------------------
 # Analysis handlers
 # ---------------------------------------------------------------------------
 

--- a/mureo/mcp/_tools_meta_ads_audiences.py
+++ b/mureo/mcp/_tools_meta_ads_audiences.py
@@ -402,4 +402,105 @@ TOOLS: list[Tool] = [
             "required": ["name"],
         },
     ),
+    # === Targeting discovery ===
+    Tool(
+        name="meta_ads_targeting_search",
+        description=(
+            "Searches Meta's interest-targeting catalogue by keyword and "
+            "resolves interest names to the internal IDs used in an ad "
+            "set's targeting spec (targeting.flexible_spec / interests). "
+            "Returns id, name, audience_size_lower_bound, "
+            "audience_size_upper_bound, path, and topic per interest. "
+            "Read-only. Use this to look up an interest ID before "
+            "meta_ads_ad_sets_create / update — agents cannot invent these "
+            "IDs. For behaviors / demographics (which keyword search does "
+            "not cover) use meta_ads_targeting_categories instead."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "query": {
+                    "type": "string",
+                    "description": (
+                        "Interest keyword to search for (e.g. 'camping', "
+                        "'yoga'). Must be non-empty."
+                    ),
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "description": ("Maximum interests returned. Default 25, max 100."),
+                },
+                "locale": {
+                    "type": "string",
+                    "description": (
+                        "Optional Graph locale (e.g. 'ja_JP') to return "
+                        "localized interest names. Omitted when unset."
+                    ),
+                },
+            },
+            "required": ["query"],
+            "additionalProperties": False,
+        },
+    ),
+    Tool(
+        name="meta_ads_targeting_categories",
+        description=(
+            "Lists a full Meta targeting category catalogue for the given "
+            "class — behaviors (e.g. 'Facebook Page admins'), demographics, "
+            "life_events, industries, income, family_statuses, "
+            "user_device, or user_os — with the internal IDs used in an ad "
+            "set's targeting spec. Returns id, name, "
+            "audience_size_lower_bound, audience_size_upper_bound, path, "
+            "and an optional description per category. Read-only. Use this "
+            "for behavior / demographic targeting, where keyword search "
+            "(meta_ads_targeting_search) is not supported — the catalogue "
+            "is finite, so this returns the whole class."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "category_class": {
+                    "type": "string",
+                    "enum": [
+                        "behaviors",
+                        "demographics",
+                        "life_events",
+                        "industries",
+                        "income",
+                        "family_statuses",
+                        "user_device",
+                        "user_os",
+                    ],
+                    "description": (
+                        "Targeting category class to enumerate. Maps to "
+                        "Graph's 'class' query param (renamed here because "
+                        "'class' is a Python keyword)."
+                    ),
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 500,
+                    "description": (
+                        "Maximum categories returned. Default 200 — larger "
+                        "than search results because catalogues are finite "
+                        "but sizeable."
+                    ),
+                },
+                "locale": {
+                    "type": "string",
+                    "description": (
+                        "Optional Graph locale (e.g. 'ja_JP') to return "
+                        "localized category names. Omitted when unset."
+                    ),
+                },
+            },
+            "required": ["category_class"],
+            "additionalProperties": False,
+        },
+    ),
 ]

--- a/mureo/mcp/tools_meta_ads.py
+++ b/mureo/mcp/tools_meta_ads.py
@@ -95,6 +95,8 @@ from mureo.mcp._handlers_meta_ads_extended import (
     handle_pixels_get,
     handle_pixels_list,
     handle_pixels_stats,
+    handle_targeting_categories,
+    handle_targeting_search,
 )
 from mureo.mcp._handlers_meta_ads_other import (
     handle_ad_rules_create,
@@ -248,6 +250,9 @@ _HANDLERS: dict[str, Any] = {
     "meta_ads_pixels_stats": handle_pixels_stats,
     "meta_ads_pixels_events": handle_pixels_events,
     "meta_ads_pixels_create": handle_pixels_create,
+    # Targeting discovery
+    "meta_ads_targeting_search": handle_targeting_search,
+    "meta_ads_targeting_categories": handle_targeting_categories,
     # Analysis
     "meta_ads_analysis_performance": handle_analysis_performance,
     "meta_ads_analysis_audience": handle_analysis_audience,

--- a/mureo/meta_ads/_targeting.py
+++ b/mureo/meta_ads/_targeting.py
@@ -1,0 +1,124 @@
+"""Meta Ads targeting-discovery mixin.
+
+Read-only resolution of Meta's internal targeting IDs (interests and
+category classes) needed to build an ad-set ``targeting`` spec. Both
+methods hit the API-root ``/search`` endpoint, which is NOT scoped to
+the ad account id — unlike every other read path in this client.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Valid ``class`` values for the adTargetingCategory search. Named
+# ``category_class`` at the tool/handler boundary because ``class`` is a
+# Python keyword; the value is passed to Graph verbatim as ``class``.
+_VALID_CATEGORY_CLASSES: frozenset[str] = frozenset(
+    {
+        "behaviors",
+        "demographics",
+        "life_events",
+        "industries",
+        "income",
+        "family_statuses",
+        "user_device",
+        "user_os",
+    }
+)
+
+
+class TargetingMixin:
+    """Meta Ads targeting-discovery mixin (read-only).
+
+    Resolves interest / behavior / demographic names to the internal IDs
+    consumed by ``targeting.flexible_spec`` / ``interests``. Used via
+    multiple inheritance with MetaAdsApiClient.
+    """
+
+    async def _get(  # type: ignore[empty-body]
+        self, path: str, params: dict[str, Any] | None = None
+    ) -> dict[str, Any]: ...
+
+    async def search_targeting_interests(
+        self,
+        query: str,
+        *,
+        limit: int = 25,
+        locale: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Search interest targeting IDs by keyword.
+
+        Args:
+            query: Interest keyword (e.g. "camping"). Must be non-empty
+                (leading / trailing whitespace is stripped).
+            limit: Maximum results to return. Default 25.
+            locale: Optional Graph locale (e.g. "ja_JP"); passed through
+                only when set so Meta returns localized names.
+
+        Returns:
+            List of interest records — each has id, name,
+            audience_size_lower_bound, audience_size_upper_bound, path,
+            topic, and related fields.
+
+        Raises:
+            ValueError: ``query`` is empty or whitespace-only.
+        """
+        clean_query = query.strip()
+        if not clean_query:
+            raise ValueError("query must be a non-empty string")
+        params: dict[str, Any] = {
+            "type": "adinterest",
+            "q": clean_query,
+            "limit": limit,
+        }
+        if locale is not None:
+            params["locale"] = locale
+        result = await self._get("/search", params)
+        return result.get("data", [])  # type: ignore[no-any-return]
+
+    async def list_targeting_categories(
+        self,
+        category_class: str,
+        *,
+        limit: int = 200,
+        locale: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """List a full targeting category catalogue.
+
+        Args:
+            category_class: One of the valid adTargetingCategory classes
+                (behaviors, demographics, life_events, industries, income,
+                family_statuses, user_device, user_os). Maps to Graph's
+                ``class`` query param.
+            limit: Maximum records to return. Default 200 — catalogues are
+                finite but larger than keyword-search results.
+            locale: Optional Graph locale (e.g. "ja_JP"); passed through
+                only when set.
+
+        Returns:
+            List of category records — each has id, name,
+            audience_size_lower_bound, audience_size_upper_bound, path,
+            and an optional description.
+
+        Raises:
+            ValueError: ``category_class`` is not a recognized class.
+                Fail fast at the boundary — Graph's error for a bad class
+                is cryptic.
+        """
+        if category_class not in _VALID_CATEGORY_CLASSES:
+            raise ValueError(
+                f"Unknown category_class: {category_class!r}. Valid classes: "
+                + ", ".join(sorted(_VALID_CATEGORY_CLASSES))
+            )
+        params: dict[str, Any] = {
+            "type": "adTargetingCategory",
+            "class": category_class,
+            "limit": limit,
+        }
+        if locale is not None:
+            params["locale"] = locale
+        result = await self._get("/search", params)
+        return result.get("data", [])  # type: ignore[no-any-return]

--- a/mureo/meta_ads/client.py
+++ b/mureo/meta_ads/client.py
@@ -22,6 +22,7 @@ from mureo.meta_ads._leads import LeadsMixin
 from mureo.meta_ads._page_posts import PagePostsMixin
 from mureo.meta_ads._pixels import PixelsMixin
 from mureo.meta_ads._split_test import SplitTestMixin
+from mureo.meta_ads._targeting import TargetingMixin
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -54,6 +55,7 @@ class MetaAdsApiClient(
     InstagramMixin,
     SplitTestMixin,
     AdRulesMixin,
+    TargetingMixin,
 ):
     """Meta Marketing API client.
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -65,15 +65,15 @@ class TestListTools:
     """Verify list_tools returns the correct tool definitions."""
 
     async def test_list_tools_returns_all_tools(self) -> None:
-        """list_tools returns all tools (Google Ads 86 + Meta Ads 84 + Search Console 10
+        """list_tools returns all tools (Google Ads 86 + Meta Ads 86 + Search Console 10
         + Rollback 2 + Analysis 1 + Mureo Context 9 + Analytics Registry 2
-        + Learning 2 + Creative Studio 5 = 201).
+        + Learning 2 + Creative Studio 5 = 203).
 
         Analytics Registry is 2: mureo_analytics_modules_list +
         mureo_analytics_run (#440)."""
         mod = _import_server_module()
         tools = await mod.handle_list_tools()
-        assert len(tools) == 201
+        assert len(tools) == 203
 
     async def test_list_tools_contains_google_and_meta(self) -> None:
         """Google Ads and Meta Ads tools are included."""

--- a/tests/test_mcp_tools_meta_ads.py
+++ b/tests/test_mcp_tools_meta_ads.py
@@ -54,9 +54,9 @@ class TestMetaAdsToolDefinitions:
     """Verify the Meta Ads tool list is defined correctly."""
 
     def test_tool_count(self) -> None:
-        """All 84 tools are defined (83 + meta_ads_pages_list)."""
+        """All 86 tools are defined (84 + targeting search / categories)."""
         mod = _import_meta_ads_tools()
-        assert len(mod.TOOLS) == 84
+        assert len(mod.TOOLS) == 86
 
     def test_bidding_control_schema_properties(self) -> None:
         """The four touched write tools expose the new bidding-control
@@ -847,6 +847,168 @@ class TestMetaAdsPageHandlers:
                 "meta_ads_pages_list", {"account_id": "act_123"}
             )
         assert "Credentials not found" in result[0].text
+
+
+@pytest.mark.unit
+class TestMetaAdsTargetingToolDefinitions:
+    """Targeting-discovery tool schema tests."""
+
+    def test_targeting_tools_present_and_strict(self) -> None:
+        mod = _import_meta_ads_tools()
+        by_name = {t.name: t for t in mod.TOOLS}
+        for name in ("meta_ads_targeting_search", "meta_ads_targeting_categories"):
+            assert name in by_name, f"{name} missing"
+            assert by_name[name].inputSchema["additionalProperties"] is False
+
+    def test_targeting_search_required_and_limit_bounds(self) -> None:
+        mod = _import_meta_ads_tools()
+        tool = next(t for t in mod.TOOLS if t.name == "meta_ads_targeting_search")
+        schema = tool.inputSchema
+        assert set(schema["required"]) == {"query"}
+        assert schema["properties"]["limit"]["maximum"] == 100
+        # account_id stays optional (credential fallback).
+        assert "account_id" in schema["properties"]
+        assert "account_id" not in schema.get("required", [])
+
+    def test_targeting_categories_class_enum(self) -> None:
+        mod = _import_meta_ads_tools()
+        tool = next(t for t in mod.TOOLS if t.name == "meta_ads_targeting_categories")
+        schema = tool.inputSchema
+        assert set(schema["required"]) == {"category_class"}
+        assert set(schema["properties"]["category_class"]["enum"]) == {
+            "behaviors",
+            "demographics",
+            "life_events",
+            "industries",
+            "income",
+            "family_statuses",
+            "user_device",
+            "user_os",
+        }
+
+
+@pytest.mark.unit
+class TestMetaAdsTargetingHandlers:
+    """Targeting-discovery handler tests."""
+
+    async def test_targeting_search_success(self) -> None:
+        mod = _import_meta_ads_tools()
+        handlers = _import_handlers()
+        creds, client = _mock_meta_ads_context()
+        client.search_targeting_interests.return_value = [
+            {"id": "6003", "name": "Camping", "audience_size_lower_bound": 1000}
+        ]
+
+        with (
+            patch.object(handlers, "load_meta_ads_credentials", return_value=creds),
+            patch.object(handlers, "create_meta_ads_client", return_value=client),
+        ):
+            result = await mod.handle_tool(
+                "meta_ads_targeting_search",
+                {"account_id": "act_123", "query": "camping", "limit": 10},
+            )
+
+        client.search_targeting_interests.assert_awaited_once()
+        call = client.search_targeting_interests.await_args
+        assert call.args[0] == "camping"
+        assert call.kwargs["limit"] == 10
+        parsed = json.loads(result[0].text)
+        assert parsed[0]["id"] == "6003"
+
+    async def test_targeting_search_forwards_locale(self) -> None:
+        mod = _import_meta_ads_tools()
+        handlers = _import_handlers()
+        creds, client = _mock_meta_ads_context()
+        client.search_targeting_interests.return_value = []
+
+        with (
+            patch.object(handlers, "load_meta_ads_credentials", return_value=creds),
+            patch.object(handlers, "create_meta_ads_client", return_value=client),
+        ):
+            await mod.handle_tool(
+                "meta_ads_targeting_search",
+                {"account_id": "act_123", "query": "camping", "locale": "ja_JP"},
+            )
+        assert client.search_targeting_interests.await_args.kwargs["locale"] == "ja_JP"
+
+    async def test_targeting_search_missing_query(self) -> None:
+        mod = _import_meta_ads_tools()
+        handlers = _import_handlers()
+        creds, client = _mock_meta_ads_context()
+        with (
+            patch.object(handlers, "load_meta_ads_credentials", return_value=creds),
+            patch.object(handlers, "create_meta_ads_client", return_value=client),
+            pytest.raises(ValueError),
+        ):
+            await mod.handle_tool(
+                "meta_ads_targeting_search", {"account_id": "act_123"}
+            )
+
+    async def test_targeting_search_no_credentials(self) -> None:
+        mod = _import_meta_ads_tools()
+        handlers = _import_handlers()
+        with patch.object(handlers, "load_meta_ads_credentials", return_value=None):
+            result = await mod.handle_tool(
+                "meta_ads_targeting_search",
+                {"account_id": "act_123", "query": "camping"},
+            )
+        assert "Credentials not found" in result[0].text
+
+    async def test_targeting_categories_success(self) -> None:
+        mod = _import_meta_ads_tools()
+        handlers = _import_handlers()
+        creds, client = _mock_meta_ads_context()
+        client.list_targeting_categories.return_value = [
+            {"id": "6002", "name": "Facebook Page admins"}
+        ]
+
+        with (
+            patch.object(handlers, "load_meta_ads_credentials", return_value=creds),
+            patch.object(handlers, "create_meta_ads_client", return_value=client),
+        ):
+            result = await mod.handle_tool(
+                "meta_ads_targeting_categories",
+                {"account_id": "act_123", "category_class": "behaviors"},
+            )
+
+        client.list_targeting_categories.assert_awaited_once()
+        assert client.list_targeting_categories.await_args.args[0] == "behaviors"
+        parsed = json.loads(result[0].text)
+        assert parsed[0]["id"] == "6002"
+
+    async def test_targeting_categories_missing_class(self) -> None:
+        mod = _import_meta_ads_tools()
+        handlers = _import_handlers()
+        creds, client = _mock_meta_ads_context()
+        with (
+            patch.object(handlers, "load_meta_ads_credentials", return_value=creds),
+            patch.object(handlers, "create_meta_ads_client", return_value=client),
+            pytest.raises(ValueError),
+        ):
+            await mod.handle_tool(
+                "meta_ads_targeting_categories", {"account_id": "act_123"}
+            )
+
+    async def test_targeting_categories_no_credentials(self) -> None:
+        mod = _import_meta_ads_tools()
+        handlers = _import_handlers()
+        with patch.object(handlers, "load_meta_ads_credentials", return_value=None):
+            result = await mod.handle_tool(
+                "meta_ads_targeting_categories",
+                {"account_id": "act_123", "category_class": "behaviors"},
+            )
+        assert "Credentials not found" in result[0].text
+
+    async def test_targeting_search_rejects_unknown_param(self) -> None:
+        """additionalProperties:false rejects an undeclared param through
+        the real validating dispatcher path."""
+        from mureo.mcp import server as mcp_server
+
+        with pytest.raises(ValueError, match="not_a_real_param|additional"):
+            await mcp_server.handle_call_tool(
+                "meta_ads_targeting_search",
+                {"account_id": "act_123", "query": "camping", "not_a_real_param": "x"},
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_meta_ads_operations.py
+++ b/tests/test_meta_ads_operations.py
@@ -1393,3 +1393,124 @@ class TestAnalysisMixin:
         result = await client.suggest_creative_improvements("camp1")
         high_cpa = [s for s in result["suggestions"] if s["type"] == "high_cpa"]
         assert len(high_cpa) >= 1
+
+
+# ===========================================================================
+# TargetingMixin tests
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestTargetingMixin:
+    """Read-only targeting-discovery mixin — interest search and category
+    catalogues via the API-root ``/search`` endpoint (NOT act_-scoped)."""
+
+    @pytest.fixture
+    def client(self):
+        from mureo.meta_ads._targeting import TargetingMixin
+
+        return _make_mock_class(TargetingMixin)()
+
+    async def test_search_interests_passes_type_q_limit(self, client) -> None:
+        client._get = AsyncMock(
+            return_value={"data": [{"id": "6003", "name": "Camping"}]}
+        )
+        result = await client.search_targeting_interests("camping", limit=10)
+
+        client._get.assert_awaited_once()
+        path, params = client._get.call_args[0]
+        assert path == "/search"
+        assert params["type"] == "adinterest"
+        assert params["q"] == "camping"
+        assert params["limit"] == 10
+        assert "locale" not in params
+        assert result == [{"id": "6003", "name": "Camping"}]
+
+    async def test_search_interests_default_limit(self, client) -> None:
+        client._get = AsyncMock(return_value={"data": []})
+        await client.search_targeting_interests("yoga")
+        params = client._get.call_args[0][1]
+        assert params["limit"] == 25
+
+    async def test_search_interests_passes_locale_when_set(self, client) -> None:
+        client._get = AsyncMock(return_value={"data": []})
+        await client.search_targeting_interests("camping", locale="ja_JP")
+        params = client._get.call_args[0][1]
+        assert params["locale"] == "ja_JP"
+
+    async def test_search_interests_omits_locale_when_none(self, client) -> None:
+        client._get = AsyncMock(return_value={"data": []})
+        await client.search_targeting_interests("camping", locale=None)
+        params = client._get.call_args[0][1]
+        assert "locale" not in params
+
+    async def test_search_interests_strips_query(self, client) -> None:
+        client._get = AsyncMock(return_value={"data": []})
+        await client.search_targeting_interests("  camping  ")
+        params = client._get.call_args[0][1]
+        assert params["q"] == "camping"
+
+    async def test_search_interests_empty_query_raises(self, client) -> None:
+        with pytest.raises(ValueError):
+            await client.search_targeting_interests("   ")
+        client._get.assert_not_called()
+
+    async def test_search_interests_returns_empty_on_missing_data(self, client) -> None:
+        client._get = AsyncMock(return_value={})
+        result = await client.search_targeting_interests("camping")
+        assert result == []
+
+    async def test_list_categories_passes_class_type_limit(self, client) -> None:
+        client._get = AsyncMock(
+            return_value={"data": [{"id": "6002", "name": "Facebook Page admins"}]}
+        )
+        result = await client.list_targeting_categories("behaviors", limit=50)
+
+        path, params = client._get.call_args[0]
+        assert path == "/search"
+        assert params["type"] == "adTargetingCategory"
+        assert params["class"] == "behaviors"
+        assert params["limit"] == 50
+        assert "q" not in params
+        assert result == [{"id": "6002", "name": "Facebook Page admins"}]
+
+    async def test_list_categories_default_limit(self, client) -> None:
+        client._get = AsyncMock(return_value={"data": []})
+        await client.list_targeting_categories("demographics")
+        params = client._get.call_args[0][1]
+        assert params["limit"] == 200
+
+    async def test_list_categories_passes_locale_when_set(self, client) -> None:
+        client._get = AsyncMock(return_value={"data": []})
+        await client.list_targeting_categories("industries", locale="ja_JP")
+        params = client._get.call_args[0][1]
+        assert params["locale"] == "ja_JP"
+
+    async def test_list_categories_omits_locale_when_none(self, client) -> None:
+        client._get = AsyncMock(return_value={"data": []})
+        await client.list_targeting_categories("industries", locale=None)
+        params = client._get.call_args[0][1]
+        assert "locale" not in params
+
+    @pytest.mark.parametrize(
+        "cls",
+        [
+            "behaviors",
+            "demographics",
+            "life_events",
+            "industries",
+            "income",
+            "family_statuses",
+            "user_device",
+            "user_os",
+        ],
+    )
+    async def test_list_categories_accepts_all_valid_classes(self, client, cls) -> None:
+        client._get = AsyncMock(return_value={"data": []})
+        await client.list_targeting_categories(cls)
+        assert client._get.call_args[0][1]["class"] == cls
+
+    async def test_list_categories_unknown_class_raises(self, client) -> None:
+        with pytest.raises(ValueError):
+            await client.list_targeting_categories("not_a_class")
+        client._get.assert_not_called()


### PR DESCRIPTION
## Summary
Two read-only tools so agents can resolve Meta internal targeting IDs for ad-set targeting specs:
- `meta_ads_targeting_search` — keyword search over ad interests (Graph `/search?type=adinterest`), returns ids + audience size bounds + category paths
- `meta_ads_targeting_categories` — full catalogue of a targeting class (`type=adTargetingCategory`): behaviors (e.g. Facebook Page admins), demographics, life_events, industries, income, family_statuses, user_device, user_os
- Both support `locale` (e.g. `ja_JP`) and `limit`; boundary validation (empty query / unknown class fail fast before any network call); `additionalProperties: false`
- New `TargetingMixin`; tool counts 201 → 203 (Meta Ads 84 → 86)

## Test plan
- TDD; 265 passing in touched suites; full suite green apart from known environment-only failures
- Code review: APPROVE, no CRITICAL/HIGH (README tool catalogue staleness noted as pre-existing, tracked separately)

## Coordination
mureo-pro follow-up (`feat/meta-targeting-toolspec`: 2 READ ToolSpecs, cardinality 86) must merge immediately after this.