### PR TITLE
refactor: extract atomic-JSON helpers into mureo.core.atomic_json

### DIFF
--- a/mureo/amazon_ads/bridge.py
+++ b/mureo/amazon_ads/bridge.py
@@ -40,8 +40,8 @@ from mureo.auth import (
     load_amazon_ads_credentials,
     save_amazon_access_token,
 )
+from mureo.core.atomic_json import ConfigWriteError
 from mureo.core.providers.credentials import AccountCredentialField
-from mureo.providers.config_writer import ConfigWriteError
 
 logger = logging.getLogger(__name__)
 

--- a/mureo/amazon_ads/manifest.py
+++ b/mureo/amazon_ads/manifest.py
@@ -34,7 +34,7 @@ from typing import TYPE_CHECKING, Any
 
 from mureo.amazon_ads.endpoints import endpoint_url, request_headers
 from mureo.core import clock
-from mureo.providers.config_writer import _atomic_write_json
+from mureo.core.atomic_json import atomic_write_json
 
 if TYPE_CHECKING:
     from mureo.auth import AmazonAdsCredentials
@@ -213,7 +213,7 @@ async def generate_manifest(
     # sibling chmodded BEFORE the data is written, fsynced, then
     # ``os.replace``d, so a reader never sees a half-written manifest,
     # the file is never world-readable, and a failure leaves no debris.
-    _atomic_write_json(doc, out)
+    atomic_write_json(doc, out)
     return out
 
 

--- a/mureo/auth.py
+++ b/mureo/auth.py
@@ -539,13 +539,13 @@ def _save_meta_token(
 ) -> None:
     """Atomically update the meta_ads token in credentials.json.
 
-    Reuses the hardened ``config_writer`` helpers rather than a local
-    read-modify-write: ``_load_existing`` returns ``{}`` only when the file is
-    absent and RAISES ``ConfigWriteError`` on malformed JSON — instead of the
+    Reuses the hardened ``mureo.core.atomic_json`` helpers rather than a local
+    read-modify-write: ``load_existing_json`` returns ``{}`` only when the file
+    is absent and RAISES ``ConfigWriteError`` on malformed JSON — instead of the
     old ``data = {}`` reset that silently erased every other provider's
     credentials (google_ads etc.) on a slightly-corrupt file. On that raise the
     caller (:func:`refresh_meta_token_if_needed`) skips the save and warns,
-    leaving the file intact. ``_atomic_write_json`` writes via tmp + fsync +
+    leaving the file intact. ``atomic_write_json`` writes via tmp + fsync +
     ``os.replace`` at ``0o600`` so a crash mid-write is durable and safe.
 
     The load -> mutate -> write cycle runs under a cross-process ``file_lock``
@@ -554,13 +554,13 @@ def _save_meta_token(
     (e.g. a wizard re-auth dropping the just-refreshed access_token, or this
     refresh dropping a freshly-saved google_ads block).
     """
-    # Lazy import mirrors ``auth_setup.save_credentials`` and avoids any
-    # import-time coupling to the providers package.
-    from mureo.providers.config_writer import _atomic_write_json, _load_existing
+    # Lazy import mirrors ``auth_setup.save_credentials`` and keeps the
+    # module import graph flat.
+    from mureo.core.atomic_json import atomic_write_json, load_existing_json
 
     path.parent.mkdir(parents=True, exist_ok=True)
     with file_lock(lock_path_for(path)):
-        data = _load_existing(path)
+        data = load_existing_json(path)
 
         meta_section = data.get("meta_ads", {})
         if not isinstance(meta_section, dict):
@@ -570,7 +570,7 @@ def _save_meta_token(
         meta_section["token_obtained_at"] = new_obtained_at
         data["meta_ads"] = meta_section
 
-        _atomic_write_json(data, path)
+        atomic_write_json(data, path)
 
 
 def save_amazon_access_token(
@@ -581,12 +581,12 @@ def save_amazon_access_token(
     """Atomically persist a refreshed Amazon access token (#113 Phase 2A).
 
     Mirrors :func:`_save_meta_token` exactly, reusing the same hardened
-    ``config_writer`` helpers instead of a local read-modify-write:
-    ``_load_existing`` returns ``{}`` only when the file is absent and
+    ``mureo.core.atomic_json`` helpers instead of a local read-modify-write:
+    ``load_existing_json`` returns ``{}`` only when the file is absent and
     RAISES ``ConfigWriteError`` on malformed JSON, so a slightly-corrupt
     credentials.json is left untouched rather than reset to ``{}`` —
     which would silently erase every other provider's section
-    (google_ads etc.). ``_atomic_write_json`` writes via tmp + fsync +
+    (google_ads etc.). ``atomic_write_json`` writes via tmp + fsync +
     ``os.replace`` at ``0o600``, so a crash mid-write is durable and the
     file is never world-readable.
 
@@ -602,14 +602,14 @@ def save_amazon_access_token(
         ConfigWriteError: the existing credentials.json is malformed;
             nothing is written.
     """
-    # Lazy import mirrors ``_save_meta_token`` and avoids any import-time
-    # coupling to the providers package.
-    from mureo.providers.config_writer import _atomic_write_json, _load_existing
+    # Lazy import mirrors ``_save_meta_token`` and keeps the module import
+    # graph flat.
+    from mureo.core.atomic_json import atomic_write_json, load_existing_json
 
     resolved = path if path is not None else _resolve_default_path()
     resolved.parent.mkdir(parents=True, exist_ok=True)
     with file_lock(lock_path_for(resolved)):
-        data = _load_existing(resolved)
+        data = load_existing_json(resolved)
 
         section = data.get("amazon_ads", {})
         if not isinstance(section, dict):
@@ -619,7 +619,7 @@ def save_amazon_access_token(
             section["refresh_token"] = refresh_token
         data["amazon_ads"] = section
 
-        _atomic_write_json(data, resolved)
+        atomic_write_json(data, resolved)
 
 
 # ---------------------------------------------------------------------------

--- a/mureo/auth_setup.py
+++ b/mureo/auth_setup.py
@@ -605,14 +605,14 @@ def _register_user_scope_mcp() -> Path:
     # hardened atomic, refuse-malformed writer (mkstemp+0o600+fsync+
     # os.replace; raises ConfigWriteError rather than clobbering a
     # corrupt-but-recoverable file) instead of a plain truncating write.
-    from mureo.providers.config_writer import _atomic_write_json, _load_existing
+    from mureo.core.atomic_json import atomic_write_json, load_existing_json
 
     path = _claude_user_config_path()
-    existing = _load_existing(path)  # {} if absent; raises on malformed
+    existing = load_existing_json(path)  # {} if absent; raises on malformed
     mcp_servers = existing.setdefault("mcpServers", {})
     mcp_servers["mureo"] = _MCP_SERVER_CONFIG
     existing["mcpServers"] = mcp_servers
-    _atomic_write_json(existing, path)
+    atomic_write_json(existing, path)
     logger.info("mureo MCP registered (user scope) via fallback merge: %s", path)
     return path
 
@@ -906,20 +906,20 @@ def save_credentials(
     resolved.parent.mkdir(parents=True, exist_ok=True)
 
     # Load existing data. Reuse the hardened reader/writer from
-    # config_writer: ``_load_existing`` returns {} only when the file is
-    # absent and RAISES ConfigWriteError on malformed JSON, instead of the
-    # old ``existing = {}`` reset that silently erased every other provider's
-    # auth on a slightly-corrupt file. ``_atomic_write_json`` (tmp + fsync +
-    # os.replace + 0o600) replaces the old truncating write so a crash mid-
-    # write can't brick all providers.
-    from mureo.providers.config_writer import _atomic_write_json, _load_existing
+    # mureo.core.atomic_json: ``load_existing_json`` returns {} only when the
+    # file is absent and RAISES ConfigWriteError on malformed JSON, instead of
+    # the old ``existing = {}`` reset that silently erased every other
+    # provider's auth on a slightly-corrupt file. ``atomic_write_json`` (tmp +
+    # fsync + os.replace + 0o600) replaces the old truncating write so a crash
+    # mid-write can't brick all providers.
+    from mureo.core.atomic_json import atomic_write_json, load_existing_json
 
     # Hold the whole read-modify-write under a cross-process ``file_lock`` so
     # a concurrent Meta 53-day auto-refresh (auth._save_meta_token) or another
     # CLI/web wizard run cannot last-writer-wins away the section this call is
     # not touching (both take the same ``credentials.json.lock``).
     with file_lock(lock_path_for(resolved)):
-        existing: dict[str, Any] = _load_existing(resolved)
+        existing: dict[str, Any] = load_existing_json(resolved)
 
         if google is not None:
             _merge_google_section(existing, google, customer_id)
@@ -929,7 +929,7 @@ def save_credentials(
         # Keep a .bak of the prior good file, then write atomically. The
         # atomic writer also applies owner-only (0o600) permissions.
         backup_file(resolved)
-        _atomic_write_json(existing, resolved)
+        atomic_write_json(existing, resolved)
 
     logger.info("Credentials saved: %s", resolved)
 

--- a/mureo/cli/amazon_cmd.py
+++ b/mureo/cli/amazon_cmd.py
@@ -37,8 +37,8 @@ from mureo.auth import (
     load_amazon_ads_credentials,
     save_amazon_access_token,
 )
+from mureo.core.atomic_json import ConfigWriteError
 from mureo.mcp.plugin_audit import _scrub as _scrub_secrets
-from mureo.providers.config_writer import ConfigWriteError
 
 amazon_app = typer.Typer(name="amazon", help="Amazon Ads official-MCP bridge setup")
 

--- a/mureo/cli/providers_cmd.py
+++ b/mureo/cli/providers_cmd.py
@@ -228,16 +228,14 @@ def _register_provider(spec: ProviderSpec) -> bool:
 
 def _mureo_block_exists() -> bool:
     """Return True iff ``mcpServers.mureo`` exists in the default settings file."""
-    from mureo.providers.config_writer import (
-        _default_settings_path,
-        _load_existing,
-    )
+    from mureo.core.atomic_json import load_existing_json
+    from mureo.providers.config_writer import _default_settings_path
 
     target = _default_settings_path()
     if not target.exists():
         return False
     try:
-        existing = _load_existing(target)
+        existing = load_existing_json(target)
     except Exception:  # noqa: BLE001 — defensive: degraded message is acceptable
         return False
     mcp_servers = existing.get("mcpServers")

--- a/mureo/core/atomic_json.py
+++ b/mureo/core/atomic_json.py
@@ -1,0 +1,150 @@
+"""Fail-closed reader + atomic writer for mureo's JSON config files (#500).
+
+Every mureo writer that owns a small JSON document on disk — Claude Code
+MCP settings (``~/.claude.json``), ``credentials.json``, the Amazon Ads
+tool manifest, ``insight_sources.json`` — needs the same two guarantees:
+
+- **fail closed on a malformed existing file.** :func:`load_existing_json`
+  returns ``{}`` *only* when the file is absent and raises
+  :class:`ConfigWriteError` when it exists but is not a JSON object, so a
+  single corrupt byte can never be "read" as empty and then written back,
+  erasing everything the caller did not touch.
+- **atomic, owner-only writes.** :func:`atomic_write_json` writes through
+  an unpredictable same-directory ``tempfile``, chmods it ``0o600``
+  *before* the data lands in it, ``fsync``s, then ``os.replace``s — so a
+  crash mid-write cannot corrupt the target, the file is never
+  world-readable, and a failure leaves no debris.
+
+These helpers used to live (private) in ``mureo.providers.config_writer``,
+which is documented for Claude Code settings only; three unrelated writers
+reached into it anyway. They are low-level by design: this module depends
+on nothing but the stdlib and :mod:`mureo.fsutil`.
+
+Note: neither function serialises the surrounding read-modify-write. A
+caller that must not lose a concurrent writer's section wraps the whole
+cycle in :func:`mureo.fsutil.file_lock` (see ``auth.save_amazon_access_token``).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from mureo.fsutil import secure_fchmod
+
+__all__ = ["ConfigWriteError", "atomic_write_json", "load_existing_json"]
+
+logger = logging.getLogger(__name__)
+
+
+class ConfigWriteError(Exception):
+    """Raised when a JSON config file cannot be safely updated.
+
+    Used specifically when an existing file contains malformed JSON — we
+    refuse to silently overwrite the file to protect user data.
+    """
+
+
+def load_existing_json(path: Path) -> dict[str, Any]:
+    """Load ``path`` as a dict, or return ``{}`` if the file is absent.
+
+    Raises:
+        ConfigWriteError: when the existing file is malformed JSON. The
+            exception message includes the path so the operator can locate
+            and fix the file manually.
+    """
+    # NOTE: the message wording ("settings") predates this module and is
+    # part of the user-visible surface (callers such as the Amazon bridge
+    # re-wrap it into their own error text); it is deliberately unchanged.
+    if not path.exists():
+        return {}
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ConfigWriteError(
+            f"failed to read existing settings at {path}: {exc}"
+        ) from exc
+    try:
+        loaded = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ConfigWriteError(
+            f"existing settings file at {path} is malformed JSON "
+            f"(refusing to overwrite to protect user data): {exc}"
+        ) from exc
+    if not isinstance(loaded, dict):
+        raise ConfigWriteError(
+            f"existing settings at {path} is not a JSON object "
+            f"(got {type(loaded).__name__}); refusing to overwrite."
+        )
+    return loaded
+
+
+def _fsync_directory(parent: Path) -> None:
+    """Best-effort ``fsync`` of ``parent`` so a rename is durable.
+
+    POSIX requires ``fsync`` on the directory to flush a rename to disk.
+    Not supported on Windows; ignore ``OSError`` there.
+    """
+    try:
+        dir_fd = os.open(str(parent), os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(dir_fd)
+    except OSError:
+        pass
+    finally:
+        os.close(dir_fd)
+
+
+def atomic_write_json(payload: dict[str, Any], path: Path) -> None:
+    """Serialize ``payload`` and atomically replace ``path``.
+
+    Uses :func:`tempfile.mkstemp` to allocate an unpredictable same-directory
+    tmp file, sets its mode to ``0o600`` before writing, ``fsync``s the data
+    to disk, then ``os.replace``s it into place. Best-effort ``fsync`` on the
+    parent directory after the rename so the directory entry is durable too.
+    On failure the tmp file is unlinked so no debris remains. The original
+    ``path`` (if any) is untouched until ``os.replace`` succeeds.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    serialized = json.dumps(payload, indent=2, ensure_ascii=False) + "\n"
+
+    # Allocate an unpredictable tmp file in the same directory as the target
+    # so ``os.replace`` is guaranteed to be a rename within the same
+    # filesystem (and therefore atomic on POSIX).
+    tmp_fd, tmp_name = tempfile.mkstemp(
+        prefix=path.name + ".",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        # Restrict permissions BEFORE writing the data so the file is never
+        # readable to other local users during the write/replace window.
+        secure_fchmod(tmp_fd)
+        with os.fdopen(tmp_fd, "w", encoding="utf-8") as fh:
+            tmp_fd = -1  # ownership transferred to ``fh``; do not close twice
+            fh.write(serialized)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp_path, path)
+        _fsync_directory(path.parent)
+    except (OSError, ValueError):
+        # Clean up the tmp file on any FS-level failure so the directory
+        # stays tidy. ``ValueError`` covers ``json.dumps`` having serialized
+        # something unexpected (defensive — payload is built internally).
+        try:
+            if tmp_fd != -1:
+                os.close(tmp_fd)
+        except OSError:
+            pass
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            logger.warning("failed to remove tmp file %s", tmp_path)
+        raise

--- a/mureo/learning/insight_sources.py
+++ b/mureo/learning/insight_sources.py
@@ -35,8 +35,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
 
+from mureo.core.atomic_json import atomic_write_json, load_existing_json
 from mureo.fsutil import backup_file
-from mureo.providers.config_writer import _atomic_write_json, _load_existing
 
 logger = logging.getLogger(__name__)
 
@@ -233,7 +233,7 @@ def add_insight_source(
     Read-modify-write with the #276-hardened safe-write stack:
 
     - the existing file is read FAIL-CLOSED via
-      :func:`mureo.providers.config_writer._load_existing` — a malformed
+      :func:`mureo.core.atomic_json.load_existing_json` — a malformed
       file raises :class:`ConfigWriteError` (NOT the tolerant
       :func:`load_insight_sources`, which would silently drop a corrupt
       file and let us clobber it);
@@ -275,14 +275,14 @@ def remove_insight_source(name: str, *, path: Path | None = None) -> bool:
 def _load_existing_sources(cfg_path: Path) -> list[dict[str, Any]]:
     """Return the on-disk ``sources`` list, reading the file FAIL-CLOSED.
 
-    Reuses :func:`mureo.providers.config_writer._load_existing` so a
+    Reuses :func:`mureo.core.atomic_json.load_existing_json` so a
     malformed file raises :class:`ConfigWriteError` (never the tolerant
     reader). A missing file yields ``[]``; a present-but-non-list
     ``sources`` value is normalised to ``[]`` so the writer rebuilds a
     well-formed file rather than refusing — only malformed JSON / a
     non-object top level fail closed.
     """
-    loaded = _load_existing(cfg_path)
+    loaded = load_existing_json(cfg_path)
     entries = loaded.get("sources")
     if not isinstance(entries, list):
         return []
@@ -292,7 +292,7 @@ def _load_existing_sources(cfg_path: Path) -> list[dict[str, Any]]:
 def _write_sources(cfg_path: Path, sources: list[dict[str, Any]]) -> None:
     """Back up the prior file then atomically write the new sources list."""
     backup_file(cfg_path)  # rolling .bak before any overwrite (no-op if absent)
-    _atomic_write_json({"sources": sources}, cfg_path)
+    atomic_write_json({"sources": sources}, cfg_path)
 
 
 def _build_source(entry: dict[str, Any]) -> InsightSource:

--- a/mureo/providers/config_writer.py
+++ b/mureo/providers/config_writer.py
@@ -18,22 +18,29 @@ Each public function:
 A separate writer (rather than reusing ``mureo.auth_setup.install_mcp_config``)
 is intentional — the four existing ``setup`` commands continue to use the
 older non-atomic writer; refactoring it is out of scope for Phase 1.
+
+The generic atomic-JSON machinery this module used to own now lives in
+:mod:`mureo.core.atomic_json` (#500) — new code writing any JSON config
+file must import it from there, not from here.
 """
 
 from __future__ import annotations
 
 import json
 import logging
-import os
 import re
 import shutil
 import subprocess  # noqa: S404 - fixed argv, shell=False (claude mcp ...)
-import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
-from mureo.fsutil import file_lock, secure_fchmod
+from mureo.core.atomic_json import (
+    ConfigWriteError,
+    atomic_write_json,
+    load_existing_json,
+)
+from mureo.fsutil import file_lock
 
 HostedConnectivity = Literal["connected", "not_connected", "unknown"]
 
@@ -45,12 +52,17 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class ConfigWriteError(Exception):
-    """Raised when ``settings.json`` cannot be safely updated.
-
-    Used specifically when an existing file contains malformed JSON — we
-    refuse to silently overwrite the file to protect user data.
-    """
+# DEPRECATED aliases — the atomic-JSON trio moved to
+# :mod:`mureo.core.atomic_json` (#500). New code imports it from there;
+# these names preserve IMPORT compatibility only (``from
+# mureo.providers.config_writer import _load_existing`` still resolves to
+# the same object). They are NOT a monkeypatch seam: this module's own
+# functions call ``load_existing_json`` / ``atomic_write_json`` directly,
+# so patching these aliases has no effect on behaviour — patch
+# ``mureo.core.atomic_json`` instead. ``ConfigWriteError`` is re-exported
+# by the import above.
+_load_existing = load_existing_json
+_atomic_write_json = atomic_write_json
 
 
 @dataclass(frozen=True)
@@ -90,104 +102,6 @@ def _settings_lock_path(settings_path: Path) -> Path:
     fallback file-mode writers.
     """
     return settings_path.with_name(settings_path.name + ".lock")
-
-
-def _load_existing(settings_path: Path) -> dict[str, Any]:
-    """Load ``settings.json`` as a dict, or return ``{}`` if absent.
-
-    Raises:
-        ConfigWriteError: when the existing file is malformed JSON. The
-            exception message includes the path so the operator can locate
-            and fix the file manually.
-    """
-    if not settings_path.exists():
-        return {}
-    try:
-        text = settings_path.read_text(encoding="utf-8")
-    except OSError as exc:
-        raise ConfigWriteError(
-            f"failed to read existing settings at {settings_path}: {exc}"
-        ) from exc
-    try:
-        loaded = json.loads(text)
-    except json.JSONDecodeError as exc:
-        raise ConfigWriteError(
-            f"existing settings file at {settings_path} is malformed JSON "
-            f"(refusing to overwrite to protect user data): {exc}"
-        ) from exc
-    if not isinstance(loaded, dict):
-        raise ConfigWriteError(
-            f"existing settings at {settings_path} is not a JSON object "
-            f"(got {type(loaded).__name__}); refusing to overwrite."
-        )
-    return loaded
-
-
-def _fsync_directory(parent: Path) -> None:
-    """Best-effort ``fsync`` of ``parent`` so a rename is durable.
-
-    POSIX requires ``fsync`` on the directory to flush a rename to disk.
-    Not supported on Windows; ignore ``OSError`` there.
-    """
-    try:
-        dir_fd = os.open(str(parent), os.O_RDONLY)
-    except OSError:
-        return
-    try:
-        os.fsync(dir_fd)
-    except OSError:
-        pass
-    finally:
-        os.close(dir_fd)
-
-
-def _atomic_write_json(payload: dict[str, Any], settings_path: Path) -> None:
-    """Serialize ``payload`` and atomically replace ``settings_path``.
-
-    Uses :func:`tempfile.mkstemp` to allocate an unpredictable same-directory
-    tmp file, sets its mode to ``0o600`` before writing, ``fsync``s the data
-    to disk, then ``os.replace``s it into place. Best-effort ``fsync`` on the
-    parent directory after the rename so the directory entry is durable too.
-    On failure the tmp file is unlinked so no debris remains. The original
-    ``settings_path`` (if any) is untouched until ``os.replace`` succeeds.
-    """
-    settings_path.parent.mkdir(parents=True, exist_ok=True)
-    serialized = json.dumps(payload, indent=2, ensure_ascii=False) + "\n"
-
-    # Allocate an unpredictable tmp file in the same directory as the target
-    # so ``os.replace`` is guaranteed to be a rename within the same
-    # filesystem (and therefore atomic on POSIX).
-    tmp_fd, tmp_name = tempfile.mkstemp(
-        prefix=settings_path.name + ".",
-        suffix=".tmp",
-        dir=str(settings_path.parent),
-    )
-    tmp_path = Path(tmp_name)
-    try:
-        # Restrict permissions BEFORE writing the data so the file is never
-        # readable to other local users during the write/replace window.
-        secure_fchmod(tmp_fd)
-        with os.fdopen(tmp_fd, "w", encoding="utf-8") as fh:
-            tmp_fd = -1  # ownership transferred to ``fh``; do not close twice
-            fh.write(serialized)
-            fh.flush()
-            os.fsync(fh.fileno())
-        os.replace(tmp_path, settings_path)
-        _fsync_directory(settings_path.parent)
-    except (OSError, ValueError):
-        # Clean up the tmp file on any FS-level failure so the directory
-        # stays tidy. ``ValueError`` covers ``json.dumps`` having serialized
-        # something unexpected (defensive — payload is built internally).
-        try:
-            if tmp_fd != -1:
-                os.close(tmp_fd)
-        except OSError:
-            pass
-        try:
-            tmp_path.unlink(missing_ok=True)
-        except OSError:
-            logger.warning("failed to remove tmp file %s", tmp_path)
-        raise
 
 
 _VALID_PROVIDER_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
@@ -343,7 +257,7 @@ def add_provider_to_claude_settings(
     # write itself atomic, not the surrounding read + write).
     target.parent.mkdir(parents=True, exist_ok=True)
     with file_lock(_settings_lock_path(target)):
-        existing = _load_existing(target)
+        existing = load_existing_json(target)
 
         mcp_servers_raw = existing.get("mcpServers")
         if mcp_servers_raw is None:
@@ -361,7 +275,7 @@ def add_provider_to_claude_settings(
         # the comparison key matches what would actually be written to disk:
         # ``_freeze_config`` converts nested lists to tuples for catalog
         # immutability, but JSON has no tuple type — the on-disk shape (and
-        # the value re-read by ``_load_existing``) is always list-form. A
+        # the value re-read by ``load_existing_json``) is always list-form. A
         # direct ``current == dict(spec.mcp_server_config)`` would compare
         # ``[..] != (..)`` and report ``changed=True`` on every re-add,
         # breaking the idempotency contract documented above.
@@ -372,7 +286,7 @@ def add_provider_to_claude_settings(
         mcp_servers[spec.id] = desired_config
         existing["mcpServers"] = mcp_servers
 
-        _atomic_write_json(existing, target)
+        atomic_write_json(existing, target)
     return AddResult(changed=True)
 
 
@@ -415,14 +329,14 @@ def remove_provider_from_claude_settings(
     # Same cross-process lock as the add path so the read-modify-write is
     # serialised against a concurrent provider edit.
     with file_lock(_settings_lock_path(target)):
-        existing = _load_existing(target)
+        existing = load_existing_json(target)
         mcp_servers = existing.get("mcpServers")
         if not isinstance(mcp_servers, dict) or provider_id not in mcp_servers:
             return RemoveResult(changed=False)
 
         del mcp_servers[provider_id]
         existing["mcpServers"] = mcp_servers
-        _atomic_write_json(existing, target)
+        atomic_write_json(existing, target)
     return RemoveResult(changed=True)
 
 

--- a/mureo/providers/mureo_env.py
+++ b/mureo/providers/mureo_env.py
@@ -22,8 +22,8 @@ time; the lookup ``KeyError`` defends against dynamic callers that bypass
 mypy strict.
 
 Atomic-write machinery is *not* duplicated here — both helpers reuse the
-private ``_load_existing`` and ``_atomic_write_json`` functions from
-:mod:`mureo.providers.config_writer` so a single contract governs all writes
+``load_existing_json`` and ``atomic_write_json`` functions from
+:mod:`mureo.core.atomic_json` so a single contract governs all writes
 to ``~/.claude/settings.json``.
 """
 
@@ -32,13 +32,15 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from mureo.core.atomic_json import (
+    ConfigWriteError,
+    atomic_write_json,
+    load_existing_json,
+)
 from mureo.providers.config_writer import (
     AddResult,
-    ConfigWriteError,
-    _atomic_write_json,
     _build_desired_config,
     _default_settings_path,
-    _load_existing,
 )
 
 if TYPE_CHECKING:
@@ -116,7 +118,7 @@ def set_mureo_disable_env(
     - If ``mcpServers.mureo.env`` already contains the exact desired
       ``{<key>: "1"}`` pair: no-op. Returns ``changed=False``.
     - Otherwise: merges the key and atomically rewrites the file via
-      :func:`mureo.providers.config_writer._atomic_write_json` (single
+      :func:`mureo.core.atomic_json.atomic_write_json` (single
       ``os.replace`` call).
 
     Raises:
@@ -130,7 +132,7 @@ def set_mureo_disable_env(
     if not target.exists():
         return SetEnvResult(changed=False, mureo_block_present=False)
 
-    existing = _load_existing(target)
+    existing = load_existing_json(target)
     mcp_servers = existing.get("mcpServers")
     if not isinstance(mcp_servers, dict):
         return SetEnvResult(changed=False, mureo_block_present=False)
@@ -149,7 +151,7 @@ def set_mureo_disable_env(
 
     mcp_servers["mureo"] = mureo_block
     existing["mcpServers"] = mcp_servers
-    _atomic_write_json(existing, target)
+    atomic_write_json(existing, target)
     return SetEnvResult(changed=True, mureo_block_present=True)
 
 
@@ -180,7 +182,7 @@ def unset_mureo_disable_env(
     if not target.exists():
         return UnsetEnvResult(changed=False)
 
-    existing = _load_existing(target)
+    existing = load_existing_json(target)
     mcp_servers = existing.get("mcpServers")
     if not isinstance(mcp_servers, dict):
         return UnsetEnvResult(changed=False)
@@ -197,7 +199,7 @@ def unset_mureo_disable_env(
     mureo_block["env"] = env_block
     mcp_servers["mureo"] = mureo_block
     existing["mcpServers"] = mcp_servers
-    _atomic_write_json(existing, target)
+    atomic_write_json(existing, target)
     return UnsetEnvResult(changed=True)
 
 
@@ -235,7 +237,7 @@ def add_provider_and_disable_in_mureo(
             a non-object ``mcpServers`` value.
     """
     target = settings_path or _default_settings_path()
-    existing = _load_existing(target)
+    existing = load_existing_json(target)
 
     mcp_servers_raw = existing.get("mcpServers")
     if mcp_servers_raw is None:
@@ -263,7 +265,7 @@ def add_provider_and_disable_in_mureo(
         return AddResult(changed=False)
 
     existing["mcpServers"] = mcp_servers
-    _atomic_write_json(existing, target)
+    atomic_write_json(existing, target)
     return AddResult(changed=True)
 
 

--- a/mureo/web/env_var_writer.py
+++ b/mureo/web/env_var_writer.py
@@ -17,8 +17,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from mureo.core.atomic_json import load_existing_json
 from mureo.fsutil import backup_file
-from mureo.providers.config_writer import _load_existing
 from mureo.web._helpers import atomic_write_json, read_json_safe
 
 if TYPE_CHECKING:
@@ -221,7 +221,7 @@ def write_credential_env_var(
     # Strict read: {} only when the file is absent; raises ConfigWriteError on
     # malformed JSON so a corrupt file is never clobbered into a one-section
     # dict that erases other providers.
-    existing = _load_existing(path)
+    existing = load_existing_json(path)
 
     section_payload_raw = existing.get(target.section)
     section_payload: dict[str, Any] = (

--- a/tests/test_core_atomic_json.py
+++ b/tests/test_core_atomic_json.py
@@ -1,0 +1,182 @@
+"""Unit tests for ``mureo.core.atomic_json`` (#500).
+
+The fail-closed reader / atomic writer used to be private to
+``mureo.providers.config_writer`` while four unrelated writers
+(credentials.json, the Amazon tool manifest, insight_sources.json,
+~/.claude.json) depended on it. These tests pin the public contract
+directly — round trip, ``0o600`` + fsync + same-directory replace, and
+fail-closed reads — plus the backwards-compatible aliases the old module
+still exposes.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from mureo.core.atomic_json import (
+    ConfigWriteError,
+    atomic_write_json,
+    load_existing_json,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestLoadExistingJson:
+    """Reads are fail-closed: ``{}`` only ever means "file is absent"."""
+
+    def test_absent_file_returns_empty_dict(self, tmp_path: Path) -> None:
+        assert load_existing_json(tmp_path / "nope.json") == {}
+
+    def test_reads_an_existing_object(self, tmp_path: Path) -> None:
+        path = tmp_path / "config.json"
+        path.write_text(json.dumps({"a": {"b": 1}}), encoding="utf-8")
+
+        assert load_existing_json(path) == {"a": {"b": 1}}
+
+    def test_malformed_json_raises_and_names_the_path(self, tmp_path: Path) -> None:
+        """A corrupt file must never read as ``{}`` — that is how a
+        single-section write erased every other provider's credentials."""
+        path = tmp_path / "credentials.json"
+        path.write_text('{"google_ads": {,,,', encoding="utf-8")
+
+        with pytest.raises(ConfigWriteError) as exc_info:
+            load_existing_json(path)
+
+        assert str(path) in str(exc_info.value)
+
+    def test_non_object_top_level_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "config.json"
+        path.write_text(json.dumps(["not", "an", "object"]), encoding="utf-8")
+
+        with pytest.raises(ConfigWriteError) as exc_info:
+            load_existing_json(path)
+
+        assert "list" in str(exc_info.value)
+
+
+class TestAtomicWriteJson:
+    """Writes are atomic, owner-only and leave no debris."""
+
+    def test_round_trip_through_the_loader(self, tmp_path: Path) -> None:
+        path = tmp_path / "nested" / "config.json"
+        payload: dict[str, Any] = {"amazon_ads": {"region": "eu"}, "n": [1, 2]}
+
+        atomic_write_json(payload, path)
+
+        assert load_existing_json(path) == payload
+        # Parent directories are created on demand.
+        assert path.parent.is_dir()
+
+    def test_replaces_from_a_same_directory_tmp_file(self, tmp_path: Path) -> None:
+        """``os.replace`` is a rename inside the target's own directory, so
+        it is atomic on POSIX (a cross-filesystem move would not be)."""
+        path = tmp_path / "config.json"
+        captured: dict[str, Any] = {}
+        real_replace = os.replace
+
+        def _spy(src: str | os.PathLike[str], dst: str | os.PathLike[str]) -> None:
+            captured["src"] = os.fspath(src)
+            captured["dst"] = os.fspath(dst)
+            real_replace(src, dst)
+
+        with patch("mureo.core.atomic_json.os.replace", side_effect=_spy):
+            atomic_write_json({"a": 1}, path)
+
+        src = Path(captured["src"])
+        assert Path(captured["dst"]) == path
+        assert src.parent == path.parent
+        assert ".tmp" in src.name
+        assert list(path.parent.glob("*.tmp*")) == []
+
+    def test_tmp_file_is_mode_0600_before_the_rename(self, tmp_path: Path) -> None:
+        """Permissions are restricted BEFORE the data lands, so the file is
+        never world-readable during the write/replace window."""
+        if os.name != "posix":
+            pytest.skip("file-mode check only meaningful on POSIX")
+
+        path = tmp_path / "credentials.json"
+        captured: dict[str, Any] = {}
+        real_replace = os.replace
+
+        def _spy(src: str | os.PathLike[str], dst: str | os.PathLike[str]) -> None:
+            captured["mode"] = stat.S_IMODE(os.stat(src).st_mode)
+            real_replace(src, dst)
+
+        with patch("mureo.core.atomic_json.os.replace", side_effect=_spy):
+            atomic_write_json({"secret": "x"}, path)
+
+        assert captured["mode"] == 0o600
+
+    def test_data_is_fsynced_before_the_rename(self, tmp_path: Path) -> None:
+        """The payload is durably on disk before the directory entry flips,
+        so a crash mid-write cannot leave a truncated config."""
+        path = tmp_path / "config.json"
+        events: list[str] = []
+        real_fsync = os.fsync
+        real_replace = os.replace
+
+        def _spy_fsync(fd: int) -> None:
+            events.append("fsync")
+            real_fsync(fd)
+
+        def _spy_replace(
+            src: str | os.PathLike[str], dst: str | os.PathLike[str]
+        ) -> None:
+            events.append("replace")
+            real_replace(src, dst)
+
+        with (
+            patch("mureo.core.atomic_json.os.fsync", side_effect=_spy_fsync),
+            patch("mureo.core.atomic_json.os.replace", side_effect=_spy_replace),
+        ):
+            atomic_write_json({"a": 1}, path)
+
+        # Data fsync, then the rename (the trailing directory fsync that
+        # makes the rename itself durable is best-effort, so it is not
+        # asserted on).
+        assert events[:2] == ["fsync", "replace"]
+
+    def test_failed_replace_leaves_the_original_intact(self, tmp_path: Path) -> None:
+        path = tmp_path / "config.json"
+        path.write_text(json.dumps({"keep": True}), encoding="utf-8")
+        pre_bytes = path.read_bytes()
+
+        def _boom(src: Any, dst: Any) -> None:
+            raise OSError("simulated atomic replace failure")
+
+        with (
+            patch("mureo.core.atomic_json.os.replace", side_effect=_boom),
+            pytest.raises(OSError),
+        ):
+            atomic_write_json({"clobbered": True}, path)
+
+        assert path.read_bytes() == pre_bytes
+        assert list(path.parent.glob("*.tmp*")) == []
+
+
+class TestConfigWriterAliasesAreTheSameObjects:
+    """``config_writer`` keeps its old import surface after the move.
+
+    Existing importers — and tests that monkeypatch the private names —
+    must keep resolving to the objects that now live in
+    :mod:`mureo.core.atomic_json`, not to stale copies.
+    """
+
+    def test_private_aliases_resolve_to_the_public_functions(self) -> None:
+        from mureo.providers import config_writer
+
+        assert config_writer._load_existing is load_existing_json
+        assert config_writer._atomic_write_json is atomic_write_json
+
+    def test_config_write_error_is_the_same_class(self) -> None:
+        from mureo.providers import config_writer
+
+        assert config_writer.ConfigWriteError is ConfigWriteError

--- a/tests/test_credentials_concurrency.py
+++ b/tests/test_credentials_concurrency.py
@@ -3,15 +3,15 @@
 ``auth._save_meta_token`` (the background Meta 53-day auto-refresh),
 ``auth.save_amazon_access_token`` (the Amazon LwA refresh, #113) and
 ``auth_setup.save_credentials`` (the CLI / web setup wizard) each do
-read -> mutate -> ``_atomic_write_json``. ``_atomic_write_json`` makes only the
+read -> mutate -> ``atomic_write_json``. ``atomic_write_json`` makes only the
 file *replace* atomic; the surrounding read-modify-write is not. Run
 concurrently they can last-writer-wins away each other's section (e.g. the
 wizard re-auth dropping a just-refreshed access_token, or the refresh dropping
 a freshly-saved google_ads block). All three paths now hold the same
 cross-process ``credentials.json.lock`` across the whole cycle.
 
-The test instruments ``config_writer._load_existing`` /
-``_atomic_write_json`` to count how many read-modify-write cycles are ever
+The test instruments ``mureo.core.atomic_json.load_existing_json`` /
+``atomic_write_json`` to count how many read-modify-write cycles are ever
 in-flight at once and widens the window with a sleep. A correct lock keeps the
 concurrency at exactly 1; removing the lock lets it climb past 1 and the test
 fails. Mirrors ``tests/test_state_concurrency.py``.
@@ -27,7 +27,7 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 
-import mureo.providers.config_writer as config_writer
+import mureo.core.atomic_json as atomic_json
 from mureo.auth import (
     GoogleAdsCredentials,
     _save_meta_token,
@@ -57,19 +57,19 @@ class _SectionMonitor:
         self._guard = threading.Lock()
         self.active = 0
         self.max_active = 0
-        self._real_load = config_writer._load_existing
-        self._real_write = config_writer._atomic_write_json
+        self._real_load = atomic_json.load_existing_json
+        self._real_write = atomic_json.atomic_write_json
 
-    def load(self, settings_path: Path) -> dict[str, Any]:
-        data = self._real_load(settings_path)
+    def load(self, path: Path) -> dict[str, Any]:
+        data = self._real_load(path)
         with self._guard:
             self.active += 1
             self.max_active = max(self.max_active, self.active)
         time.sleep(_SECTION_DELAY_S)
         return data
 
-    def write(self, payload: dict[str, Any], settings_path: Path) -> None:
-        self._real_write(payload, settings_path)
+    def write(self, payload: dict[str, Any], path: Path) -> None:
+        self._real_write(payload, path)
         with self._guard:
             self.active -= 1
 
@@ -77,8 +77,8 @@ class _SectionMonitor:
 @pytest.fixture
 def monitor(monkeypatch: pytest.MonkeyPatch) -> _SectionMonitor:
     mon = _SectionMonitor()
-    monkeypatch.setattr(config_writer, "_load_existing", mon.load)
-    monkeypatch.setattr(config_writer, "_atomic_write_json", mon.write)
+    monkeypatch.setattr(atomic_json, "load_existing_json", mon.load)
+    monkeypatch.setattr(atomic_json, "atomic_write_json", mon.write)
     return mon
 
 

--- a/tests/test_providers_config_writer.py
+++ b/tests/test_providers_config_writer.py
@@ -231,7 +231,7 @@ def test_add_provider_writes_atomically(tmp_path: Path) -> None:
         captured["dst"] = os.fspath(dst)
         real_replace(src, dst)
 
-    with patch("mureo.providers.config_writer.os.replace", side_effect=_spy_replace):
+    with patch("mureo.core.atomic_json.os.replace", side_effect=_spy_replace):
         add_provider_to_claude_settings(spec, settings_path=settings_path)
 
     src = Path(captured["src"])
@@ -272,7 +272,7 @@ def test_add_provider_cleans_up_tmp_file_on_write_failure(tmp_path: Path) -> Non
         raise OSError("simulated atomic replace failure")
 
     with (
-        patch("mureo.providers.config_writer.os.replace", side_effect=_boom),
+        patch("mureo.core.atomic_json.os.replace", side_effect=_boom),
         pytest.raises(OSError),
     ):
         add_provider_to_claude_settings(spec, settings_path=settings_path)
@@ -433,7 +433,7 @@ def test_add_provider_tmp_file_is_mode_0600(tmp_path: Path) -> None:
         captured["mode"] = stat.S_IMODE(os.stat(src).st_mode)
         real_replace(src, dst)
 
-    with patch("mureo.providers.config_writer.os.replace", side_effect=_spy_replace):
+    with patch("mureo.core.atomic_json.os.replace", side_effect=_spy_replace):
         add_provider_to_claude_settings(_make_spec(), settings_path=settings_path)
 
     assert captured["mode"] == 0o600

--- a/tests/test_providers_mureo_env.py
+++ b/tests/test_providers_mureo_env.py
@@ -168,7 +168,7 @@ def test_set_mureo_disable_env_returns_mureo_block_absent_when_no_mureo_entry(
     )
     pre_bytes = settings_path.read_bytes()
 
-    with patch("mureo.providers.config_writer.os.replace") as mock_replace:
+    with patch("mureo.core.atomic_json.os.replace") as mock_replace:
         result = set_mureo_disable_env("google_ads", settings_path=settings_path)
 
     assert result.changed is False
@@ -260,7 +260,7 @@ def test_set_mureo_disable_env_writes_atomically(tmp_path: Path) -> None:
         captured["dst"] = _os.fspath(dst)
         real_replace(src, dst)
 
-    with patch("mureo.providers.config_writer.os.replace", side_effect=_spy):
+    with patch("mureo.core.atomic_json.os.replace", side_effect=_spy):
         set_mureo_disable_env("google_ads", settings_path=settings_path)
 
     src = Path(captured["src"])
@@ -383,7 +383,7 @@ def test_unset_mureo_disable_env_noop_when_key_absent(tmp_path: Path) -> None:
     )
     pre_bytes = settings_path.read_bytes()
 
-    with patch("mureo.providers.config_writer.os.replace") as mock_replace:
+    with patch("mureo.core.atomic_json.os.replace") as mock_replace:
         result = unset_mureo_disable_env("google_ads", settings_path=settings_path)
 
     assert result.changed is False
@@ -403,7 +403,7 @@ def test_unset_mureo_disable_env_noop_when_mureo_absent(tmp_path: Path) -> None:
     )
     pre_bytes = settings_path.read_bytes()
 
-    with patch("mureo.providers.config_writer.os.replace") as mock_replace:
+    with patch("mureo.core.atomic_json.os.replace") as mock_replace:
         result = unset_mureo_disable_env("google_ads", settings_path=settings_path)
 
     assert result.changed is False
@@ -449,7 +449,7 @@ def test_add_provider_and_disable_in_mureo_single_atomic_write(
         call_count["n"] += 1
         real_replace(src, dst)
 
-    with patch("mureo.providers.config_writer.os.replace", side_effect=_spy):
+    with patch("mureo.core.atomic_json.os.replace", side_effect=_spy):
         add_provider_and_disable_in_mureo(spec, settings_path=settings_path)
 
     assert call_count["n"] == 1, (
@@ -493,9 +493,7 @@ def test_add_provider_and_disable_in_mureo_injects_extra_env(
     )
 
     payload = json.loads(settings_path.read_text(encoding="utf-8"))
-    assert payload["mcpServers"][spec.id]["env"] == {
-        "GOOGLE_ADS_DEVELOPER_TOKEN": "DT"
-    }
+    assert payload["mcpServers"][spec.id]["env"] == {"GOOGLE_ADS_DEVELOPER_TOKEN": "DT"}
     assert payload["mcpServers"]["mureo"]["env"]["MUREO_DISABLE_GOOGLE_ADS"] == "1"
     assert result.changed is True
 


### PR DESCRIPTION
Pure move of the atomic-write trio out of the Claude-Code-settings-scoped config_writer into a neutral core module, with import-compatible re-exports and all ten in-tree importers switched. Bodies unchanged; error strings byte-identical; +11 direct API tests. Closes #500.