### PR TITLE
fix(context): inject the server clock so daily checks cannot run on a stale date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a bad average). `/experiment` now advertises breakdown-exclusion and
   reallocation hypotheses as things it validates.
 
+### Changed
+
+- **`action_log` timestamps are stamped server-side (#460).**
+  `mureo_state_action_log_append` now writes the entry `timestamp` from
+  mureo's own clock (ISO 8601 with UTC offset); a value supplied by the caller
+  is still accepted by the schema — the property could not be removed without
+  breaking existing callers under `additionalProperties: false` — but is
+  **ignored**, and `timestamp` is no longer a required input. This closes the
+  loop that let a drifted model date be persisted and read back later as
+  evidence of the current date. The other action_log writers (native status
+  toggles, plugin mutations, creative-studio audits, rollback reversals) moved
+  onto the same clock, so every entry now carries a consistent offset-bearing
+  local timestamp instead of a UTC one.
+
 ### Fixed
+
+- **`/daily-check` no longer runs on a stale notion of "today" (#460).**
+  Nothing in the stack ever told the agent the current date, so it inferred
+  one from STATE.json — `reports.daily.period`, `last_synced_at`, `action_log`
+  timestamps — and sometimes short-circuited with "today's data is already
+  fetched, re-displaying" against a date days in the past. The two context
+  read tools now return **`server_now`**, the server's clock as ISO 8601 with
+  a UTC offset (`2026-07-28T10:12:33+09:00`, host-local because ad operations
+  reason in local days): `mureo_state_get` and `mureo_strategy_get` both carry
+  it, so a skill can establish the date from whichever file it reads first —
+  and a Bash-less headless host never needs to shell out to `date`.
+  `server_now` is a response-envelope field only: the STATE.json parser
+  ignores unknown top-level keys, so a copy echoed back into the file is
+  dropped by the next mureo write instead of fossilising a "today".
+  `daily-check`, `sync-state` and `budget-pacing` gain an explicit first step
+  that makes `server_now` the only source of the current date, forbids the
+  already-fetched short-circuit (a daily check always fetches fresh platform
+  data for the period ending on `server_now`'s date), and — for
+  `budget-pacing` — derives the pacing month and the elapsed / remaining day
+  counts from it.
 
 - **Meta video file upload rebuilt on the shared client machinery.**
   `meta_ads_videos_upload_file` used to open its own `httpx.AsyncClient` and

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -522,12 +522,14 @@ Cross-platform anomaly detection that operates on STATE.json's `action_log` hist
 
 Read and write the strategy context files (`STRATEGY.md`, `STATE.json`) directly through the MCP server. These tools exist for hosts that have no direct filesystem access (Claude Desktop chat, web, remote MCP); every write is atomic and validated before it replaces the file.
 
+Both read tools carry a **`server_now`** field — the server's clock as ISO 8601 with a UTC offset (e.g. `2026-07-28T10:12:33+09:00`). It is the authoritative current date for an agent that cannot run `date` (headless / Bash-less hosts): every other date in the document is history. `server_now` is a response field only and is never persisted — the parser ignores unknown top-level keys, so a copy echoed back into `STATE.json` is dropped by the next mureo write.
+
 | Tool | Description | Required Parameters |
 |------|-------------|-------------------|
-| `mureo_strategy_get` | Read STRATEGY.md — raw markdown plus an `exists` flag (empty markdown when absent) | *(none)* |
+| `mureo_strategy_get` | Read STRATEGY.md — raw markdown plus an `exists` flag (empty markdown when absent) and `server_now` | *(none)* |
 | `mureo_strategy_set` | Atomically replace STRATEGY.md (parsed for well-formedness before writing) | `markdown` |
-| `mureo_state_get` | Read STATE.json as a parsed v2 document (version, platforms, campaigns, action_log) | *(none)* |
-| `mureo_state_action_log_append` | Atomically append a single action_log entry for later evaluation | `entry` |
+| `mureo_state_get` | Read STATE.json as a parsed v2 document (version, platforms, campaigns, action_log) plus `server_now` | *(none)* |
+| `mureo_state_action_log_append` | Atomically append a single action_log entry for later evaluation (`timestamp` is stamped server-side) | `entry` |
 | `mureo_state_upsert_campaign` | Upsert a CampaignSnapshot (with optional performance `metrics`) into STATE.json | `campaign` |
 | `mureo_state_report_set` | Persist a structured daily / weekly / goal report summary for the read-only dashboard | `report`, `summary` |
 | `mureo_state_platform_metrics_set` | Set a platform-level metric rollup (feeds the YESTERDAY / LAST_30_DAYS dashboard toggle) | `platform`, `account_id` |

--- a/docs/strategy-context.md
+++ b/docs/strategy-context.md
@@ -185,7 +185,7 @@ Each entry in `action_log` records an action taken by a workflow command, with o
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `timestamp` | `string` | Yes | ISO 8601 timestamp of the action |
+| `timestamp` | `string` | No — server-stamped | ISO 8601 timestamp of the action, with UTC offset. Written by `mureo_state_action_log_append` from the **server's** clock — a value supplied by the caller is ignored, so a drifted agent date is never persisted. Always present in a stored entry |
 | `action` | `string` | Yes | Description of the action taken |
 | `platform` | `string` | Yes | Platform the action was taken on |
 | `campaign_id` | `string` | No | Campaign affected |

--- a/mureo/_data/skills/_mureo-shared/SKILL.md
+++ b/mureo/_data/skills/_mureo-shared/SKILL.md
@@ -105,10 +105,13 @@ Skills and commands describe "Read STRATEGY.md", "Update STATE.json", and "Appen
 | Read STRATEGY.md | `Read` tool | `mureo_strategy_get` MCP tool |
 | Replace STRATEGY.md | `Write` / `Edit` tool | `mureo_strategy_set` MCP tool |
 | Read STATE.json | `Read` tool | `mureo_state_get` MCP tool |
+| Establish the current date | `mureo_state_get` MCP tool (`server_now`) | `mureo_state_get` MCP tool (`server_now`) |
 | Append action_log entry | `mureo_state_action_log_append` MCP tool | `mureo_state_action_log_append` MCP tool |
 | Upsert campaign snapshot | `mureo_state_upsert_campaign` MCP tool | `mureo_state_upsert_campaign` MCP tool |
 
 When you don't have direct filesystem tools (Desktop / Cowork / web), always reach for the corresponding `mureo_*` MCP tool — they encode the same atomic-write semantics so you can't corrupt the file mid-edit.
+
+**Any skill whose work depends on "today" must call `mureo_state_get` (or `mureo_strategy_get`) and take the current date from the response's `server_now` field — on EVERY host, including Code, where you would otherwise just `Read` the file.** `server_now` is the server's own clock as ISO 8601 with UTC offset (e.g. `2026-07-28T10:12:33+09:00`) and is the **only** source of today: the dates *inside* the files (`last_synced_at`, `reports.*.period`, `action_log` timestamps) are history, and treating them as now is how a daily run ends up reporting a days-old date. Do not shell out to `date` — these skills must run in Bash-less headless hosts — and never write `server_now` back into STATE.json (it is a response field; a persisted copy becomes tomorrow's stale "today"). Relatedly, `mureo_state_action_log_append` stamps each entry's `timestamp` server-side, so never compute one yourself.
 
 For STATE.json **mutations** (`Upsert campaign snapshot` / `Append action_log entry`) prefer the `mureo_state_*` MCP tool on **every** host, **including Code**: they apply the correct schema atomically. A raw `Edit` easily omits the required `platforms[<platform>]` / `account_id`, and a platform/campaign missing those is **dropped** by the dashboard — the workspace then renders **empty / "not yet bootstrapped"** even after you wrote campaigns. Separately, `mureo_state_upsert_campaign` (and the metrics / report setters) stamp the top-level **`last_synced_at`** — the dashboard's "Synced N ago" freshness — which a hand-edit leaves stale (`mureo_state_action_log_append` does **not** re-stamp it). Hand-writing STATE.json directly with `Write` on Code is reserved for the **bulk-snapshot** flows (`sync-state` / `daily-check`); on that path you own replicating the full **STATE.json Schema** below, **including a fresh `last_synced_at`**.
 

--- a/mureo/_data/skills/budget-pacing/SKILL.md
+++ b/mureo/_data/skills/budget-pacing/SKILL.md
@@ -20,7 +20,9 @@ Track month-to-date spend against the monthly budget target, project the month-e
 
 **Before you start**: Run the **Diagnostic preamble** from ../_mureo-shared/SKILL.md — load learning insights (mureo_learning_insights_get) and consult advisors (mureo_consult_advisor) before drawing conclusions.
 
-1. **Load context**: Read STRATEGY.md (Operation Mode, `## Guardrails`, any `## Custom: Monthly Budget` section, Goal sections) and STATE.json.
+0. **Establish today**: call `mureo_state_get` **first, on every host** (including Claude Code, where you would otherwise `Read` the file) and take `server_now` from its response — ISO 8601 with UTC offset, e.g. `2026-07-28T10:12:33+09:00`. Pacing is date arithmetic, so this is load-bearing: `server_now`'s date is the **only source of the current date** — it fixes the pacing month, today's date, and therefore every elapsed/remaining-day count below. Do not shell out (this skill must run in Bash-less headless hosts) and do not read the date off STATE.json: `last_synced_at`, `reports.*.period` and `action_log` timestamps are **history**, and pacing against a stale month silently mis-states the landing. **Never write `server_now` into STATE.json** — it is a response field, and a persisted copy becomes tomorrow's stale "today".
+
+1. **Load context**: Read STRATEGY.md (Operation Mode, `## Guardrails`, any `## Custom: Monthly Budget` section, Goal sections) and STATE.json (the same `mureo_state_get` response from step 0 on MCP hosts).
 
 2. **Discover platforms**: Identify all configured platforms from STATE.json `platforms`. Also include any **hosted official-MCP connector** present in the session (e.g. TikTok, key `tiktok_ads`) and `mcp__mureo__<plugin>_*` plugin platforms — drive each via its own tools, best-effort; see `../_mureo-shared/SKILL.md` → *Hosted-connector platforms* and *Plugin platforms*.
 
@@ -44,8 +46,8 @@ Track month-to-date spend against the monthly budget target, project the month-e
 
 5. **Compute pacing** per platform and in total:
    - **MTD spend** — from step 4.
-   - **Elapsed days** — completed days this month. **Exclude today**: today's numbers are a partial, still-accumulating day and would bias the run-rate downward. Daily run-rate = MTD spend ÷ elapsed (completed) days.
-   - **Projected month-end landing** = MTD spend + run-rate × (days remaining, counting today forward).
+   - **Elapsed days** — completed days this month, derived from `server_now`: `server_now`'s day-of-month minus 1. **Exclude today**: today's numbers are a partial, still-accumulating day and would bias the run-rate downward. Daily run-rate = MTD spend ÷ elapsed (completed) days.
+   - **Projected month-end landing** = MTD spend + run-rate × (days remaining, counting today forward) — days remaining = days in `server_now`'s month − elapsed days.
    - **% vs target** = projected landing ÷ monthly target.
 
 6. **Seasonality / confidence caution**: early-month run-rates are noisy — a single big-spend or zero-spend day swings the projection hard. When **fewer than 5 days have elapsed**, label the projection **low confidence** and lead with that caveat; prefer *watch* over *act*. Also note known intra-month seasonality from STRATEGY.md (e.g. a `## Custom` seasonal ramp, weekend dips) that makes a flat run-rate misleading.
@@ -72,8 +74,8 @@ Track month-to-date spend against the monthly budget target, project the month-e
 11. **Record outcome context**: for each campaign modified, log to `action_log` (via `mureo_state_action_log_append`) with `metrics_at_action` (current MTD spend, run-rate, daily budget, projected landing) and `observation_due` **7 days** from today, so daily-check's evidence step verifies the change actually bent the trajectory toward target.
 
 12. **Persist the report summary** (best-effort): Call `mureo_state_report_set` with `report="pacing"` and a concise `summary` object so the read-only dashboard can render pacing without re-running you. Follow this convention:
-    - `generated_at`: ISO 8601 timestamp of this run
-    - `period`: the pacing month (e.g. `"2026-07"`) and elapsed/total days
+    - `generated_at`: ISO 8601 timestamp of this run — use `server_now`
+    - `period`: the pacing month from `server_now` (e.g. `"2026-07"`) and elapsed/total days
     - `kpis`: per-platform + total `{monthly_target, mtd_spend, run_rate, projected_landing, pct_vs_target}`
     - `flags`: notable items (e.g. `["google_ads_overpacing_18pct", "low_confidence_early_month"]`)
     - `narrative`: the 1-2 sentence pacing verdict (on-pace / overpacing / underpacing, with confidence)

--- a/mureo/_data/skills/daily-check/SKILL.md
+++ b/mureo/_data/skills/daily-check/SKILL.md
@@ -19,7 +19,11 @@ Run a daily health check on all marketing accounts using the strategy context.
 **Before you start**: Run the **Diagnostic preamble** from ../_mureo-shared/SKILL.md — load learning insights (mureo_learning_insights_get) and consult advisors (mureo_consult_advisor) before drawing conclusions.
 
 
-1. **Load context**: Read STRATEGY.md (especially Operation Mode, Data Sources, and all Goal sections) and STATE.json.
+0. **Establish today**: call `mureo_state_get` **first, on every host** (including Claude Code, where you would otherwise `Read` the file) and take `server_now` from its response — an ISO 8601 timestamp with UTC offset, e.g. `2026-07-28T10:12:33+09:00`. Its date is the **only source of the current date** for this run; do not ask the user, do not guess, and do not shell out (this skill must run in Bash-less headless hosts). Every other date you will see — `reports.daily.period`, `last_synced_at`, `action_log` timestamps — is **history**, never evidence of what day it is now. Also **never write `server_now` into STATE.json**: it is a response field, and a persisted copy becomes tomorrow's stale "today".
+
+   **Never short-circuit on history.** Do not conclude "today's report is already fetched — re-displaying it" (or skip a step) because a stored `period` / `last_synced_at` looks like today. A daily check **always fetches fresh platform data** for the period ending on `server_now`'s date; a stored report is at best a prior run to compare against.
+
+1. **Load context**: Read STRATEGY.md (especially Operation Mode, Data Sources, and all Goal sections) and STATE.json (the same `mureo_state_get` response from step 0 on MCP hosts).
 
 2. **Discover available platforms**: Identify all configured platforms from STATE.json `platforms` and check which data sources (Search Console, GA4) are accessible. Also enumerate installed **plugin** platforms (`mcp__mureo__<plugin>_*` tools) and any **hosted official-MCP connector** present in the session (e.g. TikTok's `tt-ads-*` tools, STATE.json key `tiktok_ads`); include them best-effort — see `_mureo-shared` → *Plugin platforms* and *Hosted-connector platforms*.
 
@@ -60,7 +64,7 @@ Run a daily health check on all marketing accounts using the strategy context.
    Goal: Organic clicks +20% -- Search Console: +12% IN PROGRESS
    ```
 
-9. **Evidence check**: Review `action_log` entries that have `observation_due` dates:
+9. **Evidence check**: Review `action_log` entries that have `observation_due` dates — compare each one against `server_now`'s date, never against another `action_log` timestamp:
    - For entries whose observation window has passed: collect current metrics for the same campaign and call **`mureo_outcome_evaluate`** with `before` = the entry's `metrics_at_action` and `after` = the current metrics. It returns a deterministic per-metric + overall **improved / regressed / inconclusive** verdict (applying the ±noise band and metric directions for you) — use it instead of eyeballing the numbers, then report with the confidence it implies (see `_mureo-learning` skill). This tool is pure/platform-agnostic, so it works for **any** platform including hosted connectors and plugins — for those, first **normalize the connector's metric names to the standard keys** (`cpa`, `conversions`, `ctr`, `cost`, …) so they can be scored (unknown names are treated as neutral/no-verdict).
    - For entries still within their observation window: note them as "pending observation" and do NOT recommend further changes to those campaigns.
    - `platform="plugin:<dist>"` entries participate in this loop on equal footing with built-ins; they have no `metrics_at_action` baseline, so evaluate them **qualitatively/advisory** (see `_mureo-shared` → *Mutating plugin tools — structural strategy parity*).
@@ -73,11 +77,11 @@ Run a daily health check on all marketing accounts using the strategy context.
 
     For each issue, suggest specific actions aligned with the current Operation Mode. Do NOT recommend actions based on single-day fluctuations — at least 7 consecutive days of critical metrics (>30% off target) before suggesting rescue.
 
-11. **Update STATE.json**: Update campaign snapshots, add notes for flagged issues, and log this daily check to the `action_log` with a summary of findings. On the Code `Write` path, use the canonical STATE.json field names — `campaign_name` (NOT the tool-output `name`), `campaign_id`, and each platform's `account_id`; a snapshot/platform missing a required field is dropped by the reporting dashboard. On the Code `Write` path also **stamp the top-level `last_synced_at` to now** so the dashboard's "Synced N ago" freshness reflects this run (the `mureo_state_upsert_campaign` / `_platform_metrics_set` tools set it for you). See `../_mureo-shared/SKILL.md` → *STATE.json Schema*.
+11. **Update STATE.json**: Update campaign snapshots, add notes for flagged issues, and log this daily check to the `action_log` with a summary of findings. On the Code `Write` path, use the canonical STATE.json field names — `campaign_name` (NOT the tool-output `name`), `campaign_id`, and each platform's `account_id`; a snapshot/platform missing a required field is dropped by the reporting dashboard. On the Code `Write` path also **stamp the top-level `last_synced_at` to `server_now`** so the dashboard's "Synced N ago" freshness reflects this run (the `mureo_state_upsert_campaign` / `_platform_metrics_set` tools set it for you). See `../_mureo-shared/SKILL.md` → *STATE.json Schema*.
 
 12. **Persist the report summary** (best-effort): Call `mureo_state_report_set` with `report="daily"` and a concise `summary` object so the read-only dashboard can render this report without re-running you. Follow this convention:
-    - `generated_at`: ISO 8601 timestamp of this run
-    - `period`: the day reviewed (e.g. `"2026-06-17"`)
+    - `generated_at`: ISO 8601 timestamp of this run — use `server_now`
+    - `period`: the day reviewed, derived from `server_now` (e.g. `"2026-06-17"`)
     - `kpis`: per-platform and/or totals headline numbers (spend, conversions, cpa, ctr)
     - `flags`: a list of **structured** flags — each a small object `{code, severity, params}` so the dashboard renders a coarse, localizable chip with the numbers on drill-down:
         - `code`: a canonical vocabulary key — one of `goals_met`, `cpa_over_target`, `cpa_under_target`, `cv_below_target`, `cv_above_target`, `spend_spike`, `cpa_spike`, `invalid_traffic_suspected`, `zero_cv_adspots`, `budget_overspend`, `budget_drift`, `tracking_suspect`, `zero_conversions`, `supply_tools_unconfigured`, `anomaly_baseline_insufficient`, `pending_observations`, `search_console_no_property`, `ga4_not_configured`.

--- a/mureo/_data/skills/sync-state/SKILL.md
+++ b/mureo/_data/skills/sync-state/SKILL.md
@@ -18,7 +18,9 @@ Synchronize STATE.json with the current state of all marketing platforms.
 
 > Note: the **Diagnostic preamble** (learning insights + advisor consult) from `../_mureo-shared/SKILL.md` is intentionally **not** required here — sync-state is mechanical data synchronization with no judgement calls.
 
-1. **Read current STATE.json** (if exists) to track changes.
+0. **Establish today**: call `mureo_state_get` **first, on every host** (including Claude Code, where you would otherwise `Read` the file) and take `server_now` from its response — ISO 8601 with UTC offset, e.g. `2026-07-28T10:12:33+09:00`. Its date is the **only source of the current date** for this sync (no shelling out — this skill must run in Bash-less headless hosts). The dates inside the document — `last_synced_at`, `reports.*.period`, `action_log` timestamps — are **history**: use them to describe what changed, never to decide what "now" is or whether a sync is still needed. **Never write `server_now` into STATE.json**; it is a response field, and a persisted copy becomes tomorrow's stale "today".
+
+1. **Read current STATE.json** (if exists) to track changes — the same `mureo_state_get` response from step 0 on MCP hosts.
 
 2. **Discover platforms**: Identify all platforms registered in STATE.json `platforms` — built-in AND plugin/bridge platforms. Per `../_mureo-shared/SKILL.md` → *Plugin platforms*, also enumerate any installed entry-point plugin that exposes `mcp__mureo__<plugin>_*` tools; its STATE.json platform key is `plugin:<dist>` (the same convention mureo uses when promoting plugin mutations into `action_log`). Also enumerate any **hosted official-MCP connector** present in the session (e.g. TikTok's `tt-ads-*` tools) — its key is a first-class ad-platform key such as `tiktok_ads`; see `../_mureo-shared/SKILL.md` → *Hosted-connector platforms*.
 
@@ -44,6 +46,6 @@ Synchronize STATE.json with the current state of all marketing platforms.
    - Status changes
    - Bidding strategy changes
 
-9. **Update `last_synced_at`** timestamp.
+9. **Update `last_synced_at`** timestamp — use `server_now` from step 0 (the `mureo_state_*` write tools stamp it for you; on the Code `Write` path write that value yourself).
 
 If STATE.json doesn't exist yet, suggest running `/onboard` first.

--- a/mureo/context/state.py
+++ b/mureo/context/state.py
@@ -131,6 +131,12 @@ def parse_state(text: str, *, strict: bool = True) -> StateDocument:
     skips nonconforming campaign / action_log entries and defaults a missing
     platform ``account_id`` to ``""`` for the read-only Reports view. Invalid
     JSON always raises regardless of ``strict``.
+
+    Unknown top-level keys are ignored (and :func:`render_state` emits only
+    the known ones), which is what keeps the ``mureo_state_get`` response
+    field ``server_now`` from ever being persisted: a document echoed back
+    into STATE.json with that key loses it on the next write instead of
+    fossilising a stale "today" (#460).
     """
     data = json.loads(text)
     campaigns_raw = data.get("campaigns", [])

--- a/mureo/core/clock.py
+++ b/mureo/core/clock.py
@@ -1,0 +1,45 @@
+"""The server clock mureo injects into its MCP responses (#460).
+
+An agent has no trustworthy notion of "today". It reads STATE.json, sees
+``reports.daily.period`` / ``last_synced_at`` / ``action_log`` timestamps
+and mistakes that history for the current date — which is how
+``/daily-check`` came to short-circuit with "today's data is already
+fetched" against a days-old date. Shelling out to ``date`` is not an
+option: the workflow skills must run in Bash-less headless hosts, so the
+clock has to travel inside MCP responses.
+
+This module is the single source of that clock:
+
+- :func:`server_now` — the host's local wall clock, timezone-aware. Ad
+  operations reason in local days (a JST operator's "yesterday" is not
+  UTC's), so the local offset is deliberate; UTC-only would roll the day
+  at the wrong moment.
+- :func:`server_now_iso` — ISO 8601 **with an explicit UTC offset** and
+  second precision (e.g. ``2026-07-28T10:12:33+09:00``).
+
+Injection point: ``server_now`` is resolved through the module global at
+call time, so freezing the clock in a test is a single
+``monkeypatch.setattr(mureo.core.clock, "server_now", lambda: frozen)``.
+For that to hold, call sites either import :func:`server_now_iso` by name
+(it looks ``server_now`` up on each call) or reach the datetime through
+the module — ``from mureo.core import clock`` / ``clock.server_now()`` —
+when they need to do date arithmetic (e.g. an ``observation_due``
+window). Never bind ``server_now`` itself into another module's
+namespace: that copy would survive the patch.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+__all__ = ["server_now", "server_now_iso"]
+
+
+def server_now() -> datetime:
+    """Current server time as a timezone-aware datetime in the host's zone."""
+    return datetime.now().astimezone()
+
+
+def server_now_iso() -> str:
+    """:func:`server_now` as ISO 8601 with a UTC offset, second precision."""
+    return server_now().isoformat(timespec="seconds")

--- a/mureo/mcp/_handlers_mureo_context.py
+++ b/mureo/mcp/_handlers_mureo_context.py
@@ -23,6 +23,21 @@ Atomic write semantics come from ``mureo.context.state._atomic_write``
 and the equivalent path in ``context.strategy``: write to a temp file
 in the same directory, then ``os.replace`` over the target. A failure
 mid-flight leaves the original intact.
+
+Server clock (#460)
+-------------------
+The two read entry points (``mureo_strategy_get`` / ``mureo_state_get``)
+carry a ``server_now`` field — the host's clock as ISO 8601 with a UTC
+offset. Skills use it as their only source of "today"; a Bash-less
+headless host cannot shell out to ``date``, and the dates *inside*
+STATE.json are history, not now. ``server_now`` lives on the RESPONSE
+envelope only: ``parse_state`` ignores unknown top-level keys and
+``render_state`` emits only the known ones, so a stray ``server_now``
+echoed back into STATE.json is dropped by the next mureo write rather
+than becoming a fossilised "today". Symmetrically,
+``mureo_state_action_log_append`` stamps the entry ``timestamp``
+server-side: a model-supplied value is ignored, so a drifted date can no
+longer be persisted and read back later as fact.
 """
 
 from __future__ import annotations
@@ -43,6 +58,7 @@ from mureo.context.state import (
     upsert_campaign,
 )
 from mureo.context.strategy import RAW_HEADING_TYPE, parse_strategy, write_strategy_file
+from mureo.core.clock import server_now_iso
 from mureo.core.runtime_context import get_runtime_context
 from mureo.fsutil import backup_file
 from mureo.mcp._helpers import _json_result, _require
@@ -109,10 +125,27 @@ def _resolve_path(
 
 async def handle_strategy_get(arguments: dict[str, Any]) -> list[TextContent]:
     path = _resolve_path(arguments, "STRATEGY.md", store_attr="strategy_path")
+    # ``server_now`` on both branches: a skill that starts from STRATEGY.md
+    # (or runs before onboarding, when neither file exists) must still be
+    # able to establish the current date without a second call.
     if not path.exists():
-        return _json_result({"markdown": "", "exists": False, "path": str(path)})
+        return _json_result(
+            {
+                "markdown": "",
+                "exists": False,
+                "path": str(path),
+                "server_now": server_now_iso(),
+            }
+        )
     text = path.read_text(encoding="utf-8")
-    return _json_result({"markdown": text, "exists": True, "path": str(path)})
+    return _json_result(
+        {
+            "markdown": text,
+            "exists": True,
+            "path": str(path),
+            "server_now": server_now_iso(),
+        }
+    )
 
 
 async def handle_strategy_set(arguments: dict[str, Any]) -> list[TextContent]:
@@ -163,7 +196,15 @@ async def handle_state_get(arguments: dict[str, Any]) -> list[TextContent]:
     # the file is absent; round-trip through render_state to keep the
     # missing-file and present-file branches in lockstep.
     doc = read_state_file(path)
-    return _json_result(_state_to_dict(doc))
+    payload = _state_to_dict(doc)
+    # Response-envelope only (#460). ``_state_to_dict`` renders the parsed
+    # document, so this key is added AFTER serialization and is never part of
+    # what gets written back: ``parse_state`` ignores unknown top-level keys
+    # and ``render_state`` emits only known ones, so an agent that echoes this
+    # response into STATE.json loses the key on the next mureo write instead
+    # of leaving a stale "today" behind.
+    payload["server_now"] = server_now_iso()
+    return _json_result(payload)
 
 
 async def handle_state_action_log_append(
@@ -173,11 +214,15 @@ async def handle_state_action_log_append(
     if not isinstance(raw, dict):
         raise ValueError("entry must be an object")
     # Required per ActionLogEntry contract.
-    timestamp = _require(raw, "timestamp")
     action = _require(raw, "action")
     platform = _require(raw, "platform")
+    # ``timestamp`` is stamped SERVER-side (#460). A model-supplied value is
+    # accepted by the schema (dropping the property would break existing
+    # callers under ``additionalProperties: false``) but deliberately ignored:
+    # it is exactly how a drifted date used to get persisted and then read
+    # back out of the action_log as evidence of "today".
     entry = ActionLogEntry(
-        timestamp=timestamp,
+        timestamp=server_now_iso(),
         action=action,
         platform=platform,
         campaign_id=raw.get("campaign_id"),

--- a/mureo/mcp/native_reversal.py
+++ b/mureo/mcp/native_reversal.py
@@ -23,9 +23,11 @@ no-ops when there is no STATE.json in the current working directory.
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 from pathlib import Path
 from typing import Any
+
+from mureo.core import clock
 
 logger = logging.getLogger(__name__)
 
@@ -210,7 +212,11 @@ def record_native_mutation(
         from mureo.context.models import ActionLogEntry
         from mureo.context.state import append_action_log
 
-        now = datetime.now(timezone.utc)
+        # Server clock (#460): the same offset-bearing local timestamp
+        # ``mureo_state_action_log_append`` stamps, so entries from both
+        # promotion paths are directly comparable — and ``observation_due``
+        # lands on the operator's local calendar day.
+        now = clock.server_now()
         entry = ActionLogEntry(
             timestamp=now.isoformat(timespec="seconds"),
             action=name,

--- a/mureo/mcp/plugin_semantics.py
+++ b/mureo/mcp/plugin_semantics.py
@@ -31,10 +31,11 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from mureo.core import clock
 from mureo.policy.declarations import BidDeclaration, BudgetDeclaration
 from mureo.throttle import ThrottleConfig
 
@@ -245,7 +246,8 @@ def record_mutation_action_log(
         from mureo.context.models import ActionLogEntry
         from mureo.context.state import append_action_log
 
-        now = datetime.now(timezone.utc)
+        # Server clock (#460) — same stamp/format as every other writer.
+        now = clock.server_now()
         days = observation_days or _DEFAULT_OBSERVATION_DAYS
         entry = ActionLogEntry(
             timestamp=now.isoformat(timespec="seconds"),

--- a/mureo/mcp/tools_creative_studio.py
+++ b/mureo/mcp/tools_creative_studio.py
@@ -25,6 +25,7 @@ from typing import Any
 from mcp.types import TextContent, Tool
 
 from mureo._image_validation import validate_image_file
+from mureo.core.clock import server_now_iso
 from mureo.creative_studio import composer
 from mureo.creative_studio.brand_kit import DEFAULT_BRAND_KIT, BrandKit, load_brand_kit
 from mureo.creative_studio.formats import FORMATS_BY_ID, generation_size_for_aspect
@@ -495,9 +496,9 @@ def _record_audit(run_id: str, manifest_path: Path) -> None:
         from mureo.context.models import ActionLogEntry
         from mureo.context.state import append_action_log
 
-        now = datetime.now(timezone.utc)
         entry = ActionLogEntry(
-            timestamp=now.isoformat(timespec="seconds"),
+            # Server clock (#460) — same stamp/format as every other writer.
+            timestamp=server_now_iso(),
             action="creative_studio_generate_visual",
             platform="creative_studio",
             summary=f"Generated key visuals (run {run_id})",
@@ -727,9 +728,9 @@ def _studio_audit(action: str, summary: str, metrics: dict[str, Any]) -> None:
         from mureo.context.models import ActionLogEntry
         from mureo.context.state import append_action_log
 
-        now = datetime.now(timezone.utc)
         entry = ActionLogEntry(
-            timestamp=now.isoformat(timespec="seconds"),
+            # Server clock (#460) — same stamp/format as every other writer.
+            timestamp=server_now_iso(),
             action=action,
             platform="creative_studio",
             summary=summary,

--- a/mureo/mcp/tools_mureo_context.py
+++ b/mureo/mcp/tools_mureo_context.py
@@ -45,13 +45,23 @@ _PATH_PROPERTY = {
 _ACTION_LOG_ENTRY_PROPERTY = {
     "type": "object",
     "description": (
-        "An action_log entry. Required: timestamp (ISO 8601), action "
-        "(short description), platform (google_ads / meta_ads / etc.). "
-        "Optional: campaign_id, summary, command, metrics_at_action, "
-        "observation_due, reversible_params, rollback_of."
+        "An action_log entry. Required: action (short description), "
+        "platform (google_ads / meta_ads / etc.). The ``timestamp`` is "
+        "stamped by the server — do not compute it. Optional: campaign_id, "
+        "summary, command, metrics_at_action, observation_due, "
+        "reversible_params, rollback_of."
     ),
     "properties": {
-        "timestamp": {"type": "string"},
+        "timestamp": {
+            "type": "string",
+            "description": (
+                "IGNORED — the server stamps the entry with its own clock "
+                "(ISO 8601 with UTC offset). Accepted only for backward "
+                "compatibility with existing callers; any value supplied "
+                "here is discarded, so a drifted client date can never be "
+                "persisted and later read back as evidence of 'today'."
+            ),
+        },
         "action": {"type": "string"},
         "platform": {"type": "string"},
         "campaign_id": {"type": "string"},
@@ -62,7 +72,7 @@ _ACTION_LOG_ENTRY_PROPERTY = {
         "reversible_params": {"type": "object"},
         "rollback_of": {"type": "integer"},
     },
-    "required": ["timestamp", "action", "platform"],
+    "required": ["action", "platform"],
 }
 
 
@@ -127,10 +137,13 @@ TOOLS: list[Tool] = [
         name="mureo_strategy_get",
         description=(
             "Read STRATEGY.md and return its raw markdown text plus an "
-            "exists flag. Returns empty markdown when the file is "
+            "exists flag and ``server_now`` (the server's clock as ISO 8601 "
+            "with UTC offset). Returns empty markdown when the file is "
             "absent (skills should treat that as 'no strategy yet', "
             "not as an error). Use this when the host has no direct "
-            "filesystem access (Claude Desktop chat, web, remote MCP)."
+            "filesystem access (Claude Desktop chat, web, remote MCP). "
+            "Treat ``server_now`` as the current date — never infer today "
+            "from dates found inside the context files."
         ),
         inputSchema={
             "type": "object",
@@ -166,7 +179,13 @@ TOOLS: list[Tool] = [
             "Read STATE.json and return its parsed v2 document: "
             "version, last_synced_at, platforms (per-platform "
             "campaigns), legacy v1 campaigns, and action_log. Returns "
-            "an empty default doc when the file is absent."
+            "an empty default doc when the file is absent. The response "
+            "also carries ``server_now`` — the server's clock as ISO 8601 "
+            "with UTC offset (e.g. 2026-07-28T10:12:33+09:00). It is the "
+            "authoritative current date: every OTHER date in the document "
+            "(last_synced_at, reports.*.period, action_log timestamps) is "
+            "history and must never be read as 'today'. ``server_now`` is a "
+            "response field only — do not write it back into STATE.json."
         ),
         inputSchema={
             "type": "object",

--- a/mureo/rollback/executor.py
+++ b/mureo/rollback/executor.py
@@ -34,11 +34,11 @@ from __future__ import annotations
 
 import contextvars
 from collections.abc import Awaitable, Callable
-from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
 from mureo.context.models import ActionLogEntry
 from mureo.context.state import append_action_log, read_state_file
+from mureo.core.clock import server_now_iso
 from mureo.rollback.models import RollbackStatus
 from mureo.rollback.planner import plan_rollback
 
@@ -192,7 +192,7 @@ async def execute_rollback(
         }
 
     new_entry = ActionLogEntry(
-        timestamp=_utc_now_iso(),
+        timestamp=server_now_iso(),
         action=plan.operation,
         platform=plan.platform,
         campaign_id=entry.campaign_id,
@@ -209,7 +209,3 @@ async def execute_rollback(
         "caveats": list(plan.caveats),
         "rollback_of": index,
     }
-
-
-def _utc_now_iso() -> str:
-    return datetime.now(tz=timezone.utc).replace(microsecond=0).isoformat()

--- a/skills/_mureo-shared/SKILL.md
+++ b/skills/_mureo-shared/SKILL.md
@@ -105,10 +105,13 @@ Skills and commands describe "Read STRATEGY.md", "Update STATE.json", and "Appen
 | Read STRATEGY.md | `Read` tool | `mureo_strategy_get` MCP tool |
 | Replace STRATEGY.md | `Write` / `Edit` tool | `mureo_strategy_set` MCP tool |
 | Read STATE.json | `Read` tool | `mureo_state_get` MCP tool |
+| Establish the current date | `mureo_state_get` MCP tool (`server_now`) | `mureo_state_get` MCP tool (`server_now`) |
 | Append action_log entry | `mureo_state_action_log_append` MCP tool | `mureo_state_action_log_append` MCP tool |
 | Upsert campaign snapshot | `mureo_state_upsert_campaign` MCP tool | `mureo_state_upsert_campaign` MCP tool |
 
 When you don't have direct filesystem tools (Desktop / Cowork / web), always reach for the corresponding `mureo_*` MCP tool — they encode the same atomic-write semantics so you can't corrupt the file mid-edit.
+
+**Any skill whose work depends on "today" must call `mureo_state_get` (or `mureo_strategy_get`) and take the current date from the response's `server_now` field — on EVERY host, including Code, where you would otherwise just `Read` the file.** `server_now` is the server's own clock as ISO 8601 with UTC offset (e.g. `2026-07-28T10:12:33+09:00`) and is the **only** source of today: the dates *inside* the files (`last_synced_at`, `reports.*.period`, `action_log` timestamps) are history, and treating them as now is how a daily run ends up reporting a days-old date. Do not shell out to `date` — these skills must run in Bash-less headless hosts — and never write `server_now` back into STATE.json (it is a response field; a persisted copy becomes tomorrow's stale "today"). Relatedly, `mureo_state_action_log_append` stamps each entry's `timestamp` server-side, so never compute one yourself.
 
 For STATE.json **mutations** (`Upsert campaign snapshot` / `Append action_log entry`) prefer the `mureo_state_*` MCP tool on **every** host, **including Code**: they apply the correct schema atomically. A raw `Edit` easily omits the required `platforms[<platform>]` / `account_id`, and a platform/campaign missing those is **dropped** by the dashboard — the workspace then renders **empty / "not yet bootstrapped"** even after you wrote campaigns. Separately, `mureo_state_upsert_campaign` (and the metrics / report setters) stamp the top-level **`last_synced_at`** — the dashboard's "Synced N ago" freshness — which a hand-edit leaves stale (`mureo_state_action_log_append` does **not** re-stamp it). Hand-writing STATE.json directly with `Write` on Code is reserved for the **bulk-snapshot** flows (`sync-state` / `daily-check`); on that path you own replicating the full **STATE.json Schema** below, **including a fresh `last_synced_at`**.
 

--- a/skills/budget-pacing/SKILL.md
+++ b/skills/budget-pacing/SKILL.md
@@ -20,7 +20,9 @@ Track month-to-date spend against the monthly budget target, project the month-e
 
 **Before you start**: Run the **Diagnostic preamble** from ../_mureo-shared/SKILL.md — load learning insights (mureo_learning_insights_get) and consult advisors (mureo_consult_advisor) before drawing conclusions.
 
-1. **Load context**: Read STRATEGY.md (Operation Mode, `## Guardrails`, any `## Custom: Monthly Budget` section, Goal sections) and STATE.json.
+0. **Establish today**: call `mureo_state_get` **first, on every host** (including Claude Code, where you would otherwise `Read` the file) and take `server_now` from its response — ISO 8601 with UTC offset, e.g. `2026-07-28T10:12:33+09:00`. Pacing is date arithmetic, so this is load-bearing: `server_now`'s date is the **only source of the current date** — it fixes the pacing month, today's date, and therefore every elapsed/remaining-day count below. Do not shell out (this skill must run in Bash-less headless hosts) and do not read the date off STATE.json: `last_synced_at`, `reports.*.period` and `action_log` timestamps are **history**, and pacing against a stale month silently mis-states the landing. **Never write `server_now` into STATE.json** — it is a response field, and a persisted copy becomes tomorrow's stale "today".
+
+1. **Load context**: Read STRATEGY.md (Operation Mode, `## Guardrails`, any `## Custom: Monthly Budget` section, Goal sections) and STATE.json (the same `mureo_state_get` response from step 0 on MCP hosts).
 
 2. **Discover platforms**: Identify all configured platforms from STATE.json `platforms`. Also include any **hosted official-MCP connector** present in the session (e.g. TikTok, key `tiktok_ads`) and `mcp__mureo__<plugin>_*` plugin platforms — drive each via its own tools, best-effort; see `../_mureo-shared/SKILL.md` → *Hosted-connector platforms* and *Plugin platforms*.
 
@@ -44,8 +46,8 @@ Track month-to-date spend against the monthly budget target, project the month-e
 
 5. **Compute pacing** per platform and in total:
    - **MTD spend** — from step 4.
-   - **Elapsed days** — completed days this month. **Exclude today**: today's numbers are a partial, still-accumulating day and would bias the run-rate downward. Daily run-rate = MTD spend ÷ elapsed (completed) days.
-   - **Projected month-end landing** = MTD spend + run-rate × (days remaining, counting today forward).
+   - **Elapsed days** — completed days this month, derived from `server_now`: `server_now`'s day-of-month minus 1. **Exclude today**: today's numbers are a partial, still-accumulating day and would bias the run-rate downward. Daily run-rate = MTD spend ÷ elapsed (completed) days.
+   - **Projected month-end landing** = MTD spend + run-rate × (days remaining, counting today forward) — days remaining = days in `server_now`'s month − elapsed days.
    - **% vs target** = projected landing ÷ monthly target.
 
 6. **Seasonality / confidence caution**: early-month run-rates are noisy — a single big-spend or zero-spend day swings the projection hard. When **fewer than 5 days have elapsed**, label the projection **low confidence** and lead with that caveat; prefer *watch* over *act*. Also note known intra-month seasonality from STRATEGY.md (e.g. a `## Custom` seasonal ramp, weekend dips) that makes a flat run-rate misleading.
@@ -72,8 +74,8 @@ Track month-to-date spend against the monthly budget target, project the month-e
 11. **Record outcome context**: for each campaign modified, log to `action_log` (via `mureo_state_action_log_append`) with `metrics_at_action` (current MTD spend, run-rate, daily budget, projected landing) and `observation_due` **7 days** from today, so daily-check's evidence step verifies the change actually bent the trajectory toward target.
 
 12. **Persist the report summary** (best-effort): Call `mureo_state_report_set` with `report="pacing"` and a concise `summary` object so the read-only dashboard can render pacing without re-running you. Follow this convention:
-    - `generated_at`: ISO 8601 timestamp of this run
-    - `period`: the pacing month (e.g. `"2026-07"`) and elapsed/total days
+    - `generated_at`: ISO 8601 timestamp of this run — use `server_now`
+    - `period`: the pacing month from `server_now` (e.g. `"2026-07"`) and elapsed/total days
     - `kpis`: per-platform + total `{monthly_target, mtd_spend, run_rate, projected_landing, pct_vs_target}`
     - `flags`: notable items (e.g. `["google_ads_overpacing_18pct", "low_confidence_early_month"]`)
     - `narrative`: the 1-2 sentence pacing verdict (on-pace / overpacing / underpacing, with confidence)

--- a/skills/daily-check/SKILL.md
+++ b/skills/daily-check/SKILL.md
@@ -19,7 +19,11 @@ Run a daily health check on all marketing accounts using the strategy context.
 **Before you start**: Run the **Diagnostic preamble** from ../_mureo-shared/SKILL.md — load learning insights (mureo_learning_insights_get) and consult advisors (mureo_consult_advisor) before drawing conclusions.
 
 
-1. **Load context**: Read STRATEGY.md (especially Operation Mode, Data Sources, and all Goal sections) and STATE.json.
+0. **Establish today**: call `mureo_state_get` **first, on every host** (including Claude Code, where you would otherwise `Read` the file) and take `server_now` from its response — an ISO 8601 timestamp with UTC offset, e.g. `2026-07-28T10:12:33+09:00`. Its date is the **only source of the current date** for this run; do not ask the user, do not guess, and do not shell out (this skill must run in Bash-less headless hosts). Every other date you will see — `reports.daily.period`, `last_synced_at`, `action_log` timestamps — is **history**, never evidence of what day it is now. Also **never write `server_now` into STATE.json**: it is a response field, and a persisted copy becomes tomorrow's stale "today".
+
+   **Never short-circuit on history.** Do not conclude "today's report is already fetched — re-displaying it" (or skip a step) because a stored `period` / `last_synced_at` looks like today. A daily check **always fetches fresh platform data** for the period ending on `server_now`'s date; a stored report is at best a prior run to compare against.
+
+1. **Load context**: Read STRATEGY.md (especially Operation Mode, Data Sources, and all Goal sections) and STATE.json (the same `mureo_state_get` response from step 0 on MCP hosts).
 
 2. **Discover available platforms**: Identify all configured platforms from STATE.json `platforms` and check which data sources (Search Console, GA4) are accessible. Also enumerate installed **plugin** platforms (`mcp__mureo__<plugin>_*` tools) and any **hosted official-MCP connector** present in the session (e.g. TikTok's `tt-ads-*` tools, STATE.json key `tiktok_ads`); include them best-effort — see `_mureo-shared` → *Plugin platforms* and *Hosted-connector platforms*.
 
@@ -60,7 +64,7 @@ Run a daily health check on all marketing accounts using the strategy context.
    Goal: Organic clicks +20% -- Search Console: +12% IN PROGRESS
    ```
 
-9. **Evidence check**: Review `action_log` entries that have `observation_due` dates:
+9. **Evidence check**: Review `action_log` entries that have `observation_due` dates — compare each one against `server_now`'s date, never against another `action_log` timestamp:
    - For entries whose observation window has passed: collect current metrics for the same campaign and call **`mureo_outcome_evaluate`** with `before` = the entry's `metrics_at_action` and `after` = the current metrics. It returns a deterministic per-metric + overall **improved / regressed / inconclusive** verdict (applying the ±noise band and metric directions for you) — use it instead of eyeballing the numbers, then report with the confidence it implies (see `_mureo-learning` skill). This tool is pure/platform-agnostic, so it works for **any** platform including hosted connectors and plugins — for those, first **normalize the connector's metric names to the standard keys** (`cpa`, `conversions`, `ctr`, `cost`, …) so they can be scored (unknown names are treated as neutral/no-verdict).
    - For entries still within their observation window: note them as "pending observation" and do NOT recommend further changes to those campaigns.
    - `platform="plugin:<dist>"` entries participate in this loop on equal footing with built-ins; they have no `metrics_at_action` baseline, so evaluate them **qualitatively/advisory** (see `_mureo-shared` → *Mutating plugin tools — structural strategy parity*).
@@ -73,11 +77,11 @@ Run a daily health check on all marketing accounts using the strategy context.
 
     For each issue, suggest specific actions aligned with the current Operation Mode. Do NOT recommend actions based on single-day fluctuations — at least 7 consecutive days of critical metrics (>30% off target) before suggesting rescue.
 
-11. **Update STATE.json**: Update campaign snapshots, add notes for flagged issues, and log this daily check to the `action_log` with a summary of findings. On the Code `Write` path, use the canonical STATE.json field names — `campaign_name` (NOT the tool-output `name`), `campaign_id`, and each platform's `account_id`; a snapshot/platform missing a required field is dropped by the reporting dashboard. On the Code `Write` path also **stamp the top-level `last_synced_at` to now** so the dashboard's "Synced N ago" freshness reflects this run (the `mureo_state_upsert_campaign` / `_platform_metrics_set` tools set it for you). See `../_mureo-shared/SKILL.md` → *STATE.json Schema*.
+11. **Update STATE.json**: Update campaign snapshots, add notes for flagged issues, and log this daily check to the `action_log` with a summary of findings. On the Code `Write` path, use the canonical STATE.json field names — `campaign_name` (NOT the tool-output `name`), `campaign_id`, and each platform's `account_id`; a snapshot/platform missing a required field is dropped by the reporting dashboard. On the Code `Write` path also **stamp the top-level `last_synced_at` to `server_now`** so the dashboard's "Synced N ago" freshness reflects this run (the `mureo_state_upsert_campaign` / `_platform_metrics_set` tools set it for you). See `../_mureo-shared/SKILL.md` → *STATE.json Schema*.
 
 12. **Persist the report summary** (best-effort): Call `mureo_state_report_set` with `report="daily"` and a concise `summary` object so the read-only dashboard can render this report without re-running you. Follow this convention:
-    - `generated_at`: ISO 8601 timestamp of this run
-    - `period`: the day reviewed (e.g. `"2026-06-17"`)
+    - `generated_at`: ISO 8601 timestamp of this run — use `server_now`
+    - `period`: the day reviewed, derived from `server_now` (e.g. `"2026-06-17"`)
     - `kpis`: per-platform and/or totals headline numbers (spend, conversions, cpa, ctr)
     - `flags`: a list of **structured** flags — each a small object `{code, severity, params}` so the dashboard renders a coarse, localizable chip with the numbers on drill-down:
         - `code`: a canonical vocabulary key — one of `goals_met`, `cpa_over_target`, `cpa_under_target`, `cv_below_target`, `cv_above_target`, `spend_spike`, `cpa_spike`, `invalid_traffic_suspected`, `zero_cv_adspots`, `budget_overspend`, `budget_drift`, `tracking_suspect`, `zero_conversions`, `supply_tools_unconfigured`, `anomaly_baseline_insufficient`, `pending_observations`, `search_console_no_property`, `ga4_not_configured`.

--- a/skills/sync-state/SKILL.md
+++ b/skills/sync-state/SKILL.md
@@ -18,7 +18,9 @@ Synchronize STATE.json with the current state of all marketing platforms.
 
 > Note: the **Diagnostic preamble** (learning insights + advisor consult) from `../_mureo-shared/SKILL.md` is intentionally **not** required here — sync-state is mechanical data synchronization with no judgement calls.
 
-1. **Read current STATE.json** (if exists) to track changes.
+0. **Establish today**: call `mureo_state_get` **first, on every host** (including Claude Code, where you would otherwise `Read` the file) and take `server_now` from its response — ISO 8601 with UTC offset, e.g. `2026-07-28T10:12:33+09:00`. Its date is the **only source of the current date** for this sync (no shelling out — this skill must run in Bash-less headless hosts). The dates inside the document — `last_synced_at`, `reports.*.period`, `action_log` timestamps — are **history**: use them to describe what changed, never to decide what "now" is or whether a sync is still needed. **Never write `server_now` into STATE.json**; it is a response field, and a persisted copy becomes tomorrow's stale "today".
+
+1. **Read current STATE.json** (if exists) to track changes — the same `mureo_state_get` response from step 0 on MCP hosts.
 
 2. **Discover platforms**: Identify all platforms registered in STATE.json `platforms` — built-in AND plugin/bridge platforms. Per `../_mureo-shared/SKILL.md` → *Plugin platforms*, also enumerate any installed entry-point plugin that exposes `mcp__mureo__<plugin>_*` tools; its STATE.json platform key is `plugin:<dist>` (the same convention mureo uses when promoting plugin mutations into `action_log`). Also enumerate any **hosted official-MCP connector** present in the session (e.g. TikTok's `tt-ads-*` tools) — its key is a first-class ad-platform key such as `tiktok_ads`; see `../_mureo-shared/SKILL.md` → *Hosted-connector platforms*.
 
@@ -44,6 +46,6 @@ Synchronize STATE.json with the current state of all marketing platforms.
    - Status changes
    - Bidding strategy changes
 
-9. **Update `last_synced_at`** timestamp.
+9. **Update `last_synced_at`** timestamp — use `server_now` from step 0 (the `mureo_state_*` write tools stamp it for you; on the Code `Write` path write that value yourself).
 
 If STATE.json doesn't exist yet, suggest running `/onboard` first.

--- a/tests/core/test_clock.py
+++ b/tests/core/test_clock.py
@@ -1,0 +1,71 @@
+"""The server clock mureo injects into its MCP responses (#460).
+
+An agent has no reliable notion of "today": it reads STATE.json, sees
+``reports.daily.period`` / ``last_synced_at`` / ``action_log`` timestamps
+and mistakes that history for the current date. The fix is a single
+server-side clock whose value travels in MCP responses, so a Bash-less
+headless host never has to shell out to ``date``.
+
+Contract pinned here:
+  - the clock is timezone-aware and uses the HOST's local offset (ad ops
+    reasoning is local-day based, so a UTC-only stamp would roll the day
+    at the wrong moment for JST/PST operators),
+  - the ISO rendering carries that explicit UTC offset,
+  - ``server_now_iso`` derives from ``server_now``, so a test can freeze
+    the clock by patching one function.
+
+Marks: unit — pure calculation, no I/O.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_OFFSET_SUFFIX = re.compile(r"[+-]\d{2}:\d{2}$")
+
+
+def test_server_now_is_timezone_aware() -> None:
+    from mureo.core.clock import server_now
+
+    now = server_now()
+    assert now.tzinfo is not None
+    assert now.utcoffset() is not None
+
+
+def test_server_now_tracks_the_real_clock() -> None:
+    from mureo.core.clock import server_now
+
+    delta = abs(server_now() - datetime.now(timezone.utc))
+    assert delta < timedelta(minutes=5)
+
+
+def test_server_now_iso_carries_an_explicit_utc_offset() -> None:
+    from mureo.core.clock import server_now_iso
+
+    text = server_now_iso()
+    assert _OFFSET_SUFFIX.search(text), f"no UTC offset in {text!r}"
+    parsed = datetime.fromisoformat(text)
+    assert parsed.tzinfo is not None
+    assert parsed.utcoffset() is not None
+
+
+def test_server_now_iso_is_second_precision() -> None:
+    """Seconds, not microseconds — the value is read by humans and models."""
+    from mureo.core.clock import server_now_iso
+
+    assert datetime.fromisoformat(server_now_iso()).microsecond == 0
+
+
+def test_server_now_iso_derives_from_server_now(monkeypatch) -> None:
+    """Patching ``server_now`` alone must move the ISO rendering too — that
+    is the injection point every clock test in this repo relies on."""
+    import mureo.core.clock as clock
+
+    frozen = datetime(2026, 7, 28, 10, 12, 33, tzinfo=timezone(timedelta(hours=9)))
+    monkeypatch.setattr(clock, "server_now", lambda: frozen)
+    assert clock.server_now_iso() == "2026-07-28T10:12:33+09:00"

--- a/tests/test_mcp_plugin_semantics.py
+++ b/tests/test_mcp_plugin_semantics.py
@@ -4,7 +4,7 @@ mutating-call promotion into STATE.json's action_log.
 
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, datetime, timedelta, timezone
 from typing import TYPE_CHECKING
 
 import pytest
@@ -120,31 +120,42 @@ class TestRecordMutationActionLog:
         assert e.observation_due is not None  # structural strategy parity
         return date.fromisoformat(e.observation_due)
 
+    def _freeze_clock(self, monkeypatch: pytest.MonkeyPatch) -> date:
+        """Freeze the shared server clock and return its LOCAL date.
+
+        The window is counted off ``mureo.core.clock.server_now`` (#460),
+        which is host-local. Comparing against a real ``datetime.now(utc)``
+        would be flaky on any positive-offset host: at 02:00 JST the local
+        date is already the next UTC day, so the delta reads N+1 and the
+        test fails for a reason that has nothing to do with the window.
+        Freezing at exactly that hour keeps the case covered — and pinned.
+        """
+        import mureo.core.clock as clock
+
+        frozen = datetime(2026, 7, 28, 2, 0, tzinfo=timezone(timedelta(hours=9)))
+        monkeypatch.setattr(clock, "server_now", lambda: frozen)
+        return frozen.date()
+
     def test_default_observation_window_when_undeclared(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        from datetime import datetime, timezone
-
         from mureo.mcp.plugin_semantics import _DEFAULT_OBSERVATION_DAYS
 
+        today = self._freeze_clock(monkeypatch)
         self._seed_state(tmp_path)
         monkeypatch.chdir(tmp_path)
         record_mutation_action_log(tool="acme_ads_pause", source="d", reversal=None)
-        today = datetime.now(timezone.utc).date()
-        delta = (self._due_date(tmp_path / "STATE.json") - today).days
-        # tolerate a UTC midnight roll-over during the test
-        assert _DEFAULT_OBSERVATION_DAYS - 1 <= delta <= _DEFAULT_OBSERVATION_DAYS
+        assert self._due_date(tmp_path / "STATE.json") == today + timedelta(
+            days=_DEFAULT_OBSERVATION_DAYS
+        )
 
     def test_declared_observation_days_honored(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        from datetime import datetime, timezone
-
+        today = self._freeze_clock(monkeypatch)
         self._seed_state(tmp_path)
         monkeypatch.chdir(tmp_path)
         record_mutation_action_log(
             tool="acme_ads_pause", source="d", reversal=None, observation_days=3
         )
-        today = datetime.now(timezone.utc).date()
-        delta = (self._due_date(tmp_path / "STATE.json") - today).days
-        assert 2 <= delta <= 3
+        assert self._due_date(tmp_path / "STATE.json") == today + timedelta(days=3)

--- a/tests/test_mcp_tools_mureo_context.py
+++ b/tests/test_mcp_tools_mureo_context.py
@@ -18,6 +18,7 @@ Coverage:
 from __future__ import annotations
 
 import json
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -807,3 +808,181 @@ async def test_set_conversion_events_read_write_path_agree(cwd_to_tmp) -> None:
     assert load_conversion_action_types("act_42") == ("offsite_conversion.custom.7",)
     # act_ prefix tolerance: a bare-id live resolve still matches.
     assert load_conversion_action_types("42") == ("offsite_conversion.custom.7",)
+
+
+# ---------------------------------------------------------------------------
+# Server clock injection (#460)
+#
+# /daily-check ran with a days-old notion of "today": the agent read
+# STATE.json, saw old dates (reports.daily.period, last_synced_at,
+# action_log timestamps) and short-circuited with "today's data is already
+# fetched". Nothing in the stack ever told it the real date, and the
+# action_log timestamps it read back as fact were its own drifted values.
+# Fix: the read entry points carry a ``server_now`` envelope field, and the
+# action_log append stamps the timestamp server-side.
+# ---------------------------------------------------------------------------
+
+
+_FROZEN_NOW = datetime(2026, 7, 28, 10, 12, 33, tzinfo=timezone(timedelta(hours=9)))
+_FROZEN_ISO = "2026-07-28T10:12:33+09:00"
+
+
+@pytest.fixture
+def frozen_clock(monkeypatch):
+    """Freeze the injected server clock (the single documented seam)."""
+    import mureo.core.clock as clock
+
+    monkeypatch.setattr(clock, "server_now", lambda: _FROZEN_NOW)
+    return _FROZEN_ISO
+
+
+async def test_state_get_returns_server_now(cwd_to_tmp, frozen_clock) -> None:
+    (cwd_to_tmp / "STATE.json").write_text(
+        json.dumps({"version": "2", "platforms": {}, "action_log": []}),
+        encoding="utf-8",
+    )
+    mod = _import_tools()
+    result = await mod.handle_tool("mureo_state_get", {})
+    payload = json.loads(result[0].text)
+    assert payload["server_now"] == frozen_clock
+
+
+async def test_state_get_server_now_is_parseable_and_offset_bearing(
+    cwd_to_tmp,
+) -> None:
+    """Real (unfrozen) clock: ISO 8601 WITH a UTC offset, close to now."""
+    mod = _import_tools()
+    result = await mod.handle_tool("mureo_state_get", {})
+    payload = json.loads(result[0].text)
+    parsed = datetime.fromisoformat(payload["server_now"])
+    assert parsed.tzinfo is not None
+    assert parsed.utcoffset() is not None
+    assert abs(parsed - datetime.now(timezone.utc)) < timedelta(minutes=5)
+
+
+async def test_state_get_server_now_present_when_file_absent(
+    cwd_to_tmp, frozen_clock
+) -> None:
+    """The empty-default branch must carry the clock too — an onboarding
+    run has no STATE.json yet and still needs to know the date."""
+    mod = _import_tools()
+    result = await mod.handle_tool("mureo_state_get", {})
+    assert json.loads(result[0].text)["server_now"] == frozen_clock
+
+
+async def test_state_get_server_now_ignores_a_stale_value_on_disk(
+    cwd_to_tmp, frozen_clock
+) -> None:
+    """A ``server_now`` that leaked into STATE.json (an agent echoing a read
+    response back through a raw Write) must never be served as the clock."""
+    (cwd_to_tmp / "STATE.json").write_text(
+        json.dumps(
+            {
+                "version": "2",
+                "server_now": "1999-01-01T00:00:00+09:00",
+                "platforms": {},
+                "action_log": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    mod = _import_tools()
+    result = await mod.handle_tool("mureo_state_get", {})
+    assert json.loads(result[0].text)["server_now"] == frozen_clock
+
+
+async def test_server_now_is_not_persisted_by_a_later_write(cwd_to_tmp) -> None:
+    """Round-trip guard: echo the whole read response back into STATE.json
+    (what a Code-path bulk `Write` does), then let any mureo write touch the
+    file — the response-only ``server_now`` key must not survive into the
+    persisted document."""
+    (cwd_to_tmp / "STATE.json").write_text(
+        json.dumps({"version": "2", "platforms": {}, "action_log": []}),
+        encoding="utf-8",
+    )
+    mod = _import_tools()
+    read = json.loads((await mod.handle_tool("mureo_state_get", {}))[0].text)
+    assert "server_now" in read
+    # The agent echoes the response verbatim into the file.
+    (cwd_to_tmp / "STATE.json").write_text(json.dumps(read), encoding="utf-8")
+
+    await mod.handle_tool(
+        "mureo_state_action_log_append",
+        {"entry": {"action": "test", "platform": "google_ads"}},
+    )
+    on_disk = json.loads((cwd_to_tmp / "STATE.json").read_text(encoding="utf-8"))
+    assert "server_now" not in on_disk
+
+
+async def test_strategy_get_returns_server_now(cwd_to_tmp, frozen_clock) -> None:
+    """STRATEGY.md is the other step-1 read; keep the clock consistent so a
+    skill that starts there does not have to make a second call."""
+    (cwd_to_tmp / "STRATEGY.md").write_text("# Strategy\n", encoding="utf-8")
+    mod = _import_tools()
+    result = await mod.handle_tool("mureo_strategy_get", {})
+    assert json.loads(result[0].text)["server_now"] == frozen_clock
+
+
+async def test_strategy_get_server_now_present_when_file_absent(
+    cwd_to_tmp, frozen_clock
+) -> None:
+    mod = _import_tools()
+    result = await mod.handle_tool("mureo_strategy_get", {})
+    payload = json.loads(result[0].text)
+    assert payload["exists"] is False
+    assert payload["server_now"] == frozen_clock
+
+
+async def test_action_log_append_ignores_client_timestamp(
+    cwd_to_tmp, frozen_clock
+) -> None:
+    """A model-supplied timestamp is accepted by the schema but IGNORED —
+    a drifted date must not be persisted and read back later as fact."""
+    mod = _import_tools()
+    result = await mod.handle_tool(
+        "mureo_state_action_log_append",
+        {
+            "entry": {
+                "timestamp": "1999-01-01T00:00:00+00:00",
+                "action": "Increased budget +20%",
+                "platform": "google_ads",
+            }
+        },
+    )
+    payload = json.loads(result[0].text)
+    assert payload["action_log"][0]["timestamp"] == frozen_clock
+    on_disk = json.loads((cwd_to_tmp / "STATE.json").read_text(encoding="utf-8"))
+    assert on_disk["action_log"][0]["timestamp"] == frozen_clock
+
+
+async def test_action_log_append_stamps_timestamp_when_omitted(
+    cwd_to_tmp, frozen_clock
+) -> None:
+    """``timestamp`` is no longer a required input — the server supplies it."""
+    mod = _import_tools()
+    result = await mod.handle_tool(
+        "mureo_state_action_log_append",
+        {"entry": {"action": "Paused campaign", "platform": "meta_ads"}},
+    )
+    payload = json.loads(result[0].text)
+    assert payload["action_log"][0]["timestamp"] == frozen_clock
+
+
+async def test_action_log_schema_documents_server_stamping() -> None:
+    mod = _import_tools()
+    tool = next(t for t in mod.TOOLS if t.name == "mureo_state_action_log_append")
+    entry = tool.inputSchema["properties"]["entry"]
+    # Kept for schema compatibility (additionalProperties: false), but no
+    # longer required and explicitly documented as ignored.
+    assert "timestamp" in entry["properties"]
+    assert "timestamp" not in entry["required"]
+    description = entry["properties"]["timestamp"]["description"].lower()
+    assert "server" in description
+    assert "ignored" in description
+
+
+@pytest.mark.parametrize("name", ["mureo_state_get", "mureo_strategy_get"])
+async def test_read_tool_descriptions_advertise_server_now(name: str) -> None:
+    mod = _import_tools()
+    tool = next(t for t in mod.TOOLS if t.name == name)
+    assert "server_now" in tool.description

--- a/tests/test_native_reversal.py
+++ b/tests/test_native_reversal.py
@@ -250,6 +250,30 @@ class TestRecordNativeMutation:
             "params": {"campaign_id": "c1"},
         }
 
+    def test_timestamp_comes_from_the_shared_server_clock(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """#460 — every action_log writer stamps the same clock, in the same
+        offset-bearing format, so entries from the native promotion path and
+        from ``mureo_state_action_log_append`` are directly comparable."""
+        from datetime import datetime, timedelta, timezone
+
+        import mureo.core.clock as clock
+        from mureo.context.state import read_state_file
+
+        frozen = datetime(2026, 7, 28, 10, 12, 33, tzinfo=timezone(timedelta(hours=9)))
+        monkeypatch.setattr(clock, "server_now", lambda: frozen)
+        _seed_state(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        nr.record_native_mutation(
+            "meta_ads_campaigns_pause", {"campaign_id": "c1"}, "ACTIVE"
+        )
+        entry = read_state_file(tmp_path / "STATE.json").action_log[0]
+        assert entry.timestamp == "2026-07-28T10:12:33+09:00"
+        # observation_due is a LOCAL calendar date derived from the same clock.
+        assert entry.observation_due is not None
+        assert entry.observation_due.startswith("2026-08-")
+
     def test_records_audit_only_when_status_unknown(
         self, tmp_path, monkeypatch
     ) -> None:

--- a/tests/test_rollback_execute.py
+++ b/tests/test_rollback_execute.py
@@ -314,6 +314,33 @@ class TestExecutorWiringContract:
         assert "0" in (new_entry.summary or "")
 
     @pytest.mark.asyncio
+    async def test_new_log_entry_uses_the_shared_server_clock(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """#460 — the reversal entry is stamped with the same server clock,
+        in the same offset-bearing format, as every other action_log writer."""
+        from datetime import datetime, timedelta, timezone
+
+        import mureo.core.clock as clock
+
+        frozen = datetime(2026, 7, 28, 10, 12, 33, tzinfo=timezone(timedelta(hours=9)))
+        monkeypatch.setattr(clock, "server_now", lambda: frozen)
+        state_file = tmp_path / "STATE.json"
+        _write_state(state_file, [_budget_update_entry()])
+
+        await execute_rollback(
+            state_file=state_file,
+            index=0,
+            confirm=True,
+            dispatcher=_FakeDispatcher(),
+        )
+
+        assert (
+            read_state_file(state_file).action_log[1].timestamp
+            == "2026-07-28T10:12:33+09:00"
+        )
+
+    @pytest.mark.asyncio
     async def test_state_file_is_valid_json_after_success(self, tmp_path: Path) -> None:
         state_file = tmp_path / "STATE.json"
         _write_state(state_file, [_budget_update_entry()])

--- a/tests/test_skill_server_now_clock.py
+++ b/tests/test_skill_server_now_clock.py
@@ -1,0 +1,120 @@
+"""The date-sensitive skills must establish "today" from ``server_now`` (#460).
+
+``/daily-check`` (and ``sync-state`` / ``budget-pacing``) used to run with a
+stale notion of today: the agent read STATE.json, saw old dates
+(``reports.daily.period``, ``last_synced_at``, ``action_log`` timestamps) and
+concluded "today's data is already fetched — re-displaying", using a days-old
+date. The MCP side now injects ``server_now`` into the read responses; these
+skills must be told to treat that value as the ONLY source of the current
+date. Shelling out to ``date`` is not an option — ``/daily-check`` must run in
+Bash-less headless hosts.
+
+Pinned here, in BOTH the packaged copy (``mureo/_data/skills``) and the
+repo-root mirror (``skills/``), kept byte-identical.
+
+Marks: unit — pure on-disk file inspection, no network.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_ROOT = Path(__file__).resolve().parent.parent
+_PACKAGED = _ROOT / "mureo" / "_data" / "skills"
+_MIRROR = _ROOT / "skills"
+
+_SKILLS = ("daily-check", "sync-state", "budget-pacing")
+
+
+def _packaged(name: str) -> Path:
+    return _PACKAGED / name / "SKILL.md"
+
+
+def _mirror(name: str) -> Path:
+    return _MIRROR / name / "SKILL.md"
+
+
+def _body(name: str) -> str:
+    return _packaged(name).read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("name", _SKILLS)
+def test_copies_are_byte_identical(name: str) -> None:
+    assert (
+        _packaged(name).read_bytes() == _mirror(name).read_bytes()
+    ), f"{name}: packaged and mirror copies differ"
+
+
+@pytest.mark.parametrize("name", _SKILLS)
+def test_server_now_is_the_clock_source(name: str) -> None:
+    """The skill must name the tool that carries the clock AND the field."""
+    body = _body(name)
+    assert "mureo_state_get" in body, f"{name}: must name the tool carrying the clock"
+    assert "server_now" in body
+    assert (
+        "only source of the current date" in body
+    ), f"{name}: must declare server_now the ONLY source of today"
+
+
+@pytest.mark.parametrize("name", _SKILLS)
+def test_state_json_dates_are_history_not_today(name: str) -> None:
+    """The three date fields the failure mode came from must be named as
+    history so a future edit cannot quietly reintroduce "read the date from
+    STATE.json"."""
+    body = _body(name)
+    assert "history" in body
+    for field in ("last_synced_at", "action_log"):
+        assert field in body, f"{name}: must name {field} as history, not today"
+
+
+@pytest.mark.parametrize("name", _SKILLS)
+def test_server_now_is_never_written_into_state(name: str) -> None:
+    """``server_now`` is a response envelope field; persisting it recreates
+    the stale-date bug for the next reader."""
+    # Case-insensitive: the sentence opens the rule in some skills and
+    # closes it in others — the prohibition is what matters, not the casing.
+    assert "never write `server_now`" in _body(name).lower()
+
+
+def test_shared_tool_selection_documents_the_clock() -> None:
+    """``_mureo-shared`` owns the host-portability table every skill reads.
+    Its "Read STATE.json -> `Read` tool" row is misleading for date-sensitive
+    work, so the clock rule has to live next to it — otherwise a skill not
+    edited for #460 keeps inferring today from the file it just read."""
+    packaged = _PACKAGED / "_mureo-shared" / "SKILL.md"
+    mirror = _MIRROR / "_mureo-shared" / "SKILL.md"
+    assert packaged.read_bytes() == mirror.read_bytes()
+    body = packaged.read_text(encoding="utf-8")
+    assert "| Establish the current date |" in body
+    assert "server_now" in body
+    assert "only** source of today" in body
+    assert "on EVERY host, including Code" in body
+    assert "never write `server_now` back into STATE.json" in body
+
+
+def test_daily_check_forbids_the_already_fetched_short_circuit() -> None:
+    """The exact observed failure: "today's report is already fetched —
+    re-displaying" against a days-old date."""
+    body = _body("daily-check")
+    assert "already fetched" in body
+    assert "re-display" in body
+    assert "reports.daily.period" in body or "reports.*.period" in body
+
+
+def test_budget_pacing_derives_elapsed_days_from_server_now() -> None:
+    """Pacing math is date arithmetic — the month, elapsed days and remaining
+    days must all come off ``server_now``, not off STATE.json history."""
+    body = _body("budget-pacing")
+    elapsed_lines = [ln for ln in body.splitlines() if "Elapsed days" in ln]
+    assert elapsed_lines, "budget-pacing must keep its elapsed-days step"
+    assert any(
+        "server_now" in ln for ln in elapsed_lines
+    ), "elapsed-days math must derive from server_now"
+    remaining_lines = [ln for ln in body.splitlines() if "days remaining" in ln]
+    assert any(
+        "server_now" in ln for ln in remaining_lines
+    ), "remaining-days math must derive from server_now"


### PR DESCRIPTION
Closes #460.

## Summary
- `mureo_state_get` / `mureo_strategy_get` responses gain a top-level `server_now` (ISO 8601 with UTC offset, new `mureo.core.clock` module) — added post-serialization, never persisted, stale on-disk copies never echoed
- `mureo_state_action_log_append` timestamps are server-stamped (supplied values accepted for schema compat but ignored); all in-tree action_log writers unified onto the shared clock
- daily-check / sync-state / budget-pacing skills gain a step-0 date-establishment discipline (server_now is the only source of today; the observed re-display shortcut is explicitly forbidden); the shared tool-selection table documents the rule for future skills
- Fixes two pre-existing observation-window tests that compared against real UTC wall time (deterministic failures on positive-offset hosts during local small hours)

## Test plan
- TDD; round-trip-strip, stale-on-disk, ignored-timestamp, frozen-clock (worst-case JST 02:00) tests; consumer sweep confirmed nothing parses/sorts action_log timestamps
- Full suite 5,986 passed (env-only failures unchanged); black/ruff/mypy clean

## Downstream
None — no tool-count change; agency/pro state stores serialize StateDocument (server_now added after serialization, cannot reach them); schema change is a loosening.