### PR TITLE
fix: stop the CLI importing Google SDKs eagerly, add a quickstart smoke

### DIFF
--- a/.github/workflows/quickstart-smoke.yml
+++ b/.github/workflows/quickstart-smoke.yml
@@ -1,0 +1,89 @@
+# Quickstart smoke test (#488).
+#
+# The README leads with a no-credentials quickstart — pip install, `mureo
+# setup claude-code --skip-auth`, `mureo demo init` — and that path is the
+# funnel entry for every first-time user. Nothing else guards it: the unit
+# suite mocks the filesystem and never installs the wheel, so a broken
+# console entry point, a setup step that writes nowhere, or a demo bundle
+# that stops importing would be reported by strangers rather than by CI.
+#
+# Every step also asserts its output is free of FutureWarning /
+# DeprecationWarning / Traceback. That is #486 concretely: two
+# google-api-core FutureWarning blocks printed before any mureo output, on
+# every command, under Python 3.10.
+#
+# All of the logic lives in scripts/quickstart_smoke.sh so a developer can
+# reproduce a red run locally with one command. This workflow only picks the
+# interpreter and what to install.
+#
+# Scope: ubuntu-latest only for now. The script is POSIX-shell and runs fine
+# on macOS (it was developed there), but a macOS matrix leg is deliberately
+# out of scope until there is evidence of a platform-specific quickstart
+# break — ci.yml already carries the Windows compat tripwire.
+name: Quickstart smoke
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  # Weekly PyPI variant: catches breakage that only shows up in the
+  # published wheel (missing package data, a bad dependency pin) or in a
+  # dependency that moved under us, neither of which a checkout install sees.
+  schedule:
+    - cron: "17 6 * * 1" # Mondays 06:17 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  # The checkout under test — the gate that runs on every PR.
+  from-checkout:
+    if: github.event_name != 'schedule'
+    name: quickstart (checkout, py${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        # 3.10 is the supported floor (and the interpreter #486 reproduced
+        # on); 3.12 is the recommended current version.
+        python-version: ["3.10", "3.12"]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Run quickstart smoke
+        env:
+          MUREO_SMOKE_PYTHON: python
+          # Defaults to this checkout. The script builds its own venv and
+          # its own sandbox HOME under this directory, so nothing it does
+          # can touch the runner's real home.
+          MUREO_SMOKE_WORKDIR: ${{ runner.temp }}/quickstart-smoke
+        run: bash scripts/quickstart_smoke.sh
+
+  # The published wheel — same assertions, installed from PyPI.
+  from-pypi:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    name: quickstart (PyPI, py${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.12"]
+    steps:
+      # Checked out for scripts/quickstart_smoke.sh only — the package
+      # under test is the one pip pulls from PyPI.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Run quickstart smoke against the published wheel
+        env:
+          MUREO_SMOKE_PYTHON: python
+          MUREO_SMOKE_INSTALL_SPEC: mureo
+          MUREO_SMOKE_WORKDIR: ${{ runner.temp }}/quickstart-smoke
+        run: bash scripts/quickstart_smoke.sh

--- a/mureo/auth.py
+++ b/mureo/auth.py
@@ -2,6 +2,17 @@
 
 Load Google Ads / Meta Ads credentials from ~/.mureo/credentials.json.
 Falls back to environment variables if the file does not exist.
+
+Platform SDKs are imported lazily, inside the ``create_*_client``
+factories (#486). This module sits on the CLI startup path — ``mureo.cli.main``
+imports ``mureo.cli.auth_cmd``, which imports this module — so a module-scope
+``from google.ads.googleads.client import ...`` made *every* command pay for
+the Google Ads SDK, including ``--help``, ``demo init`` and ``byod status``,
+which never talk to Google. On Python 3.10 that SDK also prints two
+``FutureWarning`` blocks from ``google.api_core`` at import time, so the very
+first thing a new user saw after ``pip install mureo`` was four lines of
+vendor warning noise. Credential *loading* needs no SDK; only client
+*construction* does. Guarded by ``tests/test_cli_import_hygiene.py``.
 """
 
 from __future__ import annotations
@@ -16,15 +27,14 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import httpx
-from google.oauth2.credentials import Credentials
 
 from mureo.core.secret_store import FilesystemSecretStore, SecretStore
 from mureo.fsutil import file_lock, lock_path_for
-from mureo.google_ads import GoogleAdsApiClient
-from mureo.meta_ads import MetaAdsApiClient
-from mureo.search_console import SearchConsoleApiClient
 
 if TYPE_CHECKING:
+    from mureo.google_ads import GoogleAdsApiClient
+    from mureo.meta_ads import MetaAdsApiClient
+    from mureo.search_console import SearchConsoleApiClient
     from mureo.throttle import Throttler
 
 logger = logging.getLogger(__name__)
@@ -207,6 +217,13 @@ def create_google_ads_client(
     Returns:
         GoogleAdsApiClient instance
     """
+    # Lazy import (#486): keeps the Google Ads SDK — and the two
+    # google.api_core FutureWarnings it prints on Python 3.10 — off the CLI
+    # startup path for every command that never builds a Google client.
+    from google.oauth2.credentials import Credentials
+
+    from mureo.google_ads import GoogleAdsApiClient
+
     oauth_credentials = Credentials(  # type: ignore[no-untyped-call]
         token=None,
         refresh_token=credentials.refresh_token,
@@ -240,6 +257,11 @@ def create_search_console_client(
     Returns:
         SearchConsoleApiClient instance
     """
+    # Lazy import (#486) — see create_google_ads_client.
+    from google.oauth2.credentials import Credentials
+
+    from mureo.search_console import SearchConsoleApiClient
+
     oauth_credentials = Credentials(  # type: ignore[no-untyped-call]
         token=None,
         refresh_token=credentials.refresh_token,
@@ -272,6 +294,11 @@ def create_meta_ads_client(
     Returns:
         MetaAdsApiClient instance
     """
+    # Lazy import (#486) — the Meta SDK is not a warning source, but keeping
+    # all three factories symmetrical means no platform SDK loads at CLI
+    # startup, and the import-hygiene guard stays a single simple assertion.
+    from mureo.meta_ads import MetaAdsApiClient
+
     return MetaAdsApiClient(
         access_token=credentials.access_token,
         ad_account_id=account_id,

--- a/mureo/auth_setup.py
+++ b/mureo/auth_setup.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import contextlib
 import html
 import http.server
+import importlib
 import json
 import logging
 import secrets
@@ -27,10 +28,9 @@ except ImportError:  # pragma: no cover - Windows (Unix-only stdlib)
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import httpx
-from google_auth_oauthlib.flow import Flow, InstalledAppFlow
 
 from mureo import credential_guard
 from mureo.auth import GoogleAdsCredentials, MetaAdsCredentials
@@ -41,23 +41,74 @@ from mureo.auth import GoogleAdsCredentials, MetaAdsCredentials
 from mureo.core.terminal import terminal_fd as _terminal_fd
 from mureo.fsutil import backup_file, file_lock, lock_path_for
 
-# Backward-compat re-exports of the platform-level account-discovery
-# helpers that used to live in this module. The canonical homes are
-# now :mod:`mureo.google_ads.accounts` and :mod:`mureo.meta_ads.accounts`
-# (public-API surface for configure-wizard tooling and third-party
-# setup utilities). The legacy import paths
-# ``mureo.auth_setup.list_accessible_accounts`` /
-# ``mureo.auth_setup.list_meta_ad_accounts`` remain stable via these
-# aliases — existing callers do not need to change.
-#
-# ``as <same-name>`` is the PEP 484 explicit-re-export form mypy --strict
-# requires before a downstream module can import the symbol back out.
-from mureo.google_ads.accounts import (
-    list_accessible_accounts as list_accessible_accounts,
-)
-from mureo.meta_ads.accounts import list_meta_ad_accounts as list_meta_ad_accounts
+if TYPE_CHECKING:
+    from google_auth_oauthlib.flow import Flow
+
+    # Typed views of the lazily-resolved re-exports below. ``as <same-name>``
+    # is the PEP 484 explicit-re-export form mypy --strict requires before a
+    # downstream module can import the symbol back out.
+    from mureo.google_ads.accounts import (
+        list_accessible_accounts as list_accessible_accounts,
+    )
+    from mureo.meta_ads.accounts import (
+        list_meta_ad_accounts as list_meta_ad_accounts,
+    )
 
 logger = logging.getLogger(__name__)
+
+# Backward-compat re-exports of the platform-level account-discovery helpers
+# that used to live in this module. The canonical homes are
+# :mod:`mureo.google_ads.accounts` and :mod:`mureo.meta_ads.accounts`; the
+# legacy paths ``mureo.auth_setup.list_accessible_accounts`` /
+# ``mureo.auth_setup.list_meta_ad_accounts`` stay stable via the module-level
+# ``__getattr__`` below (PEP 562), including for ``monkeypatch.setattr`` and
+# ``unittest.mock.patch``, which both getattr-then-setattr the module. The two
+# in-module call sites go through :func:`_reexport` rather than importing from
+# the source module, so those legacy patch targets keep intercepting the
+# wizards — see that helper's docstring.
+#
+# They are resolved on first access rather than at import time (#486): they
+# live in packages whose ``__init__`` loads the Google Ads SDK, and this
+# module is on the startup path of ``mureo setup <agent> --skip-auth`` (for
+# ``install_mcp_config`` / ``install_credential_guard``, neither of which
+# touches Google). Under Python 3.10 that eager chain printed two
+# ``google.api_core`` FutureWarnings in the middle of the setup output.
+_LAZY_REEXPORTS = {
+    "list_accessible_accounts": "mureo.google_ads.accounts",
+    "list_meta_ad_accounts": "mureo.meta_ads.accounts",
+}
+
+
+def __getattr__(name: str) -> Any:
+    """Resolve the deferred account-listing re-exports on first access."""
+    module_name = _LAZY_REEXPORTS.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    return getattr(importlib.import_module(module_name), name)
+
+
+def _reexport(name: str) -> Any:
+    """Return the *current* binding of a deferred re-export.
+
+    Resolved through this module's attribute lookup — deliberately NOT via a
+    function-local ``from mureo.<platform>.accounts import ...``. Both stay
+    lazy, but only attribute lookup preserves the backward-compat promise:
+
+    - unpatched, the name is not in the module ``__dict__``, so lookup falls
+      through to :func:`__getattr__` and imports the canonical function on
+      demand (the #486 laziness);
+    - patched, ``mock.patch`` / ``monkeypatch.setattr`` have setattr'd a real
+      module attribute, which shadows ``__getattr__`` — so the long-documented
+      ``patch("mureo.auth_setup.list_accessible_accounts")`` target intercepts
+      the wizard again.
+
+    A function-local source import silently defeats the second case: the patch
+    rebinds an attribute nobody reads and the real networked function runs
+    while the mock reports zero calls. Guarded by the behavioural tests in
+    ``tests/test_public_account_listing.py``.
+    """
+    return getattr(sys.modules[__name__], name)
+
 
 _GOOGLE_ADS_SCOPE = "https://www.googleapis.com/auth/adwords"
 _SEARCH_CONSOLE_SCOPE = "https://www.googleapis.com/auth/webmasters"
@@ -365,6 +416,11 @@ def build_google_flow(
     Both variants receive the same scopes so a single refresh_token
     drives both Google Ads and Search Console.
     """
+    # Lazy import (#486): google-auth-oauthlib pulls google.auth /
+    # google.oauth2 in, and this module is imported by
+    # ``mureo setup <agent> --skip-auth``, which never runs an OAuth flow.
+    from google_auth_oauthlib.flow import Flow, InstalledAppFlow
+
     config = build_google_client_config(client_id, client_secret)
     if redirect_uri is None:
         return InstalledAppFlow.from_client_config(config, scopes=_GOOGLE_SCOPES)
@@ -935,7 +991,7 @@ async def setup_google_ads(
         refresh_token=oauth_result.refresh_token,
     )
 
-    accounts = await list_accessible_accounts(temp_creds)
+    accounts = await _reexport("list_accessible_accounts")(temp_creds)
 
     selected_id: str | None = None
     login_customer_id: str | None = None
@@ -1315,7 +1371,9 @@ async def setup_meta_ads(
 
     # Retrieve ad account list
     print("\nRetrieving ad account list...")
-    accounts = await list_meta_ad_accounts(access_token=oauth_result.access_token)
+    accounts = await _reexport("list_meta_ad_accounts")(
+        access_token=oauth_result.access_token
+    )
 
     if not accounts:
         raise RuntimeError(

--- a/mureo/cli/web_auth.py
+++ b/mureo/cli/web_auth.py
@@ -39,6 +39,7 @@ import http.server
 import logging
 import secrets as _secrets
 import socketserver
+import sys
 import threading
 import urllib.parse
 from dataclasses import dataclass, field
@@ -51,8 +52,6 @@ from mureo.auth_setup import (
     exchange_google_code,
     exchange_meta_code,
     google_auth_url,
-    list_accessible_accounts,
-    list_meta_ad_accounts,
     save_credentials,
 )
 from mureo.core.secret_store import FilesystemSecretStore
@@ -62,7 +61,53 @@ if TYPE_CHECKING:
     from collections.abc import Coroutine
     from pathlib import Path
 
+    # Typed views of the deferred re-exports resolved by ``__getattr__``.
+    from mureo.google_ads.accounts import (
+        list_accessible_accounts as list_accessible_accounts,
+    )
+    from mureo.meta_ads.accounts import (
+        list_meta_ad_accounts as list_meta_ad_accounts,
+    )
+
 logger = logging.getLogger(__name__)
+
+#: Account-listing helpers this module exposes as patchable attributes.
+#:
+#: Importing them at module scope would defeat #486: they live in packages
+#: whose ``__init__`` loads the Google Ads SDK, and ``mureo configure``
+#: imports this module at startup. Note that a top-level ``from
+#: mureo.auth_setup import list_accessible_accounts`` is NOT lazy either — it
+#: *triggers* that module's ``__getattr__`` at import time.
+#:
+#: They stay real module attributes for ``patch("mureo.cli.web_auth.<name>")``
+#: (six existing tests rely on it, one of which asserts the probe is NOT
+#: called and would silently pass if the patch were bypassed) — see
+#: :func:`_reexport`.
+_LAZY_REEXPORTS = ("list_accessible_accounts", "list_meta_ad_accounts")
+
+
+def __getattr__(name: str) -> Any:
+    """Resolve the deferred account-listing re-exports on first access."""
+    if name not in _LAZY_REEXPORTS:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    from mureo import auth_setup
+
+    # ``mureo.auth_setup`` owns the module map; going through it keeps a
+    # single source of truth for where each helper actually lives.
+    return getattr(auth_setup, name)
+
+
+def _reexport(name: str) -> Any:
+    """Return the *current* binding of a deferred re-export.
+
+    Resolved through this module's attribute lookup, never a function-local
+    source import: unpatched it falls through to :func:`__getattr__` (still
+    lazy), while a patched module attribute shadows ``__getattr__`` so
+    ``patch("mureo.cli.web_auth.<name>")`` intercepts the probe. A
+    function-local import would silently bypass the patch and let the real
+    networked call run.
+    """
+    return getattr(sys.modules[__name__], name)
 
 
 # ---------------------------------------------------------------------------
@@ -751,7 +796,7 @@ class _WizardHandler(http.server.BaseHTTPRequestHandler):
             self.end_headers()
             return
         try:
-            accounts = _run_async(list_accessible_accounts(probe_creds))
+            accounts = _run_async(_reexport("list_accessible_accounts")(probe_creds))
         except Exception as exc:  # noqa: BLE001
             # Log only the exception class — the google-ads SDK
             # sometimes embeds request arguments (which could include
@@ -1001,7 +1046,7 @@ class _WizardHandler(http.server.BaseHTTPRequestHandler):
             self.end_headers()
             return
         try:
-            accounts = _run_async(list_meta_ad_accounts(access_token))
+            accounts = _run_async(_reexport("list_meta_ad_accounts")(access_token))
         except Exception as exc:  # noqa: BLE001
             # See Google-side comment above: don't emit the traceback
             # because it may contain the access_token in the request

--- a/scripts/quickstart_smoke.sh
+++ b/scripts/quickstart_smoke.sh
@@ -1,0 +1,279 @@
+#!/usr/bin/env bash
+#
+# Quickstart smoke test (#488) — run the README's no-credentials quickstart
+# end to end in a throwaway HOME and a throwaway virtualenv.
+#
+#   pip install mureo
+#   mureo setup claude-code --skip-auth
+#   mureo demo init --scenario seasonality-trap
+#
+# That path is the funnel entry for every first-time user, and nothing else
+# guards it: a broken console entry point, a setup step that writes nowhere,
+# or a demo bundle that stops importing would be reported by strangers rather
+# than by CI. Every step is also asserted to be free of FutureWarning /
+# DeprecationWarning / Traceback, which is what #486 (the google-api-core
+# FutureWarnings printed on every command under Python 3.10) looked like.
+#
+# The script owns the whole rehearsal so a developer runs LOCALLY exactly what
+# .github/workflows/quickstart-smoke.yml runs in CI — the workflow only picks
+# the interpreter and the install spec.
+#
+# Environment:
+#   MUREO_SMOKE_PYTHON        Interpreter to build the venv from (default: python3)
+#   MUREO_SMOKE_INSTALL_SPEC  What to `pip install` (default: this checkout).
+#                             Set to `mureo` for the weekly PyPI-wheel variant.
+#   MUREO_SMOKE_WORKDIR       Scratch dir to use (default: a fresh mktemp -d).
+#   MUREO_SMOKE_KEEP          Set to 1 to keep an auto-created workdir even on
+#                             success (it is always kept on failure).
+#
+# Usage:
+#   scripts/quickstart_smoke.sh
+#   MUREO_SMOKE_INSTALL_SPEC=mureo scripts/quickstart_smoke.sh
+#
+# pipefail matters here: the assertion helpers pipe command output, and
+# without it a failure on the left of a pipe would be masked by a successful
+# grep/sed on the right.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PYTHON_BIN="${MUREO_SMOKE_PYTHON:-python3}"
+INSTALL_SPEC="${MUREO_SMOKE_INSTALL_SPEC:-$REPO_ROOT}"
+if [ -n "${MUREO_SMOKE_WORKDIR:-}" ]; then
+    WORK_DIR="$MUREO_SMOKE_WORKDIR"
+    OWNS_WORKDIR=0 # caller-supplied (CI): never remove it, the caller owns it
+else
+    WORK_DIR="$(mktemp -d)"
+    OWNS_WORKDIR=1
+fi
+
+SANDBOX_HOME="$WORK_DIR/home"
+VENV_DIR="$WORK_DIR/venv"
+WORKSPACE="$WORK_DIR/workspace"
+LOG_DIR="$WORK_DIR/logs"
+
+mkdir -p "$SANDBOX_HOME" "$WORKSPACE" "$LOG_DIR"
+
+# Clean up an auto-created workdir on SUCCESS only — a venv plus 25 installed
+# skills is not something to leave behind on every local run. On failure it is
+# kept deliberately: the captured step logs under $LOG_DIR and the sandbox
+# HOME are the evidence needed to debug. MUREO_SMOKE_KEEP=1 keeps it always.
+cleanup() {
+    cleanup_rc=$?
+    if [ "$cleanup_rc" -eq 0 ] &&
+        [ "$OWNS_WORKDIR" -eq 1 ] &&
+        [ "${MUREO_SMOKE_KEEP:-0}" != "1" ]; then
+        rm -rf "$WORK_DIR"
+    elif [ "$cleanup_rc" -ne 0 ]; then
+        echo "(workdir kept for debugging: $WORK_DIR)"
+    fi
+}
+trap cleanup EXIT
+
+# A fresh HOME is the whole point: `mureo setup` writes to ~/.claude.json,
+# ~/.claude/settings.json and ~/.claude/skills/, and `mureo demo init` writes
+# to ~/.mureo/byod/. Redirecting HOME keeps the developer's real Claude Code
+# config untouched and makes the assertions below meaningful.
+export HOME="$SANDBOX_HOME"
+# Do not let a developer's ~/.mureo overrides leak in through the env.
+unset MUREO_BYOD_DIR 2>/dev/null || true
+# Deterministic, parseable CLI output.
+export NO_COLOR=1
+# PYTHONWARNINGS is deliberately NOT forced to "default": this smoke asserts
+# what a real first-time user actually SEES, under Python's stock filters.
+# The stricter all-warnings-visible check (``python -W default``) lives in
+# tests/test_cli_import_hygiene.py, where it can be scoped to mureo's own
+# import path instead of every dependency's.
+
+MUREO_BIN="$VENV_DIR/bin/mureo"
+VENV_PYTHON="$VENV_DIR/bin/python"
+
+STEP_NO=0
+
+echo "=== mureo quickstart smoke ==="
+echo "  python      : $PYTHON_BIN"
+echo "  install spec: $INSTALL_SPEC"
+echo "  sandbox HOME: $HOME"
+echo "  workdir     : $WORK_DIR"
+echo ""
+
+fail() {
+    echo ""
+    echo "SMOKE FAILED: $1"
+    exit 1
+}
+
+# Markers that must never appear in a mureo command's own output. #486 is
+# exactly the FutureWarning case: two google-api-core blocks printed before
+# any mureo output, on every command, under Python 3.10.
+NOISE_MARKERS="FutureWarning DeprecationWarning Traceback"
+
+# Run a command, capture stdout+stderr, and fail loudly on a non-zero exit or
+# (unless $1 is "--exit-only") on any noise marker in the output. Echoes the
+# captured output on failure so CI logs show the offending text, not just the
+# assertion.
+run_step() {
+    check_noise=1
+    if [ "$1" = "--exit-only" ]; then
+        check_noise=0
+        shift
+    fi
+    step_label="$1"
+    shift
+    STEP_NO=$((STEP_NO + 1))
+    step_log="$LOG_DIR/$(printf '%02d' "$STEP_NO").log"
+
+    echo "--- step $STEP_NO: $step_label"
+    set +e
+    "$@" >"$step_log" 2>&1
+    step_rc=$?
+    set -e
+
+    if [ "$step_rc" -ne 0 ]; then
+        echo "    exit code: $step_rc (expected 0)"
+        echo "    --- captured output ---"
+        sed 's/^/    /' "$step_log"
+        fail "$step_label exited $step_rc"
+    fi
+
+    if [ "$check_noise" -eq 1 ]; then
+        for marker in $NOISE_MARKERS; do
+            if grep -q "$marker" "$step_log"; then
+                echo "    --- captured output ---"
+                sed 's/^/    /' "$step_log"
+                fail "$step_label emitted '$marker' (see output above)"
+            fi
+        done
+        echo "    ok (exit 0, output free of: $NOISE_MARKERS)"
+    else
+        echo "    ok (exit 0)"
+    fi
+
+    LAST_LOG="$step_log"
+}
+
+assert_file() {
+    if [ ! -f "$1" ]; then
+        echo "    contents of $(dirname "$1"):"
+        ls -la "$(dirname "$1")" 2>&1 | sed 's/^/      /' || true
+        fail "expected file is missing: $1"
+    fi
+    echo "    ok: $1"
+}
+
+assert_dir() {
+    if [ ! -d "$1" ]; then
+        fail "expected directory is missing: $1"
+    fi
+    echo "    ok: $1/"
+}
+
+# ---------------------------------------------------------------------------
+# 1. Fresh venv + install
+# ---------------------------------------------------------------------------
+"$PYTHON_BIN" -m venv "$VENV_DIR"
+# --exit-only: the noise gate is about MUREO's output. pip emits its own
+# internal DeprecationWarnings on some interpreter/pip combinations, and a
+# genuine install failure shows up as a non-zero exit anyway.
+run_step --exit-only "pip install $INSTALL_SPEC" \
+    "$VENV_PYTHON" -m pip install --disable-pip-version-check --quiet "$INSTALL_SPEC"
+
+if [ ! -x "$MUREO_BIN" ]; then
+    fail "console entry point was not installed at $MUREO_BIN"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. mureo --version (#487) — exit 0 and a single `mureo <version>` line
+# ---------------------------------------------------------------------------
+run_step "mureo --version" "$MUREO_BIN" --version
+version_out="$(tr -d '\r' <"$LAST_LOG" | sed '/^$/d')"
+if ! printf '%s' "$version_out" | grep -Eq '^mureo [0-9]+\.[0-9]+\.[0-9]+'; then
+    echo "    got: [$version_out]"
+    fail "mureo --version did not print a 'mureo <version>' line"
+fi
+echo "    ok: $version_out"
+
+# ---------------------------------------------------------------------------
+# 3. mureo setup claude-code --skip-auth — writes land under the sandbox HOME
+# ---------------------------------------------------------------------------
+run_step "mureo setup claude-code --skip-auth" \
+    "$MUREO_BIN" setup claude-code --skip-auth
+
+# ~/.claude.json root `mcpServers` is where Claude Code reads user-scope MCP
+# servers from (auth_setup._claude_user_config_path); ~/.claude/settings.json
+# carries the credential-guard hook; skills land in ~/.claude/skills/.
+assert_file "$HOME/.claude.json"
+assert_file "$HOME/.claude/settings.json"
+assert_dir "$HOME/.claude/skills"
+assert_file "$HOME/.claude/skills/daily-check/SKILL.md"
+assert_file "$HOME/.claude/skills/_mureo-shared/SKILL.md"
+
+"$VENV_PYTHON" -c '
+import json, os, sys
+
+home = os.environ["HOME"]
+with open(os.path.join(home, ".claude.json"), encoding="utf-8") as fh:
+    data = json.load(fh)
+servers = data.get("mcpServers", {})
+if "mureo" not in servers:
+    print("FAIL: ~/.claude.json has no mcpServers.mureo entry")
+    print(json.dumps(data, indent=2)[:2000])
+    sys.exit(1)
+print("    ok: ~/.claude.json registers mcpServers.mureo")
+
+with open(os.path.join(home, ".claude", "settings.json"), encoding="utf-8") as fh:
+    settings = json.load(fh)
+hooks = settings.get("hooks", {}).get("PreToolUse", [])
+if not hooks:
+    print("FAIL: ~/.claude/settings.json has no PreToolUse credential guard")
+    print(json.dumps(settings, indent=2)[:2000])
+    sys.exit(1)
+print("    ok: ~/.claude/settings.json installs the credential guard hook")
+' || fail "mureo setup claude-code --skip-auth did not write the expected config"
+
+# ---------------------------------------------------------------------------
+# 4. mureo demo init --scenario seasonality-trap
+# ---------------------------------------------------------------------------
+cd "$WORKSPACE"
+run_step "mureo demo init --scenario seasonality-trap" \
+    "$MUREO_BIN" demo init --scenario seasonality-trap
+
+DEMO_DIR="$WORKSPACE/mureo-demo"
+assert_dir "$DEMO_DIR"
+assert_file "$DEMO_DIR/STRATEGY.md"
+assert_file "$DEMO_DIR/STATE.json"
+assert_file "$DEMO_DIR/.mcp.json"
+assert_file "$DEMO_DIR/bundle.xlsx"
+assert_file "$DEMO_DIR/README.md"
+
+# The demo bundle round-trips through `mureo byod import`, so both demo
+# platforms must be registered in ~/.mureo/byod/manifest.json with their
+# CSV directories on disk — that is what puts the MCP tools in BYOD mode.
+assert_file "$HOME/.mureo/byod/manifest.json"
+"$VENV_PYTHON" -c '
+import json, os, sys
+
+home = os.environ["HOME"]
+byod = os.path.join(home, ".mureo", "byod")
+with open(os.path.join(byod, "manifest.json"), encoding="utf-8") as fh:
+    manifest = json.load(fh)
+platforms = manifest.get("platforms", {})
+missing = [p for p in ("google_ads", "meta_ads") if p not in platforms]
+if missing:
+    print("FAIL: manifest.json does not register %s" % ", ".join(missing))
+    print(json.dumps(manifest, indent=2)[:2000])
+    sys.exit(1)
+for p in ("google_ads", "meta_ads"):
+    if not os.path.isdir(os.path.join(byod, p)):
+        print("FAIL: manifest registers %s but %s/ is missing on disk" % (p, p))
+        sys.exit(1)
+print("    ok: byod/manifest.json registers google_ads + meta_ads")
+' || fail "mureo demo init did not register both BYOD platforms"
+
+# ---------------------------------------------------------------------------
+# 5. mureo byod status inside the demo workspace
+# ---------------------------------------------------------------------------
+cd "$DEMO_DIR"
+run_step "mureo byod status" "$MUREO_BIN" byod status
+
+echo ""
+echo "=== quickstart smoke PASSED ($STEP_NO steps) ==="

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -295,8 +295,11 @@ def test_create_google_ads_client() -> None:
     )
 
     with (
-        patch("mureo.auth.Credentials") as mock_cred_cls,
-        patch("mureo.auth.GoogleAdsApiClient") as mock_client_cls,
+        # Patched at the source module, not on ``mureo.auth``: the SDK is
+        # imported lazily inside the factory (#486) so it is never a
+        # ``mureo.auth`` module attribute.
+        patch("google.oauth2.credentials.Credentials") as mock_cred_cls,
+        patch("mureo.google_ads.GoogleAdsApiClient") as mock_client_cls,
     ):
         mock_cred_cls.return_value = MagicMock()
         mock_client_instance = MagicMock()
@@ -331,8 +334,11 @@ def test_create_google_ads_client_without_login_customer_id() -> None:
     )
 
     with (
-        patch("mureo.auth.Credentials") as mock_cred_cls,
-        patch("mureo.auth.GoogleAdsApiClient") as mock_client_cls,
+        # Patched at the source module, not on ``mureo.auth``: the SDK is
+        # imported lazily inside the factory (#486) so it is never a
+        # ``mureo.auth`` module attribute.
+        patch("google.oauth2.credentials.Credentials") as mock_cred_cls,
+        patch("mureo.google_ads.GoogleAdsApiClient") as mock_client_cls,
     ):
         mock_cred_cls.return_value = MagicMock()
         mock_client_cls.return_value = MagicMock()
@@ -361,7 +367,8 @@ def test_create_meta_ads_client() -> None:
         app_secret="secret456",
     )
 
-    with patch("mureo.auth.MetaAdsApiClient") as mock_client_cls:
+    # Source-module patch target — lazily imported inside the factory (#486).
+    with patch("mureo.meta_ads.MetaAdsApiClient") as mock_client_cls:
         mock_client_instance = MagicMock()
         mock_client_cls.return_value = mock_client_instance
 

--- a/tests/test_auth_setup.py
+++ b/tests/test_auth_setup.py
@@ -469,7 +469,7 @@ async def test_setup_google_ads_flow(tmp_path: Path) -> None:
             return_value=mock_oauth_result,
         ),
         patch(
-            "mureo.auth_setup.list_accessible_accounts",
+            "mureo.google_ads.accounts.list_accessible_accounts",
             new_callable=AsyncMock,
             return_value=mock_accounts,
         ),
@@ -517,7 +517,7 @@ async def test_setup_google_ads_flow_no_accounts(tmp_path: Path) -> None:
             return_value=mock_oauth_result,
         ),
         patch(
-            "mureo.auth_setup.list_accessible_accounts",
+            "mureo.google_ads.accounts.list_accessible_accounts",
             new_callable=AsyncMock,
             return_value=[],
         ),
@@ -579,7 +579,7 @@ async def test_setup_google_ads_flow_selects_mcc_child(tmp_path: Path) -> None:
             return_value=mock_oauth_result,
         ),
         patch(
-            "mureo.auth_setup.list_accessible_accounts",
+            "mureo.google_ads.accounts.list_accessible_accounts",
             new_callable=AsyncMock,
             return_value=mock_accounts,
         ),
@@ -616,7 +616,10 @@ async def test_run_google_oauth() -> None:
     mock_flow.run_local_server.return_value = mock_credentials
 
     with patch(
-        "mureo.auth_setup.InstalledAppFlow.from_client_config",
+        # Source-module patch target: InstalledAppFlow is imported lazily
+        # inside build_google_flow (#486), so it is never an attribute
+        # of mureo.auth_setup.
+        "google_auth_oauthlib.flow.InstalledAppFlow.from_client_config",
         return_value=mock_flow,
     ) as mock_from_config:
         result = await run_google_oauth(
@@ -657,7 +660,10 @@ async def test_run_google_oauth_no_refresh_token() -> None:
     mock_flow.run_local_server.return_value = mock_credentials
 
     with patch(
-        "mureo.auth_setup.InstalledAppFlow.from_client_config",
+        # Source-module patch target: InstalledAppFlow is imported lazily
+        # inside build_google_flow (#486), so it is never an attribute
+        # of mureo.auth_setup.
+        "google_auth_oauthlib.flow.InstalledAppFlow.from_client_config",
         return_value=mock_flow,
     ):
         with pytest.raises(RuntimeError, match="Failed to obtain refresh_token"):
@@ -842,7 +848,10 @@ async def test_run_google_oauth_flow_exception() -> None:
     mock_flow.run_local_server.side_effect = Exception("Cannot open browser")
 
     with patch(
-        "mureo.auth_setup.InstalledAppFlow.from_client_config",
+        # Source-module patch target: InstalledAppFlow is imported lazily
+        # inside build_google_flow (#486), so it is never an attribute
+        # of mureo.auth_setup.
+        "google_auth_oauthlib.flow.InstalledAppFlow.from_client_config",
         return_value=mock_flow,
     ):
         with pytest.raises(Exception, match="Cannot open browser"):
@@ -1062,7 +1071,9 @@ def test_install_credential_guard_preserves_existing_hooks(tmp_path: Path) -> No
     pre_tool_use = settings["hooks"]["PreToolUse"]
     assert len(pre_tool_use) == 3
     assert pre_tool_use[0]["matcher"] == "Write"  # original
-    assert pre_tool_use[1]["matcher"] == "Read|Edit|Write|Grep|Glob|NotebookEdit"  # mureo
+    assert (
+        pre_tool_use[1]["matcher"] == "Read|Edit|Write|Grep|Glob|NotebookEdit"
+    )  # mureo
     assert pre_tool_use[2]["matcher"] == "Bash"  # mureo
 
 
@@ -1099,9 +1110,7 @@ def test_install_credential_guard_upgrades_stale_hooks(tmp_path: Path) -> None:
     claude_dir = tmp_path / ".claude"
     claude_dir.mkdir()
     settings_path = claude_dir / "settings.json"
-    stale_cmd = (
-        'python3 -c "import sys,json; sys.exit(1)" # [mureo-credential-guard]'
-    )
+    stale_cmd = 'python3 -c "import sys,json; sys.exit(1)" # [mureo-credential-guard]'
     settings_path.write_text(
         json.dumps(
             {
@@ -1770,7 +1779,7 @@ async def test_setup_meta_ads_flow(tmp_path: Path) -> None:
             return_value=mock_oauth_result,
         ),
         patch(
-            "mureo.auth_setup.list_meta_ad_accounts",
+            "mureo.meta_ads.accounts.list_meta_ad_accounts",
             new_callable=AsyncMock,
             return_value=mock_accounts,
         ),
@@ -1813,7 +1822,7 @@ async def test_setup_meta_ads_single_account(tmp_path: Path) -> None:
             return_value=mock_oauth_result,
         ),
         patch(
-            "mureo.auth_setup.list_meta_ad_accounts",
+            "mureo.meta_ads.accounts.list_meta_ad_accounts",
             new_callable=AsyncMock,
             return_value=mock_accounts,
         ),
@@ -1847,7 +1856,7 @@ async def test_setup_meta_ads_no_accounts(tmp_path: Path) -> None:
             return_value=mock_oauth_result,
         ),
         patch(
-            "mureo.auth_setup.list_meta_ad_accounts",
+            "mureo.meta_ads.accounts.list_meta_ad_accounts",
             new_callable=AsyncMock,
             return_value=[],
         ),
@@ -1884,7 +1893,7 @@ async def test_setup_meta_ads_cancel_selection(tmp_path: Path) -> None:
             return_value=mock_oauth_result,
         ),
         patch(
-            "mureo.auth_setup.list_meta_ad_accounts",
+            "mureo.meta_ads.accounts.list_meta_ad_accounts",
             new_callable=AsyncMock,
             return_value=mock_accounts,
         ),

--- a/tests/test_auth_setup_meta.py
+++ b/tests/test_auth_setup_meta.py
@@ -533,7 +533,7 @@ async def test_setup_meta_ads_flow(tmp_path: Path) -> None:
         patch("mureo.auth_setup._select_account", return_value="act_111"),
         patch("mureo.auth_setup.run_meta_oauth", new_callable=AsyncMock) as mock_oauth,
         patch(
-            "mureo.auth_setup.list_meta_ad_accounts", new_callable=AsyncMock
+            "mureo.meta_ads.accounts.list_meta_ad_accounts", new_callable=AsyncMock
         ) as mock_list_accounts,
         patch("builtins.print"),
     ):
@@ -576,7 +576,7 @@ async def test_setup_meta_ads_single_account(tmp_path: Path) -> None:
         patch("mureo.auth_setup.input_func", side_effect=["app-id-1", "app-secret-1"]),
         patch("mureo.auth_setup.run_meta_oauth", new_callable=AsyncMock) as mock_oauth,
         patch(
-            "mureo.auth_setup.list_meta_ad_accounts", new_callable=AsyncMock
+            "mureo.meta_ads.accounts.list_meta_ad_accounts", new_callable=AsyncMock
         ) as mock_list_accounts,
         patch("builtins.print"),
     ):
@@ -614,7 +614,7 @@ async def test_save_credentials_meta(tmp_path: Path) -> None:
         ),
         patch("mureo.auth_setup.run_meta_oauth", new_callable=AsyncMock) as mock_oauth,
         patch(
-            "mureo.auth_setup.list_meta_ad_accounts", new_callable=AsyncMock
+            "mureo.meta_ads.accounts.list_meta_ad_accounts", new_callable=AsyncMock
         ) as mock_list_accounts,
         patch("builtins.print"),
     ):
@@ -663,7 +663,7 @@ async def test_save_credentials_meta_preserves_existing(tmp_path: Path) -> None:
         ),
         patch("mureo.auth_setup.run_meta_oauth", new_callable=AsyncMock) as mock_oauth,
         patch(
-            "mureo.auth_setup.list_meta_ad_accounts", new_callable=AsyncMock
+            "mureo.meta_ads.accounts.list_meta_ad_accounts", new_callable=AsyncMock
         ) as mock_list_accounts,
         patch("builtins.print"),
     ):
@@ -897,7 +897,7 @@ async def test_setup_meta_ads_invalid_account_choice(tmp_path: Path) -> None:
         patch("mureo.auth_setup._select_account", return_value="act_111"),
         patch("mureo.auth_setup.run_meta_oauth", new_callable=AsyncMock) as mock_oauth,
         patch(
-            "mureo.auth_setup.list_meta_ad_accounts", new_callable=AsyncMock
+            "mureo.meta_ads.accounts.list_meta_ad_accounts", new_callable=AsyncMock
         ) as mock_list_accounts,
         patch("builtins.print"),
     ):
@@ -933,7 +933,7 @@ async def test_setup_meta_ads_out_of_range_choice(tmp_path: Path) -> None:
         ),
         patch("mureo.auth_setup.run_meta_oauth", new_callable=AsyncMock) as mock_oauth,
         patch(
-            "mureo.auth_setup.list_meta_ad_accounts", new_callable=AsyncMock
+            "mureo.meta_ads.accounts.list_meta_ad_accounts", new_callable=AsyncMock
         ) as mock_list_accounts,
         patch("builtins.print"),
     ):
@@ -973,7 +973,7 @@ async def test_setup_meta_ads_file_permissions(tmp_path: Path) -> None:
         patch("mureo.auth_setup.input_func", side_effect=["app-id", "app-secret"]),
         patch("mureo.auth_setup.run_meta_oauth", new_callable=AsyncMock) as mock_oauth,
         patch(
-            "mureo.auth_setup.list_meta_ad_accounts", new_callable=AsyncMock
+            "mureo.meta_ads.accounts.list_meta_ad_accounts", new_callable=AsyncMock
         ) as mock_list_accounts,
         patch("builtins.print"),
     ):
@@ -1135,7 +1135,7 @@ async def test_setup_meta_ads_uses_input_func(tmp_path: Path) -> None:
         patch("mureo.auth_setup.input_func", side_effect=["aid", "asec"]) as mock_input,
         patch("mureo.auth_setup.run_meta_oauth", new_callable=AsyncMock) as mock_oauth,
         patch(
-            "mureo.auth_setup.list_meta_ad_accounts", new_callable=AsyncMock
+            "mureo.meta_ads.accounts.list_meta_ad_accounts", new_callable=AsyncMock
         ) as mock_list,
         patch("builtins.print"),
     ):

--- a/tests/test_cli_import_hygiene.py
+++ b/tests/test_cli_import_hygiene.py
@@ -1,0 +1,218 @@
+"""CLI startup import hygiene — no eager Google SDK import (#486).
+
+On Python 3.10 (the minimum supported version) ``google.api_core`` emits a
+``FutureWarning`` at import time about the 2026-10-04 end of 3.10 support,
+and ``google.ads.googleads`` emits a second one for its versioned package.
+Before this guard, *every* ``mureo`` invocation printed both — including
+``--help``, ``demo init`` and ``byod status``, none of which touch Google —
+because ``mureo.cli.main`` → ``mureo.cli.auth_cmd`` → ``mureo.auth`` pulled
+the Google Ads SDK in at module scope.
+
+Four lines of vendor warning noise before any mureo output is the first
+thing a new user sees after ``pip install mureo``, so the fix is a root
+one: the SDK is imported lazily, inside the factories that actually build
+a Google client. These tests pin both halves of that contract —
+
+  - importing the CLI entry point leaves ``google.*`` out of ``sys.modules``
+    and writes nothing to stderr, and
+  - the Google path still works, importing the SDK on demand.
+
+Everything runs in a subprocess because ``sys.modules`` state is global and
+the rest of the suite imports the SDK freely.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+#: Warning/exception markers that must never appear on a CLI startup path.
+#: Mirrors the CI quickstart smoke gate (#488).
+_NOISE_MARKERS = ("FutureWarning", "DeprecationWarning", "Traceback")
+
+#: Snippet that prints every ``google`` module left in ``sys.modules``.
+_GOOGLE_MODULES_SNIPPET = (
+    "print(sorted(m for m in sys.modules "
+    "if m == 'google' or m.startswith('google.') or m.startswith('google_')))"
+)
+
+
+def _run_python(code: str) -> subprocess.CompletedProcess[str]:
+    """Run ``code`` in a fresh interpreter with all warnings enabled.
+
+    ``-W default`` re-enables the warnings Python hides by default, so a
+    regression surfaces here even when the ambient filter is quiet. ``cwd``
+    is the repo root so the checkout under test wins over any ``mureo``
+    installed in site-packages.
+    """
+    return subprocess.run(
+        [sys.executable, "-W", "default", "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        cwd=str(REPO_ROOT),
+        check=False,
+    )
+
+
+def _assert_no_noise(result: subprocess.CompletedProcess[str], label: str) -> None:
+    combined = result.stdout + result.stderr
+    for marker in _NOISE_MARKERS:
+        assert marker not in combined, (
+            f"{label} emitted {marker}:\n"
+            f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
+        )
+
+
+#: Modules on the startup path of commands that never talk to Google.
+#:
+#: - ``mureo.cli.main`` — the console entry point itself (every command).
+#: - ``mureo.auth`` — reached via ``mureo.cli.auth_cmd``; loads credentials,
+#:   which needs no SDK (only *building* a client does).
+#: - ``mureo.auth_setup`` — imported by ``mureo setup <agent> --skip-auth``
+#:   for ``install_mcp_config`` / ``install_credential_guard``, neither of
+#:   which touches Google. It also re-exports the account-listing helpers for
+#:   backward compatibility, which is what used to drag the SDK in.
+#: - ``mureo.cli.web_auth`` — the ``mureo configure`` OAuth wizard. Deferring
+#:   the re-exports behind ``__getattr__`` is not enough on its own here: a
+#:   top-level ``from mureo.auth_setup import list_accessible_accounts``
+#:   *triggers* ``__getattr__`` at import time and loads the SDK anyway.
+_SDK_FREE_MODULES = (
+    "mureo.cli.main",
+    "mureo.auth",
+    "mureo.auth_setup",
+    "mureo.cli.web_auth",
+)
+
+
+class TestCliStartupDoesNotImportGoogleSdk:
+    """CLI startup must not drag the Google SDK in."""
+
+    @pytest.mark.parametrize("module_name", _SDK_FREE_MODULES)
+    def test_import_leaves_google_out_of_sys_modules(self, module_name: str) -> None:
+        result = _run_python(
+            f"import sys\nimport {module_name}\n{_GOOGLE_MODULES_SNIPPET}\n"
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert (
+            result.stdout.strip() == "[]"
+        ), f"{module_name} imported Google modules at import time: {result.stdout.strip()}"
+
+    @pytest.mark.parametrize("module_name", _SDK_FREE_MODULES)
+    def test_import_writes_nothing_to_stderr(self, module_name: str) -> None:
+        result = _run_python(f"import {module_name}")
+
+        assert result.returncode == 0, result.stderr
+        _assert_no_noise(result, f"import {module_name}")
+        assert result.stderr == "", f"unexpected stderr:\n{result.stderr}"
+
+
+class TestCliCommandsAreNoiseFree:
+    """The commands a first-time user runs print only their own output."""
+
+    @pytest.mark.parametrize("argv", [["--help"], ["--version"], ["byod", "--help"]])
+    def test_command_output_is_free_of_warnings(self, argv: list[str]) -> None:
+        result = subprocess.run(
+            [sys.executable, "-W", "default", "-m", "mureo", *argv],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            cwd=str(REPO_ROOT),
+            check=False,
+        )
+
+        assert result.returncode == 0, result.stderr
+        _assert_no_noise(result, f"mureo {' '.join(argv)}")
+
+
+class TestGoogleAdsPathStillWorks:
+    """Laziness must not break the commands that DO need the SDK."""
+
+    def test_creating_a_google_ads_client_imports_the_sdk_on_demand(self) -> None:
+        result = _run_python(
+            "import sys\n"
+            "from mureo.auth import GoogleAdsCredentials, create_google_ads_client\n"
+            "assert 'google.ads.googleads.client' not in sys.modules, "
+            "'SDK imported eagerly by mureo.auth'\n"
+            "creds = GoogleAdsCredentials(\n"
+            "    developer_token='dev-tok',\n"
+            "    client_id='cid',\n"
+            "    client_secret='csec',\n"
+            "    refresh_token='rtok',\n"
+            "    login_customer_id='1234567890',\n"
+            ")\n"
+            "client = create_google_ads_client(creds, customer_id='5555555555')\n"
+            "assert type(client).__name__ == 'GoogleAdsApiClient', type(client)\n"
+            "assert 'google.ads.googleads.client' in sys.modules, "
+            "'SDK never loaded on demand'\n"
+            "print('OK')\n"
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip().splitlines()[-1] == "OK"
+
+    def test_account_listing_reexports_still_resolve(self) -> None:
+        """The backward-compat aliases on ``mureo.auth_setup`` still work.
+
+        ``mureo.auth_setup.list_accessible_accounts`` /
+        ``list_meta_ad_accounts`` are documented legacy import paths, so
+        deferring them must not turn either into an ``AttributeError``.
+
+        This covers *import* identity only. That the wizards still route
+        their calls through these module attributes — so patching the legacy
+        name actually intercepts the network call — is the separate,
+        behavioural guarantee proven in
+        ``tests/test_public_account_listing.py``.
+        """
+        result = _run_python(
+            "import mureo.auth_setup as m\n"
+            "from mureo.google_ads.accounts import list_accessible_accounts\n"
+            "from mureo.meta_ads.accounts import list_meta_ad_accounts\n"
+            "assert m.list_accessible_accounts is list_accessible_accounts\n"
+            "assert m.list_meta_ad_accounts is list_meta_ad_accounts\n"
+            "from mureo.auth_setup import list_accessible_accounts as viafrom\n"
+            "assert viafrom is list_accessible_accounts\n"
+            "print('OK')\n"
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip().splitlines()[-1] == "OK"
+
+    def test_google_oauth_flow_builder_still_works(self) -> None:
+        """``build_google_flow`` imports google-auth-oauthlib on demand."""
+        result = _run_python(
+            "import sys\n"
+            "import mureo.auth_setup as m\n"
+            "assert 'google_auth_oauthlib.flow' not in sys.modules, "
+            "'OAuth lib imported eagerly'\n"
+            "installed = m.build_google_flow(client_id='cid', client_secret='csec')\n"
+            "assert type(installed).__name__ == 'InstalledAppFlow', type(installed)\n"
+            "web = m.build_google_flow(client_id='cid', client_secret='csec', "
+            "redirect_uri='http://localhost:1/cb')\n"
+            "assert type(web).__name__ == 'Flow', type(web)\n"
+            "assert 'google_auth_oauthlib.flow' in sys.modules\n"
+            "print('OK')\n"
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip().splitlines()[-1] == "OK"
+
+    def test_creating_a_meta_ads_client_still_works(self) -> None:
+        result = _run_python(
+            "from mureo.auth import MetaAdsCredentials, create_meta_ads_client\n"
+            "creds = MetaAdsCredentials(access_token='tok', account_id='act_1')\n"
+            "client = create_meta_ads_client(creds, account_id='act_1')\n"
+            "assert type(client).__name__ == 'MetaAdsApiClient', type(client)\n"
+            "print('OK')\n"
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip().splitlines()[-1] == "OK"

--- a/tests/test_public_account_listing.py
+++ b/tests/test_public_account_listing.py
@@ -9,17 +9,28 @@ into the wizard's internal module.
 These tests pin the public import paths and the backward-compat
 aliases so a future refactor can't silently strand callers.
 
-Behavioural correctness is exercised by ``tests/test_auth_setup.py``
-(via the legacy import path) and stays the canonical functional
-test surface — these tests assert *only* the public-API shape, plus
-one regression test for separately-linked-MCC name resolution.
+Beyond import identity, these also pin that the legacy patch targets still
+*intercept* — the wizards must resolve the helpers through the module
+attribute, not a function-local source import. That distinction is not
+academic: while deferring these imports for #486, a function-local import
+silently bypassed ``patch("mureo.auth_setup.list_meta_ad_accounts")`` and the
+test suite made a real HTTP call to graph.facebook.com with a mock that
+reported zero calls.
+
+Broader behavioural correctness is exercised by ``tests/test_auth_setup.py``
+and stays the canonical functional test surface; this file covers the
+public-API shape, the backward-compat interception guarantee, and one
+regression test for separately-linked-MCC name resolution.
 """
 
 from __future__ import annotations
 
 import inspect
-from typing import Any
-from unittest.mock import MagicMock, patch
+from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 import pytest
 
@@ -76,6 +87,112 @@ def test_auth_setup_alias_for_list_meta_ad_accounts() -> None:
     from mureo.meta_ads.accounts import list_meta_ad_accounts as canonical
 
     assert legacy is canonical
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_legacy_patch_target_intercepts_google_wizard(tmp_path: Path) -> None:
+    """Patching the LEGACY name must still intercept the wizard's call.
+
+    Identity aliasing is not enough to keep the promise: downstream code and
+    tests have patched ``mureo.auth_setup.list_accessible_accounts`` for years
+    to stop the wizard hitting the network. If ``setup_google_ads`` resolved
+    the callable any way that bypasses the module attribute — a
+    function-local ``from mureo.google_ads.accounts import ...``, say — the
+    patch would rebind an attribute nobody reads and the REAL networked
+    function would run while the mock reported zero calls.
+    """
+    from mureo.auth_setup import OAuthResult, setup_google_ads
+
+    mock_lister = AsyncMock(
+        return_value=[
+            {
+                "id": "1234567890",
+                "name": "Account 1234567890",
+                "is_manager": False,
+                "parent_id": None,
+            }
+        ]
+    )
+
+    with (
+        patch(
+            "mureo.auth_setup.input_func",
+            side_effect=iter(["dev-token", "client-id", "client-secret"]),
+        ),
+        patch("mureo.auth_setup._select_account", return_value="1234567890"),
+        patch(
+            "mureo.auth_setup.run_google_oauth",
+            new_callable=AsyncMock,
+            return_value=OAuthResult(
+                refresh_token="1//refresh", access_token="ya29.access"
+            ),
+        ),
+        # The legacy patch target — the whole point of this test.
+        patch("mureo.auth_setup.list_accessible_accounts", mock_lister),
+        patch("builtins.print"),
+    ):
+        await setup_google_ads(credentials_path=tmp_path / "credentials.json")
+
+    assert mock_lister.called, (
+        "patching mureo.auth_setup.list_accessible_accounts no longer "
+        "intercepts setup_google_ads — the real network function ran"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_legacy_patch_target_intercepts_meta_wizard(tmp_path: Path) -> None:
+    """Same backward-compat promise for the Meta wizard."""
+    from mureo.auth_setup import MetaOAuthResult, setup_meta_ads
+
+    mock_lister = AsyncMock(
+        return_value=[{"id": "act_111", "name": "Account 1", "account_status": 1}]
+    )
+
+    with (
+        patch(
+            "mureo.auth_setup.input_func", side_effect=["my-app-id", "my-app-secret"]
+        ),
+        patch("mureo.auth_setup._select_account", return_value="act_111"),
+        patch(
+            "mureo.auth_setup.run_meta_oauth",
+            new_callable=AsyncMock,
+            return_value=MetaOAuthResult(
+                access_token="long-lived-token", expires_in=5184000
+            ),
+        ),
+        patch("mureo.auth_setup.list_meta_ad_accounts", mock_lister),
+        patch("builtins.print"),
+    ):
+        await setup_meta_ads(credentials_path=tmp_path / "credentials.json")
+
+    assert mock_lister.called, (
+        "patching mureo.auth_setup.list_meta_ad_accounts no longer "
+        "intercepts setup_meta_ads — the real network function ran"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("name", ["list_accessible_accounts", "list_meta_ad_accounts"])
+def test_legacy_patch_target_intercepts_web_auth_probe(name: str) -> None:
+    """``mureo.cli.web_auth`` resolves the probes through its own attribute.
+
+    The configure wizard patches ``mureo.cli.web_auth.<name>`` in six tests,
+    one of which (``test_web_auth_multi_account``) uses a ``side_effect`` that
+    FAILS if called — i.e. it asserts the probe does *not* run. If the module
+    resolved the callable via a function-local source import, that patch would
+    be bypassed, the assertion would never fire, and the test would pass while
+    the real network probe ran. Pin the resolution mechanism directly.
+    """
+    from mureo.cli import web_auth
+
+    sentinel = MagicMock(name=name)
+    with patch.object(web_auth, name, sentinel):
+        assert web_auth._reexport(name) is sentinel, (
+            f"mureo.cli.web_auth._reexport({name!r}) bypassed the patched "
+            "module attribute"
+        )
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Fixes #486, fixes #488. Lazy SDK imports (root fix, no warnings filter) with behavioral backward-compat for legacy patch targets — the review caught a silent bypass that made real API calls in mocked tests, now pinned by mutation-verified tests. New quickstart smoke: shared script + workflow (py3.10/3.12, temp-HOME isolation, warning/traceback-free gating on every step). Note: the weekly from-pypi variant stays red until the next release ships #486/#487 (intended signal; never blocks PRs).