### PR TITLE
feat(amazon): configure-UI setup, env-var fallback, and first-use token mint (#121)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -285,6 +285,7 @@ This rule was reinforced after PR #20 (2026-04-19, OAuth helper extraction — 6
 - Credentials are loaded from `~/.mureo/credentials.json` (priority) or environment variables (fallback)
 - Google Ads: `GOOGLE_ADS_DEVELOPER_TOKEN`, `GOOGLE_ADS_CLIENT_ID`, `GOOGLE_ADS_CLIENT_SECRET`, `GOOGLE_ADS_REFRESH_TOKEN`
 - Meta Ads: `META_ADS_ACCESS_TOKEN`, `META_ADS_APP_ID`, `META_ADS_APP_SECRET`
+- Amazon Ads: `AMAZON_ADS_CLIENT_ID` plus either `AMAZON_ADS_ACCESS_TOKEN` or both of `AMAZON_ADS_REFRESH_TOKEN` / `AMAZON_ADS_CLIENT_SECRET`; optional `AMAZON_ADS_REGION`, `AMAZON_ADS_ACCOUNT_MODE`, `AMAZON_ADS_PROFILE_ID`, `AMAZON_ADS_ACCOUNT_ID`, `AMAZON_ADS_MANAGER_ACCOUNT_ID`
 - The `auth_setup.py` wizard writes credentials to `~/.mureo/credentials.json`
 
 ## BYOD Mode (Bring Your Own Data)

--- a/docs/amazon-ads.ja.md
+++ b/docs/amazon-ads.ja.md
@@ -13,29 +13,93 @@ rollback 安全層を通ります。
 
 **範囲（正直に）:** read 中心、下記マニフェスト方式。
 Amazon のツール名はそのまま公開（taxonomy へ改名しない）— 他の
-公式 MCP と同じ扱い。LwA access トークンの自動更新は実装済み
-（後述）。Amazon の native ツール名に紐づく深いプラットフォーム
-固有分析は**まだありません**（#120 で追跡）— Amazon の分析結果は
-参考情報として扱ってください。
+公式 MCP と同じ扱い。LwA access トークンの自動発行・自動更新は
+実装済み（後述）。Amazon の native ツール名に紐づく深いプラット
+フォーム固有分析は**まだありません**（#120 で追跡）— Amazon の
+分析結果は参考情報として扱ってください。
 
 ## 1. Amazon 認証情報の取得（あなたが実施・mureo は代理入力しない）
 
 **Login with Amazon (LwA) アプリ** ＋ **Amazon Ads API** アクセス権
 のある Amazon Developer アカウントが必要です。そこから:
 
-- `client_id`（LwA アプリの client id）
-- `access_token`（LwA access トークン。**約 60 分で失効します**）
-- `refresh_token` ＋ `client_secret` — 強く推奨。この 2 つが揃うと
-  mureo が access トークンを自動更新します（後述）。無い場合は
-  失効のたびに `access_token` を手で貼り替える必要があります。
+- `client_id`（LwA アプリの client id）— 常に必須
+- `refresh_token` ＋ `client_secret` — **推奨**。この 2 つが揃うと
+  mureo が短命な access トークンを自動で発行・更新するため、以後
+  貼り替える作業がなくなります
+- `access_token` — 上記ペアがあれば任意。LwA access トークンで
+  **約 60 分で失効**します。refresh トークンを使わない場合のみ設定し、
+  失効のたびに手で貼り替えてください。
 
-## 2. `~/.mureo/credentials.json` に `amazon_ads` セクションを追加
+## 2. 設定 UI でセットアップ（推奨）
+
+```bash
+mureo configure
+```
+
+ブラウザでローカル設定 UI（`127.0.0.1` バインド）が開きます。手順:
+
+1. **ダッシュボード**を開き、**プラグイン認証情報**セクションまで
+   スクロールします。
+2. **Amazon Ads** のカードを見つけます。
+3. **クライアント ID** と、**リフレッシュトークン** ＋
+   **クライアントシークレット**（推奨）または
+   **アクセストークン**のいずれかを入力します。
+4. 必要に応じて**リージョン**（`na` / `eu` / `fe`、既定 `na`）と
+   **アカウントモード**（`dynamic` / `fixed`、既定 `dynamic`）を
+   設定します。`fixed` の場合は**プロファイル ID** /
+   **アカウント ID** / **マネージャーアカウント ID** のうち
+   1 つ以上も入力してください。
+5. **保存**をクリックします。
+
+値は `~/.mureo/credentials.json` の `amazon_ads` セクションに
+`0o600` で保存されます。シークレット項目は書き込み専用で、次回の
+編集時に空欄のままにすると保存済みの値が**保持**されます（消えま
+せん）。リージョンだけ変えたいときにトークンを打ち直す必要は
+ありません。
+
+> Amazon のブラウザサインイン（ワンクリックの OAuth 同意）ウィザードは
+> まだありません。カードは貼り付け式のフォームです。Google / Meta の
+> カードとの違いはこの点だけです。
+
+続けて手順 5（ツールマニフェスト生成）へ進んでください。
+
+## 3. 代替手段: 環境変数
+
+コンテナや CI で運用していて認証ファイルを配置したくない場合は、
+以下の環境変数を使えます。`~/.mureo/credentials.json` の
+`amazon_ads` セクションが有効な組み合わせを持つ場合はそちらが
+**優先**され、環境変数はフォールバックとしてのみ参照されます
+（Google / Meta と同じ規則）。
+
+| 変数 | 必須 | 説明 |
+|------|------|------|
+| `AMAZON_ADS_CLIENT_ID` | 必須 | LwA アプリ client id |
+| `AMAZON_ADS_REFRESH_TOKEN` | 下記参照 | LwA refresh トークン（`Atzr\|…`） |
+| `AMAZON_ADS_CLIENT_SECRET` | 下記参照 | LwA アプリの client secret |
+| `AMAZON_ADS_ACCESS_TOKEN` | 下記参照 | LwA access トークン（`Atza\|…`） |
+| `AMAZON_ADS_REGION` | 任意（既定 `na`） | `na` / `eu` / `fe`。エンドポイント選択 |
+| `AMAZON_ADS_ACCOUNT_MODE` | 任意（既定 `dynamic`） | `dynamic` / `fixed` |
+| `AMAZON_ADS_PROFILE_ID` | 任意 | **Fixed** 専用 |
+| `AMAZON_ADS_ACCOUNT_ID` | 任意 | **Fixed** 専用 |
+| `AMAZON_ADS_MANAGER_ACCOUNT_ID` | 任意 | **Fixed** 専用 |
+
+「下記参照」＝ `AMAZON_ADS_CLIENT_ID` に加えて、
+`AMAZON_ADS_ACCESS_TOKEN` **または**
+`AMAZON_ADS_REFRESH_TOKEN` と `AMAZON_ADS_CLIENT_SECRET` の**両方**。
+これに満たない場合、mureo は Amazon を「未設定」として扱います。
+
+## 4. フォールバック: `~/.mureo/credentials.json` を手で編集
+
+UI も環境変数も結局このセクションを作るだけなので、手編集も
+引き続き有効です:
 
 ```json
 {
   "amazon_ads": {
     "client_id": "amzn1.application-oa2-client.xxxxx",
-    "access_token": "Atza|xxxxx",
+    "refresh_token": "Atzr|xxxxx",
+    "client_secret": "amzn1.oa2-cs.v1.xxxxx",
     "region": "na",
     "account_mode": "dynamic"
   }
@@ -45,13 +109,13 @@ Amazon のツール名はそのまま公開（taxonomy へ改名しない）— 
 | フィールド | 必須 | 説明 |
 |-----------|------|------|
 | `client_id` | 必須 | LwA アプリ client id |
-| `access_token` | 必須 | LwA access トークン（`Atza|…`） |
+| `refresh_token` ＋ `client_secret` | 推奨 | 両方揃うと access トークンの自動発行・自動更新が有効になる |
+| `access_token` | 上記ペアが無い場合のみ必須 | LwA access トークン（`Atza\|…`）。約 60 分で失効 |
 | `region` | 任意（既定 `na`） | `na` / `eu` / `fe`。エンドポイント選択 |
 | `account_mode` | 任意（既定 `dynamic`） | `dynamic`（都度 LLM に確認）/ `fixed` |
-| `refresh_token`, `client_secret` | 推奨 | 両方揃うと access トークンの自動更新が有効になる |
 | `profile_id`, `account_id`, `manager_account_id` | 任意 | **Fixed** 専用（Fixed 発動には1つ以上必須） |
 
-## 3. ツールマニフェストを生成
+## 5. ツールマニフェストを生成
 
 ```bash
 mureo amazon refresh-manifest
@@ -65,7 +129,7 @@ mureo amazon refresh-manifest
 再実行してください。通常のトークン更新のために実行する必要は
 ありません（mureo が自動で行います。後述）。
 
-## 4. Claude / mureo MCP サーバを再起動
+## 6. Claude / mureo MCP サーバを再起動
 
 Amazon のツールが Amazon 自身の名前（例 `campaign_management-*`,
 `account_management-*`）で出現し、組み込みプラットフォームと同様に
@@ -73,42 +137,72 @@ Amazon のツールが Amazon 自身の名前（例 `campaign_management-*`,
 `action_log`（`platform=plugin:mureo-amazon-ads-bridge`）へ観測窓
 付きで昇格（#114 プラグイン安全層と同じ）。
 
-## access トークンの自動更新
+## access トークンの自動発行・自動更新
 
-`refresh_token` と `client_secret` が**両方**ある場合、約 60 分の
-失効は mureo が処理します。Amazon ツール呼び出しが最初に失敗した
-時点で Login with Amazon の更新を 1 回だけ実行し
-（リージョン別トークンホストへ `grant_type=refresh_token`）、
-新しいトークンを `~/.mureo/credentials.json` に書き戻して、呼び出しを
-1 回だけ再試行します。トークンや秘密情報がエラーメッセージ・ログに
+`refresh_token` と `client_secret` が**両方**ある場合、`access_token`
+に触る必要はありません:
+
+- **初回利用時。** `access_token` が未保存なら、mureo は最初の転送
+  呼び出しの**前に** Login with Amazon の交換を 1 回だけ実行し
+  （リージョン別トークンホストへ `grant_type=refresh_token`）、
+  発行されたトークンを `~/.mureo/credentials.json` に書き込んでから
+  処理を続行します。
+- **失効時（約 60 分）。** Amazon ツール呼び出しが最初に失敗した
+  時点で更新を 1 回だけ実行し、新しいトークンを保存して、呼び出しを
+  1 回だけ再試行します。
+
+いずれの場合も**1 回のディスパッチにつき LwA 交換は 1 回だけで、
+ループしません**。トークンや秘密情報がエラーメッセージ・ログに
 出ることはありません。
 
-- 1 呼び出しにつき更新 1 回・再試行 1 回。ループしません。
-- Amazon が `invalid_grant` を返した場合は refresh トークン自体が
-  無効です。広告主による再認可が必要で、mureo はその旨を明示します。
 - `~/.mureo/credentials.json` に書き込めない場合（多くは JSON が
   壊れているケース。他プロバイダの認証情報を失わないよう mureo は
   壊れたファイルを上書きしません）、黙って再試行せずその理由を
   付けて失敗します。
 - `mureo amazon refresh-manifest` は自動更新**しません**。保存済みの
-  `access_token` をそのまま使います。更新はツール実行経路でのみ
-  発生します。
+  `access_token` をそのまま使います。発行・更新はツール実行経路でのみ
+  発生するため、有効な access トークンが保存されている状態（または
+  ツール呼び出しで 1 度発行された後）で実行してください。
 
 `refresh_token` ＋ `client_secret` が無い場合は、失効時に
-`~/.mureo/credentials.json` の `access_token` を手動で更新してください。
+`access_token` を手動で更新してください（設定 UI の Amazon Ads
+カード、`AMAZON_ADS_ACCESS_TOKEN`、または
+`~/.mureo/credentials.json` のいずれか）。
+
+## refresh トークンも失効します（およそ 1 年ごと）
+
+Amazon の LwA refresh トークンは長寿命ですが**永続ではありません**。
+おおむね年 1 回の再認可を見込んでください。refresh トークンが無効に
+なると Amazon はトークン交換に `invalid_grant` を返し、mureo は
+「再認可が必要」であることを明示します。この時点で mureo が自動で
+できることはありません。
+
+復旧手順:
+
+1. LwA アプリを Amazon で再認可し、**新しい** `refresh_token` を
+   取得します。
+2. `mureo configure` の Amazon Ads カードの**リフレッシュトークン**
+   欄に貼り付けて保存します（または `AMAZON_ADS_REFRESH_TOKEN` /
+   `~/.mureo/credentials.json` を更新）。
+3. 次の Amazon ツール呼び出しで、そこから新しい access トークンが
+   自動発行されます。Amazon のツール構成も変わっている場合は
+   `mureo amazon refresh-manifest` も再実行してください。
 
 ## なぜ mureo が経路に入るのか
 
 公式 hosted MCP の中には、AI ホストに直接登録してホスト自身が接続・
 認証する方式のものもあります。Amazon を mureo 経由のブリッジにして
 いる理由は 2 つです。LwA 認証情報が `~/.mureo/credentials.json` に
-留まり、ホスト側の MCP 設定に一切入らないこと。そして上記の自動更新
-は mureo が経路にいて初めて成立すること（失敗を検知し、refresh
-トークンを交換し、再試行するのは mureo です）。代償として、Amazon の
-ツールは mureo MCP サーバが動いている間だけ利用できます。
+留まり、ホスト側の MCP 設定に一切入らないこと。そして上記の自動発行・
+自動更新は mureo が経路にいて初めて成立すること（失敗を検知し、
+refresh トークンを交換し、再試行するのは mureo です）。代償として、
+Amazon のツールは mureo MCP サーバが動いている間だけ利用できます。
 
 ## 注意
 
+- **ブラウザサインインは未対応**: 設定 UI の Amazon カードは貼り付け
+  式フォームです。Google / Meta のカードにあるワンクリック OAuth 同意
+  ウィザードは今後の対応です。
 - **改名なし**: ツールは Amazon の名前のまま（mureo は公式 MCP の
   ツールを改名しない＝Google/Meta 公式と同じ）。
 - **深い mureo 分析なし**: mureo の native ツール名に紐づく

--- a/docs/amazon-ads.md
+++ b/docs/amazon-ads.md
@@ -14,28 +14,92 @@ throttle / strategy / rollback safety layer.
 **Scope (honest):** read-focused, the manifest-backed bridge below.
 Amazon's own tool names are exposed as-is (no taxonomy remap) —
 consistent with how mureo treats other official MCPs. LwA access-token
-auto-refresh is built in (see below). Deep per-platform analytics
-keyed to Amazon's native tool names are **not** available yet (tracked
-in #120) — treat Amazon findings as advisory.
+minting and auto-refresh are built in (see below). Deep per-platform
+analytics keyed to Amazon's native tool names are **not** available yet
+(tracked in #120) — treat Amazon findings as advisory.
 
 ## 1. Get Amazon credentials (you do this — mureo never enters them)
 
 You need a **Login with Amazon (LwA) app** + an Amazon Developer
 account with **Amazon Ads API** access. From those, obtain:
 
-- `client_id` (the LwA application client id)
-- `access_token` (an LwA access token; **expires after ~60 minutes**)
-- `refresh_token` + `client_secret` — strongly recommended: together
-  they let mureo refresh the access token for you (see below). Without
-  them you must paste a fresh `access_token` by hand each time.
+- `client_id` (the LwA application client id) — always required
+- `refresh_token` + `client_secret` — **recommended**: together they
+  let mureo mint and refresh the short-lived access token for you, so
+  there is nothing to paste again later
+- `access_token` — optional when you have the pair above. It is an LwA
+  access token that **expires after ~60 minutes**; supply it only if
+  you are not using a refresh token, in which case you must paste a
+  fresh one by hand each time.
 
-## 2. Add the `amazon_ads` section to `~/.mureo/credentials.json`
+## 2. Set up in the configure UI (recommended)
+
+```bash
+mureo configure
+```
+
+That opens the local configuration UI in your browser (bound to
+`127.0.0.1`). Then:
+
+1. Open the **dashboard** and scroll to the **Plugin credentials**
+   section.
+2. Find the **Amazon Ads** card.
+3. Fill in **Client ID**, plus either **Refresh Token** + **Client
+   Secret** (recommended) or **Access Token**.
+4. Optionally set **Region** (`na` / `eu` / `fe`, default `na`) and
+   **Account Mode** (`dynamic` / `fixed`, default `dynamic`). In
+   `fixed` mode also fill at least one of **Profile ID**, **Account
+   ID**, **Manager Account ID**.
+5. Click **Save**.
+
+The values land in the `amazon_ads` section of
+`~/.mureo/credentials.json` at `0o600`. Secret fields are write-only in
+the form: leaving one blank on a later edit **keeps** the stored value
+rather than clearing it, so you never have to re-type a token to change
+the region.
+
+> The Amazon browser sign-in wizard (one-click OAuth consent) is not
+> built yet — the card is a form you paste into. That is the only
+> difference from the Google / Meta cards.
+
+Then continue with step 4 (build the tool manifest).
+
+## 3. Alternative: environment variables
+
+If you deploy mureo in a container or CI and would rather not ship a
+credentials file, set these instead. The `amazon_ads` section of
+`~/.mureo/credentials.json` **wins** when it holds a usable
+combination; the environment is only consulted as a fallback (same rule
+as Google and Meta).
+
+| Variable | Required | Notes |
+|----------|----------|-------|
+| `AMAZON_ADS_CLIENT_ID` | yes | LwA application client id |
+| `AMAZON_ADS_REFRESH_TOKEN` | see below | LwA refresh token (`Atzr\|…`) |
+| `AMAZON_ADS_CLIENT_SECRET` | see below | LwA application client secret |
+| `AMAZON_ADS_ACCESS_TOKEN` | see below | LwA access token (`Atza\|…`) |
+| `AMAZON_ADS_REGION` | no (default `na`) | `na` / `eu` / `fe` — picks the endpoint |
+| `AMAZON_ADS_ACCOUNT_MODE` | no (default `dynamic`) | `dynamic` or `fixed` |
+| `AMAZON_ADS_PROFILE_ID` | no | **Fixed** mode only |
+| `AMAZON_ADS_ACCOUNT_ID` | no | **Fixed** mode only |
+| `AMAZON_ADS_MANAGER_ACCOUNT_ID` | no | **Fixed** mode only |
+
+"See below" = `AMAZON_ADS_CLIENT_ID` plus **either**
+`AMAZON_ADS_ACCESS_TOKEN` **or both** of `AMAZON_ADS_REFRESH_TOKEN` and
+`AMAZON_ADS_CLIENT_SECRET`. Anything less and mureo reports Amazon as
+not configured.
+
+## 4. Fallback: edit `~/.mureo/credentials.json` by hand
+
+Everything the UI and the environment variables do is just this
+section, so hand-editing still works:
 
 ```json
 {
   "amazon_ads": {
     "client_id": "amzn1.application-oa2-client.xxxxx",
-    "access_token": "Atza|xxxxx",
+    "refresh_token": "Atzr|xxxxx",
+    "client_secret": "amzn1.oa2-cs.v1.xxxxx",
     "region": "na",
     "account_mode": "dynamic"
   }
@@ -45,13 +109,13 @@ account with **Amazon Ads API** access. From those, obtain:
 | Field | Required | Notes |
 |-------|----------|-------|
 | `client_id` | yes | LwA application client id |
-| `access_token` | yes | LwA access token (`Atza|…`) |
+| `refresh_token` + `client_secret` | recommended | both together enable automatic access-token minting + refresh |
+| `access_token` | only without the pair above | LwA access token (`Atza\|…`), expires in ~60 min |
 | `region` | no (default `na`) | `na` / `eu` / `fe` — picks the endpoint |
 | `account_mode` | no (default `dynamic`) | `dynamic` (LLM is asked per call) or `fixed` |
-| `refresh_token`, `client_secret` | recommended | both required to enable automatic access-token refresh |
 | `profile_id`, `account_id`, `manager_account_id` | no | **Fixed** mode only (≥1 required to engage Fixed) |
 
-## 3. Build the tool manifest
+## 5. Build the tool manifest
 
 ```bash
 mureo amazon refresh-manifest
@@ -67,7 +131,7 @@ Re-run this command whenever Amazon's tool surface changes, or after
 you re-authorize. It is not needed for a routine token refresh — mureo
 does that itself (see below).
 
-## 4. Restart Claude / the mureo MCP server
+## 6. Restart Claude / the mureo MCP server
 
 Amazon's tools now appear (under Amazon's own names, e.g.
 `campaign_management-*`, `account_management-*`) and are audited +
@@ -75,28 +139,53 @@ strategy-gated like built-in platforms. Mutating calls are promoted
 into `STATE.json` `action_log` (`platform=plugin:mureo-amazon-ads-bridge`)
 with an observation window, exactly like the #114 plugin safety layer.
 
-## Access-token refresh (automatic)
+## Access tokens (minted and refreshed for you)
 
-When **both** `refresh_token` and `client_secret` are present, mureo
-handles the ~60-minute expiry for you. On the first failure of an
-Amazon tool call it performs exactly one Login-with-Amazon refresh
-(`grant_type=refresh_token` against the regional token host), writes
-the new token back into `~/.mureo/credentials.json`, and retries the
-call once. Tokens and secrets never appear in error messages or logs.
+When **both** `refresh_token` and `client_secret` are present, you never
+have to touch `access_token`:
 
-- One refresh + one retry per call, never a loop.
-- If Amazon answers `invalid_grant`, the refresh token itself is dead:
-  the advertiser must re-authorize, and mureo says so explicitly.
+- **First use.** With no `access_token` stored, mureo performs one
+  Login-with-Amazon exchange (`grant_type=refresh_token` against the
+  regional token host) *before* the first forwarded call, writes the
+  minted token into `~/.mureo/credentials.json`, and proceeds.
+- **Expiry (~60 minutes).** On the first failure of an Amazon tool call
+  mureo performs exactly one refresh, persists the new token, and
+  retries the call once.
+
+Either way it is **one LwA exchange per dispatch, never a loop**, and
+tokens/secrets never appear in error messages or logs.
+
 - If `~/.mureo/credentials.json` cannot be written (most often because
   it is malformed — mureo refuses to overwrite a corrupt file and lose
   your other providers' credentials), the call fails with that reason
   rather than a silent retry loop.
 - `mureo amazon refresh-manifest` does **not** auto-refresh; it uses
-  the stored `access_token` as-is. Refresh only happens on the tool
-  dispatch path.
+  the stored `access_token` as-is. Minting and refresh only happen on
+  the tool dispatch path, so run `refresh-manifest` while a valid
+  access token is stored (or after a tool call has minted one).
 
-Without `refresh_token` + `client_secret`, update `access_token` in
-`~/.mureo/credentials.json` by hand when it expires.
+Without `refresh_token` + `client_secret`, update `access_token` (in
+the configure UI's Amazon Ads card, via `AMAZON_ADS_ACCESS_TOKEN`, or
+in `~/.mureo/credentials.json`) by hand when it expires.
+
+## Refresh tokens expire too (about once a year)
+
+Amazon's LwA refresh tokens are long-lived but **not permanent** —
+plan on re-authorizing roughly annually. When a refresh token dies,
+Amazon answers the token exchange with `invalid_grant` and mureo says
+so explicitly, telling you to re-authorize. There is nothing mureo can
+do automatically at that point.
+
+To recover:
+
+1. Re-authorize your LwA app with Amazon and obtain a **new**
+   `refresh_token`.
+2. Paste it into the **Refresh Token** field of the Amazon Ads card in
+   `mureo configure` (or update `AMAZON_ADS_REFRESH_TOKEN` /
+   `~/.mureo/credentials.json`) and save.
+3. The next Amazon tool call mints a fresh access token from it
+   automatically. Re-run `mureo amazon refresh-manifest` too if
+   Amazon's tool surface has changed since.
 
 ## Why mureo sits in the request path
 
@@ -104,13 +193,16 @@ Some official hosted MCPs are registered directly with your AI host,
 which then connects and authenticates on its own. Amazon is bridged
 through mureo instead for two reasons: the LwA credentials stay in
 `~/.mureo/credentials.json` and never enter the host's own MCP
-configuration, and the automatic refresh above only works with mureo in
-the request path — it is what observes the failure, exchanges the
-refresh token, and retries. The trade-off is that Amazon tools are
+configuration, and the automatic minting/refresh above only works with
+mureo in the request path — it is what observes the failure, exchanges
+the refresh token, and retries. The trade-off is that Amazon tools are
 available only while the mureo MCP server is running.
 
 ## Caveats
 
+- **No browser sign-in yet:** the configure UI's Amazon card is a paste
+  form. The one-click OAuth consent wizard the Google / Meta cards have
+  is a later change.
 - **No taxonomy remap:** tools keep Amazon's names (mureo does not
   rename official-MCP tools — same as Google/Meta official).
 - **No deep mureo analytics:** the per-platform analysis keyed to

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -37,7 +37,7 @@ Each subcommand also exposes explicit `--google-ads/--no-google-ads` and `--meta
 
 > `mureo auth setup --web` was **removed**; its browser credential flow is now part of the unified `mureo configure` UI.
 
-Prefer `mureo configure` when you were pointed to mureo by an AI agent that cannot safely receive terminal input, or you simply want a GUI. It starts a short-lived HTTP server on a random localhost port, opens your browser at it, and — beyond Google Ads / Meta Ads / GA4 credential entry via HTML forms and standard OAuth redirects (every field deep-linked to the right console) — also lets you pick the Claude host, run basic setup (MCP server + credential-guard hook + skills), add the official MCP providers, switch each platform between mureo-native and the official MCP, and scaffold Demo/BYOD. Flags: `--no-browser`, `--timeout-seconds N` (idle shutdown, default 600). The same security hardening (CSRF rotation, OAuth `state` re-validation, DNS-rebinding guard, localhost-pinned redirect verification, generic error surface, POST size cap, CSP) applies — see `SECURITY.md`.
+Prefer `mureo configure` when you were pointed to mureo by an AI agent that cannot safely receive terminal input, or you simply want a GUI. It starts a short-lived HTTP server on a random localhost port, opens your browser at it, and — beyond Google Ads / Meta Ads / GA4 credential entry via HTML forms and standard OAuth redirects (every field deep-linked to the right console), plus an **Amazon Ads** card in the dashboard's *Plugin credentials* section (a paste form — Amazon has no browser sign-in wizard yet; see [amazon-ads.md](amazon-ads.md)) — also lets you pick the Claude host, run basic setup (MCP server + credential-guard hook + skills), add the official MCP providers, switch each platform between mureo-native and the official MCP, and scaffold Demo/BYOD. Flags: `--no-browser`, `--timeout-seconds N` (idle shutdown, default 600). The same security hardening (CSRF rotation, OAuth `state` re-validation, DNS-rebinding guard, localhost-pinned redirect verification, generic error surface, POST size cap, CSP) applies — see `SECURITY.md`.
 
 ## How Credentials Work
 
@@ -105,6 +105,22 @@ If `~/.mureo/credentials.json` is missing or lacks the required fields, mureo fa
 | `META_ADS_ACCESS_TOKEN` | Yes | Graph API access token |
 | `META_ADS_APP_ID` | No | Meta App ID |
 | `META_ADS_APP_SECRET` | No | Meta App Secret |
+
+### Amazon Ads
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `AMAZON_ADS_CLIENT_ID` | Yes | Login with Amazon (LwA) application client ID |
+| `AMAZON_ADS_REFRESH_TOKEN` | Conditional | LwA refresh token — with the client secret, mureo mints and refreshes access tokens for you |
+| `AMAZON_ADS_CLIENT_SECRET` | Conditional | LwA application client secret |
+| `AMAZON_ADS_ACCESS_TOKEN` | Conditional | LwA access token (expires in ~60 min) |
+| `AMAZON_ADS_REGION` | No | `na` / `eu` / `fe` (default `na`) |
+| `AMAZON_ADS_ACCOUNT_MODE` | No | `dynamic` / `fixed` (default `dynamic`) |
+| `AMAZON_ADS_PROFILE_ID` | No | Fixed account mode only |
+| `AMAZON_ADS_ACCOUNT_ID` | No | Fixed account mode only |
+| `AMAZON_ADS_MANAGER_ACCOUNT_ID` | No | Fixed account mode only |
+
+"Conditional" means the client ID plus **either** `AMAZON_ADS_ACCESS_TOKEN` **or both** of `AMAZON_ADS_REFRESH_TOKEN` and `AMAZON_ADS_CLIENT_SECRET`. See [amazon-ads.md](amazon-ads.md).
 
 **Resolution order**: credentials.json takes priority. Environment variables are only checked if the corresponding section in credentials.json is missing or incomplete.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -127,7 +127,7 @@ See [authentication.md](authentication.md) for details on credentials.
 
 ## Amazon Ads Commands
 
-`mureo amazon` sets up the Amazon Ads official-MCP bridge. Amazon credentials are added to `~/.mureo/credentials.json` by hand (the `amazon_ads` section) rather than through a wizard.
+`mureo amazon` sets up the Amazon Ads official-MCP bridge. Enter the Amazon credentials first — in the **Amazon Ads** card of the **Plugin credentials** section of `mureo configure` (recommended), via the `AMAZON_ADS_*` environment variables, or by hand in the `amazon_ads` section of `~/.mureo/credentials.json`. There is no browser sign-in wizard for Amazon yet; the card is a paste form.
 
 ```bash
 # Discover Amazon's MCP tools and (re)write ~/.mureo/amazon_tools.json

--- a/mureo/amazon_ads/bridge.py
+++ b/mureo/amazon_ads/bridge.py
@@ -34,12 +34,250 @@ from mureo.auth import (
     load_amazon_ads_credentials,
     save_amazon_access_token,
 )
+from mureo.core.providers.credentials import AccountCredentialField
 from mureo.providers.config_writer import ConfigWriteError
 
 ConnectFactory = Callable[[str, dict[str, str]], AbstractAsyncContextManager[Any]]
 CredsLoader = Callable[[], AmazonAdsCredentials | None]
 Refresher = Callable[[AmazonAdsCredentials], LwaTokens]
 TokenSaver = Callable[[str, str | None], None]
+
+
+# Per-account credentials the operator supplies (#121). One field per
+# key ``mureo.auth.load_amazon_ads_credentials`` reads out of the
+# ``amazon_ads`` section, in the same order, so the configure UI's
+# generic form (``mureo.web.plugin_credentials``) writes a section the
+# loader accepts verbatim. Adding a key here without teaching the
+# loader about it — or vice versa — silently strands operator input.
+#
+# Only ``client_id`` is required: mureo accepts EITHER a pasted
+# ``access_token`` OR the durable ``refresh_token`` + ``client_secret``
+# pair it can mint one from, so neither can be marked required alone.
+_ACCOUNT_CREDENTIAL_FIELDS: tuple[AccountCredentialField, ...] = (
+    AccountCredentialField(
+        key="client_id",
+        display_name="Client ID",
+        placeholder="amzn1.application-oa2-client.xxxxx",
+        required=True,
+        description=(
+            "Login with Amazon (LwA) application client id. Find it in "
+            "the Amazon Developer console under Login with Amazon > "
+            "your Security Profile > Web Settings."
+        ),
+        display_name_i18n={"en": "Client ID", "ja": "クライアント ID"},
+        description_i18n={
+            "en": (
+                "Login with Amazon (LwA) application client id. Find it "
+                "in the Amazon Developer console under Login with Amazon "
+                "> your Security Profile > Web Settings."
+            ),
+            "ja": (
+                "Login with Amazon（LwA）アプリのクライアント ID。Amazon "
+                "Developer コンソールの「Login with Amazon」＞対象の"
+                "セキュリティプロファイル＞ウェブ設定で確認できます。"
+            ),
+        },
+    ),
+    AccountCredentialField(
+        key="access_token",
+        display_name="Access Token",
+        placeholder="Atza|xxxxx",
+        required=False,
+        secret=True,
+        description=(
+            "LwA access token — it expires after about 60 minutes. "
+            "Optional when refresh_token and client_secret are set: "
+            "mureo then mints one on the first call and refreshes it "
+            "for you. Leave blank unless you are pasting a token by hand."
+        ),
+        display_name_i18n={"en": "Access Token", "ja": "アクセストークン"},
+        description_i18n={
+            "en": (
+                "LwA access token — it expires after about 60 minutes. "
+                "Optional when refresh_token and client_secret are set: "
+                "mureo then mints one on the first call and refreshes it "
+                "for you. Leave blank unless you are pasting a token by "
+                "hand."
+            ),
+            "ja": (
+                "LwA アクセストークン（約 60 分で失効）。refresh_token と "
+                "client_secret を設定していれば任意です。その場合は初回"
+                "呼び出し時に mureo が発行し、以後も自動更新します。手動で"
+                "貼り付けるとき以外は空欄で構いません。"
+            ),
+        },
+    ),
+    AccountCredentialField(
+        key="refresh_token",
+        display_name="Refresh Token",
+        placeholder="Atzr|xxxxx",
+        required=False,
+        secret=True,
+        description=(
+            "LwA refresh token. With client_secret it lets mureo mint "
+            "and refresh the access token for you. Amazon expires "
+            "refresh tokens after about a year — paste a fresh one here "
+            "when calls start failing with an invalid_grant "
+            "re-authorize error."
+        ),
+        display_name_i18n={"en": "Refresh Token", "ja": "リフレッシュトークン"},
+        description_i18n={
+            "en": (
+                "LwA refresh token. With client_secret it lets mureo "
+                "mint and refresh the access token for you. Amazon "
+                "expires refresh tokens after about a year — paste a "
+                "fresh one here when calls start failing with an "
+                "invalid_grant re-authorize error."
+            ),
+            "ja": (
+                "LwA リフレッシュトークン。client_secret と揃うと mureo が"
+                "アクセストークンの発行・更新を自動で行います。Amazon の"
+                "リフレッシュトークンは約 1 年で失効します。invalid_grant"
+                "（再認可が必要）で呼び出しが失敗するようになったら、新しい"
+                "トークンをここに貼り直してください。"
+            ),
+        },
+    ),
+    AccountCredentialField(
+        key="client_secret",
+        display_name="Client Secret",
+        placeholder="amzn1.oa2-cs.v1.xxxxx",
+        required=False,
+        secret=True,
+        description=(
+            "LwA application client secret, from the same Security "
+            "Profile as the client id. Required together with "
+            "refresh_token for automatic access-token refresh."
+        ),
+        display_name_i18n={"en": "Client Secret", "ja": "クライアントシークレット"},
+        description_i18n={
+            "en": (
+                "LwA application client secret, from the same Security "
+                "Profile as the client id. Required together with "
+                "refresh_token for automatic access-token refresh."
+            ),
+            "ja": (
+                "LwA アプリのクライアントシークレット（クライアント ID と"
+                "同じセキュリティプロファイル）。アクセストークンの自動更新"
+                "には refresh_token と両方が必要です。"
+            ),
+        },
+    ),
+    AccountCredentialField(
+        key="region",
+        display_name="Region",
+        placeholder="na | eu | fe",
+        required=False,
+        description=(
+            "Amazon Ads region, which picks the MCP endpoint: na "
+            "(North America), eu (Europe), fe (Far East). Defaults to na."
+        ),
+        display_name_i18n={"en": "Region", "ja": "リージョン"},
+        description_i18n={
+            "en": (
+                "Amazon Ads region, which picks the MCP endpoint: na "
+                "(North America), eu (Europe), fe (Far East). Defaults "
+                "to na."
+            ),
+            "ja": (
+                "接続先エンドポイントを決める Amazon Ads のリージョン。"
+                "na（北米）/ eu（欧州）/ fe（極東）。既定は na です。"
+            ),
+        },
+    ),
+    AccountCredentialField(
+        key="account_mode",
+        display_name="Account Mode",
+        placeholder="dynamic | fixed",
+        required=False,
+        description=(
+            "dynamic lets the AI pick the advertiser account per call; "
+            "fixed pins it to the profile / account ids below. Defaults "
+            "to dynamic."
+        ),
+        display_name_i18n={"en": "Account Mode", "ja": "アカウントモード"},
+        description_i18n={
+            "en": (
+                "dynamic lets the AI pick the advertiser account per "
+                "call; fixed pins it to the profile / account ids below. "
+                "Defaults to dynamic."
+            ),
+            "ja": (
+                "dynamic は呼び出しごとに AI が広告アカウントを選びます。"
+                "fixed は下のプロファイル / アカウント ID に固定します。"
+                "既定は dynamic です。"
+            ),
+        },
+    ),
+    AccountCredentialField(
+        key="profile_id",
+        display_name="Profile ID",
+        placeholder="1234567890",
+        required=False,
+        description=(
+            "Amazon Advertising profile id, sent as the "
+            "Amazon-Advertising-API-Scope header. Fixed account mode only."
+        ),
+        display_name_i18n={"en": "Profile ID", "ja": "プロファイル ID"},
+        description_i18n={
+            "en": (
+                "Amazon Advertising profile id, sent as the "
+                "Amazon-Advertising-API-Scope header. Fixed account mode "
+                "only."
+            ),
+            "ja": (
+                "Amazon-Advertising-API-Scope ヘッダーに送る Amazon "
+                "Advertising のプロファイル ID。fixed モード専用です。"
+            ),
+        },
+    ),
+    AccountCredentialField(
+        key="account_id",
+        display_name="Account ID",
+        placeholder="ENTITY1234567890",
+        required=False,
+        description=(
+            "Advertiser account id, sent as the Amazon-Ads-AccountID "
+            "header. Fixed account mode only."
+        ),
+        display_name_i18n={"en": "Account ID", "ja": "アカウント ID"},
+        description_i18n={
+            "en": (
+                "Advertiser account id, sent as the Amazon-Ads-AccountID "
+                "header. Fixed account mode only."
+            ),
+            "ja": (
+                "Amazon-Ads-AccountID ヘッダーに送る広告アカウント ID。"
+                "fixed モード専用です。"
+            ),
+        },
+    ),
+    AccountCredentialField(
+        key="manager_account_id",
+        display_name="Manager Account ID",
+        placeholder="1234567890",
+        required=False,
+        description=(
+            "Manager account id, sent as the "
+            "Amazon-Ads-Manager-AccountID header. Fixed account mode only."
+        ),
+        display_name_i18n={
+            "en": "Manager Account ID",
+            "ja": "マネージャーアカウント ID",
+        },
+        description_i18n={
+            "en": (
+                "Manager account id, sent as the "
+                "Amazon-Ads-Manager-AccountID header. Fixed account mode "
+                "only."
+            ),
+            "ja": (
+                "Amazon-Ads-Manager-AccountID ヘッダーに送るマネージャー"
+                "アカウント ID。fixed モード専用です。"
+            ),
+        },
+    ),
+)
 
 
 class AmazonBridgeError(RuntimeError):
@@ -52,6 +290,16 @@ class AmazonAdsBridge:
 
     name = "amazon_ads"
     display_name = "Amazon Ads"
+    # #236 heading translations for the configure UI's provider card.
+    display_name_i18n = {"en": "Amazon Ads", "ja": "Amazon 広告"}
+
+    # Per-account credential fields (#121). Declared at module level
+    # as ``_ACCOUNT_CREDENTIAL_FIELDS`` — see there for the copy and
+    # the loader-parity contract; this is the class attribute
+    # ``mureo.core.providers.get_account_credential_fields`` reads.
+    account_credential_fields: tuple[AccountCredentialField, ...] = (
+        _ACCOUNT_CREDENTIAL_FIELDS
+    )
 
     def __init__(
         self,
@@ -91,8 +339,27 @@ class AmazonAdsBridge:
         if creds is None:
             raise AmazonBridgeError(
                 "amazon_ads credentials not configured in "
-                "~/.mureo/credentials.json (run the Amazon setup first)"
+                "~/.mureo/credentials.json (run `mureo configure` and fill "
+                "in the Amazon Ads card, or set the AMAZON_ADS_* env vars)"
             )
+        # #121 — the configure UI / env-var setup path stores only the
+        # durable LwA material, leaving access_token empty. Mint it here,
+        # BEFORE the first forwarded call: spending a guaranteed-to-fail
+        # round trip just to discover the obvious would be wasteful and
+        # would surface Amazon's error instead of ours. Minting consumes
+        # the single-LwA-exchange budget, so a failure afterwards is
+        # reported as-is rather than triggering a second exchange.
+        minted = False
+        if not creds.access_token:
+            creds = self._refresh_and_persist(
+                creds,
+                cause=None,
+                auth_failure_prefix=(
+                    "no amazon_ads access_token is stored and one could not "
+                    "be obtained from the refresh token"
+                ),
+            )
+            minted = True
         try:
             return await self._call(creds, name, arguments)
         except KeyboardInterrupt:
@@ -108,9 +375,50 @@ class AmazonAdsBridge:
             # error recurs; this is intentional until the 401 shape is
             # observed and can be narrowed. The original error is always
             # chained (``from first_exc``) so it is never lost.
-            if not (creds.refresh_token and creds.client_secret):
+            if minted or not (creds.refresh_token and creds.client_secret):
                 raise
             return await self._refresh_and_retry(creds, name, arguments, first_exc)
+
+    def _refresh_and_persist(
+        self,
+        creds: AmazonAdsCredentials,
+        *,
+        cause: BaseException | None,
+        auth_failure_prefix: str,
+    ) -> AmazonAdsCredentials:
+        """Mint a fresh LwA access token, persist it, return updated creds.
+
+        Shared by the two paths that may perform the single permitted LwA
+        exchange: the proactive mint (no ``access_token`` stored yet) and
+        the refresh-and-retry after a failed call. ``cause`` is the
+        original call failure on the retry path — chained onto every
+        raised :class:`AmazonBridgeError` so it is never lost — and
+        ``None`` on the mint path, where the LwA error is its own cause.
+        ``auth_failure_prefix`` names which of the two situations failed.
+        """
+        try:
+            tokens = self._refresher(creds)
+        except _LwaAuthError as auth_exc:
+            raise AmazonBridgeError(f"{auth_failure_prefix}: {auth_exc}") from (
+                cause if cause is not None else auth_exc
+            )
+        try:
+            self._token_saver(tokens.access_token, tokens.refresh_token)
+        except (ConfigWriteError, OSError) as save_exc:
+            # The new token is valid but is not on disk, so every later call
+            # would re-mint from a refresh token Amazon has already rotated
+            # against. Surface the underlying reason — typically a malformed
+            # credentials.json that mureo deliberately refuses to overwrite —
+            # instead of letting a raw traceback out.
+            raise AmazonBridgeError(
+                f"Amazon access token was refreshed but could not be saved to "
+                f"~/.mureo/credentials.json: {save_exc}"
+            ) from (cause if cause is not None else save_exc)
+        return dataclasses.replace(
+            creds,
+            access_token=tokens.access_token,
+            refresh_token=tokens.refresh_token,
+        )
 
     async def _refresh_and_retry(
         self,
@@ -125,28 +433,10 @@ class AmazonAdsBridge:
         actionable message, always chaining ``first_exc`` so the original
         call failure is never lost.
         """
-        try:
-            tokens = self._refresher(creds)
-        except _LwaAuthError as auth_exc:
-            raise AmazonBridgeError(
-                f"Amazon access token expired and refresh failed: {auth_exc}"
-            ) from first_exc
-        try:
-            self._token_saver(tokens.access_token, tokens.refresh_token)
-        except (ConfigWriteError, OSError) as save_exc:
-            # The refreshed token is valid but is not on disk, so every later
-            # call would re-refresh from a refresh token Amazon has already
-            # rotated against. Surface the underlying reason — typically a
-            # malformed credentials.json that mureo deliberately refuses to
-            # overwrite — instead of letting a raw traceback out.
-            raise AmazonBridgeError(
-                f"Amazon access token was refreshed but could not be saved to "
-                f"~/.mureo/credentials.json: {save_exc}"
-            ) from first_exc
-        refreshed = dataclasses.replace(
+        refreshed = self._refresh_and_persist(
             creds,
-            access_token=tokens.access_token,
-            refresh_token=tokens.refresh_token,
+            cause=first_exc,
+            auth_failure_prefix="Amazon access token expired and refresh failed",
         )
         try:
             return await self._call(refreshed, name, arguments)

--- a/mureo/amazon_ads/provider.py
+++ b/mureo/amazon_ads/provider.py
@@ -1,0 +1,105 @@
+"""Registry registration for the in-tree Amazon Ads bridge (#121).
+
+:class:`~mureo.amazon_ads.bridge.AmazonAdsBridge` is shipped inside
+mureo rather than as a ``mureo.providers`` entry point, so
+:meth:`Registry.discover` never sees it. Two surfaces need it in
+:data:`~mureo.core.providers.default_registry` anyway:
+
+- the MCP server, which feeds registry entries through
+  ``collect_plugin_tools`` to expose Amazon's tools, and
+- the ``mureo configure`` UI, whose plugin-credentials section renders
+  a form for every registered provider declaring
+  ``account_credential_fields``.
+
+Both call :func:`register_amazon_provider`, so the synthetic
+:class:`ProviderEntry` has exactly one definition. Registration is
+idempotent — the second call returns the already-registered entry
+without emitting a duplicate-name :class:`RegistryWarning` — and
+first-wins: an ``amazon_ads`` provider registered earlier (by a
+third-party plugin) is left in place, matching the registry's own
+shadowing policy.
+
+Ordering contract
+-----------------
+Callers MUST call :func:`register_amazon_provider` **before** running
+entry-point discovery (``discover_providers``) for the shadowing policy
+to hold. The registry is first-wins, so whichever registration lands
+first owns the ``amazon_ads`` slot: registering first is what makes the
+in-tree bridge deterministically beat a third-party distribution that
+publishes a ``mureo.providers`` entry point under the same name. Both
+in-tree callers honour this —
+:func:`mureo.mcp.server._discover_with_amazon` and
+:meth:`mureo.web.server.ConfigureWizard._discover_providers_safely` —
+so the MCP process and the configure process resolve the name
+identically.
+
+Registering first does NOT override a foreign entry that was already in
+the registry when this module's helper runs; that case keeps the
+documented first-wins behaviour and :func:`register_amazon_provider`
+returns the foreign entry.
+"""
+
+from __future__ import annotations
+
+from mureo.amazon_ads.bridge import AmazonAdsBridge
+from mureo.core.providers.registry import ProviderEntry, default_registry
+
+#: Pip-distribution label recorded on the entry. It also names the
+#: bridge in the audit trail (``source``) and in ``STATE.json``
+#: ``action_log`` entries (``platform=plugin:<this>``), so renaming it
+#: would orphan existing history.
+AMAZON_SOURCE_DISTRIBUTION = "mureo-amazon-ads-bridge"
+
+#: Registry key of the bridge — mirrors ``AmazonAdsBridge.name`` and the
+#: ``amazon_ads`` section of ``~/.mureo/credentials.json``.
+AMAZON_PROVIDER_NAME = "amazon_ads"
+
+
+def provider_entry() -> ProviderEntry:
+    """Build the synthetic :class:`ProviderEntry` for the bridge.
+
+    ``capabilities`` is empty on purpose: the bridge forwards Amazon's
+    own MCP tools verbatim and implements none of mureo's domain
+    Protocols, so it must not advertise a capability a
+    capability-filtered lookup would then try to use.
+    """
+    return ProviderEntry(
+        name=AMAZON_PROVIDER_NAME,
+        display_name=AmazonAdsBridge.display_name,
+        capabilities=frozenset(),
+        provider_class=AmazonAdsBridge,
+        source_distribution=AMAZON_SOURCE_DISTRIBUTION,
+    )
+
+
+def register_amazon_provider() -> ProviderEntry:
+    """Register the bridge in ``default_registry``; return the live entry.
+
+    Call this BEFORE entry-point discovery — see the module docstring's
+    ordering contract; the built-in only beats a same-named third-party
+    entry point if it registers first.
+
+    Safe to call repeatedly and from either startup path. The membership
+    check (rather than relying on ``register``'s first-wins branch) keeps
+    a repeat call silent: ``Registry.register`` would otherwise emit a
+    :class:`~mureo.core.providers.registry.RegistryWarning` every time,
+    and deployments that run with ``filterwarnings("error")`` would turn
+    a benign second call into a startup failure.
+
+    Returns:
+        The entry now registered under ``amazon_ads`` — this module's
+        entry, or a previously registered one (first-wins).
+    """
+    if AMAZON_PROVIDER_NAME in default_registry:
+        return default_registry.get(AMAZON_PROVIDER_NAME)
+    entry = provider_entry()
+    default_registry.register(entry)
+    return entry
+
+
+__all__ = [
+    "AMAZON_PROVIDER_NAME",
+    "AMAZON_SOURCE_DISTRIBUTION",
+    "provider_entry",
+    "register_amazon_provider",
+]

--- a/mureo/auth.py
+++ b/mureo/auth.py
@@ -227,46 +227,73 @@ def load_meta_ads_credentials(
 def load_amazon_ads_credentials(
     path: Path | None = None,
 ) -> AmazonAdsCredentials | None:
-    """Load Amazon Ads credentials from the ``amazon_ads`` section.
+    """Load Amazon Ads credentials with environment variable fallback.
 
-    Phase 1 of #113: credentials.json only — no environment-variable
-    fallback yet (Amazon env-var names are not an established contract).
-    ``client_id`` + ``access_token`` are required; an unknown
-    ``region`` / ``account_mode`` falls back to the safe defaults
-    (``na`` / ``dynamic``) rather than failing the load.
+    Priority:
+        1. ``amazon_ads`` section from the resolved
+           :class:`mureo.core.secret_store.SecretStore` (see
+           :func:`load_google_ads_credentials` for the full resolution
+           rules — same shape).
+        2. Environment variables (``AMAZON_ADS_*``, #121).
+
+    ``client_id`` is required, plus token material: EITHER a stored
+    ``access_token`` OR the ``refresh_token`` + ``client_secret`` pair
+    the bridge mints one from on first use (#121). An unknown ``region``
+    / ``account_mode`` falls back to the safe defaults (``na`` /
+    ``dynamic``) rather than failing the load.
 
     Returns:
-        AmazonAdsCredentials, or None if the section/required fields
-        are absent or the file is missing/invalid.
+        AmazonAdsCredentials, or None when neither source supplies a
+        usable combination.
     """
-    data = load_credentials(path)
-    section = data.get("amazon_ads")
-    if not isinstance(section, dict):
-        return None
+    section = _resolve_secret_store(path).load("amazon_ads")
+    credentials = _amazon_ads_from_mapping(section)
+    if credentials is not None:
+        return credentials
 
-    client_id = section.get("client_id", "")
-    access_token = section.get("access_token", "")
-    if not (client_id and access_token):
-        return None
+    # Environment variable fallback
+    return _load_amazon_ads_from_env()
 
-    region = str(section.get("region", "na")).strip().lower()
-    if region not in _AMAZON_REGIONS:
-        region = "na"
-    account_mode = str(section.get("account_mode", "dynamic")).strip().lower()
-    if account_mode not in _AMAZON_ACCOUNT_MODES:
-        account_mode = "dynamic"
+
+def _amazon_ads_from_mapping(section: dict[str, Any]) -> AmazonAdsCredentials | None:
+    """Build credentials from a raw ``amazon_ads`` mapping, or ``None``.
+
+    Shared by the file/secret-store path and the env-var path so the
+    "what counts as usable" rule has exactly one definition.
+    """
+    client_id = section.get("client_id") or ""
+    access_token = section.get("access_token") or ""
+    refresh_token = section.get("refresh_token") or None
+    client_secret = section.get("client_secret") or None
+    if not client_id:
+        return None
+    if not (access_token or (refresh_token and client_secret)):
+        return None
 
     return AmazonAdsCredentials(
         client_id=client_id,
         access_token=access_token,
-        region=region,
-        account_mode=account_mode,
-        refresh_token=section.get("refresh_token") or None,
-        client_secret=section.get("client_secret") or None,
+        region=_amazon_region(section.get("region")),
+        account_mode=_amazon_account_mode(section.get("account_mode")),
+        refresh_token=refresh_token,
+        client_secret=client_secret,
         profile_id=section.get("profile_id") or None,
         account_id=section.get("account_id") or None,
         manager_account_id=section.get("manager_account_id") or None,
     )
+
+
+def _amazon_region(value: object) -> str:
+    """Normalize a region to ``na`` / ``eu`` / ``fe`` (default ``na``)."""
+    region = str(value if value is not None else "na").strip().lower()
+    return region if region in _AMAZON_REGIONS else "na"
+
+
+def _amazon_account_mode(value: object) -> str:
+    """Normalize an account mode to ``dynamic`` / ``fixed`` (default
+    ``dynamic``)."""
+    mode = str(value if value is not None else "dynamic").strip().lower()
+    return mode if mode in _AMAZON_ACCOUNT_MODES else "dynamic"
 
 
 # ---------------------------------------------------------------------------
@@ -664,3 +691,25 @@ def _load_meta_ads_from_env() -> MetaAdsCredentials | None:
         app_secret=os.environ.get("META_ADS_APP_SECRET"),
         token_obtained_at=os.environ.get("META_ADS_TOKEN_OBTAINED_AT"),
     )
+
+
+def _load_amazon_ads_from_env() -> AmazonAdsCredentials | None:
+    """Load Amazon Ads credentials from environment variables (#121).
+
+    One env var per ``amazon_ads`` section key, so a container /
+    CI deployment can configure the bridge without a credentials file.
+    Usability is decided by :func:`_amazon_ads_from_mapping`, which is
+    also what the file path uses — the two sources cannot drift.
+    """
+    section = {
+        "client_id": os.environ.get("AMAZON_ADS_CLIENT_ID", ""),
+        "access_token": os.environ.get("AMAZON_ADS_ACCESS_TOKEN", ""),
+        "refresh_token": os.environ.get("AMAZON_ADS_REFRESH_TOKEN", ""),
+        "client_secret": os.environ.get("AMAZON_ADS_CLIENT_SECRET", ""),
+        "region": os.environ.get("AMAZON_ADS_REGION", ""),
+        "account_mode": os.environ.get("AMAZON_ADS_ACCOUNT_MODE", ""),
+        "profile_id": os.environ.get("AMAZON_ADS_PROFILE_ID", ""),
+        "account_id": os.environ.get("AMAZON_ADS_ACCOUNT_ID", ""),
+        "manager_account_id": os.environ.get("AMAZON_ADS_MANAGER_ACCOUNT_ID", ""),
+    }
+    return _amazon_ads_from_mapping(section)

--- a/mureo/mcp/server.py
+++ b/mureo/mcp/server.py
@@ -173,21 +173,33 @@ def _discover_with_amazon() -> tuple[Any, ...]:
     monkeypatched registry / module reload is still honoured. When the
     Amazon manifest is absent, ``AmazonAdsBridge.mcp_tools()`` returns
     ``()`` → no tools added → behaviour is byte-identical to before.
-    """
-    from mureo.amazon_ads.bridge import AmazonAdsBridge
-    from mureo.core.providers import registry as _registry
-    from mureo.core.providers.registry import ProviderEntry
 
+    #121: the entry is now built AND registered by
+    ``mureo.amazon_ads.provider`` — one definition shared with the
+    ``mureo configure`` UI, which needs it in ``default_registry`` to
+    render the Amazon credentials card. ``discover_providers`` returns
+    only what the entry-point pass registered, so the registration does
+    not by itself put Amazon in ``entries``; the explicit append below
+    is still what exposes the tools, guarded so an ``amazon_ads`` entry
+    point (were one ever installed) cannot double-expose them.
+
+    ORDER MATTERS: the built-in is registered BEFORE entry-point
+    discovery, matching ``ConfigureWizard._discover_providers_safely``.
+    The registry is first-wins, so registering first is what makes the
+    in-tree bridge deterministically beat a third-party plugin that
+    claims the ``amazon_ads`` name — in both processes, not just
+    whichever happened to run its registration earlier. A genuinely
+    pre-registered foreign ``amazon_ads`` (registered before this
+    function runs at all) still wins, which is the documented
+    first-wins contract.
+    """
+    from mureo.amazon_ads.provider import register_amazon_provider
+    from mureo.core.providers import registry as _registry
+
+    amazon = register_amazon_provider()
     entries = list(_registry.discover_providers())
-    entries.append(
-        ProviderEntry(
-            name="amazon_ads",
-            display_name="Amazon Ads",
-            capabilities=frozenset(),
-            provider_class=AmazonAdsBridge,
-            source_distribution="mureo-amazon-ads-bridge",
-        )
-    )
+    if not any(entry.name == amazon.name for entry in entries):
+        entries.append(amazon)
     return tuple(entries)
 
 

--- a/mureo/web/server.py
+++ b/mureo/web/server.py
@@ -156,8 +156,19 @@ class ConfigureWizard:
         with the MCP path: a plugin whose discovery hook raises
         ``SystemExit`` must not tear down configure startup. Only
         ``KeyboardInterrupt`` is honoured so Ctrl+C still works.
+
+        #121 — the in-tree Amazon Ads bridge is not a ``mureo.providers``
+        entry point, so it is registered explicitly (idempotently, from
+        the same single source the MCP startup path uses) or the Amazon
+        credentials card never renders. It goes FIRST so a wholesale
+        entry-point failure cannot take the built-in card down with it.
+        Imported lazily to keep the bridge — and the mcp SDK types it
+        pulls in — off the configure-UI import path.
         """
         try:
+            from mureo.amazon_ads.provider import register_amazon_provider
+
+            register_amazon_provider()
             discover_providers()
         except KeyboardInterrupt:
             raise

--- a/mureo/web/status_collector.py
+++ b/mureo/web/status_collector.py
@@ -150,7 +150,28 @@ def _detect_credentials_present(credentials_path: Path) -> dict[str, bool]:
     for section in sections:
         value = payload.get(section)
         out[section] = isinstance(value, dict) and bool(value)
+    out["amazon_ads"] = _amazon_credentials_usable(payload.get("amazon_ads"))
     return out
+
+
+def _amazon_credentials_usable(section: Any) -> bool:
+    """Amazon needs more than a non-empty section to be configured (#121).
+
+    A half-filled ``amazon_ads`` block (say a ``region`` and nothing
+    else) would light up the dashboard pill while every Amazon call
+    still fails, so presence mirrors
+    :func:`mureo.auth.load_amazon_ads_credentials`: a ``client_id`` plus
+    either a stored ``access_token`` or the ``refresh_token`` +
+    ``client_secret`` pair mureo mints one from.
+    """
+    if not isinstance(section, dict):
+        return False
+    if not section.get("client_id"):
+        return False
+    return bool(
+        section.get("access_token")
+        or (section.get("refresh_token") and section.get("client_secret"))
+    )
 
 
 def _detect_credentials_oauth(credentials_path: Path) -> dict[str, bool]:

--- a/tests/test_amazon_bridge.py
+++ b/tests/test_amazon_bridge.py
@@ -357,3 +357,158 @@ class TestTokenRefreshRetry:
         # original first failure preserved as the explicit cause
         assert isinstance(ei.value.__cause__, RuntimeError)
         assert "401 token expired" in str(ei.value.__cause__)
+
+
+@pytest.mark.unit
+class TestProactiveTokenMint:
+    """#121 — an empty ``access_token`` is minted BEFORE the first call.
+
+    The configure-UI / env-var setup path stores only the durable LwA
+    material (``client_id`` + ``refresh_token`` + ``client_secret``).
+    Spending a guaranteed-to-fail forwarded call just to discover that
+    would be wasteful and confusing, so the bridge mints first. The
+    one-refresh bound still holds: minting counts as the single LwA
+    exchange, so a failure afterwards is NOT retried.
+    """
+
+    def _creds(self, **kw):
+        base = dict(
+            client_id="cid",
+            access_token="",
+            refresh_token="Atzr|R",
+            client_secret="sec",
+        )
+        base.update(kw)
+        return AmazonAdsCredentials(**base)
+
+    def _mk(self, tmp_path: Path, creds, connect, **kw):
+        mp = tmp_path / "amazon_tools.json"
+        mp.write_text(json.dumps(_MANIFEST))
+        return AmazonAdsBridge(
+            manifest_path=mp,
+            creds_loader=lambda: creds,
+            connect=connect,
+            refresher=kw.get("refresher"),
+            token_saver=kw.get("token_saver"),
+        )
+
+    def test_empty_access_token_is_minted_persisted_and_used(
+        self, tmp_path: Path
+    ) -> None:
+        from mureo.amazon_ads.lwa import LwaTokens
+
+        calls: list = []
+        captured: dict = {}
+        saved: list = []
+        b = self._mk(
+            tmp_path,
+            self._creds(),
+            _connect(calls, captured, ["RESULT"]),
+            refresher=lambda c: LwaTokens("Atza|MINTED", "Atzr|R2", 3600),
+            token_saver=lambda a, r: saved.append((a, r)),
+        )
+        out = asyncio.run(b.handle_mcp_tool("campaign_management-x", {}))
+
+        assert out == ["RESULT"]
+        assert saved == [("Atza|MINTED", "Atzr|R2")]
+        assert captured["headers"]["Authorization"] == "Bearer Atza|MINTED"
+        # Exactly one forwarded call — no wasted first attempt.
+        assert calls == [("initialize",), ("call_tool", "campaign_management-x", {})]
+
+    def test_stored_access_token_is_used_as_is_without_minting(
+        self, tmp_path: Path
+    ) -> None:
+        refreshed: list = []
+        captured: dict = {}
+        b = self._mk(
+            tmp_path,
+            self._creds(access_token="Atza|STORED"),
+            _connect([], captured, ["RESULT"]),
+            refresher=lambda c: refreshed.append(1),
+            token_saver=lambda a, r: None,
+        )
+        asyncio.run(b.handle_mcp_tool("x", {}))
+        assert refreshed == []
+        assert captured["headers"]["Authorization"] == "Bearer Atza|STORED"
+
+    def test_mint_failure_surfaces_an_actionable_error_without_token_text(
+        self, tmp_path: Path
+    ) -> None:
+        from mureo.amazon_ads.lwa import AmazonAuthError
+
+        def refresher(c):
+            raise AmazonAuthError(
+                "LwA refresh token is invalid_grant — the advertiser must "
+                "re-authorize (see docs/amazon-ads.md)"
+            )
+
+        b = self._mk(
+            tmp_path,
+            self._creds(),
+            _connect([], {}, ["RESULT"]),
+            refresher=refresher,
+            token_saver=lambda a, r: None,
+        )
+        with pytest.raises(AmazonBridgeError, match="re-authorize") as ei:
+            asyncio.run(b.handle_mcp_tool("x", {}))
+        assert "Atzr|" not in str(ei.value)
+
+    def test_unpersistable_minted_token_raises_a_clear_error(
+        self, tmp_path: Path
+    ) -> None:
+        from mureo.amazon_ads.lwa import LwaTokens
+        from mureo.providers.config_writer import ConfigWriteError
+
+        def saver(access: str, refresh: str | None) -> None:
+            raise ConfigWriteError("credentials.json is malformed")
+
+        b = self._mk(
+            tmp_path,
+            self._creds(),
+            _connect([], {}, ["RESULT"]),
+            refresher=lambda c: LwaTokens("Atza|MINTED", "Atzr|R", 3600),
+            token_saver=saver,
+        )
+        with pytest.raises(AmazonBridgeError, match="malformed") as ei:
+            asyncio.run(b.handle_mcp_tool("x", {}))
+        assert "Atza|" not in str(ei.value)
+
+    def test_call_failure_after_a_mint_is_not_retried(self, tmp_path: Path) -> None:
+        """One LwA exchange per dispatch — minting consumes the budget."""
+        from mureo.amazon_ads.lwa import LwaTokens
+
+        attempts: list[str] = []
+        refreshed: list = []
+
+        class _Sess:
+            async def initialize(s):
+                pass
+
+            async def call_tool(s, name, arguments):
+                raise RuntimeError("401 token expired")
+
+        class _CM:
+            def __init__(s, url, headers):
+                attempts.append(headers["Authorization"])
+
+            async def __aenter__(s):
+                return _Sess()
+
+            async def __aexit__(s, *e):
+                return False
+
+        def refresher(c):
+            refreshed.append(1)
+            return LwaTokens("Atza|MINTED", "Atzr|R", 3600)
+
+        b = self._mk(
+            tmp_path,
+            self._creds(),
+            lambda url, headers: _CM(url, headers),
+            refresher=refresher,
+            token_saver=lambda a, r: None,
+        )
+        with pytest.raises(RuntimeError, match="401 token expired"):
+            asyncio.run(b.handle_mcp_tool("x", {}))
+        assert refreshed == [1]  # minted once, never refreshed again
+        assert attempts == ["Bearer Atza|MINTED"]  # exactly one forwarded call

--- a/tests/test_amazon_provider_registration.py
+++ b/tests/test_amazon_provider_registration.py
@@ -1,0 +1,315 @@
+"""Amazon Ads bridge as a registry provider (TDD, #121 gap 3 phase A).
+
+Amazon must be set-up-able from the configure web UI, which renders a
+generic form for every ``default_registry`` provider declaring
+``account_credential_fields``. That requires two things this module
+pins:
+
+1. ``AmazonAdsBridge`` declares every key
+   :func:`mureo.auth.load_amazon_ads_credentials` reads, with the
+   secret ones flagged ``secret=True``.
+2. A single-sourced synthetic ``ProviderEntry`` is registered into
+   ``default_registry`` — idempotently, so the MCP startup path and the
+   configure-UI discovery path can both call it.
+
+Round-trip: what the configure UI saves through
+``save_plugin_credentials`` must be a section the loader accepts.
+"""
+
+from __future__ import annotations
+
+import json
+import warnings
+from typing import TYPE_CHECKING
+
+import pytest
+
+from mureo.amazon_ads.bridge import AmazonAdsBridge
+from mureo.amazon_ads.provider import (
+    AMAZON_SOURCE_DISTRIBUTION,
+    provider_entry,
+    register_amazon_provider,
+)
+from mureo.auth import load_amazon_ads_credentials
+from mureo.core.providers import default_registry, get_account_credential_fields
+from mureo.core.providers.registry import ProviderEntry, RegistryWarning
+from mureo.core.secret_store import FilesystemSecretStore
+from mureo.web.plugin_credentials import (
+    list_plugin_credential_fields,
+    save_plugin_credentials,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+#: Every key ``load_amazon_ads_credentials`` consumes from the section.
+_LOADER_KEYS = (
+    "client_id",
+    "access_token",
+    "refresh_token",
+    "client_secret",
+    "region",
+    "account_mode",
+    "profile_id",
+    "account_id",
+    "manager_account_id",
+)
+
+#: Keys carrying credential material — never a plain-text input.
+_SECRET_KEYS = frozenset({"client_secret", "refresh_token", "access_token"})
+
+
+@pytest.fixture()
+def _isolated_registry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Give each test a private ``default_registry`` entry map."""
+    monkeypatch.setattr(default_registry, "_entries", {})
+
+
+@pytest.mark.unit
+class TestAccountCredentialFields:
+    def test_declares_every_key_the_loader_reads(self) -> None:
+        fields = get_account_credential_fields(AmazonAdsBridge)
+        assert tuple(f.key for f in fields) == _LOADER_KEYS
+
+    def test_secret_material_is_flagged_secret(self) -> None:
+        fields = get_account_credential_fields(AmazonAdsBridge)
+        secret = {f.key for f in fields if f.secret}
+        assert secret == _SECRET_KEYS
+
+    def test_client_id_is_the_only_required_field(self) -> None:
+        fields = get_account_credential_fields(AmazonAdsBridge)
+        assert [f.key for f in fields if f.required] == ["client_id"]
+
+    def test_region_and_account_mode_placeholders_list_the_options(self) -> None:
+        by_key = {f.key: f for f in get_account_credential_fields(AmazonAdsBridge)}
+        assert by_key["region"].placeholder == "na | eu | fe"
+        assert by_key["account_mode"].placeholder == "dynamic | fixed"
+
+    def test_every_field_ships_en_and_ja_copy(self) -> None:
+        for field in get_account_credential_fields(AmazonAdsBridge):
+            assert set(field.display_name_i18n) >= {"en", "ja"}, field.key
+            assert set(field.description_i18n) >= {"en", "ja"}, field.key
+
+    def test_access_token_description_says_it_is_optional(self) -> None:
+        by_key = {f.key: f for f in get_account_credential_fields(AmazonAdsBridge)}
+        access = by_key["access_token"]
+        assert access.required is False
+        assert "refresh_token" in access.description
+        assert "client_secret" in access.description
+
+    def test_heading_has_a_japanese_translation(self) -> None:
+        assert AmazonAdsBridge.display_name_i18n["ja"]
+        assert AmazonAdsBridge.display_name_i18n["en"] == "Amazon Ads"
+
+
+@pytest.mark.unit
+class TestProviderEntry:
+    def test_entry_identifies_the_bridge(self) -> None:
+        entry = provider_entry()
+        assert isinstance(entry, ProviderEntry)
+        assert entry.name == "amazon_ads"
+        assert entry.display_name == "Amazon Ads"
+        assert entry.provider_class is AmazonAdsBridge
+        assert entry.source_distribution == AMAZON_SOURCE_DISTRIBUTION
+        assert entry.capabilities == frozenset()
+
+    def test_source_distribution_matches_the_audit_trail_name(self) -> None:
+        # ``plugin:mureo-amazon-ads-bridge`` is already written into
+        # STATE.json action_log entries; renaming it would orphan history.
+        assert AMAZON_SOURCE_DISTRIBUTION == "mureo-amazon-ads-bridge"
+
+    def test_register_inserts_into_the_default_registry(
+        self, _isolated_registry: None
+    ) -> None:
+        assert "amazon_ads" not in default_registry
+        entry = register_amazon_provider()
+        assert "amazon_ads" in default_registry
+        assert default_registry.get("amazon_ads") is entry
+
+    def test_repeat_registration_is_a_silent_no_op(
+        self, _isolated_registry: None
+    ) -> None:
+        first = register_amazon_provider()
+        with warnings.catch_warnings(record=True) as captured:
+            warnings.simplefilter("always")
+            second = register_amazon_provider()
+        assert second is first
+        assert len(default_registry) == 1
+        assert not [w for w in captured if issubclass(w.category, RegistryWarning)]
+
+    def test_a_prior_third_party_registration_wins(
+        self, _isolated_registry: None
+    ) -> None:
+        """First-wins: an already-registered ``amazon_ads`` is not replaced."""
+
+        class _Other:
+            name = "amazon_ads"
+            display_name = "Someone Else"
+            capabilities = frozenset()
+
+        squatter = ProviderEntry(
+            name="amazon_ads",
+            display_name="Someone Else",
+            capabilities=frozenset(),
+            provider_class=_Other,
+            source_distribution="third-party",
+        )
+        default_registry.register(squatter)
+        assert register_amazon_provider() is squatter
+
+
+@pytest.mark.unit
+class TestConfigureServerDiscovery:
+    def test_configure_discovery_registers_amazon(
+        self, _isolated_registry: None
+    ) -> None:
+        """``mureo configure`` startup must populate the Amazon card.
+
+        The bridge is in-tree (no ``mureo.providers`` entry point), so
+        entry-point discovery alone leaves the registry without it and
+        the configure UI shows no Amazon section.
+        """
+        from mureo.web.server import ConfigureWizard
+
+        ConfigureWizard._discover_providers_safely()
+        assert "amazon_ads" in default_registry
+
+    def test_configure_discovery_registers_amazon_even_if_plugins_fail(
+        self, _isolated_registry: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from mureo.web.server import ConfigureWizard
+
+        def _boom(*_a: object, **_kw: object) -> None:
+            raise RuntimeError("entry_points exploded")
+
+        # ``_discover_providers_safely`` resolves ``discover_providers``
+        # through the module globals at call time, so patching the name
+        # on the module intercepts it.
+        monkeypatch.setattr("mureo.web.server.discover_providers", _boom)
+        ConfigureWizard._discover_providers_safely()
+        assert "amazon_ads" in default_registry
+
+
+@pytest.mark.unit
+class TestConfigureUiListing:
+    def test_amazon_card_is_listed_with_the_loader_keys(
+        self, _isolated_registry: None
+    ) -> None:
+        register_amazon_provider()
+        cards = list_plugin_credential_fields()
+        amazon = [c for c in cards if c["provider_name"] == "amazon_ads"]
+        assert len(amazon) == 1
+        card = amazon[0]
+        assert card["display_name"] == "Amazon Ads"
+        assert tuple(f["key"] for f in card["fields"]) == _LOADER_KEYS
+        assert {f["key"] for f in card["fields"] if f["secret"]} == _SECRET_KEYS
+
+    def test_japanese_locale_resolves_the_heading_and_labels(
+        self, _isolated_registry: None
+    ) -> None:
+        register_amazon_provider()
+        card = next(
+            c
+            for c in list_plugin_credential_fields("ja")
+            if c["provider_name"] == "amazon_ads"
+        )
+        assert card["display_name"] == AmazonAdsBridge.display_name_i18n["ja"]
+        labels = {f["key"]: f["display_name"] for f in card["fields"]}
+        assert labels["client_id"] != "Client ID"  # translated, not the fallback
+
+    def test_listing_never_leaks_a_stored_secret_value(
+        self, _isolated_registry: None, tmp_path: Path
+    ) -> None:
+        register_amazon_provider()
+        creds = tmp_path / "credentials.json"
+        creds.write_text(
+            json.dumps(
+                {
+                    "amazon_ads": {
+                        "client_id": "amzn1.application-oa2-client.x",
+                        "client_secret": "LEAK-SECRET",
+                        "refresh_token": "LEAK-REFRESH",
+                        "access_token": "LEAK-ACCESS",
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        payload = json.dumps(list_plugin_credential_fields())
+        for leaked in ("LEAK-SECRET", "LEAK-REFRESH", "LEAK-ACCESS"):
+            assert leaked not in payload
+
+
+@pytest.mark.unit
+class TestSaveRoundTrip:
+    def test_saved_form_is_loadable_by_the_credential_loader(
+        self, _isolated_registry: None, tmp_path: Path
+    ) -> None:
+        register_amazon_provider()
+        creds = tmp_path / "credentials.json"
+        store = FilesystemSecretStore(path=creds)
+
+        save_plugin_credentials(
+            "amazon_ads",
+            {
+                "client_id": "amzn1.application-oa2-client.x",
+                "client_secret": "lwa-secret",
+                "refresh_token": "Atzr|R",
+                "access_token": "",
+                "region": "eu",
+                "account_mode": "fixed",
+                "profile_id": "111",
+                "account_id": "222",
+                "manager_account_id": "333",
+            },
+            secret_store=store,
+        )
+
+        loaded = load_amazon_ads_credentials(path=creds)
+        assert loaded is not None
+        assert loaded.client_id == "amzn1.application-oa2-client.x"
+        assert loaded.client_secret == "lwa-secret"
+        assert loaded.refresh_token == "Atzr|R"
+        assert loaded.access_token == ""  # minted on first use
+        assert loaded.region == "eu"
+        assert loaded.account_mode == "fixed"
+        assert loaded.profile_id == "111"
+        assert loaded.account_id == "222"
+        assert loaded.manager_account_id == "333"
+
+    def test_minimal_save_with_access_token_only_is_loadable(
+        self, _isolated_registry: None, tmp_path: Path
+    ) -> None:
+        register_amazon_provider()
+        creds = tmp_path / "credentials.json"
+        save_plugin_credentials(
+            "amazon_ads",
+            {"client_id": "cid", "access_token": "Atza|T"},
+            secret_store=FilesystemSecretStore(path=creds),
+        )
+        loaded = load_amazon_ads_credentials(path=creds)
+        assert loaded is not None
+        assert loaded.access_token == "Atza|T"
+        assert loaded.region == "na"
+        assert loaded.account_mode == "dynamic"
+
+    def test_blank_secret_keeps_the_stored_value(
+        self, _isolated_registry: None, tmp_path: Path
+    ) -> None:
+        register_amazon_provider()
+        creds = tmp_path / "credentials.json"
+        store = FilesystemSecretStore(path=creds)
+        save_plugin_credentials(
+            "amazon_ads",
+            {"client_id": "cid", "refresh_token": "Atzr|R", "client_secret": "sec"},
+            secret_store=store,
+        )
+        save_plugin_credentials(
+            "amazon_ads",
+            {"client_id": "cid", "refresh_token": "", "client_secret": ""},
+            secret_store=store,
+        )
+        loaded = load_amazon_ads_credentials(path=creds)
+        assert loaded is not None
+        assert loaded.refresh_token == "Atzr|R"
+        assert loaded.client_secret == "sec"

--- a/tests/test_amazon_server_wiring.py
+++ b/tests/test_amazon_server_wiring.py
@@ -169,3 +169,200 @@ class TestAmazonServerWiring:
             assert amazon == []
         finally:
             importlib.reload(mod)
+
+
+@pytest.mark.unit
+class TestAmazonRegistryRegistration:
+    """#121 — the bridge is registered ONCE, and only once.
+
+    The synthetic ``ProviderEntry`` is now single-sourced in
+    ``mureo.amazon_ads.provider`` and registered into
+    ``default_registry`` (so the configure UI can see it) *and* fed to
+    ``collect_plugin_tools`` (so the MCP server exposes its tools).
+    Both paths must not double-count.
+    """
+
+    def test_startup_registers_amazon_in_the_default_registry(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        from mureo.amazon_ads.bridge import AmazonAdsBridge
+        from mureo.core.providers import default_registry
+
+        monkeypatch.setattr(default_registry, "_entries", {})
+        mod = _reload_server(monkeypatch, tmp_path, with_manifest=True)
+        try:
+            assert "amazon_ads" in default_registry
+            assert default_registry.get("amazon_ads").provider_class is AmazonAdsBridge
+        finally:
+            importlib.reload(mod)
+
+    def test_discover_yields_the_amazon_entry_exactly_once(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        from mureo.core.providers import default_registry
+
+        monkeypatch.setattr(default_registry, "_entries", {})
+        mod = _reload_server(monkeypatch, tmp_path, with_manifest=True)
+        try:
+            names = [e.name for e in mod._discover_with_amazon()]
+            assert names.count("amazon_ads") == 1
+            # Idempotent: calling again (as a re-discovery would) does not
+            # duplicate the entry either.
+            names = [e.name for e in mod._discover_with_amazon()]
+            assert names.count("amazon_ads") == 1
+        finally:
+            importlib.reload(mod)
+
+    def test_each_amazon_tool_is_collected_exactly_once(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        from mureo.core.providers import default_registry
+
+        monkeypatch.setattr(default_registry, "_entries", {})
+        mod = _reload_server(monkeypatch, tmp_path, with_manifest=True)
+        try:
+            names = [t.name for t in mod._PLUGIN_TOOLS]
+            assert names.count("campaign_management-create_campaign") == 1
+            assert names.count("account_management-query_advertiser_account") == 1
+            assert len(mod._ALL_TOOLS) == len({t.name for t in mod._ALL_TOOLS})
+        finally:
+            importlib.reload(mod)
+
+    def test_registration_contributes_zero_tools_without_a_manifest(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        """Registry presence must not create tools out of thin air."""
+        from mureo.core.providers import default_registry
+
+        monkeypatch.setattr(default_registry, "_entries", {})
+        mod = _reload_server(monkeypatch, tmp_path, with_manifest=False)
+        try:
+            assert "amazon_ads" in default_registry  # UI can still configure it
+            assert mod._PLUGIN_TOOLS == []
+        finally:
+            importlib.reload(mod)
+
+
+@pytest.mark.unit
+class TestBuiltInShadowingPolicy:
+    """#121 review follow-up — the built-in wins a name clash, everywhere.
+
+    ``Registry`` is first-wins, so *when* the in-tree bridge registers
+    decides whether a third-party distribution publishing a
+    ``mureo.providers`` entry point named ``amazon_ads`` can take the
+    slot. Both in-tree startup paths must therefore register the
+    built-in BEFORE running entry-point discovery. These tests pin that
+    property from the observable side (which entry comes back), not by
+    asserting call order.
+    """
+
+    def _foreign_entry(self):
+        from mureo.core.providers.registry import ProviderEntry
+
+        class _Squatter:
+            name = "amazon_ads"
+            display_name = "Amazon Ads (third party)"
+            capabilities = frozenset()
+
+        return ProviderEntry(
+            name="amazon_ads",
+            display_name="Amazon Ads (third party)",
+            capabilities=frozenset(),
+            provider_class=_Squatter,
+            source_distribution="squatter-plugin",
+        )
+
+    def _discover_publishing_foreign_amazon(self, foreign):
+        """Fake entry-point discovery that ships an ``amazon_ads`` provider.
+
+        Mirrors ``Registry._load_entry_point``: it attempts registration
+        and returns ONLY the entries actually inserted, so an entry
+        dropped by first-wins is absent from the result — exactly what
+        the real discovery pass does.
+        """
+        import warnings
+
+        from mureo.core.providers import default_registry
+        from mureo.core.providers.registry import RegistryWarning
+
+        def _discover(*_a, **_kw):
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", RegistryWarning)
+                default_registry.register(foreign)
+            stored = default_registry.get("amazon_ads")
+            return (foreign,) if stored is foreign else ()
+
+        return _discover
+
+    def test_builtin_beats_a_same_named_entry_point_plugin(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        """Registering first means the entry-point squatter is dropped."""
+        from mureo.amazon_ads.bridge import AmazonAdsBridge
+        from mureo.amazon_ads.provider import AMAZON_SOURCE_DISTRIBUTION
+        from mureo.core.providers import default_registry
+        from mureo.mcp import server as mod
+
+        monkeypatch.setattr(default_registry, "_entries", {})
+        foreign = self._foreign_entry()
+        monkeypatch.setattr(
+            "mureo.core.providers.registry.discover_providers",
+            self._discover_publishing_foreign_amazon(foreign),
+        )
+
+        entries = mod._discover_with_amazon()
+
+        amazon = [e for e in entries if e.name == "amazon_ads"]
+        assert len(amazon) == 1  # still exactly once
+        assert amazon[0].source_distribution == AMAZON_SOURCE_DISTRIBUTION
+        assert amazon[0].provider_class is AmazonAdsBridge
+        # ...and the registry agrees, so the configure UI renders the
+        # built-in's credential fields rather than the squatter's.
+        assert default_registry.get("amazon_ads").provider_class is AmazonAdsBridge
+
+    def test_a_genuinely_pre_registered_foreign_entry_still_wins(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        """First-wins is not overridden — it is only made deterministic.
+
+        A foreign ``amazon_ads`` already in the registry BEFORE the
+        startup path runs keeps the slot, matching the registry's
+        documented shadowing contract.
+        """
+        from mureo.core.providers import default_registry
+        from mureo.mcp import server as mod
+
+        foreign = self._foreign_entry()
+        monkeypatch.setattr(default_registry, "_entries", {"amazon_ads": foreign})
+        monkeypatch.setattr(
+            "mureo.core.providers.registry.discover_providers", _no_thirdparty
+        )
+
+        entries = mod._discover_with_amazon()
+
+        amazon = [e for e in entries if e.name == "amazon_ads"]
+        assert len(amazon) == 1
+        assert amazon[0] is foreign
+        assert default_registry.get("amazon_ads") is foreign
+
+    def test_configure_path_also_registers_before_discovery(self, monkeypatch) -> None:
+        """The configure process resolves the name identically (#121).
+
+        Same scenario as the MCP test above, through
+        ``ConfigureWizard._discover_providers_safely`` — the two
+        processes must not disagree about who owns ``amazon_ads``.
+        """
+        from mureo.amazon_ads.bridge import AmazonAdsBridge
+        from mureo.core.providers import default_registry
+        from mureo.web.server import ConfigureWizard
+
+        monkeypatch.setattr(default_registry, "_entries", {})
+        foreign = self._foreign_entry()
+        monkeypatch.setattr(
+            "mureo.web.server.discover_providers",
+            self._discover_publishing_foreign_amazon(foreign),
+        )
+
+        ConfigureWizard._discover_providers_safely()
+
+        assert default_registry.get("amazon_ads").provider_class is AmazonAdsBridge

--- a/tests/test_auth_amazon.py
+++ b/tests/test_auth_amazon.py
@@ -1,8 +1,11 @@
 """Amazon Ads credential loading (TDD: RED → GREEN → IMPROVE).
 
-Phase 1 of #113: ``amazon_ads`` section in ~/.mureo/credentials.json,
-mirroring the Google/Meta loaders in ``mureo.auth``. credentials.json
-only (no env fallback in Phase 1 — documented).
+#113 introduced the ``amazon_ads`` section in
+~/.mureo/credentials.json, mirroring the Google/Meta loaders in
+``mureo.auth``. #121 completed the parity: ``AMAZON_ADS_*``
+environment-variable fallback (file section wins), and ``access_token``
+became optional whenever ``refresh_token`` + ``client_secret`` let the
+bridge mint one.
 """
 
 from __future__ import annotations
@@ -113,6 +116,170 @@ class TestLoadAmazonAdsCredentials:
         assert c is not None
         with pytest.raises(dataclasses.FrozenInstanceError):
             c.access_token = "mutated"  # type: ignore[misc]
+
+
+@pytest.mark.unit
+class TestUsableWithoutAnAccessToken:
+    """#121 — ``access_token`` is optional when mureo can mint one.
+
+    The configure UI / env-var setup path only asks for the durable
+    material (``client_id`` + ``refresh_token`` + ``client_secret``);
+    the 60-minute access token is minted on first use. The loader must
+    therefore accept a section with no ``access_token``.
+    """
+
+    def test_refresh_trio_without_access_token_is_usable(self, tmp_path: Path) -> None:
+        cf = _write(
+            tmp_path,
+            {
+                "amazon_ads": {
+                    "client_id": "cid",
+                    "refresh_token": "Atzr|R",
+                    "client_secret": "sec",
+                }
+            },
+        )
+        c = load_amazon_ads_credentials(path=cf)
+        assert c is not None
+        assert c.access_token == ""  # minted on the first forwarded call
+        assert c.refresh_token == "Atzr|R"
+        assert c.client_secret == "sec"
+
+    def test_access_token_alone_is_still_usable(self, tmp_path: Path) -> None:
+        cf = _write(tmp_path, {"amazon_ads": {"client_id": "cid", "access_token": "T"}})
+        c = load_amazon_ads_credentials(path=cf)
+        assert c is not None and c.access_token == "T"
+
+    @pytest.mark.parametrize(
+        "section",
+        [
+            {"client_id": "cid"},
+            {"client_id": "cid", "refresh_token": "Atzr|R"},
+            {"client_id": "cid", "client_secret": "sec"},
+            {"refresh_token": "Atzr|R", "client_secret": "sec"},
+            {"client_id": "", "access_token": "T"},
+        ],
+        ids=[
+            "client_id_only",
+            "refresh_token_without_secret",
+            "secret_without_refresh_token",
+            "no_client_id",
+            "blank_client_id",
+        ],
+    )
+    def test_incomplete_material_is_not_usable(
+        self, tmp_path: Path, section: dict
+    ) -> None:
+        cf = _write(tmp_path, {"amazon_ads": section})
+        assert load_amazon_ads_credentials(path=cf) is None
+
+
+_AMAZON_ENV_VARS = (
+    "AMAZON_ADS_CLIENT_ID",
+    "AMAZON_ADS_CLIENT_SECRET",
+    "AMAZON_ADS_REFRESH_TOKEN",
+    "AMAZON_ADS_ACCESS_TOKEN",
+    "AMAZON_ADS_REGION",
+    "AMAZON_ADS_ACCOUNT_MODE",
+    "AMAZON_ADS_PROFILE_ID",
+    "AMAZON_ADS_ACCOUNT_ID",
+    "AMAZON_ADS_MANAGER_ACCOUNT_ID",
+)
+
+
+@pytest.fixture()
+def _clean_amazon_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in _AMAZON_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("_clean_amazon_env")
+class TestAmazonEnvVarFallback:
+    """Env-var fallback, mirroring the Google / Meta contract."""
+
+    def test_full_env_set_is_parsed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("AMAZON_ADS_CLIENT_ID", "env-cid")
+        monkeypatch.setenv("AMAZON_ADS_ACCESS_TOKEN", "Atza|ENV")
+        monkeypatch.setenv("AMAZON_ADS_REFRESH_TOKEN", "Atzr|ENV")
+        monkeypatch.setenv("AMAZON_ADS_CLIENT_SECRET", "env-sec")
+        monkeypatch.setenv("AMAZON_ADS_REGION", "FE")
+        monkeypatch.setenv("AMAZON_ADS_ACCOUNT_MODE", "fixed")
+        monkeypatch.setenv("AMAZON_ADS_PROFILE_ID", "p1")
+        monkeypatch.setenv("AMAZON_ADS_ACCOUNT_ID", "a1")
+        monkeypatch.setenv("AMAZON_ADS_MANAGER_ACCOUNT_ID", "m1")
+
+        c = load_amazon_ads_credentials(path=tmp_path / "absent.json")
+        assert c is not None
+        assert c.client_id == "env-cid"
+        assert c.access_token == "Atza|ENV"
+        assert c.refresh_token == "Atzr|ENV"
+        assert c.client_secret == "env-sec"
+        assert c.region == "fe"  # normalized like the file path
+        assert c.account_mode == "fixed"
+        assert c.profile_id == "p1"
+        assert c.account_id == "a1"
+        assert c.manager_account_id == "m1"
+
+    def test_refresh_trio_from_env_is_enough(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("AMAZON_ADS_CLIENT_ID", "env-cid")
+        monkeypatch.setenv("AMAZON_ADS_REFRESH_TOKEN", "Atzr|ENV")
+        monkeypatch.setenv("AMAZON_ADS_CLIENT_SECRET", "env-sec")
+        c = load_amazon_ads_credentials(path=tmp_path / "absent.json")
+        assert c is not None and c.access_token == ""
+
+    def test_incomplete_env_returns_none(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("AMAZON_ADS_CLIENT_ID", "env-cid")
+        assert load_amazon_ads_credentials(path=tmp_path / "absent.json") is None
+
+    def test_no_env_and_no_file_returns_none(self, tmp_path: Path) -> None:
+        assert load_amazon_ads_credentials(path=tmp_path / "absent.json") is None
+
+    def test_unknown_env_region_and_mode_fall_back_to_defaults(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("AMAZON_ADS_CLIENT_ID", "env-cid")
+        monkeypatch.setenv("AMAZON_ADS_ACCESS_TOKEN", "Atza|ENV")
+        monkeypatch.setenv("AMAZON_ADS_REGION", "antarctica")
+        monkeypatch.setenv("AMAZON_ADS_ACCOUNT_MODE", "bogus")
+        c = load_amazon_ads_credentials(path=tmp_path / "absent.json")
+        assert c is not None
+        assert c.region == "na"
+        assert c.account_mode == "dynamic"
+
+    def test_file_section_wins_over_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("AMAZON_ADS_CLIENT_ID", "env-cid")
+        monkeypatch.setenv("AMAZON_ADS_ACCESS_TOKEN", "Atza|ENV")
+        cf = _write(
+            tmp_path,
+            {"amazon_ads": {"client_id": "file-cid", "access_token": "Atza|FILE"}},
+        )
+        c = load_amazon_ads_credentials(path=cf)
+        assert c is not None
+        assert c.client_id == "file-cid"
+        assert c.access_token == "Atza|FILE"
+
+    def test_unusable_file_section_falls_through_to_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A section that cannot produce credentials is not a veto.
+
+        Mirrors Google/Meta: the file wins only when it actually yields
+        a usable credential set.
+        """
+        monkeypatch.setenv("AMAZON_ADS_CLIENT_ID", "env-cid")
+        monkeypatch.setenv("AMAZON_ADS_ACCESS_TOKEN", "Atza|ENV")
+        cf = _write(tmp_path, {"amazon_ads": {"region": "eu"}})
+        c = load_amazon_ads_credentials(path=cf)
+        assert c is not None and c.client_id == "env-cid"
 
 
 @pytest.mark.unit

--- a/tests/test_web_status_collector.py
+++ b/tests/test_web_status_collector.py
@@ -235,6 +235,64 @@ class TestCredentialsOauth:
 
 
 @pytest.mark.unit
+class TestAmazonCredentialsPresence:
+    """#121 — the Amazon bridge gets a ``credentials_present`` row.
+
+    Unlike the other sections (present ⇔ non-empty), Amazon needs a
+    ``client_id`` PLUS token material to be usable, so presence mirrors
+    ``mureo.auth.load_amazon_ads_credentials``.
+    """
+
+    def _present(self, tmp_path: Path, section: dict[str, object] | None) -> bool:
+        paths = _paths(tmp_path)
+        if section is not None:
+            _write_json(paths.credentials_path, {"amazon_ads": section})
+        snapshot = collect_status(
+            "claude-code", home=_build_home(tmp_path), paths=paths
+        )
+        return snapshot.credentials_present["amazon_ads"]
+
+    def test_missing_file_reports_absent(self, tmp_path: Path) -> None:
+        assert self._present(tmp_path, None) is False
+
+    def test_access_token_material_reports_present(self, tmp_path: Path) -> None:
+        assert (
+            self._present(tmp_path, {"client_id": "cid", "access_token": "Atza|T"})
+            is True
+        )
+
+    def test_refresh_trio_reports_present(self, tmp_path: Path) -> None:
+        assert (
+            self._present(
+                tmp_path,
+                {"client_id": "cid", "refresh_token": "Atzr|R", "client_secret": "s"},
+            )
+            is True
+        )
+
+    def test_client_id_without_token_material_reports_absent(
+        self, tmp_path: Path
+    ) -> None:
+        assert self._present(tmp_path, {"client_id": "cid", "region": "eu"}) is False
+
+    def test_token_without_client_id_reports_absent(self, tmp_path: Path) -> None:
+        assert self._present(tmp_path, {"access_token": "Atza|T"}) is False
+
+    def test_no_secret_value_reaches_the_serialized_snapshot(
+        self, tmp_path: Path
+    ) -> None:
+        paths = _paths(tmp_path)
+        _write_json(
+            paths.credentials_path,
+            {"amazon_ads": {"client_id": "cid", "access_token": "REDACTED-AMZ"}},
+        )
+        snapshot = collect_status(
+            "claude-code", home=_build_home(tmp_path), paths=paths
+        )
+        assert "REDACTED-AMZ" not in json.dumps(snapshot.as_dict(), ensure_ascii=False)
+
+
+@pytest.mark.unit
 class TestStatusSnapshotShape:
     def test_snapshot_is_frozen_dataclass(self, tmp_path: Path) -> None:
         snapshot = collect_status(


### PR DESCRIPTION
## Summary

Closes the setup-UX gap for Amazon Ads (#121 item 3, phase A). Amazon previously required hand-editing the credentials file with a self-obtained short-lived access token; it can now be configured from the configure web UI or environment variables, and the short-lived token is minted automatically.

- **Configure-UI card**: the bridge declares `account_credential_fields` (9 keys, en/ja labels; secrets masked and never round-tripped to the browser), rendered by the existing generic plugin-credentials mechanism. The provider entry is single-sourced (`mureo/amazon_ads/provider.py`) and registered by both the MCP server and the configure server.
- **Deterministic shadowing**: registration runs before entry-point discovery in both processes, so the built-in bridge always wins the `amazon_ads` name against a same-named entry-point plugin (mutation-verified — under the old order a squatter actually won in the MCP server process). A genuinely pre-registered foreign entry still wins per first-wins semantics.
- **First-use token mint**: `load_amazon_ads_credentials` now accepts `client_id` + (`access_token` OR `refresh_token` + `client_secret`); with no access token stored, the bridge performs one LwA exchange before the first forwarded call and persists the result. Bound stays one exchange + one call; a call failing after a mint is not retried.
- **Env-var fallback**: `AMAZON_ADS_*` variables mirroring the Google/Meta pattern (credentials file wins).
- **Status feed**: Amazon credential presence with loader-parity logic.
- **Docs**: `docs/amazon-ads(.ja).md` rewritten configure-UI-first (env-var table, annual refresh-token re-auth guidance), plus `authentication.md`, `cli.md`, `AGENTS.md`.

Out of scope (later PR): the browser OAuth wizard and expiry signalling — LwA redirect-URI constraints need first-party verification before that design is committed.

## Testing

- +56 tests (TDD): registry/shadowing matrix, secret non-leak through the UI listing, loader/env precedence matrix, proactive-mint bounds and failure modes, status row.
- Full suite: 6417 passed; only the known environment-only failures (local third-party plugins), zero delta.
- `ruff` / `black` / `mypy` CI gates clean.

Refs #121.
