### PR TITLE
test: stop asserting on the wall clock in the capture bounds tests (#542)

### DIFF
--- a/tests/test_amazon_reversal.py
+++ b/tests/test_amazon_reversal.py
@@ -432,10 +432,15 @@ class TestAdProductFilter:
         )
 
     async def test_slow_reads_stop_at_the_capture_deadline(self, monkeypatch) -> None:
-        """Each read returns just inside its own timeout, so only the OUTER
-        deadline can stop the probe walk. Time is faked so the assertion is on
-        read count, not on wall clock."""
-        monkeypatch.setattr(rev, "READ_TIMEOUT_SECONDS", 0.05)
+        """Only the OUTER deadline can stop this probe walk.
+
+        What is deterministic is the deadline: ``_monotonic`` is faked, so it
+        expires on a read COUNT and never on wall clock. The per-read timeout
+        is NOT faked — ``asyncio.wait_for`` runs on the real event-loop clock —
+        so it is instead given the whole remaining budget (9s for round one,
+        3s for round two) against a 1ms read. Firing it would take a
+        multi-second stall, not a loaded runner (#542).
+        """
         monkeypatch.setattr(rev, "CAPTURE_DEADLINE_SECONDS", 15.0)
         clock = _FakeClock(step=6.0)  # 0.0 (deadline set), 6.0, 12.0, 18.0 …
         monkeypatch.setattr(rev, "_monotonic", clock)
@@ -446,7 +451,7 @@ class TestAdProductFilter:
                 {"campaigns": []},
                 {"campaigns": [{"campaignId": "C2", "state": "ENABLED"}]},
             ],
-            delay=0.02,  # just under the per-read timeout: never times out
+            delay=0.001,  # a real read, three orders of magnitude inside it
         )
         out = await rev.capture_reversal(
             d,

--- a/tests/test_amazon_session_batch.py
+++ b/tests/test_amazon_session_batch.py
@@ -30,6 +30,10 @@ from mureo.amazon_ads.bridge import AmazonAdsBridge
 from mureo.amazon_ads.lwa import LwaTokens
 from mureo.auth import AmazonAdsCredentials
 
+# The same deterministic clock the non-batched deadline test drives, so both
+# halves of the bound are exercised the same way rather than two ways.
+from tests.test_amazon_reversal import _FakeClock
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -420,33 +424,106 @@ class TestPartialSequence:
 
 @pytest.mark.unit
 class TestBoundsStillHold:
-    async def test_a_hung_session_cannot_outlive_the_capture_deadline(
+    async def test_a_hung_read_is_bounded_and_still_tears_the_session_down(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        """The read hangs forever, so the PER-READ timeout is the only thing
+        that can end this call at all — reaching the assertions IS the proof
+        that the read was bounded. They are therefore on observable state,
+        never on elapsed time: a wall-clock ceiling would add nothing a hung
+        read has not already demonstrated, and a margin a loaded runner can
+        overshoot (#542).
+
+        The OUTER capture deadline is NOT exercised here. It is patched only
+        so that it cannot be the binding half of ``min(READ_TIMEOUT_SECONDS,
+        budget)``; the walk ends at the first hung probe, long before the
+        deadline could expire. The test that drives the deadline itself — with
+        reads that return well inside their own timeout, so only the deadline
+        can stop the walk — is ``test_amazon_reversal.py::TestAdProductFilter
+        ::test_slow_reads_stop_at_the_capture_deadline``.
+        """
         monkeypatch.setattr(rev, "READ_TIMEOUT_SECONDS", 0.2)
         monkeypatch.setattr(rev, "CAPTURE_DEADLINE_SECONDS", 0.5)
-        t = _FakeTransport([_HANG, _HANG, _HANG, _HANG, _HANG])
+        # ONE payload, because exactly one read happens: a timed-out probe ends
+        # the walk, so the other four ad products are never probed. (Were the
+        # walk to carry on, the missing payloads would return empty envelopes
+        # and the read count below would catch it.)
+        t = _FakeTransport([_HANG])
         b = _bridge(tmp_path, t)
-        started = time.monotonic()
         out = await b.capture_reversal(
             _UPDATE, _mutation([{"campaignId": "C1", "state": "PAUSED"}])
         )
-        elapsed = time.monotonic() - started
         assert out is None
-        assert elapsed < 0.5 + 0.4  # deadline + teardown, not 5 × the timeout
-        assert t.closed == [1]  # the hung session is still torn down
+        assert len(t.calls) == 1  # not the whole ad-product enum
+        assert t.closed == [1]  # the hung session is still torn down…
+        assert t.close_cancelled == []  # …gracefully, without the cancel fallback
+        assert _owner_tasks() == []  # nothing left holding a live session
+
+    async def test_the_capture_deadline_stops_the_walk_on_the_batched_session(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The OUTER deadline against the batch — the combination that every
+        real capture has run through since #520, and the one the test above
+        does NOT reach.
+
+        Every read returns immediately, well inside its own timeout (which is
+        the whole remaining budget here: 9s, then 3s), so nothing except the
+        capture deadline can end this walk. ``_monotonic`` is faked, so the
+        deadline expires on a read COUNT and never on wall clock — every
+        assertion below is a count or a state, none is an elapsed time (#542).
+        The non-batched twin is ``test_amazon_reversal.py::TestAdProductFilter
+        ::test_slow_reads_stop_at_the_capture_deadline``.
+        """
+        monkeypatch.setattr(rev, "CAPTURE_DEADLINE_SECONDS", 15.0)
+        # 0.0 sets the deadline, then 6.0 and 12.0 leave a budget; 18.0 does
+        # not, so the walk stops before a third probe rather than at the end
+        # of the five-product enum.
+        monkeypatch.setattr(rev, "_monotonic", _FakeClock(step=6.0))
+        t = _FakeTransport(
+            [
+                {"campaigns": [{"campaignId": "C1", "state": "ENABLED"}]},
+                {"campaigns": []},
+                # Deliberately never read: were the deadline to stop bounding
+                # the walk, this third probe would resolve C2 and the read
+                # count below would say so.
+                {"campaigns": [{"campaignId": "C2", "state": "ENABLED"}]},
+            ]
+        )
+        b = _bridge(tmp_path, t)
+        out = await b.capture_reversal(
+            _UPDATE,
+            _mutation(
+                [
+                    {"campaignId": "C1", "state": "PAUSED"},
+                    {"campaignId": "C2", "state": "PAUSED"},
+                ]
+            ),
+        )
+        assert len(t.calls) == 2  # two probes fit the budget, the third does not
+        assert t.sessions == 1  # …and the whole bounded walk shared ONE session
+        assert t.handshakes == [1]
+        assert t.closed == [1]
+        # What was captured before the deadline is kept; the entity that ran
+        # out of time is a caveat, not a guess.
+        assert out is not None
+        assert out["params"]["body"]["campaigns"] == [
+            {"campaignId": "C1", "state": "ENABLED"}
+        ]
+        assert any("C2" in c for c in out["caveats"])
 
     async def test_a_cancelled_call_still_leaves_the_session_closable(
         self, tmp_path: Path
     ) -> None:
+        """Same rule: leaving the ``async with`` at all is the bound being
+        demonstrated, so nothing here reads a clock either (#542)."""
         t = _FakeTransport([_HANG])
         b = _bridge(tmp_path, t)
-        started = time.monotonic()
         async with b.batch_dispatch() as dispatch:
             with pytest.raises(asyncio.TimeoutError):
                 await asyncio.wait_for(dispatch(_QUERY, {"body": {}}), timeout=0.1)
-        assert time.monotonic() - started < 1.0
         assert t.closed == [1]
+        assert t.close_cancelled == []  # closed gracefully, not cut loose
+        assert _owner_tasks() == []
 
 
 def _owner_tasks() -> list[asyncio.Task[Any]]:


### PR DESCRIPTION
Closes #542.

## The flake

`test_slow_reads_stop_at_the_capture_deadline` claimed in its own docstring that *"Time is faked so the assertion is on read count, not on wall clock."* Half true. `_monotonic` was faked, so the outer deadline was deterministic — but the per-read timeout goes through `asyncio.wait_for`, which reads the **real** event-loop clock. The test set `READ_TIMEOUT_SECONDS = 0.05` against a fake dispatch sleeping `0.02`, so "never times out" rested on a **30 ms margin of real time**.

A loaded runner overshoots it, the first read raises `TimeoutError`, and the walk stops after one call — which is indistinguishable from a real regression in the deadline logic. It failed on `test-windows` for a branch touching only `reports.py` and `dashboard.js`, and passed on a re-run of the same commit.

The docstring is the reason nobody questioned the margin, so it is rewritten to separate what is faked from what is not.

## The fixes

**The original test**: the per-read timeout now loses to the deadline-derived budget, and the fake sleep drops to a millisecond. The point of the test is that only the *outer* deadline can stop the walk; the inner timeout merely has to not fire.

**`TestBoundsStillHold` carried the same shape twice**, asserting `elapsed < …` on the real clock. Both now assert observables — read counts and teardown state — and read no clock at all. The argument for deleting rather than widening: with a transport whose every read hangs forever, **the call returning at all is the proof that the read was bounded**. The elapsed assertion could never have caught an unbounded read, because that regression hangs before reaching it. It only caught "finished, but slowly", and the sole slow path it named turned out to be unreachable.

**One of those two was named for a mechanism it never reaches.** A timed-out probe ends the walk, so exactly one read happens and the per-read timeout does all the work — the `[_HANG] * 5` setup implied five probes. Renamed to `test_a_hung_read_is_bounded_and_still_tears_the_session_down`, trimmed, and its docstring now points at the sibling that does drive the deadline.

**A genuinely missing test was added.** That sibling drives the deadline on the *non-batched* path, and since #520 every real capture goes through the batched session — so the combination that runs in production had no coverage at all, and the one test whose name implied it did not reach it. `test_the_capture_deadline_stops_the_walk_on_the_batched_session` asserts two probes fit the budget, one session, one handshake.

## Evidence, not assertion

The fix was measured with a harness that blocks the event loop from **inside** the awaited coroutine, after `wait_for`'s timer is armed — what a descheduled CI runner does.

- Unfixed test, 60 ms stall → reproduces the CI failure verbatim, including the same warning line.
- Fixed test: passes at 0.06 s, 0.5 s, 1 s, 2 s, 3.5 s. First failure at **9.5 s**. Threshold moved ~30 ms → ~9 s.
- The batched tests have **no failure boundary** at 1 s, 2.5 s, 5 s, 9.5 s, 12 s, 30 s. That is a property of the fake, not a design: CPython's `wait_for` returns `fut.result()` when the future completed during the blocked period, and the batched fake has no real suspension point, so it always wins the race. The non-batched sibling awaits `asyncio.sleep(0.001)` — a genuine suspension — so on resume its read is still pending and the expired timer wins. Worth knowing before anyone gives that fake a real await.

**Non-vacuity was tested, not claimed**, by mutating production code: `walk` (a timed-out read no longer ends the walk) and `deadline` (the outer bound stops bounding) each kill specific tests; `leak` (teardown neither waits nor cancels) kills all three in the class. Reported honestly: `close_cancelled == []` and `_owner_tasks() == []` are corroborating rather than load-bearing here — that distinction is covered by `TestCancellationDuringTeardown`.

Three other real-interval-vs-real-timeout sites were found by sweeping the file and left alone with stated reasons — two need the timeout to fire against a never-completing read (margin infinite in the safe direction), one relies on event-loop callback ordering, which review confirmed against CPython's `TimerHandle` comparison is deterministic rather than merely likely.

**Test-only. No production code is touched.**
