### PR TITLE
fix(auth): route all credential writers through the runtime-resolved path

### DIFF
--- a/mureo/auth.py
+++ b/mureo/auth.py
@@ -430,6 +430,12 @@ async def refresh_meta_token_if_needed(
     - token_obtained_at is known
     - Token will expire within 7 days (53+ days old)
 
+    ``path=None`` resolves the destination of the resulting write through
+    :func:`_resolve_write_path`, the same seam
+    :func:`save_amazon_access_token` uses — see that function for why a
+    ``path``-less writer must not hardcode the legacy default (#510). An
+    explicit ``path`` is never redirected.
+
     Returns original credentials if refresh is not needed or not possible.
     """
     if not _should_refresh(credentials):
@@ -452,7 +458,7 @@ async def refresh_meta_token_if_needed(
             token_obtained_at=new_obtained_at,
         )
 
-        resolved = path if path is not None else _resolve_default_path()
+        resolved = path if path is not None else _resolve_write_path()
         try:
             _save_meta_token(resolved, new_token, new_obtained_at)
         except Exception:
@@ -613,6 +619,22 @@ def save_amazon_access_token(
     leaves an existing stamp — and a legacy section's absence of one —
     untouched, which is what keeps the expiry signal honest.
 
+    ``path=None`` resolves the destination through
+    :func:`~mureo.core.runtime_context.runtime_credentials_path` — the
+    same store-capability seam the configure UI writes through (#194 /
+    #196) — instead of hardcoding the legacy default. The bridge's
+    automatic refresh (its default ``token_saver``) and ``mureo amazon``
+    both call in with no path, while
+    :func:`load_amazon_ads_credentials` reads through the active
+    ``RuntimeContext``'s ``SecretStore``; a runtime that relocates the
+    credentials file therefore used to get a token written where the
+    reader never looks — a silent read/write split-brain that made every
+    later call re-mint against an already-rotated refresh token (#510).
+    Without a registered ``mureo.runtime_context_factory`` the resolver
+    returns the legacy default unchanged, so single-backend installs are
+    byte-for-byte unaffected. An explicit ``path`` (the authorization
+    wizard's exchange, which owns its file) is never redirected.
+
     Raises:
         ConfigWriteError: the existing credentials.json is malformed;
             nothing is written.
@@ -621,7 +643,7 @@ def save_amazon_access_token(
     # graph flat.
     from mureo.core.atomic_json import atomic_write_json, load_existing_json
 
-    resolved = path if path is not None else _resolve_default_path()
+    resolved = path if path is not None else _resolve_write_path()
     resolved.parent.mkdir(parents=True, exist_ok=True)
     with file_lock(lock_path_for(resolved)):
         data = load_existing_json(resolved)
@@ -647,6 +669,35 @@ def save_amazon_access_token(
 def _resolve_default_path() -> Path:
     """Resolve the default credentials.json path."""
     return Path.home() / ".mureo" / "credentials.json"
+
+
+def _resolve_write_path() -> Path:
+    """Resolve where a ``path``-less credentials write should land.
+
+    The counterpart of :func:`_resolve_secret_store` for writers, shared
+    by the two token-refresh writers in this module
+    (:func:`save_amazon_access_token` and
+    :func:`refresh_meta_token_if_needed`) and mirrored by
+    :func:`mureo.auth_setup._resolve_write_path` for the third writer,
+    the interactive setup wizard's
+    :func:`mureo.auth_setup.save_credentials`: the loaders read through
+    the active ``RuntimeContext``'s ``SecretStore``, so a writer that
+    always targets :func:`_resolve_default_path` would write somewhere
+    the reader never consults whenever a ``mureo.runtime_context_factory``
+    relocates that store (#510).
+
+    Delegates to :func:`mureo.core.runtime_context.runtime_credentials_path`
+    — the same resolver the configure UI's write path goes through — so
+    the store-capability rules (declared ``credentials_write_path`` first,
+    then a built-in ``FilesystemSecretStore``'s ``path``, else the
+    default) have exactly one definition. With no factory registered it
+    returns :func:`_resolve_default_path` unchanged.
+
+    Imported lazily for the same reason as :func:`_resolve_secret_store`.
+    """
+    from mureo.core.runtime_context import runtime_credentials_path
+
+    return runtime_credentials_path(_resolve_default_path())
 
 
 def _resolve_secret_store(path: Path | None) -> SecretStore:

--- a/mureo/auth_setup.py
+++ b/mureo/auth_setup.py
@@ -893,14 +893,21 @@ def save_credentials(
 ) -> None:
     """Save credentials to credentials.json (merged with existing data).
 
+    ``path=None`` resolves the destination through
+    :func:`_resolve_write_path` rather than hardcoding the legacy
+    default, so a runtime that relocates the ``SecretStore`` is honored
+    on write and the wizard stops saving where nobody reads (#510). An
+    explicit ``path`` is never redirected.
+
     Args:
-        path: Path to credentials.json. Uses default path if None.
+        path: Path to credentials.json. Uses the runtime-resolved
+            default path if None.
         google: Google Ads credentials
         meta: Meta Ads credentials
         customer_id: Google Ads account (login_customer_id)
         account_id: Meta Ads ad account ID
     """
-    resolved = path if path is not None else _resolve_default_path()
+    resolved = path if path is not None else _resolve_write_path()
 
     # Create directory
     resolved.parent.mkdir(parents=True, exist_ok=True)
@@ -1031,7 +1038,10 @@ async def setup_google_ads(
         google=final_creds,
     )
 
-    print(f"\nCredentials saved: {credentials_path or _resolve_default_path()}")
+    # Report the path ``save_credentials`` actually wrote to — resolving
+    # this any other way would print the legacy location while the write
+    # went to a runtime-relocated store (#510).
+    print(f"\nCredentials saved: {credentials_path or _resolve_write_path()}")
     print("Google Ads setup complete.\n")
 
     return final_creds
@@ -1345,8 +1355,13 @@ async def setup_meta_ads(
     Returns:
         MetaAdsCredentials
     """
+    # Resolved once, then passed to ``save_credentials`` as an explicit
+    # path and echoed to the operator. It must go through the same seam
+    # ``save_credentials`` would have used for ``path=None``, or this
+    # pre-resolution would silently pin the wizard to the legacy file and
+    # bypass a runtime-relocated store (#510).
     resolved_path = (
-        credentials_path if credentials_path is not None else _resolve_default_path()
+        credentials_path if credentials_path is not None else _resolve_write_path()
     )
 
     # Display guidance
@@ -1427,3 +1442,25 @@ async def setup_meta_ads(
 def _resolve_default_path() -> Path:
     """Resolve the default credentials.json path."""
     return Path.home() / ".mureo" / "credentials.json"
+
+
+def _resolve_write_path() -> Path:
+    """Resolve where a ``path``-less setup write should land.
+
+    The setup wizard's counterpart of :func:`mureo.auth._resolve_write_path`
+    (see it for the full rationale): ``mureo.auth``'s loaders read through
+    the active ``RuntimeContext``'s ``SecretStore``, so a writer that
+    always targets :func:`_resolve_default_path` saves where the runtime
+    never looks whenever a ``mureo.runtime_context_factory`` relocates
+    that store (#510).
+
+    Delegates to :func:`mureo.core.runtime_context.runtime_credentials_path`
+    so the store-capability rules have exactly one definition; with no
+    factory registered it returns :func:`_resolve_default_path`
+    unchanged. Imported lazily, mirroring this module's other
+    function-local ``mureo.core`` imports, so the CLI startup path does
+    not pay for it.
+    """
+    from mureo.core.runtime_context import runtime_credentials_path
+
+    return runtime_credentials_path(_resolve_default_path())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,7 @@ asyncio_mode = "auto"
 markers = [
     "unit: Unit tests",
     "integration: Integration tests",
+    "real_save: Opt out of the credentials-write stub and save for real (tmp_path)",
 ]
 
 [tool.mypy]

--- a/tests/test_auth_amazon.py
+++ b/tests/test_auth_amazon.py
@@ -15,6 +15,7 @@ import dataclasses
 import json
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
@@ -23,7 +24,14 @@ from mureo.auth import (
     load_amazon_ads_credentials,
     save_amazon_access_token,
 )
+from mureo.core.runtime_context import (
+    default_runtime_context,
+    reset_runtime_context,
+)
 from mureo.providers.config_writer import ConfigWriteError
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 
 def _write(tmp_path: Path, payload: dict) -> Path:
@@ -378,3 +386,164 @@ class TestSaveAmazonAccessToken:
         save_amazon_access_token("Atza|NEW", path=cf)
 
         assert entered == [tmp_path / "credentials.json.lock"]
+
+
+# ---------------------------------------------------------------------------
+# #510 — a ``path=None`` save must land where the loader reads
+#
+# ``load_amazon_ads_credentials()`` resolves through
+# ``_resolve_secret_store`` (the active ``RuntimeContext``'s store), while
+# the saver used to fall back to the legacy ``~/.mureo/credentials.json``
+# unconditionally. In a multi-tenant runtime (an entry-point-provided
+# store that relocates the credentials file) the bridge's automatic
+# access-token refresh therefore wrote a file nobody ever read — a silent
+# read/write split-brain. The saver now resolves its default destination
+# through ``runtime_credentials_path``, the same store-capability seam
+# the configure UI uses (#194 / #196).
+#
+# Entry-point stubs and the fake stores mirror
+# ``tests/test_web_credentials_runtime_alignment.py``.
+# ---------------------------------------------------------------------------
+
+
+class _FakeEP:
+    def __init__(self, name: str, target: Any) -> None:
+        self.name = name
+        self._target = target
+
+    def load(self) -> Any:
+        return self._target
+
+
+def _patch_entry_points(monkeypatch: pytest.MonkeyPatch, eps: list[_FakeEP]) -> None:
+    """Stub ``mureo.core.runtime_context.entry_points`` for the
+    runtime-context factory group."""
+
+    def fake_entry_points(*, group: str) -> list[_FakeEP]:
+        assert group == "mureo.runtime_context_factory"
+        return eps
+
+    monkeypatch.setattr("mureo.core.runtime_context.entry_points", fake_entry_points)
+
+
+@pytest.fixture()
+def _reset_runtime_ctx() -> Iterator[None]:
+    """Each test starts and ends with a clean resolver cache so the
+    process-wide singleton cannot bleed between tests."""
+    reset_runtime_context()
+    yield
+    reset_runtime_context()
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("_clean_amazon_env", "_reset_runtime_ctx")
+class TestSaveAmazonAccessTokenFollowsRuntimeContext:
+    @staticmethod
+    def _pin_legacy_default(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+        """Point the legacy fallback at a tmp file so the real
+        ``~/.mureo/credentials.json`` is never touched by these tests."""
+        legacy = tmp_path / "legacy" / "credentials.json"
+        monkeypatch.setattr(auth_mod, "_resolve_default_path", lambda: legacy)
+        return legacy
+
+    def test_writes_to_the_store_declared_credentials_write_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A store advertising ``credentials_write_path`` steers the
+        ``path=None`` save; the legacy default stays untouched."""
+        legacy = self._pin_legacy_default(monkeypatch, tmp_path)
+        tenant = tmp_path / "tenant-a" / "credentials.json"
+
+        class _LayeredSecretStore:
+            """Filesystem-backed, but not a ``FilesystemSecretStore``."""
+
+            credentials_write_path = tenant
+
+            def load(self, key: str) -> dict:
+                if not tenant.exists():
+                    return {}
+                return dict(json.loads(tenant.read_text(encoding="utf-8")).get(key, {}))
+
+            def save(self, key: str, value: dict) -> None:  # pragma: no cover
+                return None
+
+            def delete(self, key: str) -> None:  # pragma: no cover
+                return None
+
+        ctx = dataclasses.replace(
+            default_runtime_context(), secret_store=_LayeredSecretStore()
+        )
+        _patch_entry_points(monkeypatch, [_FakeEP("tenant", lambda: ctx)])
+
+        save_amazon_access_token("Atza|NEW", "Atzr|NEW")
+
+        doc = json.loads(tenant.read_text(encoding="utf-8"))
+        assert doc["amazon_ads"]["access_token"] == "Atza|NEW"
+        assert doc["amazon_ads"]["refresh_token"] == "Atzr|NEW"
+        assert not legacy.exists()
+
+    def test_round_trips_through_the_runtime_store(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Save then load with ``path=None`` must see the same token —
+        the read and the write agree on one location."""
+        legacy = self._pin_legacy_default(monkeypatch, tmp_path)
+        tenant = tmp_path / "tenant-b" / "credentials.json"
+        tenant.parent.mkdir(parents=True)
+        tenant.write_text(
+            json.dumps({"amazon_ads": {"client_id": "cid", "access_token": "OLD"}}),
+            encoding="utf-8",
+        )
+        _patch_entry_points(
+            monkeypatch,
+            [
+                _FakeEP(
+                    "tenant",
+                    lambda: default_runtime_context(credentials_path=tenant),
+                )
+            ],
+        )
+
+        save_amazon_access_token("Atza|NEW")
+
+        c = load_amazon_ads_credentials()
+        assert c is not None and c.access_token == "Atza|NEW"
+        assert c.client_id == "cid"  # preserved
+        assert not legacy.exists()
+
+    def test_no_override_keeps_the_legacy_default(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No factory registered → single-backend installs keep writing
+        ``~/.mureo/credentials.json`` exactly as before."""
+        legacy = self._pin_legacy_default(monkeypatch, tmp_path)
+        _patch_entry_points(monkeypatch, [])
+
+        save_amazon_access_token("Atza|NEW")
+
+        doc = json.loads(legacy.read_text(encoding="utf-8"))
+        assert doc["amazon_ads"]["access_token"] == "Atza|NEW"
+
+    def test_explicit_path_wins_over_the_runtime_override(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The explicit-path branch is unchanged: the wizard exchange
+        passes its own file and must not be redirected."""
+        legacy = self._pin_legacy_default(monkeypatch, tmp_path)
+        tenant = tmp_path / "tenant-c" / "credentials.json"
+        _patch_entry_points(
+            monkeypatch,
+            [
+                _FakeEP(
+                    "tenant",
+                    lambda: default_runtime_context(credentials_path=tenant),
+                )
+            ],
+        )
+
+        cf = _write(tmp_path, {"amazon_ads": {"client_id": "cid"}})
+        save_amazon_access_token("Atza|NEW", path=cf)
+
+        assert json.loads(cf.read_text())["amazon_ads"]["access_token"] == "Atza|NEW"
+        assert not tenant.exists()
+        assert not legacy.exists()

--- a/tests/test_auth_setup.py
+++ b/tests/test_auth_setup.py
@@ -2,17 +2,26 @@
 
 from __future__ import annotations
 
+import dataclasses
 import http.client
 import json
 import sys
 import threading
 import time
 from pathlib import Path
+from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from mureo.auth import GoogleAdsCredentials
+from mureo.core.runtime_context import (
+    default_runtime_context,
+    reset_runtime_context,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 # Windows test shim: `simple_term_menu` imports Unix-only `termios` and
 # raises NotImplementedError at import on Windows, so even
@@ -1914,3 +1923,177 @@ def test_resolve_default_path() -> None:
     path = _resolve_default_path()
     assert path.name == "credentials.json"
     assert ".mureo" in str(path)
+
+
+# ---------------------------------------------------------------------------
+# #510 — a ``path=None`` setup save must land where the runtime reads
+#
+# ``mureo.auth``'s loaders resolve through the active ``RuntimeContext``'s
+# ``SecretStore``, so a writer defaulting to the legacy
+# ``~/.mureo/credentials.json`` writes where nobody reads whenever a
+# ``mureo.runtime_context_factory`` relocates that store — the interactive
+# setup wizard's flavour of the same split-brain the token-refresh writers
+# had. ``save_credentials`` now defaults through
+# ``auth_setup._resolve_write_path`` (``runtime_credentials_path``).
+#
+# Entry-point stubs and the fake stores mirror
+# ``tests/test_web_credentials_runtime_alignment.py``.
+# ---------------------------------------------------------------------------
+
+
+class _FakeEP:
+    def __init__(self, name: str, target: Any) -> None:
+        self.name = name
+        self._target = target
+
+    def load(self) -> Any:
+        return self._target
+
+
+def _patch_entry_points(monkeypatch: pytest.MonkeyPatch, eps: list[_FakeEP]) -> None:
+    """Stub ``mureo.core.runtime_context.entry_points`` for the
+    runtime-context factory group."""
+
+    def fake_entry_points(*, group: str) -> list[_FakeEP]:
+        assert group == "mureo.runtime_context_factory"
+        return eps
+
+    monkeypatch.setattr("mureo.core.runtime_context.entry_points", fake_entry_points)
+
+
+@pytest.fixture()
+def _reset_runtime_ctx() -> Iterator[None]:
+    """Each test starts and ends with a clean resolver cache so the
+    process-wide singleton cannot bleed between tests."""
+    reset_runtime_context()
+    yield
+    reset_runtime_context()
+
+
+def _pin_legacy_default(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Point the legacy fallback at a tmp file so the real
+    ``~/.mureo/credentials.json`` is never touched by these tests."""
+    from mureo import auth_setup
+
+    legacy = tmp_path / "legacy" / "credentials.json"
+    monkeypatch.setattr(auth_setup, "_resolve_default_path", lambda: legacy)
+    return legacy
+
+
+def _setup_google_creds() -> GoogleAdsCredentials:
+    return GoogleAdsCredentials(
+        developer_token="dev-tok",
+        client_id="cid",
+        client_secret="csec",
+        refresh_token="rtok",
+        login_customer_id="1234567890",
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("_reset_runtime_ctx")
+def test_save_credentials_follows_declared_credentials_write_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A store advertising ``credentials_write_path`` steers the
+    ``path=None`` save; the legacy default stays untouched."""
+    from mureo.auth_setup import save_credentials
+
+    legacy = _pin_legacy_default(monkeypatch, tmp_path)
+    tenant = tmp_path / "tenant-a" / "credentials.json"
+
+    class _LayeredSecretStore:
+        """Filesystem-backed, but not a ``FilesystemSecretStore``."""
+
+        credentials_write_path = tenant
+
+        def load(self, key: str) -> dict[str, Any]:  # pragma: no cover
+            return {}
+
+        def save(self, key: str, value: dict[str, Any]) -> None:  # pragma: no cover
+            return None
+
+        def delete(self, key: str) -> None:  # pragma: no cover
+            return None
+
+    ctx = dataclasses.replace(
+        default_runtime_context(), secret_store=_LayeredSecretStore()
+    )
+    _patch_entry_points(monkeypatch, [_FakeEP("tenant", lambda: ctx)])
+
+    save_credentials(google=_setup_google_creds(), customer_id="1234567890")
+
+    data = json.loads(tenant.read_text(encoding="utf-8"))
+    assert data["google_ads"]["developer_token"] == "dev-tok"
+    assert not legacy.exists()
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("_reset_runtime_ctx")
+def test_save_credentials_round_trips_through_the_runtime_store(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Save then load with ``path=None`` must see the same credentials —
+    the wizard write and the runtime read agree on one location."""
+    from mureo.auth import load_google_ads_credentials
+    from mureo.auth_setup import save_credentials
+
+    legacy = _pin_legacy_default(monkeypatch, tmp_path)
+    tenant = tmp_path / "tenant-b" / "credentials.json"
+    _patch_entry_points(
+        monkeypatch,
+        [_FakeEP("tenant", lambda: default_runtime_context(credentials_path=tenant))],
+    )
+
+    save_credentials(google=_setup_google_creds(), customer_id="1234567890")
+
+    reloaded = load_google_ads_credentials()
+    assert reloaded is not None
+    assert reloaded.developer_token == "dev-tok"
+    assert reloaded.customer_id == "1234567890"
+    assert not legacy.exists()
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("_reset_runtime_ctx")
+def test_save_credentials_without_override_keeps_the_legacy_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No factory registered → single-backend installs keep writing
+    ``~/.mureo/credentials.json`` exactly as before."""
+    from mureo.auth_setup import save_credentials
+
+    legacy = _pin_legacy_default(monkeypatch, tmp_path)
+    _patch_entry_points(monkeypatch, [])
+
+    save_credentials(google=_setup_google_creds(), customer_id="1234567890")
+
+    data = json.loads(legacy.read_text(encoding="utf-8"))
+    assert data["google_ads"]["developer_token"] == "dev-tok"
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("_reset_runtime_ctx")
+def test_save_credentials_explicit_path_wins_over_the_runtime_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The explicit-path branch is unchanged: a caller that names its own
+    credentials file must not be redirected."""
+    from mureo.auth_setup import save_credentials
+
+    legacy = _pin_legacy_default(monkeypatch, tmp_path)
+    tenant = tmp_path / "tenant-c" / "credentials.json"
+    _patch_entry_points(
+        monkeypatch,
+        [_FakeEP("tenant", lambda: default_runtime_context(credentials_path=tenant))],
+    )
+
+    cred_path = tmp_path / "explicit" / "credentials.json"
+    save_credentials(
+        path=cred_path, google=_setup_google_creds(), customer_id="1234567890"
+    )
+
+    data = json.loads(cred_path.read_text(encoding="utf-8"))
+    assert data["google_ads"]["developer_token"] == "dev-tok"
+    assert not tenant.exists()
+    assert not legacy.exists()

--- a/tests/test_meta_token_refresh.py
+++ b/tests/test_meta_token_refresh.py
@@ -2,18 +2,30 @@
 
 from __future__ import annotations
 
+import contextlib
+import dataclasses
 import json
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, patch
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from pathlib import Path
 
 import httpx
 import pytest
 
-from mureo.auth import MetaAdsCredentials, refresh_meta_token_if_needed
+import mureo.auth as auth_mod
+from mureo.auth import (
+    MetaAdsCredentials,
+    load_meta_ads_credentials,
+    refresh_meta_token_if_needed,
+)
+from mureo.core.runtime_context import (
+    default_runtime_context,
+    reset_runtime_context,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -375,3 +387,195 @@ async def test_refresh_preserves_other_credential_sections(
     saved_data = json.loads(cred_path.read_text(encoding="utf-8"))
     assert saved_data["google_ads"]["developer_token"] == "keep-me"
     assert saved_data["meta_ads"]["access_token"] == "new-token"
+
+
+# ---------------------------------------------------------------------------
+# 10. #510 — a ``path=None`` refresh must write where the loader reads
+#
+# ``load_meta_ads_credentials()`` resolves through ``_resolve_secret_store``
+# (the active ``RuntimeContext``'s store), while this refresh used to fall
+# back to the legacy ``~/.mureo/credentials.json`` unconditionally. Under a
+# runtime that relocates the credentials file the 53-day refresh therefore
+# wrote a file nobody reads, so every later process re-refreshed from the
+# same aging stored token until it expired. The destination is now resolved
+# through ``auth._resolve_write_path`` — i.e.
+# ``runtime_credentials_path`` — exactly like the Amazon writer.
+#
+# Entry-point stubs and the fake stores mirror
+# ``tests/test_web_credentials_runtime_alignment.py``.
+# ---------------------------------------------------------------------------
+
+
+class _FakeEP:
+    def __init__(self, name: str, target: Any) -> None:
+        self.name = name
+        self._target = target
+
+    def load(self) -> Any:
+        return self._target
+
+
+def _patch_entry_points(monkeypatch: pytest.MonkeyPatch, eps: list[_FakeEP]) -> None:
+    """Stub ``mureo.core.runtime_context.entry_points`` for the
+    runtime-context factory group."""
+
+    def fake_entry_points(*, group: str) -> list[_FakeEP]:
+        assert group == "mureo.runtime_context_factory"
+        return eps
+
+    monkeypatch.setattr("mureo.core.runtime_context.entry_points", fake_entry_points)
+
+
+@pytest.fixture()
+def _reset_runtime_ctx() -> Iterator[None]:
+    """Each test starts and ends with a clean resolver cache so the
+    process-wide singleton cannot bleed between tests."""
+    reset_runtime_context()
+    yield
+    reset_runtime_context()
+
+
+def _pin_legacy_default(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Point the legacy fallback at a tmp file so the real
+    ``~/.mureo/credentials.json`` is never touched by these tests."""
+    legacy = tmp_path / "legacy" / "credentials.json"
+    monkeypatch.setattr(auth_mod, "_resolve_default_path", lambda: legacy)
+    return legacy
+
+
+@contextlib.contextmanager
+def _graph_returns(token: str) -> Iterator[None]:
+    """Stub the Graph token-exchange call with a 200 returning ``token``."""
+    response = httpx.Response(
+        200,
+        json={"access_token": token, "token_type": "bearer", "expires_in": 5183944},
+        request=httpx.Request("GET", "https://example.com"),
+    )
+    with patch("mureo.auth.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.post.return_value = response
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+        yield
+
+
+@pytest.mark.unit
+@pytest.mark.real_save
+@pytest.mark.usefixtures("_reset_runtime_ctx")
+async def test_refresh_writes_to_the_store_declared_credentials_write_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A store advertising ``credentials_write_path`` steers the
+    ``path=None`` refresh; the legacy default stays untouched."""
+    legacy = _pin_legacy_default(monkeypatch, tmp_path)
+    tenant = tmp_path / "tenant-a" / "credentials.json"
+
+    class _LayeredSecretStore:
+        """Filesystem-backed, but not a ``FilesystemSecretStore``."""
+
+        credentials_write_path = tenant
+
+        def load(self, key: str) -> dict[str, Any]:  # pragma: no cover
+            return {}
+
+        def save(self, key: str, value: dict[str, Any]) -> None:  # pragma: no cover
+            return None
+
+        def delete(self, key: str) -> None:  # pragma: no cover
+            return None
+
+    ctx = dataclasses.replace(
+        default_runtime_context(), secret_store=_LayeredSecretStore()
+    )
+    _patch_entry_points(monkeypatch, [_FakeEP("tenant", lambda: ctx)])
+
+    creds = _make_creds(token_obtained_at=_days_ago_iso(55))
+    with _graph_returns("new-refreshed-token"):
+        await refresh_meta_token_if_needed(creds)
+
+    saved = json.loads(tenant.read_text(encoding="utf-8"))
+    assert saved["meta_ads"]["access_token"] == "new-refreshed-token"
+    assert not legacy.exists()
+
+
+@pytest.mark.unit
+@pytest.mark.real_save
+@pytest.mark.usefixtures("_reset_runtime_ctx")
+async def test_refresh_round_trips_through_the_runtime_store(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Refresh then load with ``path=None`` must see the same token —
+    the read and the write agree on one location."""
+    legacy = _pin_legacy_default(monkeypatch, tmp_path)
+    tenant = tmp_path / "tenant-b" / "credentials.json"
+    _write_credentials(
+        tenant,
+        {
+            "access_token": "old-token",
+            "app_id": "app-123",
+            "app_secret": "secret-456",
+            "token_obtained_at": _days_ago_iso(55),
+        },
+    )
+    _patch_entry_points(
+        monkeypatch,
+        [_FakeEP("tenant", lambda: default_runtime_context(credentials_path=tenant))],
+    )
+
+    creds = _make_creds(token_obtained_at=_days_ago_iso(55))
+    with _graph_returns("new-refreshed-token"):
+        await refresh_meta_token_if_needed(creds)
+
+    reloaded = load_meta_ads_credentials()
+    assert reloaded is not None
+    assert reloaded.access_token == "new-refreshed-token"
+    assert reloaded.app_id == "app-123"  # preserved
+    assert not legacy.exists()
+
+
+@pytest.mark.unit
+@pytest.mark.real_save
+@pytest.mark.usefixtures("_reset_runtime_ctx")
+async def test_refresh_without_override_keeps_the_legacy_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No factory registered → single-backend installs keep writing
+    ``~/.mureo/credentials.json`` exactly as before."""
+    legacy = _pin_legacy_default(monkeypatch, tmp_path)
+    _patch_entry_points(monkeypatch, [])
+
+    creds = _make_creds(token_obtained_at=_days_ago_iso(55))
+    with _graph_returns("new-refreshed-token"):
+        await refresh_meta_token_if_needed(creds)
+
+    saved = json.loads(legacy.read_text(encoding="utf-8"))
+    assert saved["meta_ads"]["access_token"] == "new-refreshed-token"
+
+
+@pytest.mark.unit
+@pytest.mark.real_save
+@pytest.mark.usefixtures("_reset_runtime_ctx")
+async def test_refresh_explicit_path_wins_over_the_runtime_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The explicit-path branch is unchanged: a caller that names its own
+    credentials file must not be redirected."""
+    legacy = _pin_legacy_default(monkeypatch, tmp_path)
+    tenant = tmp_path / "tenant-c" / "credentials.json"
+    _patch_entry_points(
+        monkeypatch,
+        [_FakeEP("tenant", lambda: default_runtime_context(credentials_path=tenant))],
+    )
+
+    cred_path = tmp_path / "explicit" / "credentials.json"
+    _write_credentials(cred_path, {"access_token": "old-token"})
+
+    creds = _make_creds(token_obtained_at=_days_ago_iso(55))
+    with _graph_returns("new-refreshed-token"):
+        await refresh_meta_token_if_needed(creds, path=cred_path)
+
+    saved = json.loads(cred_path.read_text(encoding="utf-8"))
+    assert saved["meta_ads"]["access_token"] == "new-refreshed-token"
+    assert not tenant.exists()
+    assert not legacy.exists()


### PR DESCRIPTION
Closes #510. All three credential writers (Amazon LwA refresh, Meta long-lived token refresh, interactive setup wizard) now resolve their default destination through runtime_credentials_path, matching the loaders — fixing the silent read/write divergence in multi-tenant runtime contexts. Behavior without a runtime context is byte-identical (test-pinned); explicit paths win everywhere. +12 RED-verified tests; full suite green except known env-only failures.