### PR TITLE
bridged tools: report a platform failure as an error, not a change (#528)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,83 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is untouched by all of this: a flat declared key still replaces the scan
   exactly as it did before.
 
+### Fixed
+
+- **A failed Amazon call is no longer recorded as a successful mutation**
+  (#528). Amazon returns a platform-side failure as ordinary successful
+  content, so the shared detector — which knows only the `API error:`
+  prefix mureo's own handlers stamp — classified it as a success and
+  promoted the call into `STATE.json`'s `action_log`, complete with an
+  observation window, a STRATEGY reminder and possibly a captured
+  reversal for a change that never happened. `AmazonAdsBridge` now
+  normalises an Amazon-declared failure into the canonical
+  `API error: <code>: <message>` result, so promotion-skip, the audit
+  trail and rollback planning all work unchanged. Amazon's message
+  reaches the agent verbatim so it can correct the call; the failure
+  text is scrubbed BEFORE it is reshaped for display, which means a
+  `code` long enough to look like an LwA authorization code renders as
+  `***` (the redactor does not guess which it is — a wrong guess would
+  put a credential in the agent's context and in `plugin_audit.jsonl`).
+  Fields beyond `code`/`message` are appended rather than dropped, a
+  body with no usable message is reported as such instead of arriving as
+  an opaque `{"code":"***"}`, and the text is capped at 4000 characters
+  with an explicit truncation marker so an outsized body cannot flood
+  the agent's context.
+
+- **The plugin audit redactor no longer assumes snake_case credential
+  key names** (#528). `clientSecret`, `refreshToken` and `accessToken`
+  were written out in cleartext because the rule required a literal
+  underscore — while `apiKey` was already handled. Every separator is
+  now optional, so the snake_case, kebab-case and camelCase spellings of
+  all five families are masked alike. This matters for real payloads
+  rather than in theory: Amazon's surface is camelCase throughout
+  (`advertiserAccountId`, `adProductFilter`, `authorizationCode`), and
+  bridged error bodies are exactly what this scrubber reads.
+
+- **The same redactor masks credential values under any key ending in
+  `code`** (#528), not only a key that is exactly `code` —
+  `authorizationCode`, `authCode` and `oauth_code` carry the same
+  material and were previously written out in full.
+
+  Both changes affect every provider's audit records, not only Amazon.
+  Note what the `code` rule actually gates on: the **value's length**,
+  not whether the key is credential-related. Any key ending in `code`
+  followed by a value of 8+ characters is masked, so
+  `barcode=0123456789`, `zipcode=`, `postcode=` and
+  `status_code=INTERNAL_SERVER_ERROR` now render as `***` too —
+  `barcode` in particular is a real Amazon catalog field. That
+  over-masking is deliberate: a legitimate field rendered as `***` costs
+  legibility, while a missed authorization code costs a credential.
+  Short values (`status_code=400`) and ordinary prose are unaffected.
+
+  The bearer-token pattern also stops at a quote instead of running to
+  the next whitespace, so redacting inside a JSON body no longer
+  swallows the rest of the document.
+
+  The discriminator is MCP's own `CallToolResult.isError` — the
+  platform's declaration that the call failed — not an inference from
+  the response body. Verified live against a real account (2026-08-05):
+  Amazon sets `isError` on both known failure shapes (the
+  `{"code": "FIELD_VALUE_IS_INVALID", ...}` envelope and the
+  `Validation failed: ...` text) and leaves it false on a successful
+  query. Content opening with `Validation failed:` is treated as a
+  failure as well, as a second signal. The body is otherwise not
+  interpreted at all, which is what makes the fix safe in both
+  directions: no Amazon tool declares an `outputSchema` and no mutation
+  success shape is documented, so any body-shape heuristic would
+  eventually read an ack such as `{"code": "CREATED", "message": "..."}`
+  as a failure and silently drop the `action_log` entry, observation
+  window and rollback candidate for a change that really happened.
+
+- **The plugin audit trail no longer reads as success for a call the
+  platform refused** (#528). A provider that returns the canonical
+  `API error:` envelope does not raise, so `plugin_audit.jsonl` recorded
+  `ok: true` with no reason while `action_log` (correctly) recorded
+  nothing. Records now carry `platform_ok: false` plus the error text
+  when the platform refused the call; `ok` keeps its meaning ("the
+  dispatch did not raise") and an ordinary success record is unchanged.
+  Applies to every plugin provider, not only Amazon.
+
 ## [0.10.39] - 2026-08-02
 
 ### Added

--- a/docs/amazon-ads.ja.md
+++ b/docs/amazon-ads.ja.md
@@ -180,6 +180,60 @@ Amazon のツールが Amazon 自身の名前（例 `campaign_management-*`,
 `action_log`（`platform=plugin:mureo-amazon-ads-bridge`）へ観測窓
 付きで昇格（#114 プラグイン安全層と同じ）。
 
+## Amazon 側で呼び出しが拒否されたとき
+
+Amazon はプラットフォーム側の失敗を通信エラーではなく通常の応答として
+返します。mureo は組み込みツールと同じ `API error: <code>: <message>`
+の形で報告します。例えばグローバルアカウントを `advertiserAccountId`
+で照会したときは次のように返ります:
+
+```
+API error: ***: Multi marketplace query requests only support query by primary resource id
+```
+
+したがって:
+
+- **拒否された呼び出しは「変更」として記録されません。** `action_log`
+  エントリも観測窓もロールバック情報も作られません（何も起きていない
+  ものを起きたことにしない）。試行自体はプラグイン監査ログ
+  （`~/.mureo/plugin_audit.jsonl`）に残り、`platform_ok: false` と理由が
+  付きます（呼び出し自体は完了しているので `ok: true`、Amazon が拒否）。
+- **Amazon の `message` はそのままエージェントに届きます。** 対処に必要
+  な情報はこちらに入っており、呼び出しを修正して再試行できます。
+- **`code` は `***` と表示されることが多く、これは意図的です。** LwA の
+  認可コードもまったく同じ `"code": "..."` の形で漏れるため、mureo の
+  伏字化処理は「Amazon のエラーコードか認可コードか」を見分けようとせず
+  値を伏せます（見分けを誤ると、エージェントの文脈と
+  `plugin_audit.jsonl` に資格情報が残るためです）。8 文字未満の短い
+  コードはそのまま表示されます。Amazon が返したその他の項目は、
+  破棄せずメッセージの後ろに付けて表示します（同じ伏字化が適用され、
+  `clientSecret` / `refreshToken` / `authorizationCode` などの
+  資格情報らしい項目は表記ゆれ（camelCase / snake_case / kebab-case）に
+  関係なく伏字になります）。判定は「項目名 ＋ 値の長さ」で行い、値の
+  中身が秘密かどうかは見ません。そのため `*code` で終わる名前の長い値
+  （Amazon の `barcode` など）も伏字になります。カタログ項目が伏字に
+  なるのは読みにくいだけですが、トークンの漏えいはそうではない——という
+  意図的なトレードオフです。
+- **Amazon がメッセージを返さなかった場合はその旨を明示します**
+  （`API error: Amazon returned no error message; raw body: ...`）。
+  `{"code":"***"}` だけを渡して判断材料ゼロにはしません。極端に長い
+  本文は `…<truncated>` を付けて切り詰め、エージェントの文脈を
+  埋め尽くさないようにしています。
+- **判定には MCP プロトコルの `isError` フラグを使います**（応答本文の
+  形からの推測ではありません）。Amazon のホスト型エンドポイントは失敗時
+  に `isError` を立てます。実アカウントで実測して確認済み（2026-08-05）:
+  既知の 2 つの失敗形——`{"code": "FIELD_VALUE_IS_INVALID", ...}` と
+  `Validation failed: ...`——はいずれも `isError=true`、成功クエリは
+  `isError=false` でした。念のため `Validation failed:` で始まる応答も
+  失敗として扱います。
+
+これは体裁ではなく正しさの問題です。Amazon のツールは `outputSchema` を
+宣言しておらず、ミューテーション成功時の形も文書化されていません。本文
+の形から推測すると、いずれ成功応答（`{"code": "CREATED", ...}` など）を
+失敗と誤読し、**実際に起きた変更の記録を黙って落として**しまいます。
+プロトコルのフラグはプラットフォーム自身の申告なので、その誤りは起き
+ません。
+
 ## ロールバック：変更前状態の自動取得
 
 Amazon への書き込みは**ロールバックできます**。下表のミューテーション

--- a/docs/amazon-ads.md
+++ b/docs/amazon-ads.md
@@ -180,6 +180,63 @@ strategy-gated like built-in platforms. Mutating calls are promoted
 into `STATE.json` `action_log` (`platform=plugin:mureo-amazon-ads-bridge`)
 with an observation window, exactly like the #114 plugin safety layer.
 
+## When Amazon rejects a call
+
+Amazon returns a platform-side failure as an ordinary response, not as a
+transport error. mureo reports it as `API error: <code>: <message>` — the
+same envelope a built-in tool produces. For example, querying a global
+account by `advertiserAccountId` comes back as:
+
+```
+API error: ***: Multi marketplace query requests only support query by primary resource id
+```
+
+so:
+
+- **A rejected call is never recorded as a change.** No `action_log`
+  entry, no observation window, no rollback entry — nothing happened, so
+  nothing is logged as having happened. The attempt is still in the
+  plugin audit trail (`~/.mureo/plugin_audit.jsonl`), where it is marked
+  `platform_ok: false` with the reason: the call itself completed
+  (`ok: true`), Amazon refused it.
+- **Amazon's `message` reaches the agent verbatim** — that is the
+  actionable half, and it is enough to correct the call and retry.
+- **The `code` is often shown as `***`, and that is intended.** An LwA
+  authorization code leaks in exactly the same `"code": "..."` shape, so
+  mureo's redactor masks the value rather than trying to tell the two
+  apart — a wrong guess there would put a credential in the agent's
+  context and in `plugin_audit.jsonl`. A short code (under 8
+  characters) is shown as-is. Any other fields Amazon returns are
+  appended after the message rather than dropped — with the same
+  redaction applied, so a credential-named field
+  (`clientSecret`, `refreshToken`, `authorizationCode`, …) is masked
+  whichever spelling it arrives in. The masking is keyed on the field
+  NAME plus the value's length, not on knowing what a secret looks
+  like, so a long innocent value under a `*code` name (Amazon's
+  `barcode`, for instance) is masked too. That is the intended
+  trade-off: a redacted catalog field is a readability annoyance, a
+  leaked token is not.
+- **If Amazon sends no message at all**, the envelope says so
+  (`API error: Amazon returned no error message; raw body: ...`) instead
+  of handing over an opaque `{"code":"***"}`. Very long bodies are
+  truncated with a `…<truncated>` marker so a runaway response cannot
+  flood the agent's context.
+- **The signal is the MCP protocol's own `isError` flag**, not a guess
+  about what the response body looks like. Amazon's hosted endpoint sets
+  `isError` on a failed call — verified live against a real account
+  (2026-08-05) for both known failure shapes, the
+  `{"code": "FIELD_VALUE_IS_INVALID", ...}` envelope and the
+  `Validation failed: ...` text, with `isError` false on a successful
+  query. mureo treats content opening with `Validation failed:` as a
+  failure too, as a second line of defence.
+
+That last point matters for correctness, not just tidiness: no Amazon
+tool declares an `outputSchema` and no mutation success shape is
+documented, so guessing from the body would eventually misread a
+success ack (`{"code": "CREATED", ...}`) as a failure and silently drop
+the `action_log` entry for a change that really happened. The protocol
+flag is the platform's own statement, so that cannot occur.
+
 ## Rollback: automatic before-state capture
 
 Amazon writes are **reversible**. Before one of the paired mutations

--- a/docs/plugin-authoring.md
+++ b/docs/plugin-authoring.md
@@ -570,6 +570,11 @@ operations that fall outside the shared Protocol, which hand-written
 Every plugin tool call is, automatically and without you opting in:
 
 - **Audited** — appended (secret-masked) to `~/.mureo/plugin_audit.jsonl`.
+  `ok` records whether the dispatch raised. If your handler reports a
+  platform-side refusal *without* raising, return it as mureo's canonical
+  `API error: ...` text envelope: the record is then additionally marked
+  `platform_ok: false` with the reason, and the call is **not** promoted
+  into `action_log` — nothing changed, so nothing is logged as a change.
 - **Throttled** — a conservative shared token bucket gates the plugin
   dispatch path. mureo never crashes on, nor silently swallows, a
   plugin exception: it is recorded then re-raised unchanged.

--- a/mureo/_data/skills/_mureo-amazon-ads/SKILL.md
+++ b/mureo/_data/skills/_mureo-amazon-ads/SKILL.md
@@ -110,6 +110,33 @@ Every point below is verified against a live account.
 6. Closing the MCP session can log `Session termination failed: 403`. It
    appears *after* the call result and is harmless — do not report it as a
    failed operation.
+7. **A rejected call comes back as `API error: <code>: <message>`.** Amazon
+   returns its failures as ordinary content, flagged with the MCP protocol's
+   `isError` (live-verified 2026-08-05 for both the
+   `{"code": "FIELD_VALUE_IS_INVALID", ...}` envelope and the
+   `Validation failed: ...` text); mureo normalises those into the same
+   `API error: ...` result a built-in tool returns. Such a call changed
+   **nothing** and is deliberately **not** recorded in `action_log` — fix the
+   arguments from the message and retry, and never report the attempt as a
+   completed change. Two things to expect when you read one:
+   - **The `code` usually arrives as `***`.** An LwA authorization code has
+     the same `"code": "..."` shape, so mureo masks the value rather than
+     guessing which it is. **When a message is present it is the diagnosis** —
+     work from it and do NOT tell the operator that the code was hidden or
+     that information is missing. Example: `API error: ***: Multi marketplace
+     query requests only support query by primary resource id` is
+     requirement 3 above, and you can act on it as-is.
+   - **`API error: Amazon returned no error message; raw body: ...` means
+     there is genuinely nothing to read** — the code is masked and Amazon sent
+     no message. Say exactly that, quote the raw body, and do not invent a
+     cause. Re-read the tool's `inputSchema` and the *Calling requirements*
+     above, state your best hypothesis as a hypothesis, and ask the operator
+     before retrying a mutation.
+   - **A `…<truncated>` suffix means the body was longer than mureo will put
+     in your context.** Report what you have and say it was truncated.
+   - **The converse holds too**: a response that merely *looks*
+     error-flavoured (`{"code": "PARTIAL", ...}`) but is not flagged is a
+     success, and a mutation returning it IS recorded.
 
 Minimal working query body:
 
@@ -254,7 +281,9 @@ subject to the same structural handling as a built-in write (see
 parity*): **confirm with the operator before the call**, gate against
 `STRATEGY.md` (Operation Mode, Goals, `## Guardrails`), and expect the
 successful call to land in `action_log` under
-`platform="plugin:mureo-amazon-ads-bridge"` with an observation window.
+`platform="plugin:mureo-amazon-ads-bridge"` with an observation window. A
+call Amazon rejects (`API error: ...`, requirement 7 above) lands nowhere —
+it changed nothing, so report it as a failed attempt, not as a change.
 
 The **13 money-carrying tools** — the ones mureo declares exact money paths
 for, so their `## Guardrails` caps are enforced exactly (all

--- a/mureo/amazon_ads/bridge.py
+++ b/mureo/amazon_ads/bridge.py
@@ -30,7 +30,7 @@ from contextlib import AbstractAsyncContextManager
 from pathlib import Path
 from typing import Any
 
-from mcp.types import Tool
+from mcp.types import TextContent, Tool
 
 from mureo.amazon_ads.endpoints import endpoint_url, request_headers
 from mureo.amazon_ads.lwa import AmazonAuthError as _LwaAuthError
@@ -90,6 +90,193 @@ def _scrub_secrets(text: str) -> str:
     except Exception:  # noqa: BLE001 — never leak because an import failed
         return "<error text withheld: redactor unavailable>"
     return _scrub(text)
+
+
+#: Opening of Amazon's plain-text schema-validation failure. Kept as a
+#: belt-and-braces second signal beside ``CallToolResult.isError`` (see
+#: :func:`_normalize_failure`): no success message plausibly begins with it,
+#: and it costs one ``str.startswith``.
+_VALIDATION_FAILURE_PREFIX = "Validation failed:"
+
+#: Stand-in when a failure arrives with no text at all — the envelope must
+#: still be produced (a failure with an empty body is still a failure), and it
+#: must still say something.
+_NO_FAILURE_TEXT = "Amazon reported a tool error with no message"
+
+#: Prefix for a body that carries no usable ``message``. Since the redactor
+#: masks most ``code`` values, such a body would otherwise reach the agent as
+#: an opaque ``{"code":"***"}`` with nothing to act on. Saying so plainly is
+#: the only honest option, and it tells the agent what to report.
+_NO_MESSAGE_TEXT = "Amazon returned no error message; raw body:"
+
+#: Hard cap on the failure text handed to the agent, with an explicit marker
+#: so a truncated diagnostic can never be mistaken for a complete one.
+#:
+#: 4000 characters. The longest failure observed live is ~150 characters, and
+#: a ``Validation errors: [...]`` list with a dozen entries still lands well
+#: under 1000, so every plausible real diagnostic survives whole (>25x the
+#: observed maximum). Past that it is a runaway or adversarial body, and an
+#: unbounded one would dump megabytes into the agent's context — the audit
+#: line has always been capped (``plugin_audit._MAX_STR``); this is the same
+#: protection for the side that reaches the model.
+_MAX_FAILURE_TEXT = 4000
+_TRUNCATION_MARKER = "…<truncated>"
+
+
+def _flatten_for_display(scrubbed: str) -> str:
+    """PRESENTATION ONLY: ``{"code": X, "message": Y, …}`` ⇒ ``X: Y (…)``.
+
+    Runs strictly AFTER a failure has been established by
+    :func:`_normalize_failure`, so it CANNOT influence whether something is a
+    failure — that is ``CallToolResult.isError``'s job alone.
+
+    **The input must already be scrubbed**, and the ordering is a security
+    property, not a style choice. The shared redactor keys on the literal
+    ``"code":`` anchor to mask what may be an LwA authorization code
+    (:func:`mureo.mcp.plugin_audit._scrub`). Flattening first would delete that
+    anchor and hand a credential to the agent AND to ``plugin_audit.jsonl`` in
+    cleartext. Scrub, then reshape what the redactor has already cleared.
+
+    The consequence is accepted deliberately: the redactor cannot tell an
+    Amazon error code from an OAuth code — and must not guess, since a wrong
+    guess here leaks a credential — so a ``code`` long enough to trip the rule
+    renders as ``***``. ``FIELD_VALUE_IS_INVALID`` is one of those, verified:
+    the live failure reads ``API error: ***: Multi marketplace query requests
+    only support query by primary resource id``. The message carries the
+    actionable content, which is what the agent needs to correct its call.
+
+    Every key that is not rendered into the summary is appended verbatim
+    rather than dropped, so a future Amazon shape does not lose information
+    silently. A body with NO usable ``message`` (absent, empty, ``null``, or
+    not a string) is prefixed with :data:`_NO_MESSAGE_TEXT`: with the code
+    masked there is nothing left to read, and an opaque ``{"code":"***"}``
+    would leave the agent guessing. A ``message`` with no usable ``code``
+    renders as the message alone — it is a perfectly good diagnosis.
+
+    Anything that does not parse is returned untouched — including a body deep
+    enough to exhaust the parser's stack (``RecursionError`` is a
+    ``RuntimeError``, so it needs naming explicitly beside ``ValueError``).
+    """
+    try:
+        payload = json.loads(scrubbed)
+        if not isinstance(payload, dict):
+            return scrubbed
+        raw_message = payload.get("message")
+        message = raw_message.strip() if isinstance(raw_message, str) else ""
+        if not message:
+            return f"{_NO_MESSAGE_TEXT} {scrubbed}"
+        rendered = message
+        rendered_keys = {"message"}
+        code = payload.get("code")
+        if not isinstance(code, bool) and isinstance(code, (str, int)):
+            rendered = f"{code}: {message}"
+            rendered_keys.add("code")
+        extras = {k: v for k, v in payload.items() if k not in rendered_keys}
+        if extras:
+            rendered = f"{rendered} ({json.dumps(extras, ensure_ascii=False)})"
+        return rendered
+    except (ValueError, RecursionError):
+        return scrubbed
+
+
+def _failure_text(content: list[Any]) -> str:
+    """Amazon's own failure text — scrubbed, reshaped and bounded.
+
+    Scrubbing happens HERE, at the point the string is taken out of the
+    response and before anything reshapes it, so every caller gets a redacted
+    string and the redactor still sees the payload in its original form
+    (see :func:`_flatten_for_display`). The result is capped last, so the
+    bound holds for every path through this function.
+    """
+    for block in content:
+        text = getattr(block, "text", None)
+        if isinstance(text, str) and text.strip():
+            return _bounded(_flatten_for_display(_scrub_secrets(text.strip())))
+    return _NO_FAILURE_TEXT
+
+
+def _bounded(text: str) -> str:
+    """Cap ``text`` at :data:`_MAX_FAILURE_TEXT`, marking any truncation."""
+    if len(text) <= _MAX_FAILURE_TEXT:
+        return text
+    return text[:_MAX_FAILURE_TEXT] + _TRUNCATION_MARKER
+
+
+def _is_validation_failure(content: list[Any]) -> bool:
+    """True if the first block opens with Amazon's validation-failure text.
+
+    Belt-and-braces ONLY, and deliberately not load-bearing: the live probe
+    (2026-08-05) shows Amazon flags BOTH known failure shapes — this one
+    included — with ``isError=True``, so this check has never been the thing
+    that catches a real failure. It exists in case a future shape arrives
+    unflagged. ``isError`` is the primary signal; do not promote this one.
+    """
+    if not content:
+        return False
+    text = getattr(content[0], "text", None)
+    return isinstance(text, str) and text.strip().startswith(_VALIDATION_FAILURE_PREFIX)
+
+
+def _normalize_failure(content: list[Any], *, is_error: bool) -> list[Any]:
+    """Rewrite an Amazon-declared failure into mureo's ``API error:`` envelope.
+
+    ``mureo.mcp._helpers.is_error_result`` — the single detector both
+    promotion paths use to skip recording a mutation that did not happen —
+    knows exactly one shape: the ``API error:`` prefix mureo's own
+    ``api_error_handler`` stamps. Bridged tools never pass through that
+    decorator, so an Amazon-side failure was promoted into ``STATE.json``'s
+    ``action_log`` as a successful mutation, complete with an
+    ``observation_due`` and possibly a captured reversal for a change that
+    never happened (#528). Normalising here keeps the shared detector
+    platform-agnostic.
+
+    The discriminator is ``CallToolResult.isError``
+    ------------------------------------------------
+    ``is_error`` is MCP's own field: the SERVER's declaration that the call
+    failed. It is a fact about the call, not an inference from the payload,
+    so no property of the response body can make it wrong.
+
+    LIVE-VERIFIED against the real account (region ``fe``, 2026-08-05), by
+    replaying the two failures from #528 as read-only calls and logging the
+    raw ``CallToolResult``:
+
+    - ``account_management-query_advertiser_account`` ``{"body": {}}``
+      (success) ⇒ ``isError=False``
+    - ``campaign_management-query_campaign`` by ``advertiserAccountId`` on a
+      global account ⇒ ``isError=True``, body
+      ``{"code": "FIELD_VALUE_IS_INVALID", "message": "Multi marketplace
+      query requests only support query by primary resource id"}``
+    - ``campaign_management-query_campaign`` with no ``adProductFilter`` ⇒
+      ``isError=True``, body ``Validation failed: provided input does not
+      match tool input schema. …``
+
+    The payload shape is therefore NOT examined, with one belt-and-braces
+    exception: content opening with ``Validation failed:``
+    (:func:`_is_validation_failure`) is also treated as a failure, since no
+    success message plausibly begins that way. Nothing else about the body
+    is read — in particular no ``code``/``message`` heuristic, which
+    misclassified plausible mutation acks (``{"code": "CREATED", …}``) as
+    failures and would have DROPPED the ``action_log`` entry for a change
+    that really happened.
+
+    A failure replaces the whole result with the canonical envelope carrying
+    Amazon's own text, scrubbed then reshaped for legibility
+    (:func:`_failure_text`). The text comes from the response, never from an
+    exception, so no traceback can reach it. An empty body still yields the
+    envelope: ``isError`` alone settles it.
+    """
+    if not (is_error or _is_validation_failure(content)):
+        return content
+    # Call-time import for the same load-bearing reason as ``_scrub_secrets``:
+    # this module is reached from ``mureo.mcp.server``'s import-time plugin
+    # collection, so a module-level ``mureo.mcp.*`` import would re-enter a
+    # partially-initialized bridge. By dispatch time ``mureo.mcp._helpers`` is
+    # long since imported — the dispatcher that calls us imports it itself.
+    from mureo.mcp._helpers import API_ERROR_PREFIX
+
+    return [
+        TextContent(type="text", text=f"{API_ERROR_PREFIX} {_failure_text(content)}")
+    ]
 
 
 def _runtime_token_saver(access_token: str, refresh_token: str | None) -> None:
@@ -629,12 +816,27 @@ class AmazonAdsBridge:
         name: str,
         arguments: dict[str, Any],
     ) -> list[Any]:
+        """Forward one call, normalising an Amazon-declared failure (#528).
+
+        The normalisation sits here rather than in ``handle_mcp_tool`` so the
+        first attempt and the post-refresh retry — the only two ways a
+        forwarded response reaches a caller — are covered by one call site,
+        and because this is where ``CallToolResult.isError`` is still in
+        scope: everything above sees only ``content``.
+
+        ``getattr`` rather than attribute access, because the session is an
+        injection seam (tests, embedders) and a stand-in result object need
+        not carry the field; absent ⇒ not a failure.
+        """
         url = endpoint_url(creds.region)
         headers = request_headers(creds)
         async with self._connect(url, headers) as session:
             await session.initialize()
             result = await session.call_tool(name, arguments)
-            return list(result.content)
+            return _normalize_failure(
+                list(result.content),
+                is_error=bool(getattr(result, "isError", False)),
+            )
 
 
 def _default_manifest_path() -> Path:

--- a/mureo/mcp/plugin_audit.py
+++ b/mureo/mcp/plugin_audit.py
@@ -47,8 +47,13 @@ _SENSITIVE_KEY = re.compile(
 # headers and Amazon LwA access/refresh tokens (Atza|… / Atzr|…). The
 # Amazon bridge is the first credentialed plugin path, so this is
 # defense-in-depth for every plugin's recorded exception text.
+#
+# Every alternative stops at whitespace OR a quote. ``Bearer\s+\S+`` used to
+# run past the closing quote of a JSON string and swallow the rest of the
+# document, leaving structurally broken text for whoever reads the record.
+# A bearer token cannot contain a quote, so stopping there cannot leak.
 _SECRET_VALUE = re.compile(
-    r"(Bearer\s+\S+|Atza\|[^\s'\"]+|Atzr\|[^\s'\"]+)",
+    r"(Bearer\s+[^\s'\"]+|Atza\|[^\s'\"]+|Atzr\|[^\s'\"]+)",
     re.IGNORECASE,
 )
 
@@ -65,16 +70,25 @@ _SECRET_VALUE = re.compile(
 # The optional quotes around the separator catch the dict/JSON rendering
 # an exception's ``repr`` produces (``{'client_secret': 'shh'}``) as well
 # as the bare form-encoded one.
+#
+# EVERY key word separator is optional (``[_-]?``), so ``client_secret``,
+# ``client-secret`` and ``clientSecret`` are all masked. Three of the five
+# alternatives once required a literal underscore, which meant the camelCase
+# spelling leaked in cleartext (#528) — and camelCase is not exotic here:
+# Amazon's own surface is camelCase throughout (``advertiserAccountId``,
+# ``adProductFilter``, ``authorizationCode``), and this scrubber's whole job
+# is redacting error bodies from surfaces like it. Matches ``_SENSITIVE_KEY``
+# above, which was already spelled this way.
 _SECRET_KEY_VALUE = re.compile(
-    r"((?:client_secret|refresh_token|access_token|api[_-]?key|password)"
+    r"((?:client[_-]?secret|refresh[_-]?token|access[_-]?token"
+    r"|api[_-]?key|password)"
     r"['\"]?\s*[:=]\s*['\"]?)[^\s,;&'\"}\])]+",
     re.IGNORECASE,
 )
 
 # ``code`` on its own is far too common in ordinary error prose ("status
 # code = 400", "error code: 17"), so it gets a deliberately narrow rule.
-# Only two shapes count, both with a word boundary in front (never
-# ``status_code=``):
+# Only two shapes count:
 #   - ``code=…`` with NO space before the ``=`` (the query-string /
 #     form-body shape an authorization code actually leaks in), and
 #   - the QUOTED dict-key shape ``'code': '…'`` that an exception repr
@@ -83,9 +97,27 @@ _SECRET_KEY_VALUE = re.compile(
 # must also be at least _MIN_CODE_VALUE_LEN token characters — Amazon's
 # authorization codes are long alphanumerics; status codes and errnos
 # are not.
+#
+# The key may END in ``code`` rather than BE it (``authorizationCode``,
+# ``authCode``, ``oauth_code``): the same credential lands in whatever field
+# name a platform picked, and the original word-boundary lookbehind let those
+# through in full (#528). Dropping the lookbehind is all that takes — the
+# pattern simply matches the ``code`` at the END of the key and leaves the
+# prefix untouched, so ``authorizationCode": "…"`` becomes
+# ``authorizationCode": "***"``. Broadening the KEY is the safe direction: the
+# length rule still keeps ``status_code=400`` and friends readable, and
+# over-masking costs legibility while under-masking costs a credential.
+#
+# Deliberately NOT written as a ``[\w-]*code`` prefix: that form backtracks
+# quadratically on a long non-matching string (a 2 MB error body hung the
+# test suite), and this scrubber runs on attacker-influenceable text.
+#
+# Not covered, deliberately: a bare NUMERIC code is never masked (an LwA
+# authorization code is a long alphanumeric string, never an integer), so the
+# asymmetry with string codes is a legibility quirk, not a leak.
 _MIN_CODE_VALUE_LEN = 8
 _CODE_KEY_VALUE = re.compile(
-    r"((?<![\w-])(?:code=['\"]?|code['\"]\s*:\s*['\"]))[^\s,;&'\"}\])]{"
+    r"((?:code=['\"]?|code['\"]\s*:\s*['\"]))[^\s,;&'\"}\])]{"
     + str(_MIN_CODE_VALUE_LEN)
     + r",}",
     re.IGNORECASE,
@@ -139,8 +171,21 @@ def record_plugin_call(
     source: str,
     ok: bool,
     error: str | None = None,
+    platform_ok: bool | None = None,
 ) -> None:
-    """Append one masked JSON-Lines audit record. Never raises."""
+    """Append one masked JSON-Lines audit record. Never raises.
+
+    Two independent outcomes, because they genuinely differ (#528):
+
+    - ``ok`` — did the dispatch complete without raising. Unchanged meaning.
+    - ``platform_ok`` — did the PLATFORM accept the call. A provider can
+      return a refusal as ordinary content (the canonical ``API error:``
+      envelope), which does not raise and so leaves ``ok`` True. Recorded as
+      ``platform_ok: false`` so this operator-facing trail does not read as a
+      success for a call that changed nothing, matching the ``action_log``
+      entry that is correctly skipped for it. Written ONLY when a failure is
+      known, so an ordinary record keeps its existing shape.
+    """
     try:
         rec = {
             "ts": datetime.now(timezone.utc).isoformat(timespec="seconds"),
@@ -149,6 +194,8 @@ def record_plugin_call(
             "ok": ok,
             "args": _mask(arguments if isinstance(arguments, dict) else {}),
         }
+        if platform_ok is False:
+            rec["platform_ok"] = False
         if error is not None:
             rec["error"] = _scrub(error)[:_MAX_STR]
         path = _audit_path()

--- a/mureo/mcp/server.py
+++ b/mureo/mcp/server.py
@@ -1037,7 +1037,20 @@ async def _dispatch_tool(name: str, arguments: dict[str, Any]) -> list[Any]:
                 error=repr(exc),
             )
             raise
-        record_plugin_call(tool=name, arguments=arguments, source=source, ok=True)
+        # The call returned, so ``ok`` (= "did not raise") stays True. But a
+        # provider can report a PLATFORM refusal as ordinary content in the
+        # canonical error envelope — the same signal that skips the
+        # action_log promotion below — and the operator-facing trail must not
+        # read as a success for a call that changed nothing (#528).
+        platform_failed = is_error_result(result)
+        record_plugin_call(
+            tool=name,
+            arguments=arguments,
+            source=source,
+            ok=True,
+            platform_ok=not platform_failed,
+            error=result[0].text if platform_failed else None,
+        )
         # Phase 2: promote a *successful mutating* call into STATE.json's
         # action_log (only when a STATE.json exists in cwd) so the agent
         # / strategy review / rollback can see it like a built-in op.

--- a/skills/_mureo-amazon-ads/SKILL.md
+++ b/skills/_mureo-amazon-ads/SKILL.md
@@ -110,6 +110,33 @@ Every point below is verified against a live account.
 6. Closing the MCP session can log `Session termination failed: 403`. It
    appears *after* the call result and is harmless — do not report it as a
    failed operation.
+7. **A rejected call comes back as `API error: <code>: <message>`.** Amazon
+   returns its failures as ordinary content, flagged with the MCP protocol's
+   `isError` (live-verified 2026-08-05 for both the
+   `{"code": "FIELD_VALUE_IS_INVALID", ...}` envelope and the
+   `Validation failed: ...` text); mureo normalises those into the same
+   `API error: ...` result a built-in tool returns. Such a call changed
+   **nothing** and is deliberately **not** recorded in `action_log` — fix the
+   arguments from the message and retry, and never report the attempt as a
+   completed change. Two things to expect when you read one:
+   - **The `code` usually arrives as `***`.** An LwA authorization code has
+     the same `"code": "..."` shape, so mureo masks the value rather than
+     guessing which it is. **When a message is present it is the diagnosis** —
+     work from it and do NOT tell the operator that the code was hidden or
+     that information is missing. Example: `API error: ***: Multi marketplace
+     query requests only support query by primary resource id` is
+     requirement 3 above, and you can act on it as-is.
+   - **`API error: Amazon returned no error message; raw body: ...` means
+     there is genuinely nothing to read** — the code is masked and Amazon sent
+     no message. Say exactly that, quote the raw body, and do not invent a
+     cause. Re-read the tool's `inputSchema` and the *Calling requirements*
+     above, state your best hypothesis as a hypothesis, and ask the operator
+     before retrying a mutation.
+   - **A `…<truncated>` suffix means the body was longer than mureo will put
+     in your context.** Report what you have and say it was truncated.
+   - **The converse holds too**: a response that merely *looks*
+     error-flavoured (`{"code": "PARTIAL", ...}`) but is not flagged is a
+     success, and a mutation returning it IS recorded.
 
 Minimal working query body:
 
@@ -254,7 +281,9 @@ subject to the same structural handling as a built-in write (see
 parity*): **confirm with the operator before the call**, gate against
 `STRATEGY.md` (Operation Mode, Goals, `## Guardrails`), and expect the
 successful call to land in `action_log` under
-`platform="plugin:mureo-amazon-ads-bridge"` with an observation window.
+`platform="plugin:mureo-amazon-ads-bridge"` with an observation window. A
+call Amazon rejects (`API error: ...`, requirement 7 above) lands nowhere —
+it changed nothing, so report it as a failed attempt, not as a change.
 
 The **13 money-carrying tools** — the ones mureo declares exact money paths
 for, so their `## Guardrails` caps are enforced exactly (all

--- a/tests/test_amazon_bridge.py
+++ b/tests/test_amazon_bridge.py
@@ -567,6 +567,424 @@ class TestProactiveTokenMint:
         assert attempts == ["Bearer Atza|MINTED"]  # exactly one forwarded call
 
 
+def _connect_result(content, *, is_error: bool = False, attempts: list | None = None):
+    """Connect factory whose session answers with ``content`` + ``isError``.
+
+    Mirrors the real ``CallToolResult``: a failure is DECLARED by the server
+    through ``isError``, not inferred from the body.
+    """
+
+    class _Sess:
+        async def initialize(self) -> None: ...
+
+        async def call_tool(self, name, arguments):
+            if attempts is not None:
+                attempts.append(name)
+            return type("R", (), {"content": content, "isError": is_error})()
+
+    class _CM:
+        def __init__(self, url, headers):
+            pass
+
+        async def __aenter__(self):
+            return _Sess()
+
+        async def __aexit__(self, *e):
+            return False
+
+    return lambda url, headers: _CM(url, headers)
+
+
+@pytest.mark.unit
+class TestFailureEnvelopeNormalization:
+    """#528 — an Amazon-declared failure becomes the canonical ``API error:``.
+
+    Amazon returns a platform-side failure as ordinary content, so
+    ``mureo.mcp._helpers.is_error_result`` — which knows only mureo's own
+    ``API error:`` prefix — said False and a mutation that never happened was
+    promoted into ``STATE.json``'s ``action_log``.
+
+    The discriminator is ``CallToolResult.isError``, MCP's own field, which is
+    LIVE-VERIFIED (region ``fe``, 2026-08-05) as ``True`` on both #528
+    failures and ``False`` on a successful query. The payload is NOT
+    inspected: every body-shape heuristic tried before this misread plausible
+    mutation acks (``{"code": "CREATED", …}``) as failures, which would DROP
+    the ``action_log`` entry for a change that really happened.
+    """
+
+    def _text(self, s: str):
+        from mcp.types import TextContent
+
+        return [TextContent(type="text", text=s)]
+
+    def _call(self, tmp_path: Path, content, *, is_error: bool = False):
+        b = _bridge(tmp_path, connect=_connect_result(content, is_error=is_error))
+        return asyncio.run(
+            b.handle_mcp_tool("campaign_management-create_campaign", {"name": "X"})
+        )
+
+    def _is_error(self, out) -> bool:
+        from mureo.mcp._helpers import is_error_result
+
+        return is_error_result(out)
+
+    def test_live_json_failure_becomes_an_api_error(self, tmp_path: Path) -> None:
+        """Live-observed shape #1, with the live-observed ``isError=True``."""
+        out = self._call(
+            tmp_path,
+            self._text(
+                '{"code":"FIELD_VALUE_IS_INVALID","message":"Multi marketplace '
+                'query requests only support query by primary resource id"}'
+            ),
+            is_error=True,
+        )
+        assert self._is_error(out)
+        text = out[0].text
+        # The MESSAGE — the actionable half — survives verbatim.
+        assert "Multi marketplace query requests" in text
+        assert "Traceback" not in text
+        # The CODE does not: the shared redactor masks the value of a quoted
+        # ``"code"`` key (it cannot tell an Amazon error code from an OAuth
+        # authorization code, and must not guess — see
+        # ``test_a_token_shaped_code_never_reaches_the_agent``).
+        assert "FIELD_VALUE_IS_INVALID" not in text
+        assert "***" in text
+
+    def test_a_token_shaped_code_never_reaches_the_agent(self, tmp_path: Path) -> None:
+        """A credential-shaped ``code`` must stay masked end to end.
+
+        The redactor masks the value of a quoted ``"code"`` key precisely
+        because an LwA authorization code leaks in that shape. Rendering the
+        payload for display must therefore happen AFTER scrubbing — flattening
+        first would strip the ``"code":`` anchor the rule keys on and hand the
+        agent (and the audit trail) the credential in cleartext.
+        """
+        secret = "AQABAAgAAAAmoFfGtYxfTKd1RVy5Z1oL8vXeqR7uKQzTOKENVALUE1234"
+        out = self._call(
+            tmp_path,
+            self._text(
+                f'{{"code": "{secret}", "message": "authorization code rejected"}}'
+            ),
+            is_error=True,
+        )
+        assert self._is_error(out)
+        assert secret not in out[0].text
+        assert "***" in out[0].text
+        assert "authorization code rejected" in out[0].text
+
+    def test_a_deeply_nested_body_does_not_escape_as_an_exception(
+        self, tmp_path: Path
+    ) -> None:
+        """``RecursionError`` is a ``RuntimeError``, so ``except ValueError``
+        misses it: the display helper must catch it and hand back the text.
+
+        Letting it escape would replace the graceful envelope with a raw
+        exception AND — with refresh credentials present — burn the one-shot
+        refresh-and-retry on a problem that is not authentication.
+        """
+        out = self._call(tmp_path, self._text("[" * 3000 + "]" * 3000), is_error=True)
+        assert self._is_error(out)
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            '{"code":"FIELD_VALUE_IS_INVALID"}',  # message absent
+            '{"code":"FIELD_VALUE_IS_INVALID","message":""}',  # empty
+            '{"code":"FIELD_VALUE_IS_INVALID","message":"   "}',  # whitespace
+            '{"code":"FIELD_VALUE_IS_INVALID","message":null}',  # null
+            '{"code":"FIELD_VALUE_IS_INVALID","message":{"nested":1}}',  # not a str
+        ],
+    )
+    def test_a_failure_with_no_usable_message_says_so(
+        self, tmp_path: Path, body: str
+    ) -> None:
+        """A masked code AND no message must not hand back an opaque blob.
+
+        The redactor masks the code, so without a message there is nothing
+        left to read. The envelope has to SAY that, otherwise the agent is
+        handed ``API error: {"code":"***"}`` and can only guess.
+        """
+        out = self._call(tmp_path, self._text(body), is_error=True)
+        assert self._is_error(out)
+        assert "no error message" in out[0].text
+
+    def test_a_message_without_a_code_is_still_rendered(self, tmp_path: Path) -> None:
+        """The message alone is a perfectly good diagnosis."""
+        out = self._call(
+            tmp_path, self._text('{"message":"campaign not found"}'), is_error=True
+        )
+        assert out[0].text == "API error: campaign not found"
+
+    def test_a_token_shaped_value_under_a_code_suffixed_key_is_masked(
+        self, tmp_path: Path
+    ) -> None:
+        """Appending extra keys made this reachable, so it must be covered.
+
+        The redactor's ``code`` rule required the key to BE ``code``; a field
+        named ``authorizationCode`` carrying the same material slipped through
+        and now lands in the agent-visible text verbatim.
+        """
+        secret = "AQABAAABBBCCCDDDauthcode123456"
+        out = self._call(
+            tmp_path,
+            self._text(
+                '{"code":"BAD","message":"rejected",'
+                f'"authorizationCode":"{secret}"}}'
+            ),
+            is_error=True,
+        )
+        assert secret not in out[0].text
+        assert "rejected" in out[0].text
+
+    def test_a_bearer_token_in_a_message_keeps_the_body_parseable(
+        self, tmp_path: Path
+    ) -> None:
+        """A redaction that eats the closing quote breaks the flattening."""
+        out = self._call(
+            tmp_path,
+            self._text(
+                '{"code":"BAD","message":"bad header Bearer sometoken.jwt.here"}'
+            ),
+            is_error=True,
+        )
+        assert out[0].text == "API error: BAD: bad header ***"
+
+    def test_the_agent_visible_text_is_bounded(self, tmp_path: Path) -> None:
+        """An unbounded body must not dump megabytes into the agent's context.
+
+        The audit line has always been capped; the agent-facing text was not.
+        """
+        from mureo.amazon_ads.bridge import _MAX_FAILURE_TEXT
+
+        huge_message = self._call(
+            tmp_path,
+            self._text('{"code":"BAD","message":"%s"}' % ("x" * 2_000_000)),
+            is_error=True,
+        )
+        assert len(huge_message[0].text) < _MAX_FAILURE_TEXT + 100
+        assert "truncated" in huge_message[0].text
+
+        extras = ",".join(f'"k{i}":"v{i}"' for i in range(50_000))
+        huge_extras = self._call(
+            tmp_path,
+            self._text('{"code":"BAD","message":"m",%s}' % extras),
+            is_error=True,
+        )
+        assert len(huge_extras[0].text) < _MAX_FAILURE_TEXT + 100
+        assert "truncated" in huge_extras[0].text
+
+    def test_unrecognised_keys_are_kept_in_the_display_text(
+        self, tmp_path: Path
+    ) -> None:
+        """Flattening must not silently discard the rest of the payload."""
+        out = self._call(
+            tmp_path,
+            self._text(
+                '{"code":"BAD","message":"bad id",'
+                '"details":[{"field":"campaignId"}],"requestId":"r-1"}'
+            ),
+            is_error=True,
+        )
+        text = out[0].text
+        assert "bad id" in text
+        assert "campaignId" in text  # details survived
+        assert "r-1" in text  # requestId survived
+
+    def test_live_validation_failure_becomes_an_api_error(self, tmp_path: Path) -> None:
+        """Live-observed shape #2 — plain text, also flagged ``isError=True``."""
+        out = self._call(
+            tmp_path,
+            self._text(
+                "Validation failed: provided input does not match tool input "
+                "schema. Validation errors: [/body: required property "
+                "'adProductFilter' not found]"
+            ),
+            is_error=True,
+        )
+        assert self._is_error(out)
+        assert "adProductFilter" in out[0].text
+        assert "Traceback" not in out[0].text
+
+    def test_is_error_normalises_a_success_looking_payload(
+        self, tmp_path: Path
+    ) -> None:
+        """The case ONLY ``isError`` can catch.
+
+        A body that reads exactly like a successful query envelope, declared
+        a failure by the server. No payload heuristic could ever see this;
+        the protocol field settles it.
+        """
+        out = self._call(
+            tmp_path,
+            self._text('{"campaigns":[{"campaignId":"C1","state":"ENABLED"}]}'),
+            is_error=True,
+        )
+        assert self._is_error(out)
+        assert "campaigns" in out[0].text  # Amazon's own body still surfaced
+
+    def test_validation_prefix_without_is_error_is_belt_and_braces(
+        self, tmp_path: Path
+    ) -> None:
+        """Second signal: no success message plausibly opens this way."""
+        out = self._call(
+            tmp_path,
+            self._text("Validation failed: provided input does not match schema."),
+            is_error=False,
+        )
+        assert self._is_error(out)
+
+    def test_is_error_with_no_text_still_yields_the_envelope(
+        self, tmp_path: Path
+    ) -> None:
+        """A declared failure with an empty body is still a failure."""
+        out = self._call(tmp_path, [], is_error=True)
+        assert self._is_error(out)
+        assert "no message" in out[0].text
+
+    def test_success_envelope_is_returned_unchanged(self, tmp_path: Path) -> None:
+        payload = '{"campaigns":[{"campaignId":"C1","state":"ENABLED"}]}'
+        out = self._call(tmp_path, self._text(payload))
+        assert not self._is_error(out)
+        assert out[0].text == payload
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            '{"code":"CREATED","message":"Campaign 123 created successfully"}',
+            '{"code":"ACCEPTED","message":"request accepted"}',
+            '{"code":"UPDATED","message":"campaign updated"}',
+            '{"code":"DELETED","message":"campaign deleted"}',
+            '{"code":"ENABLED","message":"campaign enabled"}',
+            '{"code":"IN_PROGRESS","message":"update in progress"}',
+            '{"code":"SUCCESS","message":"OK","campaignId":"C1"}',
+            '{"code": 200, "message": "Campaign updated successfully"}',
+            '{"code": 0, "message": "Campaign updated successfully"}',
+            '{"code":"PARTIAL","message":"one item failed",'
+            '"campaigns":[{"campaignId":"C1"}]}',
+        ],
+    )
+    def test_a_mutation_ack_is_never_a_failure(
+        self, tmp_path: Path, payload: str
+    ) -> None:
+        """Every ack shape the reviews produced, none of them ``isError``.
+
+        These are exactly the payloads the previous vocabulary heuristics
+        misclassified. Without ``isError`` the body cannot make the bridge
+        call something a failure, so the whole class of bug is gone by
+        construction rather than by a longer word list.
+        """
+        out = self._call(tmp_path, self._text(payload))
+        assert not self._is_error(out)
+        assert out[0].text == payload
+
+    def test_unrecognised_payload_without_is_error_is_a_success(
+        self, tmp_path: Path
+    ) -> None:
+        for payload in (
+            "Something entirely unexpected happened",
+            '{"foo":1}',
+            '{"message":"no code here"}',
+            '{"code":"NO_MESSAGE_HERE"}',
+            "[1, 2, 3]",
+        ):
+            out = self._call(tmp_path, self._text(payload))
+            assert not self._is_error(out), payload
+            assert out[0].text == payload
+
+    def test_non_text_content_is_returned_unchanged(self, tmp_path: Path) -> None:
+        out = self._call(tmp_path, ["RESULT"])
+        assert out == ["RESULT"]
+
+    def test_a_session_without_the_field_is_treated_as_a_success(
+        self, tmp_path: Path
+    ) -> None:
+        """The injection seam: a stand-in result need not carry ``isError``."""
+        out = self._call(tmp_path, self._text('{"code":"X_IS_INVALID","message":"m"}'))
+        assert not self._is_error(out)
+
+    def test_error_detail_goes_through_the_token_scrubbing(
+        self, tmp_path: Path
+    ) -> None:
+        out = self._call(
+            tmp_path,
+            self._text(
+                '{"code":"UNAUTHORIZED","message":"bad header '
+                'Bearer Atza|LEAKED-TOKEN for client_secret=hunter2"}'
+            ),
+            is_error=True,
+        )
+        assert self._is_error(out)
+        text = out[0].text
+        assert "Atza|LEAKED-TOKEN" not in text
+        assert "hunter2" not in text
+        # The message keeps the non-secret context; the quoted code value is
+        # masked like every other one (see the live-shape test).
+        assert "bad header" in text
+
+    def test_normalization_also_applies_to_the_post_refresh_retry(
+        self, tmp_path: Path
+    ) -> None:
+        """The retry leg returns through the same normalisation."""
+        from mcp.types import TextContent
+
+        from mureo.amazon_ads.lwa import LwaTokens
+
+        attempts: list[int] = []
+
+        class _Sess:
+            def __init__(s, n):
+                s._n = n
+
+            async def initialize(s):
+                pass
+
+            async def call_tool(s, name, arguments):
+                if s._n == 1:
+                    raise RuntimeError("401 token expired")
+                return type(
+                    "R",
+                    (),
+                    {
+                        "content": [
+                            TextContent(
+                                type="text",
+                                text='{"code":"BAD_REQUEST","message":"nope"}',
+                            )
+                        ],
+                        "isError": True,
+                    },
+                )()
+
+        class _CM:
+            def __init__(s, url, headers):
+                attempts.append(1)
+                s._n = len(attempts)
+
+            async def __aenter__(s):
+                return _Sess(s._n)
+
+            async def __aexit__(s, *e):
+                return False
+
+        mp = tmp_path / "amazon_tools.json"
+        mp.write_text(json.dumps(_MANIFEST))
+        b = AmazonAdsBridge(
+            manifest_path=mp,
+            creds_loader=lambda: AmazonAdsCredentials(
+                client_id="cid",
+                access_token="Atza|OLD",
+                refresh_token="Atzr|R",
+                client_secret="sec",
+            ),
+            connect=lambda url, headers: _CM(url, headers),
+            refresher=lambda c: LwaTokens("Atza|NEW", "Atzr|R2", 3600),
+            token_saver=lambda a, r: None,
+        )
+        out = asyncio.run(b.handle_mcp_tool("campaign_management-x", {}))
+        assert self._is_error(out)
+        assert "nope" in out[0].text  # message survives; quoted code is masked
+
+
 @pytest.mark.unit
 def test_importing_the_bridge_first_does_not_break_plugin_discovery() -> None:
     """Regression: the bridge must not import ``mureo.mcp`` at module level.

--- a/tests/test_amazon_server_wiring.py
+++ b/tests/test_amazon_server_wiring.py
@@ -62,14 +62,21 @@ def _no_thirdparty(**_kw):
     return ()
 
 
-def _reload_server(monkeypatch, tmp_path: Path, *, with_manifest: bool):
+def _reload_server(
+    monkeypatch,
+    tmp_path: Path,
+    *,
+    with_manifest: bool,
+    manifest: dict[str, Any] | None = None,
+    connect=_fake_connect,
+):
     from mureo.amazon_ads import bridge as bmod
     from mureo.auth import AmazonAdsCredentials
     from mureo.mcp import plugin_audit
 
     mp = tmp_path / "amazon_tools.json"
     if with_manifest:
-        mp.write_text(json.dumps(_MANIFEST))
+        mp.write_text(json.dumps(manifest or _MANIFEST))
     monkeypatch.setattr(
         "mureo.core.providers.registry.discover_providers", _no_thirdparty
     )
@@ -81,7 +88,7 @@ def _reload_server(monkeypatch, tmp_path: Path, *, with_manifest: bool):
             client_id="cid", access_token="Atza|SECRET"
         ),
     )
-    monkeypatch.setattr(bmod, "_default_connect", _fake_connect)
+    monkeypatch.setattr(bmod, "_default_connect", connect)
     monkeypatch.setattr(plugin_audit, "_audit_path", lambda: tmp_path / "audit.jsonl")
     from mureo.mcp import server as mod
 
@@ -169,6 +176,321 @@ class TestAmazonServerWiring:
             assert amazon == []
         finally:
             importlib.reload(mod)
+
+
+_REVERSIBLE_MANIFEST = {
+    "generated_at": "2026-05-18T00:00:00+00:00",
+    "region": "na",
+    "endpoint": "https://advertising-ai.amazon.com/mcp",
+    "account_mode": "dynamic",
+    "tools": [
+        {
+            "name": "campaign_management-update_campaign_state",
+            "description": "Update campaign state.",
+            "inputSchema": {"type": "object", "properties": {}},
+        },
+    ],
+}
+
+_AMAZON_ERROR_JSON = (
+    '{"code":"FIELD_VALUE_IS_INVALID","message":"Multi marketplace query '
+    'requests only support query by primary resource id"}'
+)
+_AMAZON_VALIDATION_TEXT = (
+    "Validation failed: provided input does not match tool input schema. "
+    "Validation errors: [/body: required property 'adProductFilter' not found]"
+)
+_AMAZON_SUCCESS_JSON = '{"campaigns":[{"campaignId":"C1","state":"ENABLED"}]}'
+#: Mutation acks. No mutation success shape is live-verified anywhere in this
+#: repo, so a write may answer with nothing but scalars. None of these carries
+#: ``isError``, so none of them may EVER be read as a failure — doing so would
+#: drop the ``action_log`` entry for a change that really happened.
+_AMAZON_ACKS = (
+    '{"code":"CREATED","message":"Campaign 123 created successfully"}',
+    '{"code":"ACCEPTED","message":"request accepted"}',
+    '{"code":"UPDATED","message":"campaign updated"}',
+    '{"code":"DELETED","message":"campaign deleted"}',
+    '{"code":"ENABLED","message":"campaign enabled"}',
+    '{"code":"IN_PROGRESS","message":"update in progress"}',
+    '{"code": 200, "message": "Campaign updated successfully"}',
+    '{"code":"SUCCESS","message":"OK","campaignId":"C1"}',
+)
+
+
+def _connect_returning(text: str, *, is_error: bool = False):
+    """Connect factory: every tool answers ``text`` with ``isError``.
+
+    ``isError`` is the field the real ``CallToolResult`` carries and is the
+    bridge's sole structural failure signal (live-verified 2026-08-05).
+    """
+
+    class _Sess:
+        async def initialize(self) -> None: ...
+
+        async def call_tool(self, name: str, arguments: dict[str, Any]):
+            from mcp.types import TextContent
+
+            return type(
+                "R",
+                (),
+                {
+                    "content": [TextContent(type="text", text=text)],
+                    "isError": is_error,
+                },
+            )()
+
+    class _CM:
+        async def __aenter__(self):
+            return _Sess()
+
+        async def __aexit__(self, *e):
+            return False
+
+    return lambda url, headers: _CM()
+
+
+@pytest.mark.unit
+class TestBridgedFailureIsNotRecordedAsAMutation:
+    """#528 — a platform-side failure must not land in ``action_log``.
+
+    Amazon returns its failures as ordinary successful content, so the whole
+    chain has to be checked, not just the detector: promotion is skipped, the
+    jsonl audit still records the attempt exactly as it does today, no
+    reversal is attached, and the (normalised) response still reaches the
+    agent.
+    """
+
+    def _audit(self, tmp_path: Path) -> list[dict[str, Any]]:
+        return [
+            json.loads(x) for x in (tmp_path / "audit.jsonl").read_text().splitlines()
+        ]
+
+    async def _dispatch(
+        self, monkeypatch, tmp_path, tool, text, *, manifest=None, is_error=False
+    ):
+        _seed_state(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        mod = _reload_server(
+            monkeypatch,
+            tmp_path,
+            with_manifest=True,
+            manifest=manifest,
+            connect=_connect_returning(text, is_error=is_error),
+        )
+        try:
+            return await mod.handle_call_tool(tool, {"campaignId": "C1"})
+        finally:
+            importlib.reload(mod)
+
+    async def test_json_error_envelope_skips_the_action_log(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        from mureo.context.state import read_state_file
+
+        out = await self._dispatch(
+            monkeypatch,
+            tmp_path,
+            "campaign_management-create_campaign",
+            _AMAZON_ERROR_JSON,
+            is_error=True,
+        )
+
+        doc = read_state_file(tmp_path / "STATE.json")
+        assert doc.action_log == ()  # the mutation never happened
+        # ...but the response still reaches the agent, normalised. The message
+        # survives; the quoted code value is masked by the shared redactor.
+        assert out and out[0].text.startswith("API error:")
+        assert "Multi marketplace query requests" in out[0].text
+        # ...and the attempt is still audited — as a PLATFORM failure. ``ok``
+        # keeps its meaning ("the call did not raise"), so the operator-facing
+        # trail carries the outcome separately instead of reading as success.
+        audit = self._audit(tmp_path)
+        assert audit[-1]["tool"] == "campaign_management-create_campaign"
+        assert audit[-1]["ok"] is True
+        assert audit[-1]["platform_ok"] is False
+        assert "Multi marketplace query requests" in audit[-1]["error"]
+
+    async def test_a_token_shaped_code_reaches_neither_agent_nor_audit(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        """The operator-facing trail must never carry a credential in clear.
+
+        ``plugin_audit.jsonl`` is written to disk and kept; a leak there
+        outlives the session. The scrub has to happen before the failure text
+        is reshaped for display, or the redactor's ``"code":`` anchor is gone
+        by the time it runs.
+        """
+        secret = "AQABAAgAAAAmoFfGtYxfTKd1RVy5Z1oL8vXeqR7uKQzTOKENVALUE1234"
+        out = await self._dispatch(
+            monkeypatch,
+            tmp_path,
+            "campaign_management-create_campaign",
+            f'{{"code": "{secret}", "message": "authorization code rejected"}}',
+            is_error=True,
+        )
+
+        assert secret not in out[0].text
+        assert secret not in (tmp_path / "audit.jsonl").read_text()
+        assert "authorization code rejected" in self._audit(tmp_path)[-1]["error"]
+
+    async def test_a_code_suffixed_key_reaches_neither_agent_nor_audit(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        """Same guarantee for a key the redactor's ``code`` rule used to miss."""
+        secret = "AQABAAABBBCCCDDDauthcode123456"
+        out = await self._dispatch(
+            monkeypatch,
+            tmp_path,
+            "campaign_management-create_campaign",
+            f'{{"code":"BAD","message":"rejected","authorizationCode":"{secret}"}}',
+            is_error=True,
+        )
+
+        assert secret not in out[0].text
+        assert secret not in (tmp_path / "audit.jsonl").read_text()
+
+    @pytest.mark.parametrize(
+        "key",
+        ["clientSecret", "refreshToken", "accessToken", "apiKey", "client-secret"],
+    )
+    @pytest.mark.parametrize("with_message", [True, False], ids=["message", "none"])
+    async def test_a_camel_case_credential_key_reaches_nothing(
+        self, monkeypatch, tmp_path, key, with_message
+    ) -> None:
+        """Every credential family, in the spelling Amazon's surface uses.
+
+        Both paths this change added put a raw body in front of the agent and
+        into ``plugin_audit.jsonl``: the extras append (message present) and
+        the no-message fallback (message absent). A snake_case-only redactor
+        leaks through both.
+        """
+        secret = "amzn1.oa2-cs.v1.SUPERSECRETVALUE"
+        message = '"message":"rejected",' if with_message else ""
+        out = await self._dispatch(
+            monkeypatch,
+            tmp_path,
+            "campaign_management-create_campaign",
+            f'{{"code":"BAD",{message}"{key}":"{secret}"}}',
+            is_error=True,
+        )
+
+        assert secret not in out[0].text
+        assert secret not in (tmp_path / "audit.jsonl").read_text()
+
+    async def test_validation_failure_text_skips_the_action_log(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        from mureo.context.state import read_state_file
+
+        out = await self._dispatch(
+            monkeypatch,
+            tmp_path,
+            "campaign_management-create_campaign",
+            _AMAZON_VALIDATION_TEXT,
+            is_error=True,
+        )
+
+        assert read_state_file(tmp_path / "STATE.json").action_log == ()
+        assert out[0].text.startswith("API error:")
+        assert "adProductFilter" in out[0].text
+        assert self._audit(tmp_path)[-1]["platform_ok"] is False
+
+    async def test_failed_reversible_mutation_attaches_no_reversal(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        """A reversal for a change that never happened is a phantom rollback."""
+        from mureo.context.state import read_state_file
+
+        await self._dispatch(
+            monkeypatch,
+            tmp_path,
+            "campaign_management-update_campaign_state",
+            _AMAZON_ERROR_JSON,
+            manifest=_REVERSIBLE_MANIFEST,
+            is_error=True,
+        )
+
+        doc = read_state_file(tmp_path / "STATE.json")
+        assert doc.action_log == ()  # no entry ⇒ no reversible_params either
+
+    async def test_successful_envelope_is_unchanged_and_still_promoted(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        from mureo.context.state import read_state_file
+
+        out = await self._dispatch(
+            monkeypatch,
+            tmp_path,
+            "campaign_management-create_campaign",
+            _AMAZON_SUCCESS_JSON,
+        )
+
+        assert out[0].text == _AMAZON_SUCCESS_JSON  # forwarded verbatim
+        doc = read_state_file(tmp_path / "STATE.json")
+        assert len(doc.action_log) == 1
+        assert doc.action_log[0].action == "campaign_management-create_campaign"
+        assert "platform_ok" not in self._audit(tmp_path)[-1]  # plain success
+
+    @pytest.mark.parametrize("ack", _AMAZON_ACKS)
+    async def test_a_scalar_mutation_ack_is_still_promoted(
+        self, monkeypatch, tmp_path, ack
+    ) -> None:
+        """The inverse failure mode: a real change must NOT be lost.
+
+        Every one of these acks was misclassified as a failure by an earlier
+        payload heuristic. None carries ``isError``, so each must reach
+        ``action_log`` — misreading one would drop the audit entry, the
+        observation window and the rollback candidate for a change that
+        actually happened.
+        """
+        from mureo.context.state import read_state_file
+
+        out = await self._dispatch(
+            monkeypatch, tmp_path, "campaign_management-create_campaign", ack
+        )
+
+        assert out[0].text == ack  # untouched
+        doc = read_state_file(tmp_path / "STATE.json")
+        assert len(doc.action_log) == 1
+        assert doc.action_log[0].action == "campaign_management-create_campaign"
+
+    async def test_readonly_tool_error_keeps_its_existing_behaviour(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        """Read-only tools were never promoted; normalising changes nothing."""
+        from mureo.context.state import read_state_file
+
+        out = await self._dispatch(
+            monkeypatch,
+            tmp_path,
+            "account_management-query_advertiser_account",
+            _AMAZON_ERROR_JSON,
+            is_error=True,
+        )
+
+        assert read_state_file(tmp_path / "STATE.json").action_log == ()
+        assert out[0].text.startswith("API error:")
+        # A read-only tool is audit-only either way, but the trail must still
+        # say the platform refused the call.
+        assert self._audit(tmp_path)[-1]["platform_ok"] is False
+
+    async def test_is_error_on_a_success_looking_body_skips_promotion(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        """Only ``isError`` can catch this — the body reads as a success."""
+        from mureo.context.state import read_state_file
+
+        out = await self._dispatch(
+            monkeypatch,
+            tmp_path,
+            "campaign_management-create_campaign",
+            _AMAZON_SUCCESS_JSON,
+            is_error=True,
+        )
+
+        assert read_state_file(tmp_path / "STATE.json").action_log == ()
+        assert out[0].text.startswith("API error:")
+        assert self._audit(tmp_path)[-1]["platform_ok"] is False
 
 
 @pytest.mark.unit

--- a/tests/test_mcp_plugin_audit.py
+++ b/tests/test_mcp_plugin_audit.py
@@ -99,6 +99,37 @@ class TestRecordPluginCall:
         assert second["ok"] is False
         assert second["error"] == "boom"
 
+    def test_platform_failure_is_recorded_beside_ok(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """#528 — a call that returned an error envelope did not raise.
+
+        ``ok`` keeps meaning "the call did not raise", so a platform-side
+        refusal is recorded as ``platform_ok: false``; the operator trail must
+        not read as a success for a call that changed nothing. Written only
+        when a failure is detected, so an ordinary record is unchanged.
+        """
+        log = tmp_path / "audit.jsonl"
+        monkeypatch.setattr(plugin_audit, "_audit_path", lambda: log)
+
+        record_plugin_call(tool="t", arguments={}, source="s", ok=True)
+        record_plugin_call(
+            tool="t",
+            arguments={},
+            source="s",
+            ok=True,
+            platform_ok=False,
+            error="API error: FIELD_VALUE_IS_INVALID: bad id",
+        )
+
+        first, second = (
+            json.loads(x) for x in log.read_text(encoding="utf-8").splitlines()
+        )
+        assert "platform_ok" not in first  # unchanged for a plain success
+        assert second["ok"] is True
+        assert second["platform_ok"] is False
+        assert "FIELD_VALUE_IS_INVALID" in second["error"]
+
     def test_never_raises_on_io_failure(self, monkeypatch: pytest.MonkeyPatch) -> None:
         def _boom() -> Path:
             raise OSError("disk gone")
@@ -178,12 +209,50 @@ class TestScrubFreeText:
             ("?code=ANabcdefgh12&scope=x", "ANabcdefgh12"),
             ("{'code': 'ANabcdefgh12'}", "ANabcdefgh12"),
             ("Authorization: Bearer Atza|abc", "Atza|abc"),
+            # #528 — the rule must not key on the WHOLE key being ``code``:
+            # a differently-named field holding the same material leaks.
+            (
+                '{"authorizationCode": "AQABAAABBBCCCDDDauthcode123456"}',
+                "AQABAAABBBCCCDDDauthcode123456",
+            ),
+            ("authCode=AQABAAABBBCCCDDDauthcode123456", "AQABAAABBBCCCDDD"),
+            ("&oauth_code=AQABAAABBBCCCDDDauthcode123456", "AQABAAABBBCCCDDD"),
+            # #528 — camelCase spellings of EVERY credential family. Amazon's
+            # surface is camelCase throughout (``advertiserAccountId``,
+            # ``adProductFilter``), so a snake_case-only rule leaks in exactly
+            # the payloads this scrubber exists for.
+            (
+                '{"clientSecret": "amzn1.oa2-cs.v1.SUPERSECRETVALUE"}',
+                "amzn1.oa2-cs.v1.SUPERSECRETVALUE",
+            ),
+            ('{"refreshToken": "abcdefgh12345678"}', "abcdefgh12345678"),
+            ('{"accessToken": "abcdefgh12345678"}', "abcdefgh12345678"),
+            ('{"apiKey": "sk-abcdefgh12345678"}', "sk-abcdefgh12345678"),
+            ("clientSecret=amzn1.oa2-cs.v1.SUPERSECRETVALUE", "SUPERSECRETVALUE"),
+            ("refreshToken=Atzr-plain-shaped-value", "Atzr-plain-shaped-value"),
+            ("accessToken: plain-shaped-value", "plain-shaped-value"),
+            # ...and the hyphenated spellings, for the same reason.
+            ("client-secret=amzn1.oa2-cs.v1.SUPERSECRETVALUE", "SUPERSECRETVALUE"),
+            ("refresh-token=Atzr-plain-shaped-value", "Atzr-plain-shaped-value"),
         ],
     )
     def test_credential_values_are_redacted(self, text: str, leaked: str) -> None:
         scrubbed = plugin_audit._scrub(text)
         assert leaked not in scrubbed
         assert "***" in scrubbed
+
+    def test_a_bearer_token_does_not_swallow_the_closing_quote(self) -> None:
+        """The token pattern must stop at a quote, like the ``Atza|`` ones do.
+
+        ``Bearer\\s+\\S+`` ate the closing ``"`` and everything after it,
+        leaving structurally broken JSON for whoever reads the record. No leak,
+        but a bearer token cannot contain a quote, so narrowing is free.
+        """
+        text = '{"code":"BAD","message":"bad header Bearer sometoken.jwt.here"}'
+        scrubbed = plugin_audit._scrub(text)
+
+        assert "sometoken.jwt.here" not in scrubbed
+        assert json.loads(scrubbed) == {"code": "BAD", "message": "bad header ***"}
 
     @pytest.mark.parametrize(
         "text",


### PR DESCRIPTION
Closes #528. The substantive half of #121's remaining "data-path normalization" gap.

## The defect

`is_error_result` recognises exactly one shape — the `API error:` prefix mureo's own `api_error_handler` stamps on native results. Bridged tools do not go through that decorator, and Amazon returns its failures as ordinary content:

```
{"code":"FIELD_VALUE_IS_INVALID","message":"Multi marketplace query requests only support query by primary resource id"}
Validation failed: provided input does not match tool input schema. Validation errors: [/body: required property 'adProductFilter' not found]
```

Neither starts with `API error:`, so a mutation that **failed at Amazon** was written to `action_log` as if it had succeeded — with an `observation_due`, a STRATEGY reminder, and, since before-state capture landed, a reversal attached to a change that never happened. The action log is the audit trail, the basis for outcome evaluation, and the input to rollback planning.

## The discriminator is the protocol field, not the body

`CallToolResult.isError` is the server's own declaration that the call failed. **Live-verified** against the real endpoint (region `fe`, read-only probes, nothing mutated):

| call | `isError` |
|---|---|
| `query_advertiser_account` (success) | `False` |
| `query_campaign`, multi-marketplace | `True` — `{"code":"FIELD_VALUE_IS_INVALID",…}` |
| `query_campaign`, no `adProductFilter` | `True` — `Validation failed: …` |

Body shape is never inspected to classify. Two earlier attempts at a body-shape heuristic each shipped a defect where a plausible mutation ack (`{"code":200,…}`, then `{"code":"CREATED",…}`, `ACCEPTED`, `UPDATED`, `DELETED`, `ENABLED`, `IN_PROGRESS`) was read as a failure — which would have skipped the `action_log` entry for a change that really happened, the strictly worse direction. Every one of those is now asserted end-to-end as promoted. An anchored `Validation failed:` prefix remains as belt-and-braces, documented as not load-bearing.

## Scrubbing order is a security property

The redactor anchors on the `"code"` key. Rendering `{"code": X, "message": Y}` as `X: Y` **before** scrubbing removed that anchor and put an LwA authorization code into `plugin_audit.jsonl` in the clear. Order is now scrub → parse → flatten, with the display helper documented as taking already-scrubbed input.

Consequence, deliberate: the rule masks any `"code"` value of 8 or more characters, so `FIELD_VALUE_IS_INVALID` renders as `***` and the agent works from the `message`. The rule cannot distinguish an Amazon error code from an authorization code, and a wrong guess leaks a credential. The same length-based gate means legitimate long values (`barcode=`, `zipcode=`, `status_code=INTERNAL_SERVER_ERROR`) are masked too — over-masking costs legibility, under-masking costs a credential.

While hardening this path, `clientSecret` / `refreshToken` / `accessToken` were found to leak: the credential-key rule required a literal underscore while the bridged surface is camelCase throughout (`advertiserAccountId`, `adProductFilter`, `authorizationCode`). Now matched with an optional separator, with a repo-wide sweep confirming no sibling redaction site makes the same assumption. No rotation needed — found in review, never logged.

Also: the agent-facing text is bounded (4000 chars, with a marker) the way the audit line already was; a body with no usable `message` says so instead of returning an opaque blob; a deeply-nested body no longer escapes as `RecursionError`; unrecognised keys are appended rather than dropped.

## Audit record

`platform_ok` is added. `ok` keeps its meaning — the dispatch did not raise — so an operator reading `plugin_audit.jsonl` can distinguish a call that failed at the platform from one that succeeded. A plain success record is byte-identical to before (the key is absent). Applies to every plugin returning the canonical prefix, not only Amazon.

## Verification

- 36 new tests. Reverting the production files fails them.
- Five review rounds; three CRITICALs found and closed (two body-shape misclassifications, one credential leak).
- Full suite 7096 passed, no new failures.
