### PR TITLE
chore: release 0.10.34

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mureo",
-  "version": "0.10.33",
+  "version": "0.10.34",
   "description": "Your local-first AI ad ops crew for Google Ads, Meta Ads, Search Console & GA4. mureo sits on top of the official ad-platform MCPs, gates every change against your strategy, correlates outcomes locally, and keeps an auditable decision log — credentials never leave your machine.",
   "author": {
     "name": "Logly Inc.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,114 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.34] - 2026-07-30
+
+### Added
+
+- **`mureo --version` and a `mureo version` subcommand (#490, fixes #487).**
+  The first thing a developer runs after `pip install mureo` had no answer:
+  neither an eager `--version` flag nor a `version` subcommand existed, so the
+  installed version was reachable only through `pip show`. Both now print the
+  same single `mureo <version>` line from one resolver — **installed
+  distribution metadata first** (`importlib.metadata.version("mureo")`),
+  falling back to the in-tree `mureo.__version__` when that metadata is
+  unavailable, so a source checkout or a vendored copy answers instead of
+  raising. `--version` is an eager option on the root callback: it is handled
+  before any subcommand runs, and needs no credentials, no config and no
+  network. Because that fallback would let a release bump touching only
+  `pyproject.toml` make the CLI lie about its own version, a new **drift
+  guard** pins `mureo.__version__` to `pyproject.toml` — the same guard shape
+  `tests/test_plugin_manifests.py` already applies to the plugin manifests —
+  and the `--help` tagline is pinned by test alongside it. 11 new tests.
+
+- **A quickstart smoke test now guards the README's first-run path (#493,
+  fixes #488).** The no-credentials quickstart — `pip install mureo`, `mureo
+  setup claude-code --skip-auth`, `mureo demo init --scenario
+  seasonality-trap` — is the funnel entry for every first-time user, and
+  nothing guarded it: the unit suite mocks the filesystem and never installs
+  the wheel, so a broken console entry point, a setup step that wrote nowhere,
+  or a demo bundle that stopped importing would have been reported by
+  strangers rather than by CI. `scripts/quickstart_smoke.sh` now runs that
+  path end to end in a **throwaway virtualenv and a throwaway `HOME`** — the
+  `~/.claude.json`, `~/.claude/settings.json`, `~/.claude/skills/` and
+  `~/.mureo/byod/` writes are asserted inside the sandbox, so the assertions
+  are meaningful and the developer's real Claude Code config is never touched
+  — and every step is gated on output free of `FutureWarning`,
+  `DeprecationWarning` and `Traceback`. All the logic lives in the script so a
+  red CI run reproduces locally with one command; the new
+  `.github/workflows/quickstart-smoke.yml` only picks the interpreter and the
+  install spec, running the checkout under **Python 3.10 and 3.12** on every
+  push and pull request to `main`. A weekly **from-PyPI variant** runs the
+  same assertions against the published wheel, catching breakage a checkout
+  install cannot see (missing package data, a bad dependency pin); it is
+  schedule- and dispatch-only, so it never blocks a pull request.
+
+### Fixed
+
+- **The CLI no longer imports the Google SDKs eagerly (#493, fixes #486).**
+  Under Python 3.10, two `google.api_core` `FutureWarning` blocks printed
+  ahead of any mureo output on **every** command — `--help`, `demo init`,
+  `byod status`, `setup <agent> --skip-auth`, `configure` — so the first thing
+  a new user saw after `pip install mureo` was four lines of vendor warning
+  noise. The cause was import placement, not the warnings themselves:
+  `mureo.cli.main` reaches `mureo.auth` through `mureo.cli.auth_cmd`, and both
+  `mureo.auth` and `mureo.auth_setup` pulled the platform SDKs in at module
+  scope, directly and through the account-discovery re-exports whose packages
+  load the Google Ads SDK on import. Credential *loading* needs no SDK; only
+  client *construction* does. The SDK imports now sit inside
+  `create_google_ads_client`, `create_search_console_client`,
+  `create_meta_ads_client` and `build_google_flow`, and the
+  `list_accessible_accounts` / `list_meta_ad_accounts` re-exports resolve on
+  first access through a module-level `__getattr__` (PEP 562) on both
+  `mureo.auth_setup` and `mureo.cli.web_auth`. Deferring in `auth_setup` alone
+  was not enough for `mureo configure`: a top-level `from mureo.auth_setup
+  import list_accessible_accounts` *triggers* that `__getattr__` at import
+  time and loads the SDK anyway. **This is a root fix — no warnings filter was
+  added, and nothing is being suppressed.**
+
+  **Backward compatibility is behavioral, not just nominal.** The long-
+  documented patch targets `mureo.auth_setup.list_accessible_accounts` /
+  `list_meta_ad_accounts` and their `mureo.cli.web_auth` counterparts still
+  *intercept* the wizards, because the in-module call sites resolve each name
+  through module-namespace attribute lookup rather than a function-local
+  `from mureo.<platform>.accounts import ...`. Both forms are lazy, but only
+  attribute lookup lets a `mock.patch` / `monkeypatch.setattr` binding shadow
+  `__getattr__`; the function-local import silently bypasses the patch and
+  lets the real networked call run while the mock reports zero calls. Code
+  review reproduced exactly that bypass — mocked tests making live API calls
+  — and it is now pinned by mutation-verified behavioral tests in
+  `tests/test_public_account_listing.py`.
+
+  The hygiene itself is guarded by `tests/test_cli_import_hygiene.py`, which
+  runs in subprocesses because `sys.modules` state is global: importing
+  `mureo.cli.main`, `mureo.auth`, `mureo.auth_setup` or `mureo.cli.web_auth`
+  must leave every Google module out of `sys.modules` and write nothing to
+  stderr, `mureo --help` / `--version` / `byod --help` must be noise-free
+  under `python -W default`, and the deferred paths must still work — building
+  a Google Ads client, a Search Console client, a Meta client, and the Google
+  OAuth flow each import their SDK on demand.
+
+### Docs
+
+- **TikTok Ads is documented, and setup leads with `mureo configure` (#489).**
+  Two follow-ups to the README restructure (#485), applied to `README.md` and
+  `README.ja.md` alike. TikTok Ads shipped as the `tiktok-ads-official`
+  provider — TikTok's official hosted MCP server, browser OAuth on first
+  connect, no developer token, `tiktok_ads` a first-class platform key in
+  workflow commands, reports and the action log — but neither README
+  mentioned it. It now appears in the platform lists (intro and
+  cross-platform sections) and in a new connector paragraph in the reference
+  section, renamed to cover TikTok Ads alongside GA4 and other MCP servers,
+  with the scope stated honestly: mureo-native analytics (anomaly baselines,
+  RSA audit) remain Google- and Meta-specific. Separately, the quick start,
+  BYOD, Live API and hosts sections led with raw CLI commands even though
+  `mureo configure` is the recommended flow; they now lead with the browser UI
+  everywhere it applies — the quick start is `pip install mureo` + `mureo
+  configure`, with the demo scaffold and the BYOD import reached from that
+  same dashboard and OAuth from its Connect-platforms view — and each
+  terminal command is kept as a one-line scriptable equivalent. Docs only; no
+  code, schema or behavior changed.
+
 ## [0.10.33] - 2026-07-29
 
 ### Fixed

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "mureo",
-  "version": "0.10.33",
+  "version": "0.10.34",
   "description": "Your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini.",
   "contextFileName": "CONTEXT.md"
 }

--- a/mureo/__init__.py
+++ b/mureo/__init__.py
@@ -1,3 +1,3 @@
 """mureo — your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."""
 
-__version__ = "0.10.33"
+__version__ = "0.10.34"

--- a/mureo/_data/skills/_mureo-google-ads/SKILL.md
+++ b/mureo/_data/skills/_mureo-google-ads/SKILL.md
@@ -2,7 +2,7 @@
 name: _mureo-google-ads
 description: "Google Ads: Manage campaigns, ad groups, ads, keywords, budgets, and performance analysis."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
   openclaw:
     category: "advertising"
     requires:

--- a/mureo/_data/skills/_mureo-learning/SKILL.md
+++ b/mureo/_data/skills/_mureo-learning/SKILL.md
@@ -2,7 +2,7 @@
 name: _mureo-learning
 description: "Evidence-based marketing decision framework: statistical thinking for AI agents operating ad accounts."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
   openclaw:
     category: "marketing"
     requires:

--- a/mureo/_data/skills/_mureo-meta-ads/SKILL.md
+++ b/mureo/_data/skills/_mureo-meta-ads/SKILL.md
@@ -2,7 +2,7 @@
 name: _mureo-meta-ads
 description: "Meta Ads: Manage campaigns, ad sets, ads, insights, and audiences on Facebook/Instagram."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
   openclaw:
     category: "advertising"
     requires:

--- a/mureo/_data/skills/_mureo-shared/SKILL.md
+++ b/mureo/_data/skills/_mureo-shared/SKILL.md
@@ -2,7 +2,7 @@
 name: _mureo-shared
 description: "mureo: Shared patterns for authentication, security rules, and output formatting."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
   openclaw:
     category: "advertising"
     requires:

--- a/mureo/_data/skills/_mureo-strategy/SKILL.md
+++ b/mureo/_data/skills/_mureo-strategy/SKILL.md
@@ -2,7 +2,7 @@
 name: _mureo-strategy
 description: "Strategy Context: Manage business strategy files (STRATEGY.md, STATE.json) for strategy-driven ad operations."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
   openclaw:
     category: "advertising"
     requires:

--- a/mureo/_data/skills/ad-fatigue-check/SKILL.md
+++ b/mureo/_data/skills/ad-fatigue-check/SKILL.md
@@ -2,7 +2,7 @@
 name: ad-fatigue-check
 description: "Detect creative fatigue across active ads — rising frequency, declining CTR week-over-week, and CPM drift — score each ad FATIGUED / WATCH / FRESH, and hand the evidence to a creative refresh. Use when the user asks whether creatives are worn out, why CTR is falling, if frequency is too high, when to rotate or refresh ads, or requests クリエイティブ疲弊チェック / 広告の疲弊を確認 / フリークエンシーが高い / CTRが落ちてきた / そろそろ差し替え時か. Reads active ads per platform, applies documented fatigue thresholds with noise guards, and routes fatigued ads to /creative-generate or /creative-refresh."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
 ---
 
 # Ad Fatigue Check

--- a/mureo/_data/skills/audience-review/SKILL.md
+++ b/mureo/_data/skills/audience-review/SKILL.md
@@ -2,7 +2,7 @@
 name: audience-review
 description: "Audit who your ads actually target and where they run, compare it against the STRATEGY.md Persona, and surface exclusions, bid adjustments, lookalikes, and placement pruning tied to that Persona. Use when the user asks to review targeting, audiences, demographics, placements, or device performance, to check whether spend matches the Persona, to find wasted placements (e.g. Audience Network with no conversions), or requests オーディエンスレビュー / 配置レビュー / ターゲティング見直し / ペルソナと配信のズレを確認 / 除外設定を提案して. Reads Persona + Target Audience from STRATEGY.md and drives the read-only targeting tools."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
 ---
 
 # Audience Review

--- a/mureo/_data/skills/budget-pacing/SKILL.md
+++ b/mureo/_data/skills/budget-pacing/SKILL.md
@@ -2,7 +2,7 @@
 name: budget-pacing
 description: "Month-to-date spend vs the monthly budget target, projected month-end landing, and pace alerts across all configured platforms. Use when the user asks about pacing, burn rate, whether they will overspend or underspend this month, monthly-budget tracking, landing/forecast, 'are we on budget', or requests 予算ペーシング / 着地予測 / 予算消化ペース. DISTINCT from /budget-rebalance (which reallocates budget between campaigns) — this manages total-spend trajectory toward a monthly target. Reads STRATEGY.md Guardrails / a Monthly Budget section and STATE.json."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
 ---
 
 # Budget Pacing

--- a/mureo/_data/skills/budget-rebalance/SKILL.md
+++ b/mureo/_data/skills/budget-rebalance/SKILL.md
@@ -2,7 +2,7 @@
 name: budget-rebalance
 description: "Rebalance campaign budgets across all configured platforms based on strategy and performance signals. Use when the user asks to optimize budgets, redistribute spend, scale efficient campaigns, or cap overspending ones. Reads STRATEGY.md goals, analyzes campaign efficiency, and proposes budget changes with rationale. Also use when the user asks in Japanese (予算を最適化して / 予算の再配分 / 好調なキャンペーンに予算を寄せて / 予算リバランス)."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
 ---
 
 # Budget Rebalance

--- a/mureo/_data/skills/competitive-scan/SKILL.md
+++ b/mureo/_data/skills/competitive-scan/SKILL.md
@@ -2,7 +2,7 @@
 name: competitive-scan
 description: "Scan competitor activity using auction insights and market signals. Use when the user asks about competitors, market dynamics, impression share changes, competitor moves, or competitive positioning. Also use when the user asks in Japanese (競合の動きを調べて / 競合分析 / インプレッションシェアの変化を確認 / 競合にシェアを取られていないか)."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
 ---
 
 # Competitive Scan

--- a/mureo/_data/skills/creative-generate/SKILL.md
+++ b/mureo/_data/skills/creative-generate/SKILL.md
@@ -2,7 +2,7 @@
 name: creative-generate
 description: "Generate creator-quality ad creatives — text-free key visuals plus composed banners — from a strategy-grounded brief. Use when the user asks to create ad creatives, generate ad images or banners, make banner variations, design display / social ad creatives, or asks in Japanese (クリエイティブ作成 / バナー作成 / 広告画像を生成 / バナーのバリエーションを作って). Runs a 6-step workflow (brief → copy → visuals → art-direction scoring loop → HTML/CSS composition → delivery) via the creative_studio_* MCP tools, then hands approved banners to the existing upload tools."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
 ---
 
 # Creative Generate

--- a/mureo/_data/skills/creative-refresh/SKILL.md
+++ b/mureo/_data/skills/creative-refresh/SKILL.md
@@ -2,7 +2,7 @@
 name: creative-refresh
 description: "Refresh ad copy and creative assets based on performance signals and brand voice. Use when the user asks to refresh creative, propose new ad copy, A/B test creatives, update RSA assets, rotate underperformers, or visually evaluate / compare banner (image) creatives. Also use when the user asks in Japanese (クリエイティブを刷新して / 広告文の改善案がほしい / RSAアセットの入れ替え / バナーを比較評価して)."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
 ---
 
 # Creative Refresh

--- a/mureo/_data/skills/daily-check/SKILL.md
+++ b/mureo/_data/skills/daily-check/SKILL.md
@@ -2,7 +2,7 @@
 name: daily-check
 description: "Run a daily health check on all configured ad accounts (Google Ads, Meta Ads, Search Console, GA4). Use when the user asks for a daily review, health check, status update, anomaly detection, or 'how are my campaigns doing today'. Reads STRATEGY.md and STATE.json, runs platform-specific health diagnostics, checks goal progress, evaluates pending action_log observations, and reports findings as Healthy / Watch / Action-needed. Also use when the user asks in Japanese (デイリーチェック / 今日のアカウント状況は / 異常がないか確認して / 日次ヘルスチェック)."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
 ---
 
 # Daily Check

--- a/mureo/_data/skills/experiment/SKILL.md
+++ b/mureo/_data/skills/experiment/SKILL.md
@@ -2,7 +2,7 @@
 name: experiment
 description: "Design, run, and evaluate a controlled A/B test (split test) on your ad accounts with evidence discipline — one variable, a falsifiable hypothesis, a fixed window, and a per-variant outcome verdict. Use when the user asks to run an A/B test, split test, or experiment, to 'test whether X beats Y', to validate a creative-refresh or learning hunch properly, to validate a breakdown exclusion or reallocation hypothesis before acting on it, or requests A/Bテスト / スプリットテスト設計 / 実験を回したい / どちらが勝ったか評価して / 仮説を検証したい. Forces a designed experiment instead of an ad-hoc change, records the baseline in action_log, and forbids peeking-based decisions before the window closes."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
 ---
 
 # Experiment

--- a/mureo/_data/skills/goal-review/SKILL.md
+++ b/mureo/_data/skills/goal-review/SKILL.md
@@ -2,7 +2,7 @@
 name: goal-review
 description: "Review Goal progress against STRATEGY.md targets. Use when the user asks to evaluate goal achievement, review KPI progress, assess strategy performance, or check if targets are being met. Also use when the user asks in Japanese (目標の進捗を確認 / KPIレビュー / ゴール達成状況は / 目標に届きそうか)."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
 ---
 
 # Goal Review

--- a/mureo/_data/skills/incident-postmortem/SKILL.md
+++ b/mureo/_data/skills/incident-postmortem/SKILL.md
@@ -2,7 +2,7 @@
 name: incident-postmortem
 description: "Close the learning loop after a rescue or incident — reconstruct the timeline from action_log, run root-cause analysis (platform / site / measurement / external), produce a structured postmortem document, distill reusable insights via /learn, and propose preventive guardrails. Use after a /rescue, a CPA spike, a conversion drop, or a runaway-spend event has been handled, or when the user asks for a postmortem, retrospective, root-cause writeup, or requests インシデント振り返り / ポストモーテム / 事後分析 / なぜ起きたのか / 再発防止策. Read-and-document only — makes no ad-platform writes."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
 ---
 
 # Incident Postmortem

--- a/mureo/_data/skills/lead-form-create/SKILL.md
+++ b/mureo/_data/skills/lead-form-create/SKILL.md
@@ -2,7 +2,7 @@
 name: lead-form-create
 description: "Create a Meta Instant Form (Lead Ad form) through a one-question-at-a-time interview. Use when the user asks to create a lead form, Instant Form, CV form, or similar. The agent collects required parameters via a guided dialogue, confirms, then calls meta_ads_lead_forms_create. Also use when the user asks in Japanese (リードフォームを作成 / インスタントフォームを作って / CVフォーム作成)."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
 ---
 
 # Lead Form Create

--- a/mureo/_data/skills/learn/SKILL.md
+++ b/mureo/_data/skills/learn/SKILL.md
@@ -2,7 +2,7 @@
 name: learn
 description: "Save a marketing diagnosis insight to the pro-diagnosis knowledge base so it is applied in future operations across all platforms. Use when the user runs /learn, explicitly teaches the agent a marketing insight, corrects the agent's analysis, or asks to remember/record an operational learning for next time. Also use when the user asks in Japanese (この学びを記録して / 次回から反映して / 運用の気づきを覚えておいて)."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
 ---
 
 # Learn

--- a/mureo/_data/skills/monthly-report/SKILL.md
+++ b/mureo/_data/skills/monthly-report/SKILL.md
@@ -2,7 +2,7 @@
 name: monthly-report
 description: "Stakeholder / client-facing monthly digest across all configured platforms: the previous full calendar month with month-over-month comparison, per-Goal attainment, an action-log recap grouped by command with outcome verdicts, budget utilization, and next-month recommendations. Use when the user asks for a monthly report, month-end summary, client report, monthly recap / digest, or requests 月次レポート / 月次まとめ / クライアント向けレポート. Written in plain language for a client audience."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
 ---
 
 # Monthly Report

--- a/mureo/_data/skills/onboard/SKILL.md
+++ b/mureo/_data/skills/onboard/SKILL.md
@@ -2,7 +2,7 @@
 name: onboard
 description: "Initial account setup — create STRATEGY.md and STATE.json from scratch, import platform data, and establish baseline metrics. Use when the user is starting fresh with mureo, has no STRATEGY.md yet, or asks to set up a new account. Also use when the user asks in Japanese (初期セットアップ / STRATEGY.mdを作成して / mureoを使い始めたい / アカウントの立ち上げ)."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
 ---
 
 # Onboard

--- a/mureo/_data/skills/rescue/SKILL.md
+++ b/mureo/_data/skills/rescue/SKILL.md
@@ -2,7 +2,7 @@
 name: rescue
 description: "Emergency performance fix when an ad account is in trouble. Use when the user reports a sudden CPA spike, conversion drop, runaway spend, or asks for an urgent performance rescue. Sets Operation Mode to TURNAROUND_RESCUE and applies stabilization actions. Also use when the user asks in Japanese (CPAが急に悪化した / CVが激減した / 広告費が暴走している / 緊急で立て直して)."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
 ---
 
 # Rescue

--- a/mureo/_data/skills/search-term-cleanup/SKILL.md
+++ b/mureo/_data/skills/search-term-cleanup/SKILL.md
@@ -2,7 +2,7 @@
 name: search-term-cleanup
 description: "Audit and clean up search terms (negative keywords, intent classification, query hygiene). Use when the user asks to clean up search queries, add negative keywords, review search term reports, or improve match quality. Cross-references Search Console, GA4, and ad platform data. Also use when the user asks in Japanese (検索語句のクリーンアップ / 除外キーワードを追加して / 無駄な検索クエリを止めたい)."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
 ---
 
 # Search Term Cleanup

--- a/mureo/_data/skills/sync-state/SKILL.md
+++ b/mureo/_data/skills/sync-state/SKILL.md
@@ -2,7 +2,7 @@
 name: sync-state
 description: "Sync STATE.json with current campaign data from all platforms. Use when the user asks to refresh state, sync campaigns, update STATE.json from live data, or pull latest campaign snapshots. Also use when the user asks in Japanese (STATE.jsonを更新 / 最新データに同期して / キャンペーン情報を取り込み直して)."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
 ---
 
 # Sync State

--- a/mureo/_data/skills/tracking-health/SKILL.md
+++ b/mureo/_data/skills/tracking-health/SKILL.md
@@ -2,7 +2,7 @@
 name: tracking-health
 description: "Preventive audit of conversion tracking across all configured ad platforms — Meta pixels + CAPI, Google Ads conversion actions — with a GA4 cross-check. Use when the user asks to check tracking, audit conversion measurement, verify pixels / tags, diagnose why conversions stopped or look wrong, sanity-check CV counting, or requests a 計測ヘルスチェック / タグ・計測監査 / 計測が壊れていないか確認. Reads STRATEGY.md and STATE.json, produces a per-platform tracking scorecard (OK / Watch / Broken per check) and a fix list ranked by revenue risk."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
 ---
 
 # Tracking Health

--- a/mureo/_data/skills/weekly-report/SKILL.md
+++ b/mureo/_data/skills/weekly-report/SKILL.md
@@ -2,7 +2,7 @@
 name: weekly-report
 description: "Generate a weekly summary report across all platforms. Use when the user asks for a weekly report, summary, recap, end-of-week review, or weekly digest. Also use when the user asks in Japanese (週次レポート / 今週のまとめ / 週報を作成して)."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
 ---
 
 # Weekly Report

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mureo"
-version = "0.10.33"
+version = "0.10.34"
 description = "Your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/skills/_mureo-google-ads/SKILL.md
+++ b/skills/_mureo-google-ads/SKILL.md
@@ -2,7 +2,7 @@
 name: _mureo-google-ads
 description: "Google Ads: Manage campaigns, ad groups, ads, keywords, budgets, and performance analysis."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
   openclaw:
     category: "advertising"
     requires:

--- a/skills/_mureo-learning/SKILL.md
+++ b/skills/_mureo-learning/SKILL.md
@@ -2,7 +2,7 @@
 name: _mureo-learning
 description: "Evidence-based marketing decision framework: statistical thinking for AI agents operating ad accounts."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
   openclaw:
     category: "marketing"
     requires:

--- a/skills/_mureo-meta-ads/SKILL.md
+++ b/skills/_mureo-meta-ads/SKILL.md
@@ -2,7 +2,7 @@
 name: _mureo-meta-ads
 description: "Meta Ads: Manage campaigns, ad sets, ads, insights, and audiences on Facebook/Instagram."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
   openclaw:
     category: "advertising"
     requires:

--- a/skills/_mureo-pro-diagnosis/SKILL.md
+++ b/skills/_mureo-pro-diagnosis/SKILL.md
@@ -2,7 +2,7 @@
 name: _mureo-pro-diagnosis
 description: "Professional marketing diagnostic frameworks: expert-level campaign analysis that grows with your experience."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
   openclaw:
     category: "marketing"
     requires:

--- a/skills/_mureo-shared/SKILL.md
+++ b/skills/_mureo-shared/SKILL.md
@@ -2,7 +2,7 @@
 name: _mureo-shared
 description: "mureo: Shared patterns for authentication, security rules, and output formatting."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
   openclaw:
     category: "advertising"
     requires:

--- a/skills/_mureo-strategy/SKILL.md
+++ b/skills/_mureo-strategy/SKILL.md
@@ -2,7 +2,7 @@
 name: _mureo-strategy
 description: "Strategy Context: Manage business strategy files (STRATEGY.md, STATE.json) for strategy-driven ad operations."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
   openclaw:
     category: "advertising"
     requires:

--- a/skills/ad-fatigue-check/SKILL.md
+++ b/skills/ad-fatigue-check/SKILL.md
@@ -2,7 +2,7 @@
 name: ad-fatigue-check
 description: "Detect creative fatigue across active ads — rising frequency, declining CTR week-over-week, and CPM drift — score each ad FATIGUED / WATCH / FRESH, and hand the evidence to a creative refresh. Use when the user asks whether creatives are worn out, why CTR is falling, if frequency is too high, when to rotate or refresh ads, or requests クリエイティブ疲弊チェック / 広告の疲弊を確認 / フリークエンシーが高い / CTRが落ちてきた / そろそろ差し替え時か. Reads active ads per platform, applies documented fatigue thresholds with noise guards, and routes fatigued ads to /creative-generate or /creative-refresh."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
 ---
 
 # Ad Fatigue Check

--- a/skills/audience-review/SKILL.md
+++ b/skills/audience-review/SKILL.md
@@ -2,7 +2,7 @@
 name: audience-review
 description: "Audit who your ads actually target and where they run, compare it against the STRATEGY.md Persona, and surface exclusions, bid adjustments, lookalikes, and placement pruning tied to that Persona. Use when the user asks to review targeting, audiences, demographics, placements, or device performance, to check whether spend matches the Persona, to find wasted placements (e.g. Audience Network with no conversions), or requests オーディエンスレビュー / 配置レビュー / ターゲティング見直し / ペルソナと配信のズレを確認 / 除外設定を提案して. Reads Persona + Target Audience from STRATEGY.md and drives the read-only targeting tools."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
 ---
 
 # Audience Review

--- a/skills/budget-pacing/SKILL.md
+++ b/skills/budget-pacing/SKILL.md
@@ -2,7 +2,7 @@
 name: budget-pacing
 description: "Month-to-date spend vs the monthly budget target, projected month-end landing, and pace alerts across all configured platforms. Use when the user asks about pacing, burn rate, whether they will overspend or underspend this month, monthly-budget tracking, landing/forecast, 'are we on budget', or requests 予算ペーシング / 着地予測 / 予算消化ペース. DISTINCT from /budget-rebalance (which reallocates budget between campaigns) — this manages total-spend trajectory toward a monthly target. Reads STRATEGY.md Guardrails / a Monthly Budget section and STATE.json."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
 ---
 
 # Budget Pacing

--- a/skills/budget-rebalance/SKILL.md
+++ b/skills/budget-rebalance/SKILL.md
@@ -2,7 +2,7 @@
 name: budget-rebalance
 description: "Rebalance campaign budgets across all configured platforms based on strategy and performance signals. Use when the user asks to optimize budgets, redistribute spend, scale efficient campaigns, or cap overspending ones. Reads STRATEGY.md goals, analyzes campaign efficiency, and proposes budget changes with rationale. Also use when the user asks in Japanese (予算を最適化して / 予算の再配分 / 好調なキャンペーンに予算を寄せて / 予算リバランス)."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
 ---
 
 # Budget Rebalance

--- a/skills/competitive-scan/SKILL.md
+++ b/skills/competitive-scan/SKILL.md
@@ -2,7 +2,7 @@
 name: competitive-scan
 description: "Scan competitor activity using auction insights and market signals. Use when the user asks about competitors, market dynamics, impression share changes, competitor moves, or competitive positioning. Also use when the user asks in Japanese (競合の動きを調べて / 競合分析 / インプレッションシェアの変化を確認 / 競合にシェアを取られていないか)."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
 ---
 
 # Competitive Scan

--- a/skills/creative-generate/SKILL.md
+++ b/skills/creative-generate/SKILL.md
@@ -2,7 +2,7 @@
 name: creative-generate
 description: "Generate creator-quality ad creatives — text-free key visuals plus composed banners — from a strategy-grounded brief. Use when the user asks to create ad creatives, generate ad images or banners, make banner variations, design display / social ad creatives, or asks in Japanese (クリエイティブ作成 / バナー作成 / 広告画像を生成 / バナーのバリエーションを作って). Runs a 6-step workflow (brief → copy → visuals → art-direction scoring loop → HTML/CSS composition → delivery) via the creative_studio_* MCP tools, then hands approved banners to the existing upload tools."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
 ---
 
 # Creative Generate

--- a/skills/creative-refresh/SKILL.md
+++ b/skills/creative-refresh/SKILL.md
@@ -2,7 +2,7 @@
 name: creative-refresh
 description: "Refresh ad copy and creative assets based on performance signals and brand voice. Use when the user asks to refresh creative, propose new ad copy, A/B test creatives, update RSA assets, rotate underperformers, or visually evaluate / compare banner (image) creatives. Also use when the user asks in Japanese (クリエイティブを刷新して / 広告文の改善案がほしい / RSAアセットの入れ替え / バナーを比較評価して)."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
 ---
 
 # Creative Refresh

--- a/skills/daily-check/SKILL.md
+++ b/skills/daily-check/SKILL.md
@@ -2,7 +2,7 @@
 name: daily-check
 description: "Run a daily health check on all configured ad accounts (Google Ads, Meta Ads, Search Console, GA4). Use when the user asks for a daily review, health check, status update, anomaly detection, or 'how are my campaigns doing today'. Reads STRATEGY.md and STATE.json, runs platform-specific health diagnostics, checks goal progress, evaluates pending action_log observations, and reports findings as Healthy / Watch / Action-needed. Also use when the user asks in Japanese (デイリーチェック / 今日のアカウント状況は / 異常がないか確認して / 日次ヘルスチェック)."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
 ---
 
 # Daily Check

--- a/skills/experiment/SKILL.md
+++ b/skills/experiment/SKILL.md
@@ -2,7 +2,7 @@
 name: experiment
 description: "Design, run, and evaluate a controlled A/B test (split test) on your ad accounts with evidence discipline — one variable, a falsifiable hypothesis, a fixed window, and a per-variant outcome verdict. Use when the user asks to run an A/B test, split test, or experiment, to 'test whether X beats Y', to validate a creative-refresh or learning hunch properly, to validate a breakdown exclusion or reallocation hypothesis before acting on it, or requests A/Bテスト / スプリットテスト設計 / 実験を回したい / どちらが勝ったか評価して / 仮説を検証したい. Forces a designed experiment instead of an ad-hoc change, records the baseline in action_log, and forbids peeking-based decisions before the window closes."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
 ---
 
 # Experiment

--- a/skills/goal-review/SKILL.md
+++ b/skills/goal-review/SKILL.md
@@ -2,7 +2,7 @@
 name: goal-review
 description: "Review Goal progress against STRATEGY.md targets. Use when the user asks to evaluate goal achievement, review KPI progress, assess strategy performance, or check if targets are being met. Also use when the user asks in Japanese (目標の進捗を確認 / KPIレビュー / ゴール達成状況は / 目標に届きそうか)."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
 ---
 
 # Goal Review

--- a/skills/incident-postmortem/SKILL.md
+++ b/skills/incident-postmortem/SKILL.md
@@ -2,7 +2,7 @@
 name: incident-postmortem
 description: "Close the learning loop after a rescue or incident — reconstruct the timeline from action_log, run root-cause analysis (platform / site / measurement / external), produce a structured postmortem document, distill reusable insights via /learn, and propose preventive guardrails. Use after a /rescue, a CPA spike, a conversion drop, or a runaway-spend event has been handled, or when the user asks for a postmortem, retrospective, root-cause writeup, or requests インシデント振り返り / ポストモーテム / 事後分析 / なぜ起きたのか / 再発防止策. Read-and-document only — makes no ad-platform writes."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
 ---
 
 # Incident Postmortem

--- a/skills/lead-form-create/SKILL.md
+++ b/skills/lead-form-create/SKILL.md
@@ -2,7 +2,7 @@
 name: lead-form-create
 description: "Create a Meta Instant Form (Lead Ad form) through a one-question-at-a-time interview. Use when the user asks to create a lead form, Instant Form, CV form, or similar. The agent collects required parameters via a guided dialogue, confirms, then calls meta_ads_lead_forms_create. Also use when the user asks in Japanese (リードフォームを作成 / インスタントフォームを作って / CVフォーム作成)."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
 ---
 
 # Lead Form Create

--- a/skills/learn/SKILL.md
+++ b/skills/learn/SKILL.md
@@ -2,7 +2,7 @@
 name: learn
 description: "Save a marketing diagnosis insight to the pro-diagnosis knowledge base so it is applied in future operations across all platforms. Use when the user runs /learn, explicitly teaches the agent a marketing insight, corrects the agent's analysis, or asks to remember/record an operational learning for next time. Also use when the user asks in Japanese (この学びを記録して / 次回から反映して / 運用の気づきを覚えておいて)."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
 ---
 
 # Learn

--- a/skills/monthly-report/SKILL.md
+++ b/skills/monthly-report/SKILL.md
@@ -2,7 +2,7 @@
 name: monthly-report
 description: "Stakeholder / client-facing monthly digest across all configured platforms: the previous full calendar month with month-over-month comparison, per-Goal attainment, an action-log recap grouped by command with outcome verdicts, budget utilization, and next-month recommendations. Use when the user asks for a monthly report, month-end summary, client report, monthly recap / digest, or requests 月次レポート / 月次まとめ / クライアント向けレポート. Written in plain language for a client audience."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
 ---
 
 # Monthly Report

--- a/skills/onboard/SKILL.md
+++ b/skills/onboard/SKILL.md
@@ -2,7 +2,7 @@
 name: onboard
 description: "Initial account setup — create STRATEGY.md and STATE.json from scratch, import platform data, and establish baseline metrics. Use when the user is starting fresh with mureo, has no STRATEGY.md yet, or asks to set up a new account. Also use when the user asks in Japanese (初期セットアップ / STRATEGY.mdを作成して / mureoを使い始めたい / アカウントの立ち上げ)."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
 ---
 
 # Onboard

--- a/skills/rescue/SKILL.md
+++ b/skills/rescue/SKILL.md
@@ -2,7 +2,7 @@
 name: rescue
 description: "Emergency performance fix when an ad account is in trouble. Use when the user reports a sudden CPA spike, conversion drop, runaway spend, or asks for an urgent performance rescue. Sets Operation Mode to TURNAROUND_RESCUE and applies stabilization actions. Also use when the user asks in Japanese (CPAが急に悪化した / CVが激減した / 広告費が暴走している / 緊急で立て直して)."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
 ---
 
 # Rescue

--- a/skills/search-term-cleanup/SKILL.md
+++ b/skills/search-term-cleanup/SKILL.md
@@ -2,7 +2,7 @@
 name: search-term-cleanup
 description: "Audit and clean up search terms (negative keywords, intent classification, query hygiene). Use when the user asks to clean up search queries, add negative keywords, review search term reports, or improve match quality. Cross-references Search Console, GA4, and ad platform data. Also use when the user asks in Japanese (検索語句のクリーンアップ / 除外キーワードを追加して / 無駄な検索クエリを止めたい)."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
 ---
 
 # Search Term Cleanup

--- a/skills/sync-state/SKILL.md
+++ b/skills/sync-state/SKILL.md
@@ -2,7 +2,7 @@
 name: sync-state
 description: "Sync STATE.json with current campaign data from all platforms. Use when the user asks to refresh state, sync campaigns, update STATE.json from live data, or pull latest campaign snapshots. Also use when the user asks in Japanese (STATE.jsonを更新 / 最新データに同期して / キャンペーン情報を取り込み直して)."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
 ---
 
 # Sync State

--- a/skills/tracking-health/SKILL.md
+++ b/skills/tracking-health/SKILL.md
@@ -2,7 +2,7 @@
 name: tracking-health
 description: "Preventive audit of conversion tracking across all configured ad platforms — Meta pixels + CAPI, Google Ads conversion actions — with a GA4 cross-check. Use when the user asks to check tracking, audit conversion measurement, verify pixels / tags, diagnose why conversions stopped or look wrong, sanity-check CV counting, or requests a 計測ヘルスチェック / タグ・計測監査 / 計測が壊れていないか確認. Reads STRATEGY.md and STATE.json, produces a per-platform tracking scorecard (OK / Watch / Broken per check) and a fix list ranked by revenue risk."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
 ---
 
 # Tracking Health

--- a/skills/weekly-report/SKILL.md
+++ b/skills/weekly-report/SKILL.md
@@ -2,7 +2,7 @@
 name: weekly-report
 description: "Generate a weekly summary report across all platforms. Use when the user asks for a weekly report, summary, recap, end-of-week review, or weekly digest. Also use when the user asks in Japanese (週次レポート / 今週のまとめ / 週報を作成して)."
 metadata:
-  version: 0.10.33
+  version: 0.10.34
 ---
 
 # Weekly Report


### PR DESCRIPTION
Version bump on all 55 surfaces + CHANGELOG cut. Ships #490 (mureo --version; fixes #487), #493 (lazy SDK imports + quickstart smoke; fixes #486/#488), #489 (README docs). After merge: publish GitHub Release v0.10.34 (triggers PyPI publish), then dispatch the from-pypi quickstart smoke to confirm it goes green.