### PR TITLE
feat(safety): budget/bid pattern fallback, manifest staleness, and Amazon core parity (#121)

### DIFF
--- a/docs/amazon-ads.ja.md
+++ b/docs/amazon-ads.ja.md
@@ -159,10 +159,15 @@ Amazon のツールが Amazon 自身の名前（例 `campaign_management-*`,
   壊れているケース。他プロバイダの認証情報を失わないよう mureo は
   壊れたファイルを上書きしません）、黙って再試行せずその理由を
   付けて失敗します。
-- `mureo amazon refresh-manifest` は自動更新**しません**。保存済みの
-  `access_token` をそのまま使います。発行・更新はツール実行経路でのみ
-  発生するため、有効な access トークンが保存されている状態（または
-  ツール呼び出しで 1 度発行された後）で実行してください。
+- `mureo amazon refresh-manifest` も同じ方法でトークンを発行します。
+  `access_token` が未保存で `refresh_token` ＋ `client_secret` がある
+  場合、LwA 交換を 1 回だけ実行してトークンを保存してからマニフェスト
+  を生成します。そのため refresh トークンのみの構成でも、最初の
+  コマンドからそのまま動作します（access トークンを貼り付ける必要は
+  ありません）。なお、保存済みの access トークンが失効している場合の
+  再発行は行いません。401 で失敗したら、ツール呼び出しでトークンが
+  更新されたあとに再実行するか、`access_token` を空にして新規発行を
+  促してください。
 
 `refresh_token` ＋ `client_secret` が無い場合は、失効時に
 `access_token` を手動で更新してください（設定 UI の Amazon Ads

--- a/docs/amazon-ads.md
+++ b/docs/amazon-ads.md
@@ -159,10 +159,15 @@ tokens/secrets never appear in error messages or logs.
   it is malformed — mureo refuses to overwrite a corrupt file and lose
   your other providers' credentials), the call fails with that reason
   rather than a silent retry loop.
-- `mureo amazon refresh-manifest` does **not** auto-refresh; it uses
-  the stored `access_token` as-is. Minting and refresh only happen on
-  the tool dispatch path, so run `refresh-manifest` while a valid
-  access token is stored (or after a tool call has minted one).
+- `mureo amazon refresh-manifest` mints a token the same way: if no
+  `access_token` is stored and `refresh_token` + `client_secret` are,
+  it performs one LwA exchange, saves the token, and then generates the
+  manifest. So the refresh-token-only setup works from the very first
+  command — no need to paste an access token just to discover the
+  tools. (It does not *re-*mint an already-stored token that has since
+  expired; if the command fails with a 401, run it again after a tool
+  call has refreshed the token, or clear `access_token` to force a
+  fresh mint.)
 
 Without `refresh_token` + `client_secret`, update `access_token` (in
 the configure UI's Amazon Ads card, via `AMAZON_ADS_ACCESS_TOKEN`, or

--- a/mureo/amazon_ads/bridge.py
+++ b/mureo/amazon_ads/bridge.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import dataclasses
 import json
+import logging
 from collections.abc import Callable
 from contextlib import AbstractAsyncContextManager
 from pathlib import Path
@@ -28,7 +29,12 @@ from mcp.types import Tool
 from mureo.amazon_ads.endpoints import endpoint_url, request_headers
 from mureo.amazon_ads.lwa import AmazonAuthError as _LwaAuthError
 from mureo.amazon_ads.lwa import LwaTokens, refresh_access_token
-from mureo.amazon_ads.manifest import _default_connect, manifest_path
+from mureo.amazon_ads.manifest import (
+    _default_connect,
+    document_age_days,
+    is_stale,
+    manifest_path,
+)
 from mureo.auth import (
     AmazonAdsCredentials,
     load_amazon_ads_credentials,
@@ -37,10 +43,72 @@ from mureo.auth import (
 from mureo.core.providers.credentials import AccountCredentialField
 from mureo.providers.config_writer import ConfigWriteError
 
+logger = logging.getLogger(__name__)
+
 ConnectFactory = Callable[[str, dict[str, str]], AbstractAsyncContextManager[Any]]
 CredsLoader = Callable[[], AmazonAdsCredentials | None]
 Refresher = Callable[[AmazonAdsCredentials], LwaTokens]
 TokenSaver = Callable[[str, str | None], None]
+
+#: Process-wide latch for the stale-manifest warning. ``mcp_tools()`` runs at
+#: server start and on every tool-list refresh, so warning per call would be
+#: spam; the latch arms only when a warning is actually emitted, so a fresh
+#: read never silences a later stale one.
+_stale_manifest_warned = False
+
+
+def _scrub_secrets(text: str) -> str:
+    """Redact secret-shaped substrings from an operator-facing error string.
+
+    Delegates to the audit trail's redactor so there is ONE definition of
+    "what a token looks like" across every string mureo shows a human or an
+    agent (the audit log, the CLI, and here).
+
+    Imported lazily, and that is load-bearing rather than stylistic:
+    ``mureo.mcp.__init__`` imports ``mureo.mcp.server``, which builds its
+    plugin tool list at import time and reaches this bridge through
+    ``mureo.amazon_ads.provider``. A module-level ``from mureo.mcp.plugin_audit
+    import _scrub`` therefore re-enters a partially-initialized
+    ``mureo.amazon_ads.bridge`` and collapses plugin discovery to an
+    ImportError — observed, not hypothetical. Resolving it at call time breaks
+    the cycle; by then both modules are fully imported.
+
+    Fail-safe: if the redactor cannot be resolved at all, the text is dropped
+    rather than passed through unredacted. An unhelpful message is a much
+    smaller problem than a leaked token.
+    """
+    try:
+        from mureo.mcp.plugin_audit import _scrub
+    except Exception:  # noqa: BLE001 — never leak because an import failed
+        return "<error text withheld: redactor unavailable>"
+    return _scrub(text)
+
+
+def _warn_once_if_stale(path: Path, doc: Any) -> None:
+    """Warn (once per process) that the served manifest is stale.
+
+    Deliberately advisory: the tools are still exposed. The manifest is a
+    snapshot of a tool surface mureo does not own, so an old one means the
+    exposed list has probably drifted — worth saying out loud, not worth
+    refusing to work over. Never raises; ``mcp_tools()`` runs at server start.
+    """
+    global _stale_manifest_warned
+    if _stale_manifest_warned:
+        return
+    try:
+        age = document_age_days(doc)
+        if not is_stale(age):
+            return
+        logger.warning(
+            "Amazon tool manifest is stale (%.0f days old, %s); the exposed "
+            "tool list may no longer match Amazon's. Run `mureo amazon "
+            "refresh-manifest` to regenerate it.",
+            age,
+            path,
+        )
+    except Exception:  # noqa: BLE001 — a freshness hint must never break start
+        return
+    _stale_manifest_warned = True
 
 
 # Per-account credentials the operator supplies (#121). One field per
@@ -324,6 +392,7 @@ class AmazonAdsBridge:
             items = raw.get("tools", []) if isinstance(raw, dict) else []
         except (OSError, ValueError, TypeError):
             return ()  # missing / unreadable / malformed ⇒ no Amazon tools
+        _warn_once_if_stale(Path(self._manifest_path), raw)
         tools: list[Tool] = []
         for entry in items if isinstance(items, list) else []:
             try:
@@ -399,9 +468,9 @@ class AmazonAdsBridge:
         try:
             tokens = self._refresher(creds)
         except _LwaAuthError as auth_exc:
-            raise AmazonBridgeError(f"{auth_failure_prefix}: {auth_exc}") from (
-                cause if cause is not None else auth_exc
-            )
+            raise AmazonBridgeError(
+                f"{auth_failure_prefix}: {_scrub_secrets(str(auth_exc))}"
+            ) from (cause if cause is not None else auth_exc)
         try:
             self._token_saver(tokens.access_token, tokens.refresh_token)
         except (ConfigWriteError, OSError) as save_exc:
@@ -410,9 +479,17 @@ class AmazonAdsBridge:
             # against. Surface the underlying reason — typically a malformed
             # credentials.json that mureo deliberately refuses to overwrite —
             # instead of letting a raw traceback out.
+            #
+            # Both nested messages are scrubbed on the way into ours. mureo's
+            # own LwA and writer errors are token-free by construction, but
+            # neither is guaranteed to be: ``_token_saver`` is injectable, an
+            # OSError carries whatever filename or payload the OS put in it,
+            # and this text lands in an agent-visible tool result. Scrubbing at
+            # the point the string is BUILT is the only place that stays true
+            # as those inputs change.
             raise AmazonBridgeError(
                 f"Amazon access token was refreshed but could not be saved to "
-                f"~/.mureo/credentials.json: {save_exc}"
+                f"~/.mureo/credentials.json: {_scrub_secrets(str(save_exc))}"
             ) from (cause if cause is not None else save_exc)
         return dataclasses.replace(
             creds,

--- a/mureo/amazon_ads/manifest.py
+++ b/mureo/amazon_ads/manifest.py
@@ -1,4 +1,4 @@
-"""Generate the Amazon MCP tool manifest.
+"""Generate — and age-check — the Amazon MCP tool manifest.
 
 Credentialed/network in production (one authenticated MCP session to
 the region endpoint). The result is written to
@@ -8,11 +8,24 @@ pure, credential-free, network-free read at mureo server start.
 The MCP client session is dependency-injected (``connect``) so the
 core is unit-testable without a real Amazon connection or the mcp SDK
 transport.
+
+**Staleness.** The manifest is a *snapshot* of a tool surface mureo does
+not own, so it drifts: tools appear, disappear, and change schema
+upstream while the local copy says otherwise. ``generated_at`` has always
+been written; :func:`manifest_age_days` / :func:`is_manifest_stale` are
+what finally read it, with a 30-day default threshold overridable via
+``MUREO_AMAZON_MANIFEST_MAX_AGE_DAYS``. Staleness is *reported*, never
+enforced — an old manifest still serves its tools (refusing to would
+break a working setup over a heuristic); the configure-UI status row,
+the CLI refresh command, and a one-shot bridge warning surface it.
 """
 
 from __future__ import annotations
 
 import asyncio
+import json
+import logging
+import os
 from collections.abc import AsyncIterator, Callable
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from datetime import datetime, timezone
@@ -20,19 +33,123 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from mureo.amazon_ads.endpoints import endpoint_url, request_headers
+from mureo.core import clock
 from mureo.providers.config_writer import _atomic_write_json
 
 if TYPE_CHECKING:
     from mureo.auth import AmazonAdsCredentials
 
+logger = logging.getLogger(__name__)
+
 # (url, headers) -> async context manager yielding an object with
 # ``await initialize()`` and ``await list_tools()`` (mcp ClientSession).
 ConnectFactory = Callable[[str, dict[str, str]], AbstractAsyncContextManager[Any]]
 
+#: Manifest file name, in ``~/.mureo``. Named once so the status collector
+#: (which resolves it under an injected home) and :func:`manifest_path` cannot
+#: drift apart.
+MANIFEST_FILENAME = "amazon_tools.json"
+
+#: How old a manifest may be before mureo calls it stale. Amazon's tool
+#: surface is not versioned for us, so this is a judgement call, not a fact:
+#: long enough that a stable setup is never nagged, short enough that a
+#: months-old snapshot is called out.
+DEFAULT_MANIFEST_MAX_AGE_DAYS = 30
+
+#: Operator override for :data:`DEFAULT_MANIFEST_MAX_AGE_DAYS`, in days.
+MANIFEST_MAX_AGE_ENV = "MUREO_AMAZON_MANIFEST_MAX_AGE_DAYS"
+
 
 def manifest_path() -> Path:
     """Default manifest location: ``~/.mureo/amazon_tools.json``."""
-    return Path.home() / ".mureo" / "amazon_tools.json"
+    return Path.home() / ".mureo" / MANIFEST_FILENAME
+
+
+def manifest_max_age_days() -> float:
+    """The staleness threshold in days, honouring the env override.
+
+    An unusable override (blank, non-numeric, zero or negative) falls back to
+    the default rather than raising or disabling the check: this runs on the
+    status/CLI display path, where a typo in an env var must not take a
+    surface down, and "0 days" would report every manifest as stale.
+    """
+    raw = os.environ.get(MANIFEST_MAX_AGE_ENV)
+    if raw is None:
+        return float(DEFAULT_MANIFEST_MAX_AGE_DAYS)
+    try:
+        value = float(raw.strip())
+    except (AttributeError, ValueError):
+        return float(DEFAULT_MANIFEST_MAX_AGE_DAYS)
+    if value <= 0:
+        return float(DEFAULT_MANIFEST_MAX_AGE_DAYS)
+    return value
+
+
+def _parse_generated_at(raw: Any) -> datetime | None:
+    """Parse a manifest ``generated_at`` into an aware datetime, or ``None``.
+
+    Accepts what :func:`generate_manifest` writes (ISO 8601 with an explicit
+    offset) plus the two shapes a hand-edited or foreign file may carry: a
+    ``Z`` suffix (``datetime.fromisoformat`` rejects it before 3.11) and a
+    naive timestamp, which is read as host-local — the same assumption
+    :func:`mureo.core.clock.server_now` makes.
+    """
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    text = raw.strip()
+    if text.endswith(("Z", "z")):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.astimezone()
+    return parsed
+
+
+def document_age_days(doc: Any) -> float | None:
+    """Age in days of an already-parsed manifest document, or ``None``.
+
+    ``None`` means "cannot tell" — no document, no ``generated_at``, or an
+    unparseable one — and every caller reports that as *unknown*, never as
+    stale. A future timestamp (clock skew, or a machine that travelled
+    timezones) clamps to ``0.0``: it is not aged, and a negative age would
+    render as nonsense.
+    """
+    if not isinstance(doc, dict):
+        return None
+    generated = _parse_generated_at(doc.get("generated_at"))
+    if generated is None:
+        return None
+    delta = clock.server_now() - generated
+    return max(0.0, delta.total_seconds() / 86_400)
+
+
+def manifest_age_days(path: Path | None = None) -> float | None:
+    """Age in days of the manifest at ``path``, or ``None`` when unknowable.
+
+    Never raises: a missing, unreadable, or malformed manifest is an unknown
+    age. This is display/telemetry, not a gate.
+    """
+    target = path or manifest_path()
+    try:
+        doc = json.loads(Path(target).read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError):
+        return None
+    return document_age_days(doc)
+
+
+def is_stale(age_days: float | None) -> bool:
+    """Is ``age_days`` past the configured threshold? Unknown ⇒ ``False``."""
+    if age_days is None:
+        return False
+    return age_days > manifest_max_age_days()
+
+
+def is_manifest_stale(path: Path | None = None) -> bool:
+    """Is the manifest at ``path`` older than the configured threshold?"""
+    return is_stale(manifest_age_days(path))
 
 
 def _default_connect(

--- a/mureo/amazon_ads/provider.py
+++ b/mureo/amazon_ads/provider.py
@@ -41,6 +41,8 @@ returns the foreign entry.
 
 from __future__ import annotations
 
+import os
+
 from mureo.amazon_ads.bridge import AmazonAdsBridge
 from mureo.core.providers.registry import ProviderEntry, default_registry
 
@@ -53,6 +55,25 @@ AMAZON_SOURCE_DISTRIBUTION = "mureo-amazon-ads-bridge"
 #: Registry key of the bridge — mirrors ``AmazonAdsBridge.name`` and the
 #: ``amazon_ads`` section of ``~/.mureo/credentials.json``.
 AMAZON_PROVIDER_NAME = "amazon_ads"
+
+#: Coexistence control, matching ``MUREO_DISABLE_GOOGLE_ADS`` and friends
+#: (:mod:`mureo.providers.mureo_env`). Set to the exact string ``"1"`` to keep
+#: mureo from registering the bridge at all — the escape hatch for an operator
+#: who has wired Amazon's own MCP into their host directly and does not want
+#: the same tools exposed twice.
+AMAZON_DISABLE_ENV_VAR = "MUREO_DISABLE_AMAZON_ADS"
+
+
+def amazon_ads_disabled() -> bool:
+    """Is the bridge switched off via :data:`AMAZON_DISABLE_ENV_VAR`?
+
+    Exact-string ``== "1"``, the contract every other ``MUREO_DISABLE_*`` gate
+    holds (``"0"`` / ``""`` / ``"true"`` / ``"  1  "`` leave it enabled). Read
+    at CALL time rather than at import so both startup paths — the MCP server,
+    which calls this during module import, and the configure UI, which calls it
+    when the wizard is constructed — observe the same environment.
+    """
+    return os.environ.get(AMAZON_DISABLE_ENV_VAR) == "1"
 
 
 def provider_entry() -> ProviderEntry:
@@ -98,8 +119,10 @@ def register_amazon_provider() -> ProviderEntry:
 
 
 __all__ = [
+    "AMAZON_DISABLE_ENV_VAR",
     "AMAZON_PROVIDER_NAME",
     "AMAZON_SOURCE_DISTRIBUTION",
+    "amazon_ads_disabled",
     "provider_entry",
     "register_amazon_provider",
 ]

--- a/mureo/analytics/protocol.py
+++ b/mureo/analytics/protocol.py
@@ -63,10 +63,17 @@ class AnalyticsModule(Protocol):
     """
 
     platform: str
-    """Stable platform identifier (e.g. ``"google_ads"``, ``"amazon_ads"``).
+    """Stable platform identifier (e.g. ``"google_ads"``, ``"meta_ads"``).
 
     MUST match the platform name used in STATE.json ``platforms`` and in
     the corresponding provider's ``name`` so a skill can join the two.
+
+    For a platform mureo reaches through a **plugin or bridge** rather than
+    natively, that key is the canonical ``plugin:<distribution>`` form built by
+    :func:`mureo.core.platform_keys.plugin_platform_key` — NOT the provider's
+    short registry name. The two differ, and writing the short name here would
+    produce analytics that silently never join with the action log or the
+    ``platforms`` snapshots the bridge's own dispatch records.
     """
 
     def capabilities(self) -> frozenset[AnalyticsCapability]:

--- a/mureo/cli/amazon_cmd.py
+++ b/mureo/cli/amazon_cmd.py
@@ -6,17 +6,115 @@ authenticated discovery: it connects to the region endpoint using the
 Amazon's MCP tools, and writes ``~/.mureo/amazon_tools.json``. The
 mureo MCP server then reads that manifest at start (pure, no network)
 to expose the Amazon tools through mureo's safety layer.
+
+Two things happen before the connection:
+
+- the CURRENT manifest's age is reported, so the operator can see
+  whether this is a routine refresh or a long-overdue one (audit #47);
+- when only the durable LwA material is stored (``refresh_token`` +
+  ``client_secret``, the recommended setup), an access token is minted
+  and persisted first (audit #49). Without that this command sent an
+  empty bearer token and 401'd against a perfectly valid configuration
+  — on the very first command an operator runs.
 """
 
 from __future__ import annotations
 
+import dataclasses
+
 import typer
 
-from mureo.amazon_ads.manifest import generate_manifest_sync
-from mureo.auth import load_amazon_ads_credentials
+from mureo.amazon_ads.lwa import AmazonAuthError, refresh_access_token
+from mureo.amazon_ads.manifest import (
+    generate_manifest_sync,
+    is_stale,
+    manifest_age_days,
+    manifest_max_age_days,
+    manifest_path,
+)
+from mureo.auth import (
+    AmazonAdsCredentials,
+    load_amazon_ads_credentials,
+    save_amazon_access_token,
+)
 from mureo.mcp.plugin_audit import _scrub as _scrub_secrets
+from mureo.providers.config_writer import ConfigWriteError
 
 amazon_app = typer.Typer(name="amazon", help="Amazon Ads official-MCP bridge setup")
+
+
+def _echo_manifest_age() -> None:
+    """Report how old the manifest being replaced is (never raises)."""
+    path = manifest_path()
+    if not path.exists():
+        typer.echo("No existing Amazon tool manifest; generating the first one.")
+        return
+    age = manifest_age_days(path)
+    if age is None:
+        typer.echo(
+            "An Amazon tool manifest exists but its age is unknown "
+            "(no usable generated_at); refreshing it."
+        )
+        return
+    line = f"Existing Amazon tool manifest is {age:.1f} days old."
+    if is_stale(age):
+        line += (
+            f" That is past the {manifest_max_age_days():.0f}-day staleness "
+            f"threshold — refreshing is overdue."
+        )
+    typer.echo(line)
+
+
+def _ensure_access_token(creds: AmazonAdsCredentials) -> AmazonAdsCredentials:
+    """Mint + persist an access token when only durable LwA material is stored.
+
+    The dispatch path already does this before its first forwarded call; this
+    command did not, so the recommended refresh-token-only setup made it send
+    an empty bearer token and fail with Amazon's 401 instead of mureo's own
+    message. Exactly one LwA exchange, never a loop — a failure exits rather
+    than retrying.
+    """
+    if creds.access_token:
+        return creds
+    if not (creds.refresh_token and creds.client_secret):
+        typer.echo(
+            "no amazon_ads access_token is stored, and there is no "
+            "refresh_token + client_secret pair to mint one from. Add them "
+            "(or paste an access_token) in the configure UI's Amazon Ads "
+            "card, via the AMAZON_ADS_* env vars, or in "
+            "~/.mureo/credentials.json — see docs/amazon-ads.md.",
+            err=True,
+        )
+        raise typer.Exit(1)
+    try:
+        tokens = refresh_access_token(creds)
+    except AmazonAuthError as exc:
+        typer.echo(
+            f"no amazon_ads access_token is stored and one could not be "
+            f"obtained from the refresh token: {_scrub_secrets(str(exc))}",
+            err=True,
+        )
+        raise typer.Exit(1) from None
+    try:
+        save_amazon_access_token(tokens.access_token, tokens.refresh_token)
+    except (ConfigWriteError, OSError) as exc:
+        # Fatal, mirroring the bridge: the new token is valid but not on disk,
+        # so every later call would re-mint against a refresh token Amazon has
+        # already rotated. The underlying reason (typically a malformed
+        # credentials.json mureo deliberately refuses to overwrite) is what the
+        # operator needs to fix.
+        typer.echo(
+            f"Amazon access token was minted but could not be saved to "
+            f"~/.mureo/credentials.json: {_scrub_secrets(str(exc))}",
+            err=True,
+        )
+        raise typer.Exit(1) from None
+    typer.echo("Minted a fresh Amazon access token from the stored refresh token.")
+    return dataclasses.replace(
+        creds,
+        access_token=tokens.access_token,
+        refresh_token=tokens.refresh_token,
+    )
 
 
 @amazon_app.command("refresh-manifest")
@@ -24,8 +122,9 @@ def refresh_manifest() -> None:
     """Discover Amazon's MCP tools and (re)write the local manifest.
 
     Requires an ``amazon_ads`` section in ~/.mureo/credentials.json
-    (client_id + access_token, plus region/account_mode). Re-run this
-    whenever the access token is renewed or the tool surface changes.
+    (client_id plus either an access_token or the refresh_token +
+    client_secret pair mureo mints one from, along with
+    region/account_mode). Re-run this whenever the tool surface changes.
     """
     creds = load_amazon_ads_credentials()
     if creds is None:
@@ -36,6 +135,8 @@ def refresh_manifest() -> None:
             err=True,
         )
         raise typer.Exit(1)
+    _echo_manifest_age()
+    creds = _ensure_access_token(creds)
     try:
         path = generate_manifest_sync(creds)
     except Exception as exc:  # noqa: BLE001 — surface a clean CLI error

--- a/mureo/core/tool_names.py
+++ b/mureo/core/tool_names.py
@@ -1,0 +1,64 @@
+"""Shared vocabulary for reading intent out of a tool name.
+
+Two safety surfaces need the same answer to "does this name describe a read?"
+and they must not drift apart:
+
+- :mod:`mureo.rollback.planner` — a read has nothing to undo, so it plans no
+  rollback.
+- :mod:`mureo.mcp.server`'s guardrail pattern-fallback registration — a read
+  moves no money, so subjecting it to a heuristic budget/bid scan could only
+  produce false DENIALS.
+
+Two copies of the prefix list would eventually disagree, and the disagreement
+would be silent in both directions (an unrollback-able read here, a denied
+read there), so the list and the matcher live here once.
+
+**Namespace-aware by construction.** A bridged MCP server commonly namespaces
+its tools with a hyphen (``campaign_management-list_campaigns``), and a plain
+``startswith`` against the whole name matches none of those. Matching anchors
+per hyphen-delimited segment instead. A name without a hyphen is a single
+segment, so native mureo tool names behave exactly as they did — including the
+deliberate non-match of mid-word hits like ``listing_update``.
+
+**Heuristic, and deliberately so.** These are name shapes, not declarations.
+Where the answer gates a DENIAL the asymmetry matters: mutations on ad
+platforms are consistently verb-named (``create_`` / ``update_`` / ``delete_``
+/ ``set_``), so a name that reads like a read almost never is a mutation, while
+treating a genuine read as a mutation breaks harmless calls. Hence the
+exemption is keyed on read-shaped names rather than on a mutation allow-list.
+"""
+
+from __future__ import annotations
+
+__all__ = ["READ_ONLY_PREFIXES", "is_read_only_tool_name"]
+
+#: Verb prefixes that mark a tool name as a read. Anchored at the start of a
+#: namespace segment (see :func:`is_read_only_tool_name`); the trailing
+#: underscore is what keeps ``listing_update`` / ``getter_config`` from
+#: matching.
+READ_ONLY_PREFIXES: tuple[str, ...] = (
+    "list_",
+    "get_",
+    "analyze_",
+    "diagnose_",
+    "inspect_",
+    "report_",
+    "check_",
+    "search_",
+    "query_",
+)
+
+
+def is_read_only_tool_name(name: str) -> bool:
+    """Does ``name`` describe a read, by shape?
+
+    Case-insensitive, and anchored per hyphen-delimited namespace segment so a
+    bridged ``campaign_management-list_campaigns`` reads the same as a native
+    ``list_campaigns``.
+    """
+    lowered = name.lower()
+    return any(
+        segment.startswith(prefix)
+        for segment in lowered.split("-")
+        for prefix in READ_ONLY_PREFIXES
+    )

--- a/mureo/mcp/server.py
+++ b/mureo/mcp/server.py
@@ -17,6 +17,9 @@ before launching the server (typically written by ``mureo providers add
   ships no native GA4 tools yet).
 - ``MUREO_DISABLE_CREATIVE_STUDIO`` — skip the ``creative_studio_*`` tool
   family (image-generation providers + visual generation).
+- ``MUREO_DISABLE_AMAZON_ADS`` — do not register the in-tree Amazon Ads
+  bridge, so none of its manifest tools are exposed (see
+  ``mureo.amazon_ads.provider.amazon_ads_disabled``).
 
 The env vars are read **once at module import time**; the server starts
 once per process and the gate is a startup decision. Search Console is
@@ -193,8 +196,17 @@ def _discover_with_amazon() -> tuple[Any, ...]:
     function runs at all) still wins, which is the documented
     first-wins contract.
     """
-    from mureo.amazon_ads.provider import register_amazon_provider
+    from mureo.amazon_ads.provider import amazon_ads_disabled, register_amazon_provider
     from mureo.core.providers import registry as _registry
+
+    if amazon_ads_disabled():
+        # ``MUREO_DISABLE_AMAZON_ADS=1`` — the bridge is neither registered nor
+        # appended, so no Amazon tools are exposed AND the configure UI does
+        # not render a card for a bridge this server will not serve. A
+        # third-party ``amazon_ads`` entry point (were one installed) is left
+        # to discovery, exactly as the other MUREO_DISABLE_* gates leave the
+        # official MCP they step aside for.
+        return tuple(_registry.discover_providers())
 
     amazon = register_amazon_provider()
     entries = list(_registry.discover_providers())
@@ -363,8 +375,65 @@ def _register_plugin_bid_declarations(
             )
 
 
+def _register_plugin_pattern_fallbacks(
+    semantics: dict[str, ToolSemantics],
+) -> None:
+    """Mark MUTATING plugin tools for the gate's pattern fallback.
+
+    The two registrations above only help a plugin that CAN declare. A bridged
+    tool surface — someone else's tool definitions forwarded verbatim, e.g. from
+    a manifest snapshot — carries no mureo ``_meta`` at all, so it declares
+    nothing and every ``## Guardrails`` budget/bid cap was silently unenforced
+    for its mutations. Registering the mutating tools here lets the gate fall
+    back to the best-effort key-shape scan
+    (:mod:`mureo.policy.pattern_scan`) for the channels no declaration covers.
+
+    Reads are deliberately excluded — they move no money, so scanning their
+    arguments could only produce false denials — and "read" is decided by TWO
+    signals, because on this surface neither is sufficient alone:
+
+    - ``annotations.readOnlyHint``, when the tool declares it; and
+    - the tool NAME, via the shared read vocabulary in
+      :mod:`mureo.core.tool_names` (the same list and matcher the rollback
+      planner uses, single-sourced so the two cannot drift).
+
+    The name check is what matters here. ``derive_semantics`` defaults an
+    undeclared tool to *mutating* — correct for auditing, where over-recording
+    is harmless — and a manifest snapshot declares nothing, so every read from
+    a bridged surface arrives as "mutating". Without the name check, a listing
+    call carrying a numeric budget-shaped FILTER argument would be refused
+    outright. The error costs are asymmetric: platform mutations are
+    consistently verb-named (``create_`` / ``update_`` / ``delete_`` /
+    ``set_``), so a read-shaped name is almost never a mutation, whereas a
+    mutation-shaped name that is really a read costs only a wasted scan of
+    arguments that carry no budget.
+
+    TODO (Wave 2): replace this name heuristic with the tools' verified
+    ``readOnlyHint`` / ``destructiveHint`` annotations once a real bridged
+    manifest has been inspected and its annotation coverage is known.
+
+    Best-effort: a registry failure must not take the server down.
+    """
+    from mureo.core.tool_names import is_read_only_tool_name
+    from mureo.policy.pattern_scan import register_pattern_fallback_tool
+
+    for name, sem in semantics.items():
+        if not sem.mutating or is_read_only_tool_name(name):
+            continue
+        try:
+            register_pattern_fallback_tool(name)
+        except Exception:  # noqa: BLE001 — never break startup on a hint
+            logger.warning(
+                "could not register the guardrail pattern fallback for "
+                "plugin tool '%s'",
+                name,
+                exc_info=True,
+            )
+
+
 _register_plugin_budget_declarations(_PLUGIN_SEMANTICS)
 _register_plugin_bid_declarations(_PLUGIN_SEMANTICS)
+_register_plugin_pattern_fallbacks(_PLUGIN_SEMANTICS)
 
 
 # Guardrail parity (#114 follow-up): top-level ``inputSchema`` property names

--- a/mureo/policy/pattern_scan.py
+++ b/mureo/policy/pattern_scan.py
@@ -1,0 +1,259 @@
+"""Best-effort budget/bid pattern scan for declaration-less plugin tools.
+
+The third module of the policy trio (:mod:`mureo.policy.strategy_gate` is the
+gate, :mod:`mureo.policy.declarations` is the exact-key seam). It exists for
+one gap: a plugin whose tool surface arrives as a **manifest snapshot** — an
+official-MCP bridge that forwards someone else's tool definitions verbatim —
+cannot carry mureo ``_meta`` declarations, because mureo does not author those
+tools. Such a provider can declare nothing, so every ``## Guardrails`` budget
+and bid cap was silently unenforced for its mutations, on the one surface where
+real money moves.
+
+The fallback is deliberately **pattern-based and generic** — it encodes no
+platform's argument vocabulary, only the shape of one:
+
+- a key whose name contains ``budget`` (case-insensitively) carries a proposed
+  budget;
+- a key whose name carries ``bid`` as a word fragment (``bid``, ``bid_amount``,
+  ``bidAmount``, ``default_bid``, ``maxBid`` — but not ``forbidden``) carries a
+  proposed bid;
+- a matching key that ALSO contains ``micros`` is divided by 1e6, mirroring the
+  built-in Google micros convention.
+
+Nested ``dict`` / ``list`` arguments are walked (bounded by
+:data:`_MAX_DEPTH`), because a bridged tool commonly nests its payload under a
+resource object. Only a key that itself matches is read: crediting every value
+*underneath* a matching key would read sibling identifiers as amounts and deny
+on a ten-digit resource id. For the same reason identifier-shaped keys
+(``*_id`` / ``*Id`` / ``*_ids``) are excluded, and mureo's own caller-supplied
+convention keys (``current_daily_budget`` / ``projected_total_daily_budget``)
+are excluded from the budget predicate — they are context the caller computes,
+not a proposal, and reading one as a proposal would deny a *decrease*.
+
+Honest limits, since best-effort must not be mistaken for exhaustive: a scalar
+inside a list has no key of its own and is not read; a budget spelled without
+the word ``budget`` (a bare ``amount`` outside the built-in scan's reach) is
+not found; an unrelated numeric field that happens to be budget-named reads as
+a proposal and can over-block. All of these resolve the same way — declare the
+exact keys (see :mod:`mureo.policy.declarations`), which always take
+precedence over this scan.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from mureo.policy.declarations import _UNREADABLE, _saturate, _Unreadable
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+__all__ = [
+    "PatternAmount",
+    "has_pattern_fallback",
+    "is_bid_key",
+    "is_budget_key",
+    "register_pattern_fallback_tool",
+    "reset_pattern_fallback_tools",
+    "scan_bid_amount",
+    "scan_budget_amount",
+]
+
+#: How deep the argument walk goes. Real tool payloads nest two or three
+#: levels; the bound keeps a pathological (or hostile) argument tree from
+#: turning a policy check into a stack walk.
+_MAX_DEPTH = 8
+
+#: mureo's cross-provider caller-supplied budget context. Never a proposal —
+#: see :data:`mureo.policy.strategy_gate._CONVENTION_CURRENT_KEY`.
+_CONVENTION_KEYS = frozenset({"current_daily_budget", "projected_total_daily_budget"})
+
+
+@dataclass(frozen=True)
+class PatternAmount:
+    """One scan result: the largest match, or the key that made it unreadable.
+
+    ``value`` is the LARGEST finite amount found under a matching key (the
+    conservative choice: the cap must be checked against the biggest thing the
+    call proposes). ``unreadable_key`` names the first matching key that was
+    present but carried a non-finite number, so the gate can fail closed the
+    same way it does for the built-in scan and the declared path.
+    """
+
+    value: float | None = None
+    unreadable_key: str | None = None
+
+
+def _is_identifier_key(key: str) -> bool:
+    """Is ``key`` an identifier rather than an amount?
+
+    ``budget_id`` contains ``budget`` and ``bid_id`` contains ``bid``, but both
+    carry a resource id — typically a ten-digit integer that would exceed every
+    cap and deny an otherwise fine call. The boundary is explicit (``_id`` /
+    ``_ids`` / camelCase ``Id`` / ``Ids``) rather than a bare ``endswith("id")``
+    because ``bid`` itself ends in ``id``.
+    """
+    lowered = key.lower()
+    return (
+        lowered in {"id", "ids"}
+        or lowered.endswith(("_id", "_ids"))
+        or key.endswith(("Id", "Ids"))
+    )
+
+
+def is_budget_key(key: str) -> bool:
+    """Does ``key`` name a proposed budget? (case-insensitive ``budget``)"""
+    if key in _CONVENTION_KEYS or _is_identifier_key(key):
+        return False
+    return "budget" in key.lower()
+
+
+def is_bid_key(key: str) -> bool:
+    """Does ``key`` carry ``bid`` as a word fragment (not ``forbidden``)?
+
+    Accepts ``bid``, a ``bid``-prefixed name (``bid_amount``, ``bidAmount``), a
+    ``bid``-suffixed one (``default_bid``, ``maxBid``), an underscore-delimited
+    ``bid`` anywhere, and a camelCase ``Bid``. A bare substring test would drag
+    in ``forbidden`` and ``morbidity``.
+    """
+    if _is_identifier_key(key):
+        return False
+    lowered = key.lower()
+    if "bid" not in lowered:
+        return False
+    return (
+        lowered.startswith("bid")
+        or lowered.endswith("bid")
+        or "bid_" in lowered
+        or "_bid" in lowered
+        or "Bid" in key
+    )
+
+
+def _is_micros_key(key: str) -> bool:
+    return "micros" in key.lower()
+
+
+#: A thousands-grouped decimal: ``1,000``, ``-1,234,567.89``. Strictly
+#: grouped on purpose. The looser "digits and commas" reading would swallow
+#: ``"1,5"`` — which is *one and a half* in most of Europe — and re-read it as
+#: fifteen, a 10x over-read of a real-money figure. Anything that is not
+#: unambiguous grouping stays ignored, which is this scan's documented default.
+_GROUPED_NUMBER_RE = re.compile(r"^-?\d{1,3}(?:,\d{3})+(?:\.\d+)?$")
+
+
+def _degrouped(text: str) -> float | None:
+    """``"1,000,000"`` → ``1000000.0``; anything else → ``None``.
+
+    A JSON body that round-trips through a form encoder or a spreadsheet
+    export commonly arrives with grouped numerals, and ``float()`` rejects
+    them — so a real budget would read as "no proposal" and sail past the cap.
+    """
+    if _GROUPED_NUMBER_RE.match(text) is None:
+        return None
+    try:
+        return float(text.replace(",", ""))
+    except ValueError:  # pragma: no cover — the regex already guarantees this
+        return None
+
+
+def _read_amount(key: str, raw: Any) -> float | _Unreadable | None:
+    """Read one matching key's value as an amount in currency units.
+
+    Three outcomes, mirroring :func:`mureo.policy.declarations._declared_amount`
+    with ONE deliberate difference: a non-numeric value is *ignored* rather than
+    treated as unreadable. The declared path knows the key really is a budget,
+    so garbage there is a fault worth denying on; here the key was matched by a
+    heuristic, and ``{"budget_type": "DAILY"}`` is an ordinary enum, not an
+    attack. A present-but-non-finite NUMBER still denies — that is the overflow
+    / ``NaN`` bypass this whole layer exists to close.
+    """
+    if isinstance(raw, bool):
+        return None
+    if isinstance(raw, (int, float)):
+        value = _saturate(raw)
+    elif isinstance(raw, str):
+        stripped = raw.strip()
+        if not stripped:
+            return None
+        try:
+            value = float(stripped)
+        except ValueError:
+            grouped = _degrouped(stripped)
+            if grouped is None:
+                return None
+            value = grouped
+    else:
+        return None
+    if not math.isfinite(value):
+        return _UNREADABLE
+    return value / 1_000_000 if _is_micros_key(key) else value
+
+
+def _scan(arguments: Any, matches: Callable[[str], bool]) -> PatternAmount:
+    """Walk ``arguments``, returning the largest amount under a matching key.
+
+    ``matches`` is the key predicate (:func:`is_budget_key` /
+    :func:`is_bid_key`). The first unreadable match short-circuits: the gate
+    denies on it, so there is nothing to gain from scanning further.
+    """
+    best: float | None = None
+    stack: list[tuple[Any, int]] = [(arguments, 0)]
+    while stack:
+        node, depth = stack.pop()
+        if depth > _MAX_DEPTH:
+            continue
+        if isinstance(node, dict):
+            for key, value in node.items():
+                if isinstance(value, (dict, list)):
+                    stack.append((value, depth + 1))
+                    continue
+                if not isinstance(key, str) or not matches(key):
+                    continue
+                amount = _read_amount(key, value)
+                if isinstance(amount, _Unreadable):
+                    return PatternAmount(unreadable_key=key)
+                if amount is not None and (best is None or amount > best):
+                    best = amount
+        elif isinstance(node, list):
+            for item in node:
+                if isinstance(item, (dict, list)):
+                    stack.append((item, depth + 1))
+    return PatternAmount(value=best)
+
+
+def scan_budget_amount(arguments: dict[str, Any]) -> PatternAmount:
+    """Largest budget-shaped amount in ``arguments`` (best-effort)."""
+    return _scan(arguments, is_budget_key)
+
+
+def scan_bid_amount(arguments: dict[str, Any]) -> PatternAmount:
+    """Largest bid-shaped amount in ``arguments`` (best-effort)."""
+    return _scan(arguments, is_bid_key)
+
+
+# Tool names eligible for the fallback: MUTATING plugin tools, registered by
+# ``mureo.mcp.server`` from plugin tool metadata at import — the same shape as
+# the declaration registries next door, so the pure decision layer stays
+# I/O-free and needs no plugin imports. Membership alone does not enable the
+# scan for a channel that HAS a declaration: the gate consults the declaration
+# first and the scan only fills the gap it leaves.
+_PATTERN_FALLBACK_TOOLS: set[str] = set()
+
+
+def register_pattern_fallback_tool(tool_name: str) -> None:
+    """Mark ``tool_name`` as eligible for the pattern fallback."""
+    _PATTERN_FALLBACK_TOOLS.add(tool_name)
+
+
+def has_pattern_fallback(tool_name: str) -> bool:
+    """Is ``tool_name`` a registered declaration-less plugin mutation?"""
+    return tool_name in _PATTERN_FALLBACK_TOOLS
+
+
+def reset_pattern_fallback_tools() -> None:
+    """Drop every registration (tests; a re-discovery re-registers)."""
+    _PATTERN_FALLBACK_TOOLS.clear()

--- a/mureo/policy/strategy_gate.py
+++ b/mureo/policy/strategy_gate.py
@@ -19,6 +19,29 @@ Fail-open by contract: when there is no ``## Guardrails`` section, or it is
 empty, or STRATEGY.md is unreadable, the gate **allows** (abstains). It only
 ever denies on an explicit, machine-readable rule the operator wrote. This
 keeps mureo's default behaviour identical to "no enforcement".
+
+Three ways a budget/bid reaches a cap
+-------------------------------------
+
+1. The **built-in key scan** — the Google/Meta argument spellings hard-coded
+   below (``daily_budget``, ``amount_micros``, ``bid_amount``,
+   ``cpc_bid_micros``, …).
+2. An **exact-key declaration** (:mod:`mureo.policy.declarations`) — a plugin
+   names the keys its tools carry, in standard MCP metadata. Authoritative:
+   it REPLACES the built-in scan for the channels it covers.
+3. The **pattern fallback** (:mod:`mureo.policy.pattern_scan`) — for a
+   registered MUTATING plugin tool that declared nothing, budget-shaped and
+   bid-shaped argument keys are read heuristically (recursively, micros-aware)
+   and held to the same caps, with the same fail-closed handling of a
+   non-finite figure and the same deny envelope.
+
+The fallback is **best-effort by construction**: it matches on key *shape*, so
+it can miss a budget spelled without the word (and it can over-block a
+budget-named field that is not a proposal). It exists because a bridged tool
+surface — someone else's tool definitions, forwarded verbatim — cannot carry
+mureo declarations at all, and "no declaration" must not mean "no cap" where
+real money moves. **Exact-key declarations always take precedence**: for a
+channel that has one, the scan is not consulted.
 """
 
 from __future__ import annotations
@@ -56,6 +79,13 @@ from mureo.policy.declarations import (
     reset_bid_declarations,
     reset_budget_declarations,
 )
+from mureo.policy.pattern_scan import (
+    has_pattern_fallback,
+    register_pattern_fallback_tool,
+    reset_pattern_fallback_tools,
+    scan_bid_amount,
+    scan_budget_amount,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -82,6 +112,9 @@ __all__ = [
     "_BUDGET_DECLARATIONS",
     "_BID_DECLARATIONS",
     "_UNREADABLE",
+    "has_pattern_fallback",
+    "register_pattern_fallback_tool",
+    "reset_pattern_fallback_tools",
 ]
 
 # The (case-insensitive) STRATEGY.md section that carries machine-readable
@@ -147,8 +180,26 @@ class _BudgetInputs:
     unreadable_key: str | None = None
 
 
+def _merge_pattern(channel: float | None, pattern: float | None) -> float | None:
+    """Fold a pattern-scanned amount into a resolved channel (larger wins).
+
+    Additive, never subtractive: the built-in scan keeps whatever it found, and
+    the fallback can only raise the figure a cap is checked against. Taking the
+    larger of the two is the conservative direction — the check must see the
+    biggest amount the call proposes.
+    """
+    if pattern is None:
+        return channel
+    if channel is None:
+        return pattern
+    return max(channel, pattern)
+
+
 def _budget_inputs(
-    arguments: dict[str, Any], declaration: BudgetDeclaration | None
+    arguments: dict[str, Any],
+    declaration: BudgetDeclaration | None,
+    *,
+    pattern_fallback: bool = False,
 ) -> _BudgetInputs:
     """Resolve the budget channels from declared keys, else the built-in scan.
 
@@ -182,6 +233,20 @@ def _budget_inputs(
             if value is not None and not math.isfinite(value):
                 return _BudgetInputs(unreadable_key=label)
         proposed, current, lifetime, total = (v for _, v in channels)
+        if pattern_fallback:
+            # Best-effort key-shape scan for a declaration-less plugin
+            # mutation. Folded into BOTH proposal channels because a matched
+            # key's channel is exactly what the scan cannot know: the amount is
+            # held to every budget cap the operator configured rather than
+            # slipping past the one it happens not to be named for. The two
+            # CALLER-supplied channels (current / projected total) are
+            # deliberately untouched — they are mureo's own convention keys,
+            # already read above, and are never a proposal.
+            scanned = scan_budget_amount(arguments)
+            if scanned.unreadable_key is not None:
+                return _BudgetInputs(unreadable_key=scanned.unreadable_key)
+            proposed = _merge_pattern(proposed, scanned.value)
+            lifetime = _merge_pattern(lifetime, scanned.value)
         return _BudgetInputs(
             proposed=proposed, current=current, lifetime=lifetime, total=total
         )
@@ -422,7 +487,10 @@ class _BidInputs:
 
 
 def _bid_inputs(
-    arguments: dict[str, Any], declaration: BidDeclaration | None = None
+    arguments: dict[str, Any],
+    declaration: BidDeclaration | None = None,
+    *,
+    pattern_fallback: bool = False,
 ) -> _BidInputs:
     """Resolve the bid channels from declared keys, else the built-in scan.
 
@@ -453,6 +521,16 @@ def _bid_inputs(
             if value is not None and not math.isfinite(value):
                 return _BidInputs(unreadable_key=label)
         bid_amount, cpc_bid = (v for _, v in channels)
+        if pattern_fallback:
+            # The bid twin of the budget fallback above, folded into both bid
+            # channels for the same reason: a heuristically matched key does
+            # not announce whether it is an ad-set bid cap or a CPC bid, so it
+            # is held to whichever caps the operator configured.
+            scanned = scan_bid_amount(arguments)
+            if scanned.unreadable_key is not None:
+                return _BidInputs(unreadable_key=scanned.unreadable_key)
+            bid_amount = _merge_pattern(bid_amount, scanned.value)
+            cpc_bid = _merge_pattern(cpc_bid, scanned.value)
         return _BidInputs(bid_amount=bid_amount, cpc_bid=cpc_bid)
     resolved: list[float | None] = []
     for key in (declaration.bid_amount_key, declaration.cpc_bid_key):
@@ -471,6 +549,7 @@ def evaluate_guardrails(
     *,
     budget_declaration: BudgetDeclaration | None = None,
     bid_declaration: BidDeclaration | None = None,
+    pattern_fallback: bool = False,
 ) -> PolicyDecision:
     """Pure decision: does ``tool_name(arguments)`` violate ``guardrails``?
 
@@ -493,6 +572,14 @@ def evaluate_guardrails(
     that tool, so a plugin bid tool is enforced by ``max_bid_amount_per_ad_set``
     / ``max_cpc_bid_per_ad_group`` (see :class:`BidDeclaration`). Omitted ⇒
     unchanged behavior.
+
+    ``pattern_fallback`` turns on the best-effort key-shape scan
+    (:mod:`mureo.policy.pattern_scan`) for the channels that have NO
+    declaration — the only enforcement available to a tool surface that cannot
+    carry declarations at all. It is additive: the built-in scan still runs and
+    the larger figure wins. Per-family, so declaring a budget does not switch
+    the bid fallback off (or vice versa). Default ``False`` ⇒ every existing
+    caller is byte-identical.
     """
     if guardrails.is_empty():
         return PolicyDecision(allowed=True)
@@ -506,7 +593,9 @@ def evaluate_guardrails(
             ),
         )
 
-    inputs = _budget_inputs(arguments, budget_declaration)
+    inputs = _budget_inputs(
+        arguments, budget_declaration, pattern_fallback=pattern_fallback
+    )
     if inputs.unreadable_key is not None:
         # Fail CLOSED: the operator wrote a cap and the tool's declared
         # budget argument carries garbage, so the cap CANNOT be checked.
@@ -608,7 +697,7 @@ def evaluate_guardrails(
     # saturated to inf, or a bare NaN/Infinity the wire allows) fails CLOSED
     # here, before any ``bid > cap`` comparison where ``nan > cap`` (False)
     # would silently defeat the cap.
-    bids = _bid_inputs(arguments, bid_declaration)
+    bids = _bid_inputs(arguments, bid_declaration, pattern_fallback=pattern_fallback)
     if bids.unreadable_key is not None:
         return PolicyDecision(
             allowed=False,
@@ -708,6 +797,10 @@ class StrategyPolicyGate:
                 # The bid twin of #414: a plugin tool that declared its bid keys
                 # is enforced by the same gate through the same choke point.
                 bid_declaration=bid_declaration_for(tool_name),
+                # A MUTATING plugin tool that declared NOTHING (a bridged tool
+                # surface cannot) falls back to the best-effort key-shape scan
+                # rather than to no enforcement at all.
+                pattern_fallback=has_pattern_fallback(tool_name),
             )
         except Exception:  # noqa: BLE001 — abstain on any unexpected error
             logger.debug("StrategyPolicyGate: abstaining on error", exc_info=True)

--- a/mureo/rollback/planner.py
+++ b/mureo/rollback/planner.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import copy
 from typing import TYPE_CHECKING, Any
 
+from mureo.core.tool_names import READ_ONLY_PREFIXES, is_read_only_tool_name
 from mureo.rollback.models import RollbackPlan, RollbackStatus
 
 if TYPE_CHECKING:
@@ -78,16 +79,26 @@ _DESTRUCTIVE_VERBS: tuple[str, ...] = (
     "_transfer",
 )
 
-_READ_ONLY_PREFIXES: tuple[str, ...] = (
-    "list_",
-    "get_",
-    "analyze_",
-    "diagnose_",
-    "inspect_",
-    "report_",
-    "check_",
-    "search_",
-)
+# The read-verb vocabulary lives in :mod:`mureo.core.tool_names`, shared with
+# the MCP server's guardrail pattern-fallback registration. Two copies would
+# drift, and the drift would be silent on both sides — an unrollback-able read
+# here, a heuristically denied read there. Re-exported under the historical
+# private name so this module's import surface is unchanged.
+_READ_ONLY_PREFIXES = READ_ONLY_PREFIXES
+
+
+def _normalize_separators(name: str) -> str:
+    """Treat a hyphen namespace separator as an underscore.
+
+    A bridged MCP server commonly namespaces its tools
+    (``campaign_management-delete_campaign``), and against those names the
+    underscore-anchored verbs above matched NOTHING: ``_delete`` is not in
+    ``…management-delete_campaign``, so a delete read as a harmless write and
+    the destructive-verb safety net was off for the entire bridge. Native tool
+    names contain no hyphen, so this is a no-op for them and their behaviour is
+    byte-identical.
+    """
+    return name.replace("-", "_")
 
 
 def _plugin_reversal_keys(operation: str) -> tuple[bool, frozenset[str] | None]:
@@ -157,7 +168,8 @@ def plan_rollback(entry: ActionLogEntry) -> RollbackPlan | None:
             notes="reversible_params is missing a dict 'params' key.",
         )
 
-    if any(verb in operation for verb in _DESTRUCTIVE_VERBS):
+    normalized_operation = _normalize_separators(operation)
+    if any(verb in normalized_operation for verb in _DESTRUCTIVE_VERBS):
         return _not_supported(
             entry,
             notes=(
@@ -213,8 +225,16 @@ def plan_rollback(entry: ActionLogEntry) -> RollbackPlan | None:
 
 
 def _is_read_only(action: str) -> bool:
-    lowered = action.lower()
-    return any(lowered.startswith(prefix) for prefix in _READ_ONLY_PREFIXES)
+    """Does ``action`` name a read? (shared matcher — see the import above)
+
+    The prefixes anchor at the start of a *namespace segment*, not just of the
+    whole name: a bridged server's ``campaign_management-list_campaigns`` is as
+    much a read as a native ``list_campaigns``, and treating it as a write made
+    the planner emit a NOT_SUPPORTED plan for an action with nothing to undo.
+    A name with no hyphen is one segment, so native behaviour is unchanged —
+    including the deliberate non-match of mid-word hits like ``listing_update``.
+    """
+    return is_read_only_tool_name(action)
 
 
 def _not_supported(entry: ActionLogEntry, *, notes: str) -> RollbackPlan:

--- a/mureo/web/reports.py
+++ b/mureo/web/reports.py
@@ -95,6 +95,22 @@ _BUILTIN_DISPLAY_NAMES: dict[str, str] = {
     "tiktok_ads": "TikTok Ads",
 }
 
+# Distribution → display name for OFFICIAL, in-tree bridges (audit #30).
+# These ride the ``plugin:<dist>`` dispatch path to reuse the plugin safety
+# layer, but that is an implementation detail: they ship inside mureo, so
+# labelling them "(plugin)" would tell the operator a first-party integration
+# is third-party. Only in-tree bridges belong here; a genuine third-party
+# distribution keeps the suffix.
+#
+# The key is spelled out rather than imported from
+# ``mureo.amazon_ads.provider.AMAZON_SOURCE_DISTRIBUTION`` on purpose: that
+# module pulls the bridge (and the mcp SDK types it imports) onto the
+# configure-UI import path, which the wizard deliberately avoids. A test pins
+# the two strings together.
+_OFFICIAL_BRIDGE_DISPLAY_NAMES: dict[str, str] = {
+    "mureo-amazon-ads-bridge": "Amazon Ads",
+}
+
 # Canonical period tokens in dashboard-toggle order. The default view is the
 # most recent day (``YESTERDAY``) — daily-check runs every day, so the prior
 # day's state is what an operator checks first; ``LAST_30_DAYS`` is the
@@ -113,8 +129,12 @@ def platform_display_name(key: str) -> str:
     Rules:
     - A built-in key (``google_ads`` / ``meta_ads`` / ``search_console`` /
       ``ga4``) → its registered name.
-    - A ``plugin:<dist>`` key → a humanized label from ``<dist>``: drop a
-      leading ``mureo-`` and a trailing ``-bridge``, title-case the
+    - A ``plugin:<dist>`` key naming an OFFICIAL in-tree bridge → its
+      registered name, with no ``" (plugin)"`` suffix (e.g.
+      ``plugin:mureo-amazon-ads-bridge`` → ``"Amazon Ads"``). See
+      :data:`_OFFICIAL_BRIDGE_DISPLAY_NAMES`.
+    - Any other ``plugin:<dist>`` key → a humanized label from ``<dist>``:
+      drop a leading ``mureo-`` and a trailing ``-bridge``, title-case the
       hyphen-separated words, and suffix ``" (plugin)"`` (e.g.
       ``plugin:mureo-logly-bridge`` → ``"Logly (plugin)"``,
       ``plugin:acme-ads`` → ``"Acme Ads (plugin)"``).
@@ -126,7 +146,11 @@ def platform_display_name(key: str) -> str:
         return builtin
     # Issue #481: the canonical plugin key — see mureo.core.platform_keys.
     if is_plugin_platform_key(key):
-        label = _humanize_dist(plugin_distribution(key))
+        dist = plugin_distribution(key)
+        official = _OFFICIAL_BRIDGE_DISPLAY_NAMES.get(dist)
+        if official is not None:
+            return official
+        label = _humanize_dist(dist)
         return f"{label} (plugin)" if label else key
     return key
 

--- a/mureo/web/server.py
+++ b/mureo/web/server.py
@@ -164,11 +164,20 @@ class ConfigureWizard:
         entry-point failure cannot take the built-in card down with it.
         Imported lazily to keep the bridge — and the mcp SDK types it
         pulls in — off the configure-UI import path.
+
+        Audit #53 — ``MUREO_DISABLE_AMAZON_ADS=1`` skips that registration,
+        matching the MCP server's own gate. Both processes must agree: a card
+        rendered here for a bridge the server does not serve would invite the
+        operator to configure credentials that go nowhere.
         """
         try:
-            from mureo.amazon_ads.provider import register_amazon_provider
+            from mureo.amazon_ads.provider import (
+                amazon_ads_disabled,
+                register_amazon_provider,
+            )
 
-            register_amazon_provider()
+            if not amazon_ads_disabled():
+                register_amazon_provider()
             discover_providers()
         except KeyboardInterrupt:
             raise

--- a/mureo/web/status_collector.py
+++ b/mureo/web/status_collector.py
@@ -16,7 +16,7 @@ used by AWS / Stripe surface UIs.
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from mureo.web._helpers import read_json_safe
@@ -74,6 +74,15 @@ class StatusSnapshot:
     # ``home is None`` gate and relayed through here; defaults False so
     # standalone OSS and direct callers are unchanged.
     multi_account_auth: bool = False
+    # Audit #47: the Amazon tool manifest's freshness —
+    # ``{"present": bool, "stale": bool, "age_days": float | None}``. The
+    # manifest is a snapshot of a tool surface mureo does not own, so an old
+    # one means the exposed tool list has quietly drifted from reality.
+    # ``age_days`` is ``None`` when it cannot be determined (absent manifest,
+    # or an unusable ``generated_at``), and an unknown age is never reported
+    # as stale. Defaults to an empty dict so direct constructions of this
+    # snapshot (tests, alternate callers) keep working.
+    amazon_manifest: dict[str, Any] = field(default_factory=dict)
 
     def as_dict(self) -> dict[str, Any]:
         return {
@@ -86,6 +95,7 @@ class StatusSnapshot:
             "legacy_commands_present": self.legacy_commands_present,
             "mureo_disable": dict(self.mureo_disable),
             "multi_account_auth": self.multi_account_auth,
+            "amazon_manifest": dict(self.amazon_manifest),
         }
 
 
@@ -172,6 +182,36 @@ def _amazon_credentials_usable(section: Any) -> bool:
         section.get("access_token")
         or (section.get("refresh_token") and section.get("client_secret"))
     )
+
+
+def _detect_amazon_manifest(credentials_path: Path) -> dict[str, Any]:
+    """Freshness of ``~/.mureo/amazon_tools.json`` (audit #47).
+
+    The manifest lives beside ``credentials.json``, so the path is derived
+    from ``credentials_path`` rather than from ``Path.home()`` — the collector
+    reads exactly the tree it was handed, which is what keeps a test (or a
+    non-default home) from being answered with the operator's real manifest.
+
+    Read-only and never raises, like every other detector here: an unreadable
+    or timestamp-less manifest reports ``present`` with an unknown age, and an
+    unknown age is never called stale.
+    """
+    from mureo.amazon_ads.manifest import (
+        MANIFEST_FILENAME,
+        is_stale,
+        manifest_age_days,
+    )
+
+    path = credentials_path.parent / MANIFEST_FILENAME
+    present = path.exists()
+    age = manifest_age_days(path) if present else None
+    return {
+        "present": present,
+        "stale": is_stale(age),
+        # Rounded for display: the dashboard shows "N days old", and a raw
+        # float carries a precision this figure does not have.
+        "age_days": None if age is None else round(age, 1),
+    }
 
 
 def _detect_credentials_oauth(credentials_path: Path) -> dict[str, bool]:
@@ -337,6 +377,7 @@ def collect_status(
     env_vars = _collect_env_vars(resolved.credentials_path)
     legacy = _detect_legacy_commands(resolved.commands_dir)
     mureo_disable = _detect_mureo_disable(resolved.mcp_registry_path)
+    amazon_manifest = _detect_amazon_manifest(resolved.credentials_path)
     return StatusSnapshot(
         host=resolved.host,
         setup_parts=setup_parts,
@@ -347,4 +388,5 @@ def collect_status(
         legacy_commands_present=legacy,
         mureo_disable=mureo_disable,
         multi_account_auth=multi_account_auth,
+        amazon_manifest=amazon_manifest,
     )

--- a/tests/test_amazon_bridge.py
+++ b/tests/test_amazon_bridge.py
@@ -283,6 +283,59 @@ class TestTokenRefreshRetry:
         assert "Atza|" not in str(ei.value)  # no token material in the message
         assert isinstance(ei.value.__cause__, RuntimeError)  # original chained
 
+    def test_a_save_error_carrying_token_text_is_scrubbed(self, tmp_path: Path) -> None:
+        """The nested error's text is not mureo's to trust.
+
+        ``_token_saver`` is injectable and an ``OSError`` carries whatever the
+        OS put in it, so the underlying message can contain token material —
+        and this string lands in an agent-visible tool result. It goes through
+        the same secret-shape redactor the audit trail and the CLI use.
+        """
+        from mureo.amazon_ads.lwa import LwaTokens
+
+        def saver(access: str, refresh: str | None) -> None:
+            raise OSError(
+                "failed writing credentials.json: payload was "
+                "Atza|LEAKED-access-token-abc123"
+            )
+
+        b = self._mk(
+            tmp_path,
+            self._creds(),
+            self._connect_seq([], fail_first=1),
+            refresher=lambda c: LwaTokens("Atza|NEW", "Atzr|R", 3600),
+            token_saver=saver,
+        )
+        with pytest.raises(AmazonBridgeError) as ei:
+            asyncio.run(b.handle_mcp_tool("x", {}))
+        message = str(ei.value)
+        assert "LEAKED" not in message
+        assert "Atza|" not in message
+        assert "***" in message
+        # The actionable part survives the scrub.
+        assert "could not be saved" in message
+
+    def test_an_lwa_error_carrying_token_text_is_scrubbed(self, tmp_path: Path) -> None:
+        """Same discipline on the mint/refresh failure path."""
+        from mureo.amazon_ads.lwa import AmazonAuthError
+
+        def refresher(creds):
+            raise AmazonAuthError("invalid_grant for Atzr|LEAKED-refresh-xyz789")
+
+        b = self._mk(
+            tmp_path,
+            self._creds(),
+            self._connect_seq([], fail_first=1),
+            refresher=refresher,
+            token_saver=lambda a, r: None,
+        )
+        with pytest.raises(AmazonBridgeError) as ei:
+            asyncio.run(b.handle_mcp_tool("x", {}))
+        message = str(ei.value)
+        assert "LEAKED" not in message
+        assert "Atzr|" not in message
+        assert "***" in message
+
     def test_retry_after_refresh_still_failing_raises(self, tmp_path: Path) -> None:
         from mureo.amazon_ads.lwa import LwaTokens
 
@@ -512,3 +565,34 @@ class TestProactiveTokenMint:
             asyncio.run(b.handle_mcp_tool("x", {}))
         assert refreshed == [1]  # minted once, never refreshed again
         assert attempts == ["Bearer Atza|MINTED"]  # exactly one forwarded call
+
+
+@pytest.mark.unit
+def test_importing_the_bridge_first_does_not_break_plugin_discovery() -> None:
+    """Regression: the bridge must not import ``mureo.mcp`` at module level.
+
+    ``mureo.mcp.__init__`` imports the server, which builds its plugin tool
+    list AT IMPORT TIME by reaching this bridge through
+    ``mureo.amazon_ads.provider``. Any module-level ``mureo.mcp.*`` import here
+    re-enters a partially-initialized bridge, and the failure is quiet: plugin
+    discovery degrades to a warning and mureo starts with ZERO plugin tools —
+    including every Amazon tool. Run in a subprocess so the import order is the
+    real one rather than whatever the test session already cached.
+    """
+    import subprocess
+    import sys
+
+    source = (
+        "import warnings\n"
+        "warnings.simplefilter('error')\n"
+        "import mureo.amazon_ads.bridge\n"  # bridge FIRST — the risky order
+        "import mureo.mcp.server as s\n"
+        "assert s._PLUGIN_DISPATCH is not None\n"
+        "print('ok')\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", source], capture_output=True, text=True, timeout=120
+    )
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+    assert "circular import" not in result.stderr

--- a/tests/test_amazon_manifest_staleness.py
+++ b/tests/test_amazon_manifest_staleness.py
@@ -1,0 +1,230 @@
+"""Amazon tool-manifest staleness (audit #47).
+
+``generate_manifest`` has always written ``generated_at``; nothing ever read
+it. A manifest is a snapshot of someone else's tool surface, so an old one
+means mureo is exposing tools that may no longer exist (or hiding ones that
+now do) with no signal anywhere. These tests pin the age helpers and the three
+surfaces that report them: the configure-UI status row, the CLI refresh
+command, and a one-shot bridge warning.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from mureo.amazon_ads import manifest as manifest_mod
+from mureo.amazon_ads.manifest import (
+    DEFAULT_MANIFEST_MAX_AGE_DAYS,
+    MANIFEST_MAX_AGE_ENV,
+    is_manifest_stale,
+    manifest_age_days,
+    manifest_max_age_days,
+)
+
+
+def _write(path: Path, generated_at: Any) -> Path:
+    doc: dict[str, Any] = {"region": "na", "tools": []}
+    if generated_at is not None:
+        doc["generated_at"] = generated_at
+    path.write_text(json.dumps(doc), encoding="utf-8")
+    return path
+
+
+def _iso(days_ago: float) -> str:
+    moment = datetime.now(timezone.utc) - timedelta(days=days_ago)
+    return moment.isoformat(timespec="seconds")
+
+
+@pytest.mark.unit
+class TestManifestMaxAgeDays:
+    def test_defaults_to_30(self, monkeypatch: Any) -> None:
+        monkeypatch.delenv(MANIFEST_MAX_AGE_ENV, raising=False)
+        assert manifest_max_age_days() == DEFAULT_MANIFEST_MAX_AGE_DAYS
+        assert DEFAULT_MANIFEST_MAX_AGE_DAYS == 30
+
+    def test_env_override(self, monkeypatch: Any) -> None:
+        monkeypatch.setenv(MANIFEST_MAX_AGE_ENV, "7")
+        assert manifest_max_age_days() == 7.0
+
+    @pytest.mark.parametrize("raw", ["", "  ", "soon", "-3", "0"])
+    def test_unusable_override_falls_back_to_the_default(
+        self, monkeypatch: Any, raw: str
+    ) -> None:
+        monkeypatch.setenv(MANIFEST_MAX_AGE_ENV, raw)
+        assert manifest_max_age_days() == DEFAULT_MANIFEST_MAX_AGE_DAYS
+
+
+@pytest.mark.unit
+class TestManifestAgeDays:
+    def test_missing_file_is_none(self, tmp_path: Path) -> None:
+        assert manifest_age_days(tmp_path / "nope.json") is None
+
+    @pytest.mark.parametrize("generated_at", [None, "", "not-a-date", 12345, {"a": 1}])
+    def test_unusable_timestamp_is_none(
+        self, tmp_path: Path, generated_at: Any
+    ) -> None:
+        path = _write(tmp_path / "m.json", generated_at)
+        assert manifest_age_days(path) is None
+
+    def test_malformed_json_is_none(self, tmp_path: Path) -> None:
+        path = tmp_path / "m.json"
+        path.write_text("{not json", encoding="utf-8")
+        assert manifest_age_days(path) is None
+
+    def test_reads_the_age_in_days(self, tmp_path: Path) -> None:
+        path = _write(tmp_path / "m.json", _iso(3))
+        age = manifest_age_days(path)
+        assert age is not None
+        assert 2.9 < age < 3.1
+
+    def test_a_z_suffixed_timestamp_is_understood(self, tmp_path: Path) -> None:
+        moment = datetime.now(timezone.utc) - timedelta(days=2)
+        path = _write(
+            tmp_path / "m.json",
+            moment.replace(tzinfo=None).isoformat(timespec="seconds") + "Z",
+        )
+        age = manifest_age_days(path)
+        assert age is not None
+        assert 1.9 < age < 2.1
+
+    def test_a_naive_timestamp_is_read_as_local(self, tmp_path: Path) -> None:
+        moment = datetime.now().astimezone() - timedelta(days=5)
+        path = _write(tmp_path / "m.json", moment.replace(tzinfo=None).isoformat())
+        age = manifest_age_days(path)
+        assert age is not None
+        assert 4.9 < age < 5.1
+
+    def test_a_future_timestamp_clamps_to_zero(self, tmp_path: Path) -> None:
+        path = _write(tmp_path / "m.json", _iso(-10))
+        assert manifest_age_days(path) == 0.0
+
+    def test_it_uses_the_injectable_clock(
+        self, tmp_path: Path, monkeypatch: Any
+    ) -> None:
+        from mureo.core import clock
+
+        written = datetime.now(timezone.utc)
+        path = _write(tmp_path / "m.json", written.isoformat(timespec="seconds"))
+        monkeypatch.setattr(
+            clock, "server_now", lambda: (written + timedelta(days=42)).astimezone()
+        )
+        age = manifest_age_days(path)
+        assert age is not None
+        assert 41.9 < age < 42.1
+
+
+@pytest.mark.unit
+class TestIsManifestStale:
+    def test_fresh_is_not_stale(self, tmp_path: Path) -> None:
+        assert is_manifest_stale(_write(tmp_path / "m.json", _iso(1))) is False
+
+    def test_old_is_stale(self, tmp_path: Path) -> None:
+        assert is_manifest_stale(_write(tmp_path / "m.json", _iso(45))) is True
+
+    def test_unknown_age_is_not_stale(self, tmp_path: Path) -> None:
+        """Never claim staleness we cannot prove — an absent manifest is
+        reported as absent, not as stale."""
+        assert is_manifest_stale(tmp_path / "nope.json") is False
+
+    def test_the_threshold_is_overridable(
+        self, tmp_path: Path, monkeypatch: Any
+    ) -> None:
+        path = _write(tmp_path / "m.json", _iso(10))
+        assert is_manifest_stale(path) is False
+        monkeypatch.setenv(MANIFEST_MAX_AGE_ENV, "7")
+        assert is_manifest_stale(path) is True
+
+    def test_default_path_is_the_manifest_path(
+        self, tmp_path: Path, monkeypatch: Any
+    ) -> None:
+        path = _write(tmp_path / "amazon_tools.json", _iso(45))
+        monkeypatch.setattr(manifest_mod, "manifest_path", lambda: path)
+        assert is_manifest_stale() is True
+
+
+@pytest.mark.unit
+class TestBridgeStaleWarning:
+    """The bridge warns ONCE per process when it serves a stale manifest.
+
+    ``mcp_tools()`` runs at mureo server start and on every tool-list refresh,
+    so a per-call warning would be log spam; silence would be worse — the
+    operator would never learn the tool list is months old. And it stays a
+    warning: an old manifest still serves its tools, because refusing to would
+    break a working setup over a heuristic.
+    """
+
+    def _bridge(self, tmp_path: Path, days_old: float) -> Any:
+        from mureo.amazon_ads.bridge import AmazonAdsBridge
+
+        tmp_path.mkdir(parents=True, exist_ok=True)
+        path = tmp_path / "amazon_tools.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "generated_at": _iso(days_old),
+                    "tools": [
+                        {
+                            "name": "campaign_management-list_campaigns",
+                            "description": "x",
+                            "inputSchema": {"type": "object", "properties": {}},
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        return AmazonAdsBridge(manifest_path=path)
+
+    @pytest.fixture(autouse=True)
+    def _reset_flag(self) -> Any:
+        from mureo.amazon_ads import bridge as bridge_mod
+
+        bridge_mod._stale_manifest_warned = False
+        yield
+        bridge_mod._stale_manifest_warned = False
+
+    def test_a_stale_manifest_warns_once(self, tmp_path: Path, caplog: Any) -> None:
+        bridge = self._bridge(tmp_path, 90)
+        with caplog.at_level("WARNING", logger="mureo.amazon_ads.bridge"):
+            assert len(bridge.mcp_tools()) == 1
+            assert len(bridge.mcp_tools()) == 1
+        warnings = [r for r in caplog.records if "manifest is stale" in r.getMessage()]
+        assert len(warnings) == 1
+        assert "refresh-manifest" in warnings[0].getMessage()
+
+    def test_a_fresh_manifest_does_not_warn(self, tmp_path: Path, caplog: Any) -> None:
+        bridge = self._bridge(tmp_path, 1)
+        with caplog.at_level("WARNING", logger="mureo.amazon_ads.bridge"):
+            assert len(bridge.mcp_tools()) == 1
+        assert [
+            r for r in caplog.records if "manifest is stale" in r.getMessage()
+        ] == []
+
+    def test_an_absent_manifest_does_not_warn(
+        self, tmp_path: Path, caplog: Any
+    ) -> None:
+        from mureo.amazon_ads.bridge import AmazonAdsBridge
+
+        bridge = AmazonAdsBridge(manifest_path=tmp_path / "nope.json")
+        with caplog.at_level("WARNING", logger="mureo.amazon_ads.bridge"):
+            assert bridge.mcp_tools() == ()
+        assert caplog.records == []
+
+    def test_a_fresh_read_does_not_suppress_a_later_warning(
+        self, tmp_path: Path, caplog: Any
+    ) -> None:
+        """The one-shot latch arms on an actual warning, not on any read."""
+        fresh = self._bridge(tmp_path, 1)
+        fresh.mcp_tools()
+        stale = self._bridge(tmp_path / "old", 90)
+        with caplog.at_level("WARNING", logger="mureo.amazon_ads.bridge"):
+            stale.mcp_tools()
+        assert (
+            len([r for r in caplog.records if "manifest is stale" in r.getMessage()])
+            == 1
+        )

--- a/tests/test_amazon_server_wiring.py
+++ b/tests/test_amazon_server_wiring.py
@@ -366,3 +366,77 @@ class TestBuiltInShadowingPolicy:
         ConfigureWizard._discover_providers_safely()
 
         assert default_registry.get("amazon_ads").provider_class is AmazonAdsBridge
+
+
+@pytest.mark.unit
+class TestAmazonDisableEnvVar:
+    """``MUREO_DISABLE_AMAZON_ADS=1`` steps the bridge aside (audit #53).
+
+    Google / Meta / GA4 all have a ``MUREO_DISABLE_*`` coexistence control;
+    Amazon had none, so an operator who wired Amazon's MCP up directly in
+    their host had no way to stop mureo from ALSO exposing the same tools.
+    The two processes that register the provider — the MCP server and the
+    configure UI — must agree, or the dashboard would advertise a card for a
+    bridge the server does not serve.
+    """
+
+    def test_mcp_discovery_omits_amazon_when_disabled(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        from mureo.core.providers import default_registry
+        from mureo.mcp import server as mod
+
+        monkeypatch.setattr(default_registry, "_entries", {})
+        monkeypatch.setattr(
+            "mureo.core.providers.registry.discover_providers", _no_thirdparty
+        )
+        monkeypatch.setenv("MUREO_DISABLE_AMAZON_ADS", "1")
+
+        entries = mod._discover_with_amazon()
+
+        assert [e for e in entries if e.name == "amazon_ads"] == []
+        # Not registered either: a disabled bridge must not linger in the
+        # registry for the configure UI to render a card from.
+        assert "amazon_ads" not in default_registry
+
+    def test_mcp_server_exposes_no_amazon_tools_when_disabled(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        from mureo.core.providers import default_registry
+
+        monkeypatch.setattr(default_registry, "_entries", {})
+        monkeypatch.setenv("MUREO_DISABLE_AMAZON_ADS", "1")
+        mod = _reload_server(monkeypatch, tmp_path, with_manifest=True)
+        try:
+            assert "campaign_management-create_campaign" not in mod._PLUGIN_NAMES
+        finally:
+            monkeypatch.delenv("MUREO_DISABLE_AMAZON_ADS", raising=False)
+            importlib.reload(mod)
+
+    def test_configure_process_omits_amazon_when_disabled(self, monkeypatch) -> None:
+        from mureo.core.providers import default_registry
+        from mureo.web.server import ConfigureWizard
+
+        monkeypatch.setattr(default_registry, "_entries", {})
+        monkeypatch.setattr("mureo.web.server.discover_providers", _no_thirdparty)
+        monkeypatch.setenv("MUREO_DISABLE_AMAZON_ADS", "1")
+
+        ConfigureWizard._discover_providers_safely()
+
+        assert "amazon_ads" not in default_registry
+
+    @pytest.mark.parametrize("value", ["0", "", "true", "  1  ", "yes"])
+    def test_truthy_coercion_does_not_disable(self, monkeypatch, value) -> None:
+        """Exact-string ``"1"``, matching every other MUREO_DISABLE_* gate."""
+        from mureo.core.providers import default_registry
+        from mureo.mcp import server as mod
+
+        monkeypatch.setattr(default_registry, "_entries", {})
+        monkeypatch.setattr(
+            "mureo.core.providers.registry.discover_providers", _no_thirdparty
+        )
+        monkeypatch.setenv("MUREO_DISABLE_AMAZON_ADS", value)
+
+        entries = mod._discover_with_amazon()
+
+        assert [e.name for e in entries if e.name == "amazon_ads"] == ["amazon_ads"]

--- a/tests/test_cli_amazon.py
+++ b/tests/test_cli_amazon.py
@@ -7,13 +7,30 @@ failure exit.
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 from typer.testing import CliRunner
 
+from mureo.amazon_ads.lwa import AmazonAuthError, LwaTokens
 from mureo.auth import AmazonAdsCredentials
 from mureo.cli.main import app
 
 runner = CliRunner()
+
+
+def _creds(**kw: Any) -> AmazonAdsCredentials:
+    base: dict[str, Any] = {"client_id": "cid", "access_token": "tok"}
+    base.update(kw)
+    return AmazonAdsCredentials(**base)
+
+
+@pytest.fixture(autouse=True)
+def _no_real_manifest(monkeypatch: Any, tmp_path: Any) -> None:
+    """Keep the age banner off the operator's real ~/.mureo manifest."""
+    monkeypatch.setattr(
+        "mureo.cli.amazon_cmd.manifest_path", lambda: tmp_path / "amazon_tools.json"
+    )
 
 
 @pytest.mark.unit
@@ -60,3 +77,177 @@ class TestAmazonRefreshManifest:
         # M2: token shape scrubbed from the terminal error
         assert "LEAKED" not in r.output
         assert "***" in r.output
+
+
+@pytest.mark.unit
+class TestManifestAgeBanner:
+    """Audit #47 — the command reports the current manifest's age first.
+
+    Refreshing a two-day-old manifest and refreshing a year-old one are very
+    different operations; the operator should be told which one this is.
+    """
+
+    def _run(self, monkeypatch: Any, tmp_path: Any, generated_at: str | None) -> Any:
+        import json
+
+        path = tmp_path / "amazon_tools.json"
+        if generated_at is not None:
+            path.write_text(
+                json.dumps({"generated_at": generated_at, "tools": []}),
+                encoding="utf-8",
+            )
+        monkeypatch.setattr(
+            "mureo.cli.amazon_cmd.load_amazon_ads_credentials", lambda *a, **k: _creds()
+        )
+        monkeypatch.setattr(
+            "mureo.cli.amazon_cmd.generate_manifest_sync", lambda creds: path
+        )
+        return runner.invoke(app, ["amazon", "refresh-manifest"])
+
+    def _iso(self, days_ago: float) -> str:
+        from datetime import datetime, timedelta, timezone
+
+        return (datetime.now(timezone.utc) - timedelta(days=days_ago)).isoformat(
+            timespec="seconds"
+        )
+
+    def test_absent_manifest_says_so(self, monkeypatch: Any, tmp_path: Any) -> None:
+        r = self._run(monkeypatch, tmp_path, None)
+        assert r.exit_code == 0
+        assert "No existing Amazon tool manifest" in r.output
+
+    def test_fresh_manifest_reports_its_age(
+        self, monkeypatch: Any, tmp_path: Any
+    ) -> None:
+        r = self._run(monkeypatch, tmp_path, self._iso(3))
+        assert r.exit_code == 0
+        assert "3.0 days old" in r.output
+        assert "stale" not in r.output.lower()
+
+    def test_stale_manifest_is_called_out(
+        self, monkeypatch: Any, tmp_path: Any
+    ) -> None:
+        r = self._run(monkeypatch, tmp_path, self._iso(90))
+        assert r.exit_code == 0
+        assert "90.0 days old" in r.output
+        assert "stale" in r.output.lower()
+
+    def test_unreadable_timestamp_does_not_break_the_command(
+        self, monkeypatch: Any, tmp_path: Any
+    ) -> None:
+        r = self._run(monkeypatch, tmp_path, "not-a-date")
+        assert r.exit_code == 0
+        assert "age is unknown" in r.output
+
+
+@pytest.mark.unit
+class TestMintBeforeRefresh:
+    """Audit #49 — the recommended refresh-token-only setup used to 401.
+
+    ``request_headers`` was handed an empty ``access_token``, so the very
+    command an operator runs first failed against a perfectly valid setup.
+    Minting happens here now, exactly as the dispatch path does it.
+    """
+
+    def _wire(
+        self,
+        monkeypatch: Any,
+        tmp_path: Any,
+        creds: AmazonAdsCredentials,
+        refresher: Any,
+        saver: Any = None,
+    ) -> list[AmazonAdsCredentials]:
+        seen: list[AmazonAdsCredentials] = []
+
+        def _generate(c: AmazonAdsCredentials):
+            seen.append(c)
+            return tmp_path / "amazon_tools.json"
+
+        monkeypatch.setattr(
+            "mureo.cli.amazon_cmd.load_amazon_ads_credentials", lambda *a, **k: creds
+        )
+        monkeypatch.setattr("mureo.cli.amazon_cmd.generate_manifest_sync", _generate)
+        monkeypatch.setattr("mureo.cli.amazon_cmd.refresh_access_token", refresher)
+        monkeypatch.setattr(
+            "mureo.cli.amazon_cmd.save_amazon_access_token",
+            saver or (lambda *a, **k: None),
+        )
+        return seen
+
+    def test_empty_access_token_is_minted_and_persisted(
+        self, monkeypatch: Any, tmp_path: Any
+    ) -> None:
+        saved: list[tuple] = []
+        creds = _creds(access_token="", refresh_token="Atzr|R", client_secret="s")
+        seen = self._wire(
+            monkeypatch,
+            tmp_path,
+            creds,
+            lambda c: LwaTokens(
+                access_token="Atza|MINTED", refresh_token="Atzr|R2", expires_in=3600
+            ),
+            saver=lambda *a: saved.append(a),
+        )
+        r = runner.invoke(app, ["amazon", "refresh-manifest"])
+        assert r.exit_code == 0
+        assert saved == [("Atza|MINTED", "Atzr|R2")]
+        # The generator receives the MINTED token, not the empty one.
+        assert seen[0].access_token == "Atza|MINTED"
+        assert seen[0].refresh_token == "Atzr|R2"
+        assert "MINTED" not in r.output
+
+    def test_a_stored_access_token_is_used_as_is(
+        self, monkeypatch: Any, tmp_path: Any
+    ) -> None:
+        def _never(c):
+            raise AssertionError("must not mint when a token is already stored")
+
+        seen = self._wire(monkeypatch, tmp_path, _creds(), _never)
+        r = runner.invoke(app, ["amazon", "refresh-manifest"])
+        assert r.exit_code == 0
+        assert seen[0].access_token == "tok"
+
+    def test_without_refresh_material_nothing_is_minted(
+        self, monkeypatch: Any, tmp_path: Any
+    ) -> None:
+        def _never(c):
+            raise AssertionError("must not mint without refresh_token+client_secret")
+
+        creds = _creds(access_token="", refresh_token="Atzr|R")  # no client_secret
+        self._wire(monkeypatch, tmp_path, creds, _never)
+        r = runner.invoke(app, ["amazon", "refresh-manifest"])
+        assert r.exit_code == 1
+        assert "no amazon_ads access_token" in r.output
+
+    def test_a_failed_mint_exits_1_without_leaking(
+        self, monkeypatch: Any, tmp_path: Any
+    ) -> None:
+        def _boom(c):
+            raise AmazonAuthError("invalid_grant for Atzr|LEAKED-token-123")
+
+        creds = _creds(access_token="", refresh_token="Atzr|R", client_secret="s")
+        self._wire(monkeypatch, tmp_path, creds, _boom)
+        r = runner.invoke(app, ["amazon", "refresh-manifest"])
+        assert r.exit_code == 1
+        assert "could not be obtained" in r.output
+        assert "LEAKED" not in r.output
+
+    def test_a_failed_save_exits_1(self, monkeypatch: Any, tmp_path: Any) -> None:
+        from mureo.providers.config_writer import ConfigWriteError
+
+        def _bad_save(*a: Any) -> None:
+            raise ConfigWriteError("credentials.json is malformed")
+
+        creds = _creds(access_token="", refresh_token="Atzr|R", client_secret="s")
+        self._wire(
+            monkeypatch,
+            tmp_path,
+            creds,
+            lambda c: LwaTokens(
+                access_token="Atza|M", refresh_token="Atzr|R", expires_in=3600
+            ),
+            saver=_bad_save,
+        )
+        r = runner.invoke(app, ["amazon", "refresh-manifest"])
+        assert r.exit_code == 1
+        assert "could not be saved" in r.output

--- a/tests/test_rollback.py
+++ b/tests/test_rollback.py
@@ -358,3 +358,97 @@ class TestPluginReversalEscapeHatch:
         assert plan.status == RollbackStatus.NOT_SUPPORTED
         assert "destructive" in plan.notes.lower()
         assert consulted == []  # hook never reached for a destructive op
+
+
+@pytest.mark.unit
+class TestHyphenNamespacedToolNames:
+    """A bridged MCP server may namespace its tools with a hyphen
+    (``campaign_management-delete_campaign``). The verb / read-only
+    detection keyed on ``_delete`` and ``list_`` never matched those, so a
+    destructive reversal read as harmless and a read-only action read as a
+    write. Native (hyphen-free) names are unaffected.
+    """
+
+    @pytest.mark.parametrize(
+        "action",
+        [
+            "campaign_management-list_campaigns",
+            "reporting-get_report",
+            "campaign_management-search_keywords",
+        ],
+    )
+    def test_hyphen_namespaced_reads_are_read_only(self, action: str) -> None:
+        assert plan_rollback(_entry(action=action, reversible_params=None)) is None
+
+    def test_a_hyphen_namespaced_read_with_a_hint_is_flagged(self) -> None:
+        entry = _entry(
+            action="campaign_management-list_campaigns",
+            reversible_params={"operation": "x", "params": {}},
+        )
+        plan = plan_rollback(entry)
+        assert plan is not None
+        assert plan.status == RollbackStatus.NOT_SUPPORTED
+        assert "Read-only action" in plan.notes
+
+    @pytest.mark.parametrize(
+        "operation",
+        [
+            "campaign_management-delete_campaign",
+            "campaign_management-remove_keywords",
+            "billing-transfer_funds",
+        ],
+    )
+    def test_hyphen_namespaced_destructive_verbs_are_refused(
+        self, operation: str, monkeypatch
+    ) -> None:
+        consulted: list[str] = []
+
+        def _spy(op: str):
+            consulted.append(op)
+            return (True, None)
+
+        monkeypatch.setattr("mureo.rollback.planner._plugin_reversal_keys", _spy)
+        entry = _entry(
+            action="campaign_management-update_campaign",
+            reversible_params={"operation": operation, "params": {}},
+        )
+        plan = plan_rollback(entry)
+        assert plan is not None
+        assert plan.status == RollbackStatus.NOT_SUPPORTED
+        assert "destructive" in plan.notes.lower()
+        assert consulted == []
+
+    def test_a_hyphen_namespaced_write_is_still_plannable(self, monkeypatch) -> None:
+        """Generalizing the match must not turn every namespaced name into a
+        refusal — a harmless namespaced reversal still plans."""
+        monkeypatch.setattr(
+            "mureo.rollback.planner._plugin_reversal_keys",
+            lambda op: (True, frozenset({"campaign_id"})),
+        )
+        entry = _entry(
+            action="campaign_management-update_campaign",
+            platform="plugin:acme-dist",
+            reversible_params={
+                "operation": "campaign_management-update_campaign",
+                "params": {"campaign_id": "123"},
+            },
+        )
+        plan = plan_rollback(entry)
+        assert plan is not None
+        assert plan.status == RollbackStatus.SUPPORTED
+
+    @pytest.mark.parametrize(
+        "action",
+        [
+            # Native names keep their exact behaviour: the read-only prefixes
+            # anchor at the start of the name, never mid-word.
+            "google_ads_campaigns_list",
+            "update_budget",
+            "listing_update",
+        ],
+    )
+    def test_native_names_are_unchanged(self, action: str) -> None:
+        entry = _entry(action=action, reversible_params=None)
+        plan = plan_rollback(entry)
+        assert plan is not None
+        assert plan.status == RollbackStatus.NOT_SUPPORTED

--- a/tests/test_strategy_gate_pattern_fallback.py
+++ b/tests/test_strategy_gate_pattern_fallback.py
@@ -1,0 +1,543 @@
+"""Pattern fallback for declaration-less plugin mutations (audit #17/#18).
+
+A plugin whose tools come from a manifest snapshot cannot carry mureo
+``_meta`` declarations, so :class:`BudgetDeclaration` / :class:`BidDeclaration`
+are unavailable to it and every ``## Guardrails`` budget/bid cap was silently
+unenforced for its mutations — on a surface where real money moves.
+
+This adds a conservative, best-effort pattern scan: for a MUTATING plugin tool
+with no registered declaration, numeric arguments under budget-shaped /
+bid-shaped key names are read as proposals and held to the same caps, with the
+same fail-closed discipline and the same deny envelope as the built-in scan.
+Exact-key declarations always take precedence.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from mureo.policy.pattern_scan import (
+    has_pattern_fallback,
+    is_bid_key,
+    is_budget_key,
+    register_pattern_fallback_tool,
+    reset_pattern_fallback_tools,
+    scan_bid_amount,
+    scan_budget_amount,
+)
+from mureo.policy.strategy_gate import (
+    BidDeclaration,
+    BudgetDeclaration,
+    Guardrails,
+    evaluate_guardrails,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+_CAPS = Guardrails(max_daily_budget_per_campaign=10_000)
+_BID_CAPS = Guardrails(max_bid_amount_per_ad_set=500)
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry() -> Iterator[None]:
+    """Isolate the process-global fallback registry WITHOUT destroying it.
+
+    ``mureo.mcp.server`` populates it once at import from real plugin
+    discovery; a destructive clear would drop those registrations for the
+    rest of the pytest session.
+    """
+    from mureo.policy.pattern_scan import _PATTERN_FALLBACK_TOOLS
+
+    saved = set(_PATTERN_FALLBACK_TOOLS)
+    reset_pattern_fallback_tools()
+    yield
+    reset_pattern_fallback_tools()
+    _PATTERN_FALLBACK_TOOLS.update(saved)
+
+
+# ---------------------------------------------------------------------------
+# Key predicates
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestBudgetKeyPredicate:
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "budget",
+            "daily_budget",
+            "dailyBudget",
+            "BUDGET",
+            "budget_amount_micros",
+            "campaign_budget",
+        ],
+    )
+    def test_budget_shaped_keys_match(self, key: str) -> None:
+        assert is_budget_key(key) is True
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "amount",
+            "spend",
+            # mureo's own caller-supplied convention keys are context, not a
+            # proposal — reading them as one would deny a decrease.
+            "current_daily_budget",
+            "projected_total_daily_budget",
+            # identifiers are never amounts
+            "budget_id",
+            "budget_ids",
+            "budgetId",
+        ],
+    )
+    def test_non_proposal_keys_do_not_match(self, key: str) -> None:
+        assert is_budget_key(key) is False
+
+
+@pytest.mark.unit
+class TestBidKeyPredicate:
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "bid",
+            "bid_amount",
+            "bidAmount",
+            "default_bid",
+            "maxBid",
+            "cpc_bid_micros",
+            "BID",
+        ],
+    )
+    def test_bid_shaped_keys_match(self, key: str) -> None:
+        assert is_bid_key(key) is True
+
+    @pytest.mark.parametrize(
+        "key",
+        ["forbidden", "forbidden_zone", "budget", "morbidity", "bid_id", "bidId"],
+    )
+    def test_false_positives_are_excluded(self, key: str) -> None:
+        assert is_bid_key(key) is False
+
+
+# ---------------------------------------------------------------------------
+# The scan itself
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestScan:
+    def test_absent_is_none(self) -> None:
+        assert scan_budget_amount({"name": "x"}).value is None
+
+    def test_reads_a_top_level_numeric(self) -> None:
+        assert scan_budget_amount({"daily_budget": 250.0}).value == 250.0
+
+    def test_reads_through_nested_dicts_and_lists(self) -> None:
+        args = {"campaigns": [{"settings": {"dailyBudget": 400}}]}
+        assert scan_budget_amount(args).value == 400
+
+    def test_takes_the_maximum_of_several_matches(self) -> None:
+        args = {"budget": 100, "nested": {"weekly_budget": 900}}
+        assert scan_budget_amount(args).value == 900
+
+    def test_micros_keys_are_scaled(self) -> None:
+        assert scan_budget_amount({"budget_micros": 12_000_000}).value == 12.0
+
+    def test_numeric_strings_are_read(self) -> None:
+        assert scan_budget_amount({"daily_budget": "250"}).value == 250.0
+
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [
+            ("1,000", 1000.0),
+            ("1,000,000", 1_000_000.0),
+            ("1,234,567.89", 1_234_567.89),
+            ("-2,500", -2500.0),
+            ("  12,000  ", 12_000.0),
+        ],
+    )
+    def test_comma_grouped_numeric_strings_are_read(
+        self, text: str, expected: float
+    ) -> None:
+        """A form encoder / spreadsheet export groups its numerals; without
+        this, a real budget read as 'no proposal' and sailed past the cap."""
+        assert scan_budget_amount({"daily_budget": text}).value == expected
+        assert scan_bid_amount({"bid_amount": text}).value == expected
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            # European decimal comma — reading this as 15 would be a 10x
+            # over-read of a real-money figure, so ambiguous grouping is
+            # ignored rather than guessed at.
+            "1,5",
+            "1,23",
+            "12,34567",
+            "1,000,00",
+            ",000",
+            "1,,000",
+            "1,000,",
+            "USD 1,000",
+            "1,000 JPY",
+        ],
+    )
+    def test_ambiguous_or_malformed_grouping_is_ignored(self, text: str) -> None:
+        assert scan_budget_amount({"daily_budget": text}).value is None
+        assert scan_bid_amount({"bid_amount": text}).value is None
+
+    def test_a_grouped_micros_string_is_still_scaled(self) -> None:
+        assert scan_budget_amount({"budget_micros": "12,000,000"}).value == 12.0
+
+    def test_non_numeric_strings_are_ignored(self) -> None:
+        assert scan_budget_amount({"budget_type": "DAILY"}).value is None
+
+    def test_booleans_are_ignored(self) -> None:
+        assert scan_budget_amount({"budget_enabled": True}).value is None
+
+    @pytest.mark.parametrize("value", [float("inf"), float("nan"), 10**400])
+    def test_a_non_finite_match_is_unreadable(self, value: Any) -> None:
+        result = scan_budget_amount({"daily_budget": value})
+        assert result.value is None
+        assert result.unreadable_key == "daily_budget"
+
+    def test_bid_scan_reads_bid_shaped_keys(self) -> None:
+        assert scan_bid_amount({"ad_groups": [{"default_bid": 4.5}]}).value == 4.5
+
+    def test_deeply_nested_beyond_the_depth_limit_is_ignored(self) -> None:
+        node: dict[str, Any] = {"daily_budget": 99_999}
+        for _ in range(20):
+            node = {"wrap": node}
+        assert scan_budget_amount(node).value is None
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRegistry:
+    def test_register_and_lookup(self) -> None:
+        assert has_pattern_fallback("acme-do_thing") is False
+        register_pattern_fallback_tool("acme-do_thing")
+        assert has_pattern_fallback("acme-do_thing") is True
+
+    def test_reset_clears(self) -> None:
+        register_pattern_fallback_tool("acme-do_thing")
+        reset_pattern_fallback_tools()
+        assert has_pattern_fallback("acme-do_thing") is False
+
+
+# ---------------------------------------------------------------------------
+# Enforcement through evaluate_guardrails
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestEvaluateWithFallback:
+    def test_over_cap_is_blocked(self) -> None:
+        decision = evaluate_guardrails(
+            "campaign_management-update_campaign",
+            {"campaign": {"dailyBudget": 25_000}},
+            _CAPS,
+            pattern_fallback=True,
+        )
+        assert decision.allowed is False
+        assert "max_daily_budget_per_campaign" in (decision.reason or "")
+        assert "25,000" in (decision.reason or "")
+
+    def test_under_cap_is_allowed(self) -> None:
+        decision = evaluate_guardrails(
+            "campaign_management-update_campaign",
+            {"campaign": {"dailyBudget": 900}},
+            _CAPS,
+            pattern_fallback=True,
+        )
+        assert decision.allowed is True
+
+    def test_without_the_fallback_it_sails_past(self) -> None:
+        """The gap this closes: no declaration, no fallback ⇒ unenforced."""
+        decision = evaluate_guardrails(
+            "campaign_management-update_campaign",
+            {"campaign": {"dailyBudget": 25_000}},
+            _CAPS,
+        )
+        assert decision.allowed is True
+
+    def test_a_declaration_takes_precedence(self) -> None:
+        """An exact-key declaration owns the tool's vocabulary; the
+        best-effort scan must not second-guess it."""
+        decision = evaluate_guardrails(
+            "acme_update",
+            {"stray_budget": 25_000, "spend_limit": 100},
+            _CAPS,
+            budget_declaration=BudgetDeclaration(daily_key="spend_limit"),
+            pattern_fallback=True,
+        )
+        assert decision.allowed is True
+
+    def test_increase_pct_uses_the_convention_baseline(self) -> None:
+        decision = evaluate_guardrails(
+            "campaign_management-update_campaign",
+            {"dailyBudget": 5_000, "current_daily_budget": 1_000},
+            Guardrails(max_daily_budget_increase_pct=20),
+            pattern_fallback=True,
+        )
+        assert decision.allowed is False
+        assert "max_daily_budget_increase_pct" in (decision.reason or "")
+
+    def test_lifetime_cap_also_constrains_a_pattern_match(self) -> None:
+        decision = evaluate_guardrails(
+            "campaign_management-update_campaign",
+            {"campaign_budget": 900_000},
+            Guardrails(max_lifetime_budget_per_campaign=500_000),
+            pattern_fallback=True,
+        )
+        assert decision.allowed is False
+        assert "max_lifetime_budget_per_campaign" in (decision.reason or "")
+
+    def test_a_non_finite_pattern_match_fails_closed(self) -> None:
+        decision = evaluate_guardrails(
+            "campaign_management-update_campaign",
+            {"dailyBudget": float("inf")},
+            _CAPS,
+            pattern_fallback=True,
+        )
+        assert decision.allowed is False
+        assert "dailyBudget" in (decision.reason or "")
+
+    def test_no_guardrails_still_fails_open(self) -> None:
+        decision = evaluate_guardrails(
+            "campaign_management-update_campaign",
+            {"dailyBudget": float("inf")},
+            Guardrails(),
+            pattern_fallback=True,
+        )
+        assert decision.allowed is True
+
+    def test_bid_over_cap_is_blocked(self) -> None:
+        decision = evaluate_guardrails(
+            "ad_group_management-update_bid",
+            {"ad_group": {"defaultBid": 900}},
+            _BID_CAPS,
+            pattern_fallback=True,
+        )
+        assert decision.allowed is False
+        assert "max_bid_amount_per_ad_set" in (decision.reason or "")
+
+    def test_cpc_bid_cap_also_constrains_a_pattern_match(self) -> None:
+        decision = evaluate_guardrails(
+            "ad_group_management-update_bid",
+            {"bid_micros": 9_000_000},
+            Guardrails(max_cpc_bid_per_ad_group=5),
+            pattern_fallback=True,
+        )
+        assert decision.allowed is False
+        assert "max_cpc_bid_per_ad_group" in (decision.reason or "")
+
+    def test_a_bid_declaration_takes_precedence(self) -> None:
+        decision = evaluate_guardrails(
+            "acme_update",
+            {"stray_bid": 900, "bid_cap": 10},
+            _BID_CAPS,
+            bid_declaration=BidDeclaration(bid_amount_key="bid_cap"),
+            pattern_fallback=True,
+        )
+        assert decision.allowed is True
+
+    def test_the_builtin_scan_still_applies_alongside(self) -> None:
+        """The fallback is additive: built-in spellings keep working."""
+        decision = evaluate_guardrails(
+            "campaign_management-update_campaign",
+            {"daily_budget": 25_000},
+            _CAPS,
+            pattern_fallback=True,
+        )
+        assert decision.allowed is False
+
+    def test_an_identifier_argument_does_not_false_trip(self) -> None:
+        decision = evaluate_guardrails(
+            "campaign_management-update_campaign",
+            {"budget_id": 1234567890123, "dailyBudget": 100},
+            _CAPS,
+            pattern_fallback=True,
+        )
+        assert decision.allowed is True
+
+
+# ---------------------------------------------------------------------------
+# Gate + registry integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGateIntegration:
+    def test_gate_applies_the_fallback_for_a_registered_tool(
+        self, tmp_path: Any, monkeypatch: Any
+    ) -> None:
+        import mureo.policy.strategy_gate as sg
+        from mureo.core.runtime_context import reset_runtime_context
+        from mureo.policy.strategy_gate import StrategyPolicyGate
+
+        (tmp_path / "STRATEGY.md").write_text(
+            "## Guardrails\n- max_daily_budget_per_campaign: 10000\n",
+            encoding="utf-8",
+        )
+        monkeypatch.chdir(tmp_path)
+        reset_runtime_context()
+        sg._cache.clear()
+        try:
+            register_pattern_fallback_tool("campaign_management-update_campaign")
+            gate = StrategyPolicyGate()
+            denied = gate.evaluate(
+                "campaign_management-update_campaign", {"dailyBudget": 25_000}
+            )
+            assert denied.allowed is False
+            allowed = gate.evaluate("some_unregistered_tool", {"dailyBudget": 25_000})
+            assert allowed.allowed is True
+        finally:
+            reset_runtime_context()
+            sg._cache.clear()
+
+
+@pytest.mark.unit
+def test_server_registers_mutating_plugin_tools_for_the_fallback() -> None:
+    """A declaration-less MUTATING plugin tool is registered; a read is not."""
+    from mcp.types import Tool, ToolAnnotations
+
+    from mureo.mcp.plugin_semantics import derive_semantics
+    from mureo.mcp.server import _register_plugin_pattern_fallbacks
+
+    mutating = Tool(
+        name="campaign_management-update_campaign",
+        description="x",
+        inputSchema={"type": "object", "properties": {}},
+    )
+    read_only = Tool(
+        name="campaign_management-list_campaigns",
+        description="x",
+        inputSchema={"type": "object", "properties": {}},
+        annotations=ToolAnnotations(readOnlyHint=True),
+    )
+    semantics = {t.name: derive_semantics(t) for t in (mutating, read_only)}
+    _register_plugin_pattern_fallbacks(semantics)
+
+    assert has_pattern_fallback("campaign_management-update_campaign") is True
+    assert has_pattern_fallback("campaign_management-list_campaigns") is False
+
+
+def _semantics_for(*names: str) -> dict[str, Any]:
+    """Semantics for tools that declare NOTHING — no annotations, no meta.
+
+    This is the shape a manifest snapshot produces, and it is exactly the case
+    that matters: ``derive_semantics`` defaults an undeclared tool to
+    *mutating*, so the name is the only signal available.
+    """
+    from mcp.types import Tool
+
+    from mureo.mcp.plugin_semantics import derive_semantics
+
+    tools = [
+        Tool(
+            name=name,
+            description="x",
+            inputSchema={"type": "object", "properties": {}},
+        )
+        for name in names
+    ]
+    return {t.name: derive_semantics(t) for t in tools}
+
+
+@pytest.mark.unit
+class TestReadNameExemption:
+    """A read tool without ``readOnlyHint`` must not be denial-gated.
+
+    ``derive_semantics`` treats an undeclared tool as mutating (the right
+    default for auditing), and a manifest snapshot declares nothing — so every
+    read from a bridged surface arrived here as "mutating". Handing those to a
+    heuristic budget/bid scan can only produce FALSE DENIALS: a listing call
+    with a numeric budget-shaped *filter* argument would be refused.
+
+    The exemption is keyed on read-shaped NAMES rather than on a mutation
+    allow-list because the error costs are asymmetric: platform mutations are
+    consistently verb-named (``create_`` / ``update_`` / ``delete_`` /
+    ``set_``), so a read-shaped name is almost never a mutation, while a
+    mutation-shaped name that is really a read costs only a scan of arguments
+    that carry no budget.
+    """
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "campaign_management-list_campaigns",
+            "account_management-query_advertiser_account",
+            "reporting-get_report",
+            "reporting-search_terms",
+            "insights-analyze_performance",
+            # Native (hyphen-free) read names are exempted on the same rule.
+            "list_campaigns",
+        ],
+    )
+    def test_read_shaped_names_are_not_registered(self, name: str) -> None:
+        from mureo.mcp.server import _register_plugin_pattern_fallbacks
+
+        _register_plugin_pattern_fallbacks(_semantics_for(name))
+        assert has_pattern_fallback(name) is False
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "campaign_management-create_campaign",
+            "campaign_management-update_campaign",
+            "campaign_management-set_budget",
+            "campaign_management-delete_campaign",
+            # A mid-word hit is not a read prefix, so it stays registered.
+            "campaign_management-listing_update",
+            "acme_ads_update_budget",
+        ],
+    )
+    def test_mutation_shaped_names_are_still_registered(self, name: str) -> None:
+        from mureo.mcp.server import _register_plugin_pattern_fallbacks
+
+        _register_plugin_pattern_fallbacks(_semantics_for(name))
+        assert has_pattern_fallback(name) is True
+
+    def test_the_exemption_uses_the_shared_read_vocabulary(self) -> None:
+        """One list, two safety surfaces — see mureo.core.tool_names."""
+        from mureo.core.tool_names import is_read_only_tool_name
+        from mureo.rollback import planner
+
+        assert planner._READ_ONLY_PREFIXES is not None
+        assert is_read_only_tool_name("campaign_management-list_x") is True
+        assert planner._is_read_only("campaign_management-list_x") is True
+
+    def test_a_read_with_a_budget_shaped_filter_is_not_denied(
+        self, tmp_path: Any, monkeypatch: Any
+    ) -> None:
+        """The bug this closes, end to end through the real gate."""
+        import mureo.policy.strategy_gate as sg
+        from mureo.core.runtime_context import reset_runtime_context
+        from mureo.mcp.server import _register_plugin_pattern_fallbacks
+        from mureo.policy.strategy_gate import StrategyPolicyGate
+
+        (tmp_path / "STRATEGY.md").write_text(
+            "## Guardrails\n- max_daily_budget_per_campaign: 10000\n",
+            encoding="utf-8",
+        )
+        monkeypatch.chdir(tmp_path)
+        reset_runtime_context()
+        sg._cache.clear()
+        try:
+            name = "campaign_management-list_campaigns"
+            _register_plugin_pattern_fallbacks(_semantics_for(name))
+            decision = StrategyPolicyGate().evaluate(
+                name, {"min_daily_budget_filter": 50_000}
+            )
+            assert decision.allowed is True
+        finally:
+            reset_runtime_context()
+            sg._cache.clear()

--- a/tests/test_web_reports.py
+++ b/tests/test_web_reports.py
@@ -182,6 +182,25 @@ def test_platform_display_name_labels() -> None:
 
 
 @pytest.mark.unit
+def test_official_bridge_dists_render_without_the_plugin_suffix() -> None:
+    """Audit #30 — the Amazon bridge ships inside mureo.
+
+    It rides the plugin dispatch path for safety-layer reuse, which is an
+    implementation detail; labelling it "(plugin)" tells the operator it is
+    third-party when it is first-party. Other dists keep the suffix.
+    """
+    from mureo.amazon_ads.provider import AMAZON_SOURCE_DISTRIBUTION
+    from mureo.web.reports import _OFFICIAL_BRIDGE_DISPLAY_NAMES, platform_display_name
+
+    assert platform_display_name("plugin:mureo-amazon-ads-bridge") == "Amazon Ads"
+    # The override is keyed on the real distribution name, not a guess.
+    assert AMAZON_SOURCE_DISTRIBUTION in _OFFICIAL_BRIDGE_DISPLAY_NAMES
+    # Every other plugin dist is unchanged.
+    assert platform_display_name("plugin:mureo-logly-bridge") == "Logly (plugin)"
+    assert platform_display_name("plugin:acme-ads") == "Acme Ads (plugin)"
+
+
+@pytest.mark.unit
 def test_summary_carries_totals_period_and_campaign_count(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/test_web_status_collector.py
+++ b/tests/test_web_status_collector.py
@@ -293,6 +293,66 @@ class TestAmazonCredentialsPresence:
 
 
 @pytest.mark.unit
+class TestAmazonManifestRow:
+    """Audit #47 — the tool manifest's age is surfaced, not just written.
+
+    The manifest is a snapshot of Amazon's tool surface; a months-old one
+    silently exposes a stale tool list. The row reports present/absent, the
+    age in days, and whether that age is past the threshold.
+    """
+
+    def _row(self, tmp_path: Path, generated_at: object | None) -> dict:
+        paths = _paths(tmp_path)
+        if generated_at is not None:
+            _write_json(
+                paths.credentials_path.parent / "amazon_tools.json",
+                {"generated_at": generated_at, "tools": []},
+            )
+        snapshot = collect_status(
+            "claude-code", home=_build_home(tmp_path), paths=paths
+        )
+        return snapshot.amazon_manifest
+
+    def _iso(self, days_ago: float) -> str:
+        from datetime import datetime, timedelta, timezone
+
+        moment = datetime.now(timezone.utc) - timedelta(days=days_ago)
+        return moment.isoformat(timespec="seconds")
+
+    def test_absent_manifest(self, tmp_path: Path) -> None:
+        row = self._row(tmp_path, None)
+        assert row == {"present": False, "stale": False, "age_days": None}
+
+    def test_fresh_manifest(self, tmp_path: Path) -> None:
+        row = self._row(tmp_path, self._iso(2))
+        assert row["present"] is True
+        assert row["stale"] is False
+        assert 1.9 < row["age_days"] < 2.1
+
+    def test_stale_manifest(self, tmp_path: Path) -> None:
+        row = self._row(tmp_path, self._iso(60))
+        assert row["present"] is True
+        assert row["stale"] is True
+
+    def test_unreadable_timestamp_is_present_with_unknown_age(
+        self, tmp_path: Path
+    ) -> None:
+        row = self._row(tmp_path, "not-a-date")
+        assert row == {"present": True, "stale": False, "age_days": None}
+
+    def test_the_row_survives_serialization(self, tmp_path: Path) -> None:
+        paths = _paths(tmp_path)
+        _write_json(
+            paths.credentials_path.parent / "amazon_tools.json",
+            {"generated_at": self._iso(1), "tools": []},
+        )
+        snapshot = collect_status(
+            "claude-code", home=_build_home(tmp_path), paths=paths
+        )
+        assert snapshot.as_dict()["amazon_manifest"] == snapshot.amazon_manifest
+
+
+@pytest.mark.unit
 class TestStatusSnapshotShape:
     def test_snapshot_is_frozen_dataclass(self, tmp_path: Path) -> None:
         snapshot = collect_status(


### PR DESCRIPTION
Closes the safety-side gaps from the Amazon first-class parity audit. See the commit message for the full list: pattern-based budget/bid cap enforcement for declaration-less plugin tools (over-blocking direction, read-named tools exempt via a shared vocabulary), hyphen-aware rollback matching, manifest staleness detection, refresh-manifest 401 fix (mints via LwA), MUREO_DISABLE_AMAZON_ADS, bridge error scrubbing (plus a real circular-import fix pinned by a subprocess test). +150 tests, full suite green except known env-only failures. Note: the guardrail also gates rollback legs — a reversal restoring an over-cap value is denied like any other write (fail-safe by design). Refs #121.