### PR TITLE
feat(amazon): runtime-bindable token persistence for multi-tenant hosts

### DIFF
--- a/mureo/amazon_ads/bridge.py
+++ b/mureo/amazon_ads/bridge.py
@@ -84,6 +84,45 @@ def _scrub_secrets(text: str) -> str:
     return _scrub(text)
 
 
+def _runtime_token_saver(access_token: str, refresh_token: str | None) -> None:
+    """Persist a runtime-refreshed LwA token, honoring the active runtime.
+
+    The default ``token_saver`` when none is injected at construction —
+    which is every deployment, since the plugin collection path builds the
+    bridge zero-arg. Two destinations, decided at persist time (#511):
+
+    - The active ``RuntimeContext``'s ``SecretStore`` offers an
+      ``amazon_token_saver`` capability ⇒ write through it. A multi-tenant
+      host binds the refresh to the ACTIVE tenant's store, which is the
+      only place its own reads will look. Without this, refreshes land in
+      the operator-shared base whose reads strip per-client token fields,
+      so every dispatch would re-mint from a refresh token Amazon has
+      already rotated.
+    - No capability (single-tenant OSS, or a backend that did not opt in)
+      ⇒ :func:`mureo.auth.save_amazon_access_token`, i.e. the
+      runtime-resolved ``credentials.json`` exactly as before (#512).
+
+    Resolved per call, not at construction: the capability belongs to the
+    runtime context, which a host may install after the bridge is built.
+
+    The import is deliberately at call time, for the same load-bearing
+    reason as :func:`_scrub_secrets` — this module is reached from
+    ``mureo.mcp.server``'s import-time plugin collection, so a module-level
+    import into that graph risks re-entering a partially-initialized module.
+
+    Raises whatever the chosen saver raises; ``_refresh_and_persist`` maps
+    ``ConfigWriteError`` / ``OSError`` onto :class:`AmazonBridgeError` for
+    both destinations alike.
+    """
+    from mureo.core.runtime_context import runtime_amazon_token_saver
+
+    saver = runtime_amazon_token_saver()
+    if saver is not None:
+        saver(access_token, refresh_token)
+        return
+    save_amazon_access_token(access_token, refresh_token)
+
+
 def _warn_once_if_stale(path: Path, doc: Any) -> None:
     """Warn (once per process) that the served manifest is stale.
 
@@ -382,7 +421,9 @@ class AmazonAdsBridge:
         self._creds_loader: CredsLoader = creds_loader or load_amazon_ads_credentials
         self._connect: ConnectFactory = connect or _default_connect
         self._refresher: Refresher = refresher or refresh_access_token
-        self._token_saver: TokenSaver = token_saver or save_amazon_access_token
+        # An injected saver always wins; the default routes through the
+        # runtime capability seam (see ``_runtime_token_saver``).
+        self._token_saver: TokenSaver = token_saver or _runtime_token_saver
 
     # -- collection-time (pure, never raises) -------------------------------
 
@@ -464,6 +505,15 @@ class AmazonAdsBridge:
         raised :class:`AmazonBridgeError` so it is never lost — and
         ``None`` on the mint path, where the LwA error is its own cause.
         ``auth_failure_prefix`` names which of the two situations failed.
+
+        Where the token lands is the ``_token_saver``'s business: an
+        injected saver (tests, embedders) is used verbatim, while the
+        default binds the write to the active runtime — the ACTIVE tenant's
+        store when a multi-tenant host offers one, and the
+        runtime-resolved ``credentials.json`` otherwise (#511; see
+        :func:`_runtime_token_saver`). Single-tenant installs are
+        unaffected. Either destination's ``ConfigWriteError`` / ``OSError``
+        is mapped to the same :class:`AmazonBridgeError` below.
         """
         try:
             tokens = self._refresher(creds)

--- a/mureo/core/runtime_context.py
+++ b/mureo/core/runtime_context.py
@@ -22,7 +22,7 @@ strings are rejected at construction time.
 
 from __future__ import annotations
 
-from collections.abc import Collection, Mapping
+from collections.abc import Callable, Collection, Mapping
 from dataclasses import dataclass
 from importlib.metadata import entry_points
 from pathlib import Path
@@ -345,6 +345,52 @@ def runtime_ui_plugin_credential_fields() -> dict[str, frozenset[str]] | None:
             continue
         scoped[provider] = frozenset(str(k) for k in keys)
     return scoped or None
+
+
+def runtime_amazon_token_saver() -> Callable[[str, str | None], None] | None:
+    """Return the persister the active ``SecretStore`` offers for
+    runtime-refreshed Amazon LwA tokens, or ``None``.
+
+    The Amazon bridge mints and refreshes the short-lived LwA access token
+    on its own (one exchange per dispatch) and must persist the result so
+    the next call does not burn another exchange against a refresh token
+    Amazon has already rotated. Its default writer targets the
+    runtime-resolved ``credentials.json`` (#512) — correct for a
+    single-tenant install, but in a multi-tenant deployment that file is
+    the operator-shared base, whose reads strip the per-client token
+    fields, so refreshed tokens are written where nothing reads them back.
+
+    A host that keeps per-tenant tokens in its own store closes this by
+    exposing ``amazon_token_saver`` — a callable taking
+    ``(access_token, refresh_token | None)`` — on its ``SecretStore``. The
+    bridge then binds each refresh to the ACTIVE tenant's store. Joins the
+    store-capability family of :func:`runtime_credentials_path` (#196),
+    :func:`runtime_multi_account_auth` (#198), and
+    :func:`runtime_ui_plugin_credential_fields` (#207).
+
+    Resolution:
+
+    - **No factory registered** → ``None``. Single-tenant OSS keeps the
+      existing behavior byte-identically; the gate is on entry-point
+      *presence* so the default store is never consulted.
+    - **Store declares a callable ``amazon_token_saver``** → that callable.
+    - **Attribute absent or not callable** → ``None``. A mis-typed
+      declaration must not break the refresh path, so anything the resolver
+      cannot call collapses to "no capability" and the bridge falls back to
+      its default writer (mirroring the defensive reads of the siblings).
+
+    A registered-but-broken factory surfaces its
+    :class:`RuntimeContextFactoryError` here, as everywhere else in the
+    family — a packaging mistake is made visible rather than hidden.
+    """
+    if not list(entry_points(group=RUNTIME_CONTEXT_FACTORY_ENTRY_POINT_GROUP)):
+        return None
+    store = get_runtime_context().secret_store
+    declared = getattr(store, "amazon_token_saver", None)
+    if not callable(declared):
+        return None
+    saver: Callable[[str, str | None], None] = declared
+    return saver
 
 
 def runtime_search_console_sites() -> frozenset[str] | None:

--- a/mureo/core/secret_store.py
+++ b/mureo/core/secret_store.py
@@ -108,6 +108,23 @@ class SecretStore(Protocol):
       :func:`mureo.core.runtime_context.runtime_ui_plugin_credential_fields`;
       omit it for single-account stores so every declared field renders
       as today.
+
+    - ``search_console_sites`` / ``meta_account_ids`` /
+      ``google_ads_customer_ids: Collection[str]`` — per-client account
+      allow-lists a multi-tenant backend declares so cross-client reads
+      are constrained to the active client's accounts (#375/#411). Read
+      defensively via the matching
+      ``mureo.core.runtime_context.runtime_*`` resolvers; omit them for
+      single-account stores.
+
+    - ``amazon_token_saver: Callable[[str, str | None], None]`` — a
+      persistence callable ``(access_token, refresh_token)`` the Amazon
+      bridge's runtime token refresh uses instead of the default
+      credentials-file writer, so a multi-tenant backend can bind
+      refreshed tokens to the active tenant's own store (#511). Read
+      defensively (only a callable is honored) via
+      :func:`mureo.core.runtime_context.runtime_amazon_token_saver`;
+      omit it to keep the default write path.
     """
 
     def load(self, key: str) -> dict[str, Any]: ...

--- a/tests/test_amazon_runtime_token_saver.py
+++ b/tests/test_amazon_runtime_token_saver.py
@@ -1,0 +1,325 @@
+"""#511 — a multi-tenant host can bind the Amazon bridge's token writes.
+
+``AmazonAdsBridge`` is constructed zero-arg by the plugin collection path,
+so its DEFAULT ``token_saver`` is the only one a deployment ever gets.
+That default writes through ``mureo.auth.save_amazon_access_token``, which
+since #512 resolves to the runtime-resolved credentials file — in a
+multi-tenant deployment the operator-shared base, whose reads strip the
+per-client token fields. Runtime-refreshed tokens therefore round-tripped
+into a file nobody reads back (no leak, but no reuse either).
+
+The active ``RuntimeContext``'s ``SecretStore`` may now offer its own
+``amazon_token_saver`` capability; the default saver consults it at persist
+time and writes to the ACTIVE tenant's store instead. Same store-capability
+family as ``runtime_credentials_path`` (#196),
+``runtime_multi_account_auth`` (#198), and
+``runtime_ui_plugin_credential_fields`` (#207): entry-point gated,
+``getattr`` off the store, ``None`` when absent or unusable.
+
+An explicitly injected ``token_saver`` always wins — single-tenant OSS and
+every existing test path are byte-identical.
+
+Entry-point stubs mirror ``tests/test_auth_amazon.py`` /
+``tests/test_plugin_credentials_field_scope.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import json
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from mureo.amazon_ads.bridge import AmazonAdsBridge, AmazonBridgeError
+from mureo.amazon_ads.lwa import LwaTokens
+from mureo.auth import AmazonAdsCredentials
+from mureo.core.runtime_context import (
+    default_runtime_context,
+    reset_runtime_context,
+    runtime_amazon_token_saver,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Entry-point + store stubs
+# ---------------------------------------------------------------------------
+
+
+class _FakeEP:
+    def __init__(self, name: str, target: Any) -> None:
+        self.name = name
+        self._target = target
+
+    def load(self) -> Any:
+        return self._target
+
+
+def _patch_eps(monkeypatch: pytest.MonkeyPatch, eps: list[_FakeEP]) -> None:
+    def fake_entry_points(*, group: str) -> list[_FakeEP]:
+        assert group == "mureo.runtime_context_factory"
+        return eps
+
+    monkeypatch.setattr("mureo.core.runtime_context.entry_points", fake_entry_points)
+
+
+def _store(**attrs: Any) -> Any:
+    class _S:
+        def load(self, key: str) -> dict[str, Any]:
+            return {}
+
+        def save(self, key: str, value: dict[str, Any]) -> None:
+            return None
+
+        def delete(self, key: str) -> None:
+            return None
+
+    s = _S()
+    for k, v in attrs.items():
+        setattr(s, k, v)
+    return s
+
+
+def _ctx_with(store: Any) -> Any:
+    return dataclasses.replace(default_runtime_context(), secret_store=store)
+
+
+def _install_store(monkeypatch: pytest.MonkeyPatch, store: Any) -> None:
+    """Register a single factory entry point serving ``store``."""
+    ctx = _ctx_with(store)
+    _patch_eps(monkeypatch, [_FakeEP("tenant", lambda: ctx)])
+
+
+@pytest.fixture(autouse=True)
+def _reset_ctx() -> Iterator[None]:
+    reset_runtime_context()
+    yield
+    reset_runtime_context()
+
+
+# ---------------------------------------------------------------------------
+# runtime_amazon_token_saver resolver
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_resolver_none_when_no_factory(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Standalone OSS never consults the default store."""
+    _patch_eps(monkeypatch, [])
+    assert runtime_amazon_token_saver() is None
+
+
+@pytest.mark.unit
+def test_resolver_returns_the_declared_callable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: list[tuple[str, str | None]] = []
+
+    def saver(access: str, refresh: str | None) -> None:
+        seen.append((access, refresh))
+
+    _install_store(monkeypatch, _store(amazon_token_saver=saver))
+
+    resolved = runtime_amazon_token_saver()
+    assert resolved is not None
+    resolved("Atza|NEW", "Atzr|NEW")
+    assert seen == [("Atza|NEW", "Atzr|NEW")]
+
+
+@pytest.mark.unit
+def test_resolver_none_when_attribute_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A store that does not opt in keeps the legacy writer."""
+    _install_store(monkeypatch, _store())
+    assert runtime_amazon_token_saver() is None
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("declared", ["not-a-callable", 7, {"a": 1}, None])
+def test_resolver_none_when_attribute_not_callable(
+    monkeypatch: pytest.MonkeyPatch, declared: object
+) -> None:
+    """A mis-typed declaration must not be called; it collapses to the
+    legacy writer rather than crashing the refresh path."""
+    _install_store(monkeypatch, _store(amazon_token_saver=declared))
+    assert runtime_amazon_token_saver() is None
+
+
+# ---------------------------------------------------------------------------
+# Bridge — the DEFAULT saver honors the capability
+# ---------------------------------------------------------------------------
+
+_MANIFEST = {
+    "generated_at": "2026-05-18T00:00:00+00:00",
+    "region": "na",
+    "endpoint": "https://advertising-ai.amazon.com/mcp",
+    "account_mode": "dynamic",
+    "tools": [],
+}
+
+
+def _connect_seq(attempts: list[str], *, fail_first: int) -> Any:
+    """Connect factory whose first ``fail_first`` calls raise (a 401-ish
+    failure), so the bridge takes its refresh-persist-retry path."""
+
+    class _Sess:
+        def __init__(self, n: int) -> None:
+            self._n = n
+
+        async def initialize(self) -> None:
+            return None
+
+        async def call_tool(self, name: str, arguments: dict[str, Any]) -> Any:
+            if self._n <= fail_first:
+                raise RuntimeError("401 token expired")
+            return type("R", (), {"content": [f"ok#{self._n}"]})()
+
+    class _CM:
+        def __init__(self, url: str, headers: dict[str, str]) -> None:
+            attempts.append(headers["Authorization"])
+            self._n = len(attempts)
+
+        async def __aenter__(self) -> _Sess:
+            return _Sess(self._n)
+
+        async def __aexit__(self, *e: Any) -> bool:
+            return False
+
+    return lambda url, headers: _CM(url, headers)
+
+
+def _creds() -> AmazonAdsCredentials:
+    return AmazonAdsCredentials(
+        client_id="cid",
+        access_token="Atza|OLD",
+        refresh_token="Atzr|R",
+        client_secret="sec",
+    )
+
+
+def _bridge(tmp_path: Path, connect: Any, **kw: Any) -> AmazonAdsBridge:
+    mp = tmp_path / "amazon_tools.json"
+    mp.write_text(json.dumps(_MANIFEST))
+    return AmazonAdsBridge(
+        manifest_path=mp,
+        creds_loader=_creds,
+        connect=connect,
+        refresher=lambda c: LwaTokens("Atza|NEW", "Atzr|R2", 3600),
+        token_saver=kw.get("token_saver"),
+    )
+
+
+def _stub_legacy_saver(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, str | None]]:
+    """Replace ``save_amazon_access_token`` as the bridge sees it, so a
+    fallback is observable and the real ``~/.mureo`` is never touched."""
+    legacy: list[tuple[str, str | None]] = []
+    monkeypatch.setattr(
+        "mureo.amazon_ads.bridge.save_amazon_access_token",
+        lambda access, refresh=None, **kw: legacy.append((access, refresh)),
+    )
+    return legacy
+
+
+@pytest.mark.unit
+class TestBridgeDefaultTokenSaverFollowsRuntimeContext:
+    def test_capability_receives_the_refreshed_tokens(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The host-bound saver persists the refresh; the operator-shared
+        legacy writer is not touched."""
+        legacy = _stub_legacy_saver(monkeypatch)
+        tenant: list[tuple[str, str | None]] = []
+        _install_store(
+            monkeypatch,
+            _store(amazon_token_saver=lambda a, r: tenant.append((a, r))),
+        )
+
+        attempts: list[str] = []
+        b = _bridge(tmp_path, _connect_seq(attempts, fail_first=1))
+        out = asyncio.run(b.handle_mcp_tool("x", {}))
+
+        assert out == ["ok#2"]
+        assert tenant == [("Atza|NEW", "Atzr|R2")]
+        assert legacy == []
+        assert attempts[1] == "Bearer Atza|NEW"  # retry used the refreshed token
+
+    def test_without_the_capability_the_legacy_writer_is_used(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No factory registered → byte-identical to today."""
+        legacy = _stub_legacy_saver(monkeypatch)
+        _patch_eps(monkeypatch, [])
+
+        attempts: list[str] = []
+        b = _bridge(tmp_path, _connect_seq(attempts, fail_first=1))
+        out = asyncio.run(b.handle_mcp_tool("x", {}))
+
+        assert out == ["ok#2"]
+        assert legacy == [("Atza|NEW", "Atzr|R2")]
+
+    def test_a_store_without_the_attribute_uses_the_legacy_writer(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A registered backend that does not opt in keeps #512's behavior."""
+        legacy = _stub_legacy_saver(monkeypatch)
+        _install_store(monkeypatch, _store())
+
+        attempts: list[str] = []
+        b = _bridge(tmp_path, _connect_seq(attempts, fail_first=1))
+        asyncio.run(b.handle_mcp_tool("x", {}))
+
+        assert legacy == [("Atza|NEW", "Atzr|R2")]
+
+    def test_injected_token_saver_wins_over_the_capability(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An explicit constructor argument is never second-guessed."""
+        legacy = _stub_legacy_saver(monkeypatch)
+        tenant: list[tuple[str, str | None]] = []
+        _install_store(
+            monkeypatch,
+            _store(amazon_token_saver=lambda a, r: tenant.append((a, r))),
+        )
+
+        injected: list[tuple[str, str | None]] = []
+        attempts: list[str] = []
+        b = _bridge(
+            tmp_path,
+            _connect_seq(attempts, fail_first=1),
+            token_saver=lambda a, r: injected.append((a, r)),
+        )
+        asyncio.run(b.handle_mcp_tool("x", {}))
+
+        assert injected == [("Atza|NEW", "Atzr|R2")]
+        assert tenant == []
+        assert legacy == []
+
+    def test_a_failing_capability_surfaces_the_same_bridge_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A host saver raising ``OSError`` maps to the same actionable,
+        scrubbed ``AmazonBridgeError`` a failed local save produces."""
+        _stub_legacy_saver(monkeypatch)
+
+        def saver(access: str, refresh: str | None) -> None:
+            raise OSError(
+                "tenant store write failed: payload was "
+                "Atza|LEAKED-access-token-abc123"
+            )
+
+        _install_store(monkeypatch, _store(amazon_token_saver=saver))
+
+        attempts: list[str] = []
+        b = _bridge(tmp_path, _connect_seq(attempts, fail_first=1))
+        with pytest.raises(AmazonBridgeError) as ei:
+            asyncio.run(b.handle_mcp_tool("x", {}))
+
+        message = str(ei.value)
+        assert "could not be saved" in message
+        assert "LEAKED" not in message
+        assert "Atza|" not in message
+        assert isinstance(ei.value.__cause__, RuntimeError)  # original chained


### PR DESCRIPTION
Closes #511. New runtime capability runtime_amazon_token_saver() (same entry-point-gated getattr family as #196/#198/#207): a secret store may declare amazon_token_saver(access_token, refresh_token) and the Amazon bridge's default persistence binds to it at persist time — multi-tenant hosts write refreshed tokens to the active tenant's own store. Single-tenant behavior byte-identical; injected savers win; failure surface unchanged. Protocol capability docs updated for #375/#411/#511. +12 tests.