### PR TITLE
docs: mention TikTok Ads and lead setup with mureo configure

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -47,15 +47,16 @@ mureoは、**AI 広告運用のためのローカル制御平面（control plane
 
 ## クイックスタート（2分で動きを見る）
 
-広告アカウントの認証情報も、OAuth も、サインアップも不要です。3 コマンドで合成データのデモアカウントが用意され、mureo が Claude Code に接続されます。
+広告アカウントの認証情報も、OAuth も、サインアップも不要です。
 
 ```bash
 pip install mureo
-mureo setup claude-code --skip-auth
-mureo demo init --scenario seasonality-trap
+mureo configure
 ```
 
-生成された `mureo-demo/` ディレクトリを Claude Code で開いて、こう聞いてください。
+`mureo configure` はローカル（`127.0.0.1` にバインド。外部からはアクセス不可）にブラウザ UI を起動し、ターミナルに秘密情報を貼り付けることなくすべてを案内します。Claude アプリを選び、1クリックの基本セットアップを実行し、同じダッシュボードから合成データの**デモシナリオ**を用意できます。（ターミナル派には `mureo setup claude-code --skip-auth && mureo demo init --scenario seasonality-trap` が同じことをします。）
+
+生成されたデモディレクトリを Claude Code で開いて、こう聞いてください。
 
 ```
 /daily-check
@@ -67,7 +68,7 @@ mureo demo init --scenario seasonality-trap
 
 ### 道 A: 自分のデータで試す（BYOD、5〜10分、OAuth 不要）
 
-**Google Ads / Meta Ads から XLSX として書き出して mureo に取り込むだけで、媒体をまたいだ戦略レベルの診断が手に入ります。** OAuth も Developer Token の審査待ちも一切不要です。
+**Google Ads / Meta Ads から XLSX として書き出して mureo に取り込むだけで、媒体をまたいだ戦略レベルの診断が手に入ります。** OAuth も Developer Token の審査待ちも一切不要です。取り込みは `mureo configure` のダッシュボード（デモと同じ Demo / BYOD セクション）から、またはターミナルからできます。
 
 ```bash
 mureo byod import ~/Downloads/mureo-google-ads.xlsx
@@ -83,11 +84,7 @@ BYOD は**設計として読み取り専用**です。すべての変更系ツ�
 
 mureo を Google Ads / Meta Ads API に直接接続します。実際に変更を実行する場合（`/rescue`、`/budget-rebalance`、`/creative-refresh`、rollback）、および GA4 / Search Console を使う場合はこちらが必須です。
 
-```bash
-mureo configure
-```
-
-`mureo configure` はローカル（`127.0.0.1` にバインド。外部からはアクセス不可）にブラウザ UI を起動し、Claude アプリの選択、1クリックの基本セットアップ、各コンソールへのディープリンク付き Google / Meta OAuth、公式 MCP プロバイダの登録まで案内します。ターミナル派には `mureo auth setup` ＋ `mureo setup claude-code` が同じことをします。**[認証ガイド →](docs/authentication.md)**
+同じ `mureo configure` の UI で「プラットフォーム接続」を開くと、各コンソールへのディープリンク付きで Google / Meta OAuth をブラウザ内で完了でき、公式 MCP プロバイダの登録もできます。（ターミナル派には `mureo auth setup` が同じことをします。）**[認証ガイド →](docs/authentication.md)**
 
 前提: Google Ads の Developer Token と OAuth クライアント、Meta の App ID と Secret（開発モードのままで構いません）。取得手順もウィザードが案内します。
 
@@ -111,7 +108,7 @@ mureo configure
 
 ### そのほかのエージェントとホスト
 
-基準となるホストは Claude Code ですが、どのセットアップも 1 コマンドで完了します。
+Claude 系ホスト（Claude Code / Claude Desktop）は `mureo configure` だけで最後まで設定できます。下の表はスクリプト化したい場合の同等コマンドと、Claude 以外のホストの一覧です。
 
 | ホスト | コマンド | 補足 |
 |------|---------|-------|

--- a/README.ja.md
+++ b/README.ja.md
@@ -34,13 +34,13 @@ Claude Code、Cursor、Codex、Gemini に対応。mureo は各広告プラット
 
 ## mureoとは
 
-mureoは、**AI 広告運用のためのローカル制御平面（control plane）** です。インストールすると、AIエージェント（Claude Code、Cursor、Codex、Geminiなど）が Google 広告・Meta 広告・Search Console・GA4 を *mureo を経由して* 操作できるようになります。すべての判断はあなたの事業戦略に基づき、実際の成果に紐づき、後から再生可能な監査ログに残ります。
+mureoは、**AI 広告運用のためのローカル制御平面（control plane）** です。インストールすると、AIエージェント（Claude Code、Cursor、Codex、Geminiなど）が Google 広告・Meta 広告・TikTok 広告・Search Console・GA4 を *mureo を経由して* 操作できるようになります。すべての判断はあなたの事業戦略に基づき、実際の成果に紐づき、後から再生可能な監査ログに残ります。
 
 各広告プラットフォームの公式 MCP（Meta Ads MCP / Google Ads MCP など）が出揃うと、mureo はそれらをドライバとして利用します。mureo の価値は API 接続そのものではなく、**その周辺で起きること**にあります。
 
 - **戦略準拠** — すべての判断が `STRATEGY.md`（ペルソナ・USP・ブランドボイス・目標）を読み込む
 - **セーフティゲート** — rollback allow-list、GAQL ガード、BYOD 既定 read-only、認証情報ガード、プラットフォーム別スロットリング
-- **クロスプラットフォーム** — Google 広告 / Meta 広告 / Search Console / GA4 を 1 つのワークフローで
+- **クロスプラットフォーム** — Google 広告 / Meta 広告 / TikTok 広告 / Search Console / GA4 を 1 つのワークフローで
 - **監査可能** — 追記専用 action log、rollback 対応
 - **ローカルファースト** — 認証情報は端末の外に出ない
 - **学習可能** — `/learn` でアカウント固有のナレッジを継続的に蓄積
@@ -134,13 +134,13 @@ mureo configure
 
 ### 媒体横断の分析
 
-Google広告、Meta広告、Search Console、GA4を1つのワークフローでまとめて処理します。
+Google広告、Meta広告、TikTok広告、Search Console、GA4を1つのワークフローでまとめて処理します。
 
 - `/daily-check` -- 全媒体の配信状況・広告パフォーマンス・自然検索のトレンド・サイト内行動を一括取得し、相関させて1つのレポートにまとめます。
 - `/search-term-cleanup` -- 有料キーワードと自然検索の順位を突き合わせ、無駄な重複出稿を洗い出します。
 - `/competitive-scan` -- オークション分析と自然検索の順位データを統合して、競合の全体像を把握します。
 
-設定済みの媒体はエージェントが自動検出します。後からMeta広告を追加しても、全コマンドがそのまま対応します。
+設定済みの媒体はエージェントが自動検出します。後からMeta広告やTikTok広告を追加しても、全コマンドがそのまま対応します。
 
 ### 広告運用の専門知識
 
@@ -303,7 +303,9 @@ mureo auth check-meta      # Meta広告の認証情報を表示（マスク済�
 - **STRATEGY.md** — ペルソナ、USP、ブランドボイス、目標、運用モード。詳細は [docs/strategy-context.md](docs/strategy-context.md)。
 - **STATE.json** — キャンペーンのスナップショット、action log。ワークフローコマンドが自動で更新します。
 
-### GA4 とその他の MCP サーバーの接続
+### TikTok 広告、GA4、その他の MCP サーバーの接続
+
+**TikTok 広告**は、TikTok の公式ホスト型 MCP（TikTok for Business MCP Server）経由で対応しています。mureo は公式プロバイダ `tiktok-ads-official` として同梱しており、`mureo configure` のダッシュボードまたは `mureo providers add` で追加し、初回接続時にブラウザで TikTok for Business アカウントにサインインして認可するだけです（Developer Token は不要）。接続後は `tiktok_ads` が他媒体と同格のプラットフォームとして扱われ、`/daily-check` やレポートに含まれ、承認済みの変更は action log に記録されます。mureo ネイティブの分析（異常検知の基準値、RSA 監査）は引き続き Google / Meta 向けです。
 
 GA4 の MCP サーバー（例: [Google Analytics MCP](https://github.com/googleanalytics/google-analytics-mcp)）を mureo と併設すると、ワークフローコマンドが GA4 のデータ（CVR、ユーザー行動、LP パフォーマンス）も取り込みます。GA4 はオプションで、なくても全コマンドが動作します。mureo は同じセッション内の任意の MCP サーバーと共存でき、利用可能なデータをワークフローが自動的に取り込みます。セットアップ手順: **[連携ガイド →](docs/integrations.md)**（英語）
 

--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ Works with Claude Code, Cursor, Codex & Gemini. mureo sits on top of the officia
 
 ## What is mureo?
 
-mureo is a **local-first control plane for AI ad ops**. Once installed, AI agents (Claude Code, Cursor, Codex, Gemini, etc.) operate Google Ads, Meta Ads, Search Console, and GA4 *through mureo* — which keeps every action grounded in your business strategy, tied to real outcomes, and recorded in an audit log you can replay.
+mureo is a **local-first control plane for AI ad ops**. Once installed, AI agents (Claude Code, Cursor, Codex, Gemini, etc.) operate Google Ads, Meta Ads, TikTok Ads, Search Console, and GA4 *through mureo* — which keeps every action grounded in your business strategy, tied to real outcomes, and recorded in an audit log you can replay.
 
 When official ad-platform MCPs ship (Meta Ads MCP, Google Ads MCP, etc.), mureo uses them as drivers. mureo's value is not the API connection — it is **what happens around it**:
 
 - **Strategy-grounded** — every decision reads `STRATEGY.md` (persona, USP, brand voice, goals)
 - **Safety-gated** — rollback allow-list, GAQL guards, BYOD read-only by default, credential guard, per-platform throttle
-- **Cross-platform** — Google Ads / Meta Ads / Search Console / GA4 in one workflow
+- **Cross-platform** — Google Ads / Meta Ads / TikTok Ads / Search Console / GA4 in one workflow
 - **Auditable** — append-only action log with rollback
 - **Local-first** — credentials never leave your machine
 - **Learnable** — `/learn` builds account-specific knowledge over time
@@ -138,13 +138,13 @@ Every operation starts from `STRATEGY.md` -- your persona, USP, brand voice, goa
 
 ### Cross-platform analysis
 
-mureo orchestrates across Google Ads, Meta Ads, Search Console, and GA4 in a single workflow:
+mureo orchestrates across Google Ads, Meta Ads, TikTok Ads, Search Console, and GA4 in a single workflow:
 
 - `/daily-check` -- pulls delivery status, ad performance, organic search trends, and site behavior across all platforms, then correlates them into one health report.
 - `/search-term-cleanup` -- compares paid keywords against organic rankings to eliminate wasteful overlap.
 - `/competitive-scan` -- combines auction insights with organic position data for a complete competitive picture.
 
-The agent auto-discovers your configured platforms. Add Meta Ads later? Every command adapts automatically.
+The agent auto-discovers your configured platforms. Add Meta Ads or TikTok Ads later? Every command adapts automatically.
 
 ### Built-in marketing expertise
 
@@ -337,7 +337,9 @@ Two local files drive strategy-aware operations. Run `/onboard` to generate them
 - **STRATEGY.md** -- Persona, USP, Brand Voice, Goals, Operation Mode. See [docs/strategy-context.md](docs/strategy-context.md).
 - **STATE.json** -- Campaign snapshots, action log. Updated automatically by workflow commands.
 
-### Connecting GA4 and other MCP servers
+### Connecting TikTok Ads, GA4, and other MCP servers
+
+**TikTok Ads** is supported through TikTok's official hosted MCP (the "TikTok for Business MCP Server"). mureo ships it as the `tiktok-ads-official` provider — add it from the `mureo configure` dashboard or with `mureo providers add`, then authenticate in the browser with your TikTok for Business account on first connect (no developer token required). Once connected, workflow commands treat `tiktok_ads` as a first-class platform: `/daily-check` and the reports include it, and confirmed changes are recorded in the action log. mureo-native analytics (anomaly baselines, RSA audit) remain Google / Meta specific.
 
 mureo's workflow commands leverage GA4 data (conversion rates, user behavior, landing page performance) when a GA4 MCP server — e.g. [Google Analytics MCP](https://github.com/googleanalytics/google-analytics-mcp) — is configured alongside mureo. GA4 is optional; all commands work without it. mureo also works alongside any other MCP server in the same session, and workflow commands incorporate their data when available. Setup walkthroughs: **[Integrations Guide →](docs/integrations.md)**
 

--- a/README.md
+++ b/README.md
@@ -47,15 +47,16 @@ When official ad-platform MCPs ship (Meta Ads MCP, Google Ads MCP, etc.), mureo 
 
 ## Quick start — see it work in 2 minutes
 
-No ad-account credentials, no OAuth, no sign-up. Three commands scaffold a synthetic demo account and wire mureo into Claude Code:
+No ad-account credentials, no OAuth, no sign-up:
 
 ```bash
 pip install mureo
-mureo setup claude-code --skip-auth
-mureo demo init --scenario seasonality-trap
+mureo configure
 ```
 
-Then open the generated `mureo-demo/` directory in Claude Code and ask:
+`mureo configure` opens a local browser UI (bound to `127.0.0.1`, no remote access) that walks you through everything without pasting a single secret into a terminal: pick your Claude app, run the one-click basic setup, and scaffold a synthetic **demo scenario** from the same dashboard. (Terminal equivalent: `mureo setup claude-code --skip-auth && mureo demo init --scenario seasonality-trap`.)
+
+Then open the generated demo directory in Claude Code and ask:
 
 ```
 /daily-check
@@ -67,7 +68,7 @@ When you're ready to point mureo at *your* data, pick one of the two paths below
 
 ### Path A: Bring your own data (BYOD) — 5–10 min, no OAuth
 
-**Export your real account data as an XLSX, drop it into mureo, and get a strategy-grounded multi-platform diagnosis** — no OAuth flow, no developer-token approval.
+**Export your real account data as an XLSX, drop it into mureo, and get a strategy-grounded multi-platform diagnosis** — no OAuth flow, no developer-token approval. Import the bundle from the `mureo configure` dashboard (the same Demo / BYOD section), or from the terminal:
 
 ```bash
 mureo byod import ~/Downloads/mureo-google-ads.xlsx
@@ -83,11 +84,7 @@ BYOD is **read-only by construction**: every mutation tool returns `{"status": "
 
 Connect mureo directly to the Google Ads / Meta Ads APIs. Required to actually execute changes (`/rescue`, `/budget-rebalance`, `/creative-refresh`, rollback) and for GA4 / Search Console support.
 
-```bash
-mureo configure
-```
-
-`mureo configure` opens a local browser UI (bound to `127.0.0.1`, no remote access) that walks you through everything: pick your Claude app, one-click basic setup, interactive Google / Meta OAuth with deep links to each console, and official-MCP provider registration. Prefer the terminal? `mureo auth setup` + `mureo setup claude-code` do the same. **[Authentication guide →](docs/authentication.md)**
+In the same `mureo configure` UI, open **Connect platforms**: interactive Google / Meta OAuth in the browser, with each field deep-linking to the right console page, plus official-MCP provider registration. (Terminal equivalent: `mureo auth setup`.) **[Authentication guide →](docs/authentication.md)**
 
 Prerequisites: a Google Ads Developer Token + OAuth Client, and/or a Meta App ID + Secret (development mode is fine). Both wizards walk you through obtaining them.
 
@@ -111,7 +108,7 @@ The presence of `~/.mureo/byod/manifest.json` is the switch — imported platfor
 
 ### Other agents and hosts
 
-Claude Code is the reference host, but every setup has a one-command equivalent:
+`mureo configure` covers the Claude hosts (Claude Code / Claude Desktop) end to end. The commands below are the scriptable equivalents, plus the non-Claude hosts:
 
 | Host | Command | Notes |
 |------|---------|-------|


### PR DESCRIPTION
Two follow-ups to the README restructure (#485), both languages:

## 1. TikTok Ads was missing entirely

TikTok Ads support shipped as the `tiktok-ads-official` provider (TikTok's official hosted "TikTok for Business MCP Server", browser-OAuth on first connect, first-class `tiktok_ads` platform key in workflow commands, reports, and the action log) — but neither README mentioned TikTok.

- Added to the platform lists (intro + cross-platform sections)
- New connector paragraph in the reference section (renamed to "Connecting TikTok Ads, GA4, and other MCP servers"), with honest scope: mureo-native analytics (anomaly baselines, RSA audit) remain Google / Meta specific
- Wording grounded in `mureo/providers/catalog.py` and docs/integrations.md

## 2. `mureo configure` is the recommended flow — lead with it

The quick start, BYOD, Live API, and hosts sections led with raw CLI commands. Reordered so the browser UI is the primary path everywhere it applies (quick start = `pip install mureo` + `mureo configure`, demo scaffold and BYOD import from the same dashboard, Connect-platforms for OAuth), with each terminal command kept as a one-line scriptable equivalent.

Docs-only change (per AGENTS.md, visual review sufficient).