### PR TITLE
feat(mcp): enforce additionalProperties: false on all builtin tool schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Strict input schemas across the entire builtin MCP tool registry.**
+  Every builtin tool (all 203 across Google Ads, Meta Ads, Search Console,
+  rollback, analysis, mureo-context, analytics-registry, learning, and
+  creative-studio) now declares `additionalProperties: false` on its
+  top-level `inputSchema`. Previously an unknown or misspelled parameter
+  passed server-side validation and was then silently discarded by the
+  handler's whitelist — a typo like `budgett` became a no-op. Such a call
+  now fails validation with a clear error naming the offending key.
+  **Breaking for any caller that relied on typo-tolerance / passing extra
+  keys.** Nested object properties (e.g. Meta's `targeting` blob) are
+  intentionally left open so they stay forward-compatible with the
+  platform Graph/GAQL sub-object surfaces, which evolve independently of
+  mureo releases. A new enforcement test
+  (`tests/test_mcp_strict_input_schemas.py`) guards the invariant so any
+  future tool that omits it fails CI. Generalizes the earlier four-tool
+  change below to the whole registry.
+
 - **Stricter input validation on the four Meta Ads campaign / ad-set write
   tools.** `meta_ads_campaigns_create`, `meta_ads_campaigns_update`,
   `meta_ads_ad_sets_create`, and `meta_ads_ad_sets_update` now declare

--- a/mureo/_data/skills/_mureo-google-ads/SKILL.md
+++ b/mureo/_data/skills/_mureo-google-ads/SKILL.md
@@ -361,7 +361,7 @@ immediate request but is not remembered.
 
 - `create` -- Create a sitelink extension. **Requires user confirmation.**
   ```
-  Required: customer_id, campaign_id, sitelink_text, final_url (string)
+  Required: customer_id, campaign_id, link_text, final_url (string)
   ```
 
 - `remove` -- Remove a sitelink extension. **Requires user confirmation.**
@@ -712,7 +712,7 @@ Step 6: Add campaign-level negative keywords
   -> google_ads_negative_keywords_add {customer_id, campaign_id, keywords: [...]}
 
 Step 7: Add sitelink extensions
-  -> google_ads_sitelinks_create {customer_id, campaign_id, sitelink_text, final_url}
+  -> google_ads_sitelinks_create {customer_id, campaign_id, link_text, final_url}
 
 Step 8: Add callout extensions
   -> google_ads_callouts_create {customer_id, campaign_id, callout_text}
@@ -846,7 +846,7 @@ Improving responsive search ad performance:
 
 ```
 Step 1: Analyze RSA asset performance
-  -> google_ads_rsa_assets_analyze {customer_id, ad_group_id}
+  -> google_ads_rsa_assets_analyze {customer_id, campaign_id}
 
 Step 2: Audit RSA assets for best practices
   -> google_ads_rsa_assets_audit {customer_id, campaign_id}
@@ -855,7 +855,7 @@ Step 3: Compare ad variants
   -> google_ads_ad_performance_compare {customer_id, ad_group_id}
 
 Step 4: Check landing page relevance
-  -> google_ads_landing_page_analyze {customer_id, campaign_id}
+  -> google_ads_landing_page_analyze {customer_id, url}
 ```
 
 ### 8. Account Audit

--- a/mureo/_data/skills/_mureo-meta-ads/SKILL.md
+++ b/mureo/_data/skills/_mureo-meta-ads/SKILL.md
@@ -677,7 +677,7 @@ Step 2: Create ad set with targeting (CONFIRM WITH USER)
   -> meta_ads_ad_sets_create {account_id, campaign_id, name, daily_budget, targeting}
 
 Step 3: Upload image and create creative
-  -> meta_ads_creatives_upload_image {account_id, file_path}
+  -> meta_ads_creatives_upload_image {account_id, image_url}
   -> meta_ads_creatives_create {account_id, name, image_hash, link_url, page_id}
 
 Step 4: Create ad linking to creative (CONFIRM WITH USER)
@@ -720,8 +720,8 @@ Step 2: Add products or create a feed
   -> meta_ads_products_add {account_id, catalog_id, retailer_id, name, ...}
   -> meta_ads_feeds_create {account_id, catalog_id, name, feed_url}
 
-Step 3: Create a dynamic product ad creative (CONFIRM WITH USER)
-  -> meta_ads_creatives_create_dynamic {account_id, catalog_id}
+Step 3: Create a dynamic creative (multi-asset optimization) (CONFIRM WITH USER)
+  -> meta_ads_creatives_create_dynamic {account_id, name, page_id, image_hashes, bodies, titles, link_url}
 ```
 
 ### 6. Lead Generation (Instant Form, end-to-end)

--- a/mureo/mcp/_tools_google_ads_analysis.py
+++ b/mureo/mcp/_tools_google_ads_analysis.py
@@ -119,6 +119,7 @@ TOOLS: list[Tool] = [
                 "period": _PERIOD_PARAM,
             },
             "required": [],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -161,6 +162,7 @@ TOOLS: list[Tool] = [
                 "period": _PERIOD_PARAM,
             },
             "required": [],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -205,6 +207,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["campaign_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -233,6 +236,7 @@ TOOLS: list[Tool] = [
                 "period": _PERIOD_PARAM,
             },
             "required": ["campaign_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -264,6 +268,7 @@ TOOLS: list[Tool] = [
                 "period": _PERIOD_PARAM,
             },
             "required": ["campaign_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -294,6 +299,7 @@ TOOLS: list[Tool] = [
                 "period": _PERIOD_PARAM,
             },
             "required": ["campaign_id"],
+            "additionalProperties": False,
         },
     ),
     # === Network performance report ===
@@ -321,6 +327,7 @@ TOOLS: list[Tool] = [
                 "period": _PERIOD_PARAM,
             },
             "required": [],
+            "additionalProperties": False,
         },
     ),
     # === Per-ad report ===
@@ -350,6 +357,7 @@ TOOLS: list[Tool] = [
                 "period": _PERIOD_PARAM,
             },
             "required": [],
+            "additionalProperties": False,
         },
     ),
     # === Search Term Analysis ===
@@ -378,6 +386,7 @@ TOOLS: list[Tool] = [
                 "period": _PERIOD_PARAM,
             },
             "required": ["campaign_id"],
+            "additionalProperties": False,
         },
     ),
     # === Performance analysis ===
@@ -412,6 +421,7 @@ TOOLS: list[Tool] = [
                 "period": _SHORT_PERIOD_PARAM,
             },
             "required": ["campaign_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -442,6 +452,7 @@ TOOLS: list[Tool] = [
                 "campaign_id": _CAMPAIGN_ID_PARAM,
             },
             "required": ["campaign_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -468,6 +479,7 @@ TOOLS: list[Tool] = [
                 "customer_id": _CUSTOMER_ID_PARAM,
             },
             "required": [],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -503,6 +515,7 @@ TOOLS: list[Tool] = [
                 "period": _PERIOD_PARAM,
             },
             "required": ["ad_group_id"],
+            "additionalProperties": False,
         },
     ),
     # === Budget analysis ===
@@ -530,6 +543,7 @@ TOOLS: list[Tool] = [
                 "period": _PERIOD_PARAM,
             },
             "required": [],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -561,6 +575,7 @@ TOOLS: list[Tool] = [
                 "period": _PERIOD_PARAM,
             },
             "required": [],
+            "additionalProperties": False,
         },
     ),
     # === Auction insights ===
@@ -589,6 +604,7 @@ TOOLS: list[Tool] = [
                 "period": _PERIOD_PARAM,
             },
             "required": ["campaign_id"],
+            "additionalProperties": False,
         },
     ),
     # === RSA analysis ===
@@ -617,6 +633,7 @@ TOOLS: list[Tool] = [
                 "period": _PERIOD_PARAM,
             },
             "required": ["campaign_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -646,6 +663,7 @@ TOOLS: list[Tool] = [
                 "period": _PERIOD_PARAM,
             },
             "required": ["campaign_id"],
+            "additionalProperties": False,
         },
     ),
     # === BtoB ===
@@ -674,6 +692,7 @@ TOOLS: list[Tool] = [
                 "period": _PERIOD_PARAM,
             },
             "required": ["campaign_id"],
+            "additionalProperties": False,
         },
     ),
     # === Creative ===
@@ -718,6 +737,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["url"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -761,6 +781,7 @@ TOOLS: list[Tool] = [
                 "ad_group_id": _AD_GROUP_ID_FILTER_PARAM,
             },
             "required": ["campaign_id", "url"],
+            "additionalProperties": False,
         },
     ),
     # === Monitoring ===
@@ -789,6 +810,7 @@ TOOLS: list[Tool] = [
                 "campaign_id": _CAMPAIGN_ID_PARAM,
             },
             "required": ["campaign_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -826,6 +848,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["campaign_id", "target_cpa"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -864,6 +887,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["campaign_id", "target_cv_daily"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -897,6 +921,7 @@ TOOLS: list[Tool] = [
                 "campaign_id": _CAMPAIGN_ID_PARAM,
             },
             "required": ["campaign_id"],
+            "additionalProperties": False,
         },
     ),
     # === Capture ===
@@ -909,6 +934,7 @@ TOOLS: list[Tool] = [
                 "url": {"type": "string", "description": "URL to capture"},
             },
             "required": ["url"],
+            "additionalProperties": False,
         },
     ),
 ]

--- a/mureo/mcp/_tools_google_ads_assets.py
+++ b/mureo/mcp/_tools_google_ads_assets.py
@@ -57,6 +57,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["file_path"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -85,6 +86,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": [],
+            "additionalProperties": False,
         },
     ),
 ]

--- a/mureo/mcp/_tools_google_ads_campaigns.py
+++ b/mureo/mcp/_tools_google_ads_campaigns.py
@@ -48,6 +48,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": [],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -73,6 +74,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["campaign_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -136,6 +138,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["name"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -181,6 +184,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["campaign_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -214,6 +218,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["campaign_id", "status"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -238,6 +243,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["campaign_id"],
+            "additionalProperties": False,
         },
     ),
     # === Ad Groups ===
@@ -273,6 +279,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": [],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -316,6 +323,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["campaign_id", "name"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -361,6 +369,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["ad_group_id"],
+            "additionalProperties": False,
         },
     ),
     # === Ads ===
@@ -394,6 +403,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": [],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -463,6 +473,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["ad_group_id", "headlines", "descriptions"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -573,6 +584,7 @@ TOOLS: list[Tool] = [
                 "square_marketing_image_paths",
                 "final_url",
             ],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -632,6 +644,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["ad_group_id", "ad_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -666,6 +679,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["ad_group_id", "ad_id", "status"],
+            "additionalProperties": False,
         },
     ),
     # === Ad policy details ===
@@ -694,6 +708,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["ad_group_id", "ad_id"],
+            "additionalProperties": False,
         },
     ),
     # === Budgets ===
@@ -723,6 +738,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["campaign_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -798,6 +814,7 @@ TOOLS: list[Tool] = [
                 {"required": ["total_amount"]},
                 {"required": ["total_amount_micros"]},
             ],
+            "additionalProperties": False,
         },
     ),
     # === Budget creation ===
@@ -874,6 +891,7 @@ TOOLS: list[Tool] = [
                 {"required": ["total_amount"]},
                 {"required": ["total_amount_micros"]},
             ],
+            "additionalProperties": False,
         },
     ),
     # === Account ===
@@ -895,6 +913,7 @@ TOOLS: list[Tool] = [
                 "customer_id": _CUSTOMER_ID_PARAM,
             },
             "required": [],
+            "additionalProperties": False,
         },
     ),
 ]

--- a/mureo/mcp/_tools_google_ads_extensions.py
+++ b/mureo/mcp/_tools_google_ads_extensions.py
@@ -72,6 +72,7 @@ TOOLS: list[Tool] = [
                 "campaign_id": _CAMPAIGN_ID_PARAM,
             },
             "required": ["campaign_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -131,6 +132,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["campaign_id", "link_text", "final_url"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -161,6 +163,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["campaign_id", "asset_id"],
+            "additionalProperties": False,
         },
     ),
     # === Callouts ===
@@ -182,6 +185,7 @@ TOOLS: list[Tool] = [
                 "campaign_id": _CAMPAIGN_ID_PARAM,
             },
             "required": ["campaign_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -215,6 +219,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["campaign_id", "callout_text"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -243,6 +248,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["campaign_id", "asset_id"],
+            "additionalProperties": False,
         },
     ),
     # === Conversions ===
@@ -265,6 +271,7 @@ TOOLS: list[Tool] = [
                 "customer_id": _CUSTOMER_ID_PARAM,
             },
             "required": [],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -288,6 +295,7 @@ TOOLS: list[Tool] = [
                 "conversion_action_id": _CONVERSION_ACTION_ID_PARAM,
             },
             "required": ["conversion_action_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -325,6 +333,7 @@ TOOLS: list[Tool] = [
                 "period": _PERIOD_PARAM,
             },
             "required": [],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -440,6 +449,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["name"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -539,6 +549,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["conversion_action_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -559,6 +570,7 @@ TOOLS: list[Tool] = [
                 "conversion_action_id": _CONVERSION_ACTION_ID_PARAM,
             },
             "required": ["conversion_action_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -581,6 +593,7 @@ TOOLS: list[Tool] = [
                 "conversion_action_id": _CONVERSION_ACTION_ID_PARAM,
             },
             "required": ["conversion_action_id"],
+            "additionalProperties": False,
         },
     ),
     # === Recommendations ===
@@ -621,6 +634,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": [],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -654,6 +668,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["resource_name"],
+            "additionalProperties": False,
         },
     ),
     # === Device Targeting ===
@@ -681,6 +696,7 @@ TOOLS: list[Tool] = [
                 "campaign_id": _CAMPAIGN_ID_PARAM,
             },
             "required": ["campaign_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -724,6 +740,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["campaign_id", "enabled_devices"],
+            "additionalProperties": False,
         },
     ),
     # === Bid adjustments ===
@@ -749,6 +766,7 @@ TOOLS: list[Tool] = [
                 "campaign_id": _CAMPAIGN_ID_PARAM,
             },
             "required": ["campaign_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -791,6 +809,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["campaign_id", "criterion_id", "bid_modifier"],
+            "additionalProperties": False,
         },
     ),
     # === Geographic Targeting ===
@@ -815,6 +834,7 @@ TOOLS: list[Tool] = [
                 "campaign_id": _CAMPAIGN_ID_PARAM,
             },
             "required": ["campaign_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -862,6 +882,7 @@ TOOLS: list[Tool] = [
                 {"required": ["add_locations"]},
                 {"required": ["remove_criterion_ids"]},
             ],
+            "additionalProperties": False,
         },
     ),
     # === Ad schedules ===
@@ -909,6 +930,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["campaign_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -993,6 +1015,7 @@ TOOLS: list[Tool] = [
                 {"required": ["add_schedules"]},
                 {"required": ["remove_criterion_ids"]},
             ],
+            "additionalProperties": False,
         },
     ),
     # === Change History ===
@@ -1039,6 +1062,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": [],
+            "additionalProperties": False,
         },
     ),
 ]

--- a/mureo/mcp/_tools_google_ads_keywords.py
+++ b/mureo/mcp/_tools_google_ads_keywords.py
@@ -84,6 +84,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": [],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -121,6 +122,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["ad_group_id", "keywords"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -152,6 +154,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["ad_group_id", "criterion_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -199,6 +202,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["seed_keywords"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -225,6 +229,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["campaign_id"],
+            "additionalProperties": False,
         },
     ),
     # === Negative Keywords ===
@@ -247,6 +252,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["campaign_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -285,6 +291,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["campaign_id", "keywords"],
+            "additionalProperties": False,
         },
     ),
     # === Keyword pause ===
@@ -319,6 +326,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["ad_group_id", "criterion_id"],
+            "additionalProperties": False,
         },
     ),
     # === Negative keyword removal ===
@@ -351,6 +359,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["campaign_id", "criterion_id"],
+            "additionalProperties": False,
         },
     ),
     # === Ad group-level negative keyword addition ===
@@ -389,6 +398,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["ad_group_id", "keywords"],
+            "additionalProperties": False,
         },
     ),
     # === Automatic negative keyword suggestions ===
@@ -439,6 +449,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["campaign_id"],
+            "additionalProperties": False,
         },
     ),
     # === Keyword Inventory ===
@@ -482,6 +493,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["campaign_id"],
+            "additionalProperties": False,
         },
     ),
     # === Cross-ad-group keyword duplicate detection ===
@@ -515,6 +527,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["campaign_id"],
+            "additionalProperties": False,
         },
     ),
 ]

--- a/mureo/mcp/_tools_google_ads_targeting.py
+++ b/mureo/mcp/_tools_google_ads_targeting.py
@@ -55,6 +55,7 @@ TOOLS: list[Tool] = [
                 "campaign_id": _CAMPAIGN_ID_PARAM,
             },
             "required": [],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -82,6 +83,7 @@ TOOLS: list[Tool] = [
                 "campaign_id": _CAMPAIGN_ID_PARAM,
             },
             "required": [],
+            "additionalProperties": False,
         },
     ),
 ]

--- a/mureo/mcp/_tools_meta_ads_audiences.py
+++ b/mureo/mcp/_tools_meta_ads_audiences.py
@@ -49,6 +49,7 @@ TOOLS: list[Tool] = [
                 "limit": _LIMIT_PARAM,
             },
             "required": [],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -140,6 +141,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["name"],
+            "additionalProperties": False,
         },
     ),
     # === Audience get / delete / lookalike ===
@@ -166,6 +168,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["audience_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -191,6 +194,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["audience_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -271,6 +275,7 @@ TOOLS: list[Tool] = [
                 "country",
                 "ratio",
             ],
+            "additionalProperties": False,
         },
     ),
     # === Pixels ===
@@ -291,6 +296,7 @@ TOOLS: list[Tool] = [
                 "limit": _LIMIT_PARAM,
             },
             "required": [],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -314,6 +320,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["pixel_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -345,6 +352,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["pixel_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -370,6 +378,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["pixel_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -400,6 +409,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["name"],
+            "additionalProperties": False,
         },
     ),
     # === Targeting discovery ===

--- a/mureo/mcp/_tools_meta_ads_campaigns.py
+++ b/mureo/mcp/_tools_meta_ads_campaigns.py
@@ -157,6 +157,7 @@ TOOLS: list[Tool] = [
                 "limit": _LIMIT_PARAM,
             },
             "required": [],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -182,6 +183,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["campaign_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -338,6 +340,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["campaign_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -360,6 +363,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["campaign_id"],
+            "additionalProperties": False,
         },
     ),
     # === Ad sets ===
@@ -388,6 +392,7 @@ TOOLS: list[Tool] = [
                 "limit": _LIMIT_PARAM,
             },
             "required": [],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -611,6 +616,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["ad_set_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -632,6 +638,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["ad_set_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -654,6 +661,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["ad_set_id"],
+            "additionalProperties": False,
         },
     ),
     # === Ads ===
@@ -682,6 +690,7 @@ TOOLS: list[Tool] = [
                 "limit": _LIMIT_PARAM,
             },
             "required": [],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -726,6 +735,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["ad_set_id", "name", "creative_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -762,6 +772,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["ad_id"],
+            "additionalProperties": False,
         },
     ),
     # === Ad get / pause / enable ===
@@ -786,6 +797,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["ad_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -808,6 +820,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["ad_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -828,6 +841,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["ad_id"],
+            "additionalProperties": False,
         },
     ),
 ]

--- a/mureo/mcp/_tools_meta_ads_catalog.py
+++ b/mureo/mcp/_tools_meta_ads_catalog.py
@@ -48,6 +48,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["business_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -77,6 +78,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["business_id", "name"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -101,6 +103,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["catalog_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -124,6 +127,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["catalog_id"],
+            "additionalProperties": False,
         },
     ),
     # === Products ===
@@ -156,6 +160,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["catalog_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -277,6 +282,7 @@ TOOLS: list[Tool] = [
                 "url",
                 "image_url",
             ],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -303,6 +309,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["product_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -375,6 +382,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["product_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -401,6 +409,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["product_id"],
+            "additionalProperties": False,
         },
     ),
     # === Feeds ===
@@ -425,6 +434,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["catalog_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -476,6 +486,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["catalog_id", "name", "feed_url"],
+            "additionalProperties": False,
         },
     ),
 ]

--- a/mureo/mcp/_tools_meta_ads_conversions.py
+++ b/mureo/mcp/_tools_meta_ads_conversions.py
@@ -155,6 +155,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["pixel_id", "events"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -230,6 +231,7 @@ TOOLS: list[Tool] = [
                 "currency",
                 "value",
             ],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -269,6 +271,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["pixel_id", "event_time", "user_data"],
+            "additionalProperties": False,
         },
     ),
 ]

--- a/mureo/mcp/_tools_meta_ads_creatives.py
+++ b/mureo/mcp/_tools_meta_ads_creatives.py
@@ -68,6 +68,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": [],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -161,6 +162,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["name", "page_id", "link_url"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -285,6 +287,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["name", "page_id", "form_id", "link_url"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -382,6 +385,7 @@ TOOLS: list[Tool] = [
                 "titles",
                 "link_url",
             ],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -408,6 +412,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["image_url"],
+            "additionalProperties": False,
         },
     ),
     # === Carousel & Collection ===
@@ -497,6 +502,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["page_id", "cards", "link"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -553,6 +559,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["page_id", "product_ids", "link"],
+            "additionalProperties": False,
         },
     ),
     # === Image upload ===
@@ -586,6 +593,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["file_path"],
+            "additionalProperties": False,
         },
     ),
     # === Video Upload ===
@@ -621,6 +629,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["video_url"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -653,6 +662,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["file_path"],
+            "additionalProperties": False,
         },
     ),
 ]

--- a/mureo/mcp/_tools_meta_ads_insights.py
+++ b/mureo/mcp/_tools_meta_ads_insights.py
@@ -70,6 +70,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": [],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -117,6 +118,7 @@ TOOLS: list[Tool] = [
                 "period": _PERIOD_PARAM,
             },
             "required": ["campaign_id"],
+            "additionalProperties": False,
         },
     ),
     # === Performance analysis ===
@@ -146,6 +148,7 @@ TOOLS: list[Tool] = [
                 "period": _PERIOD_PARAM,
             },
             "required": [],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -171,6 +174,7 @@ TOOLS: list[Tool] = [
                 "period": _PERIOD_PARAM,
             },
             "required": ["campaign_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -196,6 +200,7 @@ TOOLS: list[Tool] = [
                 "period": _PERIOD_PARAM,
             },
             "required": ["campaign_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -221,6 +226,7 @@ TOOLS: list[Tool] = [
                 "period": _PERIOD_PARAM,
             },
             "required": ["campaign_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -251,6 +257,7 @@ TOOLS: list[Tool] = [
                 "period": _PERIOD_PARAM,
             },
             "required": ["ad_set_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -276,6 +283,7 @@ TOOLS: list[Tool] = [
                 "period": _PERIOD_PARAM,
             },
             "required": ["campaign_id"],
+            "additionalProperties": False,
         },
     ),
 ]

--- a/mureo/mcp/_tools_meta_ads_leads.py
+++ b/mureo/mcp/_tools_meta_ads_leads.py
@@ -52,6 +52,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["page_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -79,6 +80,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["form_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -233,6 +235,7 @@ TOOLS: list[Tool] = [
                 "questions",
                 "privacy_policy_url",
             ],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -269,6 +272,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["form_id", "status"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -312,6 +316,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["form_id", "page_id", "new_name"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -364,6 +369,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["form_id", "output_path"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -396,6 +402,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["form_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -430,6 +437,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["ad_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -481,6 +489,7 @@ TOOLS: list[Tool] = [
                 {"required": ["file_path"]},
                 {"required": ["image_url"]},
             ],
+            "additionalProperties": False,
         },
     ),
 ]

--- a/mureo/mcp/_tools_meta_ads_other.py
+++ b/mureo/mcp/_tools_meta_ads_other.py
@@ -58,6 +58,7 @@ TOOLS: list[Tool] = [
                 "limit": _LIMIT_50,
             },
             "required": [],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -83,6 +84,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["study_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -173,6 +175,7 @@ TOOLS: list[Tool] = [
                 "start_time",
                 "end_time",
             ],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -196,6 +199,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["study_id"],
+            "additionalProperties": False,
         },
     ),
     # === Automated Rules (Ad Rules) ===
@@ -217,6 +221,7 @@ TOOLS: list[Tool] = [
                 "limit": _LIMIT_50,
             },
             "required": [],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -243,6 +248,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["rule_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -311,6 +317,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["name", "evaluation_spec", "execution_spec"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -381,6 +388,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["rule_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -406,6 +414,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["rule_id"],
+            "additionalProperties": False,
         },
     ),
     # === Page Posts ===
@@ -436,6 +445,7 @@ TOOLS: list[Tool] = [
                 "limit": _LIMIT_25,
             },
             "required": ["page_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -483,6 +493,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["page_id", "post_id", "ad_set_id"],
+            "additionalProperties": False,
         },
     ),
     # === Pages ===
@@ -502,6 +513,7 @@ TOOLS: list[Tool] = [
                 "account_id": _ACCOUNT_ID_PARAM,
             },
             "required": [],
+            "additionalProperties": False,
         },
     ),
     # === Instagram ===
@@ -520,6 +532,7 @@ TOOLS: list[Tool] = [
                 "account_id": _ACCOUNT_ID_PARAM,
             },
             "required": [],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -546,6 +559,7 @@ TOOLS: list[Tool] = [
                 "limit": _LIMIT_25,
             },
             "required": ["ig_user_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -587,6 +601,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["ig_user_id", "media_id", "ad_set_id"],
+            "additionalProperties": False,
         },
     ),
 ]

--- a/mureo/mcp/_tools_search_console.py
+++ b/mureo/mcp/_tools_search_console.py
@@ -68,6 +68,7 @@ TOOLS: list[Tool] = [
         inputSchema={
             "type": "object",
             "properties": {},
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -91,6 +92,7 @@ TOOLS: list[Tool] = [
                 "site_url": _SITE_URL_PARAM,
             },
             "required": [],
+            "additionalProperties": False,
         },
     ),
     # === Search Analytics ===
@@ -155,6 +157,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["start_date", "end_date"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -184,6 +187,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["start_date", "end_date"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -213,6 +217,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["start_date", "end_date"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -242,6 +247,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["start_date", "end_date"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -329,6 +335,7 @@ TOOLS: list[Tool] = [
                 "start_date_2",
                 "end_date_2",
             ],
+            "additionalProperties": False,
         },
     ),
     # === Sitemaps ===
@@ -352,6 +359,7 @@ TOOLS: list[Tool] = [
                 "site_url": _SITE_URL_PARAM,
             },
             "required": [],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -399,6 +407,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["feedpath"],
+            "additionalProperties": False,
         },
     ),
     # === URL Inspection ===
@@ -440,6 +449,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["inspection_url"],
+            "additionalProperties": False,
         },
     ),
 ]

--- a/mureo/mcp/tools_analysis.py
+++ b/mureo/mcp/tools_analysis.py
@@ -92,6 +92,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["current"],
+            "additionalProperties": False,
         },
     ),
 ]

--- a/mureo/mcp/tools_analytics_registry.py
+++ b/mureo/mcp/tools_analytics_registry.py
@@ -56,7 +56,7 @@ TOOLS: list[Tool] = [
             "Built-in (google_ads, meta_ads) and plugin-supplied "
             "modules appear in the same shape."
         ),
-        inputSchema={"type": "object", "properties": {}},
+        inputSchema={"type": "object", "properties": {}, "additionalProperties": False},
     ),
     Tool(
         name="mureo_analytics_run",
@@ -112,6 +112,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["platform", "capability", "account_id"],
+            "additionalProperties": False,
         },
     ),
 ]

--- a/mureo/mcp/tools_creative_studio.py
+++ b/mureo/mcp/tools_creative_studio.py
@@ -117,7 +117,7 @@ TOOLS: list[Tool] = [
             "creative_studio_generate_visual to see which providers can be "
             "selected."
         ),
-        inputSchema={"type": "object", "properties": {}},
+        inputSchema={"type": "object", "properties": {}, "additionalProperties": False},
     ),
     Tool(
         name="creative_studio_generate_visual",
@@ -179,6 +179,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["prompt"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -189,7 +190,7 @@ TOOLS: list[Tool] = [
             "tasteful neutral defaults are returned and 'defaults_used' is "
             "true. Use this to judge brand fit before composing banners."
         ),
-        inputSchema={"type": "object", "properties": {}},
+        inputSchema={"type": "object", "properties": {}, "additionalProperties": False},
     ),
     Tool(
         name="creative_studio_edit_visual",
@@ -226,6 +227,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["path", "instruction"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -288,6 +290,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["visual_path", "headline", "cta"],
+            "additionalProperties": False,
         },
     ),
 ]

--- a/mureo/mcp/tools_learning.py
+++ b/mureo/mcp/tools_learning.py
@@ -121,6 +121,7 @@ TOOLS: list[Tool] = [
             "type": "object",
             "properties": {},
             "required": [],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -172,6 +173,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["question"],
+            "additionalProperties": False,
         },
     ),
 ]

--- a/mureo/mcp/tools_mureo_context.py
+++ b/mureo/mcp/tools_mureo_context.py
@@ -135,6 +135,7 @@ TOOLS: list[Tool] = [
         inputSchema={
             "type": "object",
             "properties": {"path": _PATH_PROPERTY},
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -156,6 +157,7 @@ TOOLS: list[Tool] = [
                 "path": _PATH_PROPERTY,
             },
             "required": ["markdown"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -169,6 +171,7 @@ TOOLS: list[Tool] = [
         inputSchema={
             "type": "object",
             "properties": {"path": _PATH_PROPERTY},
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -186,6 +189,7 @@ TOOLS: list[Tool] = [
                 "path": _PATH_PROPERTY,
             },
             "required": ["entry"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -206,6 +210,7 @@ TOOLS: list[Tool] = [
                 "path": _PATH_PROPERTY,
             },
             "required": ["campaign"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -256,6 +261,7 @@ TOOLS: list[Tool] = [
                 "path": _PATH_PROPERTY,
             },
             "required": ["report", "summary"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -321,6 +327,7 @@ TOOLS: list[Tool] = [
                 "path": _PATH_PROPERTY,
             },
             "required": ["platform", "account_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -373,6 +380,7 @@ TOOLS: list[Tool] = [
                 "path": _PATH_PROPERTY,
             },
             "required": ["platform", "account_id"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -415,6 +423,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["before", "after"],
+            "additionalProperties": False,
         },
     ),
 ]

--- a/mureo/mcp/tools_rollback.py
+++ b/mureo/mcp/tools_rollback.py
@@ -47,6 +47,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["index"],
+            "additionalProperties": False,
         },
     ),
     Tool(
@@ -80,6 +81,7 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["index", "confirm"],
+            "additionalProperties": False,
         },
     ),
 ]

--- a/skills/_mureo-google-ads/SKILL.md
+++ b/skills/_mureo-google-ads/SKILL.md
@@ -361,7 +361,7 @@ immediate request but is not remembered.
 
 - `create` -- Create a sitelink extension. **Requires user confirmation.**
   ```
-  Required: customer_id, campaign_id, sitelink_text, final_url (string)
+  Required: customer_id, campaign_id, link_text, final_url (string)
   ```
 
 - `remove` -- Remove a sitelink extension. **Requires user confirmation.**
@@ -712,7 +712,7 @@ Step 6: Add campaign-level negative keywords
   -> google_ads_negative_keywords_add {customer_id, campaign_id, keywords: [...]}
 
 Step 7: Add sitelink extensions
-  -> google_ads_sitelinks_create {customer_id, campaign_id, sitelink_text, final_url}
+  -> google_ads_sitelinks_create {customer_id, campaign_id, link_text, final_url}
 
 Step 8: Add callout extensions
   -> google_ads_callouts_create {customer_id, campaign_id, callout_text}
@@ -846,7 +846,7 @@ Improving responsive search ad performance:
 
 ```
 Step 1: Analyze RSA asset performance
-  -> google_ads_rsa_assets_analyze {customer_id, ad_group_id}
+  -> google_ads_rsa_assets_analyze {customer_id, campaign_id}
 
 Step 2: Audit RSA assets for best practices
   -> google_ads_rsa_assets_audit {customer_id, campaign_id}
@@ -855,7 +855,7 @@ Step 3: Compare ad variants
   -> google_ads_ad_performance_compare {customer_id, ad_group_id}
 
 Step 4: Check landing page relevance
-  -> google_ads_landing_page_analyze {customer_id, campaign_id}
+  -> google_ads_landing_page_analyze {customer_id, url}
 ```
 
 ### 8. Account Audit

--- a/skills/_mureo-meta-ads/SKILL.md
+++ b/skills/_mureo-meta-ads/SKILL.md
@@ -677,7 +677,7 @@ Step 2: Create ad set with targeting (CONFIRM WITH USER)
   -> meta_ads_ad_sets_create {account_id, campaign_id, name, daily_budget, targeting}
 
 Step 3: Upload image and create creative
-  -> meta_ads_creatives_upload_image {account_id, file_path}
+  -> meta_ads_creatives_upload_image {account_id, image_url}
   -> meta_ads_creatives_create {account_id, name, image_hash, link_url, page_id}
 
 Step 4: Create ad linking to creative (CONFIRM WITH USER)
@@ -720,8 +720,8 @@ Step 2: Add products or create a feed
   -> meta_ads_products_add {account_id, catalog_id, retailer_id, name, ...}
   -> meta_ads_feeds_create {account_id, catalog_id, name, feed_url}
 
-Step 3: Create a dynamic product ad creative (CONFIRM WITH USER)
-  -> meta_ads_creatives_create_dynamic {account_id, catalog_id}
+Step 3: Create a dynamic creative (multi-asset optimization) (CONFIRM WITH USER)
+  -> meta_ads_creatives_create_dynamic {account_id, name, page_id, image_hashes, bodies, titles, link_url}
 ```
 
 ### 6. Lead Generation (Instant Form, end-to-end)

--- a/tests/analytics/test_mcp_tool.py
+++ b/tests/analytics/test_mcp_tool.py
@@ -28,7 +28,11 @@ def _reset_registry() -> Iterator[None]:
 @pytest.mark.unit
 def test_tool_definition_is_zero_arg() -> None:
     tool = next(t for t in TOOLS if t.name == "mureo_analytics_modules_list")
-    assert tool.inputSchema == {"type": "object", "properties": {}}
+    assert tool.inputSchema == {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": False,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_strict_input_schemas.py
+++ b/tests/test_mcp_strict_input_schemas.py
@@ -1,0 +1,100 @@
+"""Regression guard: every builtin MCP tool's inputSchema must close its
+top-level object with ``additionalProperties: false``.
+
+Historically these schemas omitted ``additionalProperties``, so unknown
+parameters passed server-side validation (``server._validate_tool_input``)
+and were then silently discarded by each handler's explicit
+``_opt``/``_require`` whitelist. A caller who mistyped a parameter name
+(``budgett`` for ``budget``) got a silent no-op instead of an error — a
+real, field-reported footgun. Declaring ``additionalProperties: false``
+turns that silent drop into an explicit validation failure.
+
+Scope decisions:
+
+* **Top level only.** This test asserts the *top-level* object schema is
+  closed. Nested object properties (e.g. Meta's ``targeting`` blob) are
+  intentionally left open: they mirror the platform Graph/GAQL sub-object
+  surfaces, which evolve independently of mureo releases, and closing them
+  would reject valid forward-compatible sub-fields the handler forwards
+  wholesale. Only the top-level parameter set is a fixed, handler-owned
+  whitelist, so only the top level is closed.
+* **Builtin registries only.** Plugin-provided tools (entry-point plugins,
+  logly bridges, etc.) are out of scope — their schemas are owned by the
+  plugin author, and ``server._build_tool_validators`` already tolerates a
+  permissive plugin schema. This test imports the builtin registry modules
+  directly rather than the assembled ``server._ALL_TOOLS`` so the plugin
+  surface never leaks in.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def _all_builtin_tools():
+    """Return every Tool from the nine builtin registries.
+
+    Imported straight from the registry modules (not ``server._ALL_TOOLS``)
+    so env-gating and plugin tools cannot affect the set under test.
+    """
+    from mureo.mcp import (
+        tools_analysis,
+        tools_analytics_registry,
+        tools_creative_studio,
+        tools_google_ads,
+        tools_learning,
+        tools_meta_ads,
+        tools_mureo_context,
+        tools_rollback,
+        tools_search_console,
+    )
+
+    out = []
+    for mod in (
+        tools_google_ads,
+        tools_meta_ads,
+        tools_search_console,
+        tools_rollback,
+        tools_analysis,
+        tools_mureo_context,
+        tools_analytics_registry,
+        tools_learning,
+        tools_creative_studio,
+    ):
+        out.extend(mod.TOOLS)
+    return out
+
+
+@pytest.mark.unit
+def test_every_builtin_tool_declares_additional_properties_false() -> None:
+    """Every builtin tool's top-level inputSchema is closed.
+
+    A tool whose top-level schema omits ``additionalProperties: false`` lets
+    unknown parameters through server-side validation, where the handler
+    then silently drops them. Any newly added tool that forgets this fails
+    here immediately.
+    """
+    offenders = []
+    for tool in _all_builtin_tools():
+        schema = getattr(tool, "inputSchema", None)
+        if not isinstance(schema, dict):
+            offenders.append((tool.name, "no inputSchema dict"))
+            continue
+        if schema.get("type") != "object":
+            # Every builtin tool schema is an object; flag anything else so
+            # the assumption stays true.
+            offenders.append((tool.name, f"top-level type={schema.get('type')!r}"))
+            continue
+        if schema.get("additionalProperties") is not False:
+            offenders.append(
+                (
+                    tool.name,
+                    f"additionalProperties={schema.get('additionalProperties')!r}",
+                )
+            )
+    assert not offenders, (
+        "These builtin tool schemas do not declare "
+        '`"additionalProperties": False` at the top level, so unknown '
+        "parameters pass validation and are silently dropped by the "
+        f"handler whitelist:\n{offenders}"
+    )

--- a/tests/test_mcp_tools_advisor.py
+++ b/tests/test_mcp_tools_advisor.py
@@ -80,6 +80,7 @@ class TestConsultAdvisorToolDefinition:
             "type": "object",
             "properties": {},
             "required": [],
+            "additionalProperties": False,
         }
 
 

--- a/tests/test_mcp_tools_learning.py
+++ b/tests/test_mcp_tools_learning.py
@@ -51,13 +51,15 @@ class TestLearningInsightsToolDefinition:
         """The tool takes no arguments — its job is to surface every
         insight in the operator-tier knowledge base. Callers must not
         be tempted to pass a filter / scope hint that we silently
-        ignore."""
+        ignore. ``additionalProperties: false`` now enforces that: an
+        unknown key is rejected at validation instead of dropped."""
         mod = _import_learning_tools()
         tool = next(t for t in mod.TOOLS if t.name == "mureo_learning_insights_get")
         assert tool.inputSchema == {
             "type": "object",
             "properties": {},
             "required": [],
+            "additionalProperties": False,
         }
 
     def test_tool_description_references_learn_skill(self) -> None:
@@ -166,8 +168,7 @@ diagnostic workflow.
         # scaffold-only — guards against a regression where the
         # derived marker drifts and starts catching everything.
         insight = (
-            "### Use micro-conversions when CV is sparse\n\n"
-            "**Situation:** ...\n"
+            "### Use micro-conversions when CV is sparse\n\n" "**Situation:** ...\n"
         )
         assert _is_scaffold_only(_OPERATOR_SCAFFOLD + insight) is False
 


### PR DESCRIPTION
## Summary
Closes the silent-parameter-drop footgun reported from the field: unknown args now fail validation with a clear error instead of being ignored.
- All 203 builtin tools (9 registries) declare `additionalProperties: false` at the schema top level (197 fixed, 6 already strict; zero exceptions needed — no builtin handler forwards args generically)
- Permanent enforcement test covering all nine registries; future tools cannot regress
- Nested objects (Meta `targeting`, GAQL structures) deliberately left open for provider forward-compat
- Fixes 5 pre-existing skill-doc examples using parameter names the handlers never accepted (silent no-ops before; hard errors after)
- **Breaking** for callers relying on typo-tolerance — CHANGELOG Changed entry included

## Test plan
- TDD: enforcement test written first (RED: 197 offenders), then mechanical fix; suite 5769 passed (remaining failures are known environment-only: plugin-inflated counts, network-dependent live tests)
- Code review: APPROVE, no CRITICAL/HIGH; mechanical fidelity verified programmatically (203/203, no nested closures)

## Coordination
No mureo-pro follow-up required (verified): its dispatchers derive their own schemas and already force `additionalProperties: false`; parity tests compare names/required sets only.