### PR TITLE
docs(skills): allocation and learning-state diagnostic discipline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Cross-platform allocation & learning-state diagnostic discipline.** The
+  pro-diagnosis framework catalogue (`skills/_mureo-pro-diagnosis`) gains an
+  *Allocation & Learning-State Discipline* section covering three principles
+  that hold identically on Meta and Google Ads: **judge by marginal efficiency,
+  not averages** (a bad average is a candidate, not a verdict — saturated
+  winners scale badly and suppressed losers look worse than they are);
+  **respect learning states** (a Meta ad set in its learning phase or a Google
+  Ads bid strategy in "Learning" is Watch-only, its cost per result is not
+  steady-state, and edits that reset the clock need a reason worth the reset —
+  prefer target steps of ~20% or less); and **don't hand-optimize inside an
+  auto-allocated unit** (per-breakdown rows are outcomes of the platform's own
+  allocation, not levers — Smart Bidding ignores manual bid adjustments except
+  a −100% device opt-out, so cutting an expensive-looking row shrinks the
+  optimizer's inventory rather than redirecting its budget). Each principle
+  ships with per-platform manifestations and "what to say instead" phrasing for
+  recommendations. Guard notes pointing back at the section were added across
+  the operational skills: `daily-check` (learning-state entities are Watch, not
+  Action-needed), `budget-rebalance` (every reallocation reason must be
+  marginal, not an average ranking), `audience-review` (no breakdown-average
+  exclusions; validate via `/experiment` and act at the platform's optimization
+  unit), `ad-fatigue-check` (learning-phase instability is not creative
+  fatigue), and `search-term-cleanup` (systematic waste vs low-volume terms with
+  a bad average). `/experiment` now advertises breakdown-exclusion and
+  reallocation hypotheses as things it validates.
+
 ## [0.10.30] - 2026-07-27
 
 ### Added

--- a/mureo/_data/skills/ad-fatigue-check/SKILL.md
+++ b/mureo/_data/skills/ad-fatigue-check/SKILL.md
@@ -41,6 +41,7 @@ Find the ads whose audience has seen them too many times. Creative fatigue is a 
 5. **Noise guards (apply before assigning any verdict)**:
    - **Minimum impressions per window**: require **≥ 1,000 impressions in each** of the two adjacent windows before reading a CTR trend (the CTR sample floor from `../_mureo-learning/SKILL.md`). Below that, the ad is **insufficient-data**, not fatigued.
    - **Single-day dips never count** — the comparison is week-over-week on 7-day windows precisely so one bad Tuesday cannot trigger a rotation.
+   - **Learning-state noise is not fatigue.** An ad whose ad set is in its Meta learning phase (new, or recently reset by a significant edit), or whose Google Ads bid strategy shows "Learning", has unstable delivery by design — soft CTR and drifting CPM there are the learning window, not a worn-out creative. Mark those **insufficient-data / re-check after the window**, never FATIGUED, and do not rotate creative on that basis (a creative swap resets the phase again). See `../_mureo-pro-diagnosis/SKILL.md` → *Allocation & Learning-State Discipline*.
    - Note confounders: a new competitor, a seasonal lull, or a landing-page change can mimic fatigue — flag them rather than blaming the creative.
 
 6. **Ranked table** — worst first:

--- a/mureo/_data/skills/audience-review/SKILL.md
+++ b/mureo/_data/skills/audience-review/SKILL.md
@@ -45,11 +45,13 @@ Reconcile **who you say you want** (the STRATEGY.md Persona / Target Audience) w
 
    | Platform | Segment / Placement | Current | Signal | Recommendation | Persona/Goal rationale |
    |----------|---------------------|---------|--------|----------------|------------------------|
-   | Meta | Audience Network | on, ¥18k spend | 0 conv | Exclude placement | Persona converts on IG Feed; AN is waste |
+   | Meta | Audience Network | on, ¥18k spend | 0 conv | Flag as hypothesis — validate the exclusion via /experiment (see Allocation & Learning-State Discipline) | Persona converts on IG Feed; AN looks like waste, but the row is an allocation outcome |
    | Google | Mobile | +0% modifier | CPA 1.8× Desktop | −20% device bid | Protect Goal CPA |
    | Meta | (Persona lookalike) | none | — | Create 1% LAL of purchasers | Persona = past-buyer profile |
 
    Recommendation types: **exclusions**, **bid adjustments**, **lookalike creation**, **placement pruning**. Reference past `action_log` outcomes — if a device bid adjustment was previously REJECTED as no-impact, note that before proposing it again.
+
+   **A breakdown average is never on its own grounds for an exclusion.** Where the platform allocates delivery inside the unit automatically (Meta ad-set delivery across audiences/placements; Google Ads Smart Bidding, where manual bid adjustments are ignored except a −100% device opt-out), these rows are outcomes of that allocation, not levers — cutting an expensive-looking row shrinks the optimizer's inventory and can worsen the unit. Present such rows as **hypotheses to validate via `/experiment`**, and act at the level the platform optimizes (a separate ad set, not a row exclusion). See `../_mureo-pro-diagnosis/SKILL.md` → *Allocation & Learning-State Discipline*.
 
 8. **Approval gate before ANY write**: Apply the *Confirm Before Write Operations* rule from `../_mureo-shared/SKILL.md` — show current-vs-proposed for every change and get explicit **approval**. Respect Operation Mode and `## Guardrails`; a targeting change during `ONBOARDING_LEARNING` / `CREATIVE_TESTING` is discouraged — warn and ask before proceeding.
 

--- a/mureo/_data/skills/budget-rebalance/SKILL.md
+++ b/mureo/_data/skills/budget-rebalance/SKILL.md
@@ -58,6 +58,8 @@ Analyze budget allocation and suggest rebalancing across all campaigns.
     | Platform | Campaign | Current Budget | Proposed Budget | Change | Reason |
     |----------|----------|---------------|-----------------|--------|--------|
 
+    **Every `Reason` must be marginal, not average.** A rank by average CPA identifies *candidates*; it does not justify the move. State what the next (or removed) unit of spend is expected to do — a top-average campaign that is not budget-limited is usually saturated, and a bad-average campaign may simply be spend-suppressed. Where the marginal effect is genuinely unknown, say so and offer `/experiment` instead of asserting it. See `../_mureo-pro-diagnosis/SKILL.md` → *Allocation & Learning-State Discipline*.
+
 12. **Risk assessment**: Flag any budget changes >20% (smart bidding learning risk).
 
 13. **Ask for approval** before any changes.

--- a/mureo/_data/skills/daily-check/SKILL.md
+++ b/mureo/_data/skills/daily-check/SKILL.md
@@ -47,6 +47,8 @@ Run a daily health check on all marketing accounts using the strategy context.
    - **CREATIVE_TESTING**: Audit ad asset performance across all platforms. Flag underperforming creatives.
    - **LTV_QUALITY_FOCUS**: Review search term quality and audience alignment across all platforms.
 
+   **Learning-state guard (all modes)**: An entity inside a platform learning state — a Meta ad set in its learning phase, a Google Ads bid strategy showing "Learning" after a strategy or target change — is **Watch at most, never Action needed on efficiency grounds**. Its cost per result is not steady-state, so do not read it as performance and do not propose edits that would reset the clock. See `../_mureo-pro-diagnosis/SKILL.md` → *Allocation & Learning-State Discipline*.
+
 6. **Organic search pulse** (if Search Console is available): Check top organic queries for the site. Identify any organic ranking drops that may need paid coverage, or organic gains where paid spend can be reduced.
 
 7. **On-site behavior check** (if GA4 is available): Correlate ad platform metrics with on-site behavior — LP conversion rates, bounce rates, session quality. Flag discrepancies between ad platform and GA4 conversion data.

--- a/mureo/_data/skills/experiment/SKILL.md
+++ b/mureo/_data/skills/experiment/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: experiment
-description: "Design, run, and evaluate a controlled A/B test (split test) on your ad accounts with evidence discipline — one variable, a falsifiable hypothesis, a fixed window, and a per-variant outcome verdict. Use when the user asks to run an A/B test, split test, or experiment, to 'test whether X beats Y', to validate a creative-refresh or learning hunch properly, or requests A/Bテスト / スプリットテスト設計 / 実験を回したい / どちらが勝ったか評価して / 仮説を検証したい. Forces a designed experiment instead of an ad-hoc change, records the baseline in action_log, and forbids peeking-based decisions before the window closes."
+description: "Design, run, and evaluate a controlled A/B test (split test) on your ad accounts with evidence discipline — one variable, a falsifiable hypothesis, a fixed window, and a per-variant outcome verdict. Use when the user asks to run an A/B test, split test, or experiment, to 'test whether X beats Y', to validate a creative-refresh or learning hunch properly, to validate a breakdown exclusion or reallocation hypothesis before acting on it, or requests A/Bテスト / スプリットテスト設計 / 実験を回したい / どちらが勝ったか評価して / 仮説を検証したい. Forces a designed experiment instead of an ad-hoc change, records the baseline in action_log, and forbids peeking-based decisions before the window closes."
 metadata:
   version: 0.10.30
 ---

--- a/mureo/_data/skills/search-term-cleanup/SKILL.md
+++ b/mureo/_data/skills/search-term-cleanup/SKILL.md
@@ -42,6 +42,8 @@ Review and clean up search terms and keywords across all platforms.
    - **Add candidates**: High-converting terms not yet added as keywords, terms matching USP themes
    - **Reduce candidates**: Terms well-covered by organic rankings
 
+   **Negative keywords are a marginal decision, not an average ranking.** Distinguish **systematic waste** — an n-gram or intent pattern that is wrong for the Persona at any volume, where a negative genuinely removes future spend — from a **low-volume term with a bad average**, where a handful of clicks and zero conversions is a sample-size fact, not evidence of waste. Excluding the long tail one term at a time mostly narrows match reach without saving meaningful spend. Prefer pattern-level negatives with a stated marginal saving; leave thin terms to accumulate. See `../_mureo-pro-diagnosis/SKILL.md` → *Allocation & Learning-State Discipline*.
+
 7. **Present recommendations** in a table:
    | Term | Platform | Action | Reason | Score | Campaign |
    |------|----------|--------|--------|-------|----------|

--- a/skills/_mureo-pro-diagnosis/SKILL.md
+++ b/skills/_mureo-pro-diagnosis/SKILL.md
@@ -48,6 +48,75 @@ When analyzing a campaign, work through issues in this priority:
 
 ---
 
+## Allocation & Learning-State Discipline
+
+Modern ad platforms decide *where the next impression goes* on the advertiser's behalf. That single fact invalidates a whole family of intuitive-looking moves: ranking rows in a breakdown table and cutting the worst ones. The three principles below are cross-platform — they hold on Meta and on Google Ads for the same underlying reason — and they apply **before** any exclusion, pause, or reallocation is proposed.
+
+### Judge by Marginal Efficiency, Not Averages
+
+**Principle:** A segment, placement, keyword, or campaign with a poor **average** CPA is not automatically a cut candidate. The decision-relevant quantity is the **marginal** one: what the *next* unit of spend would return, and what the *removed* unit of spend would have returned. Averages summarize history under an allocation you did not choose; margins describe the change you are about to make.
+
+**Why it holds:** Automated delivery spends the cheapest, highest-probability inventory first. An entity's average therefore blends its cheap early conversions with its progressively more expensive later ones. Two failure modes follow, and average-ranking misfires in **both** directions:
+
+- **Saturated winners scale badly.** A campaign with an excellent average has already been served its best inventory. Pushing more budget into it buys the expensive tail — the marginal CPA can be far worse than the average that justified the increase.
+- **Suppressed losers look worse than they are.** A small entity with a bad average may simply be spend-suppressed: too little delivery to have found its efficient inventory, or an average dominated by one or two costly outcomes. Cutting it removes volume that was never given a fair chance, and the "saving" reappears as higher CPA elsewhere.
+
+**How it shows up:**
+
+- **Meta** — Ad-set budgets (and campaign-level budget allocation across ad sets) are spent toward the configured optimization goal. Moving budget between ad sets changes *which* auctions get bid on, so the post-move CPA is a new outcome, not the old average carried over.
+- **Google Ads** — Smart Bidding sets bids per auction against the target. Raising a budget on a target-constrained campaign buys additional auctions that were previously below the bar; those incremental conversions cost more than the campaign's historical average. A keyword with a high average CPA but few conversions is a sample-size question first and an efficiency question second.
+
+**Already in mureo:** the evidence gates in `_mureo-learning` (minimum sample sizes, observation windows, the OBSERVING → CANDIDATE → VALIDATED lifecycle) exist precisely so a thin average is not mistaken for a verdict. Honor them before proposing any cut.
+
+**What to say instead:**
+
+- Not: *"Campaign B has a CPA of ¥8,200 vs the account's ¥5,000 — cut its budget by 40%."*
+- Say: *"Campaign B's average CPA is ¥8,200 on 11 conversions — below the 30-conversion floor, so this is not yet evidence of inefficiency. If we move ¥40k/month out of it, we should expect to lose roughly the conversions it produced at the margin, not at its average. I recommend either holding, or testing the reallocation via `/experiment` so the marginal effect is measured rather than assumed."*
+- Not: *"Campaign A has the best CPA — give it the extra budget."*
+- Say: *"Campaign A has the best average CPA and is not budget-limited, which usually means it is already getting the inventory it wants. A +20% increase will buy incremental auctions at a worse-than-average cost; I'd step it up in one increment and re-measure after the observation window rather than doubling it."*
+
+### Respect Learning States
+
+**Principle:** Automated bidding needs a stable window of data after an entity is created or significantly edited. Entities inside that window are **Watch-only**: report them, do not judge them, and do not schedule edits that restart the clock without a reason worth the reset.
+
+**Why it holds:** The bidding system is estimating conversion probability for a new configuration. Until it has enough recent outcomes, delivery is deliberately exploratory — cost per result is unstable and typically worse than the same entity's eventual steady state. Reading that instability as "performance" produces exactly the wrong action: cutting a unit that has not yet finished learning, or crediting a change with an improvement that is just the learning period ending.
+
+**How it shows up:**
+
+- **Meta** — A new or significantly edited ad set enters a **learning phase** and exits once it has accumulated enough recent optimization events (Meta's published guidance is on the order of ~50 conversions in a week for the optimized event). Significant edits — the optimization goal, the audience, the creative, or a large budget or bid change — **reset** it. An ad set that keeps getting edited can sit in a permanently unstable state and never reach steady delivery.
+- **Google Ads** — A bid strategy shows a **"Learning"** status after the strategy is switched or its target (Target CPA / Target ROAS) is changed, typically for a period of days up to about two weeks. Large target jumps make the adjustment harder and the recovery longer; prefer **small steps — roughly 20% or less at a time** — and let each settle before the next.
+
+**Already in mureo:** the Operation Mode `ONBOARDING_LEARNING`, the `observation_due` / `metrics_at_action` fields on `action_log`, and the "pending observation — do not stack changes" checks across the operational skills are the machinery for this. A learning-state entity is a `Watch` in the health report, never an `Action needed` on efficiency grounds alone.
+
+**What to say instead:**
+
+- Not: *"This ad set's CPA is 2.4× target — pause it."*
+- Say: *"This ad set was edited 4 days ago and is still in its learning phase, so its CPA is not steady-state. Marking it **Watch**; I'll re-evaluate once it has exited learning (or after the 14-day window), and I'd avoid further edits until then so the phase isn't reset again."*
+- Not: *"CPA is high — drop the Target CPA from ¥6,000 to ¥3,500."*
+- Say: *"A 42% target cut would put the strategy back into Learning and likely suppress volume sharply. I recommend stepping to ¥4,800 (−20%), letting the strategy re-stabilize, and reassessing before the next step."*
+
+### Don't Hand-Optimize Inside an Auto-Allocated Unit
+
+**Principle:** When the platform distributes delivery *within* a unit automatically, the per-breakdown numbers you can see are **outcomes of that allocation, not levers you control**. Breakdown tables generate hypotheses; they do not license exclusions.
+
+**Why it holds:** The system chose those breakdowns to hit the goal you set. A breakdown that looks expensive is often carrying cheap reach or assisted volume that made the *unit's* overall result possible; removing it does not relocate its budget into the good rows at the good rows' historical efficiency — it shrinks the auction pool the optimizer had to work with, and the unit's blended result can get **worse**. This is the same marginal-vs-average error as the first principle, applied inside a unit rather than across units.
+
+**How it shows up:**
+
+- **Meta** — Delivery within an ad set is distributed across audiences, placements, and devices automatically. A placement breakdown showing an expensive placement is a report of where the optimizer found results, not a per-placement bid you set. Placement and audience decisions belong at the level the platform optimizes — the ad set — so if a split genuinely matters, build it as a separate ad set rather than excluding a row inside a working one.
+- **Google Ads** — Under fully-automated Smart Bidding strategies (Target CPA / Target ROAS / Maximize Conversions / Maximize Conversion Value), **manual bid adjustments are ignored**, with the single exception of a **−100% device adjustment** (a full device opt-out). Reporting still shows per-device and per-segment rows, which makes them look adjustable; they are not. Performance Max reports across channels and asset groups, but channel mix is not an advertiser lever — a channel row is diagnostic, not a dial.
+
+**Already in mureo:** the `audience-review` skill deliberately routes segment findings into a recommendations table behind an approval gate rather than auto-excluding, and honestly reports where **no mutation tool exists**. Keep that discipline: the table is the hypothesis, `/experiment` is the test.
+
+**What to say instead:**
+
+- Not: *"Audience Network shows ¥18k spend and 0 conversions — exclude it."*
+- Say: *"The placement breakdown shows ¥18k on Audience Network with 0 conversions. Meta allocated that spend within the ad set, so excluding the row removes inventory the optimizer was using rather than redirecting that budget to Feed at Feed's current CPA. This is a hypothesis worth testing: I'd run a two-ad-set `/experiment` (one with the placement, one without), and act on the result."*
+- Not: *"Mobile CPA is 1.8× desktop — set a −30% mobile bid adjustment."*
+- Say: *"This campaign uses Smart Bidding, so a −30% mobile adjustment would be ignored — the only device adjustment that still applies is −100%, which opts the device out entirely. The mobile/desktop gap is a signal about the mobile landing-page experience or mobile intent; I'd investigate there rather than reach for a bid modifier that has no effect."*
+
+---
+
 ## Learned Insights
 
 This section grows as you use mureo. Each insight is learned from real campaign experience.

--- a/skills/ad-fatigue-check/SKILL.md
+++ b/skills/ad-fatigue-check/SKILL.md
@@ -41,6 +41,7 @@ Find the ads whose audience has seen them too many times. Creative fatigue is a 
 5. **Noise guards (apply before assigning any verdict)**:
    - **Minimum impressions per window**: require **≥ 1,000 impressions in each** of the two adjacent windows before reading a CTR trend (the CTR sample floor from `../_mureo-learning/SKILL.md`). Below that, the ad is **insufficient-data**, not fatigued.
    - **Single-day dips never count** — the comparison is week-over-week on 7-day windows precisely so one bad Tuesday cannot trigger a rotation.
+   - **Learning-state noise is not fatigue.** An ad whose ad set is in its Meta learning phase (new, or recently reset by a significant edit), or whose Google Ads bid strategy shows "Learning", has unstable delivery by design — soft CTR and drifting CPM there are the learning window, not a worn-out creative. Mark those **insufficient-data / re-check after the window**, never FATIGUED, and do not rotate creative on that basis (a creative swap resets the phase again). See `../_mureo-pro-diagnosis/SKILL.md` → *Allocation & Learning-State Discipline*.
    - Note confounders: a new competitor, a seasonal lull, or a landing-page change can mimic fatigue — flag them rather than blaming the creative.
 
 6. **Ranked table** — worst first:

--- a/skills/audience-review/SKILL.md
+++ b/skills/audience-review/SKILL.md
@@ -45,11 +45,13 @@ Reconcile **who you say you want** (the STRATEGY.md Persona / Target Audience) w
 
    | Platform | Segment / Placement | Current | Signal | Recommendation | Persona/Goal rationale |
    |----------|---------------------|---------|--------|----------------|------------------------|
-   | Meta | Audience Network | on, ¥18k spend | 0 conv | Exclude placement | Persona converts on IG Feed; AN is waste |
+   | Meta | Audience Network | on, ¥18k spend | 0 conv | Flag as hypothesis — validate the exclusion via /experiment (see Allocation & Learning-State Discipline) | Persona converts on IG Feed; AN looks like waste, but the row is an allocation outcome |
    | Google | Mobile | +0% modifier | CPA 1.8× Desktop | −20% device bid | Protect Goal CPA |
    | Meta | (Persona lookalike) | none | — | Create 1% LAL of purchasers | Persona = past-buyer profile |
 
    Recommendation types: **exclusions**, **bid adjustments**, **lookalike creation**, **placement pruning**. Reference past `action_log` outcomes — if a device bid adjustment was previously REJECTED as no-impact, note that before proposing it again.
+
+   **A breakdown average is never on its own grounds for an exclusion.** Where the platform allocates delivery inside the unit automatically (Meta ad-set delivery across audiences/placements; Google Ads Smart Bidding, where manual bid adjustments are ignored except a −100% device opt-out), these rows are outcomes of that allocation, not levers — cutting an expensive-looking row shrinks the optimizer's inventory and can worsen the unit. Present such rows as **hypotheses to validate via `/experiment`**, and act at the level the platform optimizes (a separate ad set, not a row exclusion). See `../_mureo-pro-diagnosis/SKILL.md` → *Allocation & Learning-State Discipline*.
 
 8. **Approval gate before ANY write**: Apply the *Confirm Before Write Operations* rule from `../_mureo-shared/SKILL.md` — show current-vs-proposed for every change and get explicit **approval**. Respect Operation Mode and `## Guardrails`; a targeting change during `ONBOARDING_LEARNING` / `CREATIVE_TESTING` is discouraged — warn and ask before proceeding.
 

--- a/skills/budget-rebalance/SKILL.md
+++ b/skills/budget-rebalance/SKILL.md
@@ -58,6 +58,8 @@ Analyze budget allocation and suggest rebalancing across all campaigns.
     | Platform | Campaign | Current Budget | Proposed Budget | Change | Reason |
     |----------|----------|---------------|-----------------|--------|--------|
 
+    **Every `Reason` must be marginal, not average.** A rank by average CPA identifies *candidates*; it does not justify the move. State what the next (or removed) unit of spend is expected to do — a top-average campaign that is not budget-limited is usually saturated, and a bad-average campaign may simply be spend-suppressed. Where the marginal effect is genuinely unknown, say so and offer `/experiment` instead of asserting it. See `../_mureo-pro-diagnosis/SKILL.md` → *Allocation & Learning-State Discipline*.
+
 12. **Risk assessment**: Flag any budget changes >20% (smart bidding learning risk).
 
 13. **Ask for approval** before any changes.

--- a/skills/daily-check/SKILL.md
+++ b/skills/daily-check/SKILL.md
@@ -47,6 +47,8 @@ Run a daily health check on all marketing accounts using the strategy context.
    - **CREATIVE_TESTING**: Audit ad asset performance across all platforms. Flag underperforming creatives.
    - **LTV_QUALITY_FOCUS**: Review search term quality and audience alignment across all platforms.
 
+   **Learning-state guard (all modes)**: An entity inside a platform learning state — a Meta ad set in its learning phase, a Google Ads bid strategy showing "Learning" after a strategy or target change — is **Watch at most, never Action needed on efficiency grounds**. Its cost per result is not steady-state, so do not read it as performance and do not propose edits that would reset the clock. See `../_mureo-pro-diagnosis/SKILL.md` → *Allocation & Learning-State Discipline*.
+
 6. **Organic search pulse** (if Search Console is available): Check top organic queries for the site. Identify any organic ranking drops that may need paid coverage, or organic gains where paid spend can be reduced.
 
 7. **On-site behavior check** (if GA4 is available): Correlate ad platform metrics with on-site behavior — LP conversion rates, bounce rates, session quality. Flag discrepancies between ad platform and GA4 conversion data.

--- a/skills/experiment/SKILL.md
+++ b/skills/experiment/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: experiment
-description: "Design, run, and evaluate a controlled A/B test (split test) on your ad accounts with evidence discipline — one variable, a falsifiable hypothesis, a fixed window, and a per-variant outcome verdict. Use when the user asks to run an A/B test, split test, or experiment, to 'test whether X beats Y', to validate a creative-refresh or learning hunch properly, or requests A/Bテスト / スプリットテスト設計 / 実験を回したい / どちらが勝ったか評価して / 仮説を検証したい. Forces a designed experiment instead of an ad-hoc change, records the baseline in action_log, and forbids peeking-based decisions before the window closes."
+description: "Design, run, and evaluate a controlled A/B test (split test) on your ad accounts with evidence discipline — one variable, a falsifiable hypothesis, a fixed window, and a per-variant outcome verdict. Use when the user asks to run an A/B test, split test, or experiment, to 'test whether X beats Y', to validate a creative-refresh or learning hunch properly, to validate a breakdown exclusion or reallocation hypothesis before acting on it, or requests A/Bテスト / スプリットテスト設計 / 実験を回したい / どちらが勝ったか評価して / 仮説を検証したい. Forces a designed experiment instead of an ad-hoc change, records the baseline in action_log, and forbids peeking-based decisions before the window closes."
 metadata:
   version: 0.10.30
 ---

--- a/skills/search-term-cleanup/SKILL.md
+++ b/skills/search-term-cleanup/SKILL.md
@@ -42,6 +42,8 @@ Review and clean up search terms and keywords across all platforms.
    - **Add candidates**: High-converting terms not yet added as keywords, terms matching USP themes
    - **Reduce candidates**: Terms well-covered by organic rankings
 
+   **Negative keywords are a marginal decision, not an average ranking.** Distinguish **systematic waste** — an n-gram or intent pattern that is wrong for the Persona at any volume, where a negative genuinely removes future spend — from a **low-volume term with a bad average**, where a handful of clicks and zero conversions is a sample-size fact, not evidence of waste. Excluding the long tail one term at a time mostly narrows match reach without saving meaningful spend. Prefer pattern-level negatives with a stated marginal saving; leave thin terms to accumulate. See `../_mureo-pro-diagnosis/SKILL.md` → *Allocation & Learning-State Discipline*.
+
 7. **Present recommendations** in a table:
    | Term | Platform | Action | Reason | Score | Campaign |
    |------|----------|--------|--------|-------|----------|


### PR DESCRIPTION
Documentation-only. Adds three cross-platform diagnostic principles (marginal efficiency over averages / respect learning states / no hand-optimization inside auto-allocated units) to the pro-diagnosis framework, with per-platform mechanics, existing-machinery cross-references, and recommendation phrasing examples; 1-3 line guards in six operational skills. Platform claims fact-checked in review (Meta learning phase, Google Learning status, Smart Bidding bid-adjustment behavior, PMax reporting semantics). Mirrors byte-identical; 385 skill/manifest tests passing.