### PR TITLE
fix: refuse a second platform key for one ad account (#534, #536)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,129 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A write can no longer create a second STATE.json entry for one ad account**
+  (#534). The `platforms` map is keyed by a free-form string and the write path
+  resolved the target by **key only** — `account_id` was written but never
+  consulted. A writer using a different spelling of the same platform (an
+  agent's key versus an automated writer's) therefore added a *second* entry
+  for one real ad account, with no error, no warning and no log line. The
+  reporting view sums every entry, so spend, conversions and CPA all inflate
+  together (#533).
+
+  A write that would leave the document holding **two keys for one account** is
+  now rejected with an error naming both keys and the account. The guard sits
+  in the state layer (`upsert_campaign`, `set_platform_metrics`,
+  `set_conversion_action_types` — all three share the same key-only
+  get-then-overwrite shape), not only in the MCP handler, so it covers a skill
+  writing through the tools and a direct in-process caller alike. It runs
+  inside the state lock against the document just read, so a rejection happens
+  before any write.
+
+  Note that "would create a duplicate" is **not** "the target key is absent":
+  reusing an existing key while changing which account it points at
+  manufactures a new duplicate just as surely. The rule therefore branches on
+  what the entry already says:
+
+  - the key **does not exist** — refuse if another key already holds the
+    account (and validate the key's shape);
+  - the key exists and its stored id **matches** the incoming one — a plain
+    update, allowed (`act_`-tolerant, so re-writing `123456` as `act_123456`
+    is still an update);
+  - the key exists and its stored id is **unknown** (`""`) — allowed, *even if
+    another key already holds the incoming account*. Stamping an identity onto
+    an entry that had none cannot create a real-world duplicate: if the two
+    keys really are one account, that was already true and merely invisible.
+    The write is what makes it detectable, and therefore repairable — so this
+    path stays open by design;
+  - the key exists and its stored id is **known and different** — a re-point:
+    refused if another key already holds the incoming account, allowed if
+    nobody does (an operator legitimately switching which account a platform
+    tracks).
+
+  The thread through all four: refuse to create a new problem, never strand an
+  operator who already has one. Which is also why:
+
+  - **A write to a key that already exists is never refused on the key's
+    shape**, even in a document that already carries a duplicate pair, a
+    padded key or an unusable one. An operator whose state is already bad must
+    still be able to sync.
+  - **Nothing is merged or deleted.** In the observed case the two entries held
+    different *partial* figures, so dropping either under-counts as much as
+    summing over-counts; reconciliation is the operator's call.
+  - **`account_id = ""` is never a join key.** The tolerant read path
+    synthesizes it for a missing field, so it means "unknown" — it neither
+    triggers the rejection nor matches another empty id. A bare-numeric id and
+    its `act_`-prefixed form are recognised as the same account.
+  - **The key you pass is never rewritten.** A key that claims the plugin
+    namespace but carries no distribution (a bare `plugin:`), or one with
+    surrounding whitespace (`" google_ads"` — a different key from
+    `google_ads`, and another route to a duplicate), is rejected on create
+    rather than repaired: nothing on the write path can tell a bare
+    distribution name from a built-in key, so silently canonicalizing would
+    fabricate one — and rewriting the key an operator sees in STATE.json and on
+    the dashboard is the same class of silent divergence this guard exists to
+    stop.
+
+  A writer that assembles a **whole** `StateDocument` and writes it wholesale
+  (`StateStore.write_state`) never calls those three functions, so the
+  create-time guard cannot see it — and it could not reject there anyway: a
+  whole-document write carries no notion of which entry is new, and refusing
+  would lock an operator out of repairing their own file. `write_state_file`,
+  the funnel every such writer passes through, now **logs a warning** naming
+  both keys and the account instead, once per process per pair. Detection, not
+  enforcement — the write always proceeds.
+
+  The join itself is defined **once**, in the new
+  `mureo.context.platform_accounts` (`normalize_account_id`,
+  `account_ids_match`, `platform_keys_for_account`,
+  `duplicate_account_entries`), and shared by the write guards, the read-only
+  Reports view and out-of-tree writers. Its empty-id and `act_`-prefix rules
+  are easy to get subtly wrong, and a private copy that drifts re-creates the
+  bug.
+
+  Known limit, documented in `docs/strategy-context.md`: the join is on
+  `account_id` alone across all keys — it must be, since the bug is one account
+  under two *different* platform keys — so two genuinely different platforms
+  that happen to share an identifier string are reported as a duplicate and the
+  second cannot be created through the API. That trade is deliberate (a clear,
+  recoverable setup-time failure beats silently double-counting real money);
+  the escape is to add the second entry by hand, after which every write to
+  either key succeeds.
+
+  All three state-write tool schemas were tightened on the same surface:
+  `platform` and `account_id` declare `minLength: 1` (not an `enum` — that
+  would reject a valid `plugin:<dist>` key) and the `platform` description
+  states the one-account-one-key rule.
+  `mureo_state_platform_metrics_set` additionally names `tiktok_ads`, a
+  first-class key the reporting view already treats as one. An MCP client that
+  passes an explicit `account_id: ""` now gets
+  `Invalid arguments for <tool>: at 'account_id': '' should be non-empty` from
+  the dispatcher's schema gate, instead of the misleading
+  `Required parameter account_id is not specified` — misleading because the
+  parameter *was* specified. (The handler-level check behind that gate was
+  corrected to say `must not be empty` as well; it is what a caller invoking a
+  handler directly, outside the schema gate, sees.) Both paths still fail
+  before any write.
+
+- **A conversion-action-type override no longer applies to every ad account**
+  (#536). The account guard in `load_conversion_action_types` was
+  falsy-collapsing (`entry.account_id and account_id and not …`): when the
+  stored `account_id` was empty the whole chain went falsy, the `return None`
+  was skipped, and the override was returned for **any** account on that
+  platform in the workspace — and symmetrically, a caller passing `""` received
+  another account's override. An empty id is reachable because the tolerant
+  read path synthesizes `""` for a missing `account_id`, so a hand-authored or
+  externally written STATE.json gets there.
+
+  An unknown id on either side now fails closed and yields `None`. That
+  direction is the safe one: the override redefines *what counts as a
+  conversion* for an account, so wrongly applying one silently miscounts an
+  unrelated account's CV and CPA, while falling back to the documented built-in
+  generic set is visible and expected. The docstring, which described a match
+  the code did not perform, was corrected too.
+
 ## [0.10.40] - 2026-08-06
 
 ### Added

--- a/docs/strategy-context.md
+++ b/docs/strategy-context.md
@@ -189,6 +189,96 @@ the reporting dashboard's label lookup, and `mureo_analytics_modules_list` /
 under another is a silent join failure; see
 `skills/_mureo-shared/SKILL.md` → *Canonical platform key*.
 
+**One ad account has exactly one platform key.** The `platforms` map is keyed
+by a free-form string, so two spellings of the same platform would otherwise
+produce two entries for one real ad account — and the reporting view sums
+every entry, inflating spend, conversions and CPA together. The STATE.json
+write path therefore rejects a write that would **create** a second key for an
+`account_id` another key already holds, with an error naming both keys and the
+account. It applies to every writer that goes through `upsert_campaign`,
+`set_platform_metrics` or `set_conversion_action_types`, MCP or not.
+
+"Would create a duplicate" is **not** "the key does not exist yet" — reusing a
+key while changing which account it points at manufactures a new duplicate just
+as surely. What happens depends on what the entry already says:
+
+| Existing entry | Incoming `account_id` | Result |
+|----------------|------------------------|--------|
+| absent | held by another key | **rejected** (create) |
+| absent | free | created |
+| same account (`act_`-tolerant) | — | plain update |
+| no `account_id` (`""`) | free | id stamped on |
+| no `account_id` (`""`) | held by another key | **allowed** — see below |
+| different known account | held by another key | **rejected** (re-point) |
+| different known account | free | re-pointed |
+
+The `""` row is deliberate and is not a loophole. An entry with no
+`account_id` does not yet claim any account, so stamping one onto it cannot
+create a real-world duplicate: if the two keys really are one account, that was
+already true and merely invisible. Allowing the write is what makes the
+duplicate *detectable* — and therefore fixable. Rejecting it would block the
+very write that reveals the problem.
+
+**A write to a key that already exists is never refused on the key's shape** —
+including a whitespace-padded key or an unusable one. An operator holding bad
+state must be able to keep syncing, or the guard becomes a trap they cannot
+escape.
+
+Three things it deliberately does **not** do:
+
+- It never rewrites the key you passed. A key that claims the plugin namespace
+  but carries no distribution (a bare `plugin:`) is rejected rather than
+  repaired, because nothing can tell a bare distribution name from a built-in
+  key — silently canonicalizing would fabricate one. A key with surrounding
+  whitespace (`" google_ads"`, a different key from `google_ads` and another
+  route to a duplicate) is likewise rejected on create rather than stripped.
+- It never merges or deletes an existing entry. The two halves of a duplicate
+  typically hold different *partial* figures, so dropping either under-counts
+  as much as summing over-counts; reconciling them is the operator's call.
+- It cannot reject on a **whole-document** write. A writer that assembles a
+  complete `StateDocument` and writes it wholesale (`StateStore.write_state`)
+  carries no notion of which entry is new, so there is nothing to refuse —
+  and refusing would lock an operator out of repairing their own file. Such a
+  write instead logs a **warning** naming both keys and the account, once per
+  process per pair. Detection, not enforcement.
+
+An `account_id` of `""` means **unknown**: it is never a join key, so it
+neither triggers this rejection nor matches another empty id.
+
+#### If your two platforms genuinely share an account id
+
+The join is on `account_id` alone, across all keys — it has to be, because the
+whole point is to catch one account stored under two *different* platform keys.
+So if you really do operate two different platforms whose account identifiers
+happen to be the same string, mureo will refuse to create the second entry and
+report them as a duplicate.
+
+This is a deliberate trade: a clear, recoverable failure at setup time is
+cheaper than silently double-counting real money on a client card at every
+sync. There is no override flag. To proceed, add the second `platforms` entry
+by hand in STATE.json — once both keys exist, every subsequent write to either
+succeeds, because the guard only ever refuses a *create*. The duplicate warning
+described above will keep appearing once per process; that is the honest signal
+that mureo cannot tell your case apart from the bug.
+
+#### The shared join
+
+The one-account-one-key rule is defined once, in
+`mureo.context.platform_accounts`, and consumed by the write guards, the
+read-only Reports view and out-of-tree writers alike:
+
+| Function | Use |
+|----------|-----|
+| `normalize_account_id(account_id)` | Fold an id to its join form (strips surrounding space and an optional `act_` prefix, case-insensitive on the prefix only). `None` / empty folds to `""`; a non-string is folded textually rather than raising |
+| `account_ids_match(a, b)` | Same **known** account? `False` whenever either side is unknown — including `("", "")` |
+| `platform_keys_for_account(platforms, account_id)` | Every key that already describes this account, in document order |
+| `duplicate_account_entries(platforms)` | One `DuplicateAccountEntry(account_id, platform_keys)` per account held under two or more keys |
+
+If you write STATE.json from outside mureo, call `duplicate_account_entries`
+on the `platforms` map you assembled **before** writing it. Do not reimplement
+the comparison — the empty-id and `act_` rules are easy to get subtly wrong,
+and a private copy that drifts re-creates the bug.
+
 ### Fields
 
 #### Root

--- a/mureo/_data/skills/_mureo-meta-ads/SKILL.md
+++ b/mureo/_data/skills/_mureo-meta-ads/SKILL.md
@@ -271,6 +271,13 @@ for that account; never summed on top of the defaults). It is stored on
 `platforms[meta_ads]` in STATE.json and applied by every Meta conversion
 counter. Pass an empty list to clear it and restore the default.
 
+The override is **scoped to the `account_id` on that entry** and applies only
+to it. If the entry carries no `account_id` (or an empty one — possible only in
+a hand-authored / externally written STATE.json), the override is **ignored**
+and the built-in generic set is used: an override belonging to an
+unidentifiable account must never redefine what counts as a conversion for a
+different one.
+
 ### analysis
 
 - `performance` -- Analyze overall performance trends.

--- a/mureo/_data/skills/_mureo-shared/SKILL.md
+++ b/mureo/_data/skills/_mureo-shared/SKILL.md
@@ -328,8 +328,26 @@ shows fewer campaigns than you wrote — get these exact names right:
   `device_targeting`, and `metrics` (the per-campaign performance object:
   `spend` / `impressions` / `clicks` / `conversions` / `cpa` / `ctr` / …).
 - **Platform entry** (`platforms[<platform>]`) — required: `account_id` (str;
-  use `""` only if genuinely unknown). Plus `campaigns[]` and the rollups the
-  dashboard actually renders: `totals`, `metrics_period`, `periods[<window>]`.
+  use `""` only if genuinely unknown — an empty id is treated as *unknown*
+  everywhere, so it never joins with another entry and never matches a
+  per-account override). Plus `campaigns[]` and the rollups the dashboard
+  actually renders: `totals`, `metrics_period`, `periods[<window>]`.
+  **One ad account has exactly one platform key.** Before writing an entry,
+  check whether that `account_id` is already stored under a *different* key
+  and write to that key instead — the reporting view sums every entry, so two
+  keys for one account inflate spend / conversions / CPA together. The
+  `mureo_state_*` write tools now **reject** a write that would create the
+  second key (naming both keys and the account); on the Code `Write` path the
+  same rule is yours to honour, and a wholesale `Write` that lands a duplicate
+  is logged as a warning rather than blocked. Pass the key exactly — a key with
+  surrounding whitespace (`" google_ads"`) is a *different* key, and is
+  rejected on create rather than silently stripped. If a document already
+  carries the duplicate pair, writes to the *existing* keys still succeed —
+  mureo never merges or deletes an entry, because the two typically hold
+  different partial figures; reconciling them is the operator's call. Changing
+  an existing key's `account_id` to one another key already holds is rejected
+  for the same reason (it creates the duplicate just as surely); pointing a
+  key at an account nobody else holds is fine.
 - **Top-level** — required: `last_synced_at` (ISO-8601 string, **stamped to
   _now_** by every campaign/metrics/report write). It drives the dashboard's
   "Synced N ago" freshness; a missing or stale value makes the data read as

--- a/mureo/_data/skills/_mureo-strategy/SKILL.md
+++ b/mureo/_data/skills/_mureo-strategy/SKILL.md
@@ -400,6 +400,16 @@ and/or `periods` for the per-window map. `periods` is merged per window key, so
 writing `YESTERDAY` never clobbers a prior `LAST_30_DAYS` bucket (and vice
 versa); omitted fields preserve their existing value.
 
+**One ad account, one platform key.** The rollup is written under the
+`platforms` key you pass, and the reporting view sums every entry — so an
+account stored under two keys double-counts spend, conversions and CPA. Pass
+the key the account is already stored under; a write that would create a
+*second* key for an `account_id` another key already holds is rejected, naming
+both keys. Existing entries are never merged or deleted (they usually hold
+different partial figures), so writes to a key that already exists always
+succeed and reconciling a duplicated document stays the operator's call. See
+`../_mureo-shared/SKILL.md` → *STATE.json Schema*.
+
 ### Reports section
 
 `reports` (top-level, optional) holds the latest agent-written summary per

--- a/mureo/context/platform_accounts.py
+++ b/mureo/context/platform_accounts.py
@@ -1,0 +1,174 @@
+"""One ad account, one platform key — the shared join (Issues #533 / #534).
+
+STATE.json's ``platforms`` map is keyed by a free-form string, and nothing in
+the key tells you which ad account it describes. Two spellings of the same
+platform — the key an agent chose while running a skill, and the key a separate
+automated writer used — therefore produce **two entries for one real ad
+account**, and the reporting view sums every entry, so spend, conversions and
+CPA all inflate together (#533).
+
+Detecting that is one rule with **three** consumers:
+
+- the STATE.json write guards in :mod:`mureo.context.state`, which refuse a
+  write that would CREATE a second key for an account another key already
+  holds, and warn (never reject) when a whole document arrives already
+  carrying one;
+- the read-only Reports view, which surfaces an existing conflict rather than
+  silently adding the entries together;
+- out-of-tree writers (mureo-agency) that assemble a whole ``StateDocument``
+  themselves and never call the upsert helpers.
+
+This module is the single source of that rule. Reimplementing it in any of the
+three would let the definitions drift, and drift here re-creates the bug.
+
+The join has exactly one subtlety, and it is load-bearing: **an empty
+``account_id`` means UNKNOWN, never a value.** The tolerant read path
+synthesizes ``""`` for a missing ``account_id``
+(:func:`mureo.context.state._platform_account_id`), so treating ``""`` as a
+value would join every id-less entry in a document into one bogus "account".
+
+Deliberately dependency-free — stdlib plus the frozen ``PlatformState`` model
+(for typing only), so every consumer can import it without an import cycle.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from mureo.context.models import PlatformState
+
+ACCOUNT_ID_PREFIX = "act_"
+"""Optional prefix Meta ad account ids carry (``act_123`` == ``123``).
+
+The MCP setter stores whatever id the operator/agent passed, while the live
+clients enforce the ``act_*`` form — so a join that did not fold this would
+read two spellings of one account as two accounts.
+"""
+
+
+@dataclass(frozen=True)
+class DuplicateAccountEntry:
+    """Two or more ``platforms`` keys that resolve to one ad account.
+
+    ``account_id`` is the id **as stored** on the first of ``platform_keys``
+    (not the normalized form), so an operator can find it in the file.
+    ``platform_keys`` is in document order and always has at least two
+    entries.
+
+    Frozen and hashable, so a caller can use it directly as a warn-once latch
+    key (see :func:`mureo.context.state._warn_on_duplicate_accounts`).
+    """
+
+    account_id: str
+    platform_keys: tuple[str, ...]
+
+
+def normalize_account_id(account_id: object) -> str:
+    """Fold ``account_id`` to the form the join compares.
+
+    Strips surrounding whitespace and an optional ``act_`` prefix. An
+    **unknown** id (``None``, empty, or whitespace-only) folds to ``""``, which
+    :func:`account_ids_match` treats as matching nothing at all — including
+    another unknown id.
+
+    Case: the **prefix** folds case-insensitively (``ACT_1`` == ``act_1`` ==
+    ``1``), the rest of the id does **not** (``AbC`` != ``abc``). Real ad
+    account ids are numeric so this is nearly moot, but a plugin platform may
+    use a case-significant alphanumeric id, and folding the whole string would
+    silently join two genuinely different accounts — the exact failure this
+    module exists to prevent.
+
+    Type: takes ``object``, not ``str``, on purpose. A non-string (a
+    hand-edited ``"account_id": 12345``, i.e. a JSON number) is folded to its
+    ``str()`` form rather than raising. This module is consumed out-of-tree by
+    writers that assemble ``PlatformState`` from loosely-typed sources, and it
+    is a **detection** helper — raising here would surface as an unrelated
+    ``AttributeError`` from inside a write guard, whereas coercing keeps the
+    duplicate detectable, which is the whole point. ``None`` is the one
+    non-string that is NOT coerced: ``str(None) == "None"`` would join every
+    id-less entry under a bogus account.
+    """
+    if account_id is None:
+        return ""
+    text = account_id if isinstance(account_id, str) else str(account_id)
+    text = text.strip()
+    if text[: len(ACCOUNT_ID_PREFIX)].lower() == ACCOUNT_ID_PREFIX:
+        return text[len(ACCOUNT_ID_PREFIX) :]
+    return text
+
+
+def account_ids_match(a: object, b: object) -> bool:
+    """Return ``True`` when ``a`` and ``b`` are the same KNOWN ad account.
+
+    An unknown id on either side never matches — ``account_ids_match("", "")``
+    is ``False``. That is the whole point: ``""`` means "this entry did not say
+    which account it describes", and two entries that both declined to say are
+    not thereby the same account.
+    """
+    normalized = normalize_account_id(a)
+    return bool(normalized) and normalized == normalize_account_id(b)
+
+
+def platform_keys_for_account(
+    platforms: Mapping[str, PlatformState] | None, account_id: object
+) -> tuple[str, ...]:
+    """Return every key in ``platforms`` whose entry describes ``account_id``.
+
+    Document order. Empty when ``account_id`` is unknown, when ``platforms``
+    is ``None``/empty, or when no entry matches — so a caller can read the
+    result as "the keys this account is already stored under".
+    """
+    if not platforms or not normalize_account_id(account_id):
+        return ()
+    return tuple(
+        key
+        for key, entry in platforms.items()
+        if account_ids_match(entry.account_id, account_id)
+    )
+
+
+def duplicate_account_entries(
+    platforms: Mapping[str, PlatformState] | None,
+) -> tuple[DuplicateAccountEntry, ...]:
+    """Group ``platforms`` keys that resolve to ONE ad account.
+
+    Returns one :class:`DuplicateAccountEntry` per account held under two or
+    more keys, in the document order of each group's first key; an account
+    under a single key, and every entry with an unknown ``account_id``, are
+    omitted. An empty result means the document has no duplicate to report.
+
+    This is *detection*, not repair: the grouped entries typically hold
+    different **partial** figures, so dropping either under-counts as much as
+    summing over-counts. What to do about a group is the caller's decision —
+    the write path refuses to create a new one, the read path surfaces it, and
+    neither merges or deletes anything.
+    """
+    if not platforms:
+        return ()
+    grouped: dict[str, tuple[str, list[str]]] = {}
+    for key, entry in platforms.items():
+        normalized = normalize_account_id(entry.account_id)
+        if not normalized:  # unknown — never a join key
+            continue
+        if normalized not in grouped:
+            grouped[normalized] = (entry.account_id, [])
+        grouped[normalized][1].append(key)
+    return tuple(
+        DuplicateAccountEntry(account_id=stored_id, platform_keys=tuple(keys))
+        for stored_id, keys in grouped.values()
+        if len(keys) > 1
+    )
+
+
+__all__ = [
+    "ACCOUNT_ID_PREFIX",
+    "DuplicateAccountEntry",
+    "account_ids_match",
+    "duplicate_account_entries",
+    "normalize_account_id",
+    "platform_keys_for_account",
+]

--- a/mureo/context/platform_guards.py
+++ b/mureo/context/platform_guards.py
@@ -1,0 +1,280 @@
+"""Write-time guards for STATE.json's ``platforms`` map (Issue #534).
+
+Two guards, at two different layers, doing deliberately different jobs:
+
+- :func:`guard_platform_entry_write` **refuses** a targeted write that would
+  create a second platform key for one ad account. It is called by the
+  ``platforms``-touching writers in :mod:`mureo.context.state`, from inside
+  their locked ``_build``, so a rejection lands before anything is written.
+- :func:`warn_on_duplicate_accounts` only **reports**. It hangs off
+  ``write_state_file``, the funnel every whole-document writer passes through,
+  and exists because such a writer never calls the targeted helpers at all.
+
+Both delegate the "is this the same ad account?" question to
+:mod:`mureo.context.platform_accounts`, which is the single source of that
+rule (shared with the read-only Reports view and with out-of-tree writers).
+This module is the **policy** layer over that join: what to refuse, what to
+merely report, and what to leave alone. It lives beside ``state.py`` rather
+than inside it because nothing else in that module needs it.
+
+The rule :func:`guard_platform_entry_write` enforces
+--------------------------------------------------
+
+"Would create a duplicate" is **not** "the target key is absent": reusing an
+existing key while changing which account it points at manufactures a new
+duplicate just as surely. So the decision branches on what the entry already
+says:
+
+1. **The key does not exist.** A true create: validate the key's shape
+   (:func:`reject_unusable_platform_key`) and refuse if another key already
+   holds ``account_id``.
+2. **The key exists and its stored id matches the incoming one.** A plain
+   update — nothing about identity changes, so allow it. The match is
+   ``act_``-tolerant, so re-writing ``123456`` as ``act_123456`` is still an
+   update, not a re-point.
+3. **The key exists and its stored id is UNKNOWN (``""``).** Allow — even if
+   the incoming id is already held by another key. This branch is deliberate
+   and is not a hole: stamping an identity onto an entry that had none cannot
+   create a real-world duplicate. If the two keys really are one account, that
+   was *already true* and merely invisible; the write is what makes it
+   **detectable** by
+   :func:`~mureo.context.platform_accounts.duplicate_account_entries` and
+   therefore surfaceable to the operator. Rejecting here would block the very
+   write that reveals the problem, so this is the repair path and it stays
+   open.
+4. **The key exists and its stored id is known and different.** A re-point:
+   refuse if another key already holds the incoming account, allow if nobody
+   does (an operator legitimately switching which account a platform tracks).
+   The key's shape is *not* re-validated — the entry already exists, and
+   refusing here would strand an operator holding a padded or unusable key
+   rather than letting them keep working.
+
+The thread through all four: **refuse to create a new problem, never strand an
+operator who already has one.** Nothing here deletes or merges an entry either
+— the two halves of a duplicate typically hold different *partial* figures, so
+the repair is the operator's call, informed by the read side.
+
+One corner this does **not** defend: writing an explicit ``account_id=""``
+onto an entry that holds a known id silently reverts that entry to "unknown",
+because ``""`` is by contract free rather than taken. The MCP surface blocks
+it (schema ``minLength`` plus the handler's own check), so a caller reaching
+these functions from **outside** that gate — anything assembling
+``PlatformState`` from loosely-typed sources — must pass the entry's existing
+id, never ``""`` to mean "leave it alone".
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from mureo.context.platform_accounts import (
+    DuplicateAccountEntry,
+    account_ids_match,
+    duplicate_account_entries,
+    normalize_account_id,
+    platform_keys_for_account,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from mureo.context.models import PlatformState, StateDocument
+
+logger = logging.getLogger(__name__)
+
+_DUPLICATE_ACCOUNT_WARNED: set[tuple[str, DuplicateAccountEntry]] = set()
+"""Process-wide latch for the duplicate-account warning.
+
+Keyed by ``(state file path, group)``: :func:`warn_on_duplicate_accounts` runs
+on EVERY state write, so warning per call would flood the log for an operator
+whose document already carries a duplicate — while keying by group means one
+reported pair can never silence another, and including the path means one
+workspace's duplicate cannot silence the identical duplicate in a different
+workspace (an agency process serves many).
+
+Growth is bounded by :data:`_DUPLICATE_ACCOUNT_WARN_LATCH_MAX`. Without that
+cap the set would grow with the number of distinct (workspace, duplicate
+group) pairs a long-lived multi-tenant process encounters — small in practice,
+since a duplicate is a defect an operator repairs, but not bounded by
+anything structural. On reaching the cap the latch is cleared rather than
+evicted selectively: the failure mode of a cleared latch is warning again,
+which is the safe direction for a visibility feature.
+"""
+
+_DUPLICATE_ACCOUNT_WARN_LATCH_MAX = 256
+"""Cap on :data:`_DUPLICATE_ACCOUNT_WARNED` before it is cleared."""
+
+
+def reject_unusable_platform_key(platform: str) -> None:
+    """Reject a ``platform`` string that cannot serve as a map key (#534).
+
+    Three shapes are refused, and **nothing is rewritten**:
+
+    - an empty / whitespace-only key, which indexes an entry no surface can
+      resolve a platform from;
+    - a key with surrounding whitespace (``" google_ads"``), which is a
+      distinct dict key from the unpadded one and so is another route to two
+      entries for one account — never intentional;
+    - a key that claims the plugin namespace without being canonical
+      (a bare ``"plugin:"`` carries no distribution, so it joins with
+      nothing — see :mod:`mureo.core.platform_keys`).
+
+    Why reject rather than silently canonicalize or strip: the write path
+    cannot tell a bare distribution name from a built-in key or an arbitrary
+    string, so ``plugin_platform_key()`` applied here would fabricate
+    ``plugin:google_ads`` from a built-in. Where the canonical form IS knowable
+    — a key that is already canonical — that call is a no-op by construction.
+    And rewriting the key an operator passed changes the key they see in
+    STATE.json and on the dashboard without saying so, which is the same class
+    of silent divergence this guard exists to stop.
+
+    Create-only; see :func:`guard_platform_entry_write`.
+    """
+    # Imported lazily: ``mureo.core.__init__`` pulls in ``runtime_context`` ->
+    # ``state_store`` -> ``mureo.context.state``, which imports this module —
+    # a module-level import here would be a cycle.
+    from mureo.core.platform_keys import (
+        PLUGIN_PLATFORM_PREFIX,
+        is_plugin_platform_key,
+    )
+
+    if not platform.strip():
+        raise ValueError("platform must be a non-empty platform key")
+    if platform != platform.strip():
+        raise ValueError(
+            f"platform {platform!r} has surrounding whitespace, which makes it "
+            f"a different key from {platform.strip()!r} — pass the key without "
+            f"it (it is not stripped for you, so the stored key always stays "
+            f"the one you passed)"
+        )
+    if platform.startswith(PLUGIN_PLATFORM_PREFIX) and not is_plugin_platform_key(
+        platform
+    ):
+        raise ValueError(
+            f"platform {platform!r} is not a usable platform key: a plugin "
+            f"platform key is {PLUGIN_PLATFORM_PREFIX}<distribution> "
+            f"(e.g. {PLUGIN_PLATFORM_PREFIX}mureo-logly-bridge)"
+        )
+
+
+def _reject_account_already_taken(
+    platforms: dict[str, PlatformState],
+    platform: str,
+    account_id: str,
+    *,
+    creating: bool,
+) -> None:
+    """Refuse when ``account_id`` is already stored under a different key.
+
+    ``platforms`` is keyed by an arbitrary string and ``account_id`` was never
+    consulted, so a writer using a different spelling of the same platform
+    silently produced a second entry for one real account — which the reports
+    view then adds to the first (#533).
+
+    ``creating`` only picks the verb in the message: refusing to *create* a
+    key and refusing to *re-point* an existing one at a taken account are the
+    same rule, and the operator needs to be told which of the two they just
+    attempted.
+
+    The join lives in :mod:`mureo.context.platform_accounts` — ``act_``
+    tolerant, and treating an empty ``account_id`` as UNKNOWN rather than as a
+    value, because the tolerant read path synthesizes ``""`` for a missing one.
+    """
+    existing_keys = platform_keys_for_account(platforms, account_id)
+    if not existing_keys:
+        return
+    named = ", ".join(repr(k) for k in existing_keys)
+    what = "create" if creating else "re-point"
+    raise ValueError(
+        f"refusing to {what} platform {platform!r}: account_id "
+        f"{account_id!r} is already stored under platform {named}. Two "
+        f"platform keys for one ad account are summed by the reporting view, "
+        f"so the KPIs would double-count. Write to {existing_keys[0]!r} "
+        f"instead, or repair STATE.json first if these are genuinely "
+        f"different accounts."
+    )
+
+
+def guard_platform_entry_write(
+    platforms: dict[str, PlatformState], platform: str, account_id: str
+) -> None:
+    """Refuse a write that would create a duplicate ad-account entry (#534).
+
+    The four branches below, and the reasoning for each, are set out in this
+    module's docstring — including why branch (3) allows a write that looks
+    like it should be refused, and the one corner this does not defend.
+
+    Raises ``ValueError`` on a rejected write. Called from inside each writer's
+    ``_build``, i.e. under the state lock against the document just read, so a
+    rejection propagates out of ``_locked_state_mutation`` before anything is
+    written.
+    """
+    existing = platforms.get(platform)
+    if existing is None:  # (1) create
+        reject_unusable_platform_key(platform)
+        _reject_account_already_taken(platforms, platform, account_id, creating=True)
+        return
+    if account_ids_match(existing.account_id, account_id):  # (2) plain update
+        return
+    if not normalize_account_id(existing.account_id):  # (3) stamping an id on
+        return
+    # (4) re-point. The stored id differs from the incoming one, so this key
+    # cannot be among the matches — no need to exclude it.
+    _reject_account_already_taken(platforms, platform, account_id, creating=False)
+
+
+def warn_on_duplicate_accounts(path: Path, doc: StateDocument) -> None:
+    """Log one warning per ad account held under two or more platform keys.
+
+    **Detection, not enforcement — this must never reject a write.** A document
+    that already carries a duplicate has to stay writable, or the operator
+    holding that state can neither sync nor repair it. Enforcement cannot live
+    here for a second reason: a whole-document write carries no notion of which
+    entry is "new", so there is nothing to refuse — the create-vs-update
+    distinction only exists in the targeted writers
+    (:func:`guard_platform_entry_write`), which is why they do the refusing.
+
+    What this covers that they cannot: a writer that assembles a complete
+    :class:`~mureo.context.models.StateDocument` itself and writes it wholesale
+    — mureo-agency's digest sync is the observed one — never calls
+    ``upsert_campaign`` / ``set_platform_metrics`` /
+    ``set_conversion_action_types``, so the create-time guard never sees it.
+    Every such writer still funnels through ``write_state_file``
+    (``FilesystemStateStore.write_state`` included), so the duplicate is at
+    least made visible in the log instead of silently double-counting on a
+    client card.
+
+    Warns once per process per ``(path, group)`` — this runs on every write.
+    Never raises: a detection failure must not take down a state write.
+    """
+    try:
+        for group in duplicate_account_entries(doc.platforms):
+            key = (str(path), group)
+            if key in _DUPLICATE_ACCOUNT_WARNED:
+                continue
+            logger.warning(
+                "%s: ad account %s is stored under %d platform keys (%s). The "
+                "reporting view sums every entry, so this account's spend / "
+                "conversions / CPA are double-counted. Keep one key per ad "
+                "account; mureo does not merge or drop either entry because "
+                "they may hold different partial figures.",
+                path,
+                group.account_id,
+                len(group.platform_keys),
+                ", ".join(group.platform_keys),
+            )
+            if len(_DUPLICATE_ACCOUNT_WARNED) >= _DUPLICATE_ACCOUNT_WARN_LATCH_MAX:
+                # Bounded, and biased towards visibility: a cleared latch
+                # re-warns, it never goes quiet.
+                _DUPLICATE_ACCOUNT_WARNED.clear()
+            _DUPLICATE_ACCOUNT_WARNED.add(key)
+    except Exception:  # noqa: BLE001 — a detection hint must never break a write
+        logger.debug("duplicate-account detection failed", exc_info=True)
+
+
+__all__ = [
+    "guard_platform_entry_write",
+    "reject_unusable_platform_key",
+    "warn_on_duplicate_accounts",
+]

--- a/mureo/context/state.py
+++ b/mureo/context/state.py
@@ -24,6 +24,11 @@ from mureo.context.models import (
     PlatformState,
     StateDocument,
 )
+from mureo.context.platform_accounts import account_ids_match
+from mureo.context.platform_guards import (
+    guard_platform_entry_write,
+    warn_on_duplicate_accounts,
+)
 from mureo.fsutil import file_lock
 
 logger = logging.getLogger(__name__)
@@ -459,7 +464,13 @@ def read_state_file(path: Path, *, strict: bool = True) -> StateDocument:
 
 
 def write_state_file(path: Path, doc: StateDocument) -> None:
-    """Atomically write a StateDocument to a STATE.json file."""
+    """Atomically write a StateDocument to a STATE.json file.
+
+    Also emits the advisory duplicate-account warning (#534) — see
+    :func:`mureo.context.platform_guards.warn_on_duplicate_accounts`. The write
+    proceeds regardless.
+    """
+    warn_on_duplicate_accounts(path, doc)
     text = render_state(doc)
     _atomic_write(path, text)
 
@@ -578,6 +589,12 @@ def upsert_campaign(
 
     Returns:
         The updated :class:`StateDocument`.
+
+    Raises:
+        ValueError: ``platform`` is not a usable platform key, or the write
+            would create a SECOND key for an account another key already
+            holds (see
+            :func:`mureo.context.platform_guards.guard_platform_entry_write`).
     """
 
     def _build(doc: StateDocument) -> StateDocument:
@@ -588,6 +605,7 @@ def upsert_campaign(
         # entry exists, carries the (required) account_id, and holds the
         # campaign.
         platforms = dict(doc.platforms) if doc.platforms else {}
+        guard_platform_entry_write(platforms, platform, account_id)
         existing = platforms.get(platform)
         platforms[platform] = PlatformState(
             account_id=account_id,
@@ -735,10 +753,17 @@ def set_platform_metrics(
 
     Returns:
         The updated :class:`StateDocument`.
+
+    Raises:
+        ValueError: ``platform`` is not a usable platform key, or the write
+            would create a SECOND key for an account another key already
+            holds (see
+            :func:`mureo.context.platform_guards.guard_platform_entry_write`).
     """
 
     def _build(doc: StateDocument) -> StateDocument:
         platforms = dict(doc.platforms) if doc.platforms else {}
+        guard_platform_entry_write(platforms, platform, account_id)
         existing = platforms.get(platform)
 
         merged_periods: dict[str, dict[str, Any]] | None
@@ -817,6 +842,12 @@ def set_conversion_action_types(
 
     Returns:
         The updated :class:`StateDocument`.
+
+    Raises:
+        ValueError: ``platform`` is not a usable platform key, or the write
+            would create a SECOND key for an account another key already
+            holds (see
+            :func:`mureo.context.platform_guards.guard_platform_entry_write`).
     """
     cleaned: tuple[str, ...] | None = None
     if conversion_action_types:
@@ -829,6 +860,7 @@ def set_conversion_action_types(
 
     def _build(doc: StateDocument) -> StateDocument:
         platforms = dict(doc.platforms) if doc.platforms else {}
+        guard_platform_entry_write(platforms, platform, account_id)
         existing = platforms.get(platform)
         platforms[platform] = PlatformState(
             account_id=account_id,
@@ -880,17 +912,6 @@ def _workspace_state_path() -> Path:
     return _Path("STATE.json")
 
 
-def _account_id_eq(a: str, b: str) -> bool:
-    """Compare Meta account ids tolerant of the optional ``act_`` prefix (#342).
-
-    The MCP setter stores whatever id the operator/agent passed; the live
-    counters resolve with the ``act_*`` form the client enforces. Comparing
-    after stripping a leading ``act_`` keeps a bare-numeric override from
-    silently never matching.
-    """
-    return a.removeprefix("act_") == b.removeprefix("act_")
-
-
 def load_conversion_action_types(
     account_id: str,
     *,
@@ -903,6 +924,12 @@ def load_conversion_action_types(
     it is set AND the entry's ``account_id`` matches ``account_id`` (tolerant
     of the ``act_`` prefix); otherwise ``None`` so the conversion counters fall
     back to the built-in generic set.
+
+    An **unknown** id on either side never matches (#536) — see
+    :func:`~mureo.context.platform_accounts.account_ids_match`. An override
+    applied to the wrong account silently redefines what counts as a
+    conversion for it, so falling back to the built-in set is the safe
+    direction.
 
     Reads the ACTIVE workspace ``STATE.json`` (resolved via the runtime context
     — the same file the MCP state tools write to). **Never raises**: a missing
@@ -924,11 +951,10 @@ def load_conversion_action_types(
     entry = doc.platforms.get(platform)
     if entry is None or not entry.conversion_action_types:
         return None
-    if (
-        entry.account_id
-        and account_id
-        and not _account_id_eq(entry.account_id, account_id)
-    ):
+    # Fail closed on an unknown id (#536), via the SHARED join so the
+    # override's read side and the duplicate guard's write side cannot
+    # disagree about what "the same account" means.
+    if not account_ids_match(entry.account_id, account_id):
         return None
     return entry.conversion_action_types
 

--- a/mureo/mcp/_helpers.py
+++ b/mureo/mcp/_helpers.py
@@ -58,10 +58,18 @@ async def _close_clients(bucket: list[Any]) -> None:
 
 
 def _require(arguments: dict[str, Any], key: str) -> Any:
-    """Retrieve a required parameter. Raises ValueError if missing."""
+    """Retrieve a required parameter. Raises ValueError if missing or empty.
+
+    The two cases get distinct messages (#534): "not specified" is misleading
+    for a parameter that WAS specified as ``""``, and it sends the caller
+    looking for a missing argument instead of an empty one. Both still fail
+    before any write.
+    """
     value = arguments.get(key)
-    if value is None or value == "":
+    if value is None:
         raise ValueError(f"Required parameter {key} is not specified")
+    if value == "":
+        raise ValueError(f"Required parameter {key} must not be empty")
     return value
 
 

--- a/mureo/mcp/tools_mureo_context.py
+++ b/mureo/mcp/tools_mureo_context.py
@@ -188,16 +188,27 @@ _CAMPAIGN_PROPERTY = {
         "status": {"type": "string"},
         "platform": {
             "type": "string",
+            # No enum: a valid key includes ``plugin:<dist>`` for any installed
+            # bridge, which no fixed list can enumerate. minLength is the
+            # constraint that IS always true.
+            "minLength": 1,
             "description": (
                 "Platform key this campaign belongs to, e.g. "
-                "``google_ads`` / ``meta_ads``."
+                "``google_ads`` / ``meta_ads`` / ``tiktok_ads``, or a plugin "
+                "bridge ``plugin:<dist>``. Use the SAME key the account is "
+                "already stored under — one ad account has exactly one "
+                "platform key, and a second key for an account another key "
+                "already holds is REJECTED (the reporting view sums the "
+                "entries, so it would double-count)."
             ),
         },
         "account_id": {
             "type": "string",
+            "minLength": 1,
             "description": (
                 "Platform account id (Google ``customer_id`` / Meta "
-                "``act_*``) written onto the platform entry."
+                "``act_*``) written onto the platform entry, and used to "
+                "detect a second entry for the same account."
             ),
         },
         "bidding_strategy_type": {"type": "string"},
@@ -432,17 +443,28 @@ TOOLS: list[Tool] = [
             "properties": {
                 "platform": {
                     "type": "string",
+                    # No enum: a valid key includes ``plugin:<dist>`` for any
+                    # installed bridge, which no fixed list can enumerate.
+                    # minLength is the constraint that IS always true.
+                    "minLength": 1,
                     "description": (
                         "Platform key: a built-in (``google_ads`` / "
-                        "``meta_ads`` / ``search_console`` / ``ga4``) or a "
-                        "plugin bridge ``plugin:<dist>``."
+                        "``meta_ads`` / ``tiktok_ads`` / ``search_console`` / "
+                        "``ga4``) or a plugin bridge ``plugin:<dist>``. Use "
+                        "the SAME key the account is already stored under — "
+                        "one ad account has exactly one platform key, and a "
+                        "second key for an account another key already holds "
+                        "is REJECTED (the reporting view sums the entries, so "
+                        "it would double-count)."
                     ),
                 },
                 "account_id": {
                     "type": "string",
+                    "minLength": 1,
                     "description": (
                         "The platform account id (Google customer_id / Meta "
-                        "act_*). Always written onto the platform entry."
+                        "act_*). Always written onto the platform entry, and "
+                        "used to detect a second entry for the same account."
                     ),
                 },
                 "totals": {
@@ -501,16 +523,26 @@ TOOLS: list[Tool] = [
             "properties": {
                 "platform": {
                     "type": "string",
+                    # No enum: see mureo_state_platform_metrics_set.
+                    "minLength": 1,
                     "description": (
                         "Platform key — normally ``meta_ads`` (the override "
-                        "only affects the Meta conversion counters)."
+                        "only affects the Meta conversion counters). Use the "
+                        "SAME key the account is already stored under — one "
+                        "ad account has exactly one platform key, and a "
+                        "second key for an account another key already holds "
+                        "is REJECTED (the reporting view sums the entries, so "
+                        "it would double-count)."
                     ),
                 },
                 "account_id": {
                     "type": "string",
+                    "minLength": 1,
                     "description": (
                         "The Meta ad account id (``act_*``). Always written "
-                        "onto the platform entry."
+                        "onto the platform entry, and used to detect a second "
+                        "entry for the same account. The override applies "
+                        "ONLY to this account."
                     ),
                 },
                 "conversion_action_types": {

--- a/skills/_mureo-meta-ads/SKILL.md
+++ b/skills/_mureo-meta-ads/SKILL.md
@@ -271,6 +271,13 @@ for that account; never summed on top of the defaults). It is stored on
 `platforms[meta_ads]` in STATE.json and applied by every Meta conversion
 counter. Pass an empty list to clear it and restore the default.
 
+The override is **scoped to the `account_id` on that entry** and applies only
+to it. If the entry carries no `account_id` (or an empty one — possible only in
+a hand-authored / externally written STATE.json), the override is **ignored**
+and the built-in generic set is used: an override belonging to an
+unidentifiable account must never redefine what counts as a conversion for a
+different one.
+
 ### analysis
 
 - `performance` -- Analyze overall performance trends.

--- a/skills/_mureo-shared/SKILL.md
+++ b/skills/_mureo-shared/SKILL.md
@@ -328,8 +328,26 @@ shows fewer campaigns than you wrote — get these exact names right:
   `device_targeting`, and `metrics` (the per-campaign performance object:
   `spend` / `impressions` / `clicks` / `conversions` / `cpa` / `ctr` / …).
 - **Platform entry** (`platforms[<platform>]`) — required: `account_id` (str;
-  use `""` only if genuinely unknown). Plus `campaigns[]` and the rollups the
-  dashboard actually renders: `totals`, `metrics_period`, `periods[<window>]`.
+  use `""` only if genuinely unknown — an empty id is treated as *unknown*
+  everywhere, so it never joins with another entry and never matches a
+  per-account override). Plus `campaigns[]` and the rollups the dashboard
+  actually renders: `totals`, `metrics_period`, `periods[<window>]`.
+  **One ad account has exactly one platform key.** Before writing an entry,
+  check whether that `account_id` is already stored under a *different* key
+  and write to that key instead — the reporting view sums every entry, so two
+  keys for one account inflate spend / conversions / CPA together. The
+  `mureo_state_*` write tools now **reject** a write that would create the
+  second key (naming both keys and the account); on the Code `Write` path the
+  same rule is yours to honour, and a wholesale `Write` that lands a duplicate
+  is logged as a warning rather than blocked. Pass the key exactly — a key with
+  surrounding whitespace (`" google_ads"`) is a *different* key, and is
+  rejected on create rather than silently stripped. If a document already
+  carries the duplicate pair, writes to the *existing* keys still succeed —
+  mureo never merges or deletes an entry, because the two typically hold
+  different partial figures; reconciling them is the operator's call. Changing
+  an existing key's `account_id` to one another key already holds is rejected
+  for the same reason (it creates the duplicate just as surely); pointing a
+  key at an account nobody else holds is fine.
 - **Top-level** — required: `last_synced_at` (ISO-8601 string, **stamped to
   _now_** by every campaign/metrics/report write). It drives the dashboard's
   "Synced N ago" freshness; a missing or stale value makes the data read as

--- a/skills/_mureo-strategy/SKILL.md
+++ b/skills/_mureo-strategy/SKILL.md
@@ -400,6 +400,16 @@ and/or `periods` for the per-window map. `periods` is merged per window key, so
 writing `YESTERDAY` never clobbers a prior `LAST_30_DAYS` bucket (and vice
 versa); omitted fields preserve their existing value.
 
+**One ad account, one platform key.** The rollup is written under the
+`platforms` key you pass, and the reporting view sums every entry — so an
+account stored under two keys double-counts spend, conversions and CPA. Pass
+the key the account is already stored under; a write that would create a
+*second* key for an `account_id` another key already holds is rejected, naming
+both keys. Existing entries are never merged or deleted (they usually hold
+different partial figures), so writes to a key that already exists always
+succeed and reconciling a duplicated document stays the operator's call. See
+`../_mureo-shared/SKILL.md` → *STATE.json Schema*.
+
 ### Reports section
 
 `reports` (top-level, optional) holds the latest agent-written summary per

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,28 @@
+"""Session-wide fixtures for the whole test suite."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_duplicate_account_warn_latch():
+    """Clear the process-wide duplicate-account warn-once latch (#534).
+
+    ``mureo.context.platform_guards`` suppresses a repeat warning for a
+    ``(state file, duplicate group)`` pair it has already reported. That is
+    correct in production and a test-isolation hazard here: ANY test that
+    writes a duplicated document — several do so incidentally, e.g. while
+    proving that an already-duplicated document stays writable — arms the
+    latch, and a later test asserting on the warning would then see nothing,
+    with the outcome depending on collection order.
+
+    Autouse and defined in the root ``conftest.py`` on purpose: a per-class
+    fixture only protects the class that remembers to add one, which is
+    exactly the failure mode this replaces.
+    """
+    from mureo.context import platform_guards
+
+    platform_guards._DUPLICATE_ACCOUNT_WARNED.clear()
+    yield
+    platform_guards._DUPLICATE_ACCOUNT_WARNED.clear()

--- a/tests/test_mcp_tools_mureo_context.py
+++ b/tests/test_mcp_tools_mureo_context.py
@@ -716,6 +716,123 @@ async def test_platform_metrics_set_requires_platform_and_account(cwd_to_tmp) ->
         )
 
 
+def _metrics_schema() -> dict:
+    mod = _import_tools()
+    tool = next(t for t in mod.TOOLS if t.name == "mureo_state_platform_metrics_set")
+    return tool.inputSchema
+
+
+def _platform_account_props(tool_name: str) -> dict:
+    """The ``platform`` / ``account_id`` properties of a state-write tool,
+    wherever the tool nests them."""
+    mod = _import_tools()
+    tool = next(t for t in mod.TOOLS if t.name == tool_name)
+    props = tool.inputSchema["properties"]
+    if "campaign" in props:  # mureo_state_upsert_campaign nests them
+        props = props["campaign"]["properties"]
+    return props
+
+
+def test_platform_metrics_schema_documents_tiktok_ads() -> None:
+    """#534 — ``tiktok_ads`` is a first-class ad-platform key (the reporting
+    view treats it as one), so the tool that writes platform rollups must
+    name it."""
+    platform = _metrics_schema()["properties"]["platform"]
+    assert "tiktok_ads" in platform["description"]
+
+
+def test_platform_metrics_schema_constrains_non_empty_strings() -> None:
+    """#534 — a bare ``{"type": "string"}`` accepts ``""``. An enum would
+    reject a valid ``plugin:<dist>`` key, so the genuinely correct constraint
+    is a minimum length."""
+    props = _metrics_schema()["properties"]
+    assert props["platform"]["minLength"] == 1
+    assert props["account_id"]["minLength"] == 1
+
+
+@pytest.mark.parametrize(
+    "tool_name",
+    [
+        "mureo_state_platform_metrics_set",
+        "mureo_state_upsert_campaign",
+        "mureo_state_set_conversion_events",
+    ],
+)
+def test_every_state_write_tool_states_the_one_account_one_key_rule(
+    tool_name: str,
+) -> None:
+    """#534 — the runtime guard covers all three writers, so all three schemas
+    must say so; an inconsistent one just teaches the next reader the wrong
+    rule."""
+    props = _platform_account_props(tool_name)
+    assert props["platform"]["minLength"] == 1
+    assert props["account_id"]["minLength"] == 1
+    assert "one platform key" in props["platform"]["description"]
+
+
+async def test_platform_metrics_set_rejects_explicit_empty_account_id(
+    cwd_to_tmp,
+) -> None:
+    """#534 — an explicitly-passed ``""`` must not be reported as "not
+    specified"; it WAS specified. Still fail-before-write.
+
+    This is the DIRECT-handler path (no schema gate) — see
+    ``test_empty_account_id_through_the_real_dispatcher`` for what an MCP
+    client actually sees.
+    """
+    mod = _import_tools()
+    with pytest.raises(ValueError, match="account_id must not be empty"):
+        await mod.handle_tool(
+            "mureo_state_platform_metrics_set",
+            {"platform": "google_ads", "account_id": ""},
+        )
+    assert not (cwd_to_tmp / "STATE.json").exists()
+
+
+async def test_empty_account_id_through_the_real_dispatcher(cwd_to_tmp) -> None:
+    """What an MCP CLIENT observes for ``account_id=""``.
+
+    ``handle_call_tool`` schema-validates against the declared ``inputSchema``
+    before any handler runs, so the ``minLength: 1`` constraint fires first and
+    the handler's own message is never reached on this path. Asserted here so
+    the schema and the docs describe the message that is actually emitted.
+    """
+    from mureo.mcp import server as server_mod
+
+    with pytest.raises(ValueError) as exc:
+        await server_mod.handle_call_tool(
+            "mureo_state_platform_metrics_set",
+            {"platform": "google_ads", "account_id": ""},
+        )
+    message = str(exc.value)
+    assert "account_id" in message
+    assert "non-empty" in message
+    assert not (cwd_to_tmp / "STATE.json").exists()
+
+
+async def test_platform_metrics_set_rejects_a_duplicate_account(cwd_to_tmp) -> None:
+    """#534 — the second key for one ad account is refused through the tool
+    surface too, naming both keys and the account."""
+    mod = _import_tools()
+    await mod.handle_tool(
+        "mureo_state_platform_metrics_set",
+        {"platform": "meta_ads", "account_id": "act_1", "totals": {"spend": 1.0}},
+    )
+    with pytest.raises(ValueError) as exc:
+        await mod.handle_tool(
+            "mureo_state_platform_metrics_set",
+            {
+                "platform": "plugin:mureo-logly-bridge",
+                "account_id": "act_1",
+                "totals": {"spend": 2.0},
+            },
+        )
+    message = str(exc.value)
+    assert "meta_ads" in message
+    assert "plugin:mureo-logly-bridge" in message
+    assert "act_1" in message
+
+
 async def test_platform_metrics_set_rejects_malformed_shapes(cwd_to_tmp) -> None:
     mod = _import_tools()
     base = {"platform": "google_ads", "account_id": "act_123"}

--- a/tests/test_platform_accounts.py
+++ b/tests/test_platform_accounts.py
@@ -1,0 +1,182 @@
+"""The shared one-account-one-platform-key join (#533 / #534).
+
+This is the single source of the rule for THREE consumers — the STATE.json
+write guards, the read-only Reports view that surfaces an existing conflict,
+and out-of-tree writers (mureo-agency) that assemble a whole ``StateDocument``
+themselves. Reimplementing the join in any of them would let it drift, and
+drift here re-creates the double-counting bug, so its public surface is pinned
+here.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mureo.context.models import PlatformState
+from mureo.context.platform_accounts import (
+    DuplicateAccountEntry,
+    account_ids_match,
+    duplicate_account_entries,
+    normalize_account_id,
+    platform_keys_for_account,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _platforms(**pairs: str) -> dict[str, PlatformState]:
+    return {key: PlatformState(account_id=acct) for key, acct in pairs.items()}
+
+
+# ---------------------------------------------------------------------------
+# normalize_account_id / account_ids_match
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_folds_the_act_prefix_and_surrounding_space() -> None:
+    assert normalize_account_id("act_123") == "123"
+    assert normalize_account_id("123") == "123"
+    assert normalize_account_id("  act_123  ") == "123"
+
+
+def test_normalize_of_an_unknown_id_is_empty() -> None:
+    """An empty / whitespace-only id means UNKNOWN, not a value."""
+    assert normalize_account_id("") == ""
+    assert normalize_account_id("   ") == ""
+
+
+def test_match_is_tolerant_of_the_act_prefix() -> None:
+    assert account_ids_match("act_123", "123")
+    assert account_ids_match("123", "act_123")
+    assert not account_ids_match("123", "456")
+
+
+def test_an_unknown_id_never_matches_anything_including_another_unknown() -> None:
+    assert not account_ids_match("", "")
+    assert not account_ids_match("", "act_1")
+    assert not account_ids_match("act_1", "")
+    assert not account_ids_match("   ", "   ")
+
+
+# ---------------------------------------------------------------------------
+# platform_keys_for_account
+# ---------------------------------------------------------------------------
+
+
+def test_platform_keys_for_account_finds_every_key_in_document_order() -> None:
+    platforms = _platforms(meta_ads="act_1", google_ads="999")
+    platforms["plugin:mureo-logly-bridge"] = PlatformState(account_id="1")
+    assert platform_keys_for_account(platforms, "act_1") == (
+        "meta_ads",
+        "plugin:mureo-logly-bridge",
+    )
+
+
+def test_platform_keys_for_account_ignores_unknown_ids() -> None:
+    platforms = _platforms(legacy="", meta_ads="act_1")
+    assert platform_keys_for_account(platforms, "") == ()
+    assert platform_keys_for_account(platforms, "act_1") == ("meta_ads",)
+
+
+def test_platform_keys_for_account_accepts_none() -> None:
+    assert platform_keys_for_account(None, "act_1") == ()
+
+
+# ---------------------------------------------------------------------------
+# duplicate_account_entries
+# ---------------------------------------------------------------------------
+
+
+def test_no_duplicates_yields_nothing() -> None:
+    assert duplicate_account_entries(_platforms(meta_ads="act_1", ga="999")) == ()
+    assert duplicate_account_entries(None) == ()
+    assert duplicate_account_entries({}) == ()
+
+
+def test_two_keys_for_one_account_are_grouped() -> None:
+    platforms = _platforms(meta_ads="act_1")
+    platforms["plugin:mureo-logly-bridge"] = PlatformState(account_id="1")
+    groups = duplicate_account_entries(platforms)
+    assert groups == (
+        DuplicateAccountEntry(
+            account_id="act_1",
+            platform_keys=("meta_ads", "plugin:mureo-logly-bridge"),
+        ),
+    )
+    # The reported account_id is the one AS STORED on the first key, so an
+    # operator can find it in the file.
+    assert groups[0].account_id == "act_1"
+
+
+def test_three_keys_for_one_account_form_one_group() -> None:
+    platforms = _platforms(a="act_1", b="1", c="act_1")
+    groups = duplicate_account_entries(platforms)
+    assert len(groups) == 1
+    assert groups[0].platform_keys == ("a", "b", "c")
+
+
+def test_unknown_ids_are_never_grouped_with_each_other() -> None:
+    """Two entries that both omitted account_id are not "the same account"."""
+    platforms = _platforms(legacy_one="", legacy_two="", blank="   ")
+    assert duplicate_account_entries(platforms) == ()
+
+
+def test_the_group_is_hashable_so_it_can_latch_a_warn_once() -> None:
+    platforms = _platforms(meta_ads="act_1", other="act_1")
+    (group,) = duplicate_account_entries(platforms)
+    assert {group, group} == {group}
+
+
+# ---------------------------------------------------------------------------
+# Hostile input — this module is consumed out-of-tree
+# ---------------------------------------------------------------------------
+
+
+def test_a_non_string_id_is_folded_textually_not_raised_on() -> None:
+    """A hand-edited ``"account_id": 12345`` (a JSON number) must not blow up
+    a detection helper.
+
+    mureo-agency assembles ``PlatformState`` from loosely-typed sources, so a
+    non-``str`` id is a question of when, not if. Coercing textually keeps the
+    duplicate DETECTABLE — raising from inside a write guard would surface as
+    the wrong exception type from an unrelated call.
+    """
+    assert normalize_account_id(12345) == "12345"  # type: ignore[arg-type]
+    assert account_ids_match(12345, "12345")  # type: ignore[arg-type]
+    assert account_ids_match("act_12345", 12345)  # type: ignore[arg-type]
+
+
+def test_none_is_unknown_not_the_string_none() -> None:
+    """``str(None)`` would join every id-less entry under a bogus "None"."""
+    assert normalize_account_id(None) == ""  # type: ignore[arg-type]
+    assert not account_ids_match(None, None)  # type: ignore[arg-type]
+
+
+def test_a_non_string_id_in_a_document_is_grouped_not_raised_on() -> None:
+    platforms = {
+        "meta_ads": PlatformState(account_id=12345),  # type: ignore[arg-type]
+        "plugin:x": PlatformState(account_id="12345"),
+    }
+    (group,) = duplicate_account_entries(platforms)
+    assert group.platform_keys == ("meta_ads", "plugin:x")
+
+
+# ---------------------------------------------------------------------------
+# Case sensitivity
+# ---------------------------------------------------------------------------
+
+
+def test_the_act_prefix_folds_case_insensitively() -> None:
+    """Only the PREFIX folds — a hand-typed ``ACT_1`` is the same account."""
+    assert normalize_account_id("ACT_1") == "1"
+    assert normalize_account_id("Act_1") == "1"
+    assert account_ids_match("ACT_1", "act_1")
+    assert account_ids_match("ACT_1", "1")
+
+
+def test_the_id_body_stays_case_sensitive() -> None:
+    """Deliberate: real ad account ids are numeric, but a plugin platform may
+    use a case-significant alphanumeric id, and folding the whole string would
+    join two genuinely different accounts."""
+    assert normalize_account_id("AbC") == "AbC"
+    assert not account_ids_match("AbC", "abc")

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1884,6 +1884,527 @@ class TestConversionActionTypesOverride:
         # Live counters resolve with the act_* form.
         assert load_conversion_action_types("act_123456", path=p) == ("lead",)
 
+    def _state_with_override(self, tmp_path: Path, *, account_id: str) -> Path:
+        """A hand-authored / externally written STATE.json carrying an override.
+
+        Written as raw JSON rather than through ``set_conversion_action_types``
+        because the MCP write path blocks an empty ``account_id`` — the only
+        way an entry reaches ``load_conversion_action_types`` with one is a
+        file mureo did not write (#536).
+        """
+        p = tmp_path / "STATE.json"
+        p.write_text(
+            json.dumps(
+                {
+                    "version": "2",
+                    "platforms": {
+                        "meta_ads": {
+                            "account_id": account_id,
+                            "campaigns": [],
+                            "conversion_action_types": ["lead"],
+                        }
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        return p
+
+    def test_empty_stored_account_id_never_matches(self, tmp_path: Path) -> None:
+        """#536 — an entry whose ``account_id`` is empty must not hand its
+        override to every account on the platform.
+
+        The override redefines what counts as a conversion, so applying one
+        recorded for an unknown account to an unrelated account silently
+        miscounts its CV/CPA. An unknown id fails closed: the counters fall
+        back to the documented built-in generic set.
+        """
+        from mureo.context.state import load_conversion_action_types
+
+        p = self._state_with_override(tmp_path, account_id="")
+        assert load_conversion_action_types("act_1", path=p) is None
+        assert load_conversion_action_types("act_2", path=p) is None
+
+    def test_missing_stored_account_id_never_matches(self, tmp_path: Path) -> None:
+        """#536 — the tolerant read path synthesizes ``""`` for a missing
+        ``account_id``, which must be "unknown", never a join key."""
+        from mureo.context.state import load_conversion_action_types
+
+        p = tmp_path / "STATE.json"
+        p.write_text(
+            json.dumps(
+                {
+                    "version": "2",
+                    "platforms": {
+                        "meta_ads": {
+                            "campaigns": [],
+                            "conversion_action_types": ["lead"],
+                        }
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        assert load_conversion_action_types("act_1", path=p) is None
+
+    def test_empty_requested_account_id_never_matches(self, tmp_path: Path) -> None:
+        """#536 — the second conjunct was symmetrically broken: a caller
+        passing ``""`` received another account's override."""
+        from mureo.context.state import load_conversion_action_types
+
+        p = self._state_with_override(tmp_path, account_id="act_1")
+        assert load_conversion_action_types("", path=p) is None
+
+    def test_control_known_ids_still_match_and_mismatch(self, tmp_path: Path) -> None:
+        """#536 control — the fix must not break the matching case."""
+        from mureo.context.state import load_conversion_action_types
+
+        p = self._state_with_override(tmp_path, account_id="act_1")
+        assert load_conversion_action_types("act_1", path=p) == ("lead",)
+        assert load_conversion_action_types("act_2", path=p) is None
+
+
+# ---------------------------------------------------------------------------
+# #534 — one ad account, one platform key
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDuplicateAccountEntryGuard:
+    """#534 — a write that would create a SECOND platform key for an ad account
+    already stored under another key is rejected.
+
+    The guard lives in the state layer rather than only in the MCP handler
+    because the writer that produced the observed duplicate writes through
+    these functions directly and never passes MCP validation.
+    """
+
+    def _seed(self, tmp_path: Path, platform: str, account_id: str) -> Path:
+        path = tmp_path / "STATE.json"
+        set_platform_metrics(path, platform, account_id, totals={"spend": 1.0})
+        return path
+
+    def test_second_key_for_the_same_account_is_rejected(self, tmp_path: Path) -> None:
+        path = self._seed(tmp_path, "meta_ads", "act_1")
+        with pytest.raises(ValueError) as exc:
+            set_platform_metrics(
+                path, "plugin:mureo-logly-bridge", "act_1", totals={"spend": 2.0}
+            )
+        message = str(exc.value)
+        # Names BOTH keys and the account so the operator can repair it.
+        assert "plugin:mureo-logly-bridge" in message
+        assert "meta_ads" in message
+        assert "act_1" in message
+        # Fail-before-write: no second entry landed.
+        assert set(read_state_file(path).platforms) == {"meta_ads"}
+
+    def test_non_canonical_and_canonical_plugin_key_collide(
+        self, tmp_path: Path
+    ) -> None:
+        """The registry-name spelling and the canonical ``plugin:<dist>`` key
+        are two keys for one account — exactly the #533 ingress."""
+        path = self._seed(tmp_path, "mureo-logly-bridge", "act_1")
+        with pytest.raises(ValueError, match="mureo-logly-bridge"):
+            set_platform_metrics(
+                path, "plugin:mureo-logly-bridge", "act_1", totals={"spend": 2.0}
+            )
+
+    def test_act_prefix_variants_are_the_same_account(self, tmp_path: Path) -> None:
+        path = self._seed(tmp_path, "meta_ads", "123456")
+        with pytest.raises(ValueError, match="123456"):
+            set_platform_metrics(path, "plugin:x", "act_123456", totals={"spend": 2.0})
+
+    def test_update_of_an_existing_entry_always_succeeds(self, tmp_path: Path) -> None:
+        """An operator whose document ALREADY holds the duplicate pair must
+        still be able to sync — rejecting their updates would strand them with
+        state they cannot fix."""
+        path = tmp_path / "STATE.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "version": "2",
+                    "platforms": {
+                        "meta_ads": {"account_id": "act_1", "campaigns": []},
+                        "plugin:mureo-logly-bridge": {
+                            "account_id": "act_1",
+                            "campaigns": [],
+                        },
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        doc = set_platform_metrics(path, "meta_ads", "act_1", totals={"spend": 9.0})
+        assert doc.platforms["meta_ads"].totals == {"spend": 9.0}
+        doc = set_platform_metrics(
+            path, "plugin:mureo-logly-bridge", "act_1", totals={"spend": 8.0}
+        )
+        assert doc.platforms["plugin:mureo-logly-bridge"].totals == {"spend": 8.0}
+        # Neither entry was deleted or merged — repair is the operator's call.
+        assert set(doc.platforms) == {"meta_ads", "plugin:mureo-logly-bridge"}
+
+    def test_different_accounts_under_different_keys_are_fine(
+        self, tmp_path: Path
+    ) -> None:
+        path = self._seed(tmp_path, "google_ads", "123")
+        doc = set_platform_metrics(path, "meta_ads", "act_9", totals={"spend": 2.0})
+        assert set(doc.platforms) == {"google_ads", "meta_ads"}
+
+    def test_empty_stored_account_id_never_joins(self, tmp_path: Path) -> None:
+        """``""`` is "unknown", not a value that equals another ``""``."""
+        path = tmp_path / "STATE.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "version": "2",
+                    "platforms": {"legacy": {"account_id": "", "campaigns": []}},
+                }
+            ),
+            encoding="utf-8",
+        )
+        doc = set_platform_metrics(path, "meta_ads", "act_1", totals={"spend": 1.0})
+        assert set(doc.platforms) == {"legacy", "meta_ads"}
+
+    def test_empty_incoming_account_id_never_joins(self, tmp_path: Path) -> None:
+        path = tmp_path / "STATE.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "version": "2",
+                    "platforms": {"legacy": {"account_id": "", "campaigns": []}},
+                }
+            ),
+            encoding="utf-8",
+        )
+        doc = set_platform_metrics(path, "meta_ads", "", totals={"spend": 1.0})
+        assert set(doc.platforms) == {"legacy", "meta_ads"}
+
+    def test_upsert_campaign_shares_the_guard(self, tmp_path: Path) -> None:
+        """Same key-only get-then-overwrite shape, same ingress."""
+        path = self._seed(tmp_path, "meta_ads", "act_1")
+        with pytest.raises(ValueError, match="meta_ads"):
+            upsert_campaign(
+                path,
+                CampaignSnapshot(campaign_id="c1", campaign_name="C1", status="ACTIVE"),
+                platform="plugin:mureo-logly-bridge",
+                account_id="act_1",
+            )
+        assert set(read_state_file(path).platforms) == {"meta_ads"}
+
+    def test_set_conversion_action_types_shares_the_guard(self, tmp_path: Path) -> None:
+        from mureo.context.state import set_conversion_action_types
+
+        path = self._seed(tmp_path, "meta_ads", "act_1")
+        with pytest.raises(ValueError, match="meta_ads"):
+            set_conversion_action_types(
+                path, "plugin:mureo-logly-bridge", "act_1", ["lead"]
+            )
+        assert set(read_state_file(path).platforms) == {"meta_ads"}
+
+    def test_rejects_a_platform_key_that_is_not_a_key(self, tmp_path: Path) -> None:
+        """An empty / whitespace-only key, and a plugin key carrying no
+        distribution (``"plugin:"``), are not usable keys."""
+        path = tmp_path / "STATE.json"
+        for bad in ("", "   ", "plugin:"):
+            with pytest.raises(ValueError, match="platform"):
+                set_platform_metrics(path, bad, "act_1", totals={"spend": 1.0})
+        assert not path.exists()
+
+    def test_a_canonical_plugin_key_is_written_verbatim(self, tmp_path: Path) -> None:
+        """The write path never rewrites the key the operator passed."""
+        path = tmp_path / "STATE.json"
+        doc = set_platform_metrics(
+            path, "plugin:mureo-logly-bridge", "act_1", totals={"spend": 1.0}
+        )
+        assert set(doc.platforms) == {"plugin:mureo-logly-bridge"}
+
+    # -- re-pointing an EXISTING key at a different account -----------------
+    #
+    # "Create" is not "the key is absent". Reusing a key while changing which
+    # account it describes manufactures a brand-new duplicate through the
+    # guarded functions themselves, which is how the first cut of this guard
+    # leaked.
+
+    def test_repointing_a_key_onto_a_taken_account_is_rejected(
+        self, tmp_path: Path
+    ) -> None:
+        path = tmp_path / "STATE.json"
+        set_platform_metrics(path, "google_ads", "act_2", totals={"spend": 1.0})
+        set_platform_metrics(path, "meta_ads", "act_1", totals={"spend": 1.0})
+        # meta_ads exists, but re-pointing it at act_2 would make TWO keys for
+        # act_2 — a create in every sense that matters.
+        with pytest.raises(ValueError) as exc:
+            set_platform_metrics(path, "meta_ads", "act_2", totals={"spend": 5.0})
+        message = str(exc.value)
+        assert "meta_ads" in message
+        assert "google_ads" in message
+        assert "act_2" in message
+        stored = {k: v.account_id for k, v in read_state_file(path).platforms.items()}
+        assert stored == {"google_ads": "act_2", "meta_ads": "act_1"}
+
+    def test_repointing_a_key_onto_a_free_account_is_allowed(
+        self, tmp_path: Path
+    ) -> None:
+        """Re-pointing at an account nobody else holds is a legitimate move
+        (an operator switching which account a platform tracks)."""
+        path = tmp_path / "STATE.json"
+        set_platform_metrics(path, "meta_ads", "act_1", totals={"spend": 1.0})
+        doc = set_platform_metrics(path, "meta_ads", "act_9", totals={"spend": 5.0})
+        assert doc.platforms["meta_ads"].account_id == "act_9"
+
+    def test_a_plain_update_keeps_working(self, tmp_path: Path) -> None:
+        """Branch 1: the stored id MATCHES the incoming one — nothing about
+        identity changes, so the write is a plain update."""
+        path = tmp_path / "STATE.json"
+        set_platform_metrics(path, "meta_ads", "123456", totals={"spend": 1.0})
+        # act_-tolerant: the same account in the other spelling is still a
+        # plain update, not a re-point.
+        doc = set_platform_metrics(path, "meta_ads", "act_123456", totals={"spend": 2})
+        assert doc.platforms["meta_ads"].totals == {"spend": 2}
+
+    def test_stamping_an_id_onto_an_idless_entry_is_allowed_even_if_it_collides(
+        self, tmp_path: Path
+    ) -> None:
+        """Branch 2, and deliberately NOT a hole.
+
+        The existing entry has no ``account_id``, so it does not yet claim any
+        account. Stamping one on cannot create a real-world duplicate: if the
+        two keys really are one account, that was already true and merely
+        invisible. Allowing the write is what makes the duplicate DETECTABLE
+        (``duplicate_account_entries`` can now see it) and therefore
+        surfaceable to the operator — rejecting would block the very write
+        that reveals the problem. This is the repair path.
+        """
+        path = tmp_path / "STATE.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "version": "2",
+                    "platforms": {
+                        "google_ads": {"account_id": "act_1"},
+                        "legacy": {"account_id": ""},
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        doc = set_platform_metrics(path, "legacy", "act_1", totals={"spend": 1.0})
+        assert doc.platforms["legacy"].account_id == "act_1"
+        # ...and the now-visible duplicate is reported by the shared join.
+        from mureo.context.platform_accounts import duplicate_account_entries
+
+        (group,) = duplicate_account_entries(doc.platforms)
+        assert group.platform_keys == ("google_ads", "legacy")
+
+    def test_upsert_campaign_rejects_a_repoint(self, tmp_path: Path) -> None:
+        path = tmp_path / "STATE.json"
+        set_platform_metrics(path, "google_ads", "act_2", totals={"spend": 1.0})
+        set_platform_metrics(path, "meta_ads", "act_1", totals={"spend": 1.0})
+        with pytest.raises(ValueError, match="google_ads"):
+            upsert_campaign(
+                path,
+                CampaignSnapshot(campaign_id="c1", campaign_name="C1", status="ACTIVE"),
+                platform="meta_ads",
+                account_id="act_2",
+            )
+        assert read_state_file(path).platforms["meta_ads"].account_id == "act_1"
+
+    def test_set_conversion_action_types_rejects_a_repoint(
+        self, tmp_path: Path
+    ) -> None:
+        from mureo.context.state import set_conversion_action_types
+
+        path = tmp_path / "STATE.json"
+        set_platform_metrics(path, "google_ads", "act_2", totals={"spend": 1.0})
+        set_platform_metrics(path, "meta_ads", "act_1", totals={"spend": 1.0})
+        with pytest.raises(ValueError, match="google_ads"):
+            set_conversion_action_types(path, "meta_ads", "act_2", ["lead"])
+        assert read_state_file(path).platforms["meta_ads"].account_id == "act_1"
+
+    def test_rejects_a_padded_key_on_create(self, tmp_path: Path) -> None:
+        """``" google_ads"`` is a distinct dict key from ``"google_ads"`` —
+        never intentional, and another route to two entries for one account."""
+        path = tmp_path / "STATE.json"
+        with pytest.raises(ValueError, match="surrounding whitespace"):
+            set_platform_metrics(path, " google_ads", "123", totals={"spend": 1.0})
+        assert not path.exists()
+
+    def test_a_padded_key_that_already_exists_stays_writable(
+        self, tmp_path: Path
+    ) -> None:
+        """Same create-vs-update rule as the duplicate guard: an operator
+        holding a padded entry must still be able to write to it (and the key
+        is never silently stripped — that would change what they see)."""
+        path = tmp_path / "STATE.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "version": "2",
+                    "platforms": {" google_ads": {"account_id": "123"}},
+                }
+            ),
+            encoding="utf-8",
+        )
+        doc = set_platform_metrics(path, " google_ads", "123", totals={"spend": 1.0})
+        assert doc.platforms[" google_ads"].totals == {"spend": 1.0}
+        assert set(doc.platforms) == {" google_ads"}
+
+    def test_an_unusable_key_that_already_exists_stays_writable(
+        self, tmp_path: Path
+    ) -> None:
+        """The create-vs-update rule covers EVERY key check, not just the
+        duplicate one — otherwise a bad key strands the operator holding it."""
+        path = tmp_path / "STATE.json"
+        path.write_text(
+            json.dumps(
+                {"version": "2", "platforms": {"plugin:": {"account_id": "123"}}}
+            ),
+            encoding="utf-8",
+        )
+        doc = set_platform_metrics(path, "plugin:", "123", totals={"spend": 1.0})
+        assert doc.platforms["plugin:"].totals == {"spend": 1.0}
+
+
+# ---------------------------------------------------------------------------
+# #534 — whole-document writes: detection, not enforcement
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestWholeDocumentDuplicateWarning:
+    """A writer that assembles a whole ``StateDocument`` and writes it wholesale
+    never touches the upsert helpers, so the create-time guard cannot see it.
+
+    ``write_state_file`` is the one funnel every such writer goes through
+    (``FilesystemStateStore.write_state`` included), so the duplicate is at
+    least made VISIBLE there. It must not reject: a document that already
+    contains a duplicate has to stay writable or the operator can never repair
+    it.
+    """
+
+    def _duplicated_doc(self) -> StateDocument:
+        return StateDocument(
+            version="2",
+            platforms={
+                "meta_ads": PlatformState(account_id="act_1"),
+                "plugin:mureo-logly-bridge": PlatformState(account_id="1"),
+            },
+        )
+
+    # The warn-once latch is reset by the session-wide autouse fixture in
+    # tests/conftest.py — see there for why it does not live on this class.
+
+    def test_warns_naming_both_keys_and_the_account(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        path = tmp_path / "STATE.json"
+        with caplog.at_level(logging.WARNING, logger="mureo.context.platform_guards"):
+            write_state_file(path, self._duplicated_doc())
+        (record,) = [r for r in caplog.records if r.levelno == logging.WARNING]
+        message = record.getMessage()
+        assert "meta_ads" in message
+        assert "plugin:mureo-logly-bridge" in message
+        assert "act_1" in message
+
+    def test_the_write_still_happens(self, tmp_path: Path) -> None:
+        """Detection, NOT enforcement — the document must land on disk."""
+        path = tmp_path / "STATE.json"
+        write_state_file(path, self._duplicated_doc())
+        assert set(read_state_file(path).platforms) == {
+            "meta_ads",
+            "plugin:mureo-logly-bridge",
+        }
+
+    def test_warns_once_per_process_per_group(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """This runs on every write; a per-call warning would flood the log."""
+        path = tmp_path / "STATE.json"
+        with caplog.at_level(logging.WARNING, logger="mureo.context.platform_guards"):
+            write_state_file(path, self._duplicated_doc())
+            write_state_file(path, self._duplicated_doc())
+            write_state_file(path, self._duplicated_doc())
+        assert len([r for r in caplog.records if r.levelno == logging.WARNING]) == 1
+
+    def test_a_different_group_still_warns(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The latch is per key-pair, so one warned pair cannot silence another."""
+        path = tmp_path / "STATE.json"
+        other = StateDocument(
+            version="2",
+            platforms={
+                "google_ads": PlatformState(account_id="999"),
+                "plugin:other": PlatformState(account_id="999"),
+            },
+        )
+        with caplog.at_level(logging.WARNING, logger="mureo.context.platform_guards"):
+            write_state_file(path, self._duplicated_doc())
+            write_state_file(path, other)
+        assert len([r for r in caplog.records if r.levelno == logging.WARNING]) == 2
+
+    def test_the_same_group_in_another_workspace_still_warns(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The latch is keyed by (path, group): an agency process serves many
+        workspaces, and one tenant's duplicate must not silence another's."""
+        one = tmp_path / "a" / "STATE.json"
+        two = tmp_path / "b" / "STATE.json"
+        with caplog.at_level(logging.WARNING, logger="mureo.context.platform_guards"):
+            write_state_file(one, self._duplicated_doc())
+            write_state_file(two, self._duplicated_doc())
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 2
+        assert str(one) in warnings[0].getMessage()
+        assert str(two) in warnings[1].getMessage()
+
+    def test_the_latch_is_bounded(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """It must not grow without bound in a long-lived multi-tenant process.
+        Clearing (rather than evicting) biases towards warning again, which is
+        the safe direction for a visibility feature."""
+        from mureo.context import platform_guards
+
+        cap = platform_guards._DUPLICATE_ACCOUNT_WARN_LATCH_MAX
+        with caplog.at_level(logging.WARNING, logger="mureo.context.platform_guards"):
+            for i in range(cap + 5):
+                write_state_file(
+                    tmp_path / str(i) / "STATE.json", self._duplicated_doc()
+                )
+        assert len(platform_guards._DUPLICATE_ACCOUNT_WARNED) <= cap
+
+    def test_a_clean_document_is_silent(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        path = tmp_path / "STATE.json"
+        doc = StateDocument(
+            version="2",
+            platforms={
+                "meta_ads": PlatformState(account_id="act_1"),
+                "google_ads": PlatformState(account_id="999"),
+                "legacy": PlatformState(account_id=""),
+            },
+        )
+        with caplog.at_level(logging.WARNING, logger="mureo.context.platform_guards"):
+            write_state_file(path, doc)
+        assert [r for r in caplog.records if r.levelno == logging.WARNING] == []
+
+    def test_the_store_write_state_path_is_covered(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The observed producer writes a whole document through the store."""
+        from mureo.core.state_store import FilesystemStateStore
+
+        store = FilesystemStateStore(workspace=tmp_path)
+        with caplog.at_level(logging.WARNING, logger="mureo.context.platform_guards"):
+            store.write_state(self._duplicated_doc())
+        assert [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert set(store.read_state().platforms) == {
+            "meta_ads",
+            "plugin:mureo-logly-bridge",
+        }
+
 
 # ---------------------------------------------------------------------------
 # #468 — ad-level state


### PR DESCRIPTION
Closes #534. Closes #536.

## Why

A client card on the Reports tab showed a previous-day spend more than double reality — one ad account was stored under two platform keys and the card summed both. Nothing prevented the second entry: `mureo/context/state.py` resolved a write target by platform key alone, and `account_id` was written onto the entry but never used to match.

This is the write side. The read side is #533, fixed separately.

## The rule

"Refuse to create a duplicate" is the whole decision, so it is spelled out rather than approximated by "the key does not exist yet" — that approximation was the first version of this change, and it had a hole: re-pointing an existing key at an account another key already held created a fresh duplicate through the guarded functions themselves.

| existing entry | incoming `account_id` | outcome |
|---|---|---|
| none (new key) | held by another key | **refused** |
| none (new key) | free | created |
| stored id matches | — | plain update |
| stored id unknown (`""`) | held by another key | **allowed** |
| stored id unknown (`""`) | free | id stamped on |
| stored id known, different | held by another key | **refused** (re-point) |
| stored id known, different | free | re-pointed |

The third row is deliberate. Stamping an identity onto an entry that had none cannot create a real-world duplicate — if the two keys really are one account, that was already true and merely invisible. The write is what makes it detectable, so refusing it would block the very repair that reveals the problem.

**A write to an entry that already exists always succeeds**, whatever the document already contains. An operator holding a duplicated document has to be able to sync and repair it; a guard that locks them out is worse than the state it guards against. The same reasoning keeps a pre-existing unusable or whitespace-padded key writable while refusing to create one.

## What is only detected, not prevented

The writer that produced the reported case assembles a whole `StateDocument` and calls `write_state`, so it never reaches the targeted writers. `write_state_file` now logs a warn-once naming both keys and the account, but does not refuse: a whole-document write carries no notion of which entry is new, and refusing there would strand the operator. The producer itself is fixed in `mureo-agency`.

**Neither entry is ever merged or dropped.** The two observed entries held *different partial* figures, so summing and discarding are equally wrong. mureo reports the conflict and leaves the repair to the operator.

## Shared identity layer

`mureo/context/platform_accounts.py` — `normalize_account_id`, `account_ids_match`, `platform_keys_for_account`, `duplicate_account_entries`. Stdlib-only so it can be imported by the state layer, the reporting read path (#533) and out-of-tree writers without the `mureo.core` cycle. Three consumers needing the same "are these one account?" answer is exactly how such logic drifts apart, and drift here re-creates the bug.

An empty `account_id` is **unknown**: never a join key, and never equal to another unknown.

## #536

`load_conversion_action_types` guarded with `entry.account_id and account_id and not _account_id_eq(...)`, which collapses to falsy when the stored id is empty — so an override recorded for one account was returned for **every** account on that platform, and a caller passing `""` received another account's override. It now fails closed on an unknown id on either side, using the same matcher as the write guard, so the two cannot disagree about what "same account" means.

Reachable through the tolerant read path, which synthesizes `account_id = ""` for a missing field.

## Verification

- +57 tests. Two review rounds; round 1's CRITICAL (the re-point hole) is closed and was independently re-probed in round 2 across all three writers.
- A refusal leaves the file byte-identical, does not re-stamp `last_synced_at`, holds no lock and leaves no temp file — verified, not assumed.
- Full suite 7368 passed, no new failures.

`mureo/web/reports.py` and `mureo/_data/web/dashboard.js` are untouched — #533 owns those.
