### PR TITLE
fix(creative-studio): report honest size capabilities (supported_sizes)

### DIFF
--- a/docs/creative-studio.ja.md
+++ b/docs/creative-studio.ja.md
@@ -70,6 +70,17 @@ CLI** プロバイダ）を同梱し、サードパーティは `mureo.image_pro
 | fal.ai（FLUX / Recraft 等） | `creative_studio.fal_key` | `FAL_KEY` | なし |
 | Codex CLI（`codex`、gpt-image） | —（API キー不要。ローカルの `codex login`） | — | なし |
 
+`creative_studio_providers_list` は各プロバイダの生成サイズも報告します。
+`supported_sizes` がある場合、それはそのプロバイダが実際にレンダリングする
+**厳密な** `[幅, 高さ]` のメニューです。OpenAI と Codex CLI はどちらも GPT Image
+を使っており、そのメニューは `1024x1024` / `1536x1024` / `1024x1536` です
+（1536x1536 の正方形は**存在しません**）。Google は常に `1024x1024` を生成します。
+それ以外のサイズを要求した場合は、向き（縦横）に応じて最も近いものにクランプ
+されます。fal.ai は任意の幅・高さをそのまま API に渡すため `supported_sizes` を
+報告しません（＝「固定メニューではない」という意味です）。`max_size` は軸ごとの
+上限（最大の幅・最大の高さ）にすぎず、そのまま指定できるサイズとは限りません。
+厳密なサイズが必要なときは `supported_sizes` を参照してください。
+
 **Codex CLI** プロバイダ（`name: codex`）は他とは異なり、**API キーが不要**です。
 REST エンドポイントを呼ぶ代わりに、ローカルにインストールされた
 [Codex CLI](https://developers.openai.com/codex/cli)（`codex exec`）を起動し、

--- a/docs/creative-studio.md
+++ b/docs/creative-studio.md
@@ -69,6 +69,17 @@ parties can register more under the `mureo.image_providers` entry-point group.
 | fal.ai (FLUX / Recraft …) | `creative_studio.fal_key` | `FAL_KEY` | no |
 | Codex CLI (`codex`, gpt-image) | — (no API key; local `codex login`) | — | no |
 
+`creative_studio_providers_list` also reports each provider's sizes.
+`supported_sizes`, when present, is the **exact** `[width, height]` menu the
+provider renders — OpenAI and Codex CLI both drive GPT Image, whose menu is
+`1024x1024` / `1536x1024` / `1024x1536` (there is **no** 1536x1536 square), and
+Google always renders `1024x1024`. Any other requested size is clamped to the
+nearest entry by orientation. fal.ai forwards an arbitrary width/height to its
+API, so it reports no `supported_sizes` — absence means "not a fixed menu".
+`max_size` is only a per-axis bound (largest width, largest height) and is not
+necessarily a size you can ask for; read `supported_sizes` when you need exact
+sizes.
+
 The **Codex CLI** provider (`name: codex`) is different: it needs **no API key**.
 Instead of calling a REST endpoint it shells out to the locally installed
 [Codex CLI](https://developers.openai.com/codex/cli) (`codex exec`) and uses its

--- a/mureo/creative_studio/providers/__init__.py
+++ b/mureo/creative_studio/providers/__init__.py
@@ -41,6 +41,18 @@ _FIELD_TO_ENV: dict[str, str] = {
     "fal_key": "FAL_KEY",
 }
 
+#: GPT Image's exact output-size menu, ordered square, landscape, portrait.
+#: Single source of truth for both providers that drive that model — the
+#: hosted OpenAI ``gpt-image-1`` adapter and the local Codex CLI one — so the
+#: sizes they advertise and the sizes they clamp to can never drift apart.
+#: Note there is no 1536x1536 square: see ``max_size`` in
+#: :meth:`ImageProvider.capabilities`.
+_GPT_IMAGE_SIZES: tuple[tuple[int, int], ...] = (
+    (1024, 1024),
+    (1536, 1024),
+    (1024, 1536),
+)
+
 
 class NotSupportedError(Exception):
     """Raised when a provider does not implement an optional capability.
@@ -75,7 +87,23 @@ class ImageProvider(Protocol):
         ...
 
     def capabilities(self) -> dict[str, Any]:
-        """Return ``{"edit": bool, "max_size": [width, height]}``."""
+        """Return ``{"edit": bool, "max_size": [width, height], ...}``.
+
+        ``max_size`` is the **per-axis maximum** — the largest width and the
+        largest height the provider can produce — NOT a jointly achievable
+        size: a provider may max out at 1536 on each axis while offering no
+        1536x1536 square. It is a bound, never a menu.
+
+        ``supported_sizes`` is optional and, when present, is the exact menu:
+        a list of ``[width, height]`` pairs the provider actually renders,
+        every other request being clamped to one of them. Its absence means
+        the provider takes arbitrary sizes up to ``max_size`` rather than a
+        fixed menu. Consumers needing exact sizes MUST read
+        ``supported_sizes`` and must not infer one from ``max_size``.
+
+        Providers may add further honest keys (the Codex CLI one reports
+        ``requires_api_key`` / ``auth``); consumers ignore unknown keys.
+        """
         ...
 
     async def generate(
@@ -88,6 +116,27 @@ class ImageProvider(Protocol):
         """Edit ``image`` per ``instruction``; raise :class:`NotSupportedError`
         when the provider has no edit path."""
         ...
+
+
+# ---------------------------------------------------------------------------
+# Capability helpers (shared by the built-in providers)
+# ---------------------------------------------------------------------------
+
+
+def _size_capabilities(sizes: tuple[tuple[int, int], ...]) -> dict[str, Any]:
+    """Return the ``supported_sizes`` / ``max_size`` pair for a discrete menu.
+
+    ``max_size`` is derived as the per-axis maximum across ``sizes``, matching
+    the contract documented on :meth:`ImageProvider.capabilities`. Fresh lists
+    are built on every call so a caller cannot mutate a provider's constants.
+    """
+    return {
+        "supported_sizes": [[width, height] for width, height in sizes],
+        "max_size": [
+            max(width for width, _ in sizes),
+            max(height for _, height in sizes),
+        ],
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/mureo/creative_studio/providers/codex_cli.py
+++ b/mureo/creative_studio/providers/codex_cli.py
@@ -49,9 +49,11 @@ from typing import Any
 
 from mureo.creative_studio.providers import (
     _FIELD_TO_ENV,
+    _GPT_IMAGE_SIZES,
     NotSupportedError,
     _creative_studio_secret,
     _redact,
+    _size_capabilities,
 )
 
 _BINARY = "codex"
@@ -70,12 +72,14 @@ _STDERR_TAIL = 2000
 #: The 8-byte PNG signature — the output must start with it to be accepted.
 _PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
 
-# GPT Image's supported output sizes, one per aspect class. An arbitrary
-# width/height is clamped to the nearest of these by orientation — the same
-# convention the OpenAI ``gpt-image-1`` provider uses.
-_SIZE_SQUARE = "1024x1024"
-_SIZE_LANDSCAPE = "1536x1024"
-_SIZE_PORTRAIT = "1024x1536"
+# GPT Image's supported output sizes, one per aspect class, derived from the
+# shared menu (ordered square, landscape, portrait) that the OpenAI
+# ``gpt-image-1`` provider also uses — so the sizes asked of the CLI and the
+# ones advertised in ``capabilities()`` cannot drift apart. An arbitrary
+# width/height is clamped to the nearest of these by orientation.
+_SIZE_SQUARE, _SIZE_LANDSCAPE, _SIZE_PORTRAIT = (
+    f"{width}x{height}" for width, height in _GPT_IMAGE_SIZES
+)
 
 # stderr substrings (matched case-insensitively) that indicate an auth /
 # login problem, so the error can append the `codex login` hint.
@@ -304,9 +308,11 @@ class CodexCliImageProvider:
     def capabilities(self) -> dict[str, Any]:
         # ``requires_api_key`` / ``auth`` are extra, honest metadata: unlike the
         # hosted providers this one needs no key, only a local `codex login`.
+        # ``supported_sizes`` is GPT Image's exact menu; ``max_size`` is the
+        # per-axis maximum across it — a 1536x1536 square is NOT generatable.
         return {
             "edit": False,
-            "max_size": [1536, 1536],
+            **_size_capabilities(_GPT_IMAGE_SIZES),
             "requires_api_key": False,
             "auth": "codex_cli_login",
         }

--- a/mureo/creative_studio/providers/fal.py
+++ b/mureo/creative_studio/providers/fal.py
@@ -67,6 +67,9 @@ class FalImageProvider:
         return _creative_studio_secret(_KEY_FIELD) is not None
 
     def capabilities(self) -> dict[str, Any]:
+        # No ``supported_sizes``: the requested width/height is forwarded to the
+        # API verbatim, so there is no fixed menu — any size up to the per-axis
+        # ``max_size`` bound is accepted, and absence says exactly that.
         return {"edit": False, "max_size": [1440, 1440]}
 
     def _require_key(self) -> str:

--- a/mureo/creative_studio/providers/google_images.py
+++ b/mureo/creative_studio/providers/google_images.py
@@ -20,6 +20,7 @@ import httpx
 
 from mureo.creative_studio.providers import (
     _creative_studio_secret,
+    _size_capabilities,
     provider_error,
 )
 
@@ -33,6 +34,10 @@ _URL = (
 _MODEL = "gemini-2.5-flash-image"
 _KEY_FIELD = "gemini_api_key"
 _TIMEOUT = 60.0
+
+# The model takes no size argument and always renders one square size, so the
+# "menu" is a single entry (and ``max_size`` derives from it).
+_SIZES: tuple[tuple[int, int], ...] = ((1024, 1024),)
 
 
 def _default_client_factory() -> httpx.AsyncClient:
@@ -56,7 +61,8 @@ class GoogleImageProvider:
         return _creative_studio_secret(_KEY_FIELD) is not None
 
     def capabilities(self) -> dict[str, Any]:
-        return {"edit": True, "max_size": [1024, 1024]}
+        # One fixed size, so the exact menu and the per-axis maximum coincide.
+        return {"edit": True, **_size_capabilities(_SIZES)}
 
     def _require_key(self) -> str:
         key = _creative_studio_secret(_KEY_FIELD)

--- a/mureo/creative_studio/providers/openai_images.py
+++ b/mureo/creative_studio/providers/openai_images.py
@@ -15,7 +15,9 @@ from typing import TYPE_CHECKING, Any
 import httpx
 
 from mureo.creative_studio.providers import (
+    _GPT_IMAGE_SIZES,
     _creative_studio_secret,
+    _size_capabilities,
     provider_error,
 )
 
@@ -28,11 +30,13 @@ _MODEL = "gpt-image-1"
 _KEY_FIELD = "openai_api_key"
 _TIMEOUT = 60.0
 
-# Sizes gpt-image-1 supports, one per aspect class. A requested width/height
-# is clamped to the nearest of these by orientation.
-_SIZE_SQUARE = "1024x1024"
-_SIZE_LANDSCAPE = "1536x1024"
-_SIZE_PORTRAIT = "1024x1536"
+# Sizes gpt-image-1 supports, one per aspect class, derived from the shared
+# GPT Image menu (ordered square, landscape, portrait) so the sizes this
+# provider clamps to and the ones it advertises cannot drift apart. A
+# requested width/height is clamped to the nearest of these by orientation.
+_SIZE_SQUARE, _SIZE_LANDSCAPE, _SIZE_PORTRAIT = (
+    f"{width}x{height}" for width, height in _GPT_IMAGE_SIZES
+)
 
 
 def _default_client_factory() -> httpx.AsyncClient:
@@ -56,7 +60,10 @@ class OpenAIImageProvider:
         return _creative_studio_secret(_KEY_FIELD) is not None
 
     def capabilities(self) -> dict[str, Any]:
-        return {"edit": True, "max_size": [1536, 1536]}
+        # ``supported_sizes`` is the exact menu gpt-image-1 renders; the
+        # accompanying ``max_size`` is the per-axis maximum across it (1536
+        # wide, 1536 tall) — a 1536x1536 square is NOT generatable.
+        return {"edit": True, **_size_capabilities(_GPT_IMAGE_SIZES)}
 
     @staticmethod
     def _clamp_size(width: int, height: int) -> str:

--- a/mureo/mcp/tools_creative_studio.py
+++ b/mureo/mcp/tools_creative_studio.py
@@ -114,9 +114,14 @@ TOOLS: list[Tool] = [
             "Studio. Each entry reports its name, whether it is configured "
             "(an API key in the credential store / env var, or — for the "
             "local Codex CLI provider — no key at all, just `codex login`), "
-            "its capabilities (edit support + max size), and its model ids. "
-            "Call this before creative_studio_generate_visual to see which "
-            "providers can be selected."
+            "its capabilities, and its model ids. In capabilities, 'edit' is "
+            "edit-path support, 'max_size' is the per-axis maximum ([max "
+            "width, max height]) and NOT necessarily a generatable size, and "
+            "the optional 'supported_sizes' is the exact [width, height] menu "
+            "the provider renders (other requests are clamped to it); its "
+            "absence means arbitrary sizes up to max_size. Call this before "
+            "creative_studio_generate_visual to see which providers can be "
+            "selected."
         ),
         inputSchema={"type": "object", "properties": {}, "additionalProperties": False},
     ),

--- a/tests/creative_studio/test_providers.py
+++ b/tests/creative_studio/test_providers.py
@@ -70,6 +70,70 @@ def test_available_providers_first_wins_dedupe() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Capabilities contract (supported_sizes / max_size)
+# ---------------------------------------------------------------------------
+
+#: The exact size menu GPT Image offers — square, landscape, portrait. A
+#: 1536x1536 square is NOT generatable, which is why ``max_size`` is defined
+#: as the per-axis maximum rather than a jointly achievable size.
+_GPT_IMAGE_TRIO = [[1024, 1024], [1536, 1024], [1024, 1536]]
+
+
+@pytest.mark.unit
+def test_supported_sizes_when_present_are_pairs_and_bound_max_size() -> None:
+    for provider in available_providers():
+        caps = provider.capabilities()
+        supported = caps.get("supported_sizes")
+        if supported is None:
+            continue  # absence means "not a fixed menu" (see fal)
+        assert isinstance(supported, list) and supported
+        for pair in supported:
+            assert isinstance(pair, list) and len(pair) == 2
+            assert all(isinstance(value, int) for value in pair)
+        # ``max_size`` is the per-axis maximum across the menu.
+        assert caps["max_size"] == [
+            max(width for width, _ in supported),
+            max(height for _, height in supported),
+        ]
+
+
+@pytest.mark.unit
+def test_openai_capabilities_report_the_gpt_image_size_menu() -> None:
+    caps = openai_mod.OpenAIImageProvider().capabilities()
+    assert caps["supported_sizes"] == _GPT_IMAGE_TRIO
+    # Backward compatible per-axis maxima — not a jointly achievable size.
+    assert caps["max_size"] == [1536, 1536]
+    assert [1536, 1536] not in caps["supported_sizes"]
+
+
+@pytest.mark.unit
+def test_openai_clamp_only_targets_advertised_sizes() -> None:
+    provider = openai_mod.OpenAIImageProvider()
+    advertised = {
+        f"{width}x{height}"
+        for width, height in provider.capabilities()["supported_sizes"]
+    }
+    for width, height in ((1024, 1024), (1920, 1080), (1080, 1920), (2000, 500)):
+        assert provider._clamp_size(width, height) in advertised
+
+
+@pytest.mark.unit
+def test_google_capabilities_report_its_single_size() -> None:
+    caps = google_mod.GoogleImageProvider().capabilities()
+    assert caps["supported_sizes"] == [[1024, 1024]]
+    assert caps["max_size"] == [1024, 1024]
+
+
+@pytest.mark.unit
+def test_fal_capabilities_omit_supported_sizes() -> None:
+    # fal forwards an arbitrary width/height to the API, so there is no fixed
+    # menu to advertise — absence is the honest answer.
+    caps = fal_mod.FalImageProvider().capabilities()
+    assert "supported_sizes" not in caps
+    assert caps["max_size"] == [1440, 1440]
+
+
+# ---------------------------------------------------------------------------
 # Secret resolution
 # ---------------------------------------------------------------------------
 

--- a/tests/creative_studio/test_providers_codex.py
+++ b/tests/creative_studio/test_providers_codex.py
@@ -260,6 +260,24 @@ def test_capabilities_advertise_no_api_key() -> None:
 
 
 @pytest.mark.unit
+def test_capabilities_report_the_gpt_image_size_menu() -> None:
+    caps = codex_mod.CodexCliImageProvider().capabilities()
+    # GPT Image's exact menu: square, landscape, portrait.
+    assert caps["supported_sizes"] == [[1024, 1024], [1536, 1024], [1024, 1536]]
+    # Backward compatible per-axis maxima — not a jointly achievable size.
+    assert caps["max_size"] == [1536, 1536]
+    assert [1536, 1536] not in caps["supported_sizes"]
+
+
+@pytest.mark.unit
+def test_clamp_only_targets_advertised_sizes() -> None:
+    caps = codex_mod.CodexCliImageProvider().capabilities()
+    advertised = {f"{width}x{height}" for width, height in caps["supported_sizes"]}
+    for width, height in ((1024, 1024), (1920, 1080), (1080, 1920), (2000, 500)):
+        assert codex_mod._clamp_size(width, height) in advertised
+
+
+@pytest.mark.unit
 def test_capabilities_edit_is_false() -> None:
     # The CLI edit path is agent-mediated and not reliable enough to ship
     # (see the live-validation note in the module docstring).

--- a/tests/test_mcp_tools_creative_studio.py
+++ b/tests/test_mcp_tools_creative_studio.py
@@ -183,6 +183,32 @@ async def test_providers_list_shape(monkeypatch: pytest.MonkeyPatch) -> None:
     ]
 
 
+@pytest.mark.unit
+async def test_providers_list_surfaces_supported_sizes_verbatim(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    caps = {
+        "edit": True,
+        "max_size": [1536, 1536],
+        "supported_sizes": [[1024, 1024], [1536, 1024], [1024, 1536]],
+    }
+
+    class _MenuProvider(_FakeProvider):
+        def capabilities(self) -> dict:
+            return dict(caps)
+
+    monkeypatch.setattr(mod, "available_providers", lambda: [_MenuProvider()])
+    result = await mod.handle_tool("creative_studio_providers_list", {})
+    payload = _payload(result)
+    assert payload["providers"][0]["capabilities"] == caps
+
+
+@pytest.mark.unit
+def test_providers_list_description_documents_supported_sizes() -> None:
+    tool = next(t for t in mod.TOOLS if t.name == "creative_studio_providers_list")
+    assert "supported_sizes" in tool.description
+
+
 # ---------------------------------------------------------------------------
 # generate_visual handler
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Adds an optional supported_sizes capability (exact size menu) for discrete-size providers, single-sourced with the clamp logic so the two can never drift; max_size kept byte-identical and redefined as per-axis maxima in the Protocol contract. fal deliberately omits the key (continuous sizes). Docs + tool description updated. Closes #498.