### PR TITLE
docs: quick start now says to pick the demo scenario and skip OAuth

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -47,14 +47,14 @@ mureo は、**AI 広告運用のための、ローカルで動く制御基盤（
 
 ## クイックスタート（2分で動きを見る）
 
-広告アカウントの認証情報も、OAuth も、サインアップも要りません。
+**デモシナリオ**は合成データで動くため、広告アカウントの認証情報も、OAuth も、サインアップも要りません。
 
 ```bash
 pip install mureo
 mureo configure
 ```
 
-`mureo configure` はローカル（`127.0.0.1` にバインド。外部からはアクセス不可）にブラウザ UI を起動し、ターミナルに秘密情報を貼り付けることなくすべてを案内します。Claude アプリを選び、1クリックの基本セットアップを実行し、同じダッシュボードから合成データの**デモシナリオ**を用意できます。（ターミナルでは `mureo setup claude-code --skip-auth && mureo demo init --scenario seasonality-trap` で同じことができます。）
+`mureo configure` はローカル（`127.0.0.1` にバインド。外部からはアクセス不可）にブラウザ UI を起動します。Claude アプリを選び、1クリックの基本セットアップを実行したら、Demo / BYOD セクションで**デモシナリオ**を選んでください。UI にはプラットフォーム接続（OAuth）の項目もありますが、**ここでは飛ばして構いません**。デモに認証情報は不要です。（ターミナルでは `mureo setup claude-code --skip-auth && mureo demo init --scenario seasonality-trap` で同じことができます。）
 
 生成されたデモディレクトリを Claude Code で開いて、こう聞いてください。
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -64,9 +64,9 @@ mureo configure
 
 エージェントがデモ用の `STRATEGY.md` を読み、キャンペーンデータを取得し、数値だけを見るツールが見落とす「季節性の罠」に踏み込んでいく様子を見られます。次は `/search-term-cleanup` を試してみてください。
 
-自分のデータで使う準備ができたら、次の 2 つの道から選びます。
+自分のデータで使う準備ができたら、次のどちらかに進んでください。
 
-### 道 A: 自分のデータで試す（BYOD、5〜10分、OAuth 不要）
+### まず自分のデータで試す（BYOD、5〜10分、OAuth 不要）
 
 **Google Ads / Meta Ads から XLSX として書き出して mureo に取り込むだけで、媒体をまたいだ戦略レベルの診断が手に入ります。** OAuth も Developer Token の審査待ちも要りません。取り込みは `mureo configure` のダッシュボード（デモと同じ Demo / BYOD セクション）から、またはターミナルからできます。
 
@@ -80,7 +80,7 @@ XLSX の生成は媒体ごとに一回だけのセットアップです。Google
 
 BYOD は**設計上、読み取り専用**です。すべての変更系ツールは `{"status": "skipped_in_byod_readonly"}` を返します。エージェントは分析と提案はしますが、実アカウントへの書き込みは決してしません。
 
-### 道 B: 本番接続する（Live API OAuth、全機能）
+### 本番のアカウントに接続する（Live API OAuth、全機能）
 
 mureo を Google Ads / Meta Ads API に直接接続します。実際に変更を実行する場合（`/rescue`、`/budget-rebalance`、`/creative-refresh`、rollback）と、GA4 / Search Console を使う場合はこちらが必須です。
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -18,11 +18,11 @@
   <a href="https://github.com/logly/mureo/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/logly/mureo/actions/workflows/ci.yml/badge.svg"></a>
 </p>
 
-**mureo** は、ローカルで動くAI広告運用チームです。無駄を見つけ、変更を監査し、安全に運用します。
+**mureo** は、オープンソースでローカルに動くAI広告運用チームです。無駄を見つけ、変更を監査し、安全に運用します。
 
 _お手元のPCで完結。戦略に基づく。安全に運用。_
 
-Claude Code、Cursor、Codex、Gemini で動きます。mureo は各広告プラットフォームの公式 MCP の上に乗り、AI に、守るべき戦略と、測るべき成果と、誰にでも見せられる監査証跡を持たせます。**認証情報はお手元のPCから出ません。**
+Claude Code、Cursor、Codex、Gemini で動きます。mureo は各広告プラットフォームの公式 [MCP](https://modelcontextprotocol.io/) の上に乗り、AI に、守るべき戦略と、測るべき成果と、誰にでも見せられる監査証跡を持たせます。**認証情報はお手元のPCから出ません。**ライセンスは Apache 2.0 で、無料で使えます。
 
 > チームや代理店向けの商用版（クラウド版と、ローカルで動く Agency 版）もご用意しています。詳しくは **[mureo.jp](https://mureo.jp)** をご覧ください。
 
@@ -36,7 +36,7 @@ Claude Code、Cursor、Codex、Gemini で動きます。mureo は各広告プラ
 
 mureo は、**AI 広告運用のための、ローカルで動く制御基盤（control plane）** です。インストールすると、AIエージェント（Claude Code、Cursor、Codex、Geminiなど）が Google 広告、Meta 広告、TikTok 広告、Search Console、GA4 を *mureo を経由して* 操作できるようになります。すべての判断はあなたの事業戦略に基づき、実際の成果に紐づき、後から再生できる監査ログに残ります。
 
-各広告プラットフォームの公式 MCP（Meta Ads MCP や Google Ads MCP など）が出揃うと、mureo はそれらをドライバとして利用します。mureo の価値は API 接続そのものではなく、**その周辺で起きること**にあります。
+mureo は Google 広告、Meta 広告、Search Console の接続を自前で同梱しており、各プラットフォームが公式 MCP を公開すればそれをドライバとして利用します（TikTok の公式 MCP には対応済みです）。mureo の価値は API 接続そのものではなく、**その周辺で起きること**にあります。
 
 - **戦略準拠**：すべての判断が `STRATEGY.md`（ペルソナ、USP、ブランドボイス、目標）を読み込む
 - **セーフティゲート**：rollback allow-list、GAQL ガード、BYOD は既定で read-only、認証情報ガード、プラットフォーム別スロットリング
@@ -47,7 +47,7 @@ mureo は、**AI 広告運用のための、ローカルで動く制御基盤（
 
 ## クイックスタート（2分で動きを見る）
 
-**デモシナリオ**は合成データで動くため、広告アカウントの認証情報も、OAuth も、サインアップも要りません。
+必要なのは Python 3.10 以上と [Claude Code](https://claude.com/claude-code) だけです（Cursor、Codex CLI、Gemini CLI でも動きます。詳しくは[そのほかのエージェントとホスト](#そのほかのエージェントとホスト)）。**デモシナリオ**は合成データで動くため、広告アカウントの認証情報も、OAuth も、サインアップも要りません。
 
 ```bash
 pip install mureo
@@ -56,7 +56,7 @@ mureo configure
 
 `mureo configure` はローカル（`127.0.0.1` にバインド。外部からはアクセス不可）にブラウザ UI を起動します。Claude アプリを選び、1クリックの基本セットアップを実行したら、Demo / BYOD セクションで**デモシナリオ**を選んでください。UI にはプラットフォーム接続（OAuth）の項目もありますが、**ここでは飛ばして構いません**。デモに認証情報は不要です。（ターミナルでは `mureo setup claude-code --skip-auth && mureo demo init --scenario seasonality-trap` で同じことができます。）
 
-生成されたデモディレクトリを Claude Code で開いて、こう聞いてください。
+生成されたデモディレクトリ（パスは UI に表示されます）を Claude Code で開いて、こう聞いてください。
 
 ```
 /daily-check

--- a/README.ja.md
+++ b/README.ja.md
@@ -22,7 +22,7 @@
 
 _お手元のPCで完結。戦略に基づく。安全に運用。_
 
-Claude Code、Cursor、Codex、Gemini で動きます。mureo は各広告プラットフォームの公式 [MCP](https://modelcontextprotocol.io/) の上に乗り、AI に、守るべき戦略と、測るべき成果と、誰にでも見せられる監査証跡を持たせます。**認証情報はお手元のPCから出ません。**ライセンスは Apache 2.0 で、無料で使えます。
+Claude Code、Cursor、Codex、Gemini で動きます。mureo は各広告プラットフォームの公式 [MCP](https://modelcontextprotocol.io/) の上に乗り、AI に、守るべき戦略と、測るべき成果と、誰にでも見せられる監査証跡を持たせます。**認証情報はお手元のPCから出ません。**
 
 > チームや代理店向けの商用版（クラウド版と、ローカルで動く Agency 版）もご用意しています。詳しくは **[mureo.jp](https://mureo.jp)** をご覧ください。
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -73,8 +73,10 @@ mureo configure
 ```bash
 mureo byod import ~/Downloads/mureo-google-ads.xlsx
 mureo byod import ~/Downloads/mureo-meta-ads.xlsx   # 媒体は互いに独立。片方だけでも、後から追加でも可
-# Claude Code を開いて「/daily-check を実行して」と聞く
+# Claude Code を開いて /onboard を実行し、続けて /daily-check
 ```
+
+最初に `/onboard` を一度実行すると、対話形式で `STRATEGY.md`（戦略）と `STATE.json`（状態）が生成されます。以降のコマンドはすべてこの戦略を読んで動きます。デモでこの手順が要らないのは、デモに `STRATEGY.md` が同梱されているためです。
 
 XLSX の生成は媒体ごとに一回だけのセットアップです。Google Ads は Apps Script テンプレートで約5分、Meta Ads は広告マネージャの保存済みレポートから2クリックで書き出せます（9言語のUIに対応しているため、広告マネージャを英語に切り替える必要はありません）。**[BYOD ガイド →](docs/byod.ja.md)**
 
@@ -87,6 +89,8 @@ mureo を Google Ads / Meta Ads API に直接接続します。実際に変更�
 同じ `mureo configure` の UI で「プラットフォーム接続」を開くと、各コンソールへのディープリンク付きで Google / Meta の OAuth をブラウザ内で完了でき、公式 MCP プロバイダの登録もできます。（ターミナルでは `mureo auth setup` で同じことができます。）**[認証ガイド →](docs/authentication.md)**
 
 前提として、Google Ads の Developer Token と OAuth クライアント、Meta の App ID と Secret が必要です（開発モードのままで構いません）。取得手順もウィザードが案内します。
+
+接続できたら、運用に使うディレクトリを Claude Code で開き、最初に `/onboard` を一度実行して `STRATEGY.md`（戦略）と `STATE.json`（状態）を生成してください。戦略に基づく運用は、この2つのファイルがあって初めて動きます。
 
 > **Google Cloud Console や Meta for Developers に慣れていない方へ。** OAuth フローや Developer Token の発行は、これらのコンソールを使ったことがない方には難しく感じるかもしれません。**まずはデモか BYOD から始めてください。**数分で mureo がどう動くかが分かるので、Live API のセットアップに踏み込むかどうかはそれから判断すれば大丈夫です。
 
@@ -152,7 +156,7 @@ Google広告、Meta広告、TikTok広告、Search Console、GA4を1つのワー�
 エージェントの分析を修正したり、運用で気づいたことを `/learn` でナレッジベースに保存できます。保存した知識は次回以降のセッションで自動的に読み込まれるため、同じ間違いを繰り返しません。1つのキャンペーンで得た知見が、アカウント内の似た状況にも活かされます。
 
 ```
-あなた: 「それは本当のCPA悪化じゃない。この業界はGW期間は毎年こうなる」
+あなた: /learn それは本当のCPA悪化じゃない。この業界はGW期間は毎年こうなる
 エージェント: 保存します。次回同じパターンを検知したら季節要因として報告します。
 
 → ナレッジベースに記録

--- a/README.ja.md
+++ b/README.ja.md
@@ -82,7 +82,7 @@ BYOD は**設計上、読み取り専用**です。すべての変更系ツー�
 
 ### 本番のアカウントに接続する（Live API OAuth、全機能）
 
-mureo を Google Ads / Meta Ads API に直接接続します。実際に変更を実行する場合（`/rescue`、`/budget-rebalance`、`/creative-refresh`、rollback）と、GA4 / Search Console を使う場合はこちらが必須です。
+mureo を Google Ads / Meta Ads API に直接接続します。実際に変更を実行する場合（`/rescue`、`/budget-rebalance`、`/creative-refresh` の実行や、`rollback_apply` ツールによるロールバックの適用）と、GA4 / Search Console を使う場合はこちらが必須です。
 
 同じ `mureo configure` の UI で「プラットフォーム接続」を開くと、各コンソールへのディープリンク付きで Google / Meta の OAuth をブラウザ内で完了でき、公式 MCP プロバイダの登録もできます。（ターミナルでは `mureo auth setup` で同じことができます。）**[認証ガイド →](docs/authentication.md)**
 

--- a/README.md
+++ b/README.md
@@ -73,8 +73,10 @@ When you're ready to point mureo at *your* data, pick one of the two paths below
 ```bash
 mureo byod import ~/Downloads/mureo-google-ads.xlsx
 mureo byod import ~/Downloads/mureo-meta-ads.xlsx   # platforms are independent — add either, or both
-# Open Claude Code and ask: "Run /daily-check"
+# Open Claude Code, run /onboard once, then: "Run /daily-check"
 ```
+
+The first `/onboard` run interviews you and generates `STRATEGY.md` (your strategy) and `STATE.json` (state) — the context every later command reads. The demo skips this step because it ships with a ready-made `STRATEGY.md`.
 
 Producing the XLSX is a one-time setup per platform — Google Ads via an Apps Script template (~5 min), Meta Ads via a 2-click Saved Report export (recognized in 9 languages). **[BYOD guide →](docs/byod.md)**
 
@@ -87,6 +89,8 @@ Connect mureo directly to the Google Ads / Meta Ads APIs. Required to actually e
 In the same `mureo configure` UI, open **Connect platforms**: interactive Google / Meta OAuth in the browser, with each field deep-linking to the right console page, plus official-MCP provider registration. (Terminal equivalent: `mureo auth setup`.) **[Authentication guide →](docs/authentication.md)**
 
 Prerequisites: a Google Ads Developer Token + OAuth Client, and/or a Meta App ID + Secret (development mode is fine). Both wizards walk you through obtaining them.
+
+Once connected, open your working directory in Claude Code and run `/onboard` once — it generates `STRATEGY.md` and `STATE.json`, and commands become strategy-grounded only after those exist.
 
 > **Not familiar with Google Cloud Console or Meta for Developers?** OAuth flows and developer-token registration can feel intimidating. **Start with the demo or BYOD** — see what mureo can do in minutes, then decide whether the Live API path is worth setting up.
 
@@ -156,7 +160,7 @@ Campaign diagnostics that pinpoint *why* ads aren't delivering -- budget constra
 When you correct the agent or share an operational insight, `/learn` saves it to a persistent knowledge base. That knowledge is loaded at the start of every future session, so the agent doesn't repeat the same mistakes and applies what it learned to similar situations across your account.
 
 ```
-You: "That's not a real CPA spike -- this industry always dips in Golden Week."
+You: /learn That's not a real CPA spike -- this industry always dips in Golden Week.
 Agent: Saved. I'll flag this as seasonal next time.
 
 → Written to the diagnostic knowledge base.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ BYOD is **read-only by construction**: every mutation tool returns `{"status": "
 
 ### Path B: Go live (OAuth) — full functionality
 
-Connect mureo directly to the Google Ads / Meta Ads APIs. Required to actually execute changes (`/rescue`, `/budget-rebalance`, `/creative-refresh`, rollback) and for GA4 / Search Console support.
+Connect mureo directly to the Google Ads / Meta Ads APIs. Required to actually execute changes (running `/rescue`, `/budget-rebalance`, `/creative-refresh`, or applying a rollback via the `rollback_apply` tool) and for GA4 / Search Console support.
 
 In the same `mureo configure` UI, open **Connect platforms**: interactive Google / Meta OAuth in the browser, with each field deep-linking to the right console page, plus official-MCP provider registration. (Terminal equivalent: `mureo auth setup`.) **[Authentication guide →](docs/authentication.md)**
 

--- a/README.md
+++ b/README.md
@@ -47,14 +47,14 @@ When official ad-platform MCPs ship (Meta Ads MCP, Google Ads MCP, etc.), mureo 
 
 ## Quick start — see it work in 2 minutes
 
-No ad-account credentials, no OAuth, no sign-up:
+The **demo scenario** runs on synthetic data, so it needs no ad-account credentials, no OAuth, and no sign-up:
 
 ```bash
 pip install mureo
 mureo configure
 ```
 
-`mureo configure` opens a local browser UI (bound to `127.0.0.1`, no remote access) that walks you through everything without pasting a single secret into a terminal: pick your Claude app, run the one-click basic setup, and scaffold a synthetic **demo scenario** from the same dashboard. (Terminal equivalent: `mureo setup claude-code --skip-auth && mureo demo init --scenario seasonality-trap`.)
+`mureo configure` opens a local browser UI (bound to `127.0.0.1`, no remote access). Pick your Claude app, run the one-click basic setup, and then choose a **demo scenario** in the Demo / BYOD section. The UI also offers a platform-connection (OAuth) step — **skip it for now**; the demo doesn't need it. (Terminal equivalent: `mureo setup claude-code --skip-auth && mureo demo init --scenario seasonality-trap`.)
 
 Then open the generated demo directory in Claude Code and ask:
 

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@
 
 _Local-first. Strategy-grounded. Safety-gated._
 
-Works with Claude Code, Cursor, Codex & Gemini. mureo sits on top of the official ad-platform [MCPs](https://modelcontextprotocol.io/) and gives your AI a strategy to follow, an outcome to be measured against, and an audit trail you can show to anyone — **credentials never leave your machine**. Apache 2.0, free to use.
+Works with Claude Code, Cursor, Codex & Gemini. mureo sits on top of the official ad-platform [MCPs](https://modelcontextprotocol.io/) and gives your AI a strategy to follow, an outcome to be measured against, and an audit trail you can show to anyone — **credentials never leave your machine**.
 
-> Commercial editions are also available — including a cloud-hosted service and a local Agency edition for teams and agencies. See **[mureo.jp](https://mureo.jp)** (site in Japanese).
+> Commercial editions are also available — including a cloud-hosted service and a local Agency edition for teams and agencies. See **[mureo.jp](https://mureo.jp)**.
 
 <p align="center">
   <img src="docs/img/sample-search-term-cleanup.svg" alt="mureo /search-term-cleanup output: brand self-cannibalization detected — same brand term converts at ¥4,550 CPA in one campaign vs ¥31,800 wasted in another, ~¥250,000/30d redirectable">

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@
   <a href="https://github.com/logly/mureo/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/logly/mureo/actions/workflows/ci.yml/badge.svg"></a>
 </p>
 
-**mureo** — your local-first AI ad ops crew. Find waste, audit changes, run ad accounts safely.
+**mureo** — your open-source, local-first AI ad ops crew. Find waste, audit changes, run ad accounts safely.
 
 _Local-first. Strategy-grounded. Safety-gated._
 
-Works with Claude Code, Cursor, Codex & Gemini. mureo sits on top of the official ad-platform MCPs and gives your AI a strategy to follow, an outcome to be measured against, and an audit trail you can show to anyone — **credentials never leave your machine**.
+Works with Claude Code, Cursor, Codex & Gemini. mureo sits on top of the official ad-platform [MCPs](https://modelcontextprotocol.io/) and gives your AI a strategy to follow, an outcome to be measured against, and an audit trail you can show to anyone — **credentials never leave your machine**. Apache 2.0, free to use.
 
-> Commercial editions are also available — including a cloud-hosted service and a local Agency edition for teams and agencies. See **[mureo.jp](https://mureo.jp)**.
+> Commercial editions are also available — including a cloud-hosted service and a local Agency edition for teams and agencies. See **[mureo.jp](https://mureo.jp)** (site in Japanese).
 
 <p align="center">
   <img src="docs/img/sample-search-term-cleanup.svg" alt="mureo /search-term-cleanup output: brand self-cannibalization detected — same brand term converts at ¥4,550 CPA in one campaign vs ¥31,800 wasted in another, ~¥250,000/30d redirectable">
@@ -36,7 +36,7 @@ Works with Claude Code, Cursor, Codex & Gemini. mureo sits on top of the officia
 
 mureo is a **local-first control plane for AI ad ops**. Once installed, AI agents (Claude Code, Cursor, Codex, Gemini, etc.) operate Google Ads, Meta Ads, TikTok Ads, Search Console, and GA4 *through mureo* — which keeps every action grounded in your business strategy, tied to real outcomes, and recorded in an audit log you can replay.
 
-When official ad-platform MCPs ship (Meta Ads MCP, Google Ads MCP, etc.), mureo uses them as drivers. mureo's value is not the API connection — it is **what happens around it**:
+mureo ships its own connectors for Google Ads, Meta Ads, and Search Console today, and plugs in official ad-platform MCPs as platforms release them (TikTok's is already supported). mureo's value is not the API connection — it is **what happens around it**:
 
 - **Strategy-grounded** — every decision reads `STRATEGY.md` (persona, USP, brand voice, goals)
 - **Safety-gated** — rollback allow-list, GAQL guards, BYOD read-only by default, credential guard, per-platform throttle
@@ -47,7 +47,7 @@ When official ad-platform MCPs ship (Meta Ads MCP, Google Ads MCP, etc.), mureo 
 
 ## Quick start — see it work in 2 minutes
 
-The **demo scenario** runs on synthetic data, so it needs no ad-account credentials, no OAuth, and no sign-up:
+All you need is Python 3.10+ and [Claude Code](https://claude.com/claude-code) (Cursor, Codex CLI, and Gemini CLI work too — see [Other agents and hosts](#other-agents-and-hosts)). The **demo scenario** runs on synthetic data, so it needs no ad-account credentials, no OAuth, and no sign-up:
 
 ```bash
 pip install mureo
@@ -56,7 +56,7 @@ mureo configure
 
 `mureo configure` opens a local browser UI (bound to `127.0.0.1`, no remote access). Pick your Claude app, run the one-click basic setup, and then choose a **demo scenario** in the Demo / BYOD section. The UI also offers a platform-connection (OAuth) step — **skip it for now**; the demo doesn't need it. (Terminal equivalent: `mureo setup claude-code --skip-auth && mureo demo init --scenario seasonality-trap`.)
 
-Then open the generated demo directory in Claude Code and ask:
+Then open the generated demo directory (the UI shows its path) in Claude Code and ask:
 
 ```
 /daily-check


### PR DESCRIPTION
Quick-start and feature-section fixes from a Japanese read-through, both languages unless noted:

## 1. The "no credentials" promise contradicted the configure UI

The quick start promises "no ad-account credentials, no OAuth, no sign-up" and then points at `mureo configure` — whose UI also offers a platform-connection (OAuth) step. Both READMEs now say: pick a **demo scenario** in the Demo / BYOD section and **skip** the platform-connection step.

## 2. 道A / 道B read awkwardly (Japanese only)

Replaced with plain descriptive headings: まず自分のデータで試す（BYOD） / 本番のアカウントに接続する（Live API）.

## 3. rollback looked like a slash command with a missing slash

It is not a slash command — clarified as "applying a rollback via the `rollback_apply` tool".

## 4. The /onboard step was missing from the BYOD and Live paths

The restructure dropped the old getting-started block's `/onboard` step, so readers were sent straight to `/daily-check` without the STRATEGY.md / STATE.json that strategy-grounded operation requires. Each path now ends with running `/onboard` once, with a note that the demo skips it because it ships its own STRATEGY.md.

## 5. The /learn example never showed the command

The dialogue example now starts with `/learn <insight>` so readers see how to actually invoke it.

Docs-only change (per AGENTS.md, visual review sufficient).