### PR TITLE
feat: complete the two-tier /learn loop with workspace-tier reads

### DIFF
--- a/mureo/_data/skills/learn/SKILL.md
+++ b/mureo/_data/skills/learn/SKILL.md
@@ -22,6 +22,11 @@ prior file layout); an alternate backend registered via the
 `mureo.runtime_context_factory` entry-point group can redirect or
 split the write without changing this skill.
 
+The knowledge base has two tiers — an **operator** tier shared across
+every workspace, and an optional **workspace** tier scoped to the
+current one. Use `mureo learn tiers` to find out which are available
+before deciding where an insight belongs (step 4).
+
 ## When to use
 
 - The user runs `/learn` followed by an insight, e.g.:
@@ -57,24 +62,58 @@ split the write without changing this skill.
    generalized lesson only — never record account IDs, credentials,
    access tokens, or personal data in the knowledge base.
 
-4. **Save by invoking the CLI.** Pass the approved insight verbatim
-   (including its leading blank line and trailing newline) to:
+4. **Choose the scope.** Before saving, detect which knowledge tiers
+   this installation exposes. The command is read-only — it creates
+   and modifies nothing:
 
    ```bash
-   mureo learn add "$INSIGHT_MARKDOWN"
+   mureo learn tiers
    ```
 
-   - The default `--scope operator` writes the cross-workspace tier
-     read by every diagnostic skill. Use this for general practitioner
-     know-how that applies to every account the operator runs.
-   - Pass `--scope workspace` when the insight is specific to the
-     active account and should not leak to other workspaces (only
-     meaningful when a workspace-aware KnowledgeStore backend is
-     installed; the command exits with a helpful message otherwise).
+   It prints one line per tier, e.g.:
 
-5. **Confirm.** Tell the user the insight was saved and that it will
-   be applied in future `/daily-check`, `/rescue`, `/budget-rebalance`,
-   and other diagnostic workflows.
+   ```
+   operator: configured
+   workspace: configured
+   ```
+
+   - **`workspace: configured`** — ask the user which tier to save to,
+     and present **workspace as the recommended default**. Most
+     insights worth recording are account-specific: product quirks,
+     measurement and conversion-tracking quirks, seasonality, campaign
+     history, what has already been tried on this account. Those are
+     true here and often false elsewhere, so writing them to the
+     operator tier makes every other account inherit them and the
+     agent will confidently misapply them. Reserve the operator tier
+     for genuinely generalizable cross-account know-how — platform
+     mechanics, statistical reasoning, structural rules of thumb.
+   - **`workspace: absent`** — no workspace tier is installed on this
+     machine. Save to the operator tier without asking the user.
+
+5. **Save by invoking the CLI.** Pass the approved insight verbatim
+   (including its leading blank line and trailing newline), with the
+   scope from step 4 stated explicitly:
+
+   ```bash
+   # Run ONE of these — the scope you settled on in step 4.
+   mureo learn add "$INSIGHT_MARKDOWN" --scope workspace
+   mureo learn add "$INSIGHT_MARKDOWN" --scope operator
+   ```
+
+   - `--scope operator` writes the cross-workspace tier read by every
+     diagnostic skill.
+   - `--scope workspace` writes the workspace-scoped tier, so the
+     insight stays with the active account and never leaks to other
+     workspaces. The command exits with a helpful message when no
+     workspace tier is configured — step 4 rules that case out.
+
+   Both tiers are handed to diagnostic workflows by
+   `mureo_learning_insights_get`; when the two conflict, workspace-tier
+   insights take precedence over operator-tier insights.
+
+6. **Confirm.** Tell the user the insight was saved, which tier it went
+   to, and that it will be applied in future `/daily-check`,
+   `/rescue`, `/budget-rebalance`, and other diagnostic workflows.
 
 IMPORTANT: Always save through `mureo learn add`, never by writing the
 file path manually. Going through the CLI keeps the skill compatible

--- a/mureo/cli/learn_cmd.py
+++ b/mureo/cli/learn_cmd.py
@@ -18,6 +18,11 @@ Two scopes are exposed:
 - ``workspace``: a workspace-scoped tier. Errors with a helpful
   message when the resolved store has no workspace tier configured
   (the file-backed default has none unless one is wired in).
+
+``mureo learn tiers`` is the read-only companion the skill calls
+*before* choosing a scope: it reports which tiers the resolved store
+exposes so the skill knows whether asking the user "operator or
+workspace?" is even a meaningful question.
 """
 
 from __future__ import annotations
@@ -38,6 +43,13 @@ class _Scope(str, Enum):
 
     OPERATOR = "operator"
     WORKSPACE = "workspace"
+
+
+# ``mureo learn tiers`` output vocabulary. One ``<tier>: <status>`` line
+# per tier, no decoration — the consumer is an LLM reading stdout, so
+# the format has to survive being pasted into a prompt verbatim.
+_STATUS_CONFIGURED = "configured"
+_STATUS_ABSENT = "absent"
 
 
 _TEXT_ARGUMENT = typer.Argument(
@@ -89,3 +101,40 @@ def learn_add(
         )
         raise typer.Exit(1) from None
     typer.echo("Saved to the workspace tier.")
+
+
+@learn_app.command("tiers")  # type: ignore[untyped-decorator, unused-ignore]
+def learn_tiers() -> None:
+    """Report which knowledge tiers the resolved KnowledgeStore exposes.
+
+    Read-only: nothing is created or modified. Prints one
+    ``<tier>: configured|absent`` line per tier and exits 0 — "no
+    workspace tier" is a normal configuration, not an error.
+
+    The operator tier always exists (``read_operator_knowledge`` is
+    contractually non-optional). The workspace tier is present when
+    ``read_workspace_knowledge()`` returns anything other than ``None``;
+    an empty string means "configured but nothing written yet", which
+    still counts as configured because a subsequent
+    ``--scope workspace`` write will succeed.
+
+    If the workspace-tier probe raises (a remote- or DB-backed store
+    failing), the command prints a single error line to stderr and exits
+    1 rather than reporting ``absent``. Detection was inconclusive, and
+    reporting ``absent`` would send the caller down the silent
+    operator-only path and misroute a workspace-scoped insight.
+    """
+    from mureo.core.runtime_context import get_runtime_context
+
+    store = get_runtime_context().knowledge_store
+    try:
+        has_workspace = store.read_workspace_knowledge() is not None
+    except Exception as exc:  # noqa: BLE001 — any backend failure is inconclusive
+        typer.echo(
+            f"Error: could not determine whether a workspace tier is "
+            f"configured — the KnowledgeStore raised: {exc}",
+            err=True,
+        )
+        raise typer.Exit(1) from None
+    typer.echo(f"operator: {_STATUS_CONFIGURED}")
+    typer.echo(f"workspace: {_STATUS_CONFIGURED if has_workspace else _STATUS_ABSENT}")

--- a/mureo/mcp/tools_learning.py
+++ b/mureo/mcp/tools_learning.py
@@ -1,18 +1,39 @@
 """mureo's learned-insights MCP tool surface.
 
 A single tool — :data:`TOOLS` exposes ``mureo_learning_insights_get``
-— that returns the operator-tier knowledge base for diagnostic
-workflows to consult. The data flow is the read-side counterpart to
+— that returns the knowledge base for diagnostic workflows to
+consult. The data flow is the read-side counterpart to
 ``mureo learn add``:
 
     /learn skill (markdown)
-      → mureo learn add "<insight>"  (mureo/cli/learn_cmd.py)
-      → KnowledgeStore.append_operator_knowledge()
+      → mureo learn tiers            (which tiers exist?)
+      → mureo learn add "<insight>" --scope operator|workspace
+      → KnowledgeStore.append_{operator,workspace}_knowledge()
       ↑ write side already shipped
       ↓ this module — read side
       → KnowledgeStore.read_operator_knowledge()
+      → KnowledgeStore.read_workspace_knowledge()
       → mureo_learning_insights_get  (this tool)
       → /daily-check / /rescue / /budget-rebalance / …
+
+Both KnowledgeStore tiers are read. The operator tier is shared
+across every workspace the operator opens; the workspace tier is
+optional and scoped to the current workspace. When the workspace
+tier is absent or empty the payload is byte-identical to the
+operator-only payload this tool has always returned. When it has
+content, both tiers are returned in one payload under labelled
+headings, prefixed by the rule that workspace-tier insights win over
+operator-tier insights on conflict — the workspace tier is the more
+specific evidence.
+
+Note for third-party ``KnowledgeStore`` backend authors: BOTH
+``read_operator_knowledge()`` and ``read_workspace_knowledge()`` are
+called on every ``mureo_learning_insights_get`` invocation, and the
+seven bundled diagnostic workflows each call that tool near their
+start. Keep both reads cheap — a remote-backed store should cache
+per-session rather than issuing a network round-trip per call. A read
+that raises is tolerated (the tier is skipped and a warning is logged),
+but it is not a substitute for a fast path.
 
 The tool deliberately takes no arguments: its job is to surface
 every saved insight so the agent treats them as authoritative
@@ -88,6 +109,34 @@ def _is_scaffold_only(text: str) -> bool:
     return not tail.strip()
 
 
+# --- Two-tier payload composition -----------------------------------------
+#
+# When the resolved KnowledgeStore exposes a workspace tier with real
+# content, the handler returns both tiers in one labelled payload
+# instead of the operator tier alone. The headings are module-level
+# constants so tests (and any downstream consumer that wants to split
+# the payload back apart) pin the same strings the handler emits.
+
+_OPERATOR_SECTION_HEADING = "## Operator knowledge (all workspaces)"
+
+_WORKSPACE_SECTION_HEADING = "## Workspace knowledge (current workspace)"
+
+# Stated once, at the top, before either section: the agent has to know
+# how to resolve a contradiction before it starts reading the insights.
+_PRECEDENCE_NOTE = (
+    "Workspace-tier insights take precedence over operator-tier "
+    "insights when the two conflict."
+)
+
+# Used instead of the operator body when the workspace tier has content
+# but the operator tier is empty / scaffold-only. Returning
+# ``_NO_INSIGHTS_MESSAGE`` there would hide the workspace insights.
+_NO_OPERATOR_INSIGHTS_NOTE = (
+    "(No operator-tier insights saved yet — everything below is scoped "
+    "to the current workspace.)"
+)
+
+
 _NO_ADVISORS_MESSAGE = (
     "(No external advisor sources configured. Set up "
     "~/.mureo/insight_sources.json with the MCP servers you want "
@@ -106,16 +155,20 @@ TOOLS: list[Tool] = [
     Tool(
         name="mureo_learning_insights_get",
         description=(
-            "Load every insight previously saved via /learn from the "
-            "operator-tier knowledge base. Returns the raw Markdown so "
-            "the agent can apply the lessons when forming a "
-            "diagnostic answer. Read-only. Call this near the start "
-            "of every diagnostic workflow (/daily-check, /rescue, "
-            "/budget-rebalance, /creative-refresh, /goal-review, "
-            "/competitive-scan, /search-term-cleanup) BEFORE drawing "
-            "conclusions, so accumulated practitioner know-how "
-            "informs the analysis instead of being ignored. Returns "
-            "a guidance string when no insights have been saved yet."
+            "Load every insight previously saved via /learn. Returns "
+            "both knowledge tiers as raw Markdown in one payload: the "
+            "operator tier (shared across all workspaces) and, when a "
+            "workspace tier is configured and non-empty, the workspace "
+            "tier (scoped to the current workspace) in a separate "
+            "labelled section. Workspace-tier insights take precedence "
+            "over operator-tier insights when they conflict. Read-only. "
+            "Call this near the start of every diagnostic workflow "
+            "(/daily-check, /rescue, /budget-rebalance, "
+            "/creative-refresh, /goal-review, /competitive-scan, "
+            "/search-term-cleanup) BEFORE drawing conclusions, so "
+            "accumulated practitioner know-how informs the analysis "
+            "instead of being ignored. Returns a guidance string when "
+            "no insights have been saved in either tier."
         ),
         inputSchema={
             "type": "object",
@@ -198,24 +251,123 @@ async def handle_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]
     raise ValueError(f"Unknown tool: {name}")
 
 
+def _workspace_content(store: Any) -> str | None:
+    """Return the workspace tier's text, or ``None`` when it does not
+    contribute anything.
+
+    ``None`` covers four cases the caller treats identically:
+
+    - no workspace tier is configured (the Protocol's documented
+      ``None`` return),
+    - the tier is configured but still empty / whitespace-only (a
+      configured-but-never-written file reads as ``""``),
+    - the backend returned something outside the Protocol's
+      ``str | None`` contract,
+    - the read *raised*.
+
+    The last two matter because ``KnowledgeStore`` is implementable by
+    third parties via the ``mureo.runtime_context_factory`` entry-point
+    group: a remote- or DB-backed store can fail transiently. The
+    operator tier has already been read successfully by then, and it is
+    what every diagnostic workflow actually depends on — so a broken
+    workspace tier degrades to the legacy operator-only payload instead
+    of taking the whole tool down.
+    """
+    try:
+        text = store.read_workspace_knowledge()
+    except Exception:  # noqa: BLE001 — must never break the tool
+        logger.warning(
+            "learning insights: KnowledgeStore.read_workspace_knowledge "
+            "raised — ignoring the workspace tier",
+            exc_info=True,
+        )
+        return None
+    if text is None:
+        return None
+    if not isinstance(text, str):
+        logger.warning(
+            "learning insights: KnowledgeStore.read_workspace_knowledge "
+            "returned %s, expected str | None — ignoring the workspace tier",
+            type(text).__name__,
+        )
+        return None
+    if not text.strip():
+        return None
+    return text
+
+
+def _compose_two_tier_payload(operator_text: str, workspace_text: str) -> str:
+    """Render both tiers as one labelled Markdown payload.
+
+    The precedence note comes first so the agent knows how to resolve a
+    contradiction before it reads either section. Sections are plain
+    ``##`` headings rather than ``---``-separated blocks because the
+    operator tier's raw Markdown starts with a YAML frontmatter fence,
+    which a horizontal rule would be indistinguishable from.
+
+    TRUST MODEL: both tiers are operator-authored — they only ever
+    contain text the operator approved through ``/learn`` — so they are
+    embedded verbatim, deliberately unlike advisor fragments in
+    :func:`_format_advisor_response`, which are untrusted external
+    content and go through :func:`_sanitize`. Do not drop this
+    distinction: if a tier ever becomes writable by anything other than
+    the operator (a synced/shared knowledge base, a hosted backend that
+    merges in third-party content), these bodies must be sanitized the
+    same way advisor fragments are.
+    """
+    # ``.strip()`` here is a deliberate difference from the legacy
+    # single-tier path, which returns the operator text byte-for-byte.
+    # Composing sections needs predictable spacing around the headings;
+    # the legacy path has no headings and must stay byte-identical.
+    operator_body = (
+        _NO_OPERATOR_INSIGHTS_NOTE
+        if _is_scaffold_only(operator_text)
+        else operator_text.strip()
+    )
+    return (
+        f"{_PRECEDENCE_NOTE}\n\n"
+        f"{_OPERATOR_SECTION_HEADING}\n\n"
+        f"{operator_body}\n\n"
+        f"{_WORKSPACE_SECTION_HEADING}\n\n"
+        f"{workspace_text.strip()}\n"
+    )
+
+
 async def _handle_learning_insights_get(
     arguments: dict[str, Any],  # noqa: ARG001
 ) -> list[TextContent]:
-    """Return the operator-tier knowledge base as a single
-    ``TextContent``.
+    """Return both knowledge tiers as a single ``TextContent``.
 
     Defers to the runtime context's ``KnowledgeStore`` so an
     alternate backend registered via
     ``mureo.runtime_context_factory`` (filesystem-backed by default;
     could be DB-backed or remote-fetch-backed under a third-party
     runtime context factory) works transparently.
+
+    When the workspace tier contributes nothing — absent, empty, or
+    whitespace-only — the payload is byte-identical to the
+    operator-only payload this tool has always returned, so existing
+    consumers see no change. When it does have content, both tiers are
+    composed into one labelled payload with the workspace-wins
+    precedence rule stated up front.
     """
     store = get_runtime_context().knowledge_store
-    text = store.read_operator_knowledge()
-    if _is_scaffold_only(text):
-        logger.debug("learning insights: knowledge base empty / scaffold-only")
-        return [TextContent(type="text", text=_NO_INSIGHTS_MESSAGE)]
-    return [TextContent(type="text", text=text)]
+    operator_text = store.read_operator_knowledge()
+    workspace_text = _workspace_content(store)
+
+    if workspace_text is None:
+        if _is_scaffold_only(operator_text):
+            logger.debug("learning insights: knowledge base empty / scaffold-only")
+            return [TextContent(type="text", text=_NO_INSIGHTS_MESSAGE)]
+        return [TextContent(type="text", text=operator_text)]
+
+    logger.debug("learning insights: composing operator + workspace tiers")
+    return [
+        TextContent(
+            type="text",
+            text=_compose_two_tier_payload(operator_text, workspace_text),
+        )
+    ]
 
 
 async def _handle_consult_advisor(

--- a/skills/learn/SKILL.md
+++ b/skills/learn/SKILL.md
@@ -22,6 +22,11 @@ prior file layout); an alternate backend registered via the
 `mureo.runtime_context_factory` entry-point group can redirect or
 split the write without changing this skill.
 
+The knowledge base has two tiers — an **operator** tier shared across
+every workspace, and an optional **workspace** tier scoped to the
+current one. Use `mureo learn tiers` to find out which are available
+before deciding where an insight belongs (step 4).
+
 ## When to use
 
 - The user runs `/learn` followed by an insight, e.g.:
@@ -57,24 +62,58 @@ split the write without changing this skill.
    generalized lesson only — never record account IDs, credentials,
    access tokens, or personal data in the knowledge base.
 
-4. **Save by invoking the CLI.** Pass the approved insight verbatim
-   (including its leading blank line and trailing newline) to:
+4. **Choose the scope.** Before saving, detect which knowledge tiers
+   this installation exposes. The command is read-only — it creates
+   and modifies nothing:
 
    ```bash
-   mureo learn add "$INSIGHT_MARKDOWN"
+   mureo learn tiers
    ```
 
-   - The default `--scope operator` writes the cross-workspace tier
-     read by every diagnostic skill. Use this for general practitioner
-     know-how that applies to every account the operator runs.
-   - Pass `--scope workspace` when the insight is specific to the
-     active account and should not leak to other workspaces (only
-     meaningful when a workspace-aware KnowledgeStore backend is
-     installed; the command exits with a helpful message otherwise).
+   It prints one line per tier, e.g.:
 
-5. **Confirm.** Tell the user the insight was saved and that it will
-   be applied in future `/daily-check`, `/rescue`, `/budget-rebalance`,
-   and other diagnostic workflows.
+   ```
+   operator: configured
+   workspace: configured
+   ```
+
+   - **`workspace: configured`** — ask the user which tier to save to,
+     and present **workspace as the recommended default**. Most
+     insights worth recording are account-specific: product quirks,
+     measurement and conversion-tracking quirks, seasonality, campaign
+     history, what has already been tried on this account. Those are
+     true here and often false elsewhere, so writing them to the
+     operator tier makes every other account inherit them and the
+     agent will confidently misapply them. Reserve the operator tier
+     for genuinely generalizable cross-account know-how — platform
+     mechanics, statistical reasoning, structural rules of thumb.
+   - **`workspace: absent`** — no workspace tier is installed on this
+     machine. Save to the operator tier without asking the user.
+
+5. **Save by invoking the CLI.** Pass the approved insight verbatim
+   (including its leading blank line and trailing newline), with the
+   scope from step 4 stated explicitly:
+
+   ```bash
+   # Run ONE of these — the scope you settled on in step 4.
+   mureo learn add "$INSIGHT_MARKDOWN" --scope workspace
+   mureo learn add "$INSIGHT_MARKDOWN" --scope operator
+   ```
+
+   - `--scope operator` writes the cross-workspace tier read by every
+     diagnostic skill.
+   - `--scope workspace` writes the workspace-scoped tier, so the
+     insight stays with the active account and never leaks to other
+     workspaces. The command exits with a helpful message when no
+     workspace tier is configured — step 4 rules that case out.
+
+   Both tiers are handed to diagnostic workflows by
+   `mureo_learning_insights_get`; when the two conflict, workspace-tier
+   insights take precedence over operator-tier insights.
+
+6. **Confirm.** Tell the user the insight was saved, which tier it went
+   to, and that it will be applied in future `/daily-check`,
+   `/rescue`, `/budget-rebalance`, and other diagnostic workflows.
 
 IMPORTANT: Always save through `mureo learn add`, never by writing the
 file path manually. Going through the CLI keeps the skill compatible

--- a/tests/test_cli_learn.py
+++ b/tests/test_cli_learn.py
@@ -1,5 +1,7 @@
-"""Tests for ``mureo learn add`` — the CLI bridge that routes
-``/learn`` skill writes through the KnowledgeStore Protocol.
+"""Tests for ``mureo learn add`` / ``mureo learn tiers`` — the CLI
+bridge that routes ``/learn`` skill writes through the KnowledgeStore
+Protocol, plus the read-only tier-detection command the skill calls
+before choosing a scope.
 
 The contract:
 - ``--scope operator`` (default) calls
@@ -8,14 +10,21 @@ The contract:
   ``KnowledgeStore.append_workspace_knowledge``; when the resolved
   store has no workspace tier, the command exits non-zero with a
   helpful message instead of silently dropping the insight.
+- ``mureo learn tiers`` reports which tiers the resolved store exposes
+  in a shape an LLM can parse off stdout, exits 0 either way, and
+  creates nothing on disk.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 import pytest
 from typer.testing import CliRunner
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 from mureo.core.runtime_context import (
     RuntimeContext,
@@ -47,9 +56,7 @@ class _RecordingKnowledgeStore:
         self.workspace_appends.append(insight)
 
 
-def _inject_store(
-    monkeypatch: pytest.MonkeyPatch, knowledge_store: _RecordingKnowledgeStore
-) -> None:
+def _inject_store(monkeypatch: pytest.MonkeyPatch, knowledge_store: object) -> None:
     base = default_runtime_context()
     ctx = RuntimeContext(
         secret_store=base.secret_store,
@@ -133,6 +140,112 @@ def test_workspace_scope_without_tier_exits_with_hint(
     assert result.exit_code != 0
     assert store.workspace_appends == []
     assert "--scope operator" in result.output
+
+
+@pytest.mark.unit
+class TestLearnTiers:
+    """``mureo learn tiers`` is how the ``/learn`` skill discovers
+    whether a workspace tier exists before asking the user where to
+    save. It must be read-only and machine-parseable."""
+
+    def test_reports_both_tiers_configured(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        store = _RecordingKnowledgeStore(has_workspace_tier=True)
+        _inject_store(monkeypatch, store)
+        from mureo.cli.main import app
+
+        result = runner.invoke(app, ["learn", "tiers"])
+        assert result.exit_code == 0, result.output
+        lines = [ln.strip() for ln in result.output.splitlines() if ln.strip()]
+        assert "operator: configured" in lines
+        assert "workspace: configured" in lines
+
+    def test_reports_workspace_absent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        store = _RecordingKnowledgeStore(has_workspace_tier=False)
+        _inject_store(monkeypatch, store)
+        from mureo.cli.main import app
+
+        result = runner.invoke(app, ["learn", "tiers"])
+        assert result.exit_code == 0, result.output
+        lines = [ln.strip() for ln in result.output.splitlines() if ln.strip()]
+        assert "operator: configured" in lines
+        assert "workspace: absent" in lines
+
+    def test_does_not_write_to_either_tier(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        store = _RecordingKnowledgeStore(has_workspace_tier=True)
+        _inject_store(monkeypatch, store)
+        from mureo.cli.main import app
+
+        runner.invoke(app, ["learn", "tiers"])
+        assert store.operator_appends == []
+        assert store.workspace_appends == []
+
+    def test_does_not_create_the_workspace_file_on_disk(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Detection must not touch disk beyond reads: a configured but
+        not-yet-written workspace file stays absent, and the tier still
+        reports as configured."""
+        from mureo.core.knowledge_store import FilesystemKnowledgeStore
+
+        operator_path = tmp_path / "operator" / "SKILL.md"
+        workspace_path = tmp_path / "workspace" / "SKILL.md"
+        _inject_store(
+            monkeypatch,
+            FilesystemKnowledgeStore(
+                operator_path=operator_path, workspace_path=workspace_path
+            ),
+        )
+        from mureo.cli.main import app
+
+        result = runner.invoke(app, ["learn", "tiers"])
+        assert result.exit_code == 0, result.output
+        assert "workspace: configured" in result.output
+        assert not workspace_path.exists()
+        assert not workspace_path.parent.exists()
+        assert not operator_path.exists()
+
+    def test_raising_workspace_read_exits_non_zero_with_a_clean_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Detection is inconclusive, not "absent" — reporting ``absent``
+        would push the skill into the silent legacy flow and quietly
+        misroute a workspace-scoped insight. Fail loudly, but with a
+        readable line rather than a traceback the skill would paste
+        into the conversation."""
+
+        class _ExplodingStore(_RecordingKnowledgeStore):
+            def read_workspace_knowledge(self) -> str | None:
+                raise RuntimeError("workspace backend unreachable")
+
+        _inject_store(monkeypatch, _ExplodingStore())
+        from mureo.cli.main import app
+
+        result = runner.invoke(app, ["learn", "tiers"])
+        assert result.exit_code != 0
+        assert "Traceback" not in result.output
+        assert "workspace" in result.output.lower()
+        # Must not claim a definite answer either way.
+        assert "workspace: absent" not in result.output
+        assert "workspace: configured" not in result.output
+
+    def test_filesystem_default_without_workspace_reports_absent(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from mureo.core.knowledge_store import FilesystemKnowledgeStore
+
+        _inject_store(
+            monkeypatch,
+            FilesystemKnowledgeStore(operator_path=tmp_path / "operator" / "SKILL.md"),
+        )
+        from mureo.cli.main import app
+
+        result = runner.invoke(app, ["learn", "tiers"])
+        assert result.exit_code == 0, result.output
+        assert "workspace: absent" in result.output
 
 
 @pytest.mark.unit

--- a/tests/test_mcp_tools_learning.py
+++ b/tests/test_mcp_tools_learning.py
@@ -17,10 +17,16 @@ These tests pin three things:
    ``mureo.runtime_context_factory`` entry-point group still works).
 3. The handler returns a non-empty guidance string when no insights
    have been saved yet, instead of an empty / confusing payload.
+4. The handler reads BOTH KnowledgeStore tiers: the legacy
+   operator-only payload is returned byte-identically when no
+   workspace tier is configured, and a two-section payload (with the
+   workspace-wins precedence note) when the workspace tier has
+   content.
 """
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -70,6 +76,25 @@ class TestLearningInsightsToolDefinition:
         assert "/learn" in tool.description
         assert "diagnostic" in tool.description.lower()
 
+    def test_tool_description_documents_both_tiers_and_precedence(self) -> None:
+        """The agent decides how to weigh conflicting insights from the
+        description alone — it must say both tiers are returned and
+        which one wins."""
+        mod = _import_learning_tools()
+        tool = next(t for t in mod.TOOLS if t.name == "mureo_learning_insights_get")
+        lowered = tool.description.lower()
+        assert "operator" in lowered
+        assert "workspace" in lowered
+        assert "precede" in lowered or "precedence" in lowered
+
+    def test_tool_still_takes_no_arguments_after_two_tier_read(self) -> None:
+        """Reading both tiers must not introduce a scope argument —
+        mureo-pro and every bundled skill call this tool with ``{}``."""
+        mod = _import_learning_tools()
+        tool = next(t for t in mod.TOOLS if t.name == "mureo_learning_insights_get")
+        assert tool.inputSchema["properties"] == {}
+        assert tool.inputSchema["required"] == []
+
 
 @pytest.mark.unit
 class TestLearningInsightsHandler:
@@ -84,6 +109,7 @@ class TestLearningInsightsHandler:
         fake_store.read_operator_knowledge.return_value = (
             "## Learned Insights\n\n### Use micro-conversions when CV is sparse\n"
         )
+        fake_store.read_workspace_knowledge.return_value = None
         fake_ctx = MagicMock(knowledge_store=fake_store)
         with patch(
             "mureo.mcp.tools_learning.get_runtime_context", return_value=fake_ctx
@@ -103,6 +129,7 @@ class TestLearningInsightsHandler:
         mod = _import_learning_tools()
         fake_store = MagicMock()
         fake_store.read_operator_knowledge.return_value = ""
+        fake_store.read_workspace_knowledge.return_value = None
         fake_ctx = MagicMock(knowledge_store=fake_store)
         with patch(
             "mureo.mcp.tools_learning.get_runtime_context", return_value=fake_ctx
@@ -139,6 +166,7 @@ diagnostic workflow.
 """
         fake_store = MagicMock()
         fake_store.read_operator_knowledge.return_value = scaffold_only
+        fake_store.read_workspace_knowledge.return_value = None
         fake_ctx = MagicMock(knowledge_store=fake_store)
         with patch(
             "mureo.mcp.tools_learning.get_runtime_context", return_value=fake_ctx
@@ -180,6 +208,207 @@ diagnostic workflow.
         mod = _import_learning_tools()
         with pytest.raises(ValueError, match="Unknown tool"):
             await mod.handle_tool("not_a_real_tool", {})
+
+
+_OPERATOR_TEXT = (
+    "## Learned Insights\n\n### Cap ad groups at 3 when the daily budget is small\n"
+)
+_WORKSPACE_TEXT = "## Learned Insights\n\n### This account's CV fires 2 days late\n"
+
+
+def _fake_store(operator: str, workspace: str | None) -> MagicMock:
+    """Build a KnowledgeStore double whose BOTH readers are pinned.
+
+    Leaving ``read_workspace_knowledge`` unconfigured on a bare
+    ``MagicMock`` would return a truthy ``Mock``, which is neither the
+    ``str`` nor the ``None`` the Protocol allows — the tests would then
+    exercise a state no real backend can produce.
+    """
+    store = MagicMock()
+    store.read_operator_knowledge.return_value = operator
+    store.read_workspace_knowledge.return_value = workspace
+    return store
+
+
+async def _run_handler(mod: object, store: MagicMock) -> str:
+    fake_ctx = MagicMock(knowledge_store=store)
+    with patch("mureo.mcp.tools_learning.get_runtime_context", return_value=fake_ctx):
+        result = await mod.handle_tool("mureo_learning_insights_get", {})
+    assert len(result) == 1
+    return str(result[0].text)
+
+
+@pytest.mark.unit
+class TestTwoTierRead:
+    """The handler surfaces the workspace tier alongside the operator
+    tier. Every path where the workspace tier contributes nothing must
+    stay byte-identical to the pre-two-tier behaviour, because every
+    bundled diagnostic skill (and mureo-pro) already consumes it."""
+
+    @pytest.mark.asyncio
+    async def test_workspace_absent_returns_legacy_operator_payload(self) -> None:
+        mod = _import_learning_tools()
+        text = await _run_handler(mod, _fake_store(_OPERATOR_TEXT, None))
+        assert text == _OPERATOR_TEXT
+
+    @pytest.mark.asyncio
+    async def test_workspace_absent_and_operator_empty_returns_legacy_guidance(
+        self,
+    ) -> None:
+        mod = _import_learning_tools()
+        text = await _run_handler(mod, _fake_store("", None))
+        assert text == mod._NO_INSIGHTS_MESSAGE
+
+    @pytest.mark.asyncio
+    async def test_workspace_absent_and_scaffold_only_returns_legacy_guidance(
+        self,
+    ) -> None:
+        from mureo.core.knowledge_store import _OPERATOR_SCAFFOLD
+
+        mod = _import_learning_tools()
+        text = await _run_handler(mod, _fake_store(_OPERATOR_SCAFFOLD, None))
+        assert text == mod._NO_INSIGHTS_MESSAGE
+
+    @pytest.mark.asyncio
+    async def test_empty_workspace_text_is_treated_as_absent(self) -> None:
+        """A configured-but-never-written workspace tier reads as ``""``
+        (or whitespace). It must contribute nothing rather than emit an
+        empty section the agent would quote."""
+        mod = _import_learning_tools()
+        text = await _run_handler(mod, _fake_store(_OPERATOR_TEXT, "   \n\n  "))
+        assert text == _OPERATOR_TEXT
+
+    @pytest.mark.asyncio
+    async def test_non_string_workspace_return_is_treated_as_absent(self) -> None:
+        """``KnowledgeStore`` is a third-party-implementable Protocol —
+        a backend returning something other than ``str | None`` must
+        degrade to the legacy payload, not crash the diagnostic
+        workflow."""
+        mod = _import_learning_tools()
+        text = await _run_handler(mod, _fake_store(_OPERATOR_TEXT, object()))
+        assert text == _OPERATOR_TEXT
+
+    @pytest.mark.asyncio
+    async def test_raising_workspace_read_is_treated_as_absent(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A workspace tier that *raises* must degrade exactly like one
+        that is absent. A remote- or DB-backed third-party store can
+        fail transiently; a broken workspace tier must never take down
+        the whole tool, because the operator tier — which read fine —
+        is what 7 diagnostic workflows depend on."""
+        mod = _import_learning_tools()
+        store = _fake_store(_OPERATOR_TEXT, None)
+        store.read_workspace_knowledge.side_effect = RuntimeError(
+            "workspace backend unreachable"
+        )
+
+        with caplog.at_level(logging.WARNING, logger="mureo.mcp.tools_learning"):
+            text = await _run_handler(mod, store)
+
+        assert text == _OPERATOR_TEXT
+        assert any(
+            "workspace" in rec.message.lower() and rec.levelno >= logging.WARNING
+            for rec in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_raising_workspace_read_still_reports_no_insights_when_empty(
+        self,
+    ) -> None:
+        """Degrading to legacy means the *whole* legacy contract, including
+        the empty-knowledge-base sentinel."""
+        mod = _import_learning_tools()
+        store = _fake_store("", None)
+        store.read_workspace_knowledge.side_effect = OSError("disk gone")
+
+        text = await _run_handler(mod, store)
+        assert text == mod._NO_INSIGHTS_MESSAGE
+
+    @pytest.mark.asyncio
+    async def test_both_tiers_populated_composes_two_labelled_sections(self) -> None:
+        mod = _import_learning_tools()
+        text = await _run_handler(mod, _fake_store(_OPERATOR_TEXT, _WORKSPACE_TEXT))
+
+        assert "Cap ad groups at 3 when the daily budget is small" in text
+        assert "This account's CV fires 2 days late" in text
+        assert mod._OPERATOR_SECTION_HEADING in text
+        assert mod._WORKSPACE_SECTION_HEADING in text
+        # Operator section first, workspace section second.
+        assert text.index(mod._OPERATOR_SECTION_HEADING) < text.index(
+            mod._WORKSPACE_SECTION_HEADING
+        )
+
+    @pytest.mark.asyncio
+    async def test_both_tiers_populated_states_workspace_precedence(self) -> None:
+        mod = _import_learning_tools()
+        text = await _run_handler(mod, _fake_store(_OPERATOR_TEXT, _WORKSPACE_TEXT))
+        lowered = text.lower()
+        assert "precede" in lowered or "precedence" in lowered
+        assert "conflict" in lowered
+
+    @pytest.mark.asyncio
+    async def test_workspace_content_with_empty_operator_still_shows_workspace(
+        self,
+    ) -> None:
+        """The workspace tier alone is real content — returning the
+        'nothing saved yet' sentinel here would hide it."""
+        mod = _import_learning_tools()
+        text = await _run_handler(mod, _fake_store("", _WORKSPACE_TEXT))
+
+        assert mod._NO_INSIGHTS_MESSAGE not in text
+        assert "This account's CV fires 2 days late" in text
+        assert mod._WORKSPACE_SECTION_HEADING in text
+        assert "no operator-tier insights" in text.lower()
+
+    @pytest.mark.asyncio
+    async def test_workspace_content_with_scaffold_only_operator(self) -> None:
+        from mureo.core.knowledge_store import _OPERATOR_SCAFFOLD
+
+        mod = _import_learning_tools()
+        text = await _run_handler(mod, _fake_store(_OPERATOR_SCAFFOLD, _WORKSPACE_TEXT))
+
+        assert mod._NO_INSIGHTS_MESSAGE not in text
+        assert "This account's CV fires 2 days late" in text
+        assert "no operator-tier insights" in text.lower()
+
+    @pytest.mark.asyncio
+    async def test_both_tiers_are_read_exactly_once(self) -> None:
+        mod = _import_learning_tools()
+        store = _fake_store(_OPERATOR_TEXT, _WORKSPACE_TEXT)
+        await _run_handler(mod, store)
+        store.read_operator_knowledge.assert_called_once()
+        store.read_workspace_knowledge.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_handler_never_appends_to_either_tier(self) -> None:
+        """The read tool must stay read-only."""
+        mod = _import_learning_tools()
+        store = _fake_store(_OPERATOR_TEXT, _WORKSPACE_TEXT)
+        await _run_handler(mod, store)
+        store.append_operator_knowledge.assert_not_called()
+        store.append_workspace_knowledge.assert_not_called()
+
+
+@pytest.mark.unit
+class TestMureoProCompatibility:
+    """mureo-pro pins ``tools_learning.get_runtime_context`` as a
+    module-level name and monkeypatches it. Renaming, aliasing, or
+    caching the store at import time would break their shim."""
+
+    def test_get_runtime_context_is_a_module_level_name(self) -> None:
+        mod = _import_learning_tools()
+        assert hasattr(mod, "get_runtime_context")
+
+    @pytest.mark.asyncio
+    async def test_store_is_resolved_at_call_time(self) -> None:
+        """Two calls with two different patched contexts must see two
+        different stores — i.e. no module-level caching."""
+        mod = _import_learning_tools()
+        first = await _run_handler(mod, _fake_store("first tier text\n", None))
+        second = await _run_handler(mod, _fake_store("second tier text\n", None))
+        assert first == "first tier text\n"
+        assert second == "second tier text\n"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

The KnowledgeStore Protocol has supported a workspace tier on the **write** side (`mureo learn add --scope workspace`) since the two-tier split landed, but nothing on the **read** side ever consumed it — workspace-scoped insights were invisible to every diagnostic workflow. This PR closes the loop on both sides.

## Read side

`mureo_learning_insights_get` now reads both tiers:

- **No workspace tier / empty workspace tier** → output is byte-identical to the legacy operator-only behavior (including the `_NO_INSIGHTS_MESSAGE` guidance string). Single-tier installs see zero change.
- **Workspace tier has content** → a composed payload: a precedence note ("Workspace-tier insights take precedence over operator-tier insights when the two conflict."), an `## Operator knowledge (all workspaces)` section, and an `## Workspace knowledge (current workspace)` section. An empty operator tier no longer suppresses workspace content.
- **Robustness**: a raising or non-`str` `read_workspace_knowledge()` degrades to the legacy payload with a `logger.warning` — a broken third-party workspace backend must never break the tool call (same defensive pattern as `plugin_semantics` / `native_reversal`).
- Tool description updated; schema unchanged (still zero arguments).

## Write side

- New read-only `mureo learn tiers` subcommand reports `operator: configured` / `workspace: configured|absent` (exit 0) so the `/learn` skill can branch without touching disk. An inconclusive probe (store raised) exits 1 with a clean one-line error instead of guessing `absent` and silently misrouting a workspace-scoped insight into the operator tier.
- `skills/learn/SKILL.md` (+ byte-identical bundled mirror): new "Choose the scope" step — run `mureo learn tiers`; when a workspace tier is configured, ask the user where to save with **workspace scope as the recommended default** (account-specific lessons stored in the operator tier risk misapplication on other accounts). Without a workspace tier, the legacy operator-only flow is unchanged — no new prompt.
- `mureo learn add` keeps its `--scope operator` default (backward compatible; the skill passes `--scope` explicitly).

## Compatibility

- `tools_learning` keeps the module-level `get_runtime_context` import and resolves the KnowledgeStore per-call inside the handler; both are now pinned by dedicated tests (`TestMureoProCompatibility`).
- `FilesystemKnowledgeStore` and the `KnowledgeStore` Protocol are untouched.

## Tests

- 15 new tests (two-tier composition, legacy byte-identity, raising/malformed backend degradation, `tiers` outputs + read-only guarantee, per-call store resolution). Targeted files: 38 passed.
- Full suite: 6108 passed, no new failures (the known 12 env-only failures unchanged).
- ruff / black / mypy clean.
