### PR TITLE
refactor(policy): extract declaration machinery into mureo/policy/declarations.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Internal refactor: split the plugin declaration machinery out of
+  `mureo.policy.strategy_gate`.** `BudgetDeclaration`, `BidDeclaration`, their
+  registries, and the register / lookup / reset helpers now live in the new
+  `mureo.policy.declarations` module, keeping `strategy_gate.py` within the
+  project file-size budget. No API change: every name is re-exported from
+  `mureo.policy.strategy_gate`, so all existing import paths remain stable.
+
 - **Strict input schemas across the entire builtin MCP tool registry.**
   Every builtin tool (all 203 across Google Ads, Meta Ads, Search Console,
   rollback, analysis, mureo-context, analytics-registry, learning, and

--- a/mureo/mcp/plugin_semantics.py
+++ b/mureo/mcp/plugin_semantics.py
@@ -35,7 +35,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from mureo.policy.strategy_gate import BidDeclaration, BudgetDeclaration
+from mureo.policy.declarations import BidDeclaration, BudgetDeclaration
 from mureo.throttle import ThrottleConfig
 
 if TYPE_CHECKING:

--- a/mureo/mcp/server.py
+++ b/mureo/mcp/server.py
@@ -277,7 +277,7 @@ def _register_plugin_budget_declarations(
     (no per-plugin hand-rolled gate). Best-effort: a registry failure must
     not take the server down.
     """
-    from mureo.policy.strategy_gate import register_budget_declaration
+    from mureo.policy.declarations import register_budget_declaration
 
     for name, sem in semantics.items():
         if sem.budget is None:
@@ -304,7 +304,7 @@ def _register_plugin_bid_declarations(
     gate's registry, so the ONE built-in gate enforces them. Best-effort: a
     registry failure must not take the server down.
     """
-    from mureo.policy.strategy_gate import register_bid_declaration
+    from mureo.policy.declarations import register_bid_declaration
 
     for name, sem in semantics.items():
         if sem.bid is None:

--- a/mureo/policy/declarations.py
+++ b/mureo/policy/declarations.py
@@ -1,0 +1,245 @@
+"""Plugin budget/bid declaration machinery for the strategy policy gate.
+
+Split out of :mod:`mureo.policy.strategy_gate` to keep that module within the
+project file-size budget; the two form one logical unit (the gate imports
+everything here). This is the *lower* half of the pair — it has no dependency
+on ``strategy_gate`` — so it holds the pieces the gate's pure decision layer
+builds on:
+
+- :class:`BudgetDeclaration` / :class:`BidDeclaration` — how a plugin tool
+  declares, in standard MCP metadata, where it carries its proposed budget
+  (#414) or bid, so the built-in :class:`~mureo.policy.strategy_gate.StrategyPolicyGate`
+  can enforce the operator's ``## Guardrails`` caps on a tool whose argument
+  vocabulary differs from the built-in Google/Meta spellings.
+- Their process-wide registries and register / lookup / reset helpers,
+  populated by ``mureo.mcp.server`` from plugin tool metadata at import so the
+  pure decision layer stays I/O-free and needs no plugin imports.
+- :func:`_declared_amount` and its numeric helpers (:func:`_saturate`, the
+  :data:`_UNREADABLE` sentinel) — the single reader that turns one declared
+  argument key into currency units, distinguishing "absent" from
+  "present-but-unreadable" so the gate can fail closed on garbage.
+
+Every public name here is re-exported from
+:mod:`mureo.policy.strategy_gate` for import-path compatibility — see the
+re-export block in that module.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class BudgetDeclaration:
+    """Where one tool carries its budget arguments (#414).
+
+    Built-in Google/Meta tools are covered by the hard-coded key scan in
+    :mod:`mureo.policy.strategy_gate` (``_budget_inputs``).
+    A plugin tool's arguments can be spelled anything, so the gate had no way
+    to find its budget and silently treated every plugin mutation as
+    "no budget proposed" — the operator's ``## Guardrails`` caps were
+    unenforced for that platform, with no error or warning. A plugin closes
+    that by declaring its keys in standard MCP metadata::
+
+        Tool(
+            name="acme_ads_update_budget",
+            _meta={"mureo": {"budget": {"daily": "daily_budget_micros",
+                                        "unit": "micros"}}},
+            ...
+        )
+
+    ``unit`` is ``"currency"`` (default) or ``"micros"`` (value / 1e6).
+
+    A declaration REPLACES the built-in key scan for the budgets the tool
+    **proposes** — ``daily`` and ``lifetime`` — for every one of them, not just
+    the ones it names. The plugin owns its argument vocabulary, so an unrelated
+    field that happens to be spelled ``amount`` must not false-trip a cap. The
+    corollary: declaring only ``daily`` also opts the tool out of the built-in
+    ``lifetime_budget`` / ``total_amount`` scan, so a tool that carries a
+    lifetime budget must declare ``lifetime`` too (a coincidental built-in
+    spelling stops being honored the moment you declare anything).
+
+    The two CALLER-supplied figures are the exception, and deliberately so.
+    Neither is something the tool carries: the *existing* daily budget
+    (``current_daily_budget``) and the account-wide *projected total*
+    (``projected_total_daily_budget``) are context the skills compute and pass
+    on a budget mutation, under mureo's own cross-provider convention, in
+    currency units. A declaration does not replace them, so
+    ``max_daily_budget_increase_pct`` and ``max_total_daily_budget`` go on
+    working for a declaring tool. ``current`` may still be declared where a
+    plugin really does carry the current budget itself, and that declaration
+    wins; the projected total has no key at all, because it is never a tool
+    argument.
+
+    A declared key that is present but unreadable (``inf``, ``nan``, a
+    bool, a non-numeric string) makes the gate DENY — see
+    :func:`_declared_amount`. The convention keys are held to the same
+    standard (#419).
+    """
+
+    daily_key: str | None = None
+    lifetime_key: str | None = None
+    current_key: str | None = None
+    micros: bool = False
+
+
+# Tool name → declaration. Populated by the MCP server from plugin tool
+# metadata at import (see ``mureo.mcp.server``), so the pure decision layer
+# stays I/O-free and the gate needs no plugin imports.
+_BUDGET_DECLARATIONS: dict[str, BudgetDeclaration] = {}
+
+
+def register_budget_declaration(tool_name: str, declaration: BudgetDeclaration) -> None:
+    """Bind ``tool_name``'s budget argument keys (last registration wins)."""
+    _BUDGET_DECLARATIONS[tool_name] = declaration
+
+
+def budget_declaration_for(tool_name: str) -> BudgetDeclaration | None:
+    """The declaration registered for ``tool_name``, or ``None``."""
+    return _BUDGET_DECLARATIONS.get(tool_name)
+
+
+def reset_budget_declarations() -> None:
+    """Drop every registration (tests; a re-discovery re-registers)."""
+    _BUDGET_DECLARATIONS.clear()
+
+
+@dataclass(frozen=True)
+class BidDeclaration:
+    """Where one tool carries its *bid* arguments — the bid twin of #414.
+
+    ``BudgetDeclaration`` closed the gap for budgets; bids had the same hole.
+    The gate's bid extraction (:func:`_bid_inputs`) scans only the built-in
+    Google/Meta spellings — Meta's ``bid_amount`` (minor units) and Google's
+    ``cpc_bid_micros`` (micros) — so a plugin bid tool whose argument is spelled
+    anything else was read as "no bid proposed" and sailed past
+    ``max_bid_amount_per_ad_set`` / ``max_cpc_bid_per_ad_group``, silently: no
+    startup error, no warning, on a surface where real money moves. A plugin
+    closes that by declaring its keys in standard MCP metadata::
+
+        Tool(
+            name="acme_ads_update_bid",
+            _meta={"mureo": {"bid": {"cpc_bid": "bid_cap_micros",
+                                     "unit": "micros"}}},
+            ...
+        )
+
+    A declaration names one or both of the two bid channels, mirroring how a
+    ``BudgetDeclaration`` names its daily / lifetime / current channels:
+
+    - ``bid_amount_key`` — capped by ``max_bid_amount_per_ad_set``, compared in
+      account-currency MINOR units (like Meta's ``bid_amount``, direct).
+    - ``cpc_bid_key`` — capped by ``max_cpc_bid_per_ad_group``, compared in
+      account-currency units (like Google's ``cpc_bid_micros`` after ÷1e6).
+
+    The channel a key names decides WHICH cap constrains it; ``micros`` decides
+    the UNIT (``value / 1e6`` when set, direct otherwise) — the two are declared
+    independently so a plugin states both "which guardrail caps this" and
+    "is my value micros" explicitly. Like ``BudgetDeclaration``'s single
+    ``micros`` flag, one declaration carries one unit for both channels: a bid
+    tool proposes a single bid, so the common case names exactly one channel.
+
+    A declaration REPLACES the built-in key scan for that tool (there are no
+    caller-supplied convention keys for bids, so it replaces the whole bid
+    scan): the plugin owns its argument vocabulary, so an unrelated field
+    spelled ``bid_amount`` cannot false-trip a cap. A declared key that is
+    present but unreadable (``inf``, ``nan``, a bool, a non-numeric string, a
+    nested object) makes the gate DENY through the same :func:`_bid_inputs`
+    choke point the built-in scan uses — see :func:`_declared_amount`.
+    """
+
+    bid_amount_key: str | None = None
+    cpc_bid_key: str | None = None
+    micros: bool = False
+
+
+# Tool name → bid declaration. Populated by the MCP server from plugin tool
+# metadata at import (see ``mureo.mcp.server``), exactly like the budget
+# registry above, so the pure decision layer stays I/O-free.
+_BID_DECLARATIONS: dict[str, BidDeclaration] = {}
+
+
+def register_bid_declaration(tool_name: str, declaration: BidDeclaration) -> None:
+    """Bind ``tool_name``'s bid argument keys (last registration wins)."""
+    _BID_DECLARATIONS[tool_name] = declaration
+
+
+def bid_declaration_for(tool_name: str) -> BidDeclaration | None:
+    """The bid declaration registered for ``tool_name``, or ``None``."""
+    return _BID_DECLARATIONS.get(tool_name)
+
+
+def reset_bid_declarations() -> None:
+    """Drop every bid registration (tests; a re-discovery re-registers)."""
+    _BID_DECLARATIONS.clear()
+
+
+class _Unreadable:
+    """Sentinel: a declared budget key is PRESENT but not a usable number."""
+
+
+_UNREADABLE = _Unreadable()
+
+
+def _saturate(value: int | float) -> float:
+    """``float(value)``, saturating an out-of-range ``int`` to infinity.
+
+    Python ints are arbitrary precision but floats are not, so ``float(10**400)``
+    raises ``OverflowError`` — and the downstream handler forwards the bare int
+    happily. Every budget path here funnels through this helper so an oversized
+    integer becomes ``inf`` (which exceeds any finite cap and denies) rather than
+    an exception that bubbles up to ``StrategyPolicyGate.evaluate``'s blanket
+    ``except`` and silently abstains — the exact bypass the guardrail exists to
+    prevent. A string budget never reaches here (``float("9"*309)`` already
+    saturates to ``inf`` without raising).
+    """
+    try:
+        return float(value)
+    except OverflowError:
+        return math.inf if value > 0 else -math.inf
+
+
+def _declared_amount(
+    arguments: dict[str, Any], key: str | None, *, micros: bool
+) -> float | _Unreadable | None:
+    """Read one declared budget key as currency units.
+
+    Three outcomes, and the distinction is the whole point of #414:
+
+    - ``None`` — the key is absent (or ``null`` / blank, which mean the same
+      thing): this call proposes no budget on that channel.
+    - ``float`` — a usable amount (stringified numbers are accepted; plugins
+      hit them in the wild when a JSON body round-trips through a form
+      encoder).
+    - :data:`_UNREADABLE` — the key IS present but carries garbage (a
+      non-finite ``inf``/``nan``, a bool, a non-numeric string, a nested
+      object). The caller must **deny**: silently treating it as "no
+      proposal" would let ``{"spend_limit": "inf"}`` sail past every cap —
+      re-opening the exact silent bypass this seam exists to close, and
+      making the declared path weaker than the built-in scan (where a raw
+      ``inf`` simply exceeds any finite cap and denies).
+    """
+    if not key or key not in arguments:
+        return None
+    raw = arguments[key]
+    if raw is None:
+        return None
+    if isinstance(raw, bool):
+        return _UNREADABLE
+    if isinstance(raw, (int, float)):
+        value = _saturate(raw)
+    elif isinstance(raw, str):
+        stripped = raw.strip()
+        if not stripped:
+            return None
+        try:
+            value = float(stripped)
+        except ValueError:
+            return _UNREADABLE
+    else:
+        return _UNREADABLE
+    if math.isnan(value) or math.isinf(value):
+        return _UNREADABLE
+    return value / 1_000_000 if micros else value

--- a/mureo/policy/strategy_gate.py
+++ b/mureo/policy/strategy_gate.py
@@ -32,7 +32,57 @@ from typing import Any
 
 from mureo.core.policy import PolicyDecision
 
+# The plugin budget/bid declaration machinery lives in a sibling module
+# (:mod:`mureo.policy.declarations`), split out to keep this module within the
+# project file-size budget. It is re-imported here — and listed in ``__all__``
+# below — so that ``mureo.policy.strategy_gate`` stays a stable import path:
+# the sibling bridges, mureo-pro, and the test-suite import several of these
+# names from here, so every symbol that used to live in this module must keep
+# resolving from it. ``_saturate`` / ``_declared_amount`` / ``_Unreadable`` are
+# also used directly by the decision logic below.
+from mureo.policy.declarations import (
+    _BID_DECLARATIONS,
+    _BUDGET_DECLARATIONS,
+    _UNREADABLE,
+    BidDeclaration,
+    BudgetDeclaration,
+    _declared_amount,
+    _saturate,
+    _Unreadable,
+    bid_declaration_for,
+    budget_declaration_for,
+    register_bid_declaration,
+    register_budget_declaration,
+    reset_bid_declarations,
+    reset_budget_declarations,
+)
+
 logger = logging.getLogger(__name__)
+
+# Stable import surface of this module. Membership here marks the re-exported
+# declaration names above as an explicit re-export (mypy ``--strict``'s
+# ``no_implicit_reexport``) and documents the API the downstream bridges,
+# mureo-pro, and the test-suite depend on. The three ``_``-prefixed registry
+# names are included deliberately: the test-suite imports them from this path.
+__all__ = [
+    "GUARDRAILS_HEADING",
+    "Guardrails",
+    "StrategyPolicyGate",
+    "evaluate_guardrails",
+    "guardrails_from_strategy_text",
+    "parse_guardrails",
+    "BudgetDeclaration",
+    "BidDeclaration",
+    "budget_declaration_for",
+    "bid_declaration_for",
+    "register_budget_declaration",
+    "register_bid_declaration",
+    "reset_budget_declarations",
+    "reset_bid_declarations",
+    "_BUDGET_DECLARATIONS",
+    "_BID_DECLARATIONS",
+    "_UNREADABLE",
+]
 
 # The (case-insensitive) STRATEGY.md section that carries machine-readable
 # hard rules. Unrecognized by strategy.py's section map, so it round-trips as
@@ -59,219 +109,6 @@ _CONVENTION_CURRENT_KEY = "current_daily_budget"
 _CONVENTION_TOTAL_KEY = "projected_total_daily_budget"
 
 _BULLET_RE = re.compile(r"^\s*[-*]\s*([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(.+?)\s*$")
-
-
-@dataclass(frozen=True)
-class BudgetDeclaration:
-    """Where one tool carries its budget arguments (#414).
-
-    Built-in Google/Meta tools are covered by the hard-coded key scan above.
-    A plugin tool's arguments can be spelled anything, so the gate had no way
-    to find its budget and silently treated every plugin mutation as
-    "no budget proposed" — the operator's ``## Guardrails`` caps were
-    unenforced for that platform, with no error or warning. A plugin closes
-    that by declaring its keys in standard MCP metadata::
-
-        Tool(
-            name="acme_ads_update_budget",
-            _meta={"mureo": {"budget": {"daily": "daily_budget_micros",
-                                        "unit": "micros"}}},
-            ...
-        )
-
-    ``unit`` is ``"currency"`` (default) or ``"micros"`` (value / 1e6).
-
-    A declaration REPLACES the built-in key scan for the budgets the tool
-    **proposes** — ``daily`` and ``lifetime`` — for every one of them, not just
-    the ones it names. The plugin owns its argument vocabulary, so an unrelated
-    field that happens to be spelled ``amount`` must not false-trip a cap. The
-    corollary: declaring only ``daily`` also opts the tool out of the built-in
-    ``lifetime_budget`` / ``total_amount`` scan, so a tool that carries a
-    lifetime budget must declare ``lifetime`` too (a coincidental built-in
-    spelling stops being honored the moment you declare anything).
-
-    The two CALLER-supplied figures are the exception, and deliberately so.
-    Neither is something the tool carries: the *existing* daily budget
-    (``current_daily_budget``) and the account-wide *projected total*
-    (``projected_total_daily_budget``) are context the skills compute and pass
-    on a budget mutation, under mureo's own cross-provider convention, in
-    currency units. A declaration does not replace them, so
-    ``max_daily_budget_increase_pct`` and ``max_total_daily_budget`` go on
-    working for a declaring tool. ``current`` may still be declared where a
-    plugin really does carry the current budget itself, and that declaration
-    wins; the projected total has no key at all, because it is never a tool
-    argument.
-
-    A declared key that is present but unreadable (``inf``, ``nan``, a
-    bool, a non-numeric string) makes the gate DENY — see
-    :func:`_declared_amount`. The convention keys are held to the same
-    standard (#419).
-    """
-
-    daily_key: str | None = None
-    lifetime_key: str | None = None
-    current_key: str | None = None
-    micros: bool = False
-
-
-# Tool name → declaration. Populated by the MCP server from plugin tool
-# metadata at import (see ``mureo.mcp.server``), so the pure decision layer
-# stays I/O-free and the gate needs no plugin imports.
-_BUDGET_DECLARATIONS: dict[str, BudgetDeclaration] = {}
-
-
-def register_budget_declaration(tool_name: str, declaration: BudgetDeclaration) -> None:
-    """Bind ``tool_name``'s budget argument keys (last registration wins)."""
-    _BUDGET_DECLARATIONS[tool_name] = declaration
-
-
-def budget_declaration_for(tool_name: str) -> BudgetDeclaration | None:
-    """The declaration registered for ``tool_name``, or ``None``."""
-    return _BUDGET_DECLARATIONS.get(tool_name)
-
-
-def reset_budget_declarations() -> None:
-    """Drop every registration (tests; a re-discovery re-registers)."""
-    _BUDGET_DECLARATIONS.clear()
-
-
-@dataclass(frozen=True)
-class BidDeclaration:
-    """Where one tool carries its *bid* arguments — the bid twin of #414.
-
-    ``BudgetDeclaration`` closed the gap for budgets; bids had the same hole.
-    The gate's bid extraction (:func:`_bid_inputs`) scans only the built-in
-    Google/Meta spellings — Meta's ``bid_amount`` (minor units) and Google's
-    ``cpc_bid_micros`` (micros) — so a plugin bid tool whose argument is spelled
-    anything else was read as "no bid proposed" and sailed past
-    ``max_bid_amount_per_ad_set`` / ``max_cpc_bid_per_ad_group``, silently: no
-    startup error, no warning, on a surface where real money moves. A plugin
-    closes that by declaring its keys in standard MCP metadata::
-
-        Tool(
-            name="acme_ads_update_bid",
-            _meta={"mureo": {"bid": {"cpc_bid": "bid_cap_micros",
-                                     "unit": "micros"}}},
-            ...
-        )
-
-    A declaration names one or both of the two bid channels, mirroring how a
-    ``BudgetDeclaration`` names its daily / lifetime / current channels:
-
-    - ``bid_amount_key`` — capped by ``max_bid_amount_per_ad_set``, compared in
-      account-currency MINOR units (like Meta's ``bid_amount``, direct).
-    - ``cpc_bid_key`` — capped by ``max_cpc_bid_per_ad_group``, compared in
-      account-currency units (like Google's ``cpc_bid_micros`` after ÷1e6).
-
-    The channel a key names decides WHICH cap constrains it; ``micros`` decides
-    the UNIT (``value / 1e6`` when set, direct otherwise) — the two are declared
-    independently so a plugin states both "which guardrail caps this" and
-    "is my value micros" explicitly. Like ``BudgetDeclaration``'s single
-    ``micros`` flag, one declaration carries one unit for both channels: a bid
-    tool proposes a single bid, so the common case names exactly one channel.
-
-    A declaration REPLACES the built-in key scan for that tool (there are no
-    caller-supplied convention keys for bids, so it replaces the whole bid
-    scan): the plugin owns its argument vocabulary, so an unrelated field
-    spelled ``bid_amount`` cannot false-trip a cap. A declared key that is
-    present but unreadable (``inf``, ``nan``, a bool, a non-numeric string, a
-    nested object) makes the gate DENY through the same :func:`_bid_inputs`
-    choke point the built-in scan uses — see :func:`_declared_amount`.
-    """
-
-    bid_amount_key: str | None = None
-    cpc_bid_key: str | None = None
-    micros: bool = False
-
-
-# Tool name → bid declaration. Populated by the MCP server from plugin tool
-# metadata at import (see ``mureo.mcp.server``), exactly like the budget
-# registry above, so the pure decision layer stays I/O-free.
-_BID_DECLARATIONS: dict[str, BidDeclaration] = {}
-
-
-def register_bid_declaration(tool_name: str, declaration: BidDeclaration) -> None:
-    """Bind ``tool_name``'s bid argument keys (last registration wins)."""
-    _BID_DECLARATIONS[tool_name] = declaration
-
-
-def bid_declaration_for(tool_name: str) -> BidDeclaration | None:
-    """The bid declaration registered for ``tool_name``, or ``None``."""
-    return _BID_DECLARATIONS.get(tool_name)
-
-
-def reset_bid_declarations() -> None:
-    """Drop every bid registration (tests; a re-discovery re-registers)."""
-    _BID_DECLARATIONS.clear()
-
-
-class _Unreadable:
-    """Sentinel: a declared budget key is PRESENT but not a usable number."""
-
-
-_UNREADABLE = _Unreadable()
-
-
-def _saturate(value: int | float) -> float:
-    """``float(value)``, saturating an out-of-range ``int`` to infinity.
-
-    Python ints are arbitrary precision but floats are not, so ``float(10**400)``
-    raises ``OverflowError`` — and the downstream handler forwards the bare int
-    happily. Every budget path here funnels through this helper so an oversized
-    integer becomes ``inf`` (which exceeds any finite cap and denies) rather than
-    an exception that bubbles up to ``StrategyPolicyGate.evaluate``'s blanket
-    ``except`` and silently abstains — the exact bypass the guardrail exists to
-    prevent. A string budget never reaches here (``float("9"*309)`` already
-    saturates to ``inf`` without raising).
-    """
-    try:
-        return float(value)
-    except OverflowError:
-        return math.inf if value > 0 else -math.inf
-
-
-def _declared_amount(
-    arguments: dict[str, Any], key: str | None, *, micros: bool
-) -> float | _Unreadable | None:
-    """Read one declared budget key as currency units.
-
-    Three outcomes, and the distinction is the whole point of #414:
-
-    - ``None`` — the key is absent (or ``null`` / blank, which mean the same
-      thing): this call proposes no budget on that channel.
-    - ``float`` — a usable amount (stringified numbers are accepted; plugins
-      hit them in the wild when a JSON body round-trips through a form
-      encoder).
-    - :data:`_UNREADABLE` — the key IS present but carries garbage (a
-      non-finite ``inf``/``nan``, a bool, a non-numeric string, a nested
-      object). The caller must **deny**: silently treating it as "no
-      proposal" would let ``{"spend_limit": "inf"}`` sail past every cap —
-      re-opening the exact silent bypass this seam exists to close, and
-      making the declared path weaker than the built-in scan (where a raw
-      ``inf`` simply exceeds any finite cap and denies).
-    """
-    if not key or key not in arguments:
-        return None
-    raw = arguments[key]
-    if raw is None:
-        return None
-    if isinstance(raw, bool):
-        return _UNREADABLE
-    if isinstance(raw, (int, float)):
-        value = _saturate(raw)
-    elif isinstance(raw, str):
-        stripped = raw.strip()
-        if not stripped:
-            return None
-        try:
-            value = float(stripped)
-        except ValueError:
-            return _UNREADABLE
-    else:
-        return _UNREADABLE
-    if math.isnan(value) or math.isinf(value):
-        return _UNREADABLE
-    return value / 1_000_000 if micros else value
 
 
 def _projected_total(arguments: dict[str, Any]) -> float | None:


### PR DESCRIPTION
## Summary
Pure-move refactor, zero behavior change: declaration machinery (BudgetDeclaration, BidDeclaration, registries, register/lookup/reset helpers, shared declared-key readers) extracted from strategy_gate.py (877 → 714 lines) into new declarations.py (244 lines) — back under the 800-line file budget after #456.
- `mureo.policy.strategy_gate` re-exports every moved name (stable ABI for bridges); registry dicts verified to be identical objects across both paths
- Internal callers repointed to the canonical module; no import cycle

## Test plan
- Existing test files unmodified (the no-behavior-change proof): gate + declaration suites 165 passed; byte-identical move verified mechanically in review
- Downstream verified read-only: bridges import only symbols that stayed in strategy_gate; mureo-logly-bridge test suite run against the refactored tree — 120 passed
- black / ruff / mypy clean; code review: APPROVE, no CRITICAL/HIGH/MEDIUM