### PR TITLE
feat(policy): bid-cap guardrails for Meta bid_amount and Google cpc_bid_micros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Bid-cap guardrails in `StrategyPolicyGate`.** The built-in gate now
+  enforces two new `## Guardrails` rules alongside the budget caps:
+  `max_bid_amount_per_ad_set` refuses a `meta_ads_ad_sets_create` /
+  `meta_ads_ad_sets_update` whose `bid_amount` (account-currency minor units,
+  identical to Meta's field) exceeds the cap, and `max_cpc_bid_per_ad_group`
+  refuses a `google_ads_ad_groups_create` / `google_ads_ad_groups_update`
+  whose `cpc_bid_micros` (converted from micros to currency units) exceeds the
+  cap. Bids are per-auction ceilings with distinct semantics from spend
+  budgets, so they get their own caps. The `bid_constraints.roas_average_floor`
+  (a min-ROAS floor) and Google `bid_modifier` (a bid-adjustment multiplier)
+  are not spend amounts and are deliberately not constrained. Both fields are
+  optional and default to no check (backward compatible); an oversized bid
+  saturates to infinity and is refused rather than silently abstained.
+
 - **Meta Ads targeting-discovery tools (`meta_ads_targeting_search`,
   `meta_ads_targeting_categories`).** Two read-only tools that resolve
   Meta's internal targeting IDs needed to build an ad-set `targeting`

--- a/mureo/_data/skills/_mureo-strategy/SKILL.md
+++ b/mureo/_data/skills/_mureo-strategy/SKILL.md
@@ -181,6 +181,8 @@ keys (all optional):
 - max_daily_budget_increase_pct: 20
 - max_total_daily_budget: 300000
 - max_lifetime_budget_per_campaign: 900000
+- max_bid_amount_per_ad_set: 5000   # minor units: 5000 = $50.00 (USD) but ¥5,000 (JPY)
+- max_cpc_bid_per_ad_group: 100      # currency units: 100 = $100 (USD) or ¥100 (JPY)
 - blocked_operations: google_ads_keywords_remove, meta_ads_audiences_delete
 ```
 
@@ -203,6 +205,20 @@ keys (all optional):
   `total_amount_micros` converted from micros. Lifetime and daily budgets
   have distinct semantics, so declare this cap separately — a daily cap
   alone does not constrain lifetime-budget mutations.
+- `max_bid_amount_per_ad_set` — an ad-set mutation proposing a bid *cap* above
+  this is **refused** (`meta_ads_ad_sets_create` / `meta_ads_ad_sets_update`
+  `bid_amount`). A bid is a per-auction ceiling, not a spend budget, so it is
+  capped separately from the budget rules above. Compared against Meta's native
+  `bid_amount` in Meta's **minor units** (= currency units for JPY-like
+  zero-decimal currencies, cents for USD-like). The `bid_constraints`
+  `roas_average_floor` is a min-ROAS floor, not a spend amount, so it is **not**
+  constrained by this cap.
+- `max_cpc_bid_per_ad_group` — an ad-group mutation proposing a CPC bid above
+  this is **refused** (`google_ads_ad_groups_create` /
+  `google_ads_ad_groups_update` `cpc_bid_micros`). Given in account-currency
+  **units**; the tool's `cpc_bid_micros` is converted from micros before
+  comparison. A `bid_modifier` (a bid-adjustment multiplier) is not a spend
+  amount and is not constrained by this cap.
 - `blocked_operations` — comma-separated tool names that are always refused.
   Each name must **exactly match the dispatched MCP tool name**; the gate does a
   literal string match, so a typo or a non-existent name silently never fires.

--- a/mureo/policy/strategy_gate.py
+++ b/mureo/policy/strategy_gate.py
@@ -44,6 +44,12 @@ GUARDRAILS_HEADING = "guardrails"
 # different vocabulary declares its own keys instead — see BudgetDeclaration.
 _BUDGET_KEYS = ("daily_budget", "proposed_daily_budget", "amount")
 _CURRENT_BUDGET_KEYS = ("current_daily_budget", "current")
+#: Argument keys carrying a proposed *bid cap* (distinct from a spend budget).
+#: ``bid_amount`` is Meta's ad-set bid cap in account-currency minor units
+#: (meta_ads_ad_sets_create / _update). Deliberately scalar-only: the sibling
+#: ``bid_constraints`` dict carries a ``roas_average_floor`` (a min-ROAS floor,
+#: not a spend amount) and must NOT be read as a proposed bid.
+_BID_AMOUNT_KEYS = ("bid_amount",)
 #: The cross-provider convention keys for the two budget figures the CALLER
 #: supplies rather than the tool: the *existing* daily budget and the
 #: account-wide projected total (both in currency units), which the skills pass
@@ -328,6 +334,14 @@ class Guardrails:
     max_daily_budget_increase_pct: float | None = None
     max_total_daily_budget: float | None = None
     max_lifetime_budget_per_campaign: float | None = None
+    #: Bid caps. Distinct from budgets: a bid is a per-auction ceiling, not a
+    #: spend budget, so it gets its own cap. ``max_bid_amount_per_ad_set`` is
+    #: in account-currency MINOR units — identical to Meta's ``bid_amount``
+    #: argument (yen for JPY, cents for USD). ``max_cpc_bid_per_ad_group`` is in
+    #: account-currency units — Google's ``cpc_bid_micros`` is converted from
+    #: micros before comparison, mirroring the budget-micros convention.
+    max_bid_amount_per_ad_set: float | None = None
+    max_cpc_bid_per_ad_group: float | None = None
     blocked_operations: frozenset[str] = field(default_factory=frozenset)
 
     def is_empty(self) -> bool:
@@ -336,6 +350,8 @@ class Guardrails:
             and self.max_daily_budget_increase_pct is None
             and self.max_total_daily_budget is None
             and self.max_lifetime_budget_per_campaign is None
+            and self.max_bid_amount_per_ad_set is None
+            and self.max_cpc_bid_per_ad_group is None
             and not self.blocked_operations
         )
 
@@ -358,6 +374,8 @@ def parse_guardrails(content: str) -> Guardrails:
     max_increase_pct: float | None = None
     max_total: float | None = None
     max_lifetime: float | None = None
+    max_bid_amount: float | None = None
+    max_cpc_bid: float | None = None
     blocked: set[str] = set()
 
     for line in content.splitlines():
@@ -374,6 +392,10 @@ def parse_guardrails(content: str) -> Guardrails:
             max_total = _to_float(raw)
         elif key == "max_lifetime_budget_per_campaign":
             max_lifetime = _to_float(raw)
+        elif key == "max_bid_amount_per_ad_set":
+            max_bid_amount = _to_float(raw)
+        elif key == "max_cpc_bid_per_ad_group":
+            max_cpc_bid = _to_float(raw)
         elif key == "blocked_operations":
             blocked = {op.strip() for op in raw.split(",") if op.strip()}
 
@@ -382,6 +404,8 @@ def parse_guardrails(content: str) -> Guardrails:
         max_daily_budget_increase_pct=max_increase_pct,
         max_total_daily_budget=max_total,
         max_lifetime_budget_per_campaign=max_lifetime,
+        max_bid_amount_per_ad_set=max_bid_amount,
+        max_cpc_bid_per_ad_group=max_cpc_bid,
         blocked_operations=frozenset(blocked),
     )
 
@@ -435,6 +459,81 @@ def _current_budget(arguments: dict[str, Any]) -> float | None:
         if isinstance(v, (int, float)) and not isinstance(v, bool):
             return _saturate(v)
     return None
+
+
+def _proposed_bid_amount(arguments: dict[str, Any]) -> float | None:
+    """Extract a proposed ad-set bid cap in account-currency minor units.
+
+    Mirrors :func:`_proposed_budget`: scans the built-in Meta spelling
+    (``bid_amount``) and saturates an oversized int to ``inf`` so it exceeds any
+    finite cap and denies rather than raising. Only the scalar ``bid_amount`` is
+    a spend cap; the sibling ``bid_constraints`` dict carries a
+    ``roas_average_floor`` (a min-ROAS floor, not a spend amount) and is
+    deliberately not read here — see :data:`_BID_AMOUNT_KEYS`.
+    """
+    for key in _BID_AMOUNT_KEYS:
+        v = arguments.get(key)
+        if isinstance(v, (int, float)) and not isinstance(v, bool):
+            return _saturate(v)
+    return None
+
+
+def _proposed_cpc_bid(arguments: dict[str, Any]) -> float | None:
+    """Extract a proposed Google ad-group CPC bid in account-currency units.
+
+    ``cpc_bid_micros`` (google_ads_ad_groups_create / _update) is in micros, so
+    it is divided by 1e6 to currency units before comparison — the same micros
+    convention :func:`_proposed_budget` applies to Google budgets. A
+    ``bid_modifier`` (google_ads_bid_adjustments_update) is a 0.1–10.0
+    multiplier, not a spend amount, so it is deliberately not read here.
+    """
+    micros = arguments.get("cpc_bid_micros")
+    if isinstance(micros, (int, float)) and not isinstance(micros, bool):
+        return _saturate(micros) / 1_000_000
+    return None
+
+
+@dataclass(frozen=True)
+class _BidInputs:
+    """The bid channels one evaluation needs, already resolved.
+
+    The bid analogue of :class:`_BudgetInputs` (#419). Every value here is
+    either ``None`` (no bid proposed on that channel) or a FINITE float. A
+    present-but-non-finite value — an oversized int that saturated to ``inf``, a
+    bare ``NaN`` / ``Infinity`` token ``json.loads`` accepts off the wire, or a
+    ``nan`` surviving the micros→currency division — collapses into
+    :attr:`unreadable_key` so the caller fails closed once, before any
+    ``bid > cap`` comparison (where ``nan > cap`` is always False and would
+    silently defeat the cap). ``bid_amount`` is in account-currency minor units;
+    ``cpc_bid`` is in currency units (post-division).
+    """
+
+    bid_amount: float | None = None
+    cpc_bid: float | None = None
+    #: The first bid key that was present but non-finite (⇒ deny).
+    unreadable_key: str | None = None
+
+
+def _bid_inputs(arguments: dict[str, Any]) -> _BidInputs:
+    """Resolve the bid channels, failing closed on any non-finite value.
+
+    Mirrors :func:`_budget_inputs` (#419) at a single choke point rather than
+    per-comparison: a proposed bid that is ``inf`` / ``nan`` is refused instead
+    of silently sailing past the cap. Both channels are checked AFTER the
+    micros→currency division, so a non-finite ``cpc_bid_micros`` cannot slip
+    through post-division. Only reachable once the operator has written some
+    guardrail (``evaluate_guardrails`` returns early on an empty ``Guardrails``),
+    so the fail-open default is preserved.
+    """
+    channels: list[tuple[str, float | None]] = [
+        ("bid_amount", _proposed_bid_amount(arguments)),
+        ("cpc_bid_micros", _proposed_cpc_bid(arguments)),
+    ]
+    for label, value in channels:
+        if value is not None and not math.isfinite(value):
+            return _BidInputs(unreadable_key=label)
+    bid_amount, cpc_bid = (v for _, v in channels)
+    return _BidInputs(bid_amount=bid_amount, cpc_bid=cpc_bid)
 
 
 def evaluate_guardrails(
@@ -564,6 +663,48 @@ def evaluate_guardrails(
                 f"Projected total daily budget {total:,.0f} exceeds the "
                 f"STRATEGY.md Guardrails cap of {total_cap:,.0f} "
                 f"(max_total_daily_budget)."
+            ),
+        )
+
+    # Bid caps have distinct semantics from budgets — a bid is a per-auction
+    # ceiling, not a spend budget — so they get their own caps rather than
+    # reusing the budget ones. Resolved through the same single-choke-point
+    # discipline as budgets (#419): a non-finite proposed bid (oversized int
+    # saturated to inf, or a bare NaN/Infinity the wire allows) fails CLOSED
+    # here, before any ``bid > cap`` comparison where ``nan > cap`` (False)
+    # would silently defeat the cap.
+    bids = _bid_inputs(arguments)
+    if bids.unreadable_key is not None:
+        return PolicyDecision(
+            allowed=False,
+            reason=(
+                f"Bid argument '{bids.unreadable_key}' is not a usable "
+                f"number, so the STRATEGY.md Guardrails bid caps cannot be "
+                f"verified for this call. Refusing it."
+            ),
+        )
+
+    bid = bids.bid_amount
+    bid_cap = guardrails.max_bid_amount_per_ad_set
+    if bid_cap is not None and bid is not None and bid > bid_cap:
+        return PolicyDecision(
+            allowed=False,
+            reason=(
+                f"Proposed bid amount {bid:,.0f} exceeds the "
+                f"STRATEGY.md Guardrails cap of {bid_cap:,.0f} "
+                f"(max_bid_amount_per_ad_set)."
+            ),
+        )
+
+    cpc_bid = bids.cpc_bid
+    cpc_cap = guardrails.max_cpc_bid_per_ad_group
+    if cpc_cap is not None and cpc_bid is not None and cpc_bid > cpc_cap:
+        return PolicyDecision(
+            allowed=False,
+            reason=(
+                f"Proposed CPC bid {cpc_bid:,.0f} exceeds the "
+                f"STRATEGY.md Guardrails cap of {cpc_cap:,.0f} "
+                f"(max_cpc_bid_per_ad_group)."
             ),
         )
 

--- a/skills/_mureo-strategy/SKILL.md
+++ b/skills/_mureo-strategy/SKILL.md
@@ -181,6 +181,8 @@ keys (all optional):
 - max_daily_budget_increase_pct: 20
 - max_total_daily_budget: 300000
 - max_lifetime_budget_per_campaign: 900000
+- max_bid_amount_per_ad_set: 5000   # minor units: 5000 = $50.00 (USD) but ¥5,000 (JPY)
+- max_cpc_bid_per_ad_group: 100      # currency units: 100 = $100 (USD) or ¥100 (JPY)
 - blocked_operations: google_ads_keywords_remove, meta_ads_audiences_delete
 ```
 
@@ -203,6 +205,20 @@ keys (all optional):
   `total_amount_micros` converted from micros. Lifetime and daily budgets
   have distinct semantics, so declare this cap separately — a daily cap
   alone does not constrain lifetime-budget mutations.
+- `max_bid_amount_per_ad_set` — an ad-set mutation proposing a bid *cap* above
+  this is **refused** (`meta_ads_ad_sets_create` / `meta_ads_ad_sets_update`
+  `bid_amount`). A bid is a per-auction ceiling, not a spend budget, so it is
+  capped separately from the budget rules above. Compared against Meta's native
+  `bid_amount` in Meta's **minor units** (= currency units for JPY-like
+  zero-decimal currencies, cents for USD-like). The `bid_constraints`
+  `roas_average_floor` is a min-ROAS floor, not a spend amount, so it is **not**
+  constrained by this cap.
+- `max_cpc_bid_per_ad_group` — an ad-group mutation proposing a CPC bid above
+  this is **refused** (`google_ads_ad_groups_create` /
+  `google_ads_ad_groups_update` `cpc_bid_micros`). Given in account-currency
+  **units**; the tool's `cpc_bid_micros` is converted from micros before
+  comparison. A `bid_modifier` (a bid-adjustment multiplier) is not a spend
+  amount and is not constrained by this cap.
 - `blocked_operations` — comma-separated tool names that are always refused.
   Each name must **exactly match the dispatched MCP tool name**; the gate does a
   literal string match, so a typo or a non-existent name silently never fires.

--- a/tests/test_strategy_gate_bid.py
+++ b/tests/test_strategy_gate_bid.py
@@ -1,0 +1,224 @@
+"""Tests for bid-cap guardrails in the built-in strategy policy gate.
+
+Covers the bid parameters that are separate from budgets: Meta's ad-set
+``bid_amount`` (account-currency minor units) and Google's ad-group
+``cpc_bid_micros`` (micros). A bid cap has distinct semantics from a budget
+cap, so it gets its own guardrail field and its own key scan — a
+``bid_constraints`` ROAS floor is NOT a spend amount and must not trip it.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from mureo.policy.strategy_gate import (
+    Guardrails,
+    evaluate_guardrails,
+    parse_guardrails,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestParseBidGuardrails:
+    def test_parses_bid_amount_cap(self) -> None:
+        g = parse_guardrails("- max_bid_amount_per_ad_set: 5000\n")
+        assert g.max_bid_amount_per_ad_set == 5000
+
+    def test_parses_cpc_bid_cap(self) -> None:
+        g = parse_guardrails("- max_cpc_bid_per_ad_group: 100\n")
+        assert g.max_cpc_bid_per_ad_group == 100
+
+    def test_absent_bid_fields_are_none_and_empty(self) -> None:
+        g = parse_guardrails("- max_daily_budget_per_campaign: 50000\n")
+        assert g.max_bid_amount_per_ad_set is None
+        assert g.max_cpc_bid_per_ad_group is None
+
+    def test_only_bid_cap_is_not_empty(self) -> None:
+        assert not parse_guardrails("- max_bid_amount_per_ad_set: 5000\n").is_empty()
+        assert not parse_guardrails("- max_cpc_bid_per_ad_group: 100\n").is_empty()
+
+    def test_malformed_bid_number_drops_only_that_rule(self) -> None:
+        g = parse_guardrails(
+            "- max_bid_amount_per_ad_set: abc\n- max_daily_budget_per_campaign: 100\n"
+        )
+        assert g.max_bid_amount_per_ad_set is None
+        assert g.max_daily_budget_per_campaign == 100
+
+
+class TestEvaluateBidAmountGuardrail:
+    def test_bid_under_cap_allows(self) -> None:
+        g = Guardrails(max_bid_amount_per_ad_set=5000)
+        d = evaluate_guardrails(
+            "meta_ads_ad_sets_update",
+            {"ad_set_id": "1", "bid_amount": 3000},
+            g,
+        )
+        assert d.allowed is True
+
+    def test_bid_over_cap_denies_and_names_guardrail(self) -> None:
+        g = Guardrails(max_bid_amount_per_ad_set=5000)
+        d = evaluate_guardrails(
+            "meta_ads_ad_sets_update",
+            {"ad_set_id": "1", "bid_amount": 8000},
+            g,
+        )
+        assert d.allowed is False
+        assert "max_bid_amount_per_ad_set" in d.reason
+        assert "5,000" in d.reason and "8,000" in d.reason
+
+    def test_bid_over_cap_on_create_denies(self) -> None:
+        g = Guardrails(max_bid_amount_per_ad_set=5000)
+        d = evaluate_guardrails(
+            "meta_ads_ad_sets_create",
+            {"campaign_id": "1", "name": "x", "bid_amount": 8000},
+            g,
+        )
+        assert d.allowed is False
+        assert "max_bid_amount_per_ad_set" in d.reason
+
+    def test_no_bid_cap_means_ungated(self) -> None:
+        # Some OTHER cap is set so guardrails are non-empty, but no bid cap.
+        g = Guardrails(max_daily_budget_per_campaign=50000)
+        d = evaluate_guardrails(
+            "meta_ads_ad_sets_update",
+            {"ad_set_id": "1", "bid_amount": 9_999_999},
+            g,
+        )
+        assert d.allowed is True
+
+    def test_empty_guardrails_allow_high_bid(self) -> None:
+        d = evaluate_guardrails(
+            "meta_ads_ad_sets_update",
+            {"ad_set_id": "1", "bid_amount": 9_999_999},
+            Guardrails(),
+        )
+        assert d.allowed is True
+
+    def test_bid_constraints_dict_does_not_trip_bid_cap(self) -> None:
+        """A ROAS floor is not a spend amount, so bid_constraints must not be
+        read as a proposed bid_amount and must not trip the cap."""
+        g = Guardrails(max_bid_amount_per_ad_set=5000)
+        d = evaluate_guardrails(
+            "meta_ads_ad_sets_update",
+            {"ad_set_id": "1", "bid_constraints": {"roas_average_floor": 9_999_999}},
+            g,
+        )
+        assert d.allowed is True
+
+    def test_oversized_bid_denies_not_abstains(self) -> None:
+        """A bare int too large for float64 saturates to inf (which exceeds any
+        finite cap) rather than raising into evaluate()'s blanket except."""
+        g = Guardrails(max_bid_amount_per_ad_set=5000)
+        d = evaluate_guardrails(
+            "meta_ads_ad_sets_update",
+            {"ad_set_id": "1", "bid_amount": int("9" * 309)},
+            g,
+        )
+        assert d.allowed is False
+
+
+class TestEvaluateCpcBidGuardrail:
+    def test_cpc_bid_under_cap_allows(self) -> None:
+        g = Guardrails(max_cpc_bid_per_ad_group=100)
+        d = evaluate_guardrails(
+            "google_ads_ad_groups_update",
+            {"ad_group_id": "1", "cpc_bid_micros": 50_000_000},  # 50 units
+            g,
+        )
+        assert d.allowed is True
+
+    def test_cpc_bid_over_cap_denies_and_names_guardrail(self) -> None:
+        g = Guardrails(max_cpc_bid_per_ad_group=100)
+        d = evaluate_guardrails(
+            "google_ads_ad_groups_update",
+            {"ad_group_id": "1", "cpc_bid_micros": 150_000_000},  # 150 units
+            g,
+        )
+        assert d.allowed is False
+        assert "max_cpc_bid_per_ad_group" in d.reason
+
+    def test_cpc_bid_over_cap_on_create_denies(self) -> None:
+        g = Guardrails(max_cpc_bid_per_ad_group=100)
+        d = evaluate_guardrails(
+            "google_ads_ad_groups_create",
+            {"campaign_id": "1", "name": "x", "cpc_bid_micros": 150_000_000},
+            g,
+        )
+        assert d.allowed is False
+        assert "max_cpc_bid_per_ad_group" in d.reason
+
+    def test_no_cpc_cap_means_ungated(self) -> None:
+        g = Guardrails(max_daily_budget_per_campaign=50000)
+        d = evaluate_guardrails(
+            "google_ads_ad_groups_update",
+            {"ad_group_id": "1", "cpc_bid_micros": 999_000_000},
+            g,
+        )
+        assert d.allowed is True
+
+    def test_bid_modifier_does_not_trip_cpc_cap(self) -> None:
+        """bid_modifier is a 0.1-10.0 multiplier (bid adjustment), not a spend
+        amount, so it must not be read as a proposed CPC bid."""
+        g = Guardrails(max_cpc_bid_per_ad_group=100)
+        d = evaluate_guardrails(
+            "google_ads_bid_adjustments_update",
+            {"campaign_id": "1", "criterion_id": "2", "bid_modifier": 10.0},
+            g,
+        )
+        assert d.allowed is True
+
+    def test_oversized_cpc_bid_denies_not_abstains(self) -> None:
+        g = Guardrails(max_cpc_bid_per_ad_group=100)
+        d = evaluate_guardrails(
+            "google_ads_ad_groups_update",
+            {"ad_group_id": "1", "cpc_bid_micros": int("9" * 309)},
+            g,
+        )
+        assert d.allowed is False
+
+
+class TestBidNonFiniteFailsClosed:
+    """A bare ``NaN`` / ``Infinity`` needs no overflow: ``nan > cap`` is always
+    False, so without a fail-closed choke point it silently defeats the bid
+    caps. ``json.loads`` accepts the ``NaN`` / ``Infinity`` tokens, and the gate
+    runs before schema validation, so this is wire-reachable through JSON-RPC
+    arguments. Non-finite on any capped bid channel ⇒ deny (mirrors the #419
+    budget coverage). Args are built with ``json.loads`` to prove reachability.
+    """
+
+    @pytest.mark.parametrize("token", ["NaN", "Infinity", "-Infinity"])
+    @pytest.mark.parametrize(
+        ("tool", "base"),
+        [
+            ("meta_ads_ad_sets_create", '{"campaign_id": "1", "name": "x"'),
+            ("meta_ads_ad_sets_update", '{"ad_set_id": "1"'),
+        ],
+    )
+    def test_non_finite_bid_amount_denies(
+        self, tool: str, base: str, token: str
+    ) -> None:
+        args = json.loads(f'{base}, "bid_amount": {token}}}')
+        g = Guardrails(max_bid_amount_per_ad_set=5000)
+        d = evaluate_guardrails(tool, args, g)
+        assert d.allowed is False
+        assert "not a usable number" in d.reason
+
+    @pytest.mark.parametrize("token", ["NaN", "Infinity", "-Infinity"])
+    @pytest.mark.parametrize(
+        ("tool", "base"),
+        [
+            ("google_ads_ad_groups_create", '{"campaign_id": "1", "name": "x"'),
+            ("google_ads_ad_groups_update", '{"ad_group_id": "1"'),
+        ],
+    )
+    def test_non_finite_cpc_bid_denies(self, tool: str, base: str, token: str) -> None:
+        # Non-finite must be caught POST micros->currency division, which is why
+        # _bid_inputs checks math.isfinite on the divided value.
+        args = json.loads(f'{base}, "cpc_bid_micros": {token}}}')
+        g = Guardrails(max_cpc_bid_per_ad_group=100)
+        d = evaluate_guardrails(tool, args, g)
+        assert d.allowed is False
+        assert "not a usable number" in d.reason


### PR DESCRIPTION
## Summary
Closes the gap flagged during #452 review: bids had no STRATEGY.md guardrail, unlike budgets.
- New optional Guardrails fields: `max_bid_amount_per_ad_set` (Meta, minor units) and `max_cpc_bid_per_ad_group` (Google, currency units from micros)
- Over-cap bids denied with a violation naming the guardrail; ROAS floors and bid modifiers deliberately out of scope
- NaN/Infinity fail closed at a single `_bid_inputs` choke point mirroring the #419 budget fix — review caught that the first implementation reintroduced that bypass class; fixed with 12 wire-reachability tests across all four capped channels
- Backwards compatible: absent fields = ungated; bridges construct Guardrails with keyword args only (verified)

## Test plan
- TDD; 30 tests in tests/test_strategy_gate_bid.py (18 functional + 12 non-finite); existing test_strategy_gate.py untouched and passing (122 total in the gate suites)
- black / ruff / mypy clean

## Follow-up (tracked separately)
Plugin bid-declaration mechanism (parallel to #414 BudgetDeclaration) so plugin bid tools with different argument names can also be gated.