### PR TITLE
feat(policy): plugin bid declarations so custom bid keys reach the guardrails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Plugin bid declarations.** A plugin tool can now declare where it carries
+  its proposed bid in standard MCP metadata
+  (`_meta={"mureo": {"bid": {"cpc_bid": "<key>", "unit": "micros"}}}`), so the
+  built-in `StrategyPolicyGate` enforces `max_bid_amount_per_ad_set` /
+  `max_cpc_bid_per_ad_group` on a plugin whose argument vocabulary differs from
+  the built-in Meta/Google keys — closing the bid twin of the silent-
+  underenforcement gap `BudgetDeclaration` closed for budgets (#414). The
+  declaration names one or both channels (`bid_amount`, minor units, direct;
+  `cpc_bid`, currency units, ÷1e6 when `unit: micros`), replaces the built-in
+  bid scan for that tool, and feeds the same `_bid_inputs` fail-closed choke
+  point — a present-but-unreadable declared key (`inf`/`nan`/bool/non-numeric/
+  nested) denies rather than sails through. Purely additive and opt-in:
+  undeclared tools keep today's behavior byte-identical.
+
 - **Bid-cap guardrails in `StrategyPolicyGate`.** The built-in gate now
   enforces two new `## Guardrails` rules alongside the budget caps:
   `max_bid_amount_per_ad_set` refuses a `meta_ads_ad_sets_create` /

--- a/docs/plugin-authoring.md
+++ b/docs/plugin-authoring.md
@@ -642,6 +642,11 @@ mureo-specific Protocol method:
     "current": "<key>", "unit": "currency"|"micros"}` — **declare where
     your tool carries its budget so `STRATEGY.md` `## Guardrails` caps
     are enforced on your platform too** (#414). See the next section.
+  - `"bid": {"bid_amount": "<key>", "cpc_bid": "<key>",
+    "unit": "currency"|"micros"}` — the bid twin of `budget`: **declare
+    where your tool carries its proposed bid so the `max_bid_amount_per_ad_set`
+    / `max_cpc_bid_per_ad_group` caps are enforced on your platform too**.
+    See the bid-declarations section below.
 
 ##### Budget declarations — getting your platform under the Guardrails
 
@@ -728,6 +733,67 @@ If a declaration fits your tools, you do **not** need to register your own
 `mureo.policy_gates` entry for budget enforcement — declare the keys and the
 one built-in gate does it. Some tool shapes it cannot fit; the next section
 is for those.
+
+##### Bid declarations — getting your bids under the Guardrails
+
+Bids have the same gap budgets did, and the same fix. The built-in gate also
+enforces two **bid** caps — `max_bid_amount_per_ad_set` (a per-auction ceiling
+in account-currency **minor** units, like Meta's `bid_amount`) and
+`max_cpc_bid_per_ad_group` (in account-currency units, like Google's
+`cpc_bid_micros` after ÷1e6). A bid is a per-auction ceiling, not a spend
+budget, so it gets its own caps. To find the proposed bid the gate scans the
+built-in Meta/Google keys; if your tool spells its bid any other way, the call
+is treated as "no bid proposed" and **allowed through with no error and no
+warning**. Declare your keys and that gap closes too:
+
+```python
+Tool(
+    name="acme_ads_update_bid",
+    description="Update an ad group's max CPC bid.",
+    inputSchema={
+        "type": "object",
+        "properties": {
+            "ad_group_id": {"type": "string"},
+            "bid_cap_micros": {"type": "integer"},
+        },
+        "required": ["ad_group_id", "bid_cap_micros"],
+    },
+    _meta={"mureo": {"bid": {"cpc_bid": "bid_cap_micros", "unit": "micros"}}},
+)
+```
+
+- `bid_amount` — the argument key carrying a bid capped by
+  `max_bid_amount_per_ad_set`, compared in account-currency **minor** units
+  (direct, like Meta's `bid_amount`).
+- `cpc_bid` — the argument key carrying a bid capped by
+  `max_cpc_bid_per_ad_group`, compared in account-currency units (like
+  Google's `cpc_bid_micros` after ÷1e6). At least one of `bid_amount` /
+  `cpc_bid` is required.
+- `unit` — `"currency"` (default) or `"micros"` (the value is divided by
+  1,000,000). The channel you name decides **which** cap constrains the bid;
+  `unit` decides its **units** — set `micros` when your value is in micros so
+  it lands in the cap's comparison unit, exactly as the built-in
+  `cpc_bid_micros` path does. Stringified numbers (`"20000"`) are accepted.
+  One declaration carries one unit for both channels; a bid tool proposes a
+  single bid, so the common case names exactly one channel.
+
+The rest of the semantics match a budget declaration:
+
+- **A declaration replaces the built-in bid key scan for that tool**, so an
+  unrelated field spelled `bid_amount` cannot false-trip a cap. (Unlike
+  budgets there are no caller-supplied convention keys, so it replaces the
+  whole bid scan.)
+- **A declared key that is present but unreadable makes the gate deny.** `inf`,
+  `nan`, a bool, a non-numeric string, or a nested object under your declared
+  key ⇒ the cap cannot be verified, so the call is refused rather than waved
+  through, through the same fail-closed choke point the built-in scan uses. An
+  *absent* key — or `null` / a blank string — simply means "no bid proposed".
+- **A malformed declaration is rejected whole**, never half-applied, and
+  undeclared tools keep today's behavior byte-identical.
+
+A bid whose value is nested (inside a request `body`) or derived is outside
+what a top-level-key declaration can express — use the normalize-and-delegate
+`mureo.policy_gates` gate below for those, exactly as for a nested budget.
 
 ##### When a declaration cannot reach your budget
 

--- a/mureo/mcp/plugin_semantics.py
+++ b/mureo/mcp/plugin_semantics.py
@@ -35,7 +35,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from mureo.policy.strategy_gate import BudgetDeclaration
+from mureo.policy.strategy_gate import BidDeclaration, BudgetDeclaration
 from mureo.throttle import ThrottleConfig
 
 if TYPE_CHECKING:
@@ -57,6 +57,12 @@ _DEFAULT_OBSERVATION_DAYS = 14
 #: Accepted ``budget.unit`` spellings → whether the value is in micros.
 _BUDGET_UNITS = {"currency": False, "micros": True}
 
+#: Accepted ``bid.unit`` spellings → whether the value is in micros. Shares the
+#: budget vocabulary: ``currency`` means "compare as-is" (minor units for the
+#: ``bid_amount`` channel, currency units for ``cpc_bid``), ``micros`` divides
+#: by 1e6 — exactly like the built-in ``cpc_bid_micros`` path.
+_BID_UNITS = {"currency": False, "micros": True}
+
 
 @dataclass(frozen=True)
 class ToolSemantics:
@@ -67,6 +73,7 @@ class ToolSemantics:
     throttle: ThrottleConfig | None = None
     observation_days: int | None = None
     budget: BudgetDeclaration | None = None
+    bid: BidDeclaration | None = None
 
 
 def _parse_budget(raw: Any) -> BudgetDeclaration | None:
@@ -105,6 +112,44 @@ def _parse_budget(raw: Any) -> BudgetDeclaration | None:
         lifetime_key=lifetime,
         current_key=_key("current"),
         micros=_BUDGET_UNITS[unit],
+    )
+
+
+def _parse_bid(raw: Any) -> BidDeclaration | None:
+    """Parse ``meta["mureo"]["bid"]``, or ``None`` when unusable.
+
+    The bid twin of :func:`_parse_budget`, held to the identical whole-or-
+    nothing discipline: a partial declaration would re-create the exact silent
+    underenforcement this seam exists to remove. Requires a dict carrying at
+    least one of ``bid_amount`` / ``cpc_bid`` as a non-blank string key name;
+    ``unit`` is ``currency`` (default) or ``micros``.
+    """
+    if not isinstance(raw, dict):
+        return None
+    unit = raw.get("unit", "currency")
+    if not isinstance(unit, str) or unit not in _BID_UNITS:
+        return None
+
+    def _key(name: str) -> str | None:
+        value = raw.get(name)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+        return None
+
+    bid_amount = _key("bid_amount")
+    cpc_bid = _key("cpc_bid")
+    if bid_amount is None and cpc_bid is None:
+        return None
+    # A declared-but-unusable key name (non-str) is a mistake, not an
+    # omission — refuse the whole declaration so it surfaces in testing
+    # rather than silently dropping one cap.
+    for name in ("bid_amount", "cpc_bid"):
+        if name in raw and _key(name) is None:
+            return None
+    return BidDeclaration(
+        bid_amount_key=bid_amount,
+        cpc_bid_key=cpc_bid,
+        micros=_BID_UNITS[unit],
     )
 
 
@@ -166,6 +211,7 @@ def derive_semantics(tool: Tool) -> ToolSemantics:
         throttle=throttle,
         observation_days=observation_days,
         budget=_parse_budget(section.get("budget")),
+        bid=_parse_bid(section.get("bid")),
     )
 
 

--- a/mureo/mcp/server.py
+++ b/mureo/mcp/server.py
@@ -292,7 +292,35 @@ def _register_plugin_budget_declarations(
             )
 
 
+def _register_plugin_bid_declarations(
+    semantics: dict[str, ToolSemantics],
+) -> None:
+    """Publish plugin bid declarations to the StrategyPolicyGate.
+
+    The bid twin of :func:`_register_plugin_budget_declarations`: the gate's
+    built-in bid scan only knows the Meta/Google spellings, so a plugin bid
+    tool's ``bid_amount`` / ``cpc_bid`` cap was silently unenforced. A plugin
+    declares its keys in standard MCP metadata and this wires them into the
+    gate's registry, so the ONE built-in gate enforces them. Best-effort: a
+    registry failure must not take the server down.
+    """
+    from mureo.policy.strategy_gate import register_bid_declaration
+
+    for name, sem in semantics.items():
+        if sem.bid is None:
+            continue
+        try:
+            register_bid_declaration(name, sem.bid)
+        except Exception:  # noqa: BLE001 — never break startup on a hint
+            logger.warning(
+                "could not register bid declaration for plugin tool '%s'",
+                name,
+                exc_info=True,
+            )
+
+
 _register_plugin_budget_declarations(_PLUGIN_SEMANTICS)
+_register_plugin_bid_declarations(_PLUGIN_SEMANTICS)
 
 
 # Guardrail parity (#114 follow-up): top-level ``inputSchema`` property names

--- a/mureo/policy/strategy_gate.py
+++ b/mureo/policy/strategy_gate.py
@@ -135,6 +135,76 @@ def reset_budget_declarations() -> None:
     _BUDGET_DECLARATIONS.clear()
 
 
+@dataclass(frozen=True)
+class BidDeclaration:
+    """Where one tool carries its *bid* arguments — the bid twin of #414.
+
+    ``BudgetDeclaration`` closed the gap for budgets; bids had the same hole.
+    The gate's bid extraction (:func:`_bid_inputs`) scans only the built-in
+    Google/Meta spellings — Meta's ``bid_amount`` (minor units) and Google's
+    ``cpc_bid_micros`` (micros) — so a plugin bid tool whose argument is spelled
+    anything else was read as "no bid proposed" and sailed past
+    ``max_bid_amount_per_ad_set`` / ``max_cpc_bid_per_ad_group``, silently: no
+    startup error, no warning, on a surface where real money moves. A plugin
+    closes that by declaring its keys in standard MCP metadata::
+
+        Tool(
+            name="acme_ads_update_bid",
+            _meta={"mureo": {"bid": {"cpc_bid": "bid_cap_micros",
+                                     "unit": "micros"}}},
+            ...
+        )
+
+    A declaration names one or both of the two bid channels, mirroring how a
+    ``BudgetDeclaration`` names its daily / lifetime / current channels:
+
+    - ``bid_amount_key`` — capped by ``max_bid_amount_per_ad_set``, compared in
+      account-currency MINOR units (like Meta's ``bid_amount``, direct).
+    - ``cpc_bid_key`` — capped by ``max_cpc_bid_per_ad_group``, compared in
+      account-currency units (like Google's ``cpc_bid_micros`` after ÷1e6).
+
+    The channel a key names decides WHICH cap constrains it; ``micros`` decides
+    the UNIT (``value / 1e6`` when set, direct otherwise) — the two are declared
+    independently so a plugin states both "which guardrail caps this" and
+    "is my value micros" explicitly. Like ``BudgetDeclaration``'s single
+    ``micros`` flag, one declaration carries one unit for both channels: a bid
+    tool proposes a single bid, so the common case names exactly one channel.
+
+    A declaration REPLACES the built-in key scan for that tool (there are no
+    caller-supplied convention keys for bids, so it replaces the whole bid
+    scan): the plugin owns its argument vocabulary, so an unrelated field
+    spelled ``bid_amount`` cannot false-trip a cap. A declared key that is
+    present but unreadable (``inf``, ``nan``, a bool, a non-numeric string, a
+    nested object) makes the gate DENY through the same :func:`_bid_inputs`
+    choke point the built-in scan uses — see :func:`_declared_amount`.
+    """
+
+    bid_amount_key: str | None = None
+    cpc_bid_key: str | None = None
+    micros: bool = False
+
+
+# Tool name → bid declaration. Populated by the MCP server from plugin tool
+# metadata at import (see ``mureo.mcp.server``), exactly like the budget
+# registry above, so the pure decision layer stays I/O-free.
+_BID_DECLARATIONS: dict[str, BidDeclaration] = {}
+
+
+def register_bid_declaration(tool_name: str, declaration: BidDeclaration) -> None:
+    """Bind ``tool_name``'s bid argument keys (last registration wins)."""
+    _BID_DECLARATIONS[tool_name] = declaration
+
+
+def bid_declaration_for(tool_name: str) -> BidDeclaration | None:
+    """The bid declaration registered for ``tool_name``, or ``None``."""
+    return _BID_DECLARATIONS.get(tool_name)
+
+
+def reset_bid_declarations() -> None:
+    """Drop every bid registration (tests; a re-discovery re-registers)."""
+    _BID_DECLARATIONS.clear()
+
+
 class _Unreadable:
     """Sentinel: a declared budget key is PRESENT but not a usable number."""
 
@@ -514,8 +584,10 @@ class _BidInputs:
     unreadable_key: str | None = None
 
 
-def _bid_inputs(arguments: dict[str, Any]) -> _BidInputs:
-    """Resolve the bid channels, failing closed on any non-finite value.
+def _bid_inputs(
+    arguments: dict[str, Any], declaration: BidDeclaration | None = None
+) -> _BidInputs:
+    """Resolve the bid channels from declared keys, else the built-in scan.
 
     Mirrors :func:`_budget_inputs` (#419) at a single choke point rather than
     per-comparison: a proposed bid that is ``inf`` / ``nan`` is refused instead
@@ -524,15 +596,34 @@ def _bid_inputs(arguments: dict[str, Any]) -> _BidInputs:
     through post-division. Only reachable once the operator has written some
     guardrail (``evaluate_guardrails`` returns early on an empty ``Guardrails``),
     so the fail-open default is preserved.
+
+    ``declaration`` (the bid twin of #414) names a plugin tool's bid argument
+    keys. When given it REPLACES the built-in Meta/Google key scan for that
+    tool — the plugin owns its argument vocabulary, so a stray ``bid_amount``
+    field cannot false-trip a cap. Unlike budgets there are no caller-supplied
+    convention keys, so a declaration replaces the whole bid scan. Declared keys
+    feed the SAME fail-closed logic as the built-in scan via
+    :func:`_declared_amount`: a present-but-unreadable declared key returns
+    :data:`_UNREADABLE`, collapsing into :attr:`_BidInputs.unreadable_key` so
+    the caller denies once — no second comparison path.
     """
-    channels: list[tuple[str, float | None]] = [
-        ("bid_amount", _proposed_bid_amount(arguments)),
-        ("cpc_bid_micros", _proposed_cpc_bid(arguments)),
-    ]
-    for label, value in channels:
-        if value is not None and not math.isfinite(value):
-            return _BidInputs(unreadable_key=label)
-    bid_amount, cpc_bid = (v for _, v in channels)
+    if declaration is None:
+        channels: list[tuple[str, float | None]] = [
+            ("bid_amount", _proposed_bid_amount(arguments)),
+            ("cpc_bid_micros", _proposed_cpc_bid(arguments)),
+        ]
+        for label, value in channels:
+            if value is not None and not math.isfinite(value):
+                return _BidInputs(unreadable_key=label)
+        bid_amount, cpc_bid = (v for _, v in channels)
+        return _BidInputs(bid_amount=bid_amount, cpc_bid=cpc_bid)
+    resolved: list[float | None] = []
+    for key in (declaration.bid_amount_key, declaration.cpc_bid_key):
+        declared = _declared_amount(arguments, key, micros=declaration.micros)
+        if isinstance(declared, _Unreadable):
+            return _BidInputs(unreadable_key=key)
+        resolved.append(declared)
+    bid_amount, cpc_bid = resolved
     return _BidInputs(bid_amount=bid_amount, cpc_bid=cpc_bid)
 
 
@@ -542,6 +633,7 @@ def evaluate_guardrails(
     guardrails: Guardrails,
     *,
     budget_declaration: BudgetDeclaration | None = None,
+    bid_declaration: BidDeclaration | None = None,
 ) -> PolicyDecision:
     """Pure decision: does ``tool_name(arguments)`` violate ``guardrails``?
 
@@ -558,6 +650,12 @@ def evaluate_guardrails(
     cannot switch ``max_daily_budget_increase_pct`` or ``max_total_daily_budget``
     off (see :class:`BudgetDeclaration`). Omitted (every built-in tool, and any
     plugin that has not declared) ⇒ unchanged behavior.
+
+    ``bid_declaration`` is the bid twin of the above: it names the keys carrying
+    this tool's proposed bid and REPLACES the built-in Meta/Google bid scan for
+    that tool, so a plugin bid tool is enforced by ``max_bid_amount_per_ad_set``
+    / ``max_cpc_bid_per_ad_group`` (see :class:`BidDeclaration`). Omitted ⇒
+    unchanged behavior.
     """
     if guardrails.is_empty():
         return PolicyDecision(allowed=True)
@@ -673,7 +771,7 @@ def evaluate_guardrails(
     # saturated to inf, or a bare NaN/Infinity the wire allows) fails CLOSED
     # here, before any ``bid > cap`` comparison where ``nan > cap`` (False)
     # would silently defeat the cap.
-    bids = _bid_inputs(arguments)
+    bids = _bid_inputs(arguments, bid_declaration)
     if bids.unreadable_key is not None:
         return PolicyDecision(
             allowed=False,
@@ -770,6 +868,9 @@ class StrategyPolicyGate:
                 # #414: a plugin tool that declared its budget keys is now
                 # enforced by THIS gate — no hand-rolled per-plugin gate.
                 budget_declaration=budget_declaration_for(tool_name),
+                # The bid twin of #414: a plugin tool that declared its bid keys
+                # is enforced by the same gate through the same choke point.
+                bid_declaration=bid_declaration_for(tool_name),
             )
         except Exception:  # noqa: BLE001 — abstain on any unexpected error
             logger.debug("StrategyPolicyGate: abstaining on error", exc_info=True)

--- a/tests/test_plugin_bid_declaration.py
+++ b/tests/test_plugin_bid_declaration.py
@@ -1,0 +1,369 @@
+"""Plugin bid declarations for the StrategyPolicyGate (#455 follow-up).
+
+The gate's bid extraction is hard-wired to the Google/Meta argument keys
+(``bid_amount`` in minor units, ``cpc_bid_micros`` in micros), so a plugin
+tool carrying its bid under any other name sails past every
+``max_bid_amount_per_ad_set`` / ``max_cpc_bid_per_ad_group`` cap — silently:
+no startup error, no warning, just an unenforced platform. This mirrors the
+budget seam #414 already shipped: a plugin declares its bid argument keys in
+standard MCP metadata —
+
+    _meta={"mureo": {"bid": {"cpc_bid": "bid_cap_micros", "unit": "micros"}}}
+
+— ``derive_semantics`` parses it, the server registers it, and
+``StrategyPolicyGate`` consults it for that tool ahead of the built-in key
+scan. Undeclared tools keep today's behavior byte-identical.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from mureo.policy.strategy_gate import (
+    BidDeclaration,
+    Guardrails,
+    bid_declaration_for,
+    evaluate_guardrails,
+    register_bid_declaration,
+    reset_bid_declarations,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry() -> Iterator[None]:
+    """Isolate the process-global bid registry WITHOUT destroying it.
+
+    ``mureo.mcp.server`` populates it once at import from real plugin
+    discovery; a destructive clear would drop those declarations for the
+    rest of the pytest session (inert only while no shipped plugin declares
+    a bid). Also resets the process-cached RuntimeContext and the gate's TTL
+    guardrail cache around each test so the end-to-end gate test resolves the
+    STRATEGY.md it wrote, not one a context cached by an earlier test points
+    at. Mirrors ``test_plugin_budget_declaration``'s fixture.
+    """
+    import mureo.policy.strategy_gate as sg
+    from mureo.core.runtime_context import reset_runtime_context
+    from mureo.policy.strategy_gate import _BID_DECLARATIONS
+
+    saved = dict(_BID_DECLARATIONS)
+    reset_bid_declarations()
+    reset_runtime_context()
+    sg._cache.clear()
+    yield
+    reset_bid_declarations()
+    _BID_DECLARATIONS.update(saved)
+    reset_runtime_context()
+    sg._cache.clear()
+
+
+def _tool(meta_mureo: dict[str, Any]) -> Any:
+    from mcp.types import Tool
+
+    return Tool(
+        name="acme_ads_update_bid",
+        description="x",
+        inputSchema={"type": "object", "properties": {}},
+        _meta={"mureo": meta_mureo},
+    )
+
+
+# ---------------------------------------------------------------------------
+# derive_semantics — parsing the meta["mureo"]["bid"] declaration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDeriveSemanticsBid:
+    def test_parses_full_declaration(self) -> None:
+        from mureo.mcp.plugin_semantics import derive_semantics
+
+        sem = derive_semantics(
+            _tool(
+                {
+                    "bid": {
+                        "bid_amount": "ad_set_bid",
+                        "cpc_bid": "cpc_micros",
+                        "unit": "micros",
+                    }
+                }
+            )
+        )
+        assert sem.bid == BidDeclaration(
+            bid_amount_key="ad_set_bid",
+            cpc_bid_key="cpc_micros",
+            micros=True,
+        )
+
+    def test_defaults_to_currency_unit(self) -> None:
+        from mureo.mcp.plugin_semantics import derive_semantics
+
+        sem = derive_semantics(_tool({"bid": {"bid_amount": "max_bid"}}))
+        assert sem.bid == BidDeclaration(bid_amount_key="max_bid")
+        assert sem.bid.micros is False
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "bid_amount",  # bare string, not a dict
+            {"unit": "micros"},  # neither bid_amount nor cpc_bid key
+            {"bid_amount": 123},  # non-str key name
+            {"cpc_bid": "x", "unit": "yen"},  # unknown unit
+            {"bid_amount": "ok", "cpc_bid": 123},  # one good key, one malformed
+        ],
+    )
+    def test_malformed_declaration_is_rejected(self, raw: Any) -> None:
+        """A malformed hint must not half-apply — silent misconfiguration is
+        the exact failure mode this seam exists to avoid."""
+        from mureo.mcp.plugin_semantics import derive_semantics
+
+        sem = derive_semantics(_tool({"bid": raw}))
+        assert sem.bid is None
+
+    def test_absent_bid_is_none(self) -> None:
+        from mureo.mcp.plugin_semantics import derive_semantics
+
+        assert derive_semantics(_tool({})).bid is None
+
+    def test_bid_and_budget_coexist(self) -> None:
+        """A tool that carries both a budget and a bid declares both; parsing
+        one must not clobber the other."""
+        from mureo.mcp.plugin_semantics import derive_semantics
+        from mureo.policy.strategy_gate import BudgetDeclaration
+
+        sem = derive_semantics(
+            _tool(
+                {
+                    "budget": {"daily": "daily_micros", "unit": "micros"},
+                    "bid": {"cpc_bid": "cpc_micros", "unit": "micros"},
+                }
+            )
+        )
+        assert sem.budget == BudgetDeclaration(daily_key="daily_micros", micros=True)
+        assert sem.bid == BidDeclaration(cpc_bid_key="cpc_micros", micros=True)
+
+
+# ---------------------------------------------------------------------------
+# evaluate_guardrails — declared extraction (pure)
+# ---------------------------------------------------------------------------
+
+_CAPS_BID = Guardrails(max_bid_amount_per_ad_set=5_000.0)
+_CAPS_CPC = Guardrails(max_cpc_bid_per_ad_group=100.0)
+
+
+@pytest.mark.unit
+class TestDeclaredBidExtraction:
+    def test_declared_bid_amount_key_is_enforced(self) -> None:
+        decl = BidDeclaration(bid_amount_key="max_bid")
+        decision = evaluate_guardrails(
+            "acme_ads_update_bid",
+            {"max_bid": 8_000},
+            _CAPS_BID,
+            bid_declaration=decl,
+        )
+        assert decision.allowed is False
+        assert "max_bid_amount_per_ad_set" in (decision.reason or "")
+
+    def test_under_cap_is_allowed(self) -> None:
+        decl = BidDeclaration(bid_amount_key="max_bid")
+        decision = evaluate_guardrails(
+            "acme_ads_update_bid",
+            {"max_bid": 3_000},
+            _CAPS_BID,
+            bid_declaration=decl,
+        )
+        assert decision.allowed is True
+
+    def test_declared_cpc_key_is_enforced(self) -> None:
+        decl = BidDeclaration(cpc_bid_key="cpc_bid")
+        decision = evaluate_guardrails(
+            "t",
+            {"cpc_bid": 150},
+            _CAPS_CPC,
+            bid_declaration=decl,
+        )
+        assert decision.allowed is False
+        assert "max_cpc_bid_per_ad_group" in (decision.reason or "")
+
+    def test_micros_are_converted_for_cpc(self) -> None:
+        """The motivating LOGLY case: ``bid_cap_micros`` in micros, capped by
+        ``max_cpc_bid_per_ad_group`` (currency units) after ÷1e6."""
+        decl = BidDeclaration(cpc_bid_key="bid_cap_micros", micros=True)
+        decision = evaluate_guardrails(
+            "t",
+            {"bid_cap_micros": 150_000_000},  # 150 currency units
+            _CAPS_CPC,
+            bid_declaration=decl,
+        )
+        assert decision.allowed is False
+
+    def test_micros_under_cap_is_allowed(self) -> None:
+        decl = BidDeclaration(cpc_bid_key="bid_cap_micros", micros=True)
+        decision = evaluate_guardrails(
+            "t",
+            {"bid_cap_micros": 50_000_000},  # 50 currency units
+            _CAPS_CPC,
+            bid_declaration=decl,
+        )
+        assert decision.allowed is True
+
+    def test_numeric_string_is_coerced(self) -> None:
+        """Plugins hit stringified numbers in the wild — a declared key accepts
+        them rather than silently skipping the cap."""
+        decl = BidDeclaration(bid_amount_key="max_bid")
+        decision = evaluate_guardrails(
+            "t", {"max_bid": "8000"}, _CAPS_BID, bid_declaration=decl
+        )
+        assert decision.allowed is False
+
+    def test_declaration_replaces_builtin_key_scan(self) -> None:
+        """With a declaration, the built-in Meta/Google keys are NOT scanned —
+        the plugin owns its argument vocabulary, so a stray ``bid_amount`` field
+        cannot false-trip the cap for a declaring tool."""
+        decl = BidDeclaration(cpc_bid_key="acme_cpc", micros=True)
+        decision = evaluate_guardrails(
+            "t",
+            # built-in bid_amount key present, but NOT the declared one, and the
+            # declared cpc key is absent ⇒ no bid proposed for this tool.
+            {"bid_amount": 99_999, "acme_cpc": 10_000_000},  # 10 units, under cap
+            _CAPS_BID,
+            bid_declaration=decl,
+        )
+        assert decision.allowed is True
+
+    def test_no_declaration_keeps_builtin_scan(self) -> None:
+        decision = evaluate_guardrails(
+            "meta_ads_ad_sets_update", {"bid_amount": 8_000}, _CAPS_BID
+        )
+        assert decision.allowed is False
+
+
+# ---------------------------------------------------------------------------
+# Registry + gate integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDeclarationRegistry:
+    def test_register_and_lookup(self) -> None:
+        decl = BidDeclaration(bid_amount_key="max_bid")
+        register_bid_declaration("acme_ads_update_bid", decl)
+        assert bid_declaration_for("acme_ads_update_bid") == decl
+        assert bid_declaration_for("unknown_tool") is None
+
+    def test_gate_consults_registry(self, tmp_path: Any, monkeypatch: Any) -> None:
+        """End to end: a registered plugin declaration makes the built-in
+        StrategyPolicyGate deny an over-cap plugin bid call."""
+        from mureo.policy.strategy_gate import StrategyPolicyGate
+
+        strategy = tmp_path / "STRATEGY.md"
+        strategy.write_text(
+            "## Guardrails\n- max_cpc_bid_per_ad_group: 100\n",
+            encoding="utf-8",
+        )
+        monkeypatch.chdir(tmp_path)
+        register_bid_declaration(
+            "acme_ads_update_bid",
+            BidDeclaration(cpc_bid_key="bid_cap_micros", micros=True),
+        )
+        gate = StrategyPolicyGate()
+        decision = gate.evaluate("acme_ads_update_bid", {"bid_cap_micros": 150_000_000})
+        assert decision.allowed is False
+
+
+# ---------------------------------------------------------------------------
+# Server wiring — plugin semantics land in the registry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_server_registers_declared_plugin_bids() -> None:
+    from mureo.mcp import server as server_mod
+    from mureo.mcp.plugin_semantics import ToolSemantics
+
+    semantics = {
+        "acme_ads_update_bid": ToolSemantics(
+            mutating=True,
+            bid=BidDeclaration(bid_amount_key="max_bid"),
+        ),
+        "acme_ads_list": ToolSemantics(mutating=False),
+    }
+    server_mod._register_plugin_bid_declarations(semantics)
+    assert bid_declaration_for("acme_ads_update_bid") == BidDeclaration(
+        bid_amount_key="max_bid"
+    )
+    assert bid_declaration_for("acme_ads_list") is None
+
+
+@pytest.mark.unit
+class TestUnreadableDeclaredBid:
+    """A declared key that is PRESENT but unreadable must fail CLOSED.
+
+    Returning "no proposal" for garbage would re-open the exact silent bypass
+    the seam exists to close — worse, it would make the declared path weaker
+    than the built-in scan, where a raw ``inf`` simply exceeds any finite cap
+    and denies. Feeds the SAME ``_bid_inputs`` choke point as the built-in scan.
+    """
+
+    _DECL = BidDeclaration(bid_amount_key="max_bid")
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            float("inf"),
+            float("-inf"),
+            float("nan"),
+            "inf",
+            "Infinity",
+            "nan",
+            "not-a-number",
+            "9" * 309,  # too large for float64 as a string — saturates to inf
+            int("9" * 309),  # bare int: float() raises OverflowError, not inf
+            True,  # bool is an int subclass — never a bid
+            {"amount": 1},
+            [],
+        ],
+    )
+    def test_unreadable_value_is_denied(self, value: Any) -> None:
+        decision = evaluate_guardrails(
+            "acme_ads_update_bid",
+            {"max_bid": value},
+            _CAPS_BID,
+            bid_declaration=self._DECL,
+        )
+        assert decision.allowed is False
+        assert "max_bid" in (decision.reason or "")
+
+    @pytest.mark.parametrize("value", [None, "", "   "])
+    def test_absent_like_value_carries_no_proposal(self, value: Any) -> None:
+        """JSON ``null`` / a blank string mean 'no bid here', not garbage —
+        they must not deny."""
+        decision = evaluate_guardrails(
+            "acme_ads_update_bid",
+            {"max_bid": value},
+            _CAPS_BID,
+            bid_declaration=self._DECL,
+        )
+        assert decision.allowed is True
+
+    def test_unreadable_cpc_is_denied(self) -> None:
+        decision = evaluate_guardrails(
+            "t",
+            {"cpc_micros": "inf"},
+            _CAPS_CPC,
+            bid_declaration=BidDeclaration(cpc_bid_key="cpc_micros", micros=True),
+        )
+        assert decision.allowed is False
+        assert "cpc_micros" in (decision.reason or "")
+
+    def test_no_guardrails_still_fails_open(self) -> None:
+        """Fail-closed only applies once the operator wrote a rule — an empty
+        Guardrails section keeps mureo's 'no enforcement' default."""
+        decision = evaluate_guardrails(
+            "t", {"max_bid": "inf"}, Guardrails(), bid_declaration=self._DECL
+        )
+        assert decision.allowed is True


### PR DESCRIPTION
## Summary
Closes the MEDIUM flagged in #455 review: plugin bid tools with custom argument names were silently unenforced by the new bid-cap guardrails.
- `BidDeclaration` mirrors #414's `BudgetDeclaration` line-for-line: registry, `_meta {"mureo": {"bid": ...}}` parsing with whole-or-nothing rejection, registration at server import
- Declarations replace the builtin key scan and feed the same fail-closed choke point (NaN/Infinity/bool/non-numeric/nested all deny)
- Channel selects the cap; `micros` declarations divide by 1e6 like `cpc_bid_micros`
- Additive only — no installed tool declares a bid today; builtin path byte-identical without a declaration
- Plugin-authoring docs updated

## Test plan
- TDD; 37 new tests mirroring the budget-declaration suite (registry isolation, unit conversion, non-finite fail-closed, replacement semantics); existing gate suites unmodified, 159 passing together
- Code review: APPROVE, no CRITICAL/HIGH

## Follow-up
strategy_gate.py now exceeds the 800-line budget — a refactor PR extracting the (budget + bid) declaration machinery into a sibling module follows immediately after this merges.