### PR TITLE
refactor: split the codec and the override lookup out of state.py (#538)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a stale patch target raises `AttributeError` immediately rather than
   silently reading the real workspace.
 
+- **`mureo/context/state.py` shed the STATE.json codec and the conversion
+  override lookup** (967 lines, against the 800-line limit). This module holds
+  the atomic write path and the state lock and is imported by essentially the
+  whole codebase, so the change is a **pure move**: every one of the 33
+  top-level definitions is byte-identical to its previous form, verified
+  mechanically rather than by eye.
+
+  `mureo/context/state_codec.py` now holds `parse_state` / `render_state` and
+  their per-field helpers. The two are inverses and every schema field appears
+  once in each, so the optionality rules that keep a round-trip byte-stable
+  are only checkable with both halves together — they moved as one unit rather
+  than parse alone. `mureo/context/conversion_overrides.py` holds
+  `load_conversion_action_types`: an account-scoped *setting* lookup that
+  resolves its own workspace and never raises, which is the opposite of the
+  writer contract the rest of `state.py` keeps.
+
+  Every name any caller imports — in this tree and out of it — is re-exported
+  from `mureo.context.state`, including `parse_state` and `render_state`, so
+  no import moves. What is not re-exported is the codec's private helpers
+  (`_parse_campaign`, `_snapshot_to_dict`, …), which have no callers anywhere.
+
+  One behavioural difference, and it is only visible in logs: the tolerant
+  read path's DEBUG records (`skipping unparseable …`, `missing 'account_id'`)
+  now come from the `mureo.context.state_codec` logger instead of
+  `mureo.context.state`. Level and message are unchanged.
+
+  Four functions are still over the 50-line function limit, for two different
+  reasons.
+
+  The three writers (`upsert_campaign` 89, `set_platform_metrics` 97,
+  `set_conversion_action_types` 71) were left long on purpose and are expected
+  to stay that way: their length is the merge-semantics docstring plus the
+  `_build` closure it describes, and cutting either apart would separate a
+  rule from the code that implements it.
+
+  `parse_state` (55) is a different case and is **not** permanent. Its v2
+  `platforms` loop would extract cleanly as a `_parse_platforms` helper — the
+  mirror of `_platform_state_to_dict` — bringing it to roughly 37 lines. That
+  was skipped only because it would have made one function's body differ, and
+  the "every definition is byte-identical" property is the entire reason this
+  change is reviewable. It is worth doing as its own change, where the body
+  diff is the point rather than a cost.
+
 ## [0.10.41] - 2026-08-06
 
 ### Fixed

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -134,7 +134,11 @@ mureo/
 ├── context/                 # File-based context (STRATEGY.md, STATE.json)
 │   ├── models.py            # Immutable dataclasses (ActionLogEntry.rollback_of for audit trail)
 │   ├── strategy.py          # STRATEGY.md parser / renderer
-│   ├── state.py             # STATE.json parser / renderer
+│   ├── state.py             # STATE.json read / mutate / atomic write + state lock (re-exports the two below)
+│   ├── state_codec.py       # STATE.json <-> StateDocument codec (parse_state / render_state)
+│   ├── conversion_overrides.py # Per-account conversion action_type override lookup (#342)
+│   ├── platform_accounts.py # One ad account, one platform key — the shared account-id join
+│   ├── platform_guards.py   # Write-time guards over that join (refuse / warn on duplicates)
 │   └── errors.py            # Context-specific exceptions
 ├── cli/                     # Typer CLI (setup + auth + rollback inspection; ad operations are via MCP)
 │   ├── main.py              # Entry point (mureo command) — registers all 12 sub-command groups

--- a/mureo/context/conversion_overrides.py
+++ b/mureo/context/conversion_overrides.py
@@ -1,0 +1,118 @@
+"""Per-account conversion ``action_type`` override lookup (#342, split in #538).
+
+The read half of :func:`~mureo.context.state.set_conversion_action_types`:
+given an ad account id, answer "which Meta ``action_type`` rows count as this
+account's conversions?" — or ``None`` when the operator declared nothing and
+the counters fall back to the built-in generic set.
+
+It lives beside :mod:`mureo.context.platform_accounts` rather than inside
+:mod:`mureo.context.state` because it is an account-scoped **setting lookup**,
+not part of the document read / write / merge layer. Two things follow from
+that and neither belongs in ``state``:
+
+- it resolves which STATE.json to read from the active runtime context, so
+  that the override is read from the same file the MCP state tools wrote it
+  to even under an agency / alternate ``StateStore``;
+- it **never raises**. A conversion analysis that dies because a state file
+  is missing or malformed is a worse outcome than one that falls back to the
+  built-in set, which is the opposite of the writer contract ``state`` keeps.
+
+The account join itself is not reimplemented here — it is
+:func:`~mureo.context.platform_accounts.account_ids_match`, shared with the
+duplicate-account write guard so the override's read side and the guard's
+write side cannot disagree about what "the same account" means (#536).
+
+Re-exported from :mod:`mureo.context.state`, which is where the analytics and
+Meta modules import it from.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from mureo.context.platform_accounts import account_ids_match
+from mureo.context.state_codec import parse_state
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _workspace_state_path() -> Path:
+    """Resolve the ACTIVE workspace's STATE.json — the same file the MCP state
+    tools write to (#342).
+
+    Mirrors ``_handlers_mureo_context._resolve_path``'s default resolution
+    (``store.state_path`` → ``store.workspace / STATE.json``) via the runtime
+    context, so the conversion override is read from the same file it is
+    written to — even under an agency / alternate ``StateStore`` where the
+    workspace diverges from the process cwd. ``get_runtime_context`` is
+    imported lazily to avoid an import cycle (``runtime_context`` builds on
+    ``context``). Any failure falls back to the cwd convention.
+    """
+    from pathlib import Path as _Path
+
+    try:
+        from mureo.core.runtime_context import get_runtime_context
+
+        store = get_runtime_context().state_store
+        attr = getattr(store, "state_path", None)
+        if attr is not None:
+            return _Path(attr)
+        workspace = getattr(store, "workspace", None)
+        if workspace is not None:
+            return _Path(workspace) / "STATE.json"
+    except Exception:  # noqa: BLE001 — best-effort; never break a live read.
+        pass
+    return _Path("STATE.json")
+
+
+def load_conversion_action_types(
+    account_id: str,
+    *,
+    path: Path | None = None,
+    platform: str = "meta_ads",
+) -> tuple[str, ...] | None:
+    """Read an account's operator conversion override from STATE.json (#342).
+
+    Returns the ``platforms[platform].conversion_action_types`` override when
+    it is set AND the entry's ``account_id`` matches ``account_id`` (tolerant
+    of the ``act_`` prefix); otherwise ``None`` so the conversion counters fall
+    back to the built-in generic set.
+
+    An **unknown** id on either side never matches (#536) — see
+    :func:`~mureo.context.platform_accounts.account_ids_match`. An override
+    applied to the wrong account silently redefines what counts as a
+    conversion for it, so falling back to the built-in set is the safe
+    direction.
+
+    Reads the ACTIVE workspace ``STATE.json`` (resolved via the runtime context
+    — the same file the MCP state tools write to). **Never raises**: a missing
+    / unreadable / malformed file, or an absent platform entry, all yield
+    ``None`` so a live analysis is never broken by a state-read failure.
+    """
+    state_path = path if path is not None else _workspace_state_path()
+    try:
+        if not state_path.exists():
+            return None
+        doc = parse_state(state_path.read_text(encoding="utf-8"), strict=False)
+    except Exception:  # noqa: BLE001 — never break a live analysis on a bad file.
+        # parse_state can raise OSError / ContextFileError / ValueError
+        # (JSONDecodeError) AND AttributeError/TypeError on non-object JSON;
+        # a best-effort override read must swallow all of them.
+        return None
+    if doc.platforms is None:
+        return None
+    entry = doc.platforms.get(platform)
+    if entry is None or not entry.conversion_action_types:
+        return None
+    # Fail closed on an unknown id (#536), via the SHARED join so the
+    # override's read side and the duplicate guard's write side cannot
+    # disagree about what "the same account" means.
+    if not account_ids_match(entry.account_id, account_id):
+        return None
+    return entry.conversion_action_types
+
+
+__all__ = [
+    "load_conversion_action_types",
+]

--- a/mureo/context/platform_accounts.py
+++ b/mureo/context/platform_accounts.py
@@ -24,7 +24,7 @@ three would let the definitions drift, and drift here re-creates the bug.
 The join has exactly one subtlety, and it is load-bearing: **an empty
 ``account_id`` means UNKNOWN, never a value.** The tolerant read path
 synthesizes ``""`` for a missing ``account_id``
-(:func:`mureo.context.state._platform_account_id`), so treating ``""`` as a
+(:func:`mureo.context.state_codec._platform_account_id`), so treating ``""`` as a
 value would join every id-less entry in a document into one bogus "account".
 
 Deliberately dependency-free — stdlib plus the frozen ``PlatformState`` model
@@ -60,7 +60,7 @@ class DuplicateAccountEntry:
     entries.
 
     Frozen and hashable, so a caller can use it directly as a warn-once latch
-    key (see :func:`mureo.context.state._warn_on_duplicate_accounts`).
+    key (see :func:`mureo.context.platform_guards.warn_on_duplicate_accounts`).
     """
 
     account_id: str

--- a/mureo/context/state.py
+++ b/mureo/context/state.py
@@ -1,11 +1,28 @@
-"""Read and write STATE.json."""
+"""Read, mutate and durably write STATE.json.
+
+The document layer: the atomic write (temp file -> fsync -> rename), the
+cross-process lock that makes a read -> modify -> write cycle one critical
+section, and the targeted mutators that own STATE.json's merge semantics —
+what a partial write inherits rather than resets.
+
+Two halves that used to live here were split out in #538 to bring this file
+back under the repo's size limits, both verbatim:
+
+- the JSON codec (:func:`parse_state` / :func:`render_state` and their
+  per-field helpers) is now :mod:`mureo.context.state_codec`;
+- the account conversion-override lookup
+  (:func:`load_conversion_action_types`) is now
+  :mod:`mureo.context.conversion_overrides`.
+
+Both are **re-exported from this module**, because ``mureo.context.state`` has
+always been the single import site for the whole STATE.json surface and
+callers inside and outside this tree import it from here.
+"""
 
 from __future__ import annotations
 
 import contextlib
-import copy
 import json
-import logging
 import os
 import tempfile
 from dataclasses import replace
@@ -16,394 +33,17 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from pathlib import Path
 
+    from mureo.context.models import ActionLogEntry, CampaignSnapshot
+
+from mureo.context.conversion_overrides import load_conversion_action_types
 from mureo.context.errors import ContextFileError
-from mureo.context.models import (
-    ActionLogEntry,
-    AdState,
-    CampaignSnapshot,
-    PlatformState,
-    StateDocument,
-)
-from mureo.context.platform_accounts import account_ids_match
+from mureo.context.models import PlatformState, StateDocument
 from mureo.context.platform_guards import (
     guard_platform_entry_write,
     warn_on_duplicate_accounts,
 )
+from mureo.context.state_codec import parse_state, render_state
 from mureo.fsutil import file_lock
-
-logger = logging.getLogger(__name__)
-
-# Required campaign fields
-_CAMPAIGN_REQUIRED_FIELDS: tuple[str, ...] = (
-    "campaign_id",
-    "campaign_name",
-    "status",
-)
-
-
-def _parse_ad(a: dict[str, Any]) -> AdState:
-    """Create an :class:`AdState` from a dict (``ad_id`` required).
-
-    ``ad_id`` is type-checked, not merely present-checked: it is the key every
-    later run matches on to diff statuses, so a hand-edited numeric id would
-    silently never match the string ids the platforms return.
-    """
-    if not isinstance(a, dict) or "ad_id" not in a:
-        raise ValueError(f"Ad is missing required field 'ad_id': {a}")
-    if not isinstance(a["ad_id"], str) or not a["ad_id"]:
-        raise ValueError(f"Ad 'ad_id' must be a non-empty string: {a}")
-    return AdState(
-        ad_id=a["ad_id"],
-        name=a.get("name"),
-        status=a.get("status"),
-        effective_status=a.get("effective_status"),
-        as_of=a.get("as_of"),
-    )
-
-
-def _parse_ads(raw: Any, *, strict: bool) -> tuple[AdState, ...] | None:
-    """Parse a campaign's ``ads`` list (#468).
-
-    Returns ``None`` when the key is absent — "ad-level status was never
-    fetched", which must stay distinguishable from ``()`` ("fetched, no ads").
-    ``strict=True`` raises on a nonconforming entry (the writer contract);
-    ``strict=False`` skips it, so one hand-authored ad cannot blank out a
-    whole document for the read-only Reports view.
-    """
-    if raw is None:
-        return None
-    if not isinstance(raw, list):
-        if strict:
-            raise ValueError(f"Campaign 'ads' must be a list: {raw!r}")
-        logger.debug("skipping non-list campaign 'ads' value: %r", raw)
-        return None
-    if strict:
-        return tuple(_parse_ad(a) for a in raw)
-    parsed: list[AdState] = []
-    for a in raw:
-        try:
-            parsed.append(_parse_ad(a))
-        except (ValueError, KeyError, TypeError) as exc:
-            # DEBUG, not WARNING — see _parse_campaigns.
-            logger.debug("skipping unparseable ad entry: %s", exc)
-    return tuple(parsed)
-
-
-def _parse_campaigns(
-    raw: list[dict[str, Any]], *, strict: bool
-) -> tuple[CampaignSnapshot, ...]:
-    """Parse a campaign list.
-
-    ``strict=True`` (the canonical contract relied on by every writer) raises
-    on the first nonconforming entry. ``strict=False`` skips entries that fail
-    validation, logging each one — used only by the read-only Reports view so a
-    single variant/hand-authored campaign cannot blank out a whole document
-    (whose platforms/periods/reports the dashboard actually renders).
-    """
-    if strict:
-        return tuple(_parse_campaign(c, strict=True) for c in raw)
-    parsed: list[CampaignSnapshot] = []
-    for c in raw:
-        try:
-            parsed.append(_parse_campaign(c, strict=False))
-        except (ValueError, KeyError, TypeError) as exc:
-            # DEBUG, not WARNING: the read-only Reports view re-parses on every
-            # poll, so a per-entry WARNING would flood the log for a STATE.json
-            # with many nonconforming (e.g. legacy / hand-authored) campaigns.
-            logger.debug("skipping unparseable campaign entry: %s", exc)
-    return tuple(parsed)
-
-
-def _parse_action_log(
-    raw: list[dict[str, Any]], *, strict: bool
-) -> tuple[ActionLogEntry, ...]:
-    """Parse the action_log list.
-
-    ``strict=True`` (the writer contract) raises on the first entry missing a
-    required field (``timestamp`` / ``action`` / ``platform``). ``strict=False``
-    skips such entries, logging each — used only by the read-only Reports view
-    so a single old / hand-authored entry (e.g. one written before those fields
-    were required) cannot blank out a whole document.
-    """
-    if strict:
-        return tuple(_parse_action_log_entry(e) for e in raw)
-    parsed: list[ActionLogEntry] = []
-    for e in raw:
-        try:
-            parsed.append(_parse_action_log_entry(e))
-        except (ValueError, KeyError, TypeError) as exc:
-            # DEBUG, not WARNING — see _parse_campaigns: avoid per-render log
-            # flood from a STATE.json with many nonconforming action_log entries.
-            logger.debug("skipping unparseable action_log entry: %s", exc)
-    return tuple(parsed)
-
-
-def _platform_account_id(
-    platform_key: str, platform_data: dict[str, Any], *, strict: bool
-) -> str:
-    """Resolve a platform's ``account_id``.
-
-    ``strict=True`` (the writer contract) requires the key — a missing
-    ``account_id`` raises ``KeyError`` exactly as before. ``strict=False``
-    (the read-only Reports view) defaults a missing ``account_id`` to ``""``
-    so an agent-/hand-authored STATE.json that omitted it still renders its
-    platforms/totals/periods instead of blanking the whole dashboard. Logged
-    at DEBUG (expected for non-canonical files; never per-poll WARNING noise).
-    """
-    if strict or "account_id" in platform_data:
-        # KeyError in strict if absent — unchanged writer contract. Annotated
-        # local so mypy treats the dict[str, Any] value as the declared str.
-        account_id: str = platform_data["account_id"]
-        return account_id
-    logger.debug(
-        "platform %r missing 'account_id'; defaulting to '' for the tolerant "
-        "read-only view",
-        platform_key,
-    )
-    return ""
-
-
-def _parse_conversion_action_types(raw: Any) -> tuple[str, ...] | None:
-    """Parse a platform's ``conversion_action_types`` override (#342).
-
-    Returns a tuple of non-empty string action_types, or ``None`` when the
-    field is absent / not a list / has no usable entries (so the counters
-    fall back to the built-in generic set). Tolerant by design — a malformed
-    value degrades to "no override" rather than raising.
-    """
-    if not isinstance(raw, list):
-        return None
-    cleaned = tuple(str(x).strip() for x in raw if isinstance(x, str) and x.strip())
-    return cleaned or None
-
-
-def parse_state(text: str, *, strict: bool = True) -> StateDocument:
-    """Parse a JSON string and return a StateDocument.
-
-    ``strict`` controls campaign-list, action_log AND platform validation:
-    ``True`` (default) preserves the strict writer contract (raises on a missing
-    required field, including a platform ``account_id``); ``False`` tolerantly
-    skips nonconforming campaign / action_log entries and defaults a missing
-    platform ``account_id`` to ``""`` for the read-only Reports view. Invalid
-    JSON always raises regardless of ``strict``.
-
-    Unknown top-level keys are ignored (and :func:`render_state` emits only
-    the known ones), which is what keeps the ``mureo_state_get`` response
-    field ``server_now`` from ever being persisted: a document echoed back
-    into STATE.json with that key loses it on the next write instead of
-    fossilising a stale "today" (#460).
-    """
-    data = json.loads(text)
-    campaigns_raw = data.get("campaigns", [])
-    campaigns = _parse_campaigns(campaigns_raw, strict=strict)
-
-    # v2: platforms
-    platforms: dict[str, PlatformState] | None = None
-    platforms_raw = data.get("platforms")
-    if platforms_raw is not None:
-        platforms = {}
-        for platform_key, platform_data in platforms_raw.items():
-            platform_campaigns = _parse_campaigns(
-                platform_data.get("campaigns", []), strict=strict
-            )
-            platforms[platform_key] = PlatformState(
-                account_id=_platform_account_id(
-                    platform_key, platform_data, strict=strict
-                ),
-                campaigns=platform_campaigns,
-                totals=platform_data.get("totals"),
-                metrics_period=platform_data.get("metrics_period"),
-                periods=platform_data.get("periods"),
-                conversion_action_types=_parse_conversion_action_types(
-                    platform_data.get("conversion_action_types")
-                ),
-            )
-
-    # v2: action_log
-    action_log_raw = data.get("action_log", [])
-    action_log = _parse_action_log(action_log_raw, strict=strict)
-
-    return StateDocument(
-        version=data.get("version", "1"),
-        last_synced_at=data.get("last_synced_at"),
-        customer_id=data.get("customer_id"),
-        campaigns=campaigns,
-        platforms=platforms,
-        action_log=action_log,
-        reports=data.get("reports"),
-    )
-
-
-def _parse_action_log_entry(e: dict[str, Any]) -> ActionLogEntry:
-    """Create an ActionLogEntry from a dict."""
-    return ActionLogEntry(
-        timestamp=e["timestamp"],
-        action=e["action"],
-        platform=e["platform"],
-        campaign_id=e.get("campaign_id"),
-        ad_id=e.get("ad_id"),
-        entity_type=e.get("entity_type"),
-        entity_id=e.get("entity_id"),
-        summary=e.get("summary"),
-        command=e.get("command"),
-        metrics_at_action=e.get("metrics_at_action"),
-        observation_due=e.get("observation_due"),
-        reversible_params=e.get("reversible_params"),
-        rollback_of=e.get("rollback_of"),
-        evaluation_of=e.get("evaluation_of"),
-    )
-
-
-def _parse_campaign(c: dict[str, Any], *, strict: bool = True) -> CampaignSnapshot:
-    """Create a CampaignSnapshot from a dict (with required field validation)."""
-    for field_name in _CAMPAIGN_REQUIRED_FIELDS:
-        if field_name not in c:
-            raise ValueError(f"Campaign is missing required field '{field_name}': {c}")
-    device_targeting_raw = c.get("device_targeting")
-    device_targeting: tuple[dict[str, Any], ...] | None = None
-    if device_targeting_raw is not None:
-        device_targeting = tuple(device_targeting_raw)
-    return CampaignSnapshot(
-        campaign_id=c["campaign_id"],
-        campaign_name=c["campaign_name"],
-        status=c["status"],
-        bidding_strategy_type=c.get("bidding_strategy_type"),
-        bidding_details=c.get("bidding_details"),
-        daily_budget=c.get("daily_budget"),
-        device_targeting=device_targeting,
-        campaign_goal=c.get("campaign_goal"),
-        notes=c.get("notes"),
-        metrics=c.get("metrics"),
-        ads=_parse_ads(c.get("ads"), strict=strict),
-    )
-
-
-def render_state(doc: StateDocument) -> str:
-    """Generate a JSON string from a StateDocument."""
-    data: dict[str, Any] = {
-        "version": doc.version,
-        "last_synced_at": doc.last_synced_at,
-        "customer_id": doc.customer_id,
-        "campaigns": [_snapshot_to_dict(c) for c in doc.campaigns],
-    }
-
-    # v2: platforms
-    if doc.platforms is not None:
-        data["platforms"] = {
-            key: _platform_state_to_dict(ps) for key, ps in doc.platforms.items()
-        }
-    else:
-        data["platforms"] = None
-
-    # v2: action_log
-    data["action_log"] = [_action_log_entry_to_dict(e) for e in doc.action_log]
-
-    # Optional reports section (stage-c forward-ready): emit only when present
-    # so old STATE.json files don't gain a new key.
-    if doc.reports is not None:
-        data["reports"] = copy.deepcopy(doc.reports)
-
-    return json.dumps(data, ensure_ascii=False, indent=2)
-
-
-def _platform_state_to_dict(ps: PlatformState) -> dict[str, Any]:
-    """Convert a PlatformState to a dictionary."""
-    result: dict[str, Any] = {
-        "account_id": ps.account_id,
-        "campaigns": [_snapshot_to_dict(c) for c in ps.campaigns],
-    }
-    # Optional platform-level rollup: emit only when present.
-    if ps.totals is not None:
-        result["totals"] = copy.deepcopy(ps.totals)
-    if ps.metrics_period is not None:
-        result["metrics_period"] = ps.metrics_period
-    # Per-period rollups: emit only when non-empty so legacy files (and
-    # entries with no per-period data) stay byte-stable on round-trip.
-    if ps.periods:
-        result["periods"] = copy.deepcopy(ps.periods)
-    # #342 — operator conversion override: emit only when set, as a JSON list,
-    # so legacy entries stay byte-stable.
-    if ps.conversion_action_types:
-        result["conversion_action_types"] = list(ps.conversion_action_types)
-    return result
-
-
-def _action_log_entry_to_dict(e: ActionLogEntry) -> dict[str, Any]:
-    """Convert an ActionLogEntry to a dictionary."""
-    result: dict[str, Any] = {
-        "timestamp": e.timestamp,
-        "action": e.action,
-        "platform": e.platform,
-    }
-    if e.campaign_id is not None:
-        result["campaign_id"] = e.campaign_id
-    if e.ad_id is not None:
-        result["ad_id"] = e.ad_id
-    if e.entity_type is not None:
-        result["entity_type"] = e.entity_type
-    if e.entity_id is not None:
-        result["entity_id"] = e.entity_id
-    if e.summary is not None:
-        result["summary"] = e.summary
-    if e.command is not None:
-        result["command"] = e.command
-    if e.metrics_at_action is not None:
-        result["metrics_at_action"] = copy.deepcopy(e.metrics_at_action)
-    if e.observation_due is not None:
-        result["observation_due"] = e.observation_due
-    if e.reversible_params is not None:
-        result["reversible_params"] = copy.deepcopy(e.reversible_params)
-    if e.rollback_of is not None:
-        result["rollback_of"] = e.rollback_of
-    if e.evaluation_of is not None:
-        result["evaluation_of"] = e.evaluation_of
-    return result
-
-
-def _snapshot_to_dict(c: CampaignSnapshot) -> dict[str, Any]:
-    """Convert a CampaignSnapshot to a dictionary."""
-    device_targeting: list[dict[str, Any]] | None = None
-    if c.device_targeting is not None:
-        device_targeting = list(c.device_targeting)
-    result: dict[str, Any] = {
-        "campaign_id": c.campaign_id,
-        "campaign_name": c.campaign_name,
-        "status": c.status,
-        "bidding_strategy_type": c.bidding_strategy_type,
-        "bidding_details": c.bidding_details,
-        "daily_budget": c.daily_budget,
-        "device_targeting": device_targeting,
-        "campaign_goal": c.campaign_goal,
-        "notes": c.notes,
-    }
-    # Optional metrics: emit only when present so old STATE.json files don't
-    # gain a new key (no diff churn / bloat).
-    if c.metrics is not None:
-        result["metrics"] = copy.deepcopy(c.metrics)
-    # Ad-level state (#468): emit only when it was actually fetched, so a
-    # campaign that predates this field stays byte-stable on round-trip.
-    if c.ads is not None:
-        result["ads"] = [_ad_state_to_dict(a) for a in c.ads]
-    return result
-
-
-def _ad_state_to_dict(a: AdState) -> dict[str, Any]:
-    """Convert an :class:`AdState` to a dictionary.
-
-    Optional fields are emitted only when set: an absent ``effective_status``
-    must stay absent rather than becoming an empty string a later run could
-    read as an observed value.
-    """
-    result: dict[str, Any] = {"ad_id": a.ad_id}
-    for key, value in (
-        ("name", a.name),
-        ("status", a.status),
-        ("effective_status", a.effective_status),
-        ("as_of", a.as_of),
-    ):
-        if value is not None:
-            result[key] = value
-    return result
 
 
 def _atomic_write(path: Path, content: str) -> None:
@@ -883,85 +523,29 @@ def set_conversion_action_types(
     return _locked_state_mutation(path, _build)
 
 
-def _workspace_state_path() -> Path:
-    """Resolve the ACTIVE workspace's STATE.json — the same file the MCP state
-    tools write to (#342).
-
-    Mirrors ``_handlers_mureo_context._resolve_path``'s default resolution
-    (``store.state_path`` → ``store.workspace / STATE.json``) via the runtime
-    context, so the conversion override is read from the same file it is
-    written to — even under an agency / alternate ``StateStore`` where the
-    workspace diverges from the process cwd. ``get_runtime_context`` is
-    imported lazily to avoid an import cycle (``runtime_context`` builds on
-    ``context``). Any failure falls back to the cwd convention.
-    """
-    from pathlib import Path as _Path
-
-    try:
-        from mureo.core.runtime_context import get_runtime_context
-
-        store = get_runtime_context().state_store
-        attr = getattr(store, "state_path", None)
-        if attr is not None:
-            return _Path(attr)
-        workspace = getattr(store, "workspace", None)
-        if workspace is not None:
-            return _Path(workspace) / "STATE.json"
-    except Exception:  # noqa: BLE001 — best-effort; never break a live read.
-        pass
-    return _Path("STATE.json")
-
-
-def load_conversion_action_types(
-    account_id: str,
-    *,
-    path: Path | None = None,
-    platform: str = "meta_ads",
-) -> tuple[str, ...] | None:
-    """Read an account's operator conversion override from STATE.json (#342).
-
-    Returns the ``platforms[platform].conversion_action_types`` override when
-    it is set AND the entry's ``account_id`` matches ``account_id`` (tolerant
-    of the ``act_`` prefix); otherwise ``None`` so the conversion counters fall
-    back to the built-in generic set.
-
-    An **unknown** id on either side never matches (#536) — see
-    :func:`~mureo.context.platform_accounts.account_ids_match`. An override
-    applied to the wrong account silently redefines what counts as a
-    conversion for it, so falling back to the built-in set is the safe
-    direction.
-
-    Reads the ACTIVE workspace ``STATE.json`` (resolved via the runtime context
-    — the same file the MCP state tools write to). **Never raises**: a missing
-    / unreadable / malformed file, or an absent platform entry, all yield
-    ``None`` so a live analysis is never broken by a state-read failure.
-    """
-    state_path = path if path is not None else _workspace_state_path()
-    try:
-        if not state_path.exists():
-            return None
-        doc = parse_state(state_path.read_text(encoding="utf-8"), strict=False)
-    except Exception:  # noqa: BLE001 — never break a live analysis on a bad file.
-        # parse_state can raise OSError / ContextFileError / ValueError
-        # (JSONDecodeError) AND AttributeError/TypeError on non-object JSON;
-        # a best-effort override read must swallow all of them.
-        return None
-    if doc.platforms is None:
-        return None
-    entry = doc.platforms.get(platform)
-    if entry is None or not entry.conversion_action_types:
-        return None
-    # Fail closed on an unknown id (#536), via the SHARED join so the
-    # override's read side and the duplicate guard's write side cannot
-    # disagree about what "the same account" means.
-    if not account_ids_match(entry.account_id, account_id):
-        return None
-    return entry.conversion_action_types
-
-
 def get_campaign(doc: StateDocument, campaign_id: str) -> CampaignSnapshot | None:
     """Search for a campaign by campaign_id."""
     for c in doc.campaigns:
         if c.campaign_id == campaign_id:
             return c
     return None
+
+
+__all__ = [
+    # Re-exported from mureo.context.state_codec / .conversion_overrides so
+    # every existing ``from mureo.context.state import ...`` keeps working
+    # (#538). Listed here, not merely imported, so the re-export is explicit
+    # under mypy's ``no_implicit_reexport``.
+    "load_conversion_action_types",
+    "parse_state",
+    "render_state",
+    # Defined here.
+    "append_action_log",
+    "get_campaign",
+    "read_state_file",
+    "set_conversion_action_types",
+    "set_platform_metrics",
+    "set_report",
+    "upsert_campaign",
+    "write_state_file",
+]

--- a/mureo/context/state_codec.py
+++ b/mureo/context/state_codec.py
@@ -1,0 +1,428 @@
+"""STATE.json <-> :class:`~mureo.context.models.StateDocument` codec (#538).
+
+Both directions of one contract. :func:`parse_state` and :func:`render_state`
+are inverses, and every field of the schema appears exactly twice — once in
+each — so the optionality rules that keep a round-trip byte-stable (emit
+``metrics`` / ``ads`` / ``periods`` / ``conversion_action_types`` only when
+they are actually present) can only be checked with both halves in front of
+you. Keeping them apart would let the two sides drift, and drift here silently
+rewrites an operator's STATE.json.
+
+Extracted verbatim from :mod:`mureo.context.state`, which keeps the file /
+lock / merge layer its name promises. Every public name here is re-exported
+from that module, so no caller had to move.
+
+The read side has two modes and the distinction is load-bearing:
+
+- ``strict=True`` is the **writer contract** — a nonconforming entry raises,
+  exactly as it always has.
+- ``strict=False`` is the **read-only Reports view** — a nonconforming entry
+  is skipped and logged at DEBUG (never WARNING: the dashboard re-parses on
+  every poll, so a per-entry warning would flood the daemon log), so one
+  hand-authored campaign cannot blank out a whole document.
+
+Each tolerant branch documents its own reasoning below.
+
+Dependency-free beyond stdlib and the frozen ``mureo.context.models``
+dataclasses — the same discipline :mod:`mureo.context.platform_accounts`
+keeps, and for the same reason: ``mureo.core.__init__`` ->
+``runtime_context`` -> ``state_store`` -> ``mureo.context.state`` is a real
+import chain, so a module inside it that reached back into ``mureo.core``
+would close the cycle.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import logging
+from typing import Any
+
+from mureo.context.models import (
+    ActionLogEntry,
+    AdState,
+    CampaignSnapshot,
+    PlatformState,
+    StateDocument,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Required campaign fields
+_CAMPAIGN_REQUIRED_FIELDS: tuple[str, ...] = (
+    "campaign_id",
+    "campaign_name",
+    "status",
+)
+
+
+def _parse_ad(a: dict[str, Any]) -> AdState:
+    """Create an :class:`AdState` from a dict (``ad_id`` required).
+
+    ``ad_id`` is type-checked, not merely present-checked: it is the key every
+    later run matches on to diff statuses, so a hand-edited numeric id would
+    silently never match the string ids the platforms return.
+    """
+    if not isinstance(a, dict) or "ad_id" not in a:
+        raise ValueError(f"Ad is missing required field 'ad_id': {a}")
+    if not isinstance(a["ad_id"], str) or not a["ad_id"]:
+        raise ValueError(f"Ad 'ad_id' must be a non-empty string: {a}")
+    return AdState(
+        ad_id=a["ad_id"],
+        name=a.get("name"),
+        status=a.get("status"),
+        effective_status=a.get("effective_status"),
+        as_of=a.get("as_of"),
+    )
+
+
+def _parse_ads(raw: Any, *, strict: bool) -> tuple[AdState, ...] | None:
+    """Parse a campaign's ``ads`` list (#468).
+
+    Returns ``None`` when the key is absent — "ad-level status was never
+    fetched", which must stay distinguishable from ``()`` ("fetched, no ads").
+    ``strict=True`` raises on a nonconforming entry (the writer contract);
+    ``strict=False`` skips it, so one hand-authored ad cannot blank out a
+    whole document for the read-only Reports view.
+    """
+    if raw is None:
+        return None
+    if not isinstance(raw, list):
+        if strict:
+            raise ValueError(f"Campaign 'ads' must be a list: {raw!r}")
+        logger.debug("skipping non-list campaign 'ads' value: %r", raw)
+        return None
+    if strict:
+        return tuple(_parse_ad(a) for a in raw)
+    parsed: list[AdState] = []
+    for a in raw:
+        try:
+            parsed.append(_parse_ad(a))
+        except (ValueError, KeyError, TypeError) as exc:
+            # DEBUG, not WARNING — see _parse_campaigns.
+            logger.debug("skipping unparseable ad entry: %s", exc)
+    return tuple(parsed)
+
+
+def _parse_campaigns(
+    raw: list[dict[str, Any]], *, strict: bool
+) -> tuple[CampaignSnapshot, ...]:
+    """Parse a campaign list.
+
+    ``strict=True`` (the canonical contract relied on by every writer) raises
+    on the first nonconforming entry. ``strict=False`` skips entries that fail
+    validation, logging each one — used only by the read-only Reports view so a
+    single variant/hand-authored campaign cannot blank out a whole document
+    (whose platforms/periods/reports the dashboard actually renders).
+    """
+    if strict:
+        return tuple(_parse_campaign(c, strict=True) for c in raw)
+    parsed: list[CampaignSnapshot] = []
+    for c in raw:
+        try:
+            parsed.append(_parse_campaign(c, strict=False))
+        except (ValueError, KeyError, TypeError) as exc:
+            # DEBUG, not WARNING: the read-only Reports view re-parses on every
+            # poll, so a per-entry WARNING would flood the log for a STATE.json
+            # with many nonconforming (e.g. legacy / hand-authored) campaigns.
+            logger.debug("skipping unparseable campaign entry: %s", exc)
+    return tuple(parsed)
+
+
+def _parse_action_log(
+    raw: list[dict[str, Any]], *, strict: bool
+) -> tuple[ActionLogEntry, ...]:
+    """Parse the action_log list.
+
+    ``strict=True`` (the writer contract) raises on the first entry missing a
+    required field (``timestamp`` / ``action`` / ``platform``). ``strict=False``
+    skips such entries, logging each — used only by the read-only Reports view
+    so a single old / hand-authored entry (e.g. one written before those fields
+    were required) cannot blank out a whole document.
+    """
+    if strict:
+        return tuple(_parse_action_log_entry(e) for e in raw)
+    parsed: list[ActionLogEntry] = []
+    for e in raw:
+        try:
+            parsed.append(_parse_action_log_entry(e))
+        except (ValueError, KeyError, TypeError) as exc:
+            # DEBUG, not WARNING — see _parse_campaigns: avoid per-render log
+            # flood from a STATE.json with many nonconforming action_log entries.
+            logger.debug("skipping unparseable action_log entry: %s", exc)
+    return tuple(parsed)
+
+
+def _platform_account_id(
+    platform_key: str, platform_data: dict[str, Any], *, strict: bool
+) -> str:
+    """Resolve a platform's ``account_id``.
+
+    ``strict=True`` (the writer contract) requires the key — a missing
+    ``account_id`` raises ``KeyError`` exactly as before. ``strict=False``
+    (the read-only Reports view) defaults a missing ``account_id`` to ``""``
+    so an agent-/hand-authored STATE.json that omitted it still renders its
+    platforms/totals/periods instead of blanking the whole dashboard. Logged
+    at DEBUG (expected for non-canonical files; never per-poll WARNING noise).
+    """
+    if strict or "account_id" in platform_data:
+        # KeyError in strict if absent — unchanged writer contract. Annotated
+        # local so mypy treats the dict[str, Any] value as the declared str.
+        account_id: str = platform_data["account_id"]
+        return account_id
+    logger.debug(
+        "platform %r missing 'account_id'; defaulting to '' for the tolerant "
+        "read-only view",
+        platform_key,
+    )
+    return ""
+
+
+def _parse_conversion_action_types(raw: Any) -> tuple[str, ...] | None:
+    """Parse a platform's ``conversion_action_types`` override (#342).
+
+    Returns a tuple of non-empty string action_types, or ``None`` when the
+    field is absent / not a list / has no usable entries (so the counters
+    fall back to the built-in generic set). Tolerant by design — a malformed
+    value degrades to "no override" rather than raising.
+    """
+    if not isinstance(raw, list):
+        return None
+    cleaned = tuple(str(x).strip() for x in raw if isinstance(x, str) and x.strip())
+    return cleaned or None
+
+
+def parse_state(text: str, *, strict: bool = True) -> StateDocument:
+    """Parse a JSON string and return a StateDocument.
+
+    ``strict`` controls campaign-list, action_log AND platform validation:
+    ``True`` (default) preserves the strict writer contract (raises on a missing
+    required field, including a platform ``account_id``); ``False`` tolerantly
+    skips nonconforming campaign / action_log entries and defaults a missing
+    platform ``account_id`` to ``""`` for the read-only Reports view. Invalid
+    JSON always raises regardless of ``strict``.
+
+    Unknown top-level keys are ignored (and :func:`render_state` emits only
+    the known ones), which is what keeps the ``mureo_state_get`` response
+    field ``server_now`` from ever being persisted: a document echoed back
+    into STATE.json with that key loses it on the next write instead of
+    fossilising a stale "today" (#460).
+    """
+    data = json.loads(text)
+    campaigns_raw = data.get("campaigns", [])
+    campaigns = _parse_campaigns(campaigns_raw, strict=strict)
+
+    # v2: platforms
+    platforms: dict[str, PlatformState] | None = None
+    platforms_raw = data.get("platforms")
+    if platforms_raw is not None:
+        platforms = {}
+        for platform_key, platform_data in platforms_raw.items():
+            platform_campaigns = _parse_campaigns(
+                platform_data.get("campaigns", []), strict=strict
+            )
+            platforms[platform_key] = PlatformState(
+                account_id=_platform_account_id(
+                    platform_key, platform_data, strict=strict
+                ),
+                campaigns=platform_campaigns,
+                totals=platform_data.get("totals"),
+                metrics_period=platform_data.get("metrics_period"),
+                periods=platform_data.get("periods"),
+                conversion_action_types=_parse_conversion_action_types(
+                    platform_data.get("conversion_action_types")
+                ),
+            )
+
+    # v2: action_log
+    action_log_raw = data.get("action_log", [])
+    action_log = _parse_action_log(action_log_raw, strict=strict)
+
+    return StateDocument(
+        version=data.get("version", "1"),
+        last_synced_at=data.get("last_synced_at"),
+        customer_id=data.get("customer_id"),
+        campaigns=campaigns,
+        platforms=platforms,
+        action_log=action_log,
+        reports=data.get("reports"),
+    )
+
+
+def _parse_action_log_entry(e: dict[str, Any]) -> ActionLogEntry:
+    """Create an ActionLogEntry from a dict."""
+    return ActionLogEntry(
+        timestamp=e["timestamp"],
+        action=e["action"],
+        platform=e["platform"],
+        campaign_id=e.get("campaign_id"),
+        ad_id=e.get("ad_id"),
+        entity_type=e.get("entity_type"),
+        entity_id=e.get("entity_id"),
+        summary=e.get("summary"),
+        command=e.get("command"),
+        metrics_at_action=e.get("metrics_at_action"),
+        observation_due=e.get("observation_due"),
+        reversible_params=e.get("reversible_params"),
+        rollback_of=e.get("rollback_of"),
+        evaluation_of=e.get("evaluation_of"),
+    )
+
+
+def _parse_campaign(c: dict[str, Any], *, strict: bool = True) -> CampaignSnapshot:
+    """Create a CampaignSnapshot from a dict (with required field validation)."""
+    for field_name in _CAMPAIGN_REQUIRED_FIELDS:
+        if field_name not in c:
+            raise ValueError(f"Campaign is missing required field '{field_name}': {c}")
+    device_targeting_raw = c.get("device_targeting")
+    device_targeting: tuple[dict[str, Any], ...] | None = None
+    if device_targeting_raw is not None:
+        device_targeting = tuple(device_targeting_raw)
+    return CampaignSnapshot(
+        campaign_id=c["campaign_id"],
+        campaign_name=c["campaign_name"],
+        status=c["status"],
+        bidding_strategy_type=c.get("bidding_strategy_type"),
+        bidding_details=c.get("bidding_details"),
+        daily_budget=c.get("daily_budget"),
+        device_targeting=device_targeting,
+        campaign_goal=c.get("campaign_goal"),
+        notes=c.get("notes"),
+        metrics=c.get("metrics"),
+        ads=_parse_ads(c.get("ads"), strict=strict),
+    )
+
+
+def render_state(doc: StateDocument) -> str:
+    """Generate a JSON string from a StateDocument."""
+    data: dict[str, Any] = {
+        "version": doc.version,
+        "last_synced_at": doc.last_synced_at,
+        "customer_id": doc.customer_id,
+        "campaigns": [_snapshot_to_dict(c) for c in doc.campaigns],
+    }
+
+    # v2: platforms
+    if doc.platforms is not None:
+        data["platforms"] = {
+            key: _platform_state_to_dict(ps) for key, ps in doc.platforms.items()
+        }
+    else:
+        data["platforms"] = None
+
+    # v2: action_log
+    data["action_log"] = [_action_log_entry_to_dict(e) for e in doc.action_log]
+
+    # Optional reports section (stage-c forward-ready): emit only when present
+    # so old STATE.json files don't gain a new key.
+    if doc.reports is not None:
+        data["reports"] = copy.deepcopy(doc.reports)
+
+    return json.dumps(data, ensure_ascii=False, indent=2)
+
+
+def _platform_state_to_dict(ps: PlatformState) -> dict[str, Any]:
+    """Convert a PlatformState to a dictionary."""
+    result: dict[str, Any] = {
+        "account_id": ps.account_id,
+        "campaigns": [_snapshot_to_dict(c) for c in ps.campaigns],
+    }
+    # Optional platform-level rollup: emit only when present.
+    if ps.totals is not None:
+        result["totals"] = copy.deepcopy(ps.totals)
+    if ps.metrics_period is not None:
+        result["metrics_period"] = ps.metrics_period
+    # Per-period rollups: emit only when non-empty so legacy files (and
+    # entries with no per-period data) stay byte-stable on round-trip.
+    if ps.periods:
+        result["periods"] = copy.deepcopy(ps.periods)
+    # #342 — operator conversion override: emit only when set, as a JSON list,
+    # so legacy entries stay byte-stable.
+    if ps.conversion_action_types:
+        result["conversion_action_types"] = list(ps.conversion_action_types)
+    return result
+
+
+def _action_log_entry_to_dict(e: ActionLogEntry) -> dict[str, Any]:
+    """Convert an ActionLogEntry to a dictionary."""
+    result: dict[str, Any] = {
+        "timestamp": e.timestamp,
+        "action": e.action,
+        "platform": e.platform,
+    }
+    if e.campaign_id is not None:
+        result["campaign_id"] = e.campaign_id
+    if e.ad_id is not None:
+        result["ad_id"] = e.ad_id
+    if e.entity_type is not None:
+        result["entity_type"] = e.entity_type
+    if e.entity_id is not None:
+        result["entity_id"] = e.entity_id
+    if e.summary is not None:
+        result["summary"] = e.summary
+    if e.command is not None:
+        result["command"] = e.command
+    if e.metrics_at_action is not None:
+        result["metrics_at_action"] = copy.deepcopy(e.metrics_at_action)
+    if e.observation_due is not None:
+        result["observation_due"] = e.observation_due
+    if e.reversible_params is not None:
+        result["reversible_params"] = copy.deepcopy(e.reversible_params)
+    if e.rollback_of is not None:
+        result["rollback_of"] = e.rollback_of
+    if e.evaluation_of is not None:
+        result["evaluation_of"] = e.evaluation_of
+    return result
+
+
+def _snapshot_to_dict(c: CampaignSnapshot) -> dict[str, Any]:
+    """Convert a CampaignSnapshot to a dictionary."""
+    device_targeting: list[dict[str, Any]] | None = None
+    if c.device_targeting is not None:
+        device_targeting = list(c.device_targeting)
+    result: dict[str, Any] = {
+        "campaign_id": c.campaign_id,
+        "campaign_name": c.campaign_name,
+        "status": c.status,
+        "bidding_strategy_type": c.bidding_strategy_type,
+        "bidding_details": c.bidding_details,
+        "daily_budget": c.daily_budget,
+        "device_targeting": device_targeting,
+        "campaign_goal": c.campaign_goal,
+        "notes": c.notes,
+    }
+    # Optional metrics: emit only when present so old STATE.json files don't
+    # gain a new key (no diff churn / bloat).
+    if c.metrics is not None:
+        result["metrics"] = copy.deepcopy(c.metrics)
+    # Ad-level state (#468): emit only when it was actually fetched, so a
+    # campaign that predates this field stays byte-stable on round-trip.
+    if c.ads is not None:
+        result["ads"] = [_ad_state_to_dict(a) for a in c.ads]
+    return result
+
+
+def _ad_state_to_dict(a: AdState) -> dict[str, Any]:
+    """Convert an :class:`AdState` to a dictionary.
+
+    Optional fields are emitted only when set: an absent ``effective_status``
+    must stay absent rather than becoming an empty string a later run could
+    read as an observed value.
+    """
+    result: dict[str, Any] = {"ad_id": a.ad_id}
+    for key, value in (
+        ("name", a.name),
+        ("status", a.status),
+        ("effective_status", a.effective_status),
+        ("as_of", a.as_of),
+    ):
+        if value is not None:
+            result[key] = value
+    return result
+
+
+__all__ = [
+    "parse_state",
+    "render_state",
+]

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,7 +1,27 @@
 """Import verification tests.
 
-Verifies that every module imports cleanly and that none of them pull
-in database or LLM dependencies.
+Two checks with deliberately different reach. The difference matters when you
+read a green run, so it is stated here rather than left to be inferred:
+
+- **The DB/LLM import ban covers everything.** ``TestNoForbiddenImports``
+  walks ``mureo/`` with ``rglob``, so every module in the package is checked,
+  including any added since this file was last touched.
+- **The clean-import check does not.** ``TestModuleImports`` iterates
+  ``_ALL_MODULES``, a hand-maintained list naming 46 of the 288 importable
+  modules under ``mureo/``.
+
+That subset is **drift, not policy**. No exclusion rule was ever written for
+the list; it simply stopped being extended, and whole packages — ``mcp``,
+``web``, ``core``, ``cli``, ``analytics``, ``creative_studio``,
+``amazon_ads``, ``adapters``, ``byod``, ``demo``, ``providers``, ``policy``,
+``rollback``, ``learning``, ``search_console`` — have no clean-import
+coverage here at all, while ``google_ads`` / ``meta_ads`` / ``analysis`` are
+covered only in part. So do **not** read a green ``TestModuleImports`` as
+"every module imports cleanly"; read it as "these 46 do".
+
+Closing the gap is tracked in #555 and is deliberately its own change: a
+module that legitimately cannot import standalone has to be found and judged,
+not swept into a list.
 """
 
 from __future__ import annotations
@@ -77,9 +97,13 @@ _ALL_MODULES: list[str] = [
     "mureo.analysis",
     "mureo.analysis.lp_analyzer",
     "mureo.context",
+    "mureo.context.conversion_overrides",
     "mureo.context.errors",
     "mureo.context.models",
+    "mureo.context.platform_accounts",
+    "mureo.context.platform_guards",
     "mureo.context.state",
+    "mureo.context.state_codec",
     "mureo.context.strategy",
 ]
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -501,7 +501,7 @@ class TestStateFileErrorHandling:
             "version": "2",
             "platforms": {"google_ads": {"campaigns": [], "totals": {"spend": 1.0}}},
         }
-        with caplog.at_level(logging.DEBUG, logger="mureo.context.state"):
+        with caplog.at_level(logging.DEBUG, logger="mureo.context.state_codec"):
             parse_state(json.dumps(data), strict=False)
         assert any(
             "missing 'account_id'" in r.message and r.levelno == logging.DEBUG
@@ -523,7 +523,7 @@ class TestStateFileErrorHandling:
             "campaigns": [{"id": "x", "name": "variant, no campaign_id/_name"}],
             "action_log": [{"summary": "legacy, no timestamp/action/platform"}],
         }
-        with caplog.at_level(logging.DEBUG, logger="mureo.context.state"):
+        with caplog.at_level(logging.DEBUG, logger="mureo.context.state_codec"):
             parse_state(json.dumps(data), strict=False)
 
         # The skips still happen and are observable at DEBUG …


### PR DESCRIPTION
Closes #538.

`mureo/context/state.py` was **967 lines** against the repo's 800-line limit, holding the JSON codec, the atomic write path, the cross-process lock, the document mutators, and an account-scoped override lookup. It is imported by nearly the whole codebase and by two sibling repos.

## This is a pure move, and that is the point

Every top-level definition is **byte-identical** in its new home — verified by AST-extracting each definition's source segment from `ace2629` and from the result, and comparing:

```
total base top-level defs : 33
byte-identical            : 33
differing                 : 0
dropped / newly added     : 0 / 0
```

Review re-ran that check with a different script and got the same answer. That property is what lets this be reviewed cheaply; without it, a change to the module that owns the state lock would need full behavioural review.

## The seam

**`state_codec.py`** (428) — `parse_state` and `render_state` **together**, with their twelve field helpers.

The issue suggested moving `parse_state` alone. Two problems: it transitively pulls in eight private helpers, so "move parse_state" is really "move the parse side"; and every schema field appears exactly twice, once in each direction. The optionality rules that keep a round trip byte-stable (`metrics` / `ads` / `periods` / `conversion_action_types` emitted only when present) are **only checkable with both halves in front of you**. Splitting them would have left a contract whose two ends nobody can see at once.

**`conversion_overrides.py`** (118) — `load_conversion_action_types`. This one really is the odd duck in `state.py`: the only thing there that resolves its own workspace through the runtime context, the only one that joins on ad-account id, and the only one that **deliberately never raises** — the opposite of the writers' strict contract.

**`state.py`** 967 → **551** — the document layer its name promises: atomic write, `fsync`, the sidecar lock, `_locked_state_mutation`, `read_state_file` / `write_state_file`, and the five mutators. The lock and the atomic write stay together; the merge semantics stay with the mutators, because those docstrings *are* the contract.

## One behavioural difference, and only one

`logger = logging.getLogger(__name__)` is byte-identical, but `__name__` now resolves to `state_codec`, so the tolerant read path's DEBUG records come from a different logger. Two `caplog` assertions updated; review grepped the tree and confirmed nothing else filters on that name.

## Compatibility

`state.py` gains `__all__` — not cosmetic. mypy runs `strict = true`, which implies `no_implicit_reexport`, so without it every existing `from mureo.context.state import parse_state` in the tree and in `mureo-pro` would fail. Review verified the two out-of-tree callers (`mureo-pro`'s `tenant_state_store.py` and `cloud/local/seed.py`) by running their exact import lines against this tree.

Neither new module can join the `mureo.core.__init__` → `runtime_context` → `state_store` → `mureo.context.state` cycle: `state_codec` depends on stdlib + `models` only, and `conversion_overrides`' `runtime_context` import stays lazy inside the function. The subprocess regression test guarding that cycle passes.

## Also in this change

`tests/test_imports.py`'s docstring claimed it "verifies that **every** module imports cleanly". It does not — `TestNoForbiddenImports` walks the tree with `rglob` and genuinely covers everything, but the clean-import check iterates a hand-maintained list naming **46 of 288** modules, with eight whole packages absent. The docstring now states the real reach of each half and names the subset as drift rather than policy. Closing the gap is #555, deliberately its own change: a module that legitimately cannot import standalone has to be found and judged, not swept into a list.

Two stale docstring cross-references in `platform_accounts.py` corrected (one broken by this change, one left over from #534). `docs/architecture.md`'s `context/` tree was already missing four modules; now lists all seven.

## Remaining debt, stated honestly

Four functions stay over the 50-line limit, for two different reasons. The three writers are long because the docstring is the merge contract and the `_build` closure implements it — cutting either apart separates a rule from its implementation, and they are expected to stay. `parse_state` (55) is **not** permanent: its `platforms` loop would extract cleanly as the mirror of `_platform_state_to_dict`, bringing it to ~37. It was skipped only because a differing body would have cost the byte-identity property above.

Full suite 7445 passed, zero regressions, +4 tests.
