### PR TITLE
docs: restructure README around a single no-credentials quick start

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -45,79 +45,57 @@ mureoは、**AI 広告運用のためのローカル制御平面（control plane
 - **ローカルファースト** — 認証情報は端末の外に出ない
 - **学習可能** — `/learn` でアカウント固有のナレッジを継続的に蓄積
 
-## セットアップを選ぶ
+## クイックスタート（2分で動きを見る）
 
-### 簡単な方法: `pip install` + `mureo configure`
-
-ほとんどの場合、Claude 向けの mureo セットアップは 2 コマンドで完了します — **ターミナルで秘密情報を貼り付ける必要も、JSON を手で編集する必要もありません**:
-
-```bash
-pip install mureo
-mureo configure
-```
-
-`mureo configure` はローカル（`127.0.0.1` のランダムポートにバインド — 外部からはアクセス不可）にブラウザ UI を起動し、すべての手順を案内します:
-
-- **Claude アプリを選ぶ** — *Claude Code (CLI / Desktop アプリ)* または *Claude Desktop アプリ (Chat, Cowork)*; mureo がそのホスト用の正しい設定ファイルを書き込みます。
-- **基本セットアップ** — mureo MCP サーバ、認証情報ガードフック (Claude Code 用)、ワークフロースキルを 1 クリックで登録。
-- **プラットフォーム接続** — Google / Meta OAuth を同じウィンドウで対話的に完了（各コンソールへのディープリンクあり）、または GA4 サービスアカウントのパス / project id を貼り付け。値は `~/.mureo/credentials.json` に書き込まれます。
-- **公式 MCP プロバイダ** — Google Ads / GA4 の公式 MCP を `~/.claude.json` に登録。（Meta は OAuth dynamic client registration を持たない hosted MCP のため Claude Code の user-scope サーバとして接続できません。UI には代わりに Claude.ai のアカウントコネクタとして追加する方法が表示されます — 一度設定すれば Claude Code と Claude Desktop の両方で動作します。）
-- **プラットフォーム別ツールソース** — ダッシュボードのトグルで、各プラットフォームを mureo-native ツールと公式 MCP の間で切り替え。
-- **Demo / BYOD** — デモシナリオのスキャフォールド、または XLSX バンドルの取込みを同じ UI から実行。
-
-下記のターミナルフローも引き続き利用可能です（スクリプト化したい場合に有用）。`mureo configure` は同じ操作を行うフレンドリーな入口です。
-
-### 手動 / スクリプト用 (3 モード × 3 ホスト)
-
-mureo は **3 つのモード**(どのデータを使うか)× **3 つのホスト**(どこでエージェントを動かすか)で利用できます。該当するセルのコマンドを実行 — もしくは上記の `mureo configure` を使うだけでも OK:
-
-| | Claude Code | Claude Desktop チャット | Cowork (Desktop) |
-|---|---|---|---|
-| **デモ** (合成データ) | `mureo setup claude-code --skip-auth` + `mureo demo init --scenario seasonality-trap` | `mureo install-desktop --with-demo seasonality-trap` | チャットと同じ + ワークスペースフォルダを接続 |
-| **BYOD** (自前 XLSX) | `mureo setup claude-code --skip-auth` + `mureo byod import bundle.xlsx` | `mureo install-desktop` + `mureo byod import bundle.xlsx` | チャットと同じ + フォルダ接続 |
-| **認証** (Live API) | `mureo setup claude-code` (OAuth ウィザード) | `mureo install-desktop` + `mureo configure` | チャットと同じ + フォルダ接続 |
-
-各行の詳細手順(XLSX の取得方法、置き場所、取込み方を含む): **[はじめかた →](docs/getting-started.ja.md)**
-
-## BYOD と Live API の違い
-
-> **Google Cloud Console や Meta for Developers に慣れていない方へ。** OAuth フロー / Developer Token の発行 / Business app 登録は、これらのコンソールを使ったことがない方には難しく感じるかもしれません。**まずは BYOD から始めてください** — 数分で mureo がどう動くかが分かります。それから Live API のセットアップに踏み込むかどうか判断すれば OK です。
-
-### モード A: BYOD — 5分で最初の診断、OAuth 不要
-
-**Google Ads / Meta Ads から XLSX（エクセルファイル）として書き出して mureo に取り込むだけで、媒体をまたいだ戦略レベルの診断が手に入ります。** OAuth・Developer Token・SaaSサインアップは一切不要です。
+広告アカウントの認証情報も、OAuth も、サインアップも不要です。3 コマンドで合成データのデモアカウントが用意され、mureo が Claude Code に接続されます。
 
 ```bash
 pip install mureo
 mureo setup claude-code --skip-auth
-mureo byod import ~/Downloads/mureo-google-ads.xlsx
-mureo byod import ~/Downloads/mureo-meta-ads.xlsx     # Meta は後から追加可 — 互いに独立
-# Claude Code を開いて「/daily-check を実行して」と聞く
+mureo demo init --scenario seasonality-trap
 ```
 
-XLSX の生成はプラットフォームごとの一回限りのセットアップです:
+生成された `mureo-demo/` ディレクトリを Claude Code で開いて、こう聞いてください。
 
-- **Google Ads** — Apps Script テンプレートで自分の Google スプレッドシートに出力 → XLSX としてダウンロード（約5分）。[ガイドを見る →](docs/byod.ja.md#step-2a--google-ads-script-を実行任意)
-- **Meta Ads** — 広告マネージャの保存済みレポート → 2クリックで書き出し。**9言語に対応**（English / 日本語 / 简体中文 / 繁體中文 / 한국어 / Español / Português / Deutsch / Français）。広告マネージャUIを英語に切り替える必要はありません。[ガイドを見る →](docs/byod.ja.md#step-2b--meta-広告マネージャからエクスポート任意)
+```
+/daily-check
+```
 
-**設計として読み取り専用**。すべての変更系ツール（`/rescue`、`/budget-rebalance`、`/creative-refresh`）は `{"status": "skipped_in_byod_readonly"}` を返します — エージェントは分析・提案はしますが、実アカウントへの書き込みは決してしません。後から Live API に切り替えるには `mureo byod remove --google-ads`（プラットフォーム単位）または `mureo byod clear`（全削除）。
+エージェントがデモ用の `STRATEGY.md` を読み、キャンペーンデータを取得し、数値だけを見るツールが見落とす「季節性の罠」に踏み込んでいく様子を見られます。次は `/search-term-cleanup` を試してみてください。
 
-### モード B: Live API OAuth — 全機能対応
+自分のデータに mureo を向ける準備ができたら、下の 2 つの道のどちらかを選びます。
 
-mureo を Google Ads / Meta Ads API に直接接続します。**実際に変更を実行する場合**（`/rescue`、`/budget-rebalance`、`/creative-refresh`、`mureo rollback apply`）、および GA4 / Search Console を使う場合は**必須**です。
+### 道 A: 自分のデータで試す（BYOD、5〜10分、OAuth 不要）
+
+**Google Ads / Meta Ads から XLSX として書き出して mureo に取り込むだけで、媒体をまたいだ戦略レベルの診断が手に入ります。** OAuth も Developer Token の審査待ちも一切不要です。
 
 ```bash
-pip install mureo
-mureo auth setup           # ブラウザベースのOAuthウィザード
-mureo setup claude-code    # MCP + ワークフローコマンド
+mureo byod import ~/Downloads/mureo-google-ads.xlsx
+mureo byod import ~/Downloads/mureo-meta-ads.xlsx   # 媒体は互いに独立。片方だけでも、後から追加でも可
 # Claude Code を開いて「/daily-check を実行して」と聞く
 ```
 
-前提: Google Ads Developer Token + OAuth クライアント、Meta App ID + Secret。ウィザードが両方を案内します — 下記の[認証](#認証)を参照。
+XLSX の生成は媒体ごとに一回だけのセットアップです。Google Ads は Apps Script テンプレートで約5分、Meta Ads は広告マネージャの保存済みレポートから2クリックで書き出せます（9言語のUIに対応。広告マネージャを英語に切り替える必要はありません）。**[BYOD ガイド →](docs/byod.ja.md)**
+
+BYOD は**設計として読み取り専用**です。すべての変更系ツールは `{"status": "skipped_in_byod_readonly"}` を返します。エージェントは分析と提案はしますが、実アカウントへの書き込みは決してしません。
+
+### 道 B: 本番接続する（Live API OAuth、全機能）
+
+mureo を Google Ads / Meta Ads API に直接接続します。実際に変更を実行する場合（`/rescue`、`/budget-rebalance`、`/creative-refresh`、rollback）、および GA4 / Search Console を使う場合はこちらが必須です。
+
+```bash
+mureo configure
+```
+
+`mureo configure` はローカル（`127.0.0.1` にバインド。外部からはアクセス不可）にブラウザ UI を起動し、Claude アプリの選択、1クリックの基本セットアップ、各コンソールへのディープリンク付き Google / Meta OAuth、公式 MCP プロバイダの登録まで案内します。ターミナル派には `mureo auth setup` ＋ `mureo setup claude-code` が同じことをします。**[認証ガイド →](docs/authentication.md)**
+
+前提: Google Ads の Developer Token と OAuth クライアント、Meta の App ID と Secret（開発モードのままで構いません）。取得手順もウィザードが案内します。
+
+> **Google Cloud Console や Meta for Developers に慣れていない方へ。** OAuth フローや Developer Token の発行は、これらのコンソールを使ったことがない方には難しく感じるかもしれません。**まずはデモか BYOD から始めてください。**数分で mureo がどう動くかが分かり、それから Live API のセットアップに踏み込むかどうか判断すれば大丈夫です。
 
 ### どちらのモードが合うか
 
-| 機能                                                | モード A: BYOD                          | モード B: Live API |
+| 機能                                                | BYOD                                    | Live API |
 |----------------------------------------------------|-----------------------------------------|------------------|
 | **初回セットアップ時間**                           | **プラットフォームごとに5〜10分**      | 30〜60分 |
 | **承認・待機リスク**                              | **なし**                                 | Google審査1〜3週間、却下される場合あり |
@@ -125,16 +103,26 @@ mureo setup claude-code    # MCP + ワークフローコマンド
 | `/goal-review`、`/sync-state`                     | ✅                                      | ✅ |
 | `/rescue` / `/budget-rebalance`（提案）           | ✅                                      | ✅ |
 | `/search-term-cleanup`（分析）                    | ✅ Google Ads のみ                      | ✅ |
-| `/search-term-cleanup`（実行）                    | 🛡️ プレビューのみ                       | ✅ 実アカウントで実行 |
-| `/rescue` / `/budget-rebalance`（実行）           | 🛡️ プレビューのみ                       | ✅ 実アカウントで実行 |
-| `/creative-refresh`（実行）                       | 🛡️ プレビューのみ                       | ✅ 実アカウントで実行 |
+| 実行（`/rescue`、`/budget-rebalance`、`/creative-refresh`、`/search-term-cleanup`） | 🛡️ プレビューのみ | ✅ 実アカウントで実行 |
 | `/competitive-scan`                               | ⚠️ Google Ads BYOD は auction insights 非対応（Apps Script の制約） | ✅ |
 | GA4 / Search Console                              | ❌（BYOD バンドルに含まれず）           | ✅ |
 
-**おすすめの始め方:** まず1つのプラットフォームでモード A を試す → `/daily-check` を実行 → 2つ目のプラットフォームを BYOD で追加するか、モード B にアップグレードするか判断する。`~/.mureo/byod/manifest.json` があるかどうかでモードが切り替わります — 設定フラグもグローバル切替もありません。
+`~/.mureo/byod/manifest.json` があるかどうかでモードが切り替わります。取り込んだ媒体は BYOD、それ以外は Live API で動作し、`mureo byod remove --google-ads`（媒体単位）や `mureo byod clear`（全削除）でいつでも切り替えられます。
 
-詳細は [docs/byod.ja.md](docs/byod.ja.md) を参照してください — 完全ガイド、保存済みレポート設定、プラットフォーム別エクスポート手順を掲載しています。
+### そのほかのエージェントとホスト
 
+基準となるホストは Claude Code ですが、どのセットアップも 1 コマンドで完了します。
+
+| ホスト | コマンド | 補足 |
+|------|---------|-------|
+| Claude Code | `mureo setup claude-code` | MCP サーバ＋認証情報ガード＋ワークフロースキル |
+| Claude Desktop（Chat / Cowork） | `mureo install-desktop` | Cowork ではワークスペースフォルダを接続 |
+| Cursor | `mureo setup cursor` | MCP ツールのみ（ワークフロースキルなし） |
+| Codex CLI | `mureo setup codex` | Claude Code と同等。スキルは `~/.codex/skills/` に配置、`$daily-check` で起動 |
+| Gemini CLI | `mureo setup gemini` | 拡張マニフェスト形式。PreToolUse フックは非対応 |
+| 任意の MCP クライアント / CI | Docker | **[Docker ガイド →](docs/docker.md)** |
+
+ホスト別の詳細手順（各ホストのデモ / BYOD / Live の組み合わせを含む）: **[はじめかた →](docs/getting-started.ja.md)**
 
 ## 特徴
 
@@ -189,22 +177,6 @@ AIエージェントに広告アカウントを任せる以上、認証情報の
 
 脅威モデルと脆弱性報告の手順は [SECURITY.md](SECURITY.md) を参照してください。
 
-<details>
-<summary>全機能一覧を展開</summary>
-
-| 領域 | 機能 |
-|------|------|
-| **診断** | 配信停止・低下の原因自動特定、学習期間の検出、入札戦略の分類、CV未発生キャンペーンの原因分析 |
-| **パフォーマンス** | 期間比較、コスト急騰の原因調査、アカウント全体の健全性チェック、CPA/CV目標の進捗追跡 |
-| **検索語** | N-gram分布、検索意図の分類、追加/除外候補の自動評価、有料 vs 自然検索の重複分析 |
-| **クリエイティブ** | RSA入稿チェック（禁止表現、文字幅、広告の有効性予測）、アセット別の成果分析、LP解析、広告とLPの一貫性チェック |
-| **予算** | キャンペーン横断の配分分析、再配分の提案、予算効率の評価 |
-| **競合** | オークション分析、インプレッションシェアの推移、自然検索順位との相関 |
-| **Meta広告** | 配置別分析（Facebook/Instagram/Audience Network）、コスト悪化の原因調査、A/B比較、クリエイティブ改善提案 |
-| **モニタリング** | 配信目標の達成度評価、CPA/CV目標の追跡、デバイス別分析、B2B向けチェック |
-
-</details>
-
 ## ワークフローコマンド
 
 | コマンド | できること |
@@ -219,7 +191,7 @@ AIエージェントに広告アカウントを任せる以上、認証情報の
 | `/creative-generate` | 戦略ブリーフからクリエイター品質の広告クリエイティブ（キービジュアル＋合成バナー）を生成。アートディレクションの採点ループ付き（[Creative Studio](docs/creative-studio.ja.md)） |
 | `/ad-fatigue-check` | クリエイティブ疲弊の検知（フリークエンシー・前週比CTR低下・CPM上昇）。FATIGUED/WATCH/FRESH で判定し `/creative-generate`・`/creative-refresh` へ差し替えを連携 |
 | `/experiment` | A/Bスプリットテストの設計・実行・評価。1変数・反証可能な仮説・固定期間で、バリアント別に 勝者/差なし/判定不能 を評価 |
-| `/lead-form-create` | Meta インスタントフォーム（Lead 広告フォーム）を1問1答インタビュー形式で作成。カバー画像の有無もエージェントが個別に確認 |
+| `/lead-form-create` | Meta インスタントフォーム（Lead 広告フォーム)を1問1答インタビュー形式で作成。カバー画像の有無もエージェントが個別に確認 |
 | `/budget-rebalance` | 自然検索でカバーできている領域を考慮した予算の再配分 |
 | `/budget-pacing` | 月初来の消化額と月次予算目標を比較し、着地を予測してペース警告（総消化の推移管理。`/budget-rebalance` と併用） |
 | `/competitive-scan` | 広告と自然検索の両面から競合状況を分析 |
@@ -229,18 +201,6 @@ AIエージェントに広告アカウントを任せる以上、認証情報の
 | `/monthly-report` | クライアント向けの月次ダイジェスト。前月比・目標達成度・実施アクション・予算消化をまとめる |
 | `/sync-state` | STATE.jsonを各媒体の最新データで更新 |
 | `/learn` | 運用で得た知見をナレッジベースに保存。次回以降のセッションに自動で反映 |
-
-### はじめ方
-
-```bash
-pip install mureo
-mureo setup claude-code
-
-# Claude Code上で：
-/onboard          # 初回：戦略と状態をセットアップ
-/daily-check      # 日次：全キャンペーンをチェック
-/rescue           # パフォーマンス悪化時
-```
 
 ### 例：`/creative-refresh` の実行フロー
 
@@ -287,277 +247,46 @@ STATE.jsonから接続媒体を検出:
 
 なぜ意味があるのか: `link_click` 最適化と `pixel_lead` 最適化の違いは、ダッシュボード上の数値だけ見ても気づけません。mureo は `result_indicator` をキャンペーン単位で取得するため、エージェントは「結果」列を比較する**前**に単位の違いを認識し、予算判断の前にトラッキング設定の問題として正しく分類できます。
 
-## クイックスタート
-
-### 事前に必要なもの
-
-- **Google広告** — [Google Ads API の Developer Token](https://developers.google.com/google-ads/api/docs/get-started/dev-token) と、OAuth用の Client ID / Client Secret
-- **Meta広告** — [Meta for Developers](https://developers.facebook.com/) でアプリを作成し、App ID / App Secret を取得（開発モードのままで構いません）
-
-いずれも `mureo configure`（ブラウザ）と `mureo auth setup`（ターミナル）の双方が手順を案内します。
-
-### ブラウザベースの設定 UI (`mureo configure`)
-
-> `mureo auth setup --web` は**削除**されました — ブラウザフローは統合された **`mureo configure`** UI に取り込まれています。
-
-ターミナルに長い秘密情報を貼り付けるのはミスしやすいので、`mureo configure` を実行してください。短命のローカル UI が `http://127.0.0.1:<ランダムポート>/` で起動し、ブラウザが自動で開きます。Credentials の入力だけでなく、Claude セットアップ全体をカバーします:
-
-- Claude ホストを選択（Claude Code / Claude Desktop）— mureo が該当ホストの config を書き込みます;
-- ワンクリックの **basic setup**（mureo MCP server + credential-guard hook + workflow skills）;
-- **プラットフォーム接続** — Google / Meta OAuth を同じウィンドウで対話的に完了（各欄のリンクから Google Cloud Console / Google Ads API Center / Meta for Developers の該当ページに飛べます）、または GA4 サービスアカウントのパス / project id を入力。`~/.mureo/credentials.json` に書き込まれます;
-- **公式 MCP プロバイダ**（Google Ads / GA4）を `~/.claude.json` に登録。Meta は OAuth dynamic client registration を持たない hosted MCP のため、UI にはローカル登録の代わりに Claude.ai のアカウントコネクタとして追加する方法が表示されます（Claude Code / Claude Desktop の両方で動作）;
-- ステータス確認、プラットフォームごとに mureo-native ↔ 公式 MCP を切替、**Demo / BYOD** のスキャフォールドを提供する **ダッシュボード**。
-
-フラグ: `--no-browser`（タブの自動オープンを抑止）、`--timeout-seconds N`（アイドル時の自動シャットダウン、デフォルト 600）。
+### 分析・ドメイン知識（組み込み）
 
 <details>
-<summary>ウィザードをローカル実行しても安全な理由</summary>
+<summary>全機能一覧を展開</summary>
 
-サーバは `127.0.0.1` のランダムポートにのみバインドします。フォームは CSRF トークンで保護（submit成功後に自動ローテーション）、OAuth の `state` パラメータはコールバック時に `secrets.compare_digest` で検証、`Host` ヘッダのアローリストでDNSリバインディング攻撃をブロック、リダイレクト先は `https://accounts.google.com/` と `https://www.facebook.com/` にピン留めしてあるためオープンリダイレクトは成立せず、認証情報の保存後は session 上の秘密情報をゼロクリアします。POST ボディは 16 KiB で打ち切り、`/done` 画面が配信されたらサーバを停止します。依存は標準ライブラリのみで、外部 Web フレームワークのサプライチェーン侵害を受ける面はありません。
+| 領域 | 機能 |
+|------|------|
+| **診断** | 配信停止・低下の原因自動特定、学習期間の検出、入札戦略の分類、CV未発生キャンペーンの原因分析 |
+| **パフォーマンス** | 期間比較、コスト急騰の原因調査、アカウント全体の健全性チェック、CPA/CV目標の進捗追跡 |
+| **検索語** | N-gram分布、検索意図の分類、追加/除外候補の自動評価、有料 vs 自然検索の重複分析 |
+| **クリエイティブ** | RSA入稿チェック（禁止表現、文字幅、広告の有効性予測）、アセット別の成果分析、LP解析、広告とLPの一貫性チェック |
+| **予算** | キャンペーン横断の配分分析、再配分の提案、予算効率の評価 |
+| **競合** | オークション分析、インプレッションシェアの推移、自然検索順位との相関 |
+| **Meta広告** | 配置別分析（Facebook/Instagram/Audience Network）、コスト悪化の原因調査、A/B比較、クリエイティブ改善提案 |
+| **モニタリング** | 配信目標の達成度評価、CPA/CV目標の追跡、デバイス別分析、B2B向けチェック |
 
 </details>
 
-### Claude Code（推奨）
+## リファレンス
 
-```bash
-pip install mureo
-mureo setup claude-code
-```
+### MCP サーバーとツール一覧
 
-このコマンド1つですべて完了します：
-1. Google広告 / Meta広告の認証（OAuth）
-2. Claude Code用のMCPサーバー設定
-3. 認証情報ガード（AIエージェントが認証ファイルを読めないようにブロック）
-4. ワークフローコマンド（`/daily-check`、`/rescue`、`/learn` など）
-5. スキル（ツールリファレンス、戦略ガイド、判断の仕組み、診断ナレッジ）
-
-セットアップ後、Claude Codeで `/onboard` を実行してください。
-
-### Cursor
-
-```bash
-pip install mureo
-mureo setup cursor
-```
-
-CursorはMCPツールを利用できますが、ワークフローコマンドとスキルには対応していません。
-
-### Codex CLI
-
-```bash
-pip install mureo
-mureo setup codex
-```
-
-Claude Codeと同じく4層すべて（MCPサーバー、認証情報ガード（PreToolUseフック）、ワークフローコマンド、スキル）を `~/.codex/` 配下にインストールします。ワークフローコマンドは Codex スキル形式（`~/.codex/skills/<command>/SKILL.md`）としてインストールされ、`$daily-check` または `/skills` ピッカーから呼び出せます（Codex CLI 0.117.0 以降は `~/.codex/prompts/` を読み込まなくなりました。[openai/codex#15941](https://github.com/openai/codex/issues/15941)）。
-
-### Gemini CLI
-
-```bash
-pip install mureo
-mureo setup gemini
-```
-
-mureoをGemini CLIのextensionとして `~/.gemini/extensions/mureo/` に登録し、MCPサーバー設定と `CONTEXT.md` をコンテキストファイルとして指定します。Gemini CLIはPreToolUseフックと`.md`形式のコマンドに対応していないため、これらのレイヤーはインストールされません。
-
-### CLIのみ（認証管理）
-
-```bash
-pip install mureo
-mureo auth setup
-mureo auth status
-```
-
-### Docker
-
-mureoのMCPサーバーを隔離されたコンテナで動かせます。想定ユースケース:
-
-- **Claude Code以外のMCPクライアント**: Cursor, Codex CLI, Gemini CLI, Continue, Cline, Zed など
-- **CI/CDパイプライン**: 異常検知、ロールバック dry-run、週次レポートの自動実行
-- **マルチテナント / 代理店運用**: クライアントごとにコンテナ・認証情報を分離
-- **MCPレジストリの健全性チェック**（Glama 等）
-
-> スラッシュコマンド（`/daily-check`, `/rescue` など）と credential-guard フックは Claude Code 固有のUXです。これらを使う場合は `pip install mureo` + `mureo setup claude-code` を使ってください。
-
-#### ビルドと起動
-
-```bash
-docker build -t mureo .
-docker run --rm -v ~/.mureo:/home/mureo/.mureo mureo
-```
-
-MCPクライアント側の設定で上記 `docker run` をコマンドとして指定してください。
-
-#### 認証
-
-認証情報は `/home/mureo/.mureo/credentials.json`（コンテナ内、bind mount 経由）または環境変数から読み込まれます。3つの方式から選べます:
-
-**1. マウントした認証ファイル** — ホストに `~/.mureo/credentials.json` が既にある場合（`mureo auth setup` 実行済、チーム共有、手書き等）、上記の bind mount だけで十分です。
-
-手書き用スキーマ:
+mureo は **205 の MCP ツール** を stdio で公開します。Google広告（86）、Meta広告（88）、Search Console（10）に加え、rollback、異常検知、戦略・状態コンテキスト、分析モジュールレジストリ、学習、Creative Studio を含みます。MCP 対応クライアントなら何からでも接続できます。
 
 ```json
 {
-  "google_ads": {
-    "developer_token": "...",
-    "client_id": "...apps.googleusercontent.com",
-    "client_secret": "...",
-    "refresh_token": "...",
-    "login_customer_id": "1234567890"
-  },
-  "meta_ads": { "access_token": "..." }
-}
-```
-
-必須フィールド: Google は `developer_token` / `client_id` / `client_secret` / `refresh_token`、Meta は `access_token`。Search Console は Google の OAuth 認証情報を共用（OAuth アプリに `https://www.googleapis.com/auth/webmasters` スコープが必要）。
-
-**2. 環境変数** — CI/CDで secret manager から渡す場合に便利:
-
-```bash
-docker run --rm \
-  -e GOOGLE_ADS_DEVELOPER_TOKEN=... \
-  -e GOOGLE_ADS_CLIENT_ID=... \
-  -e GOOGLE_ADS_CLIENT_SECRET=... \
-  -e GOOGLE_ADS_REFRESH_TOKEN=... \
-  -e GOOGLE_ADS_LOGIN_CUSTOMER_ID=... \
-  -e META_ADS_ACCESS_TOKEN=... \
-  mureo
-```
-
-対応環境変数: `GOOGLE_ADS_{DEVELOPER_TOKEN, CLIENT_ID, CLIENT_SECRET, REFRESH_TOKEN, LOGIN_CUSTOMER_ID, CUSTOMER_ID}`, `META_ADS_{ACCESS_TOKEN, APP_ID, APP_SECRET, TOKEN_OBTAINED_AT, ACCOUNT_ID}`。
-
-**3. Docker内で対話型ウィザード実行** — OAuthトークンをまだ持っておらず、ホストにmureoをインストールしたくない場合:
-
-```bash
-docker run -it --rm -v ~/.mureo:/home/mureo/.mureo mureo mureo auth setup
-```
-
-ターミナル上でOAuthフローを案内します。`credentials.json` はマウントボリュームに書き出されるので、次回以降は方式1で起動できます。
-
-mureo以外でOAuthトークンを取得する方法:
-
-- Google Ads OAuth 2.0: https://developers.google.com/google-ads/api/docs/oauth/overview
-- Meta 長期アクセストークン: https://developers.facebook.com/docs/facebook-login/guides/access-tokens/get-long-lived
-
-### インストール内容
-
-| 構成要素 | `mureo setup claude-code` | `mureo setup cursor` | `mureo setup codex` | `mureo setup gemini` | `mureo auth setup` |
-|---------|:---:|:---:|:---:|:---:|:---:|
-| 認証（~/.mureo/credentials.json） | Yes | Yes | Yes | Yes | Yes |
-| MCP設定 | Yes | Yes | Yes | Yes | Yes |
-| 認証情報ガード（PreToolUseフック） | Yes | N/A | Yes | N/A | Yes |
-| ワークフローコマンド | Yes（~/.claude/commands/） | N/A | Yes（~/.codex/skills/ — `$cmd`または`/skills`で起動） | N/A | No |
-| スキル | Yes（~/.claude/skills/） | N/A | Yes（~/.codex/skills/） | N/A | No |
-| Extensionマニフェスト（contextFileName） | N/A | N/A | N/A | Yes（~/.gemini/extensions/mureo/） | No |
-
-### スキル一覧
-
-| スキル | 内容 |
-|-------|------|
-| `_mureo-google-ads` | Google広告ツールのリファレンス |
-| `_mureo-meta-ads` | Meta広告ツールのリファレンス |
-| `_mureo-shared` | 認証、セキュリティルール、出力フォーマット |
-| `_mureo-strategy` | STRATEGY.md / STATE.json の仕様と使い方 |
-| `_mureo-learning` | データに基づく判断の仕組み（観察期間、サンプルサイズ、ノイズの排除） |
-| `_mureo-pro-diagnosis` | 運用で蓄積するナレッジベース（`/learn` で記録） |
-
-### GA4（Google Analytics 4）の接続
-
-GA4のMCPサーバーを接続すると、ワークフローコマンドがコンバージョン率やユーザー行動のデータも自動で取り込みます。GA4がなくても全コマンドは動作します。
-
-[Google Analytics MCP](https://github.com/googleanalytics/google-analytics-mcp) を使ったセットアップ手順：
-
-1. GCPプロジェクトで以下のAPIを有効化（リンクをクリックして「有効にする」）：
-   - [Google Analytics Admin API](https://console.cloud.google.com/apis/library/analyticsadmin.googleapis.com)
-   - [Google Analytics Data API](https://console.cloud.google.com/apis/library/analyticsdata.googleapis.com)
-
-2. インストールと認証：
-
-   ```bash
-   pipx install analytics-mcp
-
-   gcloud auth application-default login \
-     --scopes https://www.googleapis.com/auth/analytics.readonly,https://www.googleapis.com/auth/cloud-platform
-   ```
-
-3. `~/.claude/settings.json` にmureoと並列で追加：
-
-   ```json
-   {
-     "mcpServers": {
-       "mureo": {
-         "command": "python",
-         "args": ["-m", "mureo.mcp"]
-       },
-       "analytics-mcp": {
-         "command": "pipx",
-         "args": ["run", "analytics-mcp"],
-         "env": {
-           "GOOGLE_APPLICATION_CREDENTIALS": "/path/to/application_default_credentials.json",
-           "GOOGLE_PROJECT_ID": "your-gcp-project-id"
-         }
-       }
-     }
-   }
-   ```
-
-### その他のMCPサーバー
-
-mureoは他のMCPサーバーと併用できます。CRMツールなどのMCPを同じセッションに追加すれば、ワークフローコマンドがそのデータも活用します。詳細は [docs/integrations.md](docs/integrations.md) を参照してください。
-
-## 認証
-
-### セットアップ（推奨）
-
-```bash
-mureo auth setup
-```
-
-対話型のウィザードが案内します：
-
-1. **Google広告** — Developer Token + Client ID/Secret を入力 → ブラウザでOAuth → アカウント選択
-2. **Meta広告** — App ID/Secret を入力 → ブラウザでOAuth → 広告アカウント選択。Metaアプリは**開発モードのまま**で問題ありません（App Reviewは不要です）。OAuthの際に `business_management` の権限警告が表示されますが、ビジネスポートフォリオ経由のページ管理に必要なため、そのまま承認してください。
-3. **MCP設定** — Claude Code / Cursor / Codex / Gemini用の設定ファイルを自動生成
-
-認証情報は `~/.mureo/credentials.json` に保存されます。Search ConsoleはGoogle広告と同じOAuth認証を使うため、追加の設定は不要です。
-
-### credentials.json
-
-ウィザードを使わずに直接編集する場合のスキーマ（CI/CD や手書きでチームに配布する場合に有用）:
-
-```json
-{
-  "google_ads": {
-    "developer_token": "...",
-    "client_id": "...apps.googleusercontent.com",
-    "client_secret": "...",
-    "refresh_token": "...",
-    "login_customer_id": "1234567890"
-  },
-  "meta_ads": {
-    "access_token": "...",
-    "app_id": "...",
-    "app_secret": "..."
+  "mcpServers": {
+    "mureo": {
+      "command": "python",
+      "args": ["-m", "mureo.mcp"]
+    }
   }
 }
 ```
 
-必須フィールド: Google は `developer_token` / `client_id` / `client_secret` / `refresh_token`、Meta は `access_token`。`app_id` / `app_secret` を入れておくと Meta の長期アクセストークンが期限間近に自動更新されます（53日経過時点）。Search Console は Google の OAuth 認証情報を共用します（OAuth アプリに `https://www.googleapis.com/auth/webmasters` スコープが必要）。
+全ツールの一覧とクライアント設定: **[MCP サーバーガイド →](docs/mcp-server.md)**（英語）
 
-### 環境変数（代替手段）
+### 認証
 
-| 媒体 | 変数 | 必須 |
-|------|------|-----|
-| Google広告 | `GOOGLE_ADS_DEVELOPER_TOKEN` | はい |
-| Google広告 | `GOOGLE_ADS_CLIENT_ID` | はい |
-| Google広告 | `GOOGLE_ADS_CLIENT_SECRET` | はい |
-| Google広告 | `GOOGLE_ADS_REFRESH_TOKEN` | はい |
-| Google広告 | `GOOGLE_ADS_LOGIN_CUSTOMER_ID` | いいえ |
-| Meta広告 | `META_ADS_ACCESS_TOKEN` | はい |
-| Meta広告 | `META_ADS_APP_ID` | いいえ |
-| Meta広告 | `META_ADS_APP_SECRET` | いいえ |
-
-### 確認
+`mureo configure`（ブラウザ）または `mureo auth setup`（ターミナル）が Google 広告と Meta 広告の認証手順を案内し、いずれも `~/.mureo/credentials.json` に書き込みます。CI 用途には環境変数でも設定できます。Search Console は Google の OAuth 認証情報を共用します。確認はいつでも次のコマンドでできます。
 
 ```bash
 mureo auth status          # 認証状態の確認
@@ -565,131 +294,35 @@ mureo auth check-google    # Google広告の認証情報を表示（マスク済
 mureo auth check-meta      # Meta広告の認証情報を表示（マスク済み）
 ```
 
-## MCP サーバー
+スキーマ、環境変数の一覧、ホスト別のセットアップ手順: **[認証ガイド →](docs/authentication.md)**（英語）
 
-`mureo setup claude-code` / `mureo setup cursor` などのコマンドが自動で設定ファイルを書き込むため、通常は手で編集する必要はありません。手動で設定したい場合や、対応されていない MCP クライアントから利用したい場合のスニペットを以下に示します。
-
-### Claude Code 用の設定
-
-**プロジェクト単位（推奨）** — プロジェクトルートの `.mcp.json` に追加:
-
-```json
-{
-  "mcpServers": {
-    "mureo": {
-      "command": "python",
-      "args": ["-m", "mureo.mcp"]
-    }
-  }
-}
-```
-
-**グローバル設定** — `~/.claude/settings.json` に追加:
-
-```json
-{
-  "mcpServers": {
-    "mureo": {
-      "command": "python",
-      "args": ["-m", "mureo.mcp"]
-    }
-  }
-}
-```
-
-> ヒント: `mureo auth setup` がこの設定を自動で書き込むので、通常はこのスニペットを使う必要はありません。
-
-### Cursor 用の設定
-
-`.cursor/mcp.json` に追加:
-
-```json
-{
-  "mcpServers": {
-    "mureo": {
-      "command": "python",
-      "args": ["-m", "mureo.mcp"]
-    }
-  }
-}
-```
-
-## ツール一覧
-
-- **Google広告** — キャンペーン（検索/ディスプレイ）、広告グループ、検索広告（RSA）、ディスプレイ広告（RDA）、キーワード、予算、検索語、分析、RSA監査、B2B最適化、モニタリングなど
-- **Meta広告** — キャンペーン、広告セット、広告、クリエイティブ、オーディエンス、Conversions API、商品カタログ、リード広告など
-- **Search Console** — サイト管理、検索アナリティクス、URL検査、サイトマップ
-- **クリエイティブ生成（Creative Studio）** — テキストなしキービジュアルの生成、ブランドキット、画像編集、コピー/ブランドの合成によるバナー生成
-- **戦略・状態コンテキスト** — STRATEGY.md / STATE.json の読み書き、プラットフォーム別メトリクス、レポート永続化、アウトカム評価
-- **分析・学習** — 分析モジュールレジストリ（異常検知・診断・クリエイティブ監査・予算効率）、`/learn` ナレッジ、外部 advisor 連携
-
-全ツールの詳細は [英語版README](README.md#tool-list) を参照してください。
-
-## CLI
-
-```bash
-mureo setup claude-code    # Claude Code 用のワンコマンドセットアップ
-mureo setup cursor         # Cursor 用のセットアップ
-mureo auth status          # 認証状態の確認
-mureo auth check-google    # Google 広告の認証情報を表示（マスク済み）
-mureo auth check-meta      # Meta 広告の認証情報を表示（マスク済み）
-```
-
-## 戦略コンテキスト
+### 戦略コンテキスト
 
 2 つのローカルファイルが戦略準拠の運用を駆動します。`/onboard` を実行すると対話的に生成されます。
 
 - **STRATEGY.md** — ペルソナ、USP、ブランドボイス、目標、運用モード。詳細は [docs/strategy-context.md](docs/strategy-context.md)。
 - **STATE.json** — キャンペーンのスナップショット、action log。ワークフローコマンドが自動で更新します。
 
-## アーキテクチャ
+### GA4 とその他の MCP サーバーの接続
 
-```
-mureo/
-├── __init__.py              # パッケージ root
-├── auth.py                  # 認証情報のロード（~/.mureo/credentials.json + 環境変数 + Meta トークン自動更新）
-├── auth_setup.py            # 対話型セットアップウィザード（OAuth + MCP 設定）
-├── throttle.py              # レート制限（token bucket + 1時間ローリング上限）
-├── google_ads/              # Google Ads API クライアント（Mixin 構成）
-│   ├── client.py            # GoogleAdsApiClient
-│   ├── mappers.py           # レスポンスを構造化 dict にマッピング
-│   └── _*.py                # Ads / Keywords / Analysis / Diagnostics / Extensions / Monitoring / Creative / Media など Mixin 群
-├── meta_ads/                # Meta Ads API クライアント（15 Mixin、httpx ベース）
-│   ├── client.py            # MetaAdsApiClient
-│   ├── mappers.py           # レスポンスマッピング
-│   └── _*.py                # Campaigns / AdSets / Ads / Creatives / Audiences / Pixels / Insights /
-│                            #   Analysis / Catalog / Conversions / Leads / PagePosts / Instagram /
-│                            #   SplitTest / AdRules
-├── search_console/          # Search Console API クライアント（Google OAuth を共用）
-├── analytics/               # 分析モジュール Protocol + レジストリ（#120）
-│   ├── protocol.py          # AnalyticsModule Protocol + AnalyticsCapability
-│   ├── registry.py          # entry-point ベースの discovery（mureo.analytics group）
-│   ├── models.py            # Anomaly / PerformanceDiagnosis / CreativeAudit / BudgetEfficiency
-│   └── builtin/             # google_ads / meta_ads 用の組込 adapter
-├── analysis/                # 媒体横断の分析ユーティリティ
-│   ├── anomaly_detector.py  # サンプルサイズで防御した異常検知（pure function）
-│   └── lp_analyzer.py       # LP 分析エンジン
-├── context/                 # ファイルベースのコンテキスト（STRATEGY.md, STATE.json）
-│   ├── models.py            # 不変な dataclass 群（StrategyEntry, StateDocument, ActionLogEntry）
-│   ├── strategy.py          # STRATEGY.md のパーサ／ライター
-│   └── state.py             # STATE.json のパーサ／ライター
-├── rollback/                # ロールバック（allow-list 制、追記専用 audit trail）
-├── byod/                    # BYOD（XLSX バンドル取込）
-├── cli/                     # Typer CLI（setup + auth）
-└── mcp/                     # MCP サーバー（stdio ベース）
-    ├── server.py            # エントリポイント
-    ├── tool_provider.py     # MCPToolProvider Protocol（#89、プラグイン用）
-    └── _handlers_*.py       # プラットフォーム別ハンドラ
-```
+GA4 の MCP サーバー（例: [Google Analytics MCP](https://github.com/googleanalytics/google-analytics-mcp)）を mureo と併設すると、ワークフローコマンドが GA4 のデータ（CVR、ユーザー行動、LP パフォーマンス）も取り込みます。GA4 はオプションで、なくても全コマンドが動作します。mureo は同じセッション内の任意の MCP サーバーと共存でき、利用可能なデータをワークフローが自動的に取り込みます。セットアップ手順: **[連携ガイド →](docs/integrations.md)**（英語）
 
-**設計方針:**
+### プロバイダプラグインの自作
+
+pip でインストール可能なパッケージなら、mureo のソースツリーに触れずに新しい広告プラットフォーム（Microsoft/Bing 広告、Apple Search Ads、TikTok、LinkedIn、自社プラットフォームなど）を追加できます。プロバイダ Protocol を実装し、対応 capability を宣言して、entry-point group `mureo.providers` に登録するだけです。プラグインは独自のスキルや分析モジュールも同梱できます。
+
+- [docs/plugin-authoring.md](docs/plugin-authoring.md) — プラグイン開発ガイド（英語）
+- [docs/ABI-stability.md](docs/ABI-stability.md) — ABI 安定性の約束と非推奨化ポリシー（英語）
+
+### アーキテクチャ
 
 - **データベース不要** — 状態は広告プラットフォームの API またはローカルファイル（`STRATEGY.md` / `STATE.json`）に保持
 - **LLM を内蔵しない** — mureo はデータの取得と分析を担当し、推論・計画・判断はエージェント側が行います
+- **Web フレームワーク不要** — CLI（Typer）と MCP（stdio）のみ。`mureo configure` の UI も標準ライブラリの `http.server` を `127.0.0.1` で動かすだけです
 - **データは不変** — すべての dataclass で `frozen=True` を使用し、意図しない変更を防止
 - **認証情報はローカルに保存** — `~/.mureo/credentials.json` または環境変数から読み込み、公式の広告プラットフォーム API 以外には一切送信しません
 
-詳細は [docs/architecture.md](docs/architecture.md) を参照してください。
+モジュール構成とシステム図: **[アーキテクチャガイド →](docs/architecture.md)**（英語）
 
 ## 開発
 

--- a/README.md
+++ b/README.md
@@ -45,81 +45,57 @@ When official ad-platform MCPs ship (Meta Ads MCP, Google Ads MCP, etc.), mureo 
 - **Local-first** — credentials never leave your machine
 - **Learnable** — `/learn` builds account-specific knowledge over time
 
-## Choose your setup
+## Quick start — see it work in 2 minutes
 
-### The easy way: `pip install` + `mureo configure`
-
-For most people, two commands set up mureo for Claude — **no terminal secret-pasting, no JSON editing**:
-
-```bash
-pip install mureo
-mureo configure
-```
-
-`mureo configure` opens a local browser UI (bound to `127.0.0.1`, ephemeral port — no remote access) that walks you through everything:
-
-- **Pick your Claude app** — *Claude Code (CLI / Desktop app)* or *Claude Desktop app (Chat, Cowork)*; mureo writes the right config file for that host.
-- **Basic setup** — registers the mureo MCP server, the credential-guard hook (Claude Code), and the workflow skills, in one click.
-- **Connect platforms** — interactive Google / Meta OAuth in the browser (deep links to each console), or paste a GA4 service-account path / project id; values are written to `~/.mureo/credentials.json` for you.
-- **Official MCP providers** — register Google Ads / GA4 official MCPs into `~/.claude.json`. (Meta is a hosted MCP with no OAuth dynamic client registration, so it can't be wired as a Claude Code user-scope server; the UI shows how to add it as a Claude.ai account connector instead — it then works in Claude Code and Claude Desktop alike.)
-- **Per-platform tool source** — a dashboard toggle to switch each platform between mureo-native tools and the official MCP.
-- **Demo / BYOD** — scaffold a demo scenario or import your XLSX bundle from the same UI.
-
-The terminal flow below still works (and is scriptable); `mureo configure` is just the friendlier front door to the same operations.
-
-### Manual / scriptable (3 modes × 3 hosts)
-
-mureo has **3 modes** (where the data comes from) and runs across **3 hosts** (where the agent operates). Pick the cell, run the command — or just use `mureo configure` above:
-
-| | Claude Code | Claude Desktop chat | Cowork (Desktop) |
-|---|---|---|---|
-| **Demo** (synthetic) | `mureo setup claude-code --skip-auth` + `mureo demo init --scenario seasonality-trap` | `mureo install-desktop --with-demo seasonality-trap` | Same as chat + connect the workspace folder |
-| **BYOD** (your XLSX) | `mureo setup claude-code --skip-auth` + `mureo byod import bundle.xlsx` | `mureo install-desktop` + `mureo byod import bundle.xlsx` | Same as chat + connect the workspace folder |
-| **Auth** (Live API) | `mureo setup claude-code` (interactive OAuth) | `mureo install-desktop` + `mureo configure` | Same as chat + connect the workspace folder |
-
-Full per-row walkthroughs (including how to obtain your XLSX, where to put it, and how to import it): **[Getting Started →](docs/getting-started.md)**.
-
-> **Not familiar with Google Cloud Console or Meta for Developers?** OAuth flows, developer-token registration, and Business-app sign-ups can feel intimidating if you have never used those consoles before. **Start with BYOD** — you will see what mureo can do for your account in a few minutes, then decide whether the Live API path is worth setting up.
-
-## BYOD vs Live API at a glance
-
-### Mode A: BYOD — 5 minutes to first diagnosis, no OAuth
-
-**Drop a Sheet-bundle XLSX into mureo and get a strategy-grounded multi-platform diagnosis.** No OAuth flow, no developer-token approval, no SaaS sign-up.
+No ad-account credentials, no OAuth, no sign-up. Three commands scaffold a synthetic demo account and wire mureo into Claude Code:
 
 ```bash
 pip install mureo
 mureo setup claude-code --skip-auth
-mureo byod import ~/Downloads/mureo-google-ads.xlsx
-mureo byod import ~/Downloads/mureo-meta-ads.xlsx     # add Meta later — they're independent
-# Open Claude Code and ask: "Run /daily-check"
+mureo demo init --scenario seasonality-trap
 ```
 
-Producing the XLSX is a one-time setup per platform:
+Then open the generated `mureo-demo/` directory in Claude Code and ask:
 
-- **Google Ads** — Apps Script template populates a Google Sheet you own; download as XLSX (~5 min). [See guide →](docs/byod.md#google-ads-setup)
-- **Meta Ads** — Saved Report in Ads Manager → 2-click export. **Recognized in 9 languages** (English / 日本語 / 简体中文 / 繁體中文 / 한국어 / Español / Português / Deutsch / Français), so you do not need to switch Ads Manager UI to English. [See guide →](docs/byod.md#meta-ads-setup)
+```
+/daily-check
+```
 
-**Read-only by construction.** Every mutation tool (`/rescue`, `/budget-rebalance`, `/creative-refresh`) returns `{"status": "skipped_in_byod_readonly"}` — the agent analyzes and recommends but never writes to your real account. Upgrade a platform to the Live API later with `mureo byod remove --google-ads` (one platform) or `mureo byod clear` (all).
+You'll watch the agent read the demo `STRATEGY.md`, pull campaign data, and walk into a seasonality trap that numbers-only tools miss. Try `/search-term-cleanup` next.
 
-### Mode B: Live API OAuth — full functionality
+When you're ready to point mureo at *your* data, pick one of the two paths below.
 
-Connect mureo directly to Google Ads / Meta Ads APIs. **Required to actually execute changes** (`/rescue`, `/budget-rebalance`, `/creative-refresh`, `mureo rollback apply`) and for GA4 / Search Console support.
+### Path A: Bring your own data (BYOD) — 5–10 min, no OAuth
+
+**Export your real account data as an XLSX, drop it into mureo, and get a strategy-grounded multi-platform diagnosis** — no OAuth flow, no developer-token approval.
 
 ```bash
-pip install mureo
-mureo configure            # browser UI: pick host, basic setup, OAuth, providers
-# …or the terminal equivalent:
-#   mureo auth setup        # interactive OAuth in the terminal
-#   mureo setup claude-code # MCP server + workflow skills
+mureo byod import ~/Downloads/mureo-google-ads.xlsx
+mureo byod import ~/Downloads/mureo-meta-ads.xlsx   # platforms are independent — add either, or both
 # Open Claude Code and ask: "Run /daily-check"
 ```
 
-Prerequisites: Google Ads Developer Token + OAuth Client; Meta App ID + Secret. Both `mureo configure` (browser) and `mureo auth setup` (terminal) walk you through them — see [Authentication](#authentication) below.
+Producing the XLSX is a one-time setup per platform — Google Ads via an Apps Script template (~5 min), Meta Ads via a 2-click Saved Report export (recognized in 9 languages). **[BYOD guide →](docs/byod.md)**
+
+BYOD is **read-only by construction**: every mutation tool returns `{"status": "skipped_in_byod_readonly"}` — the agent analyzes and recommends but never writes to your account.
+
+### Path B: Go live (OAuth) — full functionality
+
+Connect mureo directly to the Google Ads / Meta Ads APIs. Required to actually execute changes (`/rescue`, `/budget-rebalance`, `/creative-refresh`, rollback) and for GA4 / Search Console support.
+
+```bash
+mureo configure
+```
+
+`mureo configure` opens a local browser UI (bound to `127.0.0.1`, no remote access) that walks you through everything: pick your Claude app, one-click basic setup, interactive Google / Meta OAuth with deep links to each console, and official-MCP provider registration. Prefer the terminal? `mureo auth setup` + `mureo setup claude-code` do the same. **[Authentication guide →](docs/authentication.md)**
+
+Prerequisites: a Google Ads Developer Token + OAuth Client, and/or a Meta App ID + Secret (development mode is fine). Both wizards walk you through obtaining them.
+
+> **Not familiar with Google Cloud Console or Meta for Developers?** OAuth flows and developer-token registration can feel intimidating. **Start with the demo or BYOD** — see what mureo can do in minutes, then decide whether the Live API path is worth setting up.
 
 ### Which mode fits?
 
-| Capability                                         | Mode A: BYOD                            | Mode B: Live API |
+| Capability                                         | BYOD                                    | Live API |
 |----------------------------------------------------|-----------------------------------------|------------------|
 | **First-time setup time**                          | **5–10 min per platform**               | 30–60 min |
 | **Approval / waiting risk**                        | **None**                                | 1–3 weeks Google review, sometimes rejected |
@@ -127,16 +103,26 @@ Prerequisites: Google Ads Developer Token + OAuth Client; Meta App ID + Secret. 
 | `/goal-review`, `/sync-state`                      | ✅                                      | ✅ |
 | `/rescue` / `/budget-rebalance` (proposals)        | ✅                                      | ✅ |
 | `/search-term-cleanup` (analysis)                  | ✅ Google Ads only                      | ✅ |
-| `/search-term-cleanup` (execute)                   | 🛡️ Preview only                         | ✅ Live |
-| `/rescue` / `/budget-rebalance` (execute)          | 🛡️ Preview only                         | ✅ Live |
-| `/creative-refresh` (execute)                      | 🛡️ Preview only                         | ✅ Live |
+| Execution (`/rescue`, `/budget-rebalance`, `/creative-refresh`, `/search-term-cleanup`) | 🛡️ Preview only | ✅ Live |
 | `/competitive-scan`                                | ⚠️ Google Ads BYOD has no auction insights (Ads Scripts limitation) | ✅ |
 | GA4 / Search Console                               | ❌ (not in BYOD bundle)                 | ✅ |
 
-**Recommended starting path:** Try Mode A on one platform first → run `/daily-check` → decide whether to add the second platform via BYOD or graduate to Mode B. The presence of `~/.mureo/byod/manifest.json` is the switch — no config flags, no global toggle.
+The presence of `~/.mureo/byod/manifest.json` is the switch — imported platforms run on BYOD, the rest on the Live API. Upgrade a platform any time with `mureo byod remove --google-ads` or `mureo byod clear`.
 
-See [docs/byod.md](docs/byod.md) for the full walkthrough, Saved Report config, and per-platform export instructions.
+### Other agents and hosts
 
+Claude Code is the reference host, but every setup has a one-command equivalent:
+
+| Host | Command | Notes |
+|------|---------|-------|
+| Claude Code | `mureo setup claude-code` | MCP server + credential guard + workflow skills |
+| Claude Desktop (Chat / Cowork) | `mureo install-desktop` | Then connect the workspace folder in Cowork |
+| Cursor | `mureo setup cursor` | MCP tools only (no workflow skills) |
+| Codex CLI | `mureo setup codex` | Full parity — skills land in `~/.codex/skills/`, invoke with `$daily-check` |
+| Gemini CLI | `mureo setup gemini` | Extension manifest; no PreToolUse hooks |
+| Any MCP client / CI | Docker | **[Docker guide →](docs/docker.md)** |
+
+Full per-host walkthroughs, including the Demo / BYOD / Live matrix for each: **[Getting Started →](docs/getting-started.md)**
 
 ## Features
 
@@ -195,22 +181,6 @@ Marketing accounts are a high-value target. mureo is built with defense-in-depth
 
 See [SECURITY.md](SECURITY.md) for the full threat model and vulnerability reporting process.
 
-<details>
-<summary>Full capability list</summary>
-
-| Area | Capabilities |
-|------|-------------|
-| **Diagnostics** | Automatic root cause identification for delivery issues (budget, bidding, policy, structure), learning period detection, smart bidding classification, zero-conversion analysis |
-| **Performance** | Period-over-period comparison, cost spike investigation, cross-campaign health checks, CPA/CV goal tracking |
-| **Search terms** | N-gram distribution, intent pattern detection, add/exclude candidate scoring, paid vs organic overlap analysis |
-| **Creative** | RSA validation (prohibited expressions, character width, ad strength prediction), asset-level performance audit, LP analysis, message match scoring |
-| **Budget** | Cross-campaign allocation analysis, reallocation recommendations, efficiency scoring |
-| **Competitive** | Auction insights, impression share trends, organic position correlation |
-| **Meta Ads** | Placement analysis (Facebook/Instagram/Audience Network), cost investigation, A/B comparison, creative suggestions |
-| **Monitoring** | Delivery goal evaluation, CPA/CV goal tracking, device analysis, B2B-specific checks |
-
-</details>
-
 ## Workflow Commands
 
 | Command | What it does |
@@ -235,18 +205,6 @@ See [SECURITY.md](SECURITY.md) for the full threat model and vulnerability repor
 | `/monthly-report` | Client-facing monthly digest: month-over-month comparison, goal attainment, action recap, budget utilization |
 | `/sync-state` | Refresh STATE.json from live platform data |
 | `/learn` | Save a diagnostic insight to the knowledge base for future sessions |
-
-### Getting started
-
-```
-pip install mureo
-mureo setup claude-code
-
-# Then in Claude Code:
-/onboard          # First time: set up strategy + state
-/daily-check      # Daily: check all campaigns
-/rescue           # When performance drops
-```
 
 ### Example: `/creative-refresh` in action
 
@@ -341,280 +299,28 @@ Why this matters: `link_click` vs `pixel_lead` optimization is a tracking distin
 
 </details>
 
-## Quick Start
+## Reference
 
-### Prerequisites
+### MCP server & tool list
 
-- **Google Ads** -- [Developer Token](https://developers.google.com/google-ads/api/docs/get-started/dev-token) and OAuth Client ID / Client Secret
-- **Meta Ads** -- Create an app on [Meta for Developers](https://developers.facebook.com/) to obtain an App ID / App Secret (development mode is fine)
-
-Both `mureo configure` (browser) and `mureo auth setup` (terminal) walk you through both.
-
-### Browser configuration UI (`mureo configure`)
-
-> `mureo auth setup --web` was **removed** — its browser flow is now part of the unified **`mureo configure`** UI.
-
-Pasting long secrets into a terminal prompt is error-prone. `mureo configure` starts a short-lived local UI on `http://127.0.0.1:<random-port>/` and opens your browser. Beyond credential entry it covers the whole Claude setup:
-
-- choose the Claude host (Claude Code / Claude Desktop) — mureo writes that host's config file;
-- one-click **basic setup** (mureo MCP server + credential-guard hook + workflow skills);
-- **connect platforms** — interactive Google / Meta OAuth in the same window (each field deep-links to Google Cloud Console / Google Ads API Center / Meta for Developers), or a GA4 service-account path / project id; written to `~/.mureo/credentials.json`;
-- register the **official MCP providers** (Google Ads / GA4) into `~/.claude.json`; Meta is a hosted MCP with no OAuth dynamic client registration, so the UI shows how to add it as a Claude.ai account connector (works in Claude Code and Claude Desktop) instead of registering it locally;
-- a **dashboard** to review status, switch each platform between mureo-native and the official MCP, and scaffold **Demo / BYOD**.
-
-Flags: `--no-browser` (don't auto-open a tab), `--timeout-seconds N` (idle shutdown, default 600).
-
-<details>
-<summary>Why the UI is safe to run locally</summary>
-
-The wizard binds only to `127.0.0.1` on a random OS-assigned port. The form is CSRF-protected (token rotates after every successful submit); the OAuth `state` parameter is validated with `secrets.compare_digest` on callback; a `Host`-header allow-list blocks DNS-rebinding attacks; redirect URLs are pinned to `https://accounts.google.com/` and `https://www.facebook.com/` so the wizard cannot be tricked into an open-redirect; session secrets are zeroed in memory after credentials are persisted. POST bodies are capped at 16 KiB and the process shuts the server down once the `/done` page is served. All dependencies are stdlib — no external web framework to supply-chain-compromise.
-
-</details>
-
-### Claude Code (recommended)
-
-```bash
-pip install mureo
-mureo setup claude-code
-```
-
-This single command handles everything:
-1. Google Ads / Meta Ads authentication (OAuth)
-2. MCP server configuration for Claude Code
-3. Credential guard (blocks AI agents from reading secrets)
-4. Workflow commands (`/daily-check`, `/rescue`, `/learn`, etc.)
-5. Skills (tool references, strategy guide, evidence-based decisions, diagnostic knowledge)
-
-After setup, run `/onboard` in Claude Code to get started.
-
-### Cursor
-
-```bash
-pip install mureo
-mureo setup cursor
-```
-
-Cursor supports MCP tools but does not support workflow commands or skills.
-
-### Codex CLI
-
-```bash
-pip install mureo
-mureo setup codex
-```
-
-Full parity with Claude Code: MCP server, credential guard (PreToolUse hook), workflow commands, and skills are all installed under `~/.codex/`. Workflow commands are installed as Codex skills at `~/.codex/skills/<command>/SKILL.md` (Codex CLI 0.117.0+ no longer surfaces `~/.codex/prompts/`, see [openai/codex#15941](https://github.com/openai/codex/issues/15941)); invoke them with `$daily-check` or the `/skills` picker.
-
-### Gemini CLI
-
-```bash
-pip install mureo
-mureo setup gemini
-```
-
-Registers mureo as a Gemini CLI extension at `~/.gemini/extensions/mureo/` with MCP server config and `CONTEXT.md` as the context file. Gemini CLI does not support PreToolUse hooks or the `.md` command format mureo bundles, so those layers are not installed.
-
-### CLI only (authentication management)
-
-```bash
-pip install mureo
-mureo auth setup
-mureo auth status
-```
-
-### Docker
-
-Run the mureo MCP server in an isolated container. Useful for:
-
-- **Non–Claude Code MCP clients**: Cursor, Codex CLI, Gemini CLI, Continue, Cline, Zed, or any custom MCP client.
-- **CI/CD pipelines**: scheduled anomaly checks, rollback dry-runs, weekly reports.
-- **Multi-tenant / agency ops**: isolated credentials per client via separate containers.
-- **MCP registry health checks** (Glama, etc.).
-
-> Slash commands (`/daily-check`, `/rescue`) and the credential-guard hook are Claude Code–specific UX. For those, use `pip install mureo` with `mureo setup claude-code` instead.
-
-#### Build and run
-
-```bash
-docker build -t mureo .
-docker run --rm -v ~/.mureo:/home/mureo/.mureo mureo
-```
-
-Connect your MCP client by pointing its config at this `docker run` command.
-
-#### Authentication
-
-Credentials are loaded from `/home/mureo/.mureo/credentials.json` inside the container (via bind mount) or from environment variables. Three common patterns:
-
-**1. Mounted credentials file** — if `~/.mureo/credentials.json` already exists on the host (from a prior `mureo auth setup`, a team-shared vault, or hand-crafted), the bind mount above is enough.
-
-Schema for hand-crafting:
+mureo exposes **205 MCP tools** over stdio: Google Ads (86), Meta Ads (88), Search Console (10), plus rollback, anomaly detection, strategy/state context, analytics registry, learning, and Creative Studio. Any MCP-compatible client can connect:
 
 ```json
 {
-  "google_ads": {
-    "developer_token": "...",
-    "client_id": "...apps.googleusercontent.com",
-    "client_secret": "...",
-    "refresh_token": "...",
-    "login_customer_id": "1234567890"
-  },
-  "meta_ads": { "access_token": "..." }
-}
-```
-
-Required: Google needs `developer_token` / `client_id` / `client_secret` / `refresh_token`. Meta needs `access_token`. Search Console reuses the Google OAuth credentials (OAuth app must include the `https://www.googleapis.com/auth/webmasters` scope).
-
-**2. Environment variables** — useful for CI/CD where secrets come from a secret manager:
-
-```bash
-docker run --rm \
-  -e GOOGLE_ADS_DEVELOPER_TOKEN=... \
-  -e GOOGLE_ADS_CLIENT_ID=... \
-  -e GOOGLE_ADS_CLIENT_SECRET=... \
-  -e GOOGLE_ADS_REFRESH_TOKEN=... \
-  -e GOOGLE_ADS_LOGIN_CUSTOMER_ID=... \
-  -e META_ADS_ACCESS_TOKEN=... \
-  mureo
-```
-
-Supported: `GOOGLE_ADS_{DEVELOPER_TOKEN, CLIENT_ID, CLIENT_SECRET, REFRESH_TOKEN, LOGIN_CUSTOMER_ID, CUSTOMER_ID}`, `META_ADS_{ACCESS_TOKEN, APP_ID, APP_SECRET, TOKEN_OBTAINED_AT, ACCOUNT_ID}`.
-
-**3. Interactive wizard inside Docker** — if you don't have OAuth tokens yet and don't want to install mureo on the host:
-
-```bash
-docker run -it --rm -v ~/.mureo:/home/mureo/.mureo mureo mureo auth setup
-```
-
-Walks you through the OAuth flow in the terminal and writes `credentials.json` to the mounted volume. Subsequent runs pick it up automatically (pattern 1).
-
-To obtain OAuth tokens outside mureo:
-
-- Google Ads OAuth 2.0 refresh token: https://developers.google.com/google-ads/api/docs/oauth/overview
-- Meta long-lived access token: https://developers.facebook.com/docs/facebook-login/guides/access-tokens/get-long-lived
-
-### What gets installed
-
-| Component | `mureo setup claude-code` | `mureo setup cursor` | `mureo setup codex` | `mureo setup gemini` | `mureo auth setup` |
-|-----------|:---:|:---:|:---:|:---:|:---:|
-| Authentication (~/.mureo/credentials.json) | Yes | Yes | Yes | Yes | Yes |
-| MCP configuration | Yes | Yes | Yes | Yes | Yes |
-| Credential guard (PreToolUse hook) | Yes | N/A | Yes | N/A | Yes |
-| Workflow commands | Yes (~/.claude/commands/) | N/A | Yes (~/.codex/skills/ — invoke with `$cmd` or `/skills`) | N/A | No |
-| Skills | Yes (~/.claude/skills/) | N/A | Yes (~/.codex/skills/) | N/A | No |
-| Extension manifest (contextFileName) | N/A | N/A | N/A | Yes (~/.gemini/extensions/mureo/) | No |
-
-### Skills reference
-
-| Skill | Purpose |
-|-------|---------|
-| `_mureo-google-ads` | Google Ads tool reference (parameters, examples) |
-| `_mureo-meta-ads` | Meta Ads tool reference (parameters, examples) |
-| `_mureo-shared` | Authentication, security rules, output formatting |
-| `_mureo-strategy` | STRATEGY.md / STATE.json format and usage guide |
-| `_mureo-learning` | Evidence-based marketing decision framework (observation windows, sample sizes, noise guards) |
-| `_mureo-pro-diagnosis` | Learnable diagnostic knowledge base (grows with use via `/learn`) |
-
-### Connecting GA4 (Google Analytics 4)
-
-mureo's workflow commands can leverage GA4 data (conversion rates, user behavior, landing page performance) when a GA4 MCP server is configured alongside mureo. GA4 data is optional — all commands work without it.
-
-Setup using [Google Analytics MCP](https://github.com/googleanalytics/google-analytics-mcp):
-
-1. Enable the required APIs in your GCP project:
-   - [Google Analytics Admin API](https://console.cloud.google.com/apis/library/analyticsadmin.googleapis.com) -- click "Enable"
-   - [Google Analytics Data API](https://console.cloud.google.com/apis/library/analyticsdata.googleapis.com) -- click "Enable"
-
-2. Install and authenticate:
-
-   ```bash
-   pipx install analytics-mcp
-
-   gcloud auth application-default login \
-     --scopes https://www.googleapis.com/auth/analytics.readonly,https://www.googleapis.com/auth/cloud-platform
-   ```
-
-3. Add to `~/.claude/settings.json` alongside mureo:
-
-   ```json
-   {
-     "mcpServers": {
-       "mureo": {
-         "command": "python",
-         "args": ["-m", "mureo.mcp"]
-       },
-       "analytics-mcp": {
-         "command": "pipx",
-         "args": ["run", "analytics-mcp"],
-         "env": {
-           "GOOGLE_APPLICATION_CREDENTIALS": "/path/to/application_default_credentials.json",
-           "GOOGLE_PROJECT_ID": "your-gcp-project-id"
-         }
-       }
-     }
-   }
-   ```
-
-### Connecting Other MCP Servers
-
-mureo works alongside any MCP server in the same client session. Add them to your settings and workflow commands will incorporate their data when available. See [docs/integrations.md](docs/integrations.md) for details.
-
-### Writing your own provider plugin
-
-mureo's provider abstraction lets any pip-installable package add a new ad-platform provider (Microsoft/Bing Ads, Apple Search Ads, TikTok, LinkedIn, X, in-house platforms, ...) without touching mureo's source tree. A plugin is a Python package that implements one or more of the Phase 1 Protocols (`CampaignProvider`, `KeywordProvider`, `AudienceProvider`, `ExtensionProvider`), declares which `Capability` members it supports, and registers its class under the `mureo.providers` entry-points group in `pyproject.toml`. Plugins can also ship their own `SKILL.md` files via two entry-point groups: `mureo.skills` registers *runtime context skills* that mureo discovers and matches during a workflow, while `mureo.native_skills` (#439) registers *native slash skills* that mureo deploys into `~/.claude/skills` / `~/.codex/skills` so they are directly invocable as `/<name>`.
-
-- [docs/plugin-authoring.md](docs/plugin-authoring.md) — full plugin authoring guide (quick start, Protocols, capabilities, models, skill matching, distribution patterns, security)
-- [docs/ABI-stability.md](docs/ABI-stability.md) — ABI stability promise (what is breaking, what is not, deprecation policy)
-
-## Authentication
-
-### Interactive Setup (Recommended)
-
-```bash
-mureo auth setup
-```
-
-The setup wizard walks you through:
-
-1. **Google Ads** -- Enter Developer Token + Client ID/Secret, open browser for OAuth, select a Google Ads customer account
-2. **Meta Ads** -- Enter App ID/Secret, open browser for OAuth, obtain a Long-Lived Token, select an ad account. Your Meta App can stay in **Development Mode** -- no App Review is needed since mureo operates your own ad account. You may see a permission warning for `business_management` during OAuth; this is safe to accept and required for accessing pages managed through Business Portfolio.
-3. **MCP config** -- Automatically writes `.mcp.json` (project-level) or `~/.claude/settings.json` (global) so Claude Code / Cursor can discover the server
-
-Credentials are saved to `~/.mureo/credentials.json`. Search Console reuses the same Google OAuth2 credentials as Google Ads -- no additional authentication is required.
-
-### credentials.json
-
-```json
-{
-  "google_ads": {
-    "developer_token": "YOUR_DEVELOPER_TOKEN",
-    "client_id": "YOUR_CLIENT_ID",
-    "client_secret": "YOUR_CLIENT_SECRET",
-    "refresh_token": "YOUR_REFRESH_TOKEN",
-    "login_customer_id": "1234567890"
-  },
-  "meta_ads": {
-    "access_token": "YOUR_ACCESS_TOKEN",
-    "app_id": "YOUR_APP_ID",
-    "app_secret": "YOUR_APP_SECRET"
+  "mcpServers": {
+    "mureo": {
+      "command": "python",
+      "args": ["-m", "mureo.mcp"]
+    }
   }
 }
 ```
 
-### Environment variables (fallback)
+Full tool list and client configuration: **[MCP Server Guide →](docs/mcp-server.md)**
 
-| Platform   | Variable                          | Required |
-|------------|-----------------------------------|----------|
-| Google Ads | `GOOGLE_ADS_DEVELOPER_TOKEN`      | Yes      |
-| Google Ads | `GOOGLE_ADS_CLIENT_ID`            | Yes      |
-| Google Ads | `GOOGLE_ADS_CLIENT_SECRET`        | Yes      |
-| Google Ads | `GOOGLE_ADS_REFRESH_TOKEN`        | Yes      |
-| Google Ads | `GOOGLE_ADS_LOGIN_CUSTOMER_ID`    | No       |
-| Meta Ads   | `META_ADS_ACCESS_TOKEN`           | Yes      |
-| Meta Ads   | `META_ADS_APP_ID`                 | No       |
-| Meta Ads   | `META_ADS_APP_SECRET`             | No       |
+### Authentication
 
-Verify your setup:
+`mureo configure` (browser) or `mureo auth setup` (terminal) walk you through Google Ads and Meta Ads credentials; both write `~/.mureo/credentials.json`. Environment variables work as a fallback for CI. Search Console reuses the Google OAuth credentials. Verify any time:
 
 ```bash
 mureo auth status
@@ -622,627 +328,35 @@ mureo auth check-google
 mureo auth check-meta
 ```
 
-## MCP Server
+Full schema, environment-variable reference, and per-host setup: **[Authentication Guide →](docs/authentication.md)**
 
-### Setup with Claude Code
-
-**Project-level** (recommended) -- add to `.mcp.json` in your project root:
-
-```json
-{
-  "mcpServers": {
-    "mureo": {
-      "command": "python",
-      "args": ["-m", "mureo.mcp"]
-    }
-  }
-}
-```
-
-**Global** -- add to `~/.claude/settings.json`:
-
-```json
-{
-  "mcpServers": {
-    "mureo": {
-      "command": "python",
-      "args": ["-m", "mureo.mcp"]
-    }
-  }
-}
-```
-
-> Tip: `mureo auth setup` can write this configuration automatically.
-
-### Setup with Cursor
-
-Add to `.cursor/mcp.json`:
-
-```json
-{
-  "mcpServers": {
-    "mureo": {
-      "command": "python",
-      "args": ["-m", "mureo.mcp"]
-    }
-  }
-}
-```
-
-### Tool list
-
-#### Google Ads
-
-<details>
-<summary>Click to expand Google Ads tools</summary>
-
-**Campaigns**
-
-| Tool | Description |
-|------|-------------|
-| `google_ads_campaigns_list` | List campaigns |
-| `google_ads_campaigns_get` | Get campaign details |
-| `google_ads_campaigns_create` | Create a campaign (search or display, via `channel_type`) |
-| `google_ads_campaigns_update` | Update campaign settings |
-| `google_ads_campaigns_update_status` | Change campaign status (ENABLED/PAUSED/REMOVED) |
-| `google_ads_campaigns_diagnose` | Diagnose campaign delivery status |
-
-**Ad Groups**
-
-| Tool | Description |
-|------|-------------|
-| `google_ads_ad_groups_list` | List ad groups |
-| `google_ads_ad_groups_create` | Create an ad group |
-| `google_ads_ad_groups_update` | Update an ad group |
-
-**Ads**
-
-| Tool | Description |
-|------|-------------|
-| `google_ads_ads_list` | List ads |
-| `google_ads_ads_create` | Create a responsive search ad (RSA) |
-| `google_ads_ads_create_display` | Create a responsive display ad (RDA); image files are uploaded automatically |
-| `google_ads_ads_update` | Update an ad |
-| `google_ads_ads_update_status` | Change ad status |
-| `google_ads_ads_policy_details` | Get ad policy approval details |
-
-**Keywords (8)**
-
-| Tool | Description |
-|------|-------------|
-| `google_ads_keywords_list` | List keywords |
-| `google_ads_keywords_add` | Add keywords |
-| `google_ads_keywords_remove` | Remove a keyword |
-| `google_ads_keywords_suggest` | Get keyword suggestions (Keyword Planner) |
-| `google_ads_keywords_diagnose` | Diagnose keyword quality scores |
-| `google_ads_keywords_pause` | Pause a keyword |
-| `google_ads_keywords_audit` | Audit keyword performance and quality |
-| `google_ads_keywords_cross_adgroup_duplicates` | Find duplicate keywords across ad groups |
-
-**Negative Keywords (5)**
-
-| Tool | Description |
-|------|-------------|
-| `google_ads_negative_keywords_list` | List negative keywords |
-| `google_ads_negative_keywords_add` | Add negative keywords to a campaign |
-| `google_ads_negative_keywords_remove` | Remove a negative keyword |
-| `google_ads_negative_keywords_add_to_ad_group` | Add negative keywords to an ad group |
-| `google_ads_negative_keywords_suggest` | Suggest negative keywords based on search terms |
-
-**Budget (3)**
-
-| Tool | Description |
-|------|-------------|
-| `google_ads_budget_get` | Get campaign budget |
-| `google_ads_budget_update` | Update budget |
-| `google_ads_budget_create` | Create a new campaign budget |
-
-**Accounts (1)**
-
-| Tool | Description |
-|------|-------------|
-| `google_ads_accounts_list` | List accessible Google Ads accounts |
-
-**Search Terms (2)**
-
-| Tool | Description |
-|------|-------------|
-| `google_ads_search_terms_report` | Get search terms report |
-| `google_ads_search_terms_analyze` | Analyze search terms with intent classification |
-
-**Sitelinks (3)**
-
-| Tool | Description |
-|------|-------------|
-| `google_ads_sitelinks_list` | List sitelink extensions |
-| `google_ads_sitelinks_create` | Create a sitelink extension |
-| `google_ads_sitelinks_remove` | Remove a sitelink extension |
-
-**Callouts (3)**
-
-| Tool | Description |
-|------|-------------|
-| `google_ads_callouts_list` | List callout extensions |
-| `google_ads_callouts_create` | Create a callout extension |
-| `google_ads_callouts_remove` | Remove a callout extension |
-
-**Conversions (7)**
-
-| Tool | Description |
-|------|-------------|
-| `google_ads_conversions_list` | List conversion actions |
-| `google_ads_conversions_get` | Get conversion action details |
-| `google_ads_conversions_performance` | Get conversion performance metrics |
-| `google_ads_conversions_create` | Create a conversion action |
-| `google_ads_conversions_update` | Update a conversion action |
-| `google_ads_conversions_remove` | Remove a conversion action |
-| `google_ads_conversions_tag` | Get conversion tracking tag snippet |
-
-**Targeting (11)**
-
-| Tool | Description |
-|------|-------------|
-| `google_ads_recommendations_list` | List optimization recommendations |
-| `google_ads_recommendations_apply` | Apply an optimization recommendation |
-| `google_ads_device_targeting_get` | Get device targeting settings |
-| `google_ads_device_targeting_set` | Set device targeting bid adjustments |
-| `google_ads_bid_adjustments_get` | Get bid adjustment settings |
-| `google_ads_bid_adjustments_update` | Update bid adjustments |
-| `google_ads_location_targeting_list` | List location targeting criteria |
-| `google_ads_location_targeting_update` | Update location targeting |
-| `google_ads_schedule_targeting_list` | List ad schedule targeting |
-| `google_ads_schedule_targeting_update` | Update ad schedule targeting |
-| `google_ads_change_history_list` | List account change history |
-
-**Analysis (13)**
-
-| Tool | Description |
-|------|-------------|
-| `google_ads_performance_report` | Get performance report |
-| `google_ads_performance_analyze` | Analyze performance trends and anomalies |
-| `google_ads_cost_increase_investigate` | Investigate sudden cost increases |
-| `google_ads_health_check_all` | Run a comprehensive account health check |
-| `google_ads_ad_performance_compare` | Compare ad performance across variants |
-| `google_ads_ad_performance_report` | Get detailed ad-level performance report |
-| `google_ads_network_performance_report` | Get network-level performance breakdown |
-| `google_ads_budget_efficiency` | Analyze budget utilization efficiency |
-| `google_ads_budget_reallocation` | Suggest budget reallocation across campaigns |
-| `google_ads_auction_insights_get` | Get auction insights (competitor analysis) |
-| `google_ads_rsa_assets_analyze` | Analyze RSA asset performance |
-| `google_ads_rsa_assets_audit` | Audit RSA assets for best practices |
-| `google_ads_search_terms_review` | Review search terms and suggest additions/exclusions |
-
-**B2B (1)**
-
-| Tool | Description |
-|------|-------------|
-| `google_ads_btob_optimizations` | Get B2B-specific optimization suggestions |
-
-**Creative (2)**
-
-| Tool | Description |
-|------|-------------|
-| `google_ads_landing_page_analyze` | Analyze landing page relevance and quality |
-| `google_ads_creative_research` | Research competitive creative strategies |
-
-**Monitoring (4)**
-
-| Tool | Description |
-|------|-------------|
-| `google_ads_monitoring_delivery_goal` | Monitor campaign delivery against goals |
-| `google_ads_monitoring_cpa_goal` | Monitor CPA against target goals |
-| `google_ads_monitoring_cv_goal` | Monitor conversion volume against goals |
-| `google_ads_monitoring_zero_conversions` | Detect campaigns with zero conversions |
-
-**Capture (1)**
-
-| Tool | Description |
-|------|-------------|
-| `google_ads_capture_screenshot` | Capture a screenshot of a URL |
-
-**Device (1)**
-
-| Tool | Description |
-|------|-------------|
-| `google_ads_device_analyze` | Analyze device-level performance |
-
-**CPC (1)**
-
-| Tool | Description |
-|------|-------------|
-| `google_ads_cpc_detect_trend` | Detect CPC trend (rising/stable/falling) |
-
-**Assets (1)**
-
-| Tool | Description |
-|------|-------------|
-| `google_ads_assets_upload_image` | Upload an image asset |
-
-</details>
-
-#### Meta Ads
-
-<details>
-<summary>Click to expand Meta Ads tools</summary>
-
-**Campaigns (6)**
-
-| Tool | Description |
-|------|-------------|
-| `meta_ads_campaigns_list` | List campaigns |
-| `meta_ads_campaigns_get` | Get campaign details |
-| `meta_ads_campaigns_create` | Create a campaign |
-| `meta_ads_campaigns_update` | Update a campaign |
-| `meta_ads_campaigns_pause` | Pause a campaign |
-| `meta_ads_campaigns_enable` | Enable a paused campaign |
-
-**Ad Sets (6)**
-
-| Tool | Description |
-|------|-------------|
-| `meta_ads_ad_sets_list` | List ad sets |
-| `meta_ads_ad_sets_create` | Create an ad set |
-| `meta_ads_ad_sets_update` | Update an ad set |
-| `meta_ads_ad_sets_get` | Get ad set details |
-| `meta_ads_ad_sets_pause` | Pause an ad set |
-| `meta_ads_ad_sets_enable` | Enable a paused ad set |
-
-**Ads (6)**
-
-| Tool | Description |
-|------|-------------|
-| `meta_ads_ads_list` | List ads |
-| `meta_ads_ads_create` | Create an ad |
-| `meta_ads_ads_update` | Update an ad |
-| `meta_ads_ads_get` | Get ad details |
-| `meta_ads_ads_pause` | Pause an ad |
-| `meta_ads_ads_enable` | Enable a paused ad |
-
-**Creatives (6)**
-
-| Tool | Description |
-|------|-------------|
-| `meta_ads_creatives_create_carousel` | Create a carousel creative (2-10 cards) |
-| `meta_ads_creatives_create_collection` | Create a collection creative |
-| `meta_ads_creatives_list` | List ad creatives |
-| `meta_ads_creatives_create` | Create a standard ad creative |
-| `meta_ads_creatives_create_dynamic` | Create a dynamic product ad creative |
-| `meta_ads_creatives_upload_image` | Upload an image for use in creatives |
-
-**Images (1)**
-
-| Tool | Description |
-|------|-------------|
-| `meta_ads_images_upload_file` | Upload an image from local file |
-
-**Insights (2)**
-
-| Tool | Description |
-|------|-------------|
-| `meta_ads_insights_report` | Get performance report |
-| `meta_ads_insights_breakdown` | Get breakdown report (age, gender, placement, etc.) |
-
-**Audiences (5)**
-
-| Tool | Description |
-|------|-------------|
-| `meta_ads_audiences_list` | List custom audiences |
-| `meta_ads_audiences_create` | Create a custom audience |
-| `meta_ads_audiences_get` | Get audience details |
-| `meta_ads_audiences_delete` | Delete a custom audience |
-| `meta_ads_audiences_create_lookalike` | Create a lookalike audience |
-
-**Conversions API (3)**
-
-| Tool | Description |
-|------|-------------|
-| `meta_ads_conversions_send` | Send a conversion event (generic) |
-| `meta_ads_conversions_send_purchase` | Send a purchase event |
-| `meta_ads_conversions_send_lead` | Send a lead event |
-
-**Pixels (4)**
-
-| Tool | Description |
-|------|-------------|
-| `meta_ads_pixels_list` | List pixels |
-| `meta_ads_pixels_get` | Get pixel details |
-| `meta_ads_pixels_stats` | Get pixel firing statistics |
-| `meta_ads_pixels_events` | List pixel events |
-
-**Analysis (6)**
-
-| Tool | Description |
-|------|-------------|
-| `meta_ads_analysis_performance` | Analyze overall performance trends |
-| `meta_ads_analysis_audience` | Analyze audience performance and overlap |
-| `meta_ads_analysis_placements` | Analyze placement performance breakdown |
-| `meta_ads_analysis_cost` | Analyze cost trends and efficiency |
-| `meta_ads_analysis_compare_ads` | Compare performance across ads |
-| `meta_ads_analysis_suggest_creative` | Suggest creative improvements based on data |
-
-**Product Catalog (11)**
-
-| Tool | Description |
-|------|-------------|
-| `meta_ads_catalogs_list` | List product catalogs |
-| `meta_ads_catalogs_create` | Create a product catalog |
-| `meta_ads_catalogs_get` | Get catalog details |
-| `meta_ads_catalogs_delete` | Delete a catalog |
-| `meta_ads_products_list` | List products in a catalog |
-| `meta_ads_products_add` | Add a product to a catalog |
-| `meta_ads_products_get` | Get product details |
-| `meta_ads_products_update` | Update a product |
-| `meta_ads_products_delete` | Delete a product |
-| `meta_ads_feeds_list` | List catalog feeds |
-| `meta_ads_feeds_create` | Create a catalog feed (URL + scheduled import) |
-
-**Lead Ads (5)**
-
-| Tool | Description |
-|------|-------------|
-| `meta_ads_lead_forms_list` | List lead forms (per Page) |
-| `meta_ads_lead_forms_get` | Get lead form details |
-| `meta_ads_lead_forms_create` | Create a lead form |
-| `meta_ads_leads_get` | Get leads (per form) |
-| `meta_ads_leads_get_by_ad` | Get leads (per ad) |
-
-**Videos (4)**
-
-| Tool | Description |
-|------|-------------|
-| `meta_ads_videos_upload` | Upload a video from URL |
-| `meta_ads_videos_upload_file` | Upload a video from local file |
-| `meta_ads_videos_get` | Get video processing status / metadata |
-| `meta_ads_videos_thumbnails` | List auto-generated video thumbnails |
-
-**Split Tests (4)**
-
-| Tool | Description |
-|------|-------------|
-| `meta_ads_split_tests_list` | List A/B tests |
-| `meta_ads_split_tests_get` | Get A/B test details and results |
-| `meta_ads_split_tests_create` | Create an A/B test |
-| `meta_ads_split_tests_end` | End an A/B test |
-
-**Ad Rules (5)**
-
-| Tool | Description |
-|------|-------------|
-| `meta_ads_ad_rules_list` | List automated rules |
-| `meta_ads_ad_rules_get` | Get automated rule details |
-| `meta_ads_ad_rules_create` | Create an automated rule (CPA alerts, auto-pause, etc.) |
-| `meta_ads_ad_rules_update` | Update an automated rule |
-| `meta_ads_ad_rules_delete` | Delete an automated rule |
-
-**Page Posts (2)**
-
-| Tool | Description |
-|------|-------------|
-| `meta_ads_page_posts_list` | List Facebook Page posts |
-| `meta_ads_page_posts_boost` | Boost a Page post |
-
-**Instagram (3)**
-
-| Tool | Description |
-|------|-------------|
-| `meta_ads_instagram_accounts` | List connected Instagram accounts |
-| `meta_ads_instagram_media` | List Instagram posts |
-| `meta_ads_instagram_boost` | Boost an Instagram post |
-
-</details>
-
-#### Search Console
-
-<details>
-<summary>Click to expand Search Console tools</summary>
-
-**Sites (2)**
-
-| Tool | Description |
-|------|-------------|
-| `search_console_sites_list` | List verified sites |
-| `search_console_sites_get` | Get site details |
-
-**Analytics (4)**
-
-| Tool | Description |
-|------|-------------|
-| `search_console_analytics_query` | Query search analytics data |
-| `search_console_analytics_top_queries` | Get top search queries |
-| `search_console_analytics_top_pages` | Get top pages by clicks/impressions |
-| `search_console_analytics_device_breakdown` | Get performance breakdown by device |
-| `search_console_analytics_compare_periods` | Compare search performance across time periods |
-
-**Sitemaps (2)**
-
-| Tool | Description |
-|------|-------------|
-| `search_console_sitemaps_list` | List sitemaps for a site |
-| `search_console_sitemaps_submit` | Submit a sitemap |
-
-**URL Inspection (1)**
-
-| Tool | Description |
-|------|-------------|
-| `search_console_url_inspection_inspect` | Inspect a URL for indexing status |
-
-</details>
-
-#### Rollback
-
-<details>
-<summary>Click to expand rollback tools</summary>
-
-Cross-platform tools that inspect and apply the reversal plan for a previously-recorded `action_log` entry. Apply re-dispatches through the same MCP handler used for forward actions, so the reversal re-enters the full policy gate (auth, rate limit, input validation, allow-list).
-
-| Tool | Description |
-|------|-------------|
-| `rollback_plan_get` | Inspect the reversal plan for an `action_log` entry (`supported` / `partial` / `not_supported`), its `operation` + `params`, and any caveats. Read-only; does not execute. |
-| `rollback_apply` | Execute the reversal plan for `action_log[index]`. Requires `confirm=true` as a literal boolean. Appends a new log entry tagged `rollback_of=<index>`; a second apply of the same index is refused. `state_file` is resolved strictly inside the MCP server's CWD — path traversal, symlink escape, and `rollback.*` self-recursion are all refused. |
-
-</details>
-
-#### Analysis
-
-<details>
-<summary>Click to expand analysis tools</summary>
-
-Cross-platform detection tools that operate on STATE.json's `action_log` history rather than on platform APIs directly.
-
-| Tool | Description |
-|------|-------------|
-| `analysis_anomalies_check` | Compare a campaign's current metrics against a median-based baseline built from `action_log` history. Returns severity-ordered anomalies — zero spend (CRITICAL), CPA spike (HIGH/CRITICAL, gated by 30+ conversions), CTR drop (HIGH/CRITICAL, gated by 1000+ impressions). Sample-size gates follow the `_mureo-learning` skill's statistical-thinking rules. Returns `baseline=null` when history is shorter than `min_baseline_entries` (default 7); `baseline_warning` surfaces a parseable-but-corrupt `STATE.json` without silencing live zero-spend detection. |
-
-</details>
-
-#### Mureo Context
-
-<details>
-<summary>Click to expand Mureo Context tools</summary>
-
-Read and write mureo's strategy / state context layer (STRATEGY.md / STATE.json) over MCP, so hosts without direct filesystem access (Claude Desktop chat, claude.ai web, Codex/Cursor) can still drive strategy-aware workflows. Paths are resolved strictly inside the MCP server's CWD; paths outside it are refused.
-
-| Tool | Description |
-|------|-------------|
-| `mureo_strategy_get` | Read STRATEGY.md and return its raw markdown plus an `exists` flag (empty markdown when the file is absent). |
-| `mureo_strategy_set` | Atomically replace STRATEGY.md; the content is parsed before writing, so a malformed input raises rather than corrupts the file. |
-| `mureo_state_get` | Read STATE.json and return the parsed v2 document (version, `last_synced_at`, per-platform campaigns, legacy campaigns, `action_log`). |
-| `mureo_state_upsert_campaign` | Atomically upsert a `CampaignSnapshot` — optionally with a performance `metrics` object — into STATE.json for the reporting dashboard. |
-| `mureo_state_platform_metrics_set` | Atomically set a platform-level metric rollup (`totals` plus per-window `periods` for the dashboard's YESTERDAY / LAST_30_DAYS toggle); campaigns and other platforms are preserved. |
-| `mureo_state_set_conversion_events` | Declare which Meta `action_type` rows count as this account's conversions, overriding the built-in generic set (e.g. a custom pixel event); an empty list clears the override. |
-| `mureo_state_action_log_append` | Atomically append a single `action_log` entry so an action (budget change, pause, negative-keyword add) can be evaluated later. |
-| `mureo_state_report_set` | Persist a structured daily / weekly / goal report summary into STATE.json's `reports` section so the read-only dashboard can render it without re-running the agent. |
-| `mureo_outcome_evaluate` | Deterministically score whether a logged action's outcome improved, regressed, or is inconclusive — direction-aware (lower-is-better CPA vs higher-is-better CVR) with a ±noise band. |
-
-</details>
-
-#### Analytics Registry
-
-<details>
-<summary>Click to expand analytics registry tools</summary>
-
-Discover and invoke the analytics module registered for each platform. Read-only diagnostics — built-in (`google_ads`, `meta_ads`) and plugin-supplied modules appear in the same shape.
-
-| Tool | Description |
-|------|-------------|
-| `mureo_analytics_modules_list` | List analytics modules per platform and the capabilities each advertises (`detect_anomalies`, `diagnose_performance`, `audit_creative`, `analyze_budget_efficiency`). |
-| `mureo_analytics_run` | Run one capability of a platform's analytics module and return its structured result; degrades to a structured status (`no_analytics_module` / `capability_not_available` / `error`) instead of failing the workflow. |
-
-</details>
-
-#### Learning
-
-<details>
-<summary>Click to expand learning tools</summary>
-
-Surface accumulated practitioner know-how — locally saved `/learn` insights and external advisor MCP servers — for diagnostic workflows to consult before drawing conclusions.
-
-| Tool | Description |
-|------|-------------|
-| `mureo_consult_advisor` | Consult external advisor MCP servers (vector search) for operational expertise the LLM lacks, enriched with local campaign state; advisor responses are untrusted external content. |
-| `mureo_learning_insights_get` | Load every insight previously saved via `/learn` from the operator-tier knowledge base as raw Markdown; returns a guidance string when nothing has been saved yet. |
-
-</details>
-
-#### Creative Studio
-
-<details>
-<summary>Click to expand Creative Studio tools</summary>
-
-Generate creator-quality ad creatives: text-free key visuals plus copy / brand composited into per-format banners. Composition requires the `creative` extra (`pip install 'mureo[creative]'`).
-
-| Tool | Description |
-|------|-------------|
-| `creative_studio_providers_list` | List the configured image-generation providers, whether each has an API key, its capabilities (edit support + max size), and its model ids. |
-| `creative_studio_generate_visual` | Generate text-free key-visual PNGs (a no-text constraint is appended automatically) into a new run directory with a provenance manifest. |
-| `creative_studio_brand_kit_get` | Return the loaded brand kit (colours, fonts, logo) from `./BRAND_KIT/kit.yml`, or tasteful neutral defaults when none exists. |
-| `creative_studio_edit_visual` | Refine an existing key visual through a provider's edit path (the art-direction loop), writing the edited PNG next to the input. |
-| `creative_studio_compose` | Composite headline / body / CTA / badge / logo over a key visual into per-format banner PNGs via headless-Chromium HTML/CSS rendering (pixel-perfect Japanese text). |
-
-</details>
-
-## CLI
-
-```bash
-mureo setup claude-code    # One-command setup for Claude Code
-mureo setup cursor         # Setup for Cursor
-mureo auth status          # Check authentication status
-mureo auth check-google    # Verify Google Ads credentials
-mureo auth check-meta      # Verify Meta Ads credentials
-```
-
-## Strategy Context
+### Strategy context
 
 Two local files drive strategy-aware operations. Run `/onboard` to generate them interactively.
 
 - **STRATEGY.md** -- Persona, USP, Brand Voice, Goals, Operation Mode. See [docs/strategy-context.md](docs/strategy-context.md).
 - **STATE.json** -- Campaign snapshots, action log. Updated automatically by workflow commands.
 
-## Architecture
+### Connecting GA4 and other MCP servers
 
-```
-mureo/
-├── __init__.py              # Package root
-├── auth.py                  # Credential loading (~/.mureo/credentials.json + env vars + Meta token auto-refresh)
-├── auth_setup.py            # Interactive setup wizard (OAuth + MCP config)
-├── throttle.py              # Rate limiting (token bucket + rolling hourly cap)
-├── _image_validation.py     # Image file validation utilities
-├── google_ads/              # Google Ads API client (google-ads SDK wrapper)
-│   ├── client.py            # GoogleAdsApiClient (8 Mixin: Ads, Keywords, Analysis, Creative, Diagnostics, Extensions, Media, Monitoring)
-│   ├── mappers.py           # Response mapping to structured dicts
-│   └── _*.py                # 8 Mixin modules (ads, keywords, analysis, extensions, diagnostics,
-│                            #   creative, monitoring, media) + validators + classifiers
-├── meta_ads/                # Meta Ads API client (15 Mixins, httpx-based)
-│   ├── client.py            # MetaAdsApiClient (Campaigns, AdSets, Ads, Creatives, Audiences, Pixels,
-│   │                        #   Insights, Analysis, Catalog, Conversions, Leads, PagePosts, Instagram,
-│   │                        #   SplitTest, AdRules)
-│   ├── mappers.py           # Response mapping to structured dicts
-│   └── _*.py                # 15 Mixin modules (campaigns, ads, creatives, audiences, etc.)
-├── search_console/          # Google Search Console API client (reuses Google OAuth2 credentials)
-│   └── client.py            # SearchConsoleApiClient
-├── analytics/               # Per-platform analytics-module Protocol + registry (#120, v0.9.9+)
-│   ├── protocol.py          # AnalyticsModule Protocol + AnalyticsCapability
-│   ├── registry.py          # Entry-point discovery (`mureo.analytics` group) + fault isolation
-│   ├── models.py            # Anomaly / PerformanceDiagnosis / CreativeAudit / BudgetEfficiency
-│   └── builtin/             # Built-in adapters for google_ads / meta_ads
-├── analysis/                # Cross-platform analysis utilities
-│   ├── anomaly_detector.py  # Sample-size-gated anomaly detection (pure function)
-│   └── lp_analyzer.py       # Landing page analysis engine
-├── context/                 # File-based context (STRATEGY.md, STATE.json)
-│   ├── models.py            # Immutable dataclasses (StrategyEntry, StateDocument, ActionLogEntry)
-│   ├── strategy.py          # STRATEGY.md parser / renderer
-│   ├── state.py             # STATE.json parser / renderer
-│   └── errors.py            # Context-related errors
-├── rollback/                # Allow-list-gated rollback with append-only audit trail
-├── byod/                    # BYOD bundle importer + CSV-backed clients
-├── cli/                     # Typer CLI (setup + auth only)
-│   ├── main.py              # Entry point (mureo command)
-│   ├── setup_cmd.py         # mureo setup claude-code / cursor / codex / gemini
-│   └── auth_cmd.py          # mureo auth setup / status / check-*
-└── mcp/                     # MCP server
-    ├── __main__.py                        # python -m mureo.mcp entry point
-    ├── server.py                          # MCP server setup (stdio transport)
-    ├── _helpers.py                        # Shared handler utilities
-    ├── tools_google_ads.py                # Google Ads tool definitions (aggregator)
-    ├── _tools_google_ads_*.py             # Tool definition sub-modules
-    ├── _handlers_google_ads.py            # Google Ads base handlers
-    ├── _handlers_google_ads_extensions.py # Extensions handlers
-    ├── _handlers_google_ads_analysis.py   # Analysis handlers
-    ├── tools_meta_ads.py                  # Meta Ads tool definitions (aggregator)
-    ├── _tools_meta_ads_*.py               # Tool definition sub-modules
-    ├── _handlers_meta_ads.py              # Meta Ads base handlers
-    ├── _handlers_meta_ads_extended.py     # Extended handlers
-    ├── _handlers_meta_ads_other.py        # Other handlers
-    ├── tools_search_console.py            # Search Console tool definitions
-    └── _handlers_search_console.py        # Search Console handlers
-```
+mureo's workflow commands leverage GA4 data (conversion rates, user behavior, landing page performance) when a GA4 MCP server — e.g. [Google Analytics MCP](https://github.com/googleanalytics/google-analytics-mcp) — is configured alongside mureo. GA4 is optional; all commands work without it. mureo also works alongside any other MCP server in the same session, and workflow commands incorporate their data when available. Setup walkthroughs: **[Integrations Guide →](docs/integrations.md)**
 
-**Design principles:**
+### Writing your own provider plugin
+
+Any pip-installable package can add a new ad-platform provider (Microsoft/Bing Ads, Apple Search Ads, TikTok, LinkedIn, in-house platforms, ...) without touching mureo's source tree — implement the provider Protocols, declare capabilities, and register under the `mureo.providers` entry-point group. Plugins can also ship their own skills and analytics modules.
+
+- [docs/plugin-authoring.md](docs/plugin-authoring.md) — full plugin authoring guide
+- [docs/ABI-stability.md](docs/ABI-stability.md) — ABI stability promise and deprecation policy
+
+### Architecture
 
 - **No database** -- all state is either in the ad platform APIs or in local files (`STRATEGY.md`, `STATE.json`).
 - **No LLM dependency** -- mureo does not embed an LLM. Inference, planning, and decision-making are the agent's responsibility.
+- **No web framework** -- CLI (Typer) and MCP (stdio) only; the `mureo configure` UI is stdlib `http.server` on `127.0.0.1`.
 - **Immutable data models** -- all dataclasses use `frozen=True` to prevent accidental mutation.
 - **Credentials stay local** -- loaded from `~/.mureo/credentials.json` or environment variables. Never sent anywhere except the official ad platform APIs.
+
+Module layout and system diagrams: **[Architecture Guide →](docs/architecture.md)**
 
 ## Development
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,70 @@
+# Docker Guide
+
+Run the mureo MCP server in an isolated container. Useful for:
+
+- **Non–Claude Code MCP clients**: Cursor, Codex CLI, Gemini CLI, Continue, Cline, Zed, or any custom MCP client.
+- **CI/CD pipelines**: scheduled anomaly checks, rollback dry-runs, weekly reports.
+- **Multi-tenant / agency ops**: isolated credentials per client via separate containers.
+- **MCP registry health checks** (Glama, etc.).
+
+> Slash commands (`/daily-check`, `/rescue`) and the credential-guard hook are Claude Code–specific UX. For those, use `pip install mureo` with `mureo setup claude-code` instead.
+
+## Build and run
+
+```bash
+docker build -t mureo .
+docker run --rm -v ~/.mureo:/home/mureo/.mureo mureo
+```
+
+Connect your MCP client by pointing its config at this `docker run` command.
+
+## Authentication
+
+Credentials are loaded from `/home/mureo/.mureo/credentials.json` inside the container (via bind mount) or from environment variables. Three common patterns:
+
+**1. Mounted credentials file** — if `~/.mureo/credentials.json` already exists on the host (from a prior `mureo auth setup`, a team-shared vault, or hand-crafted), the bind mount above is enough.
+
+Schema for hand-crafting:
+
+```json
+{
+  "google_ads": {
+    "developer_token": "...",
+    "client_id": "...apps.googleusercontent.com",
+    "client_secret": "...",
+    "refresh_token": "...",
+    "login_customer_id": "1234567890"
+  },
+  "meta_ads": { "access_token": "..." }
+}
+```
+
+Required: Google needs `developer_token` / `client_id` / `client_secret` / `refresh_token`. Meta needs `access_token`. Search Console reuses the Google OAuth credentials (OAuth app must include the `https://www.googleapis.com/auth/webmasters` scope).
+
+**2. Environment variables** — useful for CI/CD where secrets come from a secret manager:
+
+```bash
+docker run --rm \
+  -e GOOGLE_ADS_DEVELOPER_TOKEN=... \
+  -e GOOGLE_ADS_CLIENT_ID=... \
+  -e GOOGLE_ADS_CLIENT_SECRET=... \
+  -e GOOGLE_ADS_REFRESH_TOKEN=... \
+  -e GOOGLE_ADS_LOGIN_CUSTOMER_ID=... \
+  -e META_ADS_ACCESS_TOKEN=... \
+  mureo
+```
+
+Supported: `GOOGLE_ADS_{DEVELOPER_TOKEN, CLIENT_ID, CLIENT_SECRET, REFRESH_TOKEN, LOGIN_CUSTOMER_ID, CUSTOMER_ID}`, `META_ADS_{ACCESS_TOKEN, APP_ID, APP_SECRET, TOKEN_OBTAINED_AT, ACCOUNT_ID}`.
+
+**3. Interactive wizard inside Docker** — if you don't have OAuth tokens yet and don't want to install mureo on the host:
+
+```bash
+docker run -it --rm -v ~/.mureo:/home/mureo/.mureo mureo mureo auth setup
+```
+
+Walks you through the OAuth flow in the terminal and writes `credentials.json` to the mounted volume. Subsequent runs pick it up automatically (pattern 1).
+
+To obtain OAuth tokens outside mureo:
+
+- Google Ads OAuth 2.0 refresh token: https://developers.google.com/google-ads/api/docs/oauth/overview
+- Meta long-lived access token: https://developers.facebook.com/docs/facebook-login/guides/access-tokens/get-long-lived


### PR DESCRIPTION
## Why

The README had grown to 1,261 lines. For a first-time visitor (e.g. arriving from a Product Hunt launch) it front-loads three decisions — easy vs manual, a 3-modes × 3-hosts matrix, and a BYOD vs Live API comparison — before showing what mureo actually does. Setup instructions appear in four different forms, and a ~500-line tool table duplicates docs/mcp-server.md.

## What changed

- **One golden path on top**: `pip install mureo` → `mureo setup claude-code --skip-auth` → `mureo demo init` → `/daily-check`. Completes in ~2 minutes with **no credentials, no OAuth** — verified end-to-end in a clean venv against the PyPI package.
- BYOD and Live API become two short escalation paths under the quick start, each linking to the existing full guide (docs/byod.md, docs/authentication.md).
- Docker section moved verbatim to **docs/docker.md** (new file).
- Tool table → link to docs/mcp-server.md. Auth details → docs/authentication.md. GA4 walkthrough → docs/integrations.md. Module tree → docs/architecture.md.
- Features, Workflow Commands, real-output samples, and the Security section are kept intact.
- **README.ja.md gets the same treatment** (708 → 341 lines), reusing the existing Japanese translations for the retained sections.

**README.md: 1,261 → 375 lines. No information deleted — only relocated to the docs/ guides that already covered it.**

## Notes

- Docs-only change (per AGENTS.md, visual review sufficient).
- Found during the clean-venv verification, filed separately: #486 (FutureWarning noise on every CLI command under Python 3.10), #487 (missing `mureo --version`), #488 (CI smoke test for the quickstart path).