### PR TITLE
feat(meta): end-to-end video creative support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Meta video creatives, end to end.** `meta_ads_creatives_create` now builds
+  a video creative as well as an image one: pass `video_id` plus exactly one of
+  `video_thumbnail_image_hash` / `video_thumbnail_image_url` and the tool emits
+  `object_story_spec.video_data` (thumbnail, `title`, `message`,
+  `link_description`, and the destination link nested under
+  `call_to_action.value.link`) instead of `link_data`. Video and image
+  parameters are mutually exclusive. Two parameters that are optional for an
+  image creative are enforced as hard requirements in video mode: a thumbnail
+  (Meta requires one) and `call_to_action` — `video_data` has no `link` field,
+  so the CTA is the only carrier of the destination and accepting a CTA-less
+  video would silently discard the required `link_url`. `link_url` is injected
+  into `call_to_action.value.link` automatically; callers pass only the button
+  label. Two read-only tools complete the flow:
+  **`meta_ads_videos_get`** returns the raw nested processing `status`
+  (`video_status` / `processing_phase`) so an agent can poll until the upload is
+  ready before creating a creative, and **`meta_ads_videos_thumbnails`** lists
+  the auto-generated thumbnails (`id`, `uri`, `is_preferred`, `height`,
+  `width`) to pick one from. Both are node-level Graph reads, not
+  `act_`-scoped. Meta tool count 86 -> 88 (205 total).
+
 - **Cross-platform allocation & learning-state diagnostic discipline.** The
   pro-diagnosis framework catalogue (`skills/_mureo-pro-diagnosis`) gains an
   *Allocation & Learning-State Discipline* section covering three principles
@@ -33,6 +53,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   fatigue), and `search-term-cleanup` (systematic waste vs low-volume terms with
   a bad average). `/experiment` now advertises breakdown-exclusion and
   reallocation hypotheses as things it validates.
+
+### Fixed
+
+- **Meta video file upload rebuilt on the shared client machinery.**
+  `meta_ads_videos_upload_file` used to open its own `httpx.AsyncClient` and
+  call a bare `raise_for_status()`, so Meta's error JSON (message /
+  `error_subcode` / `fbtrace_id`) was discarded and the caller only saw httpx's
+  generic `400 Bad Request`; retries, 429 handling and rate-limit monitoring
+  did not apply either. The upload now routes through `_post`/`_request` (which
+  regained optional `files=` multipart support), surfacing Meta's diagnostics
+  for free. The multipart part keeps its documented `source` field name and the
+  real filename but now declares the real container MIME per extension
+  (`video/mp4`, `video/quicktime`, `video/x-msvideo`, `video/x-ms-wmv`,
+  `video/x-matroska`) instead of `application/octet-stream`; the file bytes are
+  materialized so a retry re-sends the full body; auth moved from an
+  `access_token` form field to the Bearer header; and the per-request timeout
+  went from 120s to 600s.
+- **Meta video size cap raised from 100 MB to 1 GB**, matching Graph's
+  documented ceiling for the non-resumable upload. Both video upload tool
+  descriptions now state the truth — supported formats MP4 / MOV / AVI / WMV /
+  MKV, up to 1 GB via these tools, larger files needing resumable upload (not
+  yet supported) — replacing the inaccurate "MP4, MOV. Recommended max 4 GB".
+- **`.flv` no longer accepted by the video upload handler.** The MCP handler's
+  extension tuple allowed `.flv` while the client's allow-list did not, so an
+  `.flv` file passed the handler gate only to be rejected one layer deeper with
+  a different message. The client set is now the single source of truth.
+- **Meta Ads skill docs corrected** for the video tools: the `### videos`
+  section documented a `description` parameter that neither tool accepts, and
+  stated neither the real format list nor the size cap. The `creatives.create`
+  entry also understated its required parameters (`page_id` / `link_url`).
+- **Meta Ads skill Tool Summary table completed.** Five shipped tools were
+  missing from the numbered table — `meta_ads_pages_list`,
+  `meta_ads_pages_upload_photo`, `meta_ads_pixels_create`,
+  `meta_ads_targeting_search` and `meta_ads_targeting_categories` — so it
+  listed 81 of 86 tools. The table now covers all 88 and is renumbered
+  sequentially.
 
 ## [0.10.30] - 2026-07-27
 

--- a/README.md
+++ b/README.md
@@ -986,12 +986,14 @@ Add to `.cursor/mcp.json`:
 | `meta_ads_leads_get` | Get leads (per form) |
 | `meta_ads_leads_get_by_ad` | Get leads (per ad) |
 
-**Videos (2)**
+**Videos (4)**
 
 | Tool | Description |
 |------|-------------|
 | `meta_ads_videos_upload` | Upload a video from URL |
 | `meta_ads_videos_upload_file` | Upload a video from local file |
+| `meta_ads_videos_get` | Get video processing status / metadata |
+| `meta_ads_videos_thumbnails` | List auto-generated video thumbnails |
 
 **Split Tests (4)**
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -419,7 +419,7 @@ When loading Meta Ads credentials, `mureo/auth.py` checks the `token_obtained_at
 
 ## Command-Based Workflow System
 
-In addition to the 201 individual MCP tools, mureo provides **workflow commands** as Claude Code native slash skills (deployed to `~/.claude/skills/`). These commands are **platform-agnostic orchestration instructions** that guide the AI agent to discover platforms, select tools, and synthesize cross-platform insights — all driven by the strategy context in `STRATEGY.md`.
+In addition to the 205 individual MCP tools, mureo provides **workflow commands** as Claude Code native slash skills (deployed to `~/.claude/skills/`). These commands are **platform-agnostic orchestration instructions** that guide the AI agent to discover platforms, select tools, and synthesize cross-platform insights — all driven by the strategy context in `STRATEGY.md`.
 
 ### How It Works
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -1,6 +1,6 @@
 # MCP Server Guide
 
-mureo exposes 203 tools via the [Model Context Protocol](https://modelcontextprotocol.io/) (MCP): 182 advertising and SEO operation tools across Google Ads (86), Meta Ads (86), and Search Console (10), 2 rollback tools, 1 cross-platform anomaly-detection tool, 9 mureo-context tools (strategy / state / reports / outcome evaluation), 2 analytics-registry tools, 2 learning tools (`mureo_learning_insights_get` for the operator's local `/learn` history and `mureo_consult_advisor` for federated retrieval against external advisor MCP servers — see [`docs/insight-federation.md`](insight-federation.md)), and 5 Creative Studio tools (text-free key-visual generation + banner composition). Any MCP-compatible client can connect and call these tools over stdio. Re-check this count when MCP tools are added or removed (`test_list_tools_returns_all_tools` pins the exact number).
+mureo exposes 205 tools via the [Model Context Protocol](https://modelcontextprotocol.io/) (MCP): 184 advertising and SEO operation tools across Google Ads (86), Meta Ads (88), and Search Console (10), 2 rollback tools, 1 cross-platform anomaly-detection tool, 9 mureo-context tools (strategy / state / reports / outcome evaluation), 2 analytics-registry tools, 2 learning tools (`mureo_learning_insights_get` for the operator's local `/learn` history and `mureo_consult_advisor` for federated retrieval against external advisor MCP servers — see [`docs/insight-federation.md`](insight-federation.md)), and 5 Creative Studio tools (text-free key-visual generation + banner composition). Any MCP-compatible client can connect and call these tools over stdio. Re-check this count when MCP tools are added or removed (`test_list_tools_returns_all_tools` pins the exact number).
 
 ## Starting the Server
 
@@ -312,7 +312,7 @@ Or use `uv` to run it:
 | Tool | Description | Required Parameters |
 |------|-------------|-------------------|
 | `meta_ads_creatives_list` | List ad creatives | `account_id` |
-| `meta_ads_creatives_create` | Create a standard ad creative | `account_id`, `name` |
+| `meta_ads_creatives_create` | Create a standard ad creative (single image **or video**) | `account_id`, `name` |
 | `meta_ads_creatives_create_carousel` | Create a carousel creative (2-10 cards) | `account_id`, `page_id`, `cards`, `link` |
 | `meta_ads_creatives_create_collection` | Create a collection creative | `account_id`, `page_id`, `product_ids`, `link` |
 | `meta_ads_creatives_create_dynamic` | Create a dynamic product ad creative | `account_id`, `catalog_id` |
@@ -420,6 +420,8 @@ Or use `uv` to run it:
 |------|-------------|-------------------|
 | `meta_ads_videos_upload` | Upload a video from URL | `account_id`, `video_url` |
 | `meta_ads_videos_upload_file` | Upload a video from local file | `account_id`, `file_path` |
+| `meta_ads_videos_get` | Get video processing status / metadata (poll before creating a creative) | `account_id`, `video_id` |
+| `meta_ads_videos_thumbnails` | List auto-generated video thumbnails | `account_id`, `video_id` |
 
 #### Creatives (Carousel & Collection)
 

--- a/docs/native-vs-official.md
+++ b/docs/native-vs-official.md
@@ -19,7 +19,7 @@ The practical differences for Google and Meta:
 | Official MCP | `googleads/google-ads-mcp` (pipx, ADC) | hosted `https://mcp.facebook.com/ads` (OAuth) |
 | Official tool count | **3 — read-only** | **29 — read + write** |
 | Official can mutate? | No | Yes (direct to live account, no undo/draft/confirm) |
-| mureo native tool count | **86** | **82** |
+| mureo native tool count | **86** | **88** |
 | mureo native can mutate? | Yes | Yes |
 | Safety (rollback, action_log, strategy gating) | native only | native only |
 | BYOD / `mureo demo` (CSV, no live API) | native only | native only |
@@ -105,7 +105,7 @@ from mureo native.
   assets (copy, images, carousels, collections, dynamic ads); Instagram-specific
   actions.
 
-### mureo native — Meta Ads (86 tools)
+### mureo native — Meta Ads (88 tools)
 
 Covers the same operational class as the official MCP **plus** every documented
 gap above:
@@ -114,7 +114,7 @@ gap above:
 - **Page discovery** (`pages_list`)
 - Audiences + **lookalikes**
 - **Targeting discovery** — interest search + category catalogues (behaviors / demographics / etc.) that resolve Meta's internal targeting IDs
-- Creatives — single / carousel / collection / dynamic / lead — + image/video upload
+- Creatives — single image **or video** / carousel / collection / dynamic / lead — + image/video upload, **video processing-status polling and thumbnail selection**
 - Insights + breakdowns; analysis (performance / audience / placements / cost / compare / suggest creative)
 - Pixels (list / get / stats / events / **create**) and **Conversions API send** (purchase / lead)
 - Catalogs / products / feeds

--- a/mureo/_data/skills/_mureo-meta-ads/SKILL.md
+++ b/mureo/_data/skills/_mureo-meta-ads/SKILL.md
@@ -49,56 +49,63 @@ metadata:
 | 29 | `meta_ads_audiences_create` | Audience | Write | Create a custom audience |
 | 30 | `meta_ads_audiences_delete` | Audience | Write | Delete a custom audience |
 | 31 | `meta_ads_audiences_create_lookalike` | Audience | Write | Create a lookalike audience |
-| 32 | `meta_ads_pixels_list` | Pixel | Read | List pixels |
-| 33 | `meta_ads_pixels_get` | Pixel | Read | Get pixel details |
-| 34 | `meta_ads_pixels_stats` | Pixel | Read | Get pixel firing statistics |
-| 35 | `meta_ads_pixels_events` | Pixel | Read | List pixel events |
-| 36 | `meta_ads_conversions_send` | CAPI | Write | Send conversion events (generic) |
-| 37 | `meta_ads_conversions_send_purchase` | CAPI | Write | Send a purchase event |
-| 38 | `meta_ads_conversions_send_lead` | CAPI | Write | Send a lead event |
-| 39 | `meta_ads_creatives_list` | Creative | Read | List ad creatives |
-| 40 | `meta_ads_creatives_create` | Creative | Write | Create a standard ad creative |
-| 41 | `meta_ads_creatives_create_dynamic` | Creative | Write | Create a dynamic product ad creative |
-| 42 | `meta_ads_creatives_upload_image` | Creative | Write | Upload an image for use in creatives |
-| 43 | `meta_ads_creatives_create_carousel` | Creative | Write | Create a carousel creative (2-10 cards) |
-| 44 | `meta_ads_creatives_create_collection` | Creative | Write | Create a collection creative |
-| 45 | `meta_ads_images_upload_file` | Image | Write | Upload an image from local file |
-| 46 | `meta_ads_catalogs_list` | Catalog | Read | List product catalogs |
-| 47 | `meta_ads_catalogs_get` | Catalog | Read | Get catalog details |
-| 48 | `meta_ads_catalogs_create` | Catalog | Write | Create a product catalog |
-| 49 | `meta_ads_catalogs_delete` | Catalog | Write | Delete a product catalog |
-| 50 | `meta_ads_products_list` | Catalog | Read | List products in a catalog |
-| 51 | `meta_ads_products_get` | Catalog | Read | Get product details |
-| 52 | `meta_ads_products_add` | Catalog | Write | Add a product to a catalog |
-| 53 | `meta_ads_products_update` | Catalog | Write | Update a product |
-| 54 | `meta_ads_products_delete` | Catalog | Write | Delete a product |
-| 55 | `meta_ads_feeds_list` | Catalog | Read | List feeds for a catalog |
-| 56 | `meta_ads_feeds_create` | Catalog | Write | Create a feed (URL-based, scheduled import) |
-| 57 | `meta_ads_lead_forms_list` | Lead | Read | List lead forms (per page) |
-| 58 | `meta_ads_lead_forms_get` | Lead | Read | Get lead form details |
-| 59 | `meta_ads_lead_forms_create` | Lead | Write | Create a lead form |
-| 60 | `meta_ads_leads_get` | Lead | Read | Get lead data (per form) |
-| 61 | `meta_ads_leads_get_by_ad` | Lead | Read | Get lead data (per ad) |
-| 62 | `meta_ads_videos_upload` | Video | Write | Upload a video from URL |
-| 63 | `meta_ads_videos_upload_file` | Video | Write | Upload a video from local file |
-| 64 | `meta_ads_split_tests_list` | Split Test | Read | List split tests |
-| 65 | `meta_ads_split_tests_get` | Split Test | Read | Get split test details and results |
-| 66 | `meta_ads_split_tests_create` | Split Test | Write | Create a split test |
-| 67 | `meta_ads_split_tests_end` | Split Test | Write | End a split test |
-| 68 | `meta_ads_ad_rules_list` | Ad Rule | Read | List automated rules |
-| 69 | `meta_ads_ad_rules_get` | Ad Rule | Read | Get rule details |
-| 70 | `meta_ads_ad_rules_create` | Ad Rule | Write | Create an automated rule |
-| 71 | `meta_ads_ad_rules_update` | Ad Rule | Write | Update an automated rule |
-| 72 | `meta_ads_ad_rules_delete` | Ad Rule | Write | Delete an automated rule |
-| 73 | `meta_ads_page_posts_list` | Page Post | Read | List Facebook page posts |
-| 74 | `meta_ads_page_posts_boost` | Page Post | Write | Boost a page post (create ad from post) |
-| 75 | `meta_ads_instagram_accounts` | Instagram | Read | List connected Instagram accounts |
-| 76 | `meta_ads_instagram_media` | Instagram | Read | List Instagram posts |
-| 77 | `meta_ads_instagram_boost` | Instagram | Write | Boost an Instagram post |
-| 78 | `meta_ads_creatives_create_lead` | Lead / Creative | Write | Create a Lead Ad AdCreative attached to an Instant Form |
-| 79 | `meta_ads_lead_forms_update` | Lead | Write | Change a lead form status (ACTIVE / ARCHIVED) |
-| 80 | `meta_ads_lead_forms_duplicate` | Lead | Write | Duplicate a lead form under a Page with a new name |
-| 81 | `meta_ads_leads_export_csv` | Lead | Write (local) | Export form leads to a local CSV file |
+| 32 | `meta_ads_targeting_search` | Targeting | Read | Search targeting interests / behaviors by keyword |
+| 33 | `meta_ads_targeting_categories` | Targeting | Read | List targeting category catalogues (behaviors, demographics, etc.) |
+| 34 | `meta_ads_pixels_list` | Pixel | Read | List pixels |
+| 35 | `meta_ads_pixels_get` | Pixel | Read | Get pixel details |
+| 36 | `meta_ads_pixels_stats` | Pixel | Read | Get pixel firing statistics |
+| 37 | `meta_ads_pixels_events` | Pixel | Read | List pixel events |
+| 38 | `meta_ads_pixels_create` | Pixel | Write | Create a pixel |
+| 39 | `meta_ads_conversions_send` | CAPI | Write | Send conversion events (generic) |
+| 40 | `meta_ads_conversions_send_purchase` | CAPI | Write | Send a purchase event |
+| 41 | `meta_ads_conversions_send_lead` | CAPI | Write | Send a lead event |
+| 42 | `meta_ads_creatives_list` | Creative | Read | List ad creatives |
+| 43 | `meta_ads_creatives_create` | Creative | Write | Create a standard ad creative (single image or video) |
+| 44 | `meta_ads_creatives_create_dynamic` | Creative | Write | Create a dynamic product ad creative |
+| 45 | `meta_ads_creatives_upload_image` | Creative | Write | Upload an image for use in creatives |
+| 46 | `meta_ads_creatives_create_carousel` | Creative | Write | Create a carousel creative (2-10 cards) |
+| 47 | `meta_ads_creatives_create_collection` | Creative | Write | Create a collection creative |
+| 48 | `meta_ads_images_upload_file` | Image | Write | Upload an image from local file |
+| 49 | `meta_ads_catalogs_list` | Catalog | Read | List product catalogs |
+| 50 | `meta_ads_catalogs_get` | Catalog | Read | Get catalog details |
+| 51 | `meta_ads_catalogs_create` | Catalog | Write | Create a product catalog |
+| 52 | `meta_ads_catalogs_delete` | Catalog | Write | Delete a product catalog |
+| 53 | `meta_ads_products_list` | Catalog | Read | List products in a catalog |
+| 54 | `meta_ads_products_get` | Catalog | Read | Get product details |
+| 55 | `meta_ads_products_add` | Catalog | Write | Add a product to a catalog |
+| 56 | `meta_ads_products_update` | Catalog | Write | Update a product |
+| 57 | `meta_ads_products_delete` | Catalog | Write | Delete a product |
+| 58 | `meta_ads_feeds_list` | Catalog | Read | List feeds for a catalog |
+| 59 | `meta_ads_feeds_create` | Catalog | Write | Create a feed (URL-based, scheduled import) |
+| 60 | `meta_ads_lead_forms_list` | Lead | Read | List lead forms (per page) |
+| 61 | `meta_ads_lead_forms_get` | Lead | Read | Get lead form details |
+| 62 | `meta_ads_lead_forms_create` | Lead | Write | Create a lead form |
+| 63 | `meta_ads_leads_get` | Lead | Read | Get lead data (per form) |
+| 64 | `meta_ads_leads_get_by_ad` | Lead | Read | Get lead data (per ad) |
+| 65 | `meta_ads_videos_upload` | Video | Write | Upload a video from URL |
+| 66 | `meta_ads_videos_upload_file` | Video | Write | Upload a video from local file |
+| 67 | `meta_ads_split_tests_list` | Split Test | Read | List split tests |
+| 68 | `meta_ads_split_tests_get` | Split Test | Read | Get split test details and results |
+| 69 | `meta_ads_split_tests_create` | Split Test | Write | Create a split test |
+| 70 | `meta_ads_split_tests_end` | Split Test | Write | End a split test |
+| 71 | `meta_ads_ad_rules_list` | Ad Rule | Read | List automated rules |
+| 72 | `meta_ads_ad_rules_get` | Ad Rule | Read | Get rule details |
+| 73 | `meta_ads_ad_rules_create` | Ad Rule | Write | Create an automated rule |
+| 74 | `meta_ads_ad_rules_update` | Ad Rule | Write | Update an automated rule |
+| 75 | `meta_ads_ad_rules_delete` | Ad Rule | Write | Delete an automated rule |
+| 76 | `meta_ads_page_posts_list` | Page Post | Read | List Facebook page posts |
+| 77 | `meta_ads_page_posts_boost` | Page Post | Write | Boost a page post (create ad from post) |
+| 78 | `meta_ads_instagram_accounts` | Instagram | Read | List connected Instagram accounts |
+| 79 | `meta_ads_instagram_media` | Instagram | Read | List Instagram posts |
+| 80 | `meta_ads_instagram_boost` | Instagram | Write | Boost an Instagram post |
+| 81 | `meta_ads_pages_list` | Page | Read | List manageable Facebook Pages (personal + business-owned) |
+| 82 | `meta_ads_pages_upload_photo` | Page | Write | Upload a Page photo (returns a Page photo id) |
+| 83 | `meta_ads_creatives_create_lead` | Lead / Creative | Write | Create a Lead Ad AdCreative attached to an Instant Form |
+| 84 | `meta_ads_lead_forms_update` | Lead | Write | Change a lead form status (ACTIVE / ARCHIVED) |
+| 85 | `meta_ads_lead_forms_duplicate` | Lead | Write | Duplicate a lead form under a Page with a new name |
+| 86 | `meta_ads_leads_export_csv` | Lead | Write (local) | Export form leads to a local CSV file |
+| 87 | `meta_ads_videos_get` | Video | Read | Get video processing status / metadata |
+| 88 | `meta_ads_videos_thumbnails` | Video | Read | List auto-generated video thumbnails |
 
 ## Key Differences from Google Ads
 
@@ -380,11 +387,20 @@ counter. Pass an empty list to clear it and restore the default.
   Optional: limit (integer, default: 50)
   ```
 
-- `create` -- Create a standard ad creative. **Requires user confirmation.**
+- `create` -- Create a standard ad creative (single image OR video). **Requires user confirmation.**
   ```
-  Required: account_id, name
-  Optional: image_hash, link_url, message, page_id
+  Required: account_id, name, page_id, link_url
+  Image mode: image_hash OR image_url (exactly one)
+  Video mode: video_id + (video_thumbnail_image_hash OR video_thumbnail_image_url)
+              + call_to_action (required in this mode)
+  Optional: message, headline, description, call_to_action (image mode)
   ```
+  Video and image parameters are mutually exclusive. Meta requires a
+  thumbnail on every video creative, and the video must be fully
+  processed first (see the Video creative flow below). `call_to_action`
+  is mandatory in video mode: Meta's `video_data` has no `link` field, so
+  the destination rides inside `call_to_action.value.link`. `link_url` is
+  injected there automatically -- pass only the button label.
 
 - `create_dynamic` -- Create a dynamic product ad creative. **Requires user confirmation.**
   ```
@@ -553,17 +569,49 @@ counter. Pass an empty list to clear it and restore the default.
 
 ### videos
 
-- `upload` -- Upload a video from URL.
+Supported formats: MP4, MOV, AVI, WMV, MKV. Up to 1 GB per file through
+these tools; larger files need Meta's resumable (chunked) upload, which
+mureo does not implement yet.
+
+- `upload` -- Upload a video from URL. **Requires user confirmation.**
   ```
   Required: account_id, video_url
-  Optional: title, description
+  Optional: title
   ```
 
-- `upload_file` -- Upload a video from local file.
+- `upload_file` -- Upload a video from local file. **Requires user confirmation.**
   ```
   Required: account_id, file_path
-  Optional: title, description
+  Optional: title
   ```
+
+- `get` -- Get video processing status / metadata.
+  ```
+  Required: account_id, video_id
+  ```
+  Returns `status` (nested: `video_status`, `processing_phase`), `id`,
+  `title`, `length`, `created_time`. Poll until the video is ready --
+  a creative that references a still-processing video is rejected.
+
+- `thumbnails` -- List auto-generated video thumbnails.
+  ```
+  Required: account_id, video_id
+  ```
+  Returns `id`, `uri`, `is_preferred`, `height`, `width` per thumbnail.
+  Prefer the `is_preferred` entry and pass its `uri` as
+  `video_thumbnail_image_url` to `creatives_create`. An empty list
+  usually means the video is still processing.
+
+#### Video creative flow
+
+1. `videos_upload` / `videos_upload_file` -> `video_id`
+2. `videos_get` -> poll until `status.video_status` reports ready
+   (typically minutes; scales with file size and length)
+3. `videos_thumbnails` -> pick a `uri` (prefer `is_preferred: true`)
+4. `creatives_create` with `video_id` + `video_thumbnail_image_url`
+   (or `video_thumbnail_image_hash`) + `call_to_action` (required in
+   video mode -- it carries the destination link) -> `creative_id`
+5. `ads_create` with that `creative_id`
 
 ### split_tests
 

--- a/mureo/mcp/_handlers_meta_ads.py
+++ b/mureo/mcp/_handlers_meta_ads.py
@@ -865,13 +865,38 @@ async def handle_videos_upload_file(args: dict[str, Any]) -> list[TextContent]:
     file_path = _require(args, "file_path")
     if not os.path.isfile(file_path):
         raise ValueError(f"File not found: {file_path}")
-    _allowed_video_ext = (".mp4", ".mov", ".avi", ".wmv", ".flv", ".mkv")
+    # Mirrors mureo.meta_ads._creatives._META_ALLOWED_VIDEO_EXTENSIONS, which is
+    # the source of truth. ``.flv`` used to be listed here only, so an .flv file
+    # passed this gate and was then rejected one layer deeper.
+    _allowed_video_ext = (".mp4", ".mov", ".avi", ".wmv", ".mkv")
     if not file_path.lower().endswith(_allowed_video_ext):
         raise ValueError(
             f"Unsupported video format. Allowed: {', '.join(_allowed_video_ext)}"
         )
     title = _opt(args, "title")
     result = await client.upload_ad_video_file(file_path, title=title)
+    return _json_result(result)
+
+
+@api_error_handler
+async def handle_videos_get(args: dict[str, Any]) -> list[TextContent]:
+    """Get a video's processing status (poll before creating a creative)."""
+    client = await _get_client(args)
+    if client is None:
+        return _no_meta_creds()
+    video_id = _require(args, "video_id")
+    result = await client.get_ad_video(video_id)
+    return _json_result(result)
+
+
+@api_error_handler
+async def handle_videos_thumbnails(args: dict[str, Any]) -> list[TextContent]:
+    """List a video's auto-generated thumbnails."""
+    client = await _get_client(args)
+    if client is None:
+        return _no_meta_creds()
+    video_id = _require(args, "video_id")
+    result = await client.list_ad_video_thumbnails(video_id)
     return _json_result(result)
 
 

--- a/mureo/mcp/_handlers_meta_ads_extended.py
+++ b/mureo/mcp/_handlers_meta_ads_extended.py
@@ -201,6 +201,9 @@ async def handle_creatives_create(args: dict[str, Any]) -> list[TextContent]:
     for key in (
         "image_url",
         "image_hash",
+        "video_id",
+        "video_thumbnail_image_hash",
+        "video_thumbnail_image_url",
         "message",
         "headline",
         "description",

--- a/mureo/mcp/_tools_meta_ads_creatives.py
+++ b/mureo/mcp/_tools_meta_ads_creatives.py
@@ -74,15 +74,25 @@ TOOLS: list[Tool] = [
     Tool(
         name="meta_ads_creatives_create",
         description=(
-            "Creates a single-image Meta Ads AdCreative. Returns the new "
-            "creative's id and object_story_id. Mutating — not "
+            "Creates a single image or video Meta Ads AdCreative. Returns "
+            "the new creative's id and object_story_id. Mutating — not "
             "automatically reversible; record before-state with "
             "mureo_state_action_log_append if you may need to roll back. "
-            "Supply "
+            "Image mode: supply "
             "exactly one of image_url or image_hash — image_url triggers "
             "Meta to fetch and host the image; image_hash references an "
             "image already uploaded via meta_ads_creatives_upload_image or "
-            "meta_ads_images_upload_file. For multi-image carousels use "
+            "meta_ads_images_upload_file. Video mode: supply video_id plus "
+            "exactly one of video_thumbnail_image_hash / "
+            "video_thumbnail_image_url — Meta requires a thumbnail on every "
+            "video creative. The video must already be fully processed: "
+            "poll meta_ads_videos_get until status.video_status reports "
+            "ready (typically a few minutes after upload), and pick a "
+            "thumbnail via meta_ads_videos_thumbnails. Video and image "
+            "parameters are mutually exclusive. Video mode also REQUIRES "
+            "call_to_action: Meta's video_data has no link field, so the "
+            "destination is carried inside the CTA and a video creative "
+            "without one is rejected. For multi-image carousels use "
             "meta_ads_creatives_create_carousel; for dynamic / automatic "
             "optimization use meta_ads_creatives_create_dynamic."
         ),
@@ -123,26 +133,66 @@ TOOLS: list[Tool] = [
                         "with image_url."
                     ),
                 },
+                "video_id": {
+                    "type": "string",
+                    "description": (
+                        "Pre-uploaded video ID from "
+                        "meta_ads_videos_upload / "
+                        "meta_ads_videos_upload_file. Switches the "
+                        "creative to video mode "
+                        "(object_story_spec.video_data). The video must be "
+                        "fully processed first — poll meta_ads_videos_get. "
+                        "Mutually exclusive with image_url / image_hash. "
+                        "Setting it makes two otherwise-optional "
+                        "parameters mandatory: one of the "
+                        "video_thumbnail_image_* parameters, and "
+                        "call_to_action."
+                    ),
+                },
+                "video_thumbnail_image_hash": {
+                    "type": "string",
+                    "description": (
+                        "Thumbnail image hash for the video creative, from "
+                        "meta_ads_creatives_upload_image / "
+                        "meta_ads_images_upload_file. Requires video_id; "
+                        "mutually exclusive with "
+                        "video_thumbnail_image_url."
+                    ),
+                },
+                "video_thumbnail_image_url": {
+                    "type": "string",
+                    "description": (
+                        "Thumbnail image URL for the video creative — "
+                        "typically a uri from meta_ads_videos_thumbnails "
+                        "(prefer the entry flagged is_preferred). Requires "
+                        "video_id; mutually exclusive with "
+                        "video_thumbnail_image_hash."
+                    ),
+                },
                 "message": {
                     "type": "string",
                     "description": (
-                        "Primary ad body text shown above the image. "
-                        "Plain text, emoji allowed. Meta recommends ≤125 "
-                        "characters to avoid truncation on mobile."
+                        "Primary ad body text shown above the image or "
+                        "video. Plain text, emoji allowed. Meta recommends "
+                        "≤125 characters to avoid truncation on mobile."
                     ),
                 },
                 "headline": {
                     "type": "string",
                     "description": (
-                        "Headline shown below the image. ~40 characters "
-                        "fits most placements without truncation."
+                        "Headline shown below the media. ~40 characters "
+                        "fits most placements without truncation. Maps to "
+                        "link_data.name in image mode and video_data.title "
+                        "in video mode."
                     ),
                 },
                 "description": {
                     "type": "string",
                     "description": (
                         "Description / link-caption text shown below the "
-                        "headline. Optional; not all placements render it."
+                        "headline. Optional; not all placements render it. "
+                        "Maps to link_data.description in image mode and "
+                        "video_data.link_description in video mode."
                     ),
                 },
                 "call_to_action": {
@@ -158,7 +208,14 @@ TOOLS: list[Tool] = [
                         "BOOK_TRAVEL",
                         "APPLY_NOW",
                     ],
-                    "description": _CTA_DESCRIPTION,
+                    "description": (
+                        _CTA_DESCRIPTION + " REQUIRED when video_id is set: "
+                        "the destination link is carried inside this button "
+                        "(video_data.call_to_action.value.link) because "
+                        "Meta's video_data has no link field of its own. "
+                        "link_url is filled in there automatically — pass "
+                        "only the button label."
+                    ),
                 },
             },
             "required": ["name", "page_id", "link_url"],
@@ -603,10 +660,13 @@ TOOLS: list[Tool] = [
             "Uploads a video to the Meta Ads account by fetching it from "
             "a public HTTPS URL. Returns the video_id to reference in "
             "creative-construction tools. Mutating — the asset is "
-            "persisted. Meta performs asynchronous processing after "
-            "upload; newly-uploaded videos may take a few minutes before "
-            "they can be attached to ads. For uploads from local files "
-            "use meta_ads_videos_upload_file."
+            "persisted. Meta fetches the URL itself and then processes "
+            "the video asynchronously: poll meta_ads_videos_get until "
+            "status.video_status reports ready (typically a few minutes) "
+            "before attaching it to a creative. Supported formats: MP4, "
+            "MOV, AVI, WMV, MKV, up to 1 GB via this tool; larger files "
+            "need resumable upload (not yet supported). For uploads from "
+            "local files use meta_ads_videos_upload_file."
         ),
         inputSchema={
             "type": "object",
@@ -617,7 +677,8 @@ TOOLS: list[Tool] = [
                     "description": (
                         "Public HTTPS URL of the video. Meta fetches it "
                         "once at upload time. Supported formats: MP4, "
-                        "MOV. Recommended max 4 GB."
+                        "MOV, AVI, WMV, MKV, up to 1 GB; larger files "
+                        "need resumable upload (not yet supported)."
                     ),
                 },
                 "title": {
@@ -638,9 +699,12 @@ TOOLS: list[Tool] = [
             "Uploads a video from a local file path to the Meta Ads "
             "account library. Returns the video_id to reference in "
             "creative-construction tools. Mutating. Meta processes the "
-            "video asynchronously after upload — allow a few minutes "
-            "before attaching the video to ads. For uploads from public "
-            "URLs use meta_ads_videos_upload."
+            "video asynchronously after upload — poll meta_ads_videos_get "
+            "until status.video_status reports ready (typically a few "
+            "minutes) before attaching it to a creative. Supported "
+            "formats: MP4, MOV, AVI, WMV, MKV, up to 1 GB via this tool; "
+            "larger files need resumable upload (not yet supported). For "
+            "uploads from public URLs use meta_ads_videos_upload."
         ),
         inputSchema={
             "type": "object",
@@ -650,7 +714,9 @@ TOOLS: list[Tool] = [
                     "type": "string",
                     "description": (
                         "Path to the video file on the agent's filesystem. "
-                        "Supported formats: MP4, MOV. Recommended max 4 GB."
+                        "Supported formats: MP4, MOV, AVI, WMV, MKV, up "
+                        "to 1 GB; larger files need resumable upload (not "
+                        "yet supported)."
                     ),
                 },
                 "title": {
@@ -662,6 +728,67 @@ TOOLS: list[Tool] = [
                 },
             },
             "required": ["file_path"],
+            "additionalProperties": False,
+        },
+    ),
+    # === Video read (processing status / thumbnails) ===
+    Tool(
+        name="meta_ads_videos_get",
+        description=(
+            "Gets an uploaded video's processing status and metadata "
+            "(status, id, title, length, created_time). Read-only — does "
+            "not modify the account. Meta processes uploads "
+            "asynchronously and rejects creatives that reference a video "
+            "still in progress, so poll this tool until the nested "
+            "status object reports the video is ready "
+            "(status.video_status, with per-stage detail in "
+            "status.processing_phase) before calling "
+            "meta_ads_creatives_create with video_id. Typical processing "
+            "takes minutes, scaling with file size and length. Once "
+            "ready, pick a thumbnail via meta_ads_videos_thumbnails."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "video_id": {
+                    "type": "string",
+                    "description": (
+                        "Video ID returned by meta_ads_videos_upload / "
+                        "meta_ads_videos_upload_file."
+                    ),
+                },
+            },
+            "required": ["video_id"],
+            "additionalProperties": False,
+        },
+    ),
+    Tool(
+        name="meta_ads_videos_thumbnails",
+        description=(
+            "Lists the thumbnails Meta auto-generated for an uploaded "
+            "video. Returns id, uri, is_preferred, height, and width per "
+            "thumbnail. Read-only — does not modify the account. Pick one "
+            "(prefer the entry with is_preferred true) and pass its uri "
+            "as video_thumbnail_image_url to "
+            "meta_ads_creatives_create. Thumbnails only exist once "
+            "processing has finished, so check meta_ads_videos_get "
+            "first — an empty list usually means the video is still "
+            "processing."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "account_id": _ACCOUNT_ID_PARAM,
+                "video_id": {
+                    "type": "string",
+                    "description": (
+                        "Video ID returned by meta_ads_videos_upload / "
+                        "meta_ads_videos_upload_file."
+                    ),
+                },
+            },
+            "required": ["video_id"],
             "additionalProperties": False,
         },
     ),

--- a/mureo/mcp/tools_meta_ads.py
+++ b/mureo/mcp/tools_meta_ads.py
@@ -64,6 +64,8 @@ from mureo.mcp._handlers_meta_ads import (
     handle_products_get,
     handle_products_list,
     handle_products_update,
+    handle_videos_get,
+    handle_videos_thumbnails,
     handle_videos_upload,
     handle_videos_upload_file,
 )
@@ -236,6 +238,8 @@ _HANDLERS: dict[str, Any] = {
     # Videos
     "meta_ads_videos_upload": handle_videos_upload,
     "meta_ads_videos_upload_file": handle_videos_upload_file,
+    "meta_ads_videos_get": handle_videos_get,
+    "meta_ads_videos_thumbnails": handle_videos_thumbnails,
     # Creatives
     "meta_ads_creatives_list": handle_creatives_list,
     "meta_ads_creatives_create": handle_creatives_create,

--- a/mureo/meta_ads/_creatives.py
+++ b/mureo/meta_ads/_creatives.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import base64
 import json
 import logging
-from typing import Any
+from typing import Any, cast
 
 import httpx
 
@@ -29,9 +29,34 @@ _META_UPLOAD_TIMEOUT_SECONDS = 60.0
 # before it is followed; see upload_ad_image).
 _MAX_IMAGE_REDIRECTS = 5
 
-# Meta Ads video upload limits
-_META_MAX_VIDEO_SIZE_BYTES = 100 * 1024 * 1024  # 100MB (practical limit)
+# Meta Ads video upload limits. 1GB is Graph's documented ceiling for the
+# non-resumable (single-request) /advideos upload; larger files require the
+# chunked resumable upload protocol, which mureo does not implement yet.
+_META_MAX_VIDEO_SIZE_BYTES = 1024 * 1024 * 1024  # 1GB
+_META_MAX_VIDEO_SIZE_LABEL = "1GB"
 _META_ALLOWED_VIDEO_EXTENSIONS = frozenset({"mp4", "mov", "avi", "wmv", "mkv"})
+
+# Real container MIME per allowed extension. Meta inspects the multipart part
+# header, so a generic ``application/octet-stream`` risks the same
+# ``FileTypeNotSupported`` rejection the /adimages multipart attempt hit.
+_META_VIDEO_MIME_TYPES: dict[str, str] = {
+    "mp4": "video/mp4",
+    "mov": "video/quicktime",
+    "avi": "video/x-msvideo",
+    "wmv": "video/x-ms-wmv",
+    "mkv": "video/x-matroska",
+}
+
+# Per-request timeout for video uploads. A file may be up to 1GB, so this
+# overrides the shared client's 30s default by a wide margin.
+_META_VIDEO_UPLOAD_TIMEOUT_SECONDS = 600.0
+
+# AdVideo retrieval fields. ``status`` is a nested object carrying
+# ``video_status`` ("processing" / "ready" / "error") and ``processing_phase``.
+_VIDEO_FIELDS = "status,id,title,length,created_time"
+
+# AdVideo thumbnail fields.
+_VIDEO_THUMBNAIL_FIELDS = "id,uri,is_preferred,height,width"
 
 # Carousel card count limits
 _CAROUSEL_MIN_CARDS = 2
@@ -42,6 +67,108 @@ _CREATIVE_FIELDS = (
     "id,name,status,title,body,image_url,image_hash,"
     "thumbnail_url,object_story_spec,url_tags"
 )
+
+
+def _validate_video_creative_mode(
+    *,
+    video_id: str | None,
+    image_url: str | None,
+    image_hash: str | None,
+    thumbnail_image_hash: str | None,
+    thumbnail_image_url: str | None,
+    call_to_action: str | None,
+) -> None:
+    """Reject ambiguous or incomplete image/video parameter combinations.
+
+    Runs before any network call so a mis-specified creative never reaches
+    Meta -- and never triggers the image auto-upload, which would persist an
+    asset for a request that cannot succeed.
+
+    Raises:
+        ValueError: Both thumbnail forms supplied; a thumbnail without
+            ``video_id``; ``video_id`` combined with image parameters; a
+            video without a thumbnail (Meta requires one); or a video
+            without ``call_to_action`` (the only carrier of the link).
+    """
+    if thumbnail_image_hash and thumbnail_image_url:
+        raise ValueError(
+            "video_thumbnail_image_hash and video_thumbnail_image_url "
+            "are mutually exclusive — supply exactly one"
+        )
+    if (thumbnail_image_hash or thumbnail_image_url) and not video_id:
+        raise ValueError(
+            "video_thumbnail_image_hash / video_thumbnail_image_url "
+            "require video_id — they are only used for video creatives"
+        )
+    if not video_id:
+        return
+
+    conflicting = [
+        key
+        for key, value in (("image_url", image_url), ("image_hash", image_hash))
+        if value
+    ]
+    if conflicting:
+        raise ValueError(
+            f"video_id cannot be combined with {', '.join(conflicting)} — "
+            f"a creative is either a video or an image. Use "
+            f"video_thumbnail_image_hash / video_thumbnail_image_url for "
+            f"the video thumbnail."
+        )
+    if not (thumbnail_image_hash or thumbnail_image_url):
+        raise ValueError(
+            "video creatives require a thumbnail — supply "
+            "video_thumbnail_image_hash or video_thumbnail_image_url "
+            "(list candidates via list_ad_video_thumbnails)"
+        )
+    if not call_to_action:
+        raise ValueError(
+            "video creatives require call_to_action — video_data carries "
+            "the destination link only inside call_to_action.value.link, "
+            "so without it the required link_url would be silently "
+            "discarded and the video would render with no clickable "
+            "destination"
+        )
+
+
+def _build_video_data(
+    *,
+    video_id: str,
+    link_url: str,
+    thumbnail_image_hash: str | None,
+    thumbnail_image_url: str | None,
+    message: str | None,
+    headline: str | None,
+    description: str | None,
+    call_to_action: str,
+) -> dict[str, Any]:
+    """Build ``object_story_spec.video_data`` for a video creative.
+
+    Follows the same idiom as the Lead Ad video branch
+    (:meth:`CreativesMixin.create_lead_ad_creative`) minus the lead-form
+    specifics: the destination link rides inside
+    ``call_to_action.value.link``, which is the only slot Meta's
+    ``video_data`` offers for it. ``link_url`` is injected there
+    automatically -- the caller passes only the CTA type, exactly as on the
+    image path. ``call_to_action`` is mandatory here; the caller is expected
+    to have run :func:`_validate_video_creative_mode` first.
+    """
+    video_data: dict[str, Any] = {"video_id": video_id}
+    if thumbnail_image_hash:
+        video_data["image_hash"] = thumbnail_image_hash
+    else:
+        video_data["image_url"] = thumbnail_image_url
+    if headline:
+        video_data["title"] = headline
+    if message:
+        video_data["message"] = message
+    if description:
+        video_data["link_description"] = description
+    video_data["call_to_action"] = {
+        "type": call_to_action,
+        "value": {"link": link_url},
+    }
+    return video_data
 
 
 class CreativesMixin:
@@ -63,6 +190,7 @@ class CreativesMixin:
         path: str,
         data: dict[str, Any] | None = None,
         timeout: float | None = None,
+        files: dict[str, Any] | None = None,
     ) -> dict[str, Any]: ...
 
     async def list_ad_creatives(
@@ -90,27 +218,103 @@ class CreativesMixin:
         *,
         image_url: str | None = None,
         image_hash: str | None = None,
+        video_id: str | None = None,
+        video_thumbnail_image_hash: str | None = None,
+        video_thumbnail_image_url: str | None = None,
         message: str | None = None,
         headline: str | None = None,
         description: str | None = None,
         call_to_action: str | None = None,
     ) -> dict[str, Any]:
-        """Create an AdCreative (specify image_url or image_hash)
+        """Create a single-image or single-video AdCreative.
+
+        Image mode (default): builds ``object_story_spec.link_data``.
+
+        Video mode (``video_id`` supplied): builds
+        ``object_story_spec.video_data``. Two parameters that are
+        optional in image mode become **mandatory** here:
+
+        * a thumbnail — exactly one of ``video_thumbnail_image_hash`` /
+          ``video_thumbnail_image_url``, because Meta requires one on
+          every video creative;
+        * ``call_to_action`` — ``video_data`` has no ``link`` field, so
+          the destination travels inside
+          ``call_to_action.value.link`` and there is nowhere else to put
+          it. ``link_url`` is injected there automatically; the caller
+          passes only the CTA type, exactly as on the image path.
 
         Args:
             name: Creative name
             page_id: Facebook page ID
             link_url: Destination link URL
-            image_url: Image URL (mutually exclusive with image_hash)
-            image_hash: Uploaded image hash (mutually exclusive with image_url)
+            image_url: Image URL (mutually exclusive with image_hash).
+                Image mode only — auto-uploaded to an image_hash.
+            image_hash: Uploaded image hash (mutually exclusive with
+                image_url). Image mode only.
+            video_id: Pre-uploaded, fully processed video ID from
+                ``upload_ad_video`` / ``upload_ad_video_file``. Poll
+                ``get_ad_video`` until ``status.video_status`` is ready
+                before creating the creative. Mutually exclusive with
+                ``image_url`` / ``image_hash``.
+            video_thumbnail_image_hash: Thumbnail image hash for video
+                mode (from ``upload_ad_image`` / ``upload_ad_image_file``).
+                Mutually exclusive with ``video_thumbnail_image_url``.
+            video_thumbnail_image_url: Thumbnail image URL for video mode
+                — e.g. a ``uri`` from ``list_ad_video_thumbnails``.
+                Mutually exclusive with ``video_thumbnail_image_hash``.
             message: Ad body text
-            headline: Headline
-            description: Description text
-            call_to_action: CTA button type (LEARN_MORE, SIGN_UP, etc.)
+            headline: Headline. Mapped to ``link_data.name`` in image
+                mode and ``video_data.title`` in video mode.
+            description: Description text. Mapped to
+                ``link_data.description`` in image mode and
+                ``video_data.link_description`` in video mode.
+            call_to_action: CTA button type (LEARN_MORE, SIGN_UP, etc.).
+                Optional in image mode; **required** in video mode,
+                where it also carries the destination link.
 
         Returns:
             Created AdCreative information.
+
+        Raises:
+            ValueError: ``video_id`` combined with image parameters; a
+                video without a thumbnail; a video without
+                ``call_to_action``; both thumbnail forms supplied; or a
+                thumbnail supplied without ``video_id``.
         """
+        _validate_video_creative_mode(
+            video_id=video_id,
+            image_url=image_url,
+            image_hash=image_hash,
+            thumbnail_image_hash=video_thumbnail_image_hash,
+            thumbnail_image_url=video_thumbnail_image_url,
+            call_to_action=call_to_action,
+        )
+
+        if video_id:
+            video_data = _build_video_data(
+                video_id=video_id,
+                link_url=link_url,
+                thumbnail_image_hash=video_thumbnail_image_hash,
+                thumbnail_image_url=video_thumbnail_image_url,
+                message=message,
+                headline=headline,
+                description=description,
+                # cast: the validator above rejects a video creative
+                # without a CTA, so it is a str on this path.
+                call_to_action=cast("str", call_to_action),
+            )
+            video_story_spec = {
+                "page_id": page_id,
+                "video_data": video_data,
+            }
+            video_creative_data: dict[str, Any] = {
+                "name": name,
+                "object_story_spec": json.dumps(video_story_spec),
+            }
+            return await self._post(
+                f"/{self._ad_account_id}/adcreatives", video_creative_data
+            )
+
         link_data: dict[str, Any] = {
             "link": link_url,
         }
@@ -518,7 +722,17 @@ class CreativesMixin:
     async def upload_ad_video_file(
         self, file_path: str, title: str | None = None
     ) -> dict[str, Any]:
-        """Upload a video from a local file
+        """Upload a video from a local file (multipart /advideos).
+
+        Routes through the shared ``_post``/``_request`` machinery instead of a
+        one-off ``httpx.AsyncClient``, so Meta's error JSON (message /
+        error_subcode / fbtrace_id), retries, 429 handling and rate-limit
+        monitoring all apply, and auth rides the Bearer header rather than an
+        ``access_token`` form field.
+
+        Files up to 1GB are accepted -- Graph's documented ceiling for this
+        non-resumable single-request form. Larger files need the chunked
+        resumable upload protocol, which is not implemented.
 
         Args:
             file_path: Local video file path
@@ -530,26 +744,83 @@ class CreativesMixin:
         Raises:
             FileNotFoundError: If the file does not exist.
             ValueError: Validation error
+            RuntimeError: If the API request fails.
         """
         path = validate_video_file(
             file_path,
             max_size_bytes=_META_MAX_VIDEO_SIZE_BYTES,
-            max_size_label="100MB",
+            max_size_label=_META_MAX_VIDEO_SIZE_LABEL,
             allowed_extensions=_META_ALLOWED_VIDEO_EXTENSIONS,
         )
 
-        url = f"{self.BASE_URL}/{self._ad_account_id}/advideos"
-        upload_data: dict[str, str] = {"access_token": self._access_token}
+        extension = path.suffix.lower().lstrip(".")
+        # validate_video_file already restricted the extension to the allowed
+        # set, which is exactly the MIME map's key set.
+        mime_type = _META_VIDEO_MIME_TYPES[extension]
+
+        # Read the whole file up front rather than handing httpx an open
+        # handle: ``_request`` re-sends the same ``files`` mapping on a 429 /
+        # transport retry, and a consumed handle would make the retry POST an
+        # empty body.
+        with open(path, "rb") as f:
+            video_bytes = f.read()
+
+        # ``source`` is the documented field name for the non-resumable
+        # /advideos upload; the real filename and container MIME travel with it
+        # so Meta can identify the format.
+        files = {"source": (path.name, video_bytes, mime_type)}
+
+        data: dict[str, Any] = {}
         if title:
-            upload_data["title"] = title
+            data["title"] = title
 
-        async with httpx.AsyncClient(timeout=120.0) as client:
-            with open(path, "rb") as f:
-                files = {"source": (path.name, f, "application/octet-stream")}
-                response = await client.post(url, files=files, data=upload_data)
+        return await self._post(
+            f"/{self._ad_account_id}/advideos",
+            data,
+            timeout=_META_VIDEO_UPLOAD_TIMEOUT_SECONDS,
+            files=files,
+        )
 
-        response.raise_for_status()
-        return response.json()  # type: ignore[no-any-return]
+    # ------------------------------------------------------------------
+    # Video read operations (node-level paths -- NOT act_-scoped)
+    # ------------------------------------------------------------------
+
+    async def get_ad_video(self, video_id: str) -> dict[str, Any]:
+        """Get an uploaded video's processing status and metadata.
+
+        Meta processes uploads asynchronously; a creative referencing a video
+        that is still processing is rejected. Poll this until
+        ``status.video_status`` reports the video is ready.
+
+        Args:
+            video_id: Video ID from ``upload_ad_video`` /
+                ``upload_ad_video_file``.
+
+        Returns:
+            ``{"id", "status", "title", "length", "created_time"}``. ``status``
+            is returned raw -- it is a nested object carrying ``video_status``
+            and ``processing_phase``, and Meta has extended its shape over
+            time, so it is passed through rather than flattened.
+        """
+        return await self._get(f"/{video_id}", {"fields": _VIDEO_FIELDS})
+
+    async def list_ad_video_thumbnails(self, video_id: str) -> list[dict[str, Any]]:
+        """List the auto-generated thumbnails for an uploaded video.
+
+        Args:
+            video_id: Video ID from ``upload_ad_video`` /
+                ``upload_ad_video_file``.
+
+        Returns:
+            List of ``{"id", "uri", "is_preferred", "height", "width"}``.
+            Meta flags one entry with ``is_preferred: true``; its ``uri`` is
+            the natural input for ``create_ad_creative``'s
+            ``video_thumbnail_image_url``.
+        """
+        result = await self._get(
+            f"/{video_id}/thumbnails", {"fields": _VIDEO_THUMBNAIL_FIELDS}
+        )
+        return result.get("data", [])  # type: ignore[no-any-return]
 
     # ------------------------------------------------------------------
     # Carousel creative

--- a/mureo/meta_ads/client.py
+++ b/mureo/meta_ads/client.py
@@ -113,6 +113,7 @@ class MetaAdsApiClient(
         path: str,
         data: dict[str, Any] | None = None,
         timeout: float | None = None,
+        files: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """POST request (with rate limit handling).
 
@@ -122,6 +123,9 @@ class MetaAdsApiClient(
             timeout: Optional per-request timeout in seconds. ``None`` uses the
                 shared client default; a value overrides it for this call (e.g.
                 large image uploads need a longer window than the default).
+            files: Optional httpx ``files`` mapping. Supplying it turns the
+                request into a multipart upload, with ``data`` carried as the
+                accompanying form fields (see ``upload_ad_video_file``).
 
         Returns:
             API response JSON
@@ -129,7 +133,9 @@ class MetaAdsApiClient(
         Raises:
             RuntimeError: If the API request fails
         """
-        return await self._request("POST", path, data=data, timeout=timeout)
+        return await self._request(
+            "POST", path, data=data, timeout=timeout, files=files
+        )
 
     async def _delete(self, path: str) -> dict[str, Any]:
         """DELETE request (with rate limit handling)."""
@@ -142,6 +148,7 @@ class MetaAdsApiClient(
         params: dict[str, Any] | None = None,
         data: dict[str, Any] | None = None,
         timeout: float | None = None,
+        files: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Execute an HTTP request (with rate limit handling and exponential backoff retry).
 
@@ -153,6 +160,12 @@ class MetaAdsApiClient(
             timeout: Optional per-request timeout in seconds. ``None`` uses the
                 shared client's default; a value overrides it for this call
                 (httpx per-request timeout override semantics).
+            files: Optional httpx ``files`` mapping (POST only). Passed
+                straight through so the request is encoded as multipart with
+                ``data`` as the accompanying form fields. Parts must carry
+                materialized ``bytes`` rather than an open file object — the
+                same mapping is re-sent on every retry attempt below, and a
+                consumed file handle would make the retry send an empty body.
 
         Returns:
             API response JSON
@@ -176,6 +189,12 @@ class MetaAdsApiClient(
         if timeout is not None:
             extra["timeout"] = timeout
 
+        # Same rule for ``files``: httpx encodes multipart only when the kwarg
+        # is actually supplied, so non-multipart callers must not receive it.
+        post_extra: dict[str, Any] = dict(extra)
+        if files is not None:
+            post_extra["files"] = files
+
         last_error: Exception | None = None
         for attempt in range(_MAX_RETRIES):
             try:
@@ -185,7 +204,7 @@ class MetaAdsApiClient(
                     )
                 elif method == "POST":
                     resp = await self._http.post(
-                        url, params=params, data=data, headers=headers, **extra
+                        url, params=params, data=data, headers=headers, **post_extra
                     )
                 elif method == "DELETE":
                     resp = await self._http.delete(

--- a/skills/_mureo-meta-ads/SKILL.md
+++ b/skills/_mureo-meta-ads/SKILL.md
@@ -49,56 +49,63 @@ metadata:
 | 29 | `meta_ads_audiences_create` | Audience | Write | Create a custom audience |
 | 30 | `meta_ads_audiences_delete` | Audience | Write | Delete a custom audience |
 | 31 | `meta_ads_audiences_create_lookalike` | Audience | Write | Create a lookalike audience |
-| 32 | `meta_ads_pixels_list` | Pixel | Read | List pixels |
-| 33 | `meta_ads_pixels_get` | Pixel | Read | Get pixel details |
-| 34 | `meta_ads_pixels_stats` | Pixel | Read | Get pixel firing statistics |
-| 35 | `meta_ads_pixels_events` | Pixel | Read | List pixel events |
-| 36 | `meta_ads_conversions_send` | CAPI | Write | Send conversion events (generic) |
-| 37 | `meta_ads_conversions_send_purchase` | CAPI | Write | Send a purchase event |
-| 38 | `meta_ads_conversions_send_lead` | CAPI | Write | Send a lead event |
-| 39 | `meta_ads_creatives_list` | Creative | Read | List ad creatives |
-| 40 | `meta_ads_creatives_create` | Creative | Write | Create a standard ad creative |
-| 41 | `meta_ads_creatives_create_dynamic` | Creative | Write | Create a dynamic product ad creative |
-| 42 | `meta_ads_creatives_upload_image` | Creative | Write | Upload an image for use in creatives |
-| 43 | `meta_ads_creatives_create_carousel` | Creative | Write | Create a carousel creative (2-10 cards) |
-| 44 | `meta_ads_creatives_create_collection` | Creative | Write | Create a collection creative |
-| 45 | `meta_ads_images_upload_file` | Image | Write | Upload an image from local file |
-| 46 | `meta_ads_catalogs_list` | Catalog | Read | List product catalogs |
-| 47 | `meta_ads_catalogs_get` | Catalog | Read | Get catalog details |
-| 48 | `meta_ads_catalogs_create` | Catalog | Write | Create a product catalog |
-| 49 | `meta_ads_catalogs_delete` | Catalog | Write | Delete a product catalog |
-| 50 | `meta_ads_products_list` | Catalog | Read | List products in a catalog |
-| 51 | `meta_ads_products_get` | Catalog | Read | Get product details |
-| 52 | `meta_ads_products_add` | Catalog | Write | Add a product to a catalog |
-| 53 | `meta_ads_products_update` | Catalog | Write | Update a product |
-| 54 | `meta_ads_products_delete` | Catalog | Write | Delete a product |
-| 55 | `meta_ads_feeds_list` | Catalog | Read | List feeds for a catalog |
-| 56 | `meta_ads_feeds_create` | Catalog | Write | Create a feed (URL-based, scheduled import) |
-| 57 | `meta_ads_lead_forms_list` | Lead | Read | List lead forms (per page) |
-| 58 | `meta_ads_lead_forms_get` | Lead | Read | Get lead form details |
-| 59 | `meta_ads_lead_forms_create` | Lead | Write | Create a lead form |
-| 60 | `meta_ads_leads_get` | Lead | Read | Get lead data (per form) |
-| 61 | `meta_ads_leads_get_by_ad` | Lead | Read | Get lead data (per ad) |
-| 62 | `meta_ads_videos_upload` | Video | Write | Upload a video from URL |
-| 63 | `meta_ads_videos_upload_file` | Video | Write | Upload a video from local file |
-| 64 | `meta_ads_split_tests_list` | Split Test | Read | List split tests |
-| 65 | `meta_ads_split_tests_get` | Split Test | Read | Get split test details and results |
-| 66 | `meta_ads_split_tests_create` | Split Test | Write | Create a split test |
-| 67 | `meta_ads_split_tests_end` | Split Test | Write | End a split test |
-| 68 | `meta_ads_ad_rules_list` | Ad Rule | Read | List automated rules |
-| 69 | `meta_ads_ad_rules_get` | Ad Rule | Read | Get rule details |
-| 70 | `meta_ads_ad_rules_create` | Ad Rule | Write | Create an automated rule |
-| 71 | `meta_ads_ad_rules_update` | Ad Rule | Write | Update an automated rule |
-| 72 | `meta_ads_ad_rules_delete` | Ad Rule | Write | Delete an automated rule |
-| 73 | `meta_ads_page_posts_list` | Page Post | Read | List Facebook page posts |
-| 74 | `meta_ads_page_posts_boost` | Page Post | Write | Boost a page post (create ad from post) |
-| 75 | `meta_ads_instagram_accounts` | Instagram | Read | List connected Instagram accounts |
-| 76 | `meta_ads_instagram_media` | Instagram | Read | List Instagram posts |
-| 77 | `meta_ads_instagram_boost` | Instagram | Write | Boost an Instagram post |
-| 78 | `meta_ads_creatives_create_lead` | Lead / Creative | Write | Create a Lead Ad AdCreative attached to an Instant Form |
-| 79 | `meta_ads_lead_forms_update` | Lead | Write | Change a lead form status (ACTIVE / ARCHIVED) |
-| 80 | `meta_ads_lead_forms_duplicate` | Lead | Write | Duplicate a lead form under a Page with a new name |
-| 81 | `meta_ads_leads_export_csv` | Lead | Write (local) | Export form leads to a local CSV file |
+| 32 | `meta_ads_targeting_search` | Targeting | Read | Search targeting interests / behaviors by keyword |
+| 33 | `meta_ads_targeting_categories` | Targeting | Read | List targeting category catalogues (behaviors, demographics, etc.) |
+| 34 | `meta_ads_pixels_list` | Pixel | Read | List pixels |
+| 35 | `meta_ads_pixels_get` | Pixel | Read | Get pixel details |
+| 36 | `meta_ads_pixels_stats` | Pixel | Read | Get pixel firing statistics |
+| 37 | `meta_ads_pixels_events` | Pixel | Read | List pixel events |
+| 38 | `meta_ads_pixels_create` | Pixel | Write | Create a pixel |
+| 39 | `meta_ads_conversions_send` | CAPI | Write | Send conversion events (generic) |
+| 40 | `meta_ads_conversions_send_purchase` | CAPI | Write | Send a purchase event |
+| 41 | `meta_ads_conversions_send_lead` | CAPI | Write | Send a lead event |
+| 42 | `meta_ads_creatives_list` | Creative | Read | List ad creatives |
+| 43 | `meta_ads_creatives_create` | Creative | Write | Create a standard ad creative (single image or video) |
+| 44 | `meta_ads_creatives_create_dynamic` | Creative | Write | Create a dynamic product ad creative |
+| 45 | `meta_ads_creatives_upload_image` | Creative | Write | Upload an image for use in creatives |
+| 46 | `meta_ads_creatives_create_carousel` | Creative | Write | Create a carousel creative (2-10 cards) |
+| 47 | `meta_ads_creatives_create_collection` | Creative | Write | Create a collection creative |
+| 48 | `meta_ads_images_upload_file` | Image | Write | Upload an image from local file |
+| 49 | `meta_ads_catalogs_list` | Catalog | Read | List product catalogs |
+| 50 | `meta_ads_catalogs_get` | Catalog | Read | Get catalog details |
+| 51 | `meta_ads_catalogs_create` | Catalog | Write | Create a product catalog |
+| 52 | `meta_ads_catalogs_delete` | Catalog | Write | Delete a product catalog |
+| 53 | `meta_ads_products_list` | Catalog | Read | List products in a catalog |
+| 54 | `meta_ads_products_get` | Catalog | Read | Get product details |
+| 55 | `meta_ads_products_add` | Catalog | Write | Add a product to a catalog |
+| 56 | `meta_ads_products_update` | Catalog | Write | Update a product |
+| 57 | `meta_ads_products_delete` | Catalog | Write | Delete a product |
+| 58 | `meta_ads_feeds_list` | Catalog | Read | List feeds for a catalog |
+| 59 | `meta_ads_feeds_create` | Catalog | Write | Create a feed (URL-based, scheduled import) |
+| 60 | `meta_ads_lead_forms_list` | Lead | Read | List lead forms (per page) |
+| 61 | `meta_ads_lead_forms_get` | Lead | Read | Get lead form details |
+| 62 | `meta_ads_lead_forms_create` | Lead | Write | Create a lead form |
+| 63 | `meta_ads_leads_get` | Lead | Read | Get lead data (per form) |
+| 64 | `meta_ads_leads_get_by_ad` | Lead | Read | Get lead data (per ad) |
+| 65 | `meta_ads_videos_upload` | Video | Write | Upload a video from URL |
+| 66 | `meta_ads_videos_upload_file` | Video | Write | Upload a video from local file |
+| 67 | `meta_ads_split_tests_list` | Split Test | Read | List split tests |
+| 68 | `meta_ads_split_tests_get` | Split Test | Read | Get split test details and results |
+| 69 | `meta_ads_split_tests_create` | Split Test | Write | Create a split test |
+| 70 | `meta_ads_split_tests_end` | Split Test | Write | End a split test |
+| 71 | `meta_ads_ad_rules_list` | Ad Rule | Read | List automated rules |
+| 72 | `meta_ads_ad_rules_get` | Ad Rule | Read | Get rule details |
+| 73 | `meta_ads_ad_rules_create` | Ad Rule | Write | Create an automated rule |
+| 74 | `meta_ads_ad_rules_update` | Ad Rule | Write | Update an automated rule |
+| 75 | `meta_ads_ad_rules_delete` | Ad Rule | Write | Delete an automated rule |
+| 76 | `meta_ads_page_posts_list` | Page Post | Read | List Facebook page posts |
+| 77 | `meta_ads_page_posts_boost` | Page Post | Write | Boost a page post (create ad from post) |
+| 78 | `meta_ads_instagram_accounts` | Instagram | Read | List connected Instagram accounts |
+| 79 | `meta_ads_instagram_media` | Instagram | Read | List Instagram posts |
+| 80 | `meta_ads_instagram_boost` | Instagram | Write | Boost an Instagram post |
+| 81 | `meta_ads_pages_list` | Page | Read | List manageable Facebook Pages (personal + business-owned) |
+| 82 | `meta_ads_pages_upload_photo` | Page | Write | Upload a Page photo (returns a Page photo id) |
+| 83 | `meta_ads_creatives_create_lead` | Lead / Creative | Write | Create a Lead Ad AdCreative attached to an Instant Form |
+| 84 | `meta_ads_lead_forms_update` | Lead | Write | Change a lead form status (ACTIVE / ARCHIVED) |
+| 85 | `meta_ads_lead_forms_duplicate` | Lead | Write | Duplicate a lead form under a Page with a new name |
+| 86 | `meta_ads_leads_export_csv` | Lead | Write (local) | Export form leads to a local CSV file |
+| 87 | `meta_ads_videos_get` | Video | Read | Get video processing status / metadata |
+| 88 | `meta_ads_videos_thumbnails` | Video | Read | List auto-generated video thumbnails |
 
 ## Key Differences from Google Ads
 
@@ -380,11 +387,20 @@ counter. Pass an empty list to clear it and restore the default.
   Optional: limit (integer, default: 50)
   ```
 
-- `create` -- Create a standard ad creative. **Requires user confirmation.**
+- `create` -- Create a standard ad creative (single image OR video). **Requires user confirmation.**
   ```
-  Required: account_id, name
-  Optional: image_hash, link_url, message, page_id
+  Required: account_id, name, page_id, link_url
+  Image mode: image_hash OR image_url (exactly one)
+  Video mode: video_id + (video_thumbnail_image_hash OR video_thumbnail_image_url)
+              + call_to_action (required in this mode)
+  Optional: message, headline, description, call_to_action (image mode)
   ```
+  Video and image parameters are mutually exclusive. Meta requires a
+  thumbnail on every video creative, and the video must be fully
+  processed first (see the Video creative flow below). `call_to_action`
+  is mandatory in video mode: Meta's `video_data` has no `link` field, so
+  the destination rides inside `call_to_action.value.link`. `link_url` is
+  injected there automatically -- pass only the button label.
 
 - `create_dynamic` -- Create a dynamic product ad creative. **Requires user confirmation.**
   ```
@@ -553,17 +569,49 @@ counter. Pass an empty list to clear it and restore the default.
 
 ### videos
 
-- `upload` -- Upload a video from URL.
+Supported formats: MP4, MOV, AVI, WMV, MKV. Up to 1 GB per file through
+these tools; larger files need Meta's resumable (chunked) upload, which
+mureo does not implement yet.
+
+- `upload` -- Upload a video from URL. **Requires user confirmation.**
   ```
   Required: account_id, video_url
-  Optional: title, description
+  Optional: title
   ```
 
-- `upload_file` -- Upload a video from local file.
+- `upload_file` -- Upload a video from local file. **Requires user confirmation.**
   ```
   Required: account_id, file_path
-  Optional: title, description
+  Optional: title
   ```
+
+- `get` -- Get video processing status / metadata.
+  ```
+  Required: account_id, video_id
+  ```
+  Returns `status` (nested: `video_status`, `processing_phase`), `id`,
+  `title`, `length`, `created_time`. Poll until the video is ready --
+  a creative that references a still-processing video is rejected.
+
+- `thumbnails` -- List auto-generated video thumbnails.
+  ```
+  Required: account_id, video_id
+  ```
+  Returns `id`, `uri`, `is_preferred`, `height`, `width` per thumbnail.
+  Prefer the `is_preferred` entry and pass its `uri` as
+  `video_thumbnail_image_url` to `creatives_create`. An empty list
+  usually means the video is still processing.
+
+#### Video creative flow
+
+1. `videos_upload` / `videos_upload_file` -> `video_id`
+2. `videos_get` -> poll until `status.video_status` reports ready
+   (typically minutes; scales with file size and length)
+3. `videos_thumbnails` -> pick a `uri` (prefer `is_preferred: true`)
+4. `creatives_create` with `video_id` + `video_thumbnail_image_url`
+   (or `video_thumbnail_image_hash`) + `call_to_action` (required in
+   video mode -- it carries the destination link) -> `creative_id`
+5. `ads_create` with that `creative_id`
 
 ### split_tests
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -65,15 +65,15 @@ class TestListTools:
     """Verify list_tools returns the correct tool definitions."""
 
     async def test_list_tools_returns_all_tools(self) -> None:
-        """list_tools returns all tools (Google Ads 86 + Meta Ads 86 + Search Console 10
+        """list_tools returns all tools (Google Ads 86 + Meta Ads 88 + Search Console 10
         + Rollback 2 + Analysis 1 + Mureo Context 9 + Analytics Registry 2
-        + Learning 2 + Creative Studio 5 = 203).
+        + Learning 2 + Creative Studio 5 = 205).
 
         Analytics Registry is 2: mureo_analytics_modules_list +
         mureo_analytics_run (#440)."""
         mod = _import_server_module()
         tools = await mod.handle_list_tools()
-        assert len(tools) == 203
+        assert len(tools) == 205
 
     async def test_list_tools_contains_google_and_meta(self) -> None:
         """Google Ads and Meta Ads tools are included."""

--- a/tests/test_mcp_tools_meta_ads.py
+++ b/tests/test_mcp_tools_meta_ads.py
@@ -54,9 +54,9 @@ class TestMetaAdsToolDefinitions:
     """Verify the Meta Ads tool list is defined correctly."""
 
     def test_tool_count(self) -> None:
-        """All 86 tools are defined (84 + targeting search / categories)."""
+        """All 88 tools are defined (86 + videos get / thumbnails)."""
         mod = _import_meta_ads_tools()
-        assert len(mod.TOOLS) == 86
+        assert len(mod.TOOLS) == 88
 
     def test_bidding_control_schema_properties(self) -> None:
         """The four touched write tools expose the new bidding-control

--- a/tests/test_meta_ads_media.py
+++ b/tests/test_meta_ads_media.py
@@ -66,6 +66,31 @@ def sample_mov(tmp_path: Path) -> Path:
     return video
 
 
+def _mock_shared_http(
+    status_code: int = 200, payload: dict[str, Any] | None = None
+) -> Any:
+    """Mock the client's shared ``self._http`` (the ``_request`` seam).
+
+    ``upload_ad_video_file`` routes through the shared ``_request``/``_post``
+    machinery (Meta error JSON surfacing, retries, rate-limit handling, Bearer
+    auth) instead of building a one-off ``httpx.AsyncClient``, so tests pin the
+    wire shape at ``client._http.post`` rather than at
+    ``_creatives.httpx.AsyncClient``. Mocking the whole httpx client (what this
+    module used to do) pins nothing about the actual request — the blind spot
+    that let the /adimages multipart bug ship.
+    """
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = payload if payload is not None else {}
+    resp.text = json.dumps(payload if payload is not None else {})
+    resp.headers = {}
+    http = MagicMock()
+    http.post = AsyncMock(return_value=resp)
+    http.get = AsyncMock(return_value=resp)
+    http.delete = AsyncMock(return_value=resp)
+    return http
+
+
 # ---------------------------------------------------------------------------
 # 1. test_upload_ad_video — upload video via URL
 # ---------------------------------------------------------------------------
@@ -119,55 +144,154 @@ class TestUploadAdVideo:
 
 @pytest.mark.unit
 class TestUploadAdVideoFile:
-    """Upload video from a local file."""
+    """Upload video from a local file (multipart via the shared client)."""
 
     @pytest.mark.asyncio()
     async def test_upload_ad_video_file(
         self, meta_client: Any, sample_video: Path
     ) -> None:
         """Successful upload returns a video_id."""
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {"id": "video_789"}
-        mock_response.raise_for_status = MagicMock()
+        meta_client._http = _mock_shared_http(200, {"id": "video_789"})
 
-        mock_http_client = AsyncMock()
-        mock_http_client.post.return_value = mock_response
-        mock_http_client.__aenter__ = AsyncMock(return_value=mock_http_client)
-        mock_http_client.__aexit__ = AsyncMock(return_value=False)
-
-        with patch(
-            "mureo.meta_ads._creatives.httpx.AsyncClient",
-            return_value=mock_http_client,
-        ):
-            result = await meta_client.upload_ad_video_file(str(sample_video))
+        result = await meta_client.upload_ad_video_file(str(sample_video))
 
         assert result["id"] == "video_789"
+        args, kwargs = meta_client._http.post.call_args
+        assert args[0].endswith("/act_123456/advideos")
 
     @pytest.mark.asyncio()
     async def test_upload_ad_video_file_with_title(
         self, meta_client: Any, sample_video: Path
     ) -> None:
-        """When title is supplied, that value is sent."""
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {"id": "video_789"}
-        mock_response.raise_for_status = MagicMock()
+        """When title is supplied, that value travels as a form field."""
+        meta_client._http = _mock_shared_http(200, {"id": "video_789"})
 
-        mock_http_client = AsyncMock()
-        mock_http_client.post.return_value = mock_response
-        mock_http_client.__aenter__ = AsyncMock(return_value=mock_http_client)
-        mock_http_client.__aexit__ = AsyncMock(return_value=False)
-
-        with patch(
-            "mureo.meta_ads._creatives.httpx.AsyncClient",
-            return_value=mock_http_client,
-        ):
-            result = await meta_client.upload_ad_video_file(
-                str(sample_video), title="カスタムタイトル"
-            )
+        result = await meta_client.upload_ad_video_file(
+            str(sample_video), title="カスタムタイトル"
+        )
 
         assert result["id"] == "video_789"
+        _, kwargs = meta_client._http.post.call_args
+        assert kwargs["data"]["title"] == "カスタムタイトル"
+
+    @pytest.mark.asyncio()
+    async def test_upload_ad_video_file_multipart_wire_shape(
+        self, meta_client: Any, sample_video: Path
+    ) -> None:
+        """The multipart part is ``source`` / real filename / real video MIME.
+
+        Meta's /advideos non-resumable upload documents the file part as
+        ``source``. Sending ``application/octet-stream`` instead of the real
+        video MIME is what got the sibling /adimages multipart body rejected
+        with ``FileTypeNotSupported``, so the per-extension MIME is pinned here.
+        """
+        meta_client._http = _mock_shared_http(200, {"id": "v"})
+
+        await meta_client.upload_ad_video_file(str(sample_video))
+
+        _, kwargs = meta_client._http.post.call_args
+        files = kwargs["files"]
+        assert set(files) == {"source"}
+        filename, content, mime = files["source"]
+        assert filename == "test_video.mp4"
+        assert content == sample_video.read_bytes()
+        assert mime == "video/mp4"
+
+    @pytest.mark.asyncio()
+    async def test_upload_ad_video_file_bearer_header_no_token_field(
+        self, meta_client: Any, sample_video: Path
+    ) -> None:
+        """Auth rides the Bearer header only — never an access_token form field."""
+        meta_client._http = _mock_shared_http(200, {"id": "v"})
+
+        await meta_client.upload_ad_video_file(str(sample_video), title="t")
+
+        _, kwargs = meta_client._http.post.call_args
+        assert kwargs["headers"]["Authorization"] == "Bearer test-token"
+        assert "access_token" not in kwargs["data"]
+        assert "test-token" not in str(kwargs["data"])
+
+    @pytest.mark.asyncio()
+    async def test_upload_ad_video_file_uses_600s_timeout(
+        self, meta_client: Any, sample_video: Path
+    ) -> None:
+        """The upload overrides the shared 30s default with a 600s timeout.
+
+        Files up to 1 GB are accepted; the shared client default would time out
+        long before such an upload finishes on a slow link.
+        """
+        meta_client._http = _mock_shared_http(200, {"id": "v"})
+
+        await meta_client.upload_ad_video_file(str(sample_video))
+
+        _, kwargs = meta_client._http.post.call_args
+        assert kwargs["timeout"] == 600.0
+
+    @pytest.mark.asyncio()
+    async def test_upload_ad_video_file_retry_resends_body(
+        self, meta_client: Any, sample_video: Path
+    ) -> None:
+        """A 429-then-200 retry re-sends the identical, non-empty file part.
+
+        ``_request`` reuses the same ``files`` mapping across retry attempts, so
+        the part must carry materialized bytes — a still-open file handle would
+        be exhausted by the first attempt and the retry would send an empty body.
+        """
+        resp_429 = MagicMock()
+        resp_429.status_code = 429
+        resp_429.headers = {}
+        resp_429.json.return_value = {}
+        resp_200 = MagicMock()
+        resp_200.status_code = 200
+        resp_200.headers = {}
+        resp_200.json.return_value = {"id": "video_retry"}
+        responses = [resp_429, resp_200]
+
+        sent_parts: list[Any] = []
+
+        def _capture(*_args: Any, **kwargs: Any) -> Any:
+            sent_parts.append(kwargs["files"]["source"])
+            return responses.pop(0)
+
+        meta_client._http = MagicMock()
+        meta_client._http.post = AsyncMock(side_effect=_capture)
+
+        with patch("mureo.meta_ads.client.asyncio.sleep", new=AsyncMock()):
+            result = await meta_client.upload_ad_video_file(str(sample_video))
+
+        assert result == {"id": "video_retry"}
+        assert len(sent_parts) == 2  # 429 attempt + 200 retry
+        assert sent_parts[0][1] == sample_video.read_bytes()  # full body
+        assert sent_parts[0] == sent_parts[1]  # identical on retry
+
+    @pytest.mark.asyncio()
+    async def test_upload_ad_video_file_surfaces_meta_error(
+        self, meta_client: Any, sample_video: Path
+    ) -> None:
+        """A 400 carrying Meta's error JSON surfaces message + subcode + fbtrace_id.
+
+        The old standalone-httpx uploader called ``raise_for_status()`` and threw
+        Meta's diagnostics away; routing through ``_request`` must surface them.
+        """
+        meta_client._http = _mock_shared_http(
+            400,
+            {
+                "error": {
+                    "message": "Invalid video file",
+                    "error_subcode": 1363037,
+                    "fbtrace_id": "VidTrace123",
+                }
+            },
+        )
+
+        with pytest.raises(RuntimeError) as excinfo:
+            await meta_client.upload_ad_video_file(str(sample_video))
+
+        message = str(excinfo.value)
+        assert "status=400" in message
+        assert "Invalid video file" in message
+        assert "subcode=1363037" in message
+        assert "VidTrace123" in message
 
 
 # ---------------------------------------------------------------------------
@@ -177,19 +301,52 @@ class TestUploadAdVideoFile:
 
 @pytest.mark.unit
 class TestUploadAdVideoFileTooLarge:
-    """Video file size limit."""
+    """Video file size limit (Graph's documented non-resumable ceiling)."""
 
     @pytest.mark.asyncio()
     async def test_upload_ad_video_file_too_large(
         self, meta_client: Any, tmp_path: Path
     ) -> None:
-        """Raises ValueError for files larger than 100MB."""
-        large_file = tmp_path / "large.mp4"
-        # 100MB + 1 byte
-        large_file.write_bytes(b"\x00" * (100 * 1024 * 1024 + 1))
+        """Raises ValueError locally for files larger than 1 GB.
 
-        with pytest.raises(ValueError, match="100MB"):
+        The check is a stat() on the path, so the oversized file is created
+        sparse — no gigabyte is actually written to the test tmp dir.
+        """
+        large_file = tmp_path / "large.mp4"
+        with open(large_file, "wb") as fh:
+            fh.truncate(1024 * 1024 * 1024 + 1)  # 1GB + 1 byte, sparse
+
+        with pytest.raises(ValueError, match="1GB"):
             await meta_client.upload_ad_video_file(str(large_file))
+
+    @pytest.mark.asyncio()
+    async def test_upload_ad_video_file_at_cap_is_accepted(
+        self, meta_client: Any, tmp_path: Path
+    ) -> None:
+        """A file exactly at the 1 GB cap passes validation.
+
+        Guards the boundary: the previous 100 MB cap rejected everything above
+        it, and an off-by-one on the new cap would silently keep rejecting
+        legitimate 1 GB uploads.
+        """
+        at_cap = tmp_path / "at_cap.mp4"
+        with open(at_cap, "wb") as fh:
+            fh.truncate(1024 * 1024 * 1024)  # exactly 1GB, sparse
+
+        from mureo._image_validation import validate_video_file
+        from mureo.meta_ads._creatives import (
+            _META_ALLOWED_VIDEO_EXTENSIONS,
+            _META_MAX_VIDEO_SIZE_BYTES,
+        )
+
+        assert _META_MAX_VIDEO_SIZE_BYTES == 1024 * 1024 * 1024
+        # Validation only (uploading would read 1GB into memory).
+        validate_video_file(
+            str(at_cap),
+            max_size_bytes=_META_MAX_VIDEO_SIZE_BYTES,
+            max_size_label="1GB",
+            allowed_extensions=_META_ALLOWED_VIDEO_EXTENSIONS,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -213,29 +370,41 @@ class TestUploadAdVideoFileInvalidFormat:
             await meta_client.upload_ad_video_file(str(txt_file))
 
     @pytest.mark.asyncio()
+    async def test_upload_ad_video_file_flv_rejected(
+        self, meta_client: Any, tmp_path: Path
+    ) -> None:
+        """``.flv`` is not in the client's allow-list and is rejected."""
+        flv = tmp_path / "legacy.flv"
+        flv.write_bytes(b"FLV\x01" + b"\x00" * 100)
+
+        with pytest.raises(ValueError, match="Unsupported video format"):
+            await meta_client.upload_ad_video_file(str(flv))
+
+    @pytest.mark.asyncio()
     async def test_upload_ad_video_file_supported_formats(
         self, meta_client: Any, tmp_path: Path
     ) -> None:
-        """mp4, mov, avi, wmv, mkv are all allowed."""
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {"id": "v1"}
-        mock_response.raise_for_status = MagicMock()
+        """mp4, mov, avi, wmv, mkv upload with their real per-format MIME."""
+        expected_mimes = {
+            "mp4": "video/mp4",
+            "mov": "video/quicktime",
+            "avi": "video/x-msvideo",
+            "wmv": "video/x-ms-wmv",
+            "mkv": "video/x-matroska",
+        }
 
-        mock_http_client = AsyncMock()
-        mock_http_client.post.return_value = mock_response
-        mock_http_client.__aenter__ = AsyncMock(return_value=mock_http_client)
-        mock_http_client.__aexit__ = AsyncMock(return_value=False)
-
-        for ext in ("mp4", "mov", "avi", "wmv", "mkv"):
+        for ext, expected_mime in expected_mimes.items():
             video = tmp_path / f"test.{ext}"
             video.write_bytes(b"\x00" * 100)
-            with patch(
-                "mureo.meta_ads._creatives.httpx.AsyncClient",
-                return_value=mock_http_client,
-            ):
-                result = await meta_client.upload_ad_video_file(str(video))
-                assert "id" in result
+            meta_client._http = _mock_shared_http(200, {"id": f"v_{ext}"})
+
+            result = await meta_client.upload_ad_video_file(str(video))
+
+            assert result["id"] == f"v_{ext}"
+            _, kwargs = meta_client._http.post.call_args
+            filename, _content, mime = kwargs["files"]["source"]
+            assert filename == f"test.{ext}"
+            assert mime == expected_mime
 
     @pytest.mark.asyncio()
     async def test_upload_ad_video_file_not_found(self, meta_client: Any) -> None:
@@ -635,6 +804,40 @@ class TestMetaAdsMediaHandlers:
         assert len(result) == 1
         data = json.loads(result[0].text)
         assert data["id"] == "video_file_1"
+
+    @pytest.mark.asyncio()
+    async def test_handle_videos_upload_file_rejects_flv(self, tmp_path: Path) -> None:
+        """``.flv`` is rejected at the handler too.
+
+        The handler's extension tuple used to allow ``.flv`` while the client's
+        allow-list did not, so an .flv upload passed the handler gate only to be
+        rejected one layer deeper with a different message. The client set is the
+        single source of truth.
+        """
+        from mureo.mcp.tools_meta_ads import handle_tool
+
+        flv = tmp_path / "legacy.flv"
+        flv.write_bytes(b"FLV\x01" + b"\x00" * 100)
+
+        mock_client = AsyncMock()
+
+        with (
+            patch(
+                "mureo.mcp._handlers_meta_ads.load_meta_ads_credentials",
+                return_value=MetaAdsCredentials(access_token="tok"),
+            ),
+            patch(
+                "mureo.mcp._handlers_meta_ads.create_meta_ads_client",
+                return_value=mock_client,
+            ),
+            pytest.raises(ValueError, match="Unsupported video format"),
+        ):
+            await handle_tool(
+                "meta_ads_videos_upload_file",
+                {"account_id": "act_123", "file_path": str(flv)},
+            )
+
+        mock_client.upload_ad_video_file.assert_not_awaited()
 
     @pytest.mark.asyncio()
     async def test_handle_creatives_create_carousel(self) -> None:

--- a/tests/test_meta_ads_video_creatives.py
+++ b/tests/test_meta_ads_video_creatives.py
@@ -1,0 +1,665 @@
+"""Tests for Meta Ads VIDEO creative support.
+
+Covers the video branch of ``create_ad_creative`` (object_story_spec.video_data),
+its MCP tool schema / handler, and the two read-only video tools
+(``meta_ads_videos_get`` / ``meta_ads_videos_thumbnails``) used to poll
+processing status and pick a thumbnail before creating the creative.
+
+TDD: tests are written first; the implementation follows.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mureo.auth import MetaAdsCredentials
+
+
+@pytest.fixture(autouse=True)
+def _standalone_meta_ads():
+    """Pin these handler tests to STANDALONE (untenanted) Meta Ads.
+
+    Mirrors the fixture used across the other Meta handler suites: with a
+    ``mureo.runtime_context_factory`` plugin installed, an undeclared
+    ``meta_account_ids`` fail-closes every account_id and breaks the
+    standalone assertions here.
+    """
+    with patch(
+        "mureo.mcp._handlers_meta_ads.runtime_meta_account_ids",
+        return_value=None,
+    ):
+        yield
+
+
+@pytest.fixture()
+def meta_client() -> Any:
+    from mureo.meta_ads.client import MetaAdsApiClient
+
+    return MetaAdsApiClient(access_token="test-token", ad_account_id="act_123456")
+
+
+def _mock_creds_and_client() -> tuple[Any, Any]:
+    return MetaAdsCredentials(access_token="tok"), AsyncMock()
+
+
+def _sent_object_story_spec(post_mock: AsyncMock) -> dict[str, Any]:
+    """Decode ``object_story_spec`` from the captured ``_post`` call."""
+    call_args = post_mock.call_args
+    data = call_args[0][1] if len(call_args[0]) > 1 else call_args[1].get("data", {})
+    return json.loads(data["object_story_spec"])  # type: ignore[no-any-return]
+
+
+# ---------------------------------------------------------------------------
+# create_ad_creative — video branch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCreateAdCreativeVideo:
+    """``create_ad_creative`` builds object_story_spec.video_data for videos."""
+
+    @pytest.mark.asyncio()
+    async def test_video_creative_with_image_hash_thumbnail(
+        self, meta_client: Any
+    ) -> None:
+        """video_id + thumbnail hash produces the documented video_data shape."""
+        meta_client._post = AsyncMock(return_value={"id": "cr_video_1"})
+
+        result = await meta_client.create_ad_creative(
+            name="Video creative",
+            page_id="page_1",
+            link_url="https://example.com/lp",
+            video_id="video_42",
+            video_thumbnail_image_hash="thumb_hash",
+            message="body text",
+            headline="Headline",
+            description="Caption",
+            call_to_action="LEARN_MORE",
+        )
+
+        assert result["id"] == "cr_video_1"
+        assert "/adcreatives" in meta_client._post.call_args[0][0]
+        oss = _sent_object_story_spec(meta_client._post)
+        assert oss["page_id"] == "page_1"
+        assert "link_data" not in oss
+        assert oss["video_data"] == {
+            "video_id": "video_42",
+            "image_hash": "thumb_hash",
+            "title": "Headline",
+            "message": "body text",
+            "link_description": "Caption",
+            "call_to_action": {
+                "type": "LEARN_MORE",
+                "value": {"link": "https://example.com/lp"},
+            },
+        }
+
+    @pytest.mark.asyncio()
+    async def test_video_creative_with_image_url_thumbnail(
+        self, meta_client: Any
+    ) -> None:
+        """The image_url thumbnail variant maps to video_data.image_url.
+
+        ``meta_ads_videos_thumbnails`` returns Meta-hosted ``uri`` values, so
+        the url variant is the natural output of the poll-then-pick flow.
+        """
+        meta_client._post = AsyncMock(return_value={"id": "cr_video_2"})
+
+        await meta_client.create_ad_creative(
+            name="Video creative",
+            page_id="page_1",
+            link_url="https://example.com/lp",
+            video_id="video_42",
+            video_thumbnail_image_url="https://scontent.example/thumb.jpg",
+            call_to_action="LEARN_MORE",
+        )
+
+        video_data = _sent_object_story_spec(meta_client._post)["video_data"]
+        assert video_data["image_url"] == "https://scontent.example/thumb.jpg"
+        assert "image_hash" not in video_data
+        # Optional copy fields are omitted rather than sent as null/empty;
+        # call_to_action is mandatory in video mode so it is always present.
+        assert set(video_data) == {"video_id", "image_url", "call_to_action"}
+
+    @pytest.mark.asyncio()
+    async def test_video_creative_requires_call_to_action(
+        self, meta_client: Any
+    ) -> None:
+        """Video mode without call_to_action is rejected locally.
+
+        ``video_data`` has no ``link`` field — the destination lives only at
+        ``call_to_action.value.link``. Accepting a CTA-less video creative
+        would silently discard the (required) link_url, so this is a hard
+        requirement enforced here rather than a documented footgun.
+        """
+        meta_client._post = AsyncMock(return_value={"id": "never"})
+
+        with pytest.raises(ValueError, match="call_to_action"):
+            await meta_client.create_ad_creative(
+                name="Video creative",
+                page_id="page_1",
+                link_url="https://example.com/lp",
+                video_id="video_42",
+                video_thumbnail_image_hash="thumb_hash",
+            )
+
+        meta_client._post.assert_not_awaited()
+
+    @pytest.mark.asyncio()
+    async def test_video_creative_cta_link_is_auto_injected(
+        self, meta_client: Any
+    ) -> None:
+        """link_url is auto-injected into call_to_action.value.link.
+
+        The caller supplies only the CTA type string (same shape as the image
+        path) — it must never have to duplicate the link inside the CTA.
+        """
+        meta_client._post = AsyncMock(return_value={"id": "cr_video_3"})
+
+        await meta_client.create_ad_creative(
+            name="Video creative",
+            page_id="page_1",
+            link_url="https://example.com/deep/landing?utm=x",
+            video_id="video_42",
+            video_thumbnail_image_hash="thumb_hash",
+            call_to_action="SHOP_NOW",
+        )
+
+        cta = _sent_object_story_spec(meta_client._post)["video_data"]["call_to_action"]
+        assert cta == {
+            "type": "SHOP_NOW",
+            "value": {"link": "https://example.com/deep/landing?utm=x"},
+        }
+
+    @pytest.mark.asyncio()
+    async def test_video_creative_requires_thumbnail(self, meta_client: Any) -> None:
+        """Meta requires a thumbnail on video creatives — fail fast locally."""
+        meta_client._post = AsyncMock(return_value={"id": "never"})
+
+        with pytest.raises(ValueError, match="thumbnail"):
+            await meta_client.create_ad_creative(
+                name="Video creative",
+                page_id="page_1",
+                link_url="https://example.com/lp",
+                video_id="video_42",
+            )
+
+        meta_client._post.assert_not_awaited()
+
+    @pytest.mark.asyncio()
+    async def test_video_thumbnail_variants_mutually_exclusive(
+        self, meta_client: Any
+    ) -> None:
+        """Supplying both thumbnail forms is ambiguous and rejected."""
+        meta_client._post = AsyncMock(return_value={"id": "never"})
+
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            await meta_client.create_ad_creative(
+                name="Video creative",
+                page_id="page_1",
+                link_url="https://example.com/lp",
+                video_id="video_42",
+                video_thumbnail_image_hash="h",
+                video_thumbnail_image_url="https://scontent.example/t.jpg",
+            )
+
+        meta_client._post.assert_not_awaited()
+
+    @pytest.mark.asyncio()
+    async def test_video_and_image_params_mutually_exclusive(
+        self, meta_client: Any
+    ) -> None:
+        """A creative is either video or image — the conflict names the keys."""
+        meta_client._post = AsyncMock(return_value={"id": "never"})
+
+        with pytest.raises(ValueError) as excinfo:
+            await meta_client.create_ad_creative(
+                name="Video creative",
+                page_id="page_1",
+                link_url="https://example.com/lp",
+                video_id="video_42",
+                video_thumbnail_image_hash="thumb_hash",
+                image_hash="img_hash",
+            )
+
+        message = str(excinfo.value)
+        assert "video_id" in message
+        assert "image_hash" in message
+        meta_client._post.assert_not_awaited()
+
+    @pytest.mark.asyncio()
+    async def test_video_and_image_url_mutually_exclusive_no_upload(
+        self, meta_client: Any
+    ) -> None:
+        """image_url + video_id must raise BEFORE the image auto-upload runs."""
+        meta_client._post = AsyncMock(return_value={"id": "never"})
+        meta_client.upload_ad_image = AsyncMock(return_value={"hash": "h"})
+
+        with pytest.raises(ValueError, match="image_url"):
+            await meta_client.create_ad_creative(
+                name="Video creative",
+                page_id="page_1",
+                link_url="https://example.com/lp",
+                video_id="video_42",
+                video_thumbnail_image_hash="thumb_hash",
+                image_url="https://example.com/img.png",
+            )
+
+        meta_client.upload_ad_image.assert_not_awaited()
+        meta_client._post.assert_not_awaited()
+
+    @pytest.mark.asyncio()
+    async def test_thumbnail_without_video_id_rejected(self, meta_client: Any) -> None:
+        """A thumbnail param without video_id would be silently dropped."""
+        meta_client._post = AsyncMock(return_value={"id": "never"})
+
+        with pytest.raises(ValueError, match="video_id"):
+            await meta_client.create_ad_creative(
+                name="Image creative",
+                page_id="page_1",
+                link_url="https://example.com/lp",
+                image_hash="img_hash",
+                video_thumbnail_image_hash="thumb_hash",
+            )
+
+        meta_client._post.assert_not_awaited()
+
+    @pytest.mark.asyncio()
+    async def test_image_path_unchanged(self, meta_client: Any) -> None:
+        """The pre-existing image path still builds link_data (no regression)."""
+        meta_client._post = AsyncMock(return_value={"id": "cr_img"})
+
+        await meta_client.create_ad_creative(
+            name="Image creative",
+            page_id="page_1",
+            link_url="https://example.com/lp",
+            image_hash="img_hash",
+            headline="Head",
+            call_to_action="SHOP_NOW",
+        )
+
+        oss = _sent_object_story_spec(meta_client._post)
+        assert "video_data" not in oss
+        assert oss["link_data"]["image_hash"] == "img_hash"
+        assert oss["link_data"]["name"] == "Head"
+        assert oss["link_data"]["call_to_action"] == {"type": "SHOP_NOW"}
+
+
+# ---------------------------------------------------------------------------
+# Video read tools — client methods
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestVideoReadClientMethods:
+    """``get_ad_video`` / ``list_ad_video_thumbnails`` hit node-level paths."""
+
+    @pytest.mark.asyncio()
+    async def test_get_ad_video_path_and_fields(self, meta_client: Any) -> None:
+        """GET /{video_id} — a node path, NOT act_-scoped."""
+        meta_client._get = AsyncMock(
+            return_value={
+                "id": "video_42",
+                "status": {"video_status": "processing", "processing_phase": {}},
+                "title": "t",
+                "length": 15.0,
+                "created_time": "2026-07-01T00:00:00+0000",
+            }
+        )
+
+        result = await meta_client.get_ad_video("video_42")
+
+        assert result["status"]["video_status"] == "processing"
+        path, params = meta_client._get.call_args[0]
+        assert path == "/video_42"
+        assert "act_" not in path
+        fields = set(params["fields"].split(","))
+        assert fields == {"status", "id", "title", "length", "created_time"}
+
+    @pytest.mark.asyncio()
+    async def test_list_ad_video_thumbnails(self, meta_client: Any) -> None:
+        """GET /{video_id}/thumbnails returns the unwrapped data list."""
+        meta_client._get = AsyncMock(
+            return_value={
+                "data": [
+                    {
+                        "id": "t1",
+                        "uri": "https://scontent.example/t1.jpg",
+                        "is_preferred": True,
+                        "height": 720,
+                        "width": 1280,
+                    },
+                    {
+                        "id": "t2",
+                        "uri": "https://scontent.example/t2.jpg",
+                        "is_preferred": False,
+                        "height": 720,
+                        "width": 1280,
+                    },
+                ]
+            }
+        )
+
+        result = await meta_client.list_ad_video_thumbnails("video_42")
+
+        assert [t["id"] for t in result] == ["t1", "t2"]
+        assert result[0]["is_preferred"] is True
+        path, params = meta_client._get.call_args[0]
+        assert path == "/video_42/thumbnails"
+        assert "act_" not in path
+        assert set(params["fields"].split(",")) == {
+            "id",
+            "uri",
+            "is_preferred",
+            "height",
+            "width",
+        }
+
+    @pytest.mark.asyncio()
+    async def test_list_ad_video_thumbnails_empty(self, meta_client: Any) -> None:
+        """A video with no thumbnails yet yields an empty list, not a KeyError."""
+        meta_client._get = AsyncMock(return_value={})
+
+        assert await meta_client.list_ad_video_thumbnails("video_42") == []
+
+
+# ---------------------------------------------------------------------------
+# Tool definitions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestVideoToolDefinitions:
+    """Schema-level pins for the new/changed tools."""
+
+    def _tool(self, name: str) -> Any:
+        from mureo.mcp.tools_meta_ads import TOOLS
+
+        tool = next((t for t in TOOLS if t.name == name), None)
+        assert tool is not None, f"Tool {name} not found"
+        return tool
+
+    def test_videos_get_schema(self) -> None:
+        tool = self._tool("meta_ads_videos_get")
+        assert set(tool.inputSchema["required"]) == {"video_id"}
+        assert tool.inputSchema["additionalProperties"] is False
+        assert "account_id" in tool.inputSchema["properties"]
+
+    def test_videos_thumbnails_schema(self) -> None:
+        tool = self._tool("meta_ads_videos_thumbnails")
+        assert set(tool.inputSchema["required"]) == {"video_id"}
+        assert tool.inputSchema["additionalProperties"] is False
+
+    def test_creatives_create_exposes_video_params(self) -> None:
+        """The video params are declared and the schema stays strict."""
+        schema = self._tool("meta_ads_creatives_create").inputSchema
+        for key in (
+            "video_id",
+            "video_thumbnail_image_hash",
+            "video_thumbnail_image_url",
+        ):
+            assert key in schema["properties"], key
+        assert schema["additionalProperties"] is False
+        # required is unchanged — video mode is opt-in. The video-mode
+        # extras (thumbnail, call_to_action) are conditional requirements
+        # that JSON Schema `required` cannot express, so they are enforced
+        # in the client layer and documented in the descriptions.
+        assert set(schema["required"]) == {"name", "page_id", "link_url"}
+
+    def test_creatives_create_documents_video_cta_requirement(self) -> None:
+        """The conditional CTA requirement is stated where an agent will read it.
+
+        It cannot live in `required`, so the tool description, the video_id
+        description and the call_to_action description must each carry it.
+        """
+        tool = self._tool("meta_ads_creatives_create")
+        props = tool.inputSchema["properties"]
+
+        assert "call_to_action" in tool.description
+        assert "call_to_action" in props["video_id"]["description"]
+        for token in ("REQUIRED", "video_id"):
+            assert token in props["call_to_action"]["description"], token
+
+    def test_creatives_create_rejects_unknown_param(self) -> None:
+        """additionalProperties: false still rejects a typo'd video param."""
+        schema = self._tool("meta_ads_creatives_create").inputSchema
+        assert "video_thumbnail" not in schema["properties"]
+        assert "video_hash" not in schema["properties"]
+
+    def test_video_upload_descriptions_state_real_limits(self) -> None:
+        """Both upload tools document the real extensions and the 1 GB cap."""
+        for name in ("meta_ads_videos_upload", "meta_ads_videos_upload_file"):
+            description = (
+                json.dumps(self._tool(name).inputSchema) + self._tool(name).description
+            )
+            assert "1 GB" in description, name
+            assert "resumable" in description, name
+            assert "MKV" in description, name
+            assert "4 GB" not in description, name
+
+
+# ---------------------------------------------------------------------------
+# Handlers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestVideoHandlers:
+    """Handler dispatch for the video tools."""
+
+    async def _dispatch(self, client: Any, name: str, args: dict[str, Any]) -> Any:
+        from mureo.mcp.tools_meta_ads import handle_tool
+
+        with (
+            patch(
+                "mureo.mcp._handlers_meta_ads.load_meta_ads_credentials",
+                return_value=MetaAdsCredentials(access_token="tok"),
+            ),
+            patch(
+                "mureo.mcp._handlers_meta_ads.create_meta_ads_client",
+                return_value=client,
+            ),
+        ):
+            return await handle_tool(name, args)
+
+    @pytest.mark.asyncio()
+    async def test_handle_videos_get(self) -> None:
+        client = AsyncMock()
+        client.get_ad_video.return_value = {
+            "id": "video_42",
+            "status": {"video_status": "ready"},
+        }
+
+        result = await self._dispatch(
+            client,
+            "meta_ads_videos_get",
+            {"account_id": "act_123", "video_id": "video_42"},
+        )
+
+        client.get_ad_video.assert_awaited_once_with("video_42")
+        parsed = json.loads(result[0].text)
+        assert parsed["status"]["video_status"] == "ready"
+
+    @pytest.mark.asyncio()
+    async def test_handle_videos_get_requires_video_id(self) -> None:
+        client = AsyncMock()
+
+        with pytest.raises(ValueError, match="video_id"):
+            await self._dispatch(client, "meta_ads_videos_get", {"account_id": "act_1"})
+
+    @pytest.mark.asyncio()
+    async def test_handle_videos_get_missing_creds(self) -> None:
+        from mureo.mcp.tools_meta_ads import handle_tool
+
+        with patch(
+            "mureo.mcp._handlers_meta_ads.load_meta_ads_credentials",
+            return_value=None,
+        ):
+            result = await handle_tool("meta_ads_videos_get", {"video_id": "video_42"})
+
+        assert "META_ADS" in result[0].text or "credentials" in result[0].text.lower()
+
+    @pytest.mark.asyncio()
+    async def test_handle_videos_thumbnails(self) -> None:
+        client = AsyncMock()
+        client.list_ad_video_thumbnails.return_value = [
+            {"id": "t1", "uri": "https://scontent.example/t1.jpg", "is_preferred": True}
+        ]
+
+        result = await self._dispatch(
+            client,
+            "meta_ads_videos_thumbnails",
+            {"account_id": "act_123", "video_id": "video_42"},
+        )
+
+        client.list_ad_video_thumbnails.assert_awaited_once_with("video_42")
+        parsed = json.loads(result[0].text)
+        assert parsed[0]["is_preferred"] is True
+
+    @pytest.mark.asyncio()
+    async def test_handle_videos_thumbnails_requires_video_id(self) -> None:
+        client = AsyncMock()
+
+        with pytest.raises(ValueError, match="video_id"):
+            await self._dispatch(
+                client, "meta_ads_videos_thumbnails", {"account_id": "act_1"}
+            )
+
+    @pytest.mark.asyncio()
+    async def test_handle_videos_thumbnails_missing_creds(self) -> None:
+        from mureo.mcp.tools_meta_ads import handle_tool
+
+        with patch(
+            "mureo.mcp._handlers_meta_ads.load_meta_ads_credentials",
+            return_value=None,
+        ):
+            result = await handle_tool(
+                "meta_ads_videos_thumbnails", {"video_id": "video_42"}
+            )
+
+        assert "META_ADS" in result[0].text or "credentials" in result[0].text.lower()
+
+    @pytest.mark.asyncio()
+    async def test_handle_creatives_create_forwards_video_params(self) -> None:
+        """The creatives_create handler round-trips the three video keys."""
+        client = AsyncMock()
+        client.create_ad_creative.return_value = {"id": "cr_video"}
+
+        result = await self._dispatch(
+            client,
+            "meta_ads_creatives_create",
+            {
+                "account_id": "act_123",
+                "name": "Video creative",
+                "page_id": "pg_1",
+                "link_url": "https://example.com",
+                "video_id": "video_42",
+                "video_thumbnail_image_url": "https://scontent.example/t.jpg",
+                "call_to_action": "LEARN_MORE",
+            },
+        )
+
+        kwargs = client.create_ad_creative.call_args.kwargs
+        assert kwargs["video_id"] == "video_42"
+        assert kwargs["video_thumbnail_image_url"] == "https://scontent.example/t.jpg"
+        assert "video_thumbnail_image_hash" not in kwargs
+        assert json.loads(result[0].text)["id"] == "cr_video"
+
+    @pytest.mark.asyncio()
+    async def test_handle_creatives_create_forwards_thumbnail_hash(self) -> None:
+        client = AsyncMock()
+        client.create_ad_creative.return_value = {"id": "cr_video"}
+
+        await self._dispatch(
+            client,
+            "meta_ads_creatives_create",
+            {
+                "account_id": "act_123",
+                "name": "Video creative",
+                "page_id": "pg_1",
+                "link_url": "https://example.com",
+                "video_id": "video_42",
+                "video_thumbnail_image_hash": "thumb_hash",
+                "call_to_action": "SIGN_UP",
+            },
+        )
+
+        kwargs = client.create_ad_creative.call_args.kwargs
+        assert kwargs["video_thumbnail_image_hash"] == "thumb_hash"
+        assert kwargs["call_to_action"] == "SIGN_UP"
+        assert "video_thumbnail_image_url" not in kwargs
+
+
+# ---------------------------------------------------------------------------
+# Dispatch registration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestVideoToolRegistration:
+    """The new tools are wired into both the registry and the dispatch map."""
+
+    def test_tools_registered(self) -> None:
+        from mureo.mcp.tools_meta_ads import TOOLS
+
+        names = {t.name for t in TOOLS}
+        assert "meta_ads_videos_get" in names
+        assert "meta_ads_videos_thumbnails" in names
+
+    def test_handlers_registered(self) -> None:
+        from mureo.mcp.tools_meta_ads import _HANDLERS
+
+        assert "meta_ads_videos_get" in _HANDLERS
+        assert "meta_ads_videos_thumbnails" in _HANDLERS
+
+    def test_video_read_tools_not_classified_mutating(self) -> None:
+        """Read-only tools must not trigger the strategy reminder."""
+        from mureo.core.strategy_reminder import is_mutating_builtin_tool
+
+        assert is_mutating_builtin_tool("meta_ads_videos_get") is False
+        assert is_mutating_builtin_tool("meta_ads_videos_thumbnails") is False
+
+
+# ---------------------------------------------------------------------------
+# _request files= plumbing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRequestFilesSupport:
+    """``_post(files=...)`` passes straight through to httpx."""
+
+    @pytest.mark.asyncio()
+    async def test_post_forwards_files(self, meta_client: Any) -> None:
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.headers = {}
+        resp.json.return_value = {"ok": True}
+        meta_client._http = MagicMock()
+        meta_client._http.post = AsyncMock(return_value=resp)
+
+        files = {"source": ("a.mp4", b"bytes", "video/mp4")}
+        await meta_client._post("/act_123456/advideos", {"title": "t"}, files=files)
+
+        _, kwargs = meta_client._http.post.call_args
+        assert kwargs["files"] == files
+        assert kwargs["data"] == {"title": "t"}
+
+    @pytest.mark.asyncio()
+    async def test_post_without_files_omits_kwarg(self, meta_client: Any) -> None:
+        """Non-multipart callers must not gain a stray ``files`` kwarg."""
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.headers = {}
+        resp.json.return_value = {"ok": True}
+        meta_client._http = MagicMock()
+        meta_client._http.post = AsyncMock(return_value=resp)
+
+        await meta_client._post("/act_123456/adimages", {"bytes": "abc"})
+
+        _, kwargs = meta_client._http.post.call_args
+        assert "files" not in kwargs


### PR DESCRIPTION
## Summary
Field report: video creative submission (入稿) was impossible for standard objectives. Video was half-built — uploads existed, but only Lead Ads could build a video creative, and videos could not be status-polled or thumbnailed.

- **`meta_ads_creatives_create` video mode**: `video_id` + required thumbnail (`video_thumbnail_image_hash` | `video_thumbnail_image_url`) → `object_story_spec.video_data`. **`call_to_action` is required in video mode** — it is the only slot carrying the destination link (auto-filled from `link_url`); omitting it would ship an unclickable paid ad (review-mandated hard error)
- **New read-only tools**: `meta_ads_videos_get` (async processing-status polling) and `meta_ads_videos_thumbnails` (auto-generated thumbnails). Meta 86 → 88, aggregate 203 → 205
- **Upload foundation repaired**: local-file upload rebuilt on the shared request machinery (documented `source` multipart field with real per-extension video MIME, Bearer-only auth, Meta error subcode/fbtrace_id surfaced, retries, 600s timeout); size cap corrected 100 MB → Graph's 1 GB non-resumable limit; `.flv` handler/client mismatch fixed
- Skill docs: corrected video entries, new step-by-step video creative flow, tool-summary table completed to 88 (5 pre-existing tools were missing)

## Test plan
- Strict TDD (37 red → green); wire shapes pinned at the HTTP seam (field name, MIME, auth, timeout, retry body identity) — closing the blind spot class that shipped the /adimages bug
- Full suite 5,952 passed (env-only failures unchanged vs baseline); black/ruff clean
- Review: HIGH (CTA requirement) fixed per reviewer's design verdict; no CRITICAL

## Coordination
mureo-pro follow-up (`feat/meta-video-toolspec`: 2 READ ToolSpecs + 3 optional keys + .flv fix, cardinality 88) must merge immediately after this lands.
