### PR TITLE
refactor: remove unused onDesktop declaration in buildProviderInstallSlot

### DIFF
--- a/mureo/_data/web/auth_wizards.js
+++ b/mureo/_data/web/auth_wizards.js
@@ -229,7 +229,6 @@
     // (no-DCR, native-coexisting) hosted provider is ever added, extend
     // this check.
     const isHosted = providerId === "meta-ads-official";
-    const onDesktop = state.host === "claude-desktop";
 
     // Hosted MCP (Meta): mureo never registers it locally on EITHER
     // host. Meta's hosted MCP has no OAuth dynamic client registration,


### PR DESCRIPTION
## Summary

Removes a dead declaration in `mureo/_data/web/auth_wizards.js`:

```js
const onDesktop = state.host === "claude-desktop";
```

`onDesktop` was declared in `buildProviderInstallSlot` but never read anywhere in the web assets — the host check is done inline where needed (`state.host === "claude-desktop"` in `auth_wizards_meta.js`'s `showManualSetup`, and `state.host === "codex"` in the branches).

## Verification

- `grep -rn onDesktop mureo/_data/web/` — zero matches after removal (and the only match before was the declaration itself)
- `node --check mureo/_data/web/auth_wizards.js` — passes
- `pytest -k web` — 1500 passed
- Code review pass — no findings; the equivalent value is independently recomputed as `isDesktopHost` inside `showManualSetup`, so nothing depended on this binding