### PR TITLE
test: execute the money-safety logic instead of grepping for it (#540)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,39 @@ jobs:
       - name: Type check
         run: mypy mureo/ --ignore-missing-imports
 
+  # Browser-asset logic guard (#540). mureo/_data/web/reports_logic.js holds
+  # the money-safety half of the Reports dashboard — the KPI-withholding
+  # condition (#533), the freshness aggregation (#535), the conflict-kind
+  # routing. The Python guards in tests/test_web_assets_*.py can only pin
+  # substrings; an inverted condition ships green past them. This job
+  # EXECUTES that logic.
+  #
+  # Deliberately dependency-free: Node's built-in test runner, no
+  # package.json, no lockfile, no npm install, no new pinned action — it
+  # uses the Node preinstalled on the runner. Adding a JS toolchain to a
+  # Python project's CI is a real cost, and this keeps it at ~1s and zero
+  # supply-chain surface. Independent of `lint` on purpose: a Python
+  # formatting failure must not hide a broken money figure.
+  #
+  # NOTE — the Node version floats with `ubuntu-latest`, ON PURPOSE. Please
+  # do NOT "fix" this by adding `actions/setup-node`: that trades a pinned
+  # version floor for a third-party action in the supply chain of every CI
+  # run. The suite uses only `node:test`, `node:assert` and `node:vm`.
+  # `node:test` shipped in Node 18.0.0 as experimental and reached stable in
+  # Node 20; `node:assert` and `node:vm` are long-stable. So the real floor
+  # is Node 20, and `ubuntu-latest` has shipped well past that since 2023 —
+  # the drift risk is a version becoming NEWER, which these APIs are
+  # backwards-compatible across. The `node --version` step exists so a
+  # future incompatibility is visible in the log instead of being guessed at.
+  test-js:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Node version
+        run: node --version
+      - name: Run browser-asset tests
+        run: node --test tests/js/*.test.js
+
   test:
     needs: lint
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,10 @@ mureo combines strategy context, workflow commands, and domain knowledge to help
 pip install -e ".[dev]"
 pytest tests/ -v
 pytest tests/ --cov=mureo --cov-report=term-missing
+
+# Browser assets (only when mureo/_data/web/ changes). Node's built-in
+# runner — no package.json, no dependencies, no build step.
+node --test tests/js/*.test.js
 ```
 
 ## Architecture
@@ -278,6 +282,15 @@ This rule was reinforced after PR #20 (2026-04-19, OAuth helper extraction — 6
 - All external API calls (Google Ads, Meta Ads) **must** be mocked in tests
 - Use `@pytest.mark.unit` / `@pytest.mark.integration` for categorization
 - Async test mode: auto (`asyncio_mode = "auto"`)
+- **Browser assets** (`mureo/_data/web/`): they ship as plain
+  `<script>`-loaded files, so nothing there may grow a bundler, a module
+  system or a build step. Rendering is guarded by the substring pins in
+  `tests/test_web_assets_*.py`. DOM-free logic goes in
+  `mureo/_data/web/reports_logic.js` — which publishes
+  `window.MUREO_REPORTS_LOGIC` for the browser and carries an inert
+  `module.exports` tail so `node --test tests/js/*.test.js` executes the
+  exact bytes the browser is served. Put new decision logic there; a
+  grep-pin cannot catch an inverted condition.
 
 ## Credential Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,6 +198,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the "every definition is byte-identical" property is the entire reason this
   change is reviewable. It is worth doing as its own change, where the body
   diff is the point rather than a cost.
+- **The Reports dashboard's money-safety logic is now executed by a test, not
+  grepped for** (#540). `aggregateClientKpis` decides whether a client card
+  renders a money figure at all — since #533 it withholds spend, conversions
+  and CPA when the document is known to double-count an ad account — and
+  `reportsCardFreshness` decides whether a card reads as stale. Neither was
+  run by anything. The `tests/test_web_assets_*.py` guards are substring
+  pins: they catch a deleted name or string, but an inverted condition, a
+  flipped comparison or a dropped branch shipped green past them, and those
+  are the failure modes that put a wrong number in front of an operator.
+
+  The DOM-free half of that section — the withholding condition, the
+  freshness aggregation, the conflict-kind routing and their helpers — moved
+  **verbatim** out of `dashboard.js` into a new asset,
+  `mureo/_data/web/reports_logic.js`, which `dashboard.js` binds at load.
+  Rendering did not move and is still pinned statically.
+
+  **Nothing about how mureo ships changed.** The new file is another plain
+  `<script>`-loaded asset served from `mureo/_data/web/`, the way
+  `amazon_oauth.js` already is: it publishes `window.MUREO_REPORTS_LOGIC`,
+  and its `module.exports` tail is dead code in a browser. No bundler, no
+  module system, no build step, no `package.json`, no JavaScript
+  dependencies. `tests/js/browser_contract.test.js` evaluates the shipped
+  bytes in a context with no CommonJS at all — the browser's — and then
+  evaluates `dashboard.js` on top of them, so the split cannot quietly leave
+  the page with a script it can no longer load. If the module is ever
+  missing or misordered, `dashboard.js` throws at load naming the module and
+  the required `<script>` order: refusing to run is right — the alternative
+  is rendering double-counted totals from an `undefined` helper — but the
+  failure takes the whole configure UI with it, so it should not also need
+  reverse-engineering.
+
+  **The logic/renderer seam is pinned too.** Extracting the decisions leaves
+  a gap the JS suite cannot see: `aggregateClientKpis` can withhold a figure
+  correctly and the card can still draw it, because one comparison points
+  the wrong way. Inverting `kpis.spend != null` makes a healthy client read
+  "—" and the double-counted one the only card showing a number; inverting
+  `if (kpis.doubleCounted)` moves the "figures withheld" note onto every
+  healthy card and off the one it describes. Both are one character, and
+  both used to pass. `tests/test_web_assets_reports_conflicts.py` now pins
+  those branches on polarity — and on which branch a string is reachable
+  from — rather than on the identifiers being present.
+
+  CI gains one dependency-free job that runs `node --test tests/js/*.test.js`
+  with the Node already on the runner. It is independent of the Python lint
+  job on purpose: a formatting failure must not hide a broken money figure.
 
 ## [0.10.41] - 2026-08-06
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,13 @@ Thank you for your interest in contributing to mureo. This guide covers the deve
 
 - Python 3.10 or later
 - Git
+- Node.js 20 or later (`node:test` was experimental before 20) — **only**
+  to run the browser-asset tests
+  (`node --test tests/js/*.test.js`). mureo ships no JavaScript
+  dependencies, there is no `package.json` and no build step; Node is used
+  purely as a test runner for the DOM-free logic in
+  `mureo/_data/web/reports_logic.js`. Skip it if you are not touching the
+  configure UI — CI runs it either way.
 
 ### Clone and Install
 
@@ -59,6 +66,28 @@ pytest -m unit
 # Integration tests only
 pytest -m integration
 ```
+
+### Browser Assets
+
+The configure UI in `mureo/_data/web/` ships as plain `<script>`-loaded
+files — no bundler, no module system, no build step. Most of it is guarded
+by the `tests/test_web_assets_*.py` pins, which grep the shipped asset for
+the names, strings and selectors a feature depends on.
+
+Grepping cannot catch an inverted condition, so the DOM-free logic behind
+the Reports dashboard's money figures lives in its own asset,
+`mureo/_data/web/reports_logic.js`, and is executed by Node's built-in test
+runner:
+
+```bash
+node --test tests/js/*.test.js
+```
+
+No install step: no `package.json`, no dependencies, no lockfile. The
+module publishes `window.MUREO_REPORTS_LOGIC` for the browser and carries an
+inert `module.exports` tail so Node can require the exact bytes the browser
+is served. When you add DOM-free logic to the configure UI, put it there
+and test it; rendering stays in `dashboard.js` and stays pinned statically.
 
 ### Test Framework
 
@@ -183,6 +212,8 @@ Never commit credentials, API keys, or tokens. Use environment variables or `~/.
 3. **Types pass**: `mypy mureo/`
 4. **Lint passes**: `ruff check mureo/`
 5. **Formatted**: `black --check mureo/ tests/`
+6. **Browser assets pass** (only if you touched `mureo/_data/web/`):
+   `node --test tests/js/*.test.js`
 
 ### PR Structure
 
@@ -232,7 +263,8 @@ mureo/
 │   ├── context/
 │   ├── cli/
 │   └── mcp/
-├── tests/               # Test suite
+├── tests/               # Test suite (pytest)
+│   └── js/              # Browser-asset tests (node --test, no deps)
 ├── docs/                # Documentation
 ├── pyproject.toml       # Project configuration
 └── README.md

--- a/mureo/_data/web/app.html
+++ b/mureo/_data/web/app.html
@@ -459,6 +459,9 @@
   <script src="/static/amazon_oauth.js"></script>
   <script src="/static/auth_wizards_meta.js"></script>
   <script src="/static/auth_wizards.js"></script>
+  <!-- The Reports dashboard's pure logic (#540). dashboard.js binds it at
+       load, so it MUST come first. -->
+  <script src="/static/reports_logic.js"></script>
   <script src="/static/dashboard.js"></script>
   <script src="/static/extensions.js"></script>
 

--- a/mureo/_data/web/dashboard.js
+++ b/mureo/_data/web/dashboard.js
@@ -1782,13 +1782,36 @@
   // renders what it is told.
   // ----------------------------------------------------------------------
 
-  // `platform_conflicts[].kind` — two INDEPENDENT findings, kept apart on
-  // purpose. "Two keys resolve to one account" means the totals on screen
-  // are double-counted right now; "unrecognised key" means that entry's
-  // identity cannot be established at all and it MAY be a duplicate. The
-  // operator's next move differs, so they never collapse into one warning.
-  const REPORTS_CONFLICT_DUPLICATE_ACCOUNT = "duplicate_account";
-  const REPORTS_CONFLICT_UNRECOGNIZED_KEY = "unrecognized_key";
+  // The pure half of this section — the KPI-withholding condition, the
+  // freshness aggregation and the conflict-kind routing — lives in
+  // reports_logic.js (#540) so a test runner can execute it. Nothing about
+  // it needs a DOM; everything below still does. Bound here by their
+  // original names so every call site downstream reads exactly as before.
+  // reports_logic.js is a plain `<script>` loaded ahead of this file (see
+  // app.html). Failing at load is deliberate — the alternative is a
+  // conflicted client's double-counted totals rendering because the
+  // withholding helper quietly became `undefined`. Everything above this
+  // point is declarations, so nothing observable has happened yet when this
+  // throws: no listener is registered, no fetch is issued, no node reaches
+  // the DOM. But it does take the whole configure UI with it, so it says
+  // what is missing and what fixes it rather than leaving whoever hits it
+  // to reverse-engineer a bare "cannot read properties of undefined".
+  if (!window.MUREO_REPORTS_LOGIC) {
+    throw new Error(
+      "dashboard.js: window.MUREO_REPORTS_LOGIC is missing. " +
+        "reports_logic.js must be served (see _STATIC_ALLOWLIST in " +
+        "mureo/web/handlers.py) and its <script> tag must come BEFORE " +
+        "dashboard.js in app.html."
+    );
+  }
+  const REPORTS_LOGIC = window.MUREO_REPORTS_LOGIC;
+  const relativeAge = REPORTS_LOGIC.relativeAge;
+  const reportsPlatformLabels = REPORTS_LOGIC.reportsPlatformLabels;
+  const reportsConflictText = REPORTS_LOGIC.reportsConflictText;
+  const reportsConflictsForKey = REPORTS_LOGIC.reportsConflictsForKey;
+  const reportsFreshnessLabel = REPORTS_LOGIC.reportsFreshnessLabel;
+  const reportsCardFreshness = REPORTS_LOGIC.reportsCardFreshness;
+  const aggregateClientKpis = REPORTS_LOGIC.aggregateClientKpis;
 
   // Canonical secondary KPI vocabulary → i18n label key. Headline (spend)
   // is rendered separately. Order here is the on-card display order.
@@ -2084,22 +2107,6 @@
   // result append.
   let reportsRenderSeq = 0;
 
-  // Humanize an ISO-8601 timestamp into a coarse "N ago" string. Falls
-  // back to the raw string if it cannot be parsed (never throws).
-  function relativeAge(iso) {
-    if (!iso) return "";
-    const then = Date.parse(iso);
-    if (Number.isNaN(then)) return String(iso);
-    const secs = Math.max(0, Math.floor((Date.now() - then) / 1000));
-    if (secs < 60) return MUREO.t("dashboard.reports_age_just_now");
-    const mins = Math.floor(secs / 60);
-    if (mins < 60) return MUREO.t("dashboard.reports_age_minutes", { n: mins });
-    const hours = Math.floor(mins / 60);
-    if (hours < 24) return MUREO.t("dashboard.reports_age_hours", { n: hours });
-    const days = Math.floor(hours / 24);
-    return MUREO.t("dashboard.reports_age_days", { n: days });
-  }
-
   // Format a raw number with thousands separators (no currency symbol —
   // the API returns raw numbers and we must not assume a currency). Non-
   // numbers pass through as plain text.
@@ -2123,144 +2130,6 @@
       return pct.toLocaleString(undefined, { maximumFractionDigits: 2 }) + "%";
     }
     return formatNumber(value);
-  }
-
-  // ------------------------------------------------------------------
-  // Conflicts (#533) + per-platform freshness (#535)
-  // ------------------------------------------------------------------
-
-  // Every conflict row of `kind` in a summary. Defensive: the key is always
-  // sent, but a proxy or an older daemon may not have it.
-  function reportsConflictsOfKind(summary, kind) {
-    const rows =
-      summary && Array.isArray(summary.platform_conflicts)
-        ? summary.platform_conflicts
-        : [];
-    return rows.filter(function (row) {
-      return row && row.kind === kind && Array.isArray(row.platform_keys);
-    });
-  }
-
-  // Does this client's aggregate double-count an ad account right now?
-  function reportsHasDoubleCount(summary) {
-    return (
-      reportsConflictsOfKind(summary, REPORTS_CONFLICT_DUPLICATE_ACCOUNT).length > 0
-    );
-  }
-
-  // key → display_name from the summary's platform rows, so a conflict names
-  // platforms the way the rest of the view does. Falls back to the raw key.
-  function reportsPlatformLabels(summary) {
-    const map = {};
-    (summary && Array.isArray(summary.platforms) ? summary.platforms : []).forEach(
-      function (p) {
-        if (p && typeof p.key === "string") map[p.key] = p.display_name || p.key;
-      }
-    );
-    return map;
-  }
-
-  function reportsKeyList(keys, labels) {
-    return (Array.isArray(keys) ? keys : [])
-      .map(function (k) {
-        return (labels && labels[k]) || String(k);
-      })
-      .join(", ");
-  }
-
-  // A conflict as one localized sentence. Untrusted platform keys are
-  // interpolated into the string and the caller sets it via textContent.
-  function reportsConflictText(row, labels) {
-    const keys = reportsKeyList(row.platform_keys, labels);
-    if (row.kind === REPORTS_CONFLICT_DUPLICATE_ACCOUNT) {
-      return MUREO.t("dashboard.reports_conflict_double_counted", { keys: keys });
-    }
-    return MUREO.t("dashboard.reports_conflict_unknown_key", { keys: keys });
-  }
-
-  // Every conflict that names `key`, so a platform card can carry its own.
-  function reportsConflictsForKey(summary, key) {
-    const rows =
-      summary && Array.isArray(summary.platform_conflicts)
-        ? summary.platform_conflicts
-        : [];
-    return rows.filter(function (row) {
-      return (
-        row && Array.isArray(row.platform_keys) && row.platform_keys.indexOf(key) >= 0
-      );
-    });
-  }
-
-  // A row's own freshness as {text, stale}. `stale === null` (fetched_at
-  // absent or unparseable) is its own state — "unknown", not "fresh" —
-  // because fetched_at is optional and writer-dependent.
-  function reportsFreshnessLabel(freshness) {
-    const f = freshness && typeof freshness === "object" ? freshness : null;
-    if (!f || !f.fetched_at || f.stale == null) {
-      return { text: MUREO.t("dashboard.reports_platform_age_unknown"), stale: false };
-    }
-    const ago = relativeAge(f.fetched_at);
-    return {
-      text: MUREO.t(
-        f.stale
-          ? "dashboard.reports_platform_stale"
-          : "dashboard.reports_platform_updated",
-        { ago: ago }
-      ),
-      stale: !!f.stale,
-    };
-  }
-
-  // The freshness of a client CARD, which shows one aggregate rather than
-  // per-platform rows. Only platforms that actually carry totals count —
-  // an advisory bridge contributes nothing to the sum, so its (absent)
-  // fetched_at says nothing about the number on screen. Among the rest the
-  // OLDEST wins, because an aggregate is only as current as its stalest
-  // input, and a single unknown means the card cannot state an age at all
-  // rather than letting a fresh sibling vouch for the rest.
-  //
-  // Three outcomes, and the text always matches the styling:
-  //   • every contributor known      → "Updated N ago" / "Stale — updated N ago"
-  //   • some unknown, none stale     → "Update time unknown" (not marked stale)
-  //   • some unknown, one is stale   → "Stale — some update times unknown"
-  // The third is the mixed case: we know something IS stale (a fresh sibling
-  // must never hide it) but we cannot honestly quote an age, so the label
-  // says exactly that instead of claiming "unknown" in stale-red.
-  function reportsCardFreshness(summary) {
-    const platforms =
-      summary && Array.isArray(summary.platforms) ? summary.platforms : [];
-    let oldest = null;
-    let oldestMs = Infinity;
-    let stale = false;
-    let unknown = false;
-    platforms.forEach(function (p) {
-      if (!p || !p.totals || typeof p.totals !== "object") return;
-      const f = p.freshness && typeof p.freshness === "object" ? p.freshness : null;
-      if (!f || !f.fetched_at || f.stale == null) {
-        unknown = true;
-        return;
-      }
-      if (f.stale) stale = true;
-      const ms = Date.parse(f.fetched_at);
-      if (!Number.isNaN(ms) && ms < oldestMs) {
-        oldestMs = ms;
-        oldest = f;
-      }
-    });
-    if (unknown || !oldest) {
-      return {
-        text: MUREO.t(
-          stale
-            ? "dashboard.reports_platform_stale_partial"
-            : "dashboard.reports_platform_age_unknown"
-        ),
-        stale: stale,
-      };
-    }
-    return reportsFreshnessLabel({
-      fetched_at: oldest.fetched_at,
-      stale: stale,
-    });
   }
 
   // Build one KPI card for a single platform entry. `summary` is optional and
@@ -2500,52 +2369,6 @@
     } catch (_err) {
       return null;
     }
-  }
-
-  // Sum a client's headline KPIs across its platforms. null when absent so a
-  // missing metric reads as "—" rather than a misleading zero.
-  //
-  // Summing across genuinely different platforms is the feature. Summing two
-  // keys that resolve to ONE ad account is the bug (#533) — so when the
-  // summary reports that conflict, the figures are WITHHELD (null) rather
-  // than shown under a warning. A number an operator triages by is worse
-  // than no number when it is known to be wrong: a doubled spend reads as a
-  // real outlier and gets acted on. The un-summed per-platform figures are
-  // one click away in the detail view, and nothing is merged or dropped to
-  // manufacture a total — the two entries hold different partial figures.
-  //
-  // The nulling happens HERE, not in the caller, so no future call site can
-  // render the double-counted sum by forgetting to check the flag.
-  // `hasFigures` reports the raw presence of data regardless, for callers
-  // deciding whether another period window is worth fetching.
-  function aggregateClientKpis(summary) {
-    const platforms =
-      summary && Array.isArray(summary.platforms) ? summary.platforms : [];
-    let spend = 0;
-    let conv = 0;
-    let hasSpend = false;
-    let hasConv = false;
-    platforms.forEach(function (p) {
-      const t = p && typeof p.totals === "object" ? p.totals : null;
-      if (!t) return;
-      if (typeof t.spend === "number" && isFinite(t.spend)) {
-        spend += t.spend;
-        hasSpend = true;
-      }
-      if (typeof t.conversions === "number" && isFinite(t.conversions)) {
-        conv += t.conversions;
-        hasConv = true;
-      }
-    });
-    const doubleCounted = reportsHasDoubleCount(summary);
-    return {
-      spend: !doubleCounted && hasSpend ? spend : null,
-      conversions: !doubleCounted && hasConv ? conv : null,
-      cpa:
-        !doubleCounted && hasSpend && hasConv && conv > 0 ? spend / conv : null,
-      hasFigures: hasSpend || hasConv,
-      doubleCounted: doubleCounted,
-    };
   }
 
   // Flags from a client's latest report (daily → weekly → goal).

--- a/mureo/_data/web/reports_logic.js
+++ b/mureo/_data/web/reports_logic.js
@@ -1,0 +1,258 @@
+// reports_logic.js — the pure half of the Reports dashboard (#540).
+//
+// Everything here is a plain function over the `/api/reports/*` wire
+// payload: no DOM, no fetch, no module state. It was MOVED here verbatim
+// from dashboard.js so it can be executed by a test runner — the
+// KPI-withholding condition (#533), the per-platform freshness
+// aggregation (#535) and the conflict-kind routing decide whether an
+// operator sees a money figure at all, and an inverted condition or a
+// reordered branch in any of them ships silently. Static substring pins
+// cannot catch that; `node --test tests/js/` can. Rendering stays in
+// dashboard.js and stays pinned statically.
+//
+// Shipping shape is unchanged: this is a plain `<script>`-loaded file,
+// no bundler, no module system, no build step. It publishes
+// `window.MUREO_REPORTS_LOGIC` the same way amazon_oauth.js publishes
+// `window.MUREO_AMAZON_OAUTH`, and it MUST load before dashboard.js.
+// The `module.exports` tail at the bottom is inert in a browser (`module`
+// is undefined there) and is what lets Node require the same bytes the
+// browser gets — the test never sees a re-implementation.
+//
+// `MUREO.t` is read from the global at CALL time, not captured at load
+// time, so this file has no load-order dependency on app.js and a test
+// can supply its own `t`.
+
+(function () {
+  "use strict";
+
+  // `platform_conflicts[].kind` — two INDEPENDENT findings, kept apart on
+  // purpose. "Two keys resolve to one account" means the totals on screen
+  // are double-counted right now; "unrecognised key" means that entry's
+  // identity cannot be established at all and it MAY be a duplicate. The
+  // operator's next move differs, so they never collapse into one warning.
+  const REPORTS_CONFLICT_DUPLICATE_ACCOUNT = "duplicate_account";
+  const REPORTS_CONFLICT_UNRECOGNIZED_KEY = "unrecognized_key";
+
+  // Humanize an ISO-8601 timestamp into a coarse "N ago" string. Falls
+  // back to the raw string if it cannot be parsed (never throws).
+  function relativeAge(iso) {
+    if (!iso) return "";
+    const then = Date.parse(iso);
+    if (Number.isNaN(then)) return String(iso);
+    const secs = Math.max(0, Math.floor((Date.now() - then) / 1000));
+    if (secs < 60) return MUREO.t("dashboard.reports_age_just_now");
+    const mins = Math.floor(secs / 60);
+    if (mins < 60) return MUREO.t("dashboard.reports_age_minutes", { n: mins });
+    const hours = Math.floor(mins / 60);
+    if (hours < 24) return MUREO.t("dashboard.reports_age_hours", { n: hours });
+    const days = Math.floor(hours / 24);
+    return MUREO.t("dashboard.reports_age_days", { n: days });
+  }
+
+  // ------------------------------------------------------------------
+  // Conflicts (#533) + per-platform freshness (#535)
+  // ------------------------------------------------------------------
+
+  // Every conflict row of `kind` in a summary. Defensive: the key is always
+  // sent, but a proxy or an older daemon may not have it.
+  function reportsConflictsOfKind(summary, kind) {
+    const rows =
+      summary && Array.isArray(summary.platform_conflicts)
+        ? summary.platform_conflicts
+        : [];
+    return rows.filter(function (row) {
+      return row && row.kind === kind && Array.isArray(row.platform_keys);
+    });
+  }
+
+  // Does this client's aggregate double-count an ad account right now?
+  function reportsHasDoubleCount(summary) {
+    return (
+      reportsConflictsOfKind(summary, REPORTS_CONFLICT_DUPLICATE_ACCOUNT).length > 0
+    );
+  }
+
+  // key → display_name from the summary's platform rows, so a conflict names
+  // platforms the way the rest of the view does. Falls back to the raw key.
+  function reportsPlatformLabels(summary) {
+    const map = {};
+    (summary && Array.isArray(summary.platforms) ? summary.platforms : []).forEach(
+      function (p) {
+        if (p && typeof p.key === "string") map[p.key] = p.display_name || p.key;
+      }
+    );
+    return map;
+  }
+
+  function reportsKeyList(keys, labels) {
+    return (Array.isArray(keys) ? keys : [])
+      .map(function (k) {
+        return (labels && labels[k]) || String(k);
+      })
+      .join(", ");
+  }
+
+  // A conflict as one localized sentence. Untrusted platform keys are
+  // interpolated into the string and the caller sets it via textContent.
+  function reportsConflictText(row, labels) {
+    const keys = reportsKeyList(row.platform_keys, labels);
+    if (row.kind === REPORTS_CONFLICT_DUPLICATE_ACCOUNT) {
+      return MUREO.t("dashboard.reports_conflict_double_counted", { keys: keys });
+    }
+    return MUREO.t("dashboard.reports_conflict_unknown_key", { keys: keys });
+  }
+
+  // Every conflict that names `key`, so a platform card can carry its own.
+  function reportsConflictsForKey(summary, key) {
+    const rows =
+      summary && Array.isArray(summary.platform_conflicts)
+        ? summary.platform_conflicts
+        : [];
+    return rows.filter(function (row) {
+      return (
+        row && Array.isArray(row.platform_keys) && row.platform_keys.indexOf(key) >= 0
+      );
+    });
+  }
+
+  // A row's own freshness as {text, stale}. `stale === null` (fetched_at
+  // absent or unparseable) is its own state — "unknown", not "fresh" —
+  // because fetched_at is optional and writer-dependent.
+  function reportsFreshnessLabel(freshness) {
+    const f = freshness && typeof freshness === "object" ? freshness : null;
+    if (!f || !f.fetched_at || f.stale == null) {
+      return { text: MUREO.t("dashboard.reports_platform_age_unknown"), stale: false };
+    }
+    const ago = relativeAge(f.fetched_at);
+    return {
+      text: MUREO.t(
+        f.stale
+          ? "dashboard.reports_platform_stale"
+          : "dashboard.reports_platform_updated",
+        { ago: ago }
+      ),
+      stale: !!f.stale,
+    };
+  }
+
+  // The freshness of a client CARD, which shows one aggregate rather than
+  // per-platform rows. Only platforms that actually carry totals count —
+  // an advisory bridge contributes nothing to the sum, so its (absent)
+  // fetched_at says nothing about the number on screen. Among the rest the
+  // OLDEST wins, because an aggregate is only as current as its stalest
+  // input, and a single unknown means the card cannot state an age at all
+  // rather than letting a fresh sibling vouch for the rest.
+  //
+  // Three outcomes, and the text always matches the styling:
+  //   • every contributor known      → "Updated N ago" / "Stale — updated N ago"
+  //   • some unknown, none stale     → "Update time unknown" (not marked stale)
+  //   • some unknown, one is stale   → "Stale — some update times unknown"
+  // The third is the mixed case: we know something IS stale (a fresh sibling
+  // must never hide it) but we cannot honestly quote an age, so the label
+  // says exactly that instead of claiming "unknown" in stale-red.
+  function reportsCardFreshness(summary) {
+    const platforms =
+      summary && Array.isArray(summary.platforms) ? summary.platforms : [];
+    let oldest = null;
+    let oldestMs = Infinity;
+    let stale = false;
+    let unknown = false;
+    platforms.forEach(function (p) {
+      if (!p || !p.totals || typeof p.totals !== "object") return;
+      const f = p.freshness && typeof p.freshness === "object" ? p.freshness : null;
+      if (!f || !f.fetched_at || f.stale == null) {
+        unknown = true;
+        return;
+      }
+      if (f.stale) stale = true;
+      const ms = Date.parse(f.fetched_at);
+      if (!Number.isNaN(ms) && ms < oldestMs) {
+        oldestMs = ms;
+        oldest = f;
+      }
+    });
+    if (unknown || !oldest) {
+      return {
+        text: MUREO.t(
+          stale
+            ? "dashboard.reports_platform_stale_partial"
+            : "dashboard.reports_platform_age_unknown"
+        ),
+        stale: stale,
+      };
+    }
+    return reportsFreshnessLabel({
+      fetched_at: oldest.fetched_at,
+      stale: stale,
+    });
+  }
+
+  // Sum a client's headline KPIs across its platforms. null when absent so a
+  // missing metric reads as "—" rather than a misleading zero.
+  //
+  // Summing across genuinely different platforms is the feature. Summing two
+  // keys that resolve to ONE ad account is the bug (#533) — so when the
+  // summary reports that conflict, the figures are WITHHELD (null) rather
+  // than shown under a warning. A number an operator triages by is worse
+  // than no number when it is known to be wrong: a doubled spend reads as a
+  // real outlier and gets acted on. The un-summed per-platform figures are
+  // one click away in the detail view, and nothing is merged or dropped to
+  // manufacture a total — the two entries hold different partial figures.
+  //
+  // The nulling happens HERE, not in the caller, so no future call site can
+  // render the double-counted sum by forgetting to check the flag.
+  // `hasFigures` reports the raw presence of data regardless, for callers
+  // deciding whether another period window is worth fetching.
+  function aggregateClientKpis(summary) {
+    const platforms =
+      summary && Array.isArray(summary.platforms) ? summary.platforms : [];
+    let spend = 0;
+    let conv = 0;
+    let hasSpend = false;
+    let hasConv = false;
+    platforms.forEach(function (p) {
+      const t = p && typeof p.totals === "object" ? p.totals : null;
+      if (!t) return;
+      if (typeof t.spend === "number" && isFinite(t.spend)) {
+        spend += t.spend;
+        hasSpend = true;
+      }
+      if (typeof t.conversions === "number" && isFinite(t.conversions)) {
+        conv += t.conversions;
+        hasConv = true;
+      }
+    });
+    const doubleCounted = reportsHasDoubleCount(summary);
+    return {
+      spend: !doubleCounted && hasSpend ? spend : null,
+      conversions: !doubleCounted && hasConv ? conv : null,
+      cpa:
+        !doubleCounted && hasSpend && hasConv && conv > 0 ? spend / conv : null,
+      hasFigures: hasSpend || hasConv,
+      doubleCounted: doubleCounted,
+    };
+  }
+
+  const api = {
+    REPORTS_CONFLICT_DUPLICATE_ACCOUNT: REPORTS_CONFLICT_DUPLICATE_ACCOUNT,
+    REPORTS_CONFLICT_UNRECOGNIZED_KEY: REPORTS_CONFLICT_UNRECOGNIZED_KEY,
+    relativeAge: relativeAge,
+    reportsConflictsOfKind: reportsConflictsOfKind,
+    reportsHasDoubleCount: reportsHasDoubleCount,
+    reportsPlatformLabels: reportsPlatformLabels,
+    reportsKeyList: reportsKeyList,
+    reportsConflictText: reportsConflictText,
+    reportsConflictsForKey: reportsConflictsForKey,
+    reportsFreshnessLabel: reportsFreshnessLabel,
+    reportsCardFreshness: reportsCardFreshness,
+    aggregateClientKpis: aggregateClientKpis,
+  };
+
+  // Browser: the global the `<script>` tag exists to publish.
+  if (typeof window !== "undefined") window.MUREO_REPORTS_LOGIC = api;
+  // Node (test runner only): `module` does not exist in a browser, so this
+  // branch is dead code there and adds no runtime module system.
+  if (typeof module === "object" && module && module.exports) {
+    module.exports = api;
+  }
+})();

--- a/mureo/web/handlers.py
+++ b/mureo/web/handlers.py
@@ -286,6 +286,7 @@ _STATIC_ALLOWLIST: tuple[str, ...] = (
     "amazon_oauth.js",
     "auth_wizards_meta.js",
     "auth_wizards.js",
+    "reports_logic.js",
     "dashboard.js",
     "extensions.js",
     "i18n.json",

--- a/tests/js/browser_contract.test.js
+++ b/tests/js/browser_contract.test.js
@@ -1,0 +1,202 @@
+// The shipping contract for the extracted module (#540).
+//
+// Run with:  node --test tests/js/
+//
+// reports_logic.test.js proves the LOGIC is right; this file proves the
+// split did not change how mureo SHIPS. mureo serves mureo/_data/web/*.js
+// as plain `<script>`-loaded assets — no bundler, no module system, no
+// build step — so the risk of "make it testable" is that the browser gets
+// a file it can no longer evaluate. reports_logic.js carries a
+// `module.exports` tail for the test runner; here the same bytes are
+// evaluated in a context that has NO module/exports/require, i.e. the
+// browser's, and asserted to publish window.MUREO_REPORTS_LOGIC anyway.
+//
+// dashboard.js is then evaluated on top of it, in load order, against a
+// stub DOM — which is what proves the binding block at the top of its
+// Reports section resolves against the real module rather than against a
+// name the extraction forgot to export.
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const WEB = path.join(__dirname, "..", "..", "mureo", "_data", "web");
+
+/** Every function the browser build of dashboard.js binds at load. */
+const BOUND_BY_DASHBOARD = [
+  "relativeAge",
+  "reportsPlatformLabels",
+  "reportsConflictText",
+  "reportsConflictsForKey",
+  "reportsFreshnessLabel",
+  "reportsCardFreshness",
+  "aggregateClientKpis",
+];
+
+function read(name) {
+  return fs.readFileSync(path.join(WEB, name), "utf-8");
+}
+
+/**
+ * A context shaped like a browser: a `window` that is also the global, a
+ * `document` that only records listeners, and no CommonJS anywhere.
+ */
+function browserContext() {
+  const listeners = [];
+  const sandbox = {
+    document: {
+      addEventListener: function (type) {
+        listeners.push(type);
+      },
+      querySelector: function () {
+        return null;
+      },
+      querySelectorAll: function () {
+        return [];
+      },
+      createElement: function () {
+        throw new Error("createElement at load time — nothing should render yet");
+      },
+    },
+    console: console,
+    setTimeout: setTimeout,
+    clearTimeout: clearTimeout,
+    fetch: function () {
+      throw new Error("fetch at load time");
+    },
+    MUREO: {
+      t: function (key) {
+        return key;
+      },
+    },
+  };
+  sandbox.window = sandbox;
+  sandbox.self = sandbox;
+  const context = vm.createContext(sandbox);
+  return { context: context, sandbox: sandbox, listeners: listeners };
+}
+
+function evaluate(context, name) {
+  // `new vm.Script` is also the parse check: a syntax error the browser
+  // would choke on fails here, before anything runs.
+  new vm.Script(read(name), { filename: name }).runInContext(context);
+}
+
+test.describe("reports_logic.js as a browser asset", function () {
+  test.it("publishes its global with no CommonJS in scope", function () {
+    const env = browserContext();
+    assert.equal(env.sandbox.module, undefined);
+    assert.equal(env.sandbox.exports, undefined);
+    assert.equal(env.sandbox.require, undefined);
+
+    evaluate(env.context, "reports_logic.js");
+
+    const api = env.sandbox.window.MUREO_REPORTS_LOGIC;
+    assert.ok(api, "window.MUREO_REPORTS_LOGIC was not published");
+    for (const name of BOUND_BY_DASHBOARD) {
+      assert.equal(typeof api[name], "function", `${name} is not exported`);
+    }
+    assert.equal(api.REPORTS_CONFLICT_DUPLICATE_ACCOUNT, "duplicate_account");
+  });
+
+  test.it("does not leak anything else into the page", function () {
+    // A plain <script> shares one global scope with every other asset, so
+    // the module must add exactly one name.
+    const env = browserContext();
+    const before = new Set(Object.keys(env.sandbox));
+    evaluate(env.context, "reports_logic.js");
+    const added = Object.keys(env.sandbox).filter(function (k) {
+      return !before.has(k);
+    });
+    assert.deepEqual(added, ["MUREO_REPORTS_LOGIC"]);
+  });
+
+  test.it("works when required by Node and loaded by a browser alike", function () {
+    // Same bytes, both entry points — the test suite is never reading a
+    // copy that could drift from the served asset.
+    const env = browserContext();
+    evaluate(env.context, "reports_logic.js");
+    const required = require(path.join(WEB, "reports_logic.js"));
+    assert.deepEqual(
+      Object.keys(env.sandbox.window.MUREO_REPORTS_LOGIC).sort(),
+      Object.keys(required).sort()
+    );
+  });
+});
+
+test.describe("dashboard.js still evaluates as a plain script", function () {
+  test.it("binds the extracted logic when loaded after it", function () {
+    const env = browserContext();
+    evaluate(env.context, "reports_logic.js");
+    evaluate(env.context, "dashboard.js");
+    // Its load-time side effects are unchanged: it only registers listeners.
+    assert.deepEqual(env.listeners, [
+      "mureo:ready",
+      "mureo:route_changed",
+      "mureo:locale_changed",
+    ]);
+  });
+
+  test.it("fails loudly AND diagnosably if the module is missing", function () {
+    // The failure mode that must NOT exist: dashboard.js loading anyway and
+    // rendering a conflicted client's double-counted totals because the
+    // withholding helper quietly became undefined. So it throws — but this
+    // file IS the configure UI, so the throw blanks the whole dashboard,
+    // and whoever sees it must not have to reverse-engineer a bare "cannot
+    // read properties of undefined". The message names the missing module
+    // and the load order that fixes it.
+    const env = browserContext();
+    assert.throws(
+      function () {
+        evaluate(env.context, "dashboard.js");
+      },
+      function (err) {
+        // Raised inside the vm realm, so `instanceof` does not apply.
+        assert.equal(err.name, "Error");
+        assert.match(err.message, /MUREO_REPORTS_LOGIC/);
+        assert.match(err.message, /reports_logic\.js/);
+        assert.match(err.message, /BEFORE/);
+        return true;
+      }
+    );
+    // The guard is not literally the file's first statement — ~1800 lines of
+    // declarations precede it — but it does run before anything OBSERVABLE,
+    // which is the property that matters: a half-initialised dashboard with
+    // live listeners and no working KPI logic would be worse than none.
+    assert.deepEqual(env.listeners, [], "a listener was registered before the guard");
+  });
+
+  test.it("keeps no copy of the moved logic", function () {
+    // A leftover definition would shadow the module and drift from it.
+    const js = read("dashboard.js");
+    for (const name of BOUND_BY_DASHBOARD) {
+      assert.ok(
+        !js.includes("function " + name + "("),
+        name + " is still defined in dashboard.js"
+      );
+    }
+    assert.ok(!js.includes("function reportsHasDoubleCount("));
+    assert.ok(!js.includes("function reportsConflictsOfKind("));
+  });
+});
+
+test.describe("every served asset parses", function () {
+  // Cheap blanket guard: a syntax error in any bundled script is a blank
+  // page, and nothing else in the repo would catch one.
+  const scripts = fs.readdirSync(WEB).filter(function (n) {
+    return n.endsWith(".js");
+  });
+
+  for (const name of scripts) {
+    test.it(name, function () {
+      new vm.Script(read(name), { filename: name });
+    });
+  }
+
+  test.it("covers the whole web directory", function () {
+    assert.ok(scripts.includes("dashboard.js"));
+    assert.ok(scripts.includes("reports_logic.js"));
+  });
+});

--- a/tests/js/reports_logic.test.js
+++ b/tests/js/reports_logic.test.js
@@ -1,0 +1,693 @@
+// Behavioural tests for mureo/_data/web/reports_logic.js (#540).
+//
+// Run with:  node --test tests/js/
+//
+// These EXECUTE the shipped bytes — `require` loads the same file the
+// browser gets over /static/reports_logic.js, no build step and no copy.
+// That is the whole point: the Python guards in tests/test_web_assets_*.py
+// pin the shape of the assets (a name, a string, a selector) and cannot
+// catch an inverted condition, a flipped comparison or a dropped branch.
+// The three behaviours below are exactly those failure modes, and each is
+// money-safety logic:
+//
+//   • aggregateClientKpis WITHHOLDS spend/conversions/CPA when the summary
+//     reports a double-counted ad account (#533). Inverting that condition
+//     puts a figure mureo knows is wrong in front of an operator.
+//   • reportsCardFreshness takes the OLDEST contributor, never the newest
+//     (#535). Taking the newest lets a fresh sibling vouch for stale data.
+//   • the conflict KIND routes to two different findings with two different
+//     operator next-moves. Collapsing them loses that.
+//
+// i18n: MUREO.t is stubbed to return the key it was handed and to record
+// the interpolated params, so assertions are on WHICH string was chosen
+// (and with what age), not on English wording.
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const WEB = path.join(__dirname, "..", "..", "mureo", "_data", "web");
+
+/** Every MUREO.t(key, params) the code under test made, most recent last. */
+const calls = [];
+
+globalThis.MUREO = {
+  t: function (key, params) {
+    calls.push({ key: key, params: params || {} });
+    return key;
+  },
+};
+
+// Loaded AFTER the stub only for tidiness — reports_logic.js reads MUREO
+// from the global at call time, so it has no load-order dependency.
+const logic = require(path.join(WEB, "reports_logic.js"));
+
+test.beforeEach(function () {
+  calls.length = 0;
+});
+
+/** Params of the most recent MUREO.t call for `key` ({} if never called). */
+function paramsFor(key) {
+  for (let i = calls.length - 1; i >= 0; i -= 1) {
+    if (calls[i].key === key) return calls[i].params;
+  }
+  return null;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const HOUR_MS = 60 * 60 * 1000;
+
+/** An ISO timestamp `ms` in the past, relative to now. */
+function ago(ms) {
+  return new Date(Date.now() - ms).toISOString();
+}
+
+/** A platform row that contributes totals to the aggregate. */
+function platform(key, totals, freshness) {
+  return {
+    key: key,
+    display_name: key.replace("_", " "),
+    totals: totals,
+    freshness: freshness,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The KPI-withholding condition (#533)
+// ---------------------------------------------------------------------------
+
+test.describe("aggregateClientKpis — withholding", function () {
+  test.it("sums across genuinely different platforms", function () {
+    const kpis = logic.aggregateClientKpis({
+      platforms: [
+        platform("google_ads", { spend: 1000, conversions: 40 }),
+        platform("meta_ads", { spend: 500, conversions: 10 }),
+      ],
+      platform_conflicts: [],
+    });
+    assert.equal(kpis.spend, 1500);
+    assert.equal(kpis.conversions, 50);
+    assert.equal(kpis.cpa, 30);
+    assert.equal(kpis.hasFigures, true);
+    assert.equal(kpis.doubleCounted, false);
+  });
+
+  test.it("withholds every money figure when an account is double-counted", function () {
+    const kpis = logic.aggregateClientKpis({
+      platforms: [
+        platform("google_ads", { spend: 1000, conversions: 40 }),
+        platform("google_ads_legacy", { spend: 1000, conversions: 40 }),
+      ],
+      platform_conflicts: [
+        {
+          kind: "duplicate_account",
+          platform_keys: ["google_ads", "google_ads_legacy"],
+        },
+      ],
+    });
+    // The regression this exists for: a doubled 2000 spend reads as a real
+    // outlier and gets acted on. No figure is better than a wrong one.
+    assert.equal(kpis.spend, null);
+    assert.equal(kpis.conversions, null);
+    assert.equal(kpis.cpa, null);
+    assert.equal(kpis.doubleCounted, true);
+    // …but the client DOES have data: the caller must not go re-fetch
+    // another period window hoping to find some.
+    assert.equal(kpis.hasFigures, true);
+  });
+
+  test.it("does not withhold for an unrecognized key alone", function () {
+    // A different finding with a different next move. "This entry's identity
+    // cannot be established" does not mean the totals on screen are wrong,
+    // so collapsing the two kinds would hide real figures for no reason.
+    const kpis = logic.aggregateClientKpis({
+      platforms: [
+        platform("google_ads", { spend: 1000, conversions: 40 }),
+        platform("plugin:mystery", { spend: 200, conversions: 10 }),
+      ],
+      platform_conflicts: [
+        { kind: "unrecognized_key", platform_keys: ["plugin:mystery"] },
+      ],
+    });
+    assert.equal(kpis.spend, 1200);
+    assert.equal(kpis.conversions, 50);
+    assert.equal(kpis.doubleCounted, false);
+  });
+
+  test.it("withholds when a duplicate rides along with other kinds", function () {
+    const kpis = logic.aggregateClientKpis({
+      platforms: [platform("google_ads", { spend: 10, conversions: 1 })],
+      platform_conflicts: [
+        { kind: "unrecognized_key", platform_keys: ["plugin:mystery"] },
+        { kind: "duplicate_account", platform_keys: ["a", "b"] },
+      ],
+    });
+    assert.equal(kpis.spend, null);
+    assert.equal(kpis.doubleCounted, true);
+  });
+
+  test.it("ignores a malformed conflict row rather than throwing", function () {
+    // platform_keys missing/not an array: the row cannot name anything, so
+    // it is not a usable finding. It must neither crash the card nor
+    // withhold figures on the strength of a row we cannot render.
+    const kpis = logic.aggregateClientKpis({
+      platforms: [platform("google_ads", { spend: 10, conversions: 2 })],
+      platform_conflicts: [{ kind: "duplicate_account" }, null, "nonsense"],
+    });
+    assert.equal(kpis.doubleCounted, false);
+    assert.equal(kpis.spend, 10);
+  });
+
+  test.it("treats a summary with no conflicts key as unconflicted", function () {
+    // An older daemon or a proxy may not send platform_conflicts at all.
+    const kpis = logic.aggregateClientKpis({
+      platforms: [platform("google_ads", { spend: 10, conversions: 2 })],
+    });
+    assert.equal(kpis.doubleCounted, false);
+    assert.equal(kpis.spend, 10);
+  });
+});
+
+test.describe("aggregateClientKpis — absent vs zero", function () {
+  test.it("reports a missing metric as null, never as 0", function () {
+    const kpis = logic.aggregateClientKpis({
+      platforms: [platform("plugin:advisory", {})],
+    });
+    assert.equal(kpis.spend, null);
+    assert.equal(kpis.conversions, null);
+    assert.equal(kpis.cpa, null);
+    assert.equal(kpis.hasFigures, false);
+  });
+
+  test.it("keeps a real zero as zero", function () {
+    const kpis = logic.aggregateClientKpis({
+      platforms: [platform("google_ads", { spend: 0, conversions: 0 })],
+    });
+    assert.equal(kpis.spend, 0);
+    assert.equal(kpis.conversions, 0);
+    assert.equal(kpis.hasFigures, true);
+  });
+
+  test.it("refuses a CPA when there are no conversions", function () {
+    // spend / 0 is Infinity, which would render as a money figure.
+    const kpis = logic.aggregateClientKpis({
+      platforms: [platform("google_ads", { spend: 900, conversions: 0 })],
+    });
+    assert.equal(kpis.spend, 900);
+    assert.equal(kpis.conversions, 0);
+    assert.equal(kpis.cpa, null);
+  });
+
+  test.it("skips non-numeric and non-finite totals", function () {
+    const kpis = logic.aggregateClientKpis({
+      platforms: [
+        platform("a", { spend: "1000", conversions: null }),
+        platform("b", { spend: Infinity, conversions: NaN }),
+        platform("c", { spend: 25, conversions: 5 }),
+      ],
+    });
+    assert.equal(kpis.spend, 25);
+    assert.equal(kpis.conversions, 5);
+    assert.equal(kpis.cpa, 5);
+  });
+
+  test.it("refuses a numeric-STRING metric instead of concatenating it", function () {
+    // `+=` on a string does not add, it concatenates: "5" then 3 gives "53",
+    // and the CPA computed from it is arithmetic on a corrupted total. A
+    // legacy daemon or a proxy emitting quoted numbers is a plausible wire
+    // shape, and it takes a SECOND contributing platform for the corruption
+    // to appear — which is why `typeof === "number"` cannot be inferred from
+    // `isFinite` alone (isFinite("5") and isFinite(null) are both true).
+    // Asserted for both metrics: the two guards are siblings, and symmetry
+    // between them is not a reason to test only one.
+    const kpis = logic.aggregateClientKpis({
+      platforms: [
+        platform("a", { spend: "10", conversions: "5" }),
+        platform("b", { spend: 20, conversions: 3 }),
+      ],
+    });
+    assert.equal(kpis.spend, 20);
+    assert.equal(kpis.conversions, 3);
+    assert.equal(kpis.cpa, 20 / 3);
+    // Type, not just value — "20" would satisfy an == comparison.
+    assert.equal(typeof kpis.spend, "number");
+    assert.equal(typeof kpis.conversions, "number");
+    assert.equal(typeof kpis.cpa, "number");
+
+    // The same shapes alone, with nothing to concatenate onto, are still
+    // absent rather than a zero-ish figure.
+    const only = logic.aggregateClientKpis({
+      platforms: [platform("a", { spend: "10", conversions: "5" })],
+    });
+    assert.equal(only.spend, null);
+    assert.equal(only.conversions, null);
+    assert.equal(only.hasFigures, false);
+  });
+
+  test.it("survives a null summary and a null platform row", function () {
+    assert.equal(logic.aggregateClientKpis(null).hasFigures, false);
+    assert.equal(logic.aggregateClientKpis({ platforms: null }).spend, null);
+    assert.equal(
+      logic.aggregateClientKpis({ platforms: [null, { totals: null }] }).spend,
+      null
+    );
+  });
+
+  test.it("reports hasFigures for a client carrying only ONE of the metrics", function () {
+    // hasFigures is not cosmetic: fetchClientCardSummary re-requests another
+    // period window when it is false. A spend-only client (no conversion
+    // tracking configured — common) has data, so treating "some figures" as
+    // "needs both" would send the card off to a different window and show
+    // the operator a period they did not select.
+    const spendOnly = logic.aggregateClientKpis({
+      platforms: [platform("google_ads", { spend: 1000 })],
+    });
+    assert.equal(spendOnly.hasFigures, true);
+    assert.equal(spendOnly.spend, 1000);
+    assert.equal(spendOnly.conversions, null);
+    assert.equal(spendOnly.cpa, null);
+
+    const convOnly = logic.aggregateClientKpis({
+      platforms: [platform("plugin:crm", { conversions: 12 })],
+    });
+    assert.equal(convOnly.hasFigures, true);
+    assert.equal(convOnly.conversions, 12);
+    assert.equal(convOnly.spend, null);
+    assert.equal(convOnly.cpa, null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The freshness aggregation (#535)
+// ---------------------------------------------------------------------------
+
+test.describe("reportsCardFreshness", function () {
+  test.it("quotes the OLDEST contributor, not the newest", function () {
+    const fresh = logic.reportsCardFreshness({
+      platforms: [
+        platform("recent", { spend: 1 }, {
+          fetched_at: ago(HOUR_MS),
+          stale: false,
+        }),
+        platform("old", { spend: 1 }, {
+          fetched_at: ago(10 * DAY_MS),
+          stale: false,
+        }),
+      ],
+    });
+    assert.equal(fresh.text, "dashboard.reports_platform_updated");
+    assert.equal(fresh.stale, false);
+    // An aggregate is only as current as its stalest input: the age quoted
+    // must be the 10-day-old row's, not the 1-hour-old sibling's.
+    assert.equal(paramsFor("dashboard.reports_platform_updated").ago,
+      "dashboard.reports_age_days");
+    assert.equal(paramsFor("dashboard.reports_age_days").n, 10);
+    assert.equal(paramsFor("dashboard.reports_age_hours"), null);
+  });
+
+  test.it("marks the card stale when any contributor is stale", function () {
+    const fresh = logic.reportsCardFreshness({
+      platforms: [
+        platform("fresh", { spend: 1 }, { fetched_at: ago(HOUR_MS), stale: false }),
+        platform("stale", { spend: 1 }, { fetched_at: ago(3 * DAY_MS), stale: true }),
+      ],
+    });
+    // A fresh sibling must never vouch for a stale one.
+    assert.equal(fresh.stale, true);
+    assert.equal(fresh.text, "dashboard.reports_platform_stale");
+    assert.equal(paramsFor("dashboard.reports_age_days").n, 3);
+  });
+
+  test.it("ignores platforms that contribute no totals", function () {
+    // An advisory bridge adds nothing to the sum, so its absent fetched_at
+    // says nothing about the number on screen — it must not drag the card
+    // into "unknown".
+    const fresh = logic.reportsCardFreshness({
+      platforms: [
+        platform("google_ads", { spend: 1 }, { fetched_at: ago(2 * HOUR_MS), stale: false }),
+        { key: "plugin:advisory", totals: null, freshness: null },
+        { key: "plugin:advisory2" },
+      ],
+    });
+    assert.equal(fresh.text, "dashboard.reports_platform_updated");
+    assert.equal(fresh.stale, false);
+    assert.equal(paramsFor("dashboard.reports_age_hours").n, 2);
+  });
+
+  test.it("says 'unknown' — not 'fresh' — when a contributor has no age", function () {
+    const fresh = logic.reportsCardFreshness({
+      platforms: [
+        platform("known", { spend: 1 }, { fetched_at: ago(HOUR_MS), stale: false }),
+        platform("nameless", { spend: 1 }, null),
+      ],
+    });
+    assert.equal(fresh.text, "dashboard.reports_platform_age_unknown");
+    assert.equal(fresh.stale, false);
+  });
+
+  test.it("a known fetched_at with an UNKNOWN stale flag is still unknown", function () {
+    // The nastiest shape on this wire: the row HAS a timestamp, so it looks
+    // answerable, but the server did not say whether it is stale. `stale`
+    // is resolved server-side against the window the figure covers; a null
+    // means "not computed", never "fine". Letting the timestamp alone carry
+    // the row would quote a confident "Updated 2h ago" for an aggregate
+    // whose staleness nobody established — the exact reassurance #535 says
+    // must not be invented. Its fresh sibling must not cover for it either.
+    const fresh = logic.reportsCardFreshness({
+      platforms: [
+        platform("answered", { spend: 1 }, {
+          fetched_at: ago(2 * HOUR_MS),
+          stale: false,
+        }),
+        platform("unanswered", { spend: 1 }, {
+          fetched_at: ago(HOUR_MS),
+          stale: null,
+        }),
+      ],
+    });
+    assert.equal(fresh.text, "dashboard.reports_platform_age_unknown");
+    assert.equal(fresh.stale, false);
+    // …and no age was quoted at all, from either row.
+    assert.equal(paramsFor("dashboard.reports_platform_updated"), null);
+  });
+
+  test.it("a contributor with no fetched_at is unknown even beside a dated one", function () {
+    // Same masking risk from the other side: `stale` is answered but the
+    // timestamp is absent. Without a dated sibling the card lands on
+    // "unknown" anyway (there is no age to quote); WITH one, dropping this
+    // guard would let the sibling's age stand in for the whole aggregate.
+    const fresh = logic.reportsCardFreshness({
+      platforms: [
+        platform("dated", { spend: 1 }, { fetched_at: ago(3 * HOUR_MS), stale: false }),
+        platform("undated", { spend: 1 }, { fetched_at: null, stale: false }),
+      ],
+    });
+    assert.equal(fresh.text, "dashboard.reports_platform_age_unknown");
+    assert.equal(fresh.stale, false);
+    assert.equal(paramsFor("dashboard.reports_platform_updated"), null);
+  });
+
+  test.it("says stale-partial when something is stale AND something is unknown", function () {
+    // The mixed case: we know something IS stale, but we cannot honestly
+    // quote an age. "Unknown" in stale-red would be a lie in both halves.
+    const fresh = logic.reportsCardFreshness({
+      platforms: [
+        platform("stale", { spend: 1 }, { fetched_at: ago(4 * DAY_MS), stale: true }),
+        platform("nameless", { spend: 1 }, { fetched_at: null, stale: null }),
+      ],
+    });
+    assert.equal(fresh.text, "dashboard.reports_platform_stale_partial");
+    assert.equal(fresh.stale, true);
+  });
+
+  test.it("accepts only a plain object as a contributor's freshness", function () {
+    // Same guard as reportsFreshnessLabel's, and it has to be repeated here
+    // because the aggregation loop reads the block directly rather than
+    // going through the label helper.
+    const callable = function () {};
+    callable.fetched_at = ago(HOUR_MS);
+    callable.stale = false;
+    const fresh = logic.reportsCardFreshness({
+      platforms: [platform("odd", { spend: 1 }, callable)],
+    });
+    assert.equal(fresh.text, "dashboard.reports_platform_age_unknown");
+    assert.equal(fresh.stale, false);
+  });
+
+  test.it("treats an unparseable fetched_at as no age at all", function () {
+    const fresh = logic.reportsCardFreshness({
+      platforms: [platform("bad", { spend: 1 }, { fetched_at: "yesterday", stale: true })],
+    });
+    assert.equal(fresh.text, "dashboard.reports_platform_stale_partial");
+    assert.equal(fresh.stale, true);
+  });
+
+  test.it("survives a null or non-object platform row", function () {
+    // `Array.isArray` guards the LIST, not its elements. This runs inside a
+    // forEach with no try/catch: a throw here escapes buildClientCard and,
+    // through the Promise.all in renderReportsIndex, blanks the whole client
+    // grid rather than one card. Its twin in aggregateClientKpis is tested;
+    // this one is the same hazard on the same wire.
+    const fresh = logic.reportsCardFreshness({
+      platforms: [
+        null,
+        undefined,
+        "nonsense",
+        7,
+        platform("real", { spend: 1 }, { fetched_at: ago(2 * HOUR_MS), stale: false }),
+      ],
+    });
+    assert.equal(fresh.text, "dashboard.reports_platform_updated");
+    assert.equal(fresh.stale, false);
+    assert.equal(paramsFor("dashboard.reports_age_hours").n, 2);
+  });
+
+  test.it("treats an OMITTED stale key exactly like an explicit null", function () {
+    // `stale` is optional and writer-dependent, so "the key is not there" is
+    // the shape a real writer produces — not the explicit null every other
+    // test here passes. `== null` covers both; `===` would cover only the
+    // explicit one and let the omitted case read as answered-and-fresh.
+    const fresh = logic.reportsCardFreshness({
+      platforms: [
+        platform("dated", { spend: 1 }, { fetched_at: ago(2 * HOUR_MS) }),
+        platform("answered", { spend: 1 }, {
+          fetched_at: ago(HOUR_MS),
+          stale: false,
+        }),
+      ],
+    });
+    assert.equal(fresh.text, "dashboard.reports_platform_age_unknown");
+    assert.equal(fresh.stale, false);
+    assert.equal(paramsFor("dashboard.reports_platform_updated"), null);
+  });
+
+  test.it("returns unknown-and-not-stale for a client with no platforms", function () {
+    for (const summary of [null, {}, { platforms: [] }, { platforms: "no" }]) {
+      const fresh = logic.reportsCardFreshness(summary);
+      assert.equal(fresh.text, "dashboard.reports_platform_age_unknown");
+      assert.equal(fresh.stale, false);
+    }
+  });
+});
+
+test.describe("reportsFreshnessLabel", function () {
+  test.it("reads a null stale flag as unknown rather than fresh", function () {
+    // fetched_at is optional and writer-dependent, so "we were not told"
+    // is its own state. Calling it fresh would be an invented reassurance.
+    const label = logic.reportsFreshnessLabel({ fetched_at: ago(HOUR_MS), stale: null });
+    assert.equal(label.text, "dashboard.reports_platform_age_unknown");
+    assert.equal(label.stale, false);
+  });
+
+  test.it("reads an OMITTED stale key the same way", function () {
+    // The shape a writer that simply does not compute staleness produces.
+    // `== null` is doing the work here; `===` would read this as answered.
+    const label = logic.reportsFreshnessLabel({ fetched_at: ago(HOUR_MS) });
+    assert.equal(label.text, "dashboard.reports_platform_age_unknown");
+    assert.equal(label.stale, false);
+  });
+
+  test.it("reads a missing block or missing fetched_at as unknown", function () {
+    for (const input of [null, undefined, "nope", {}, { stale: false }]) {
+      const label = logic.reportsFreshnessLabel(input);
+      assert.equal(label.text, "dashboard.reports_platform_age_unknown");
+      assert.equal(label.stale, false);
+    }
+  });
+
+  test.it("accepts only a plain object as a freshness block", function () {
+    // `typeof f === "object"` is not redundant with the property checks
+    // below it: something callable can carry `fetched_at`/`stale` and would
+    // otherwise be read as a real freshness block. JSON cannot produce one
+    // today, so this is the guard holding the line for the first caller
+    // that builds a summary in-process instead of parsing one off the wire.
+    const callable = function () {};
+    callable.fetched_at = ago(HOUR_MS);
+    callable.stale = false;
+    const label = logic.reportsFreshnessLabel(callable);
+    assert.equal(label.text, "dashboard.reports_platform_age_unknown");
+    assert.equal(label.stale, false);
+  });
+
+  test.it("distinguishes stale from updated", function () {
+    const stale = logic.reportsFreshnessLabel({ fetched_at: ago(2 * DAY_MS), stale: true });
+    assert.equal(stale.text, "dashboard.reports_platform_stale");
+    assert.equal(stale.stale, true);
+
+    const ok = logic.reportsFreshnessLabel({ fetched_at: ago(2 * DAY_MS), stale: false });
+    assert.equal(ok.text, "dashboard.reports_platform_updated");
+    assert.equal(ok.stale, false);
+  });
+});
+
+test.describe("relativeAge", function () {
+  test.it("buckets an age into the coarse unit it belongs to", function () {
+    assert.equal(logic.relativeAge(ago(5000)), "dashboard.reports_age_just_now");
+    assert.equal(logic.relativeAge(ago(5 * 60 * 1000)), "dashboard.reports_age_minutes");
+    assert.equal(paramsFor("dashboard.reports_age_minutes").n, 5);
+    assert.equal(logic.relativeAge(ago(5 * HOUR_MS)), "dashboard.reports_age_hours");
+    assert.equal(paramsFor("dashboard.reports_age_hours").n, 5);
+    assert.equal(logic.relativeAge(ago(5 * DAY_MS)), "dashboard.reports_age_days");
+    assert.equal(paramsFor("dashboard.reports_age_days").n, 5);
+  });
+
+  test.it("never throws on absent or unparseable input", function () {
+    assert.equal(logic.relativeAge(null), "");
+    assert.equal(logic.relativeAge(""), "");
+    assert.equal(logic.relativeAge("not-a-date"), "not-a-date");
+  });
+
+  test.it("clamps a future timestamp to 'just now' instead of a negative age", function () {
+    assert.equal(
+      logic.relativeAge(new Date(Date.now() + 5 * DAY_MS).toISOString()),
+      "dashboard.reports_age_just_now"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Conflict-kind routing
+// ---------------------------------------------------------------------------
+
+test.describe("conflict kinds", function () {
+  const DUP = { kind: "duplicate_account", platform_keys: ["google_ads", "gads_legacy"] };
+  const UNK = { kind: "unrecognized_key", platform_keys: ["plugin:mystery"] };
+  const summary = {
+    platforms: [
+      { key: "google_ads", display_name: "Google Ads" },
+      { key: "gads_legacy" },
+    ],
+    platform_conflicts: [DUP, UNK],
+  };
+
+  test.it("keeps the two findings on separate strings", function () {
+    const labels = logic.reportsPlatformLabels(summary);
+    assert.equal(
+      logic.reportsConflictText(DUP, labels),
+      "dashboard.reports_conflict_double_counted"
+    );
+    assert.equal(
+      logic.reportsConflictText(UNK, labels),
+      "dashboard.reports_conflict_unknown_key"
+    );
+  });
+
+  test.it("names the platforms the way the rest of the view does", function () {
+    const labels = logic.reportsPlatformLabels(summary);
+    logic.reportsConflictText(DUP, labels);
+    // display_name where the summary has one, raw key where it does not —
+    // a conflict must never name a platform the operator cannot find.
+    assert.equal(
+      paramsFor("dashboard.reports_conflict_double_counted").keys,
+      "Google Ads, gads_legacy"
+    );
+  });
+
+  test.it("falls back to the raw key at BOTH levels independently", function () {
+    // reportsPlatformLabels and reportsKeyList each fall back to the raw
+    // key, and end-to-end either one alone is enough — which means testing
+    // only through reportsConflictText lets one of them be deleted with the
+    // suite still green. Pin them separately so neither can mask the other.
+    // What is at stake is small but real: a conflict note reading
+    // "undefined is double-counted" names nothing the operator can act on.
+    const labels = logic.reportsPlatformLabels(summary);
+    assert.equal(labels.google_ads, "Google Ads");
+    assert.equal(labels.gads_legacy, "gads_legacy", "no display_name fallback");
+
+    assert.equal(logic.reportsKeyList(["plugin:mystery"], labels), "plugin:mystery");
+    assert.equal(logic.reportsKeyList(["google_ads"], labels), "Google Ads");
+    assert.equal(logic.reportsKeyList(["a", "b"], null), "a, b");
+  });
+
+  test.it("builds labels from a summary that is missing or malformed", function () {
+    // fetchClientCardSummary yields `{}` on any fetch failure, and these run
+    // during a render — a throw here blanks the whole Reports view.
+    for (const bad of [null, undefined, {}, { platforms: null }, { platforms: "x" }]) {
+      assert.deepEqual(logic.reportsPlatformLabels(bad), {});
+    }
+    assert.deepEqual(
+      logic.reportsPlatformLabels({ platforms: [null, { key: 7 }, {}] }),
+      {}
+    );
+    assert.deepEqual(logic.reportsKeyList(null, {}), "");
+    assert.deepEqual(logic.reportsKeyList(undefined, {}), "");
+  });
+
+  test.it("selects by kind and only from rows that name platforms", function () {
+    const dups = logic.reportsConflictsOfKind(summary, "duplicate_account");
+    assert.equal(dups.length, 1);
+    assert.equal(dups[0], DUP);
+    assert.equal(logic.reportsConflictsOfKind(summary, "unrecognized_key").length, 1);
+    assert.equal(logic.reportsConflictsOfKind(summary, "made_up").length, 0);
+    assert.equal(logic.reportsConflictsOfKind(null, "duplicate_account").length, 0);
+    assert.equal(
+      logic.reportsConflictsOfKind(
+        { platform_conflicts: [{ kind: "duplicate_account", platform_keys: "gads" }] },
+        "duplicate_account"
+      ).length,
+      0
+    );
+  });
+
+  test.it("flags a double count only for the duplicate kind", function () {
+    assert.equal(logic.reportsHasDoubleCount(summary), true);
+    assert.equal(
+      logic.reportsHasDoubleCount({ platform_conflicts: [UNK] }),
+      false
+    );
+    assert.equal(logic.reportsHasDoubleCount({ platform_conflicts: [] }), false);
+  });
+
+  test.it("hands every conflict naming a key to that platform's card", function () {
+    // The index card only renders for multi-client installs, so the
+    // per-platform card is the only surface a single-client setup sees.
+    assert.deepEqual(logic.reportsConflictsForKey(summary, "gads_legacy"), [DUP]);
+    assert.deepEqual(logic.reportsConflictsForKey(summary, "plugin:mystery"), [UNK]);
+    assert.deepEqual(logic.reportsConflictsForKey(summary, "meta_ads"), []);
+    assert.deepEqual(logic.reportsConflictsForKey(null, "google_ads"), []);
+  });
+
+  test.it("exposes the wire vocabulary it routes on", function () {
+    assert.equal(logic.REPORTS_CONFLICT_DUPLICATE_ACCOUNT, "duplicate_account");
+    assert.equal(logic.REPORTS_CONFLICT_UNRECOGNIZED_KEY, "unrecognized_key");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The strings this logic selects have to exist
+// ---------------------------------------------------------------------------
+
+test.describe("i18n", function () {
+  test.it("only ever selects keys that ship in both locales", function () {
+    const data = JSON.parse(fs.readFileSync(path.join(WEB, "i18n.json"), "utf-8"));
+    // Drive every branch that reaches MUREO.t, then check the keys exist.
+    logic.reportsCardFreshness({
+      platforms: [
+        { key: "a", totals: { spend: 1 }, freshness: { fetched_at: ago(DAY_MS), stale: false } },
+      ],
+    });
+    logic.reportsCardFreshness({
+      platforms: [
+        { key: "a", totals: { spend: 1 }, freshness: { fetched_at: ago(DAY_MS), stale: true } },
+        { key: "b", totals: { spend: 1 }, freshness: null },
+      ],
+    });
+    logic.reportsCardFreshness({ platforms: [{ key: "b", totals: {}, freshness: null }] });
+    logic.relativeAge(ago(1000));
+    logic.relativeAge(ago(60 * 1000));
+    logic.relativeAge(ago(HOUR_MS));
+    logic.reportsConflictText({ kind: "duplicate_account", platform_keys: [] }, {});
+    logic.reportsConflictText({ kind: "unrecognized_key", platform_keys: [] }, {});
+
+    assert.ok(calls.length > 0, "no i18n key was selected at all");
+    for (const call of calls) {
+      for (const locale of ["en", "ja"]) {
+        assert.ok(
+          data[locale] && data[locale][call.key],
+          `${call.key} missing from i18n.json[${locale}]`
+        );
+      }
+    }
+  });
+});

--- a/tests/test_web_assets_amazon_ux.py
+++ b/tests/test_web_assets_amazon_ux.py
@@ -1,6 +1,6 @@
 """Static-content guards for the Amazon Ads configure-UI parity work.
 
-No JS test harness ships in the repo, so the contract is pinned by
+No JS test harness runs THIS code — ``node --test tests/js/`` covers only the DOM-free Reports logic extracted in #540, so the contract here is pinned by
 grepping the bundled assets (the same convention as
 ``test_web_assets_plugin_credentials_render.py``):
 

--- a/tests/test_web_assets_meta_method_chooser.py
+++ b/tests/test_web_assets_meta_method_chooser.py
@@ -8,8 +8,8 @@ anyway and dead-ended. The two paths are mutually exclusive alternatives, so
 the step now opens with an explicit either/or chooser and reveals **only**
 the chosen flow.
 
-No JS test harness ships in the repo, so the ``auth_wizards.js`` contract is
-pinned by grepping the bundled asset: the chooser's ``data-i18n`` keys, its
+No JS test harness runs THIS code — ``node --test tests/js/`` covers only the DOM-free Reports logic extracted in #540, so the ``auth_wizards.js`` contract
+is pinned by grepping the bundled asset: the chooser's ``data-i18n`` keys, its
 radio semantics, its keyboard wiring, and — the actual bug fix — that
 nothing is preselected and neither flow is visible until the operator picks.
 """

--- a/tests/test_web_assets_meta_token_card.py
+++ b/tests/test_web_assets_meta_token_card.py
@@ -1,6 +1,6 @@
 """Static-content guards for the manual Meta system-user token card (#458).
 
-No JS test harness ships in the repo, so the ``auth_wizards.js`` contract
+No JS test harness runs THIS code — ``node --test tests/js/`` covers only the DOM-free Reports logic extracted in #540, so the ``auth_wizards.js`` contract
 for the "paste a system-user token" card is pinned by grepping the bundled
 asset. A refactor that drops the card, its Validate/Save wiring to
 ``/api/credentials/meta/token``, the account-picker, the localhost-OAuth

--- a/tests/test_web_assets_plugin_credentials_render.py
+++ b/tests/test_web_assets_plugin_credentials_render.py
@@ -6,7 +6,7 @@
 - #224: declared fields pre-fill from the list payload's current state —
   non-secret values verbatim, secrets via a ``configured`` flag only.
 
-No JS test harness ships in the repo, so the contract is pinned by
+No JS test harness runs THIS code — ``node --test tests/js/`` covers only the DOM-free Reports logic extracted in #540, so the contract is pinned by
 grepping the bundled ``dashboard.js``.
 """
 

--- a/tests/test_web_assets_plugin_oauth_card.py
+++ b/tests/test_web_assets_plugin_oauth_card.py
@@ -1,7 +1,7 @@
 """Static-content guards for the plugin-OAuth card rework (#216/#217).
 
-No JS test harness ships in the repo, so the ``dashboard.js`` OAuth card
-contract is pinned by grepping the bundled asset (read directly from
+No JS test harness runs THIS code — ``node --test tests/js/`` covers only the DOM-free Reports logic extracted in #540, so the ``dashboard.js`` OAuth
+card contract is pinned by grepping the bundled asset (read directly from
 ``mureo/_data/web/`` at runtime — no build step). A future refactor that
 drops the operator callback-URL input (#216), re-adds a Save button to an
 OAuth provider, stops sending the form values on Authenticate (#217), or

--- a/tests/test_web_assets_reports_conflicts.py
+++ b/tests/test_web_assets_reports_conflicts.py
@@ -1,9 +1,29 @@
 """Static-content guards for the Reports conflict + freshness UI (#533/#535).
 
-There is no JS build step and no JS test runner in this repo, so — as with
-``test_web_assets_reports_period_toggle.py`` — these pin the *shape* of the
-bundled assets read straight from ``mureo/_data/web/``. The behaviour they
-protect:
+**Read this with ``tests/js/reports_logic.test.js``.** Since #540 the two
+halves of this feature are guarded differently:
+
+  - the DECISIONS — withhold the KPIs when an account is double-counted,
+    take the oldest contributor's freshness, route on the conflict kind —
+    live in ``mureo/_data/web/reports_logic.js`` and are *executed* by
+    ``node --test tests/js/``. Inverted conditions and reordered branches
+    are caught there, not here.
+  - the RENDERING stays in ``dashboard.js``, still has no runner that can
+    drive a DOM, and is guarded below by pinning the *shape* of the bundled
+    assets read straight from ``mureo/_data/web/``.
+
+Between the two sits the SEAM, and it is where the remaining money-safety
+risk lives: the logic can withhold a figure correctly and the renderer can
+still draw the wrong thing, because one comparison points the wrong way.
+Neither guard sees that on its own — the JS suite never reaches the
+renderer, and a substring check reads ``!= null`` and ``== null`` alike. The
+last section of this file pins those on POLARITY and on which branch a
+string is reachable from, the way ``test_web_assets_reports_order_and_archive``
+pins the archive handler's confirm→bail→post ORDER.
+
+So these remain substring/structure pins, with the limits that implies:
+they catch a deleted name, string or selector, and they cannot tell you
+whether a card actually rendered. What they protect:
 
   - the client card must not render a KPI total it knows is double-counted,
     and must not let a flagged card read as a healthy one;
@@ -12,7 +32,16 @@ protect:
   - per-platform freshness comes from the row's own ``freshness``, never from
     the document-level ``last_synced_at``;
   - everything operator-visible is localized in both ``en`` and ``ja``;
-  - untrusted text keeps going through ``textContent``.
+  - untrusted text keeps going through ``textContent``;
+  - the extracted module is actually served and actually loaded, so the
+    split cannot leave the page with a dashboard that cannot bind it;
+  - the renderer draws the withheld/absent states the right way round, and
+    asks the logic module rather than re-deciding for itself.
+
+The reports frontend is TWO files that ship as one behaviour, so the pins
+below grep the pair as a single source (``_REPORTS_ASSETS``) — the same way
+``test_web_assets_meta_token_card.py`` greps the auth-wizard pair — rather
+than asserting which of the two a given string sits in.
 """
 
 from __future__ import annotations
@@ -24,9 +53,29 @@ import pytest
 
 _WEB = Path(__file__).resolve().parent.parent / "mureo" / "_data" / "web"
 
+# The pure logic module and the renderer that consumes it (#540).
+_REPORTS_ASSETS = ("reports_logic.js", "dashboard.js")
+
 
 def _read(name: str) -> str:
     return (_WEB / name).read_text(encoding="utf-8")
+
+
+def _read_reports() -> str:
+    return "\n".join(_read(name) for name in _REPORTS_ASSETS)
+
+
+def _function_body(js: str, signature: str) -> str:
+    """Source of the top-level function opened by ``signature``.
+
+    Top-level helpers in dashboard.js sit at two-space indent, so the first
+    ``\\n  }`` after the signature closes them; nested blocks close deeper.
+    (Same helper as ``test_web_assets_reports_order_and_archive.py``.)
+    """
+    assert signature in js, f"{signature} missing"
+    tail = js.split(signature, 1)[1]
+    assert "\n  }" in tail, f"{signature} has no two-space closing brace"
+    return tail.split("\n  }", 1)[0]
 
 
 @pytest.mark.unit
@@ -34,7 +83,7 @@ def test_dashboard_reads_the_conflict_marker_from_the_wire() -> None:
     """The grouping is done server-side (no account ids reach the browser),
     so the frontend consumes ``platform_conflicts`` rather than trying to
     join platform rows itself."""
-    js = _read("dashboard.js")
+    js = _read_reports()
     assert "platform_conflicts" in js
     assert '"duplicate_account"' in js
     assert '"unrecognized_key"' in js
@@ -45,19 +94,23 @@ def test_client_card_withholds_kpis_when_an_account_is_double_counted() -> None:
     """Summing figures that are KNOWN to be wrong, even under a warning, is
     exactly the triage error the card causes today. The aggregate is refused
     instead; the per-platform detail is one click away and is not summed."""
-    js = _read("dashboard.js")
+    js = _read_reports()
     assert "doubleCounted" in js
     # The aggregate helper itself nulls the figures, so no future caller can
     # render the double-counted sum by forgetting to check the flag.
     assert "function aggregateClientKpis(" in js
     assert "hasFigures" in js
+    # That the nulling CONDITION is the right way round is proved by
+    # tests/js/reports_logic.test.js, which executes it; this pin only says
+    # the helper still exists and is still where the card gets its figures.
+    assert "aggregateClientKpis(summary)" in _read("dashboard.js")
 
 
 @pytest.mark.unit
 def test_a_flagged_card_cannot_read_as_a_healthy_one() -> None:
     """A conflicted card carries a visible modifier class AND a note, so the
     at-a-glance grid never shows a flagged client as ordinary."""
-    js = _read("dashboard.js")
+    js = _read_reports()
     css = _read("app.css")
     assert "reports-client-card-conflict" in js
     assert ".reports-client-card.is-conflicted" in css
@@ -69,7 +122,7 @@ def test_the_two_findings_keep_separate_strings() -> None:
     """Different findings, different operator next-moves: "these KPIs are
     double-counted right now" vs "this entry's identity cannot be
     established". Merging them into one warning loses that."""
-    js = _read("dashboard.js")
+    js = _read_reports()
     assert "dashboard.reports_conflict_double_counted" in js
     assert "dashboard.reports_conflict_unknown_key" in js
 
@@ -79,7 +132,7 @@ def test_platform_cards_show_the_conflict_too() -> None:
     """The index card only renders for multi-client installs, so a
     single-client (OSS) setup would otherwise never see the finding at all —
     the per-platform card is the shared surface."""
-    js = _read("dashboard.js")
+    js = _read_reports()
     css = _read("app.css")
     assert "report-card-conflict" in js
     assert ".report-card-conflict" in css
@@ -90,7 +143,7 @@ def test_per_platform_freshness_comes_from_the_row_not_last_synced_at() -> None:
     """``last_synced_at`` is re-stamped on ANY platform write, so it cannot
     stand in for per-platform freshness (#535). The card reads the row's own
     ``freshness`` block."""
-    js = _read("dashboard.js")
+    js = _read_reports()
     assert "freshness" in js
     assert "dashboard.reports_platform_updated" in js
     assert "dashboard.reports_platform_stale" in js
@@ -146,8 +199,182 @@ def test_untrusted_keys_and_names_can_wrap() -> None:
 @pytest.mark.unit
 def test_conflict_and_freshness_text_is_rendered_via_text_content() -> None:
     """Platform keys are free-form operator/agent input. They reach the DOM
-    through ``textContent`` only — nothing in the file ever ASSIGNS
+    through ``textContent`` only — nothing in either file ever ASSIGNS
     ``innerHTML`` (the one occurrence is the comment saying so)."""
+    for name in _REPORTS_ASSETS:
+        js = _read(name)
+        assert ".innerHTML =" not in js, name
+        assert ".innerHTML=" not in js, name
+
+
+@pytest.mark.unit
+def test_the_pure_logic_is_served_and_loaded_before_its_consumer() -> None:
+    """#540 split the money-safety logic into its own asset so a test runner
+    can execute it. That only holds if the browser still gets it: it has to
+    be on the static allow-list and its ``<script>`` has to come BEFORE
+    dashboard.js, which binds it at load. Miss either and the dashboard is
+    a blank page — so this pins the shipping half of the split."""
+    from mureo.web.handlers import _STATIC_ALLOWLIST
+
+    assert "reports_logic.js" in _STATIC_ALLOWLIST
+    html = _read("app.html")
+    position = html.index("/static/reports_logic.js")
+    assert position < html.index("/static/dashboard.js")
+    # It stays a plain <script>: no type="module", no bundler entry point.
+    assert 'src="/static/reports_logic.js"></script>' in html
+
+
+@pytest.mark.unit
+def test_the_extracted_logic_is_not_re_implemented_in_the_renderer() -> None:
+    """One definition, executed by ``node --test tests/js/``. A copy left
+    behind in dashboard.js would shadow the tested one and drift from it
+    silently — which is the exact failure #540 exists to end."""
+    dashboard = _read("dashboard.js")
+    logic = _read("reports_logic.js")
+    for fn in (
+        "aggregateClientKpis",
+        "reportsCardFreshness",
+        "reportsFreshnessLabel",
+        "reportsConflictText",
+        "reportsConflictsOfKind",
+        "reportsHasDoubleCount",
+        "relativeAge",
+    ):
+        assert f"function {fn}(" in logic, f"{fn} is not in reports_logic.js"
+        assert f"function {fn}(" not in dashboard, f"{fn} is duplicated"
+    # The module publishes itself the way amazon_oauth.js does — a global on
+    # `window`, not a module system the served page would have to grow.
+    assert "window.MUREO_REPORTS_LOGIC = api" in logic
+    assert "window.MUREO_REPORTS_LOGIC" in dashboard
+
+
+# ---------------------------------------------------------------------------
+# The logic/renderer seam
+#
+# reports_logic.js decides whether a figure may be shown; buildClientCard
+# decides what is drawn. Between them sit a handful of one-character flips
+# that BOTH guards would miss: the JS suite never reaches the renderer, and
+# a substring pin sees `kpis.spend != null` and `kpis.spend == null` alike.
+# Two of them put a wrong figure in front of an operator, which is the whole
+# point of #533 — so they are pinned on POLARITY, the way #552 pinned the
+# archive handler's confirm→bail→post ORDER rather than its identifiers.
+#
+# **What these still cannot catch.** They read source, not behaviour. They
+# cannot prove the card renders at all, that the withheld note is appended
+# to the card the operator is looking at, that the KPI cell reaches the DOM,
+# or that CSS makes `is-stale` visible. A renderer that satisfied every
+# assertion below and then dropped the node on the floor would pass. Closing
+# that needs a DOM runner, which #540 deliberately did not buy.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_the_card_renders_a_spend_only_when_one_was_not_withheld() -> None:
+    """Polarity, not presence. `aggregateClientKpis` returns ``null`` for a
+    figure it refuses to state, so the card must render the number on
+    NOT-null and the em dash on null. Inverting this single comparison is
+    the worst outcome in the feature: a healthy client reads "—" while the
+    double-counted one — whose figures were withheld precisely so nobody
+    triages by them — is the only card showing a number."""
     js = _read("dashboard.js")
-    assert ".innerHTML =" not in js
-    assert ".innerHTML=" not in js
+    card = _function_body(js, "function buildClientCard(")
+    assert "kpis.spend != null ? formatNumber(kpis.spend) : " in card, (
+        "the spend cell no longer tests `kpis.spend != null` first — a "
+        "flipped comparison renders the withheld figure and hides the real one"
+    )
+    # The absent case is an em dash, never a 0: this is a triage view and a
+    # no-data client must not read as zero spend.
+    spend_cell = card.split("kpis.spend != null ?", 1)[1].split("\n", 1)[0]
+    assert '"—"' in spend_cell, spend_cell
+    assert "0" not in spend_cell, spend_cell
+    # The secondary cells are rendered only when a figure survived, so a
+    # withheld conversions/CPA leaves no cell rather than an empty one.
+    for metric in ("conversions", "cpa"):
+        assert (
+            f"if (kpis.{metric} != null) {{" in card
+        ), f"the {metric} cell no longer gates on a non-null figure"
+
+
+@pytest.mark.unit
+def test_the_withheld_warning_fires_on_the_conflicted_card() -> None:
+    """The other flip: `if (!kpis.doubleCounted)` would put "these figures
+    are withheld" on every healthy card and remove it from the one card it
+    describes — leaving the conflicted client silently short of KPIs with no
+    stated reason. Pinned as: the branch tests the TRUTHY case, and the
+    withheld string is reachable only from inside it."""
+    js = _read("dashboard.js")
+    card = _function_body(js, "function buildClientCard(")
+    assert "if (kpis.doubleCounted) {" in card, (
+        "the withheld-KPIs warning no longer branches on the truthy "
+        "doubleCounted case"
+    )
+    branch = card.split("if (kpis.doubleCounted) {", 1)[1].split("\n    }", 1)[0]
+    assert "dashboard.reports_conflict_kpis_withheld" in branch
+    # …and nowhere else, so it cannot also be emitted on a healthy card.
+    assert js.count("dashboard.reports_conflict_kpis_withheld") == 1
+
+
+@pytest.mark.unit
+def test_a_stale_freshness_marks_the_card_stale() -> None:
+    """Same class of flip on #535's half: `reportsCardFreshness` returns
+    ``stale: true`` and the card must add the modifier on TRUE. Inverted,
+    every up-to-date card renders in stale-red and the stale one renders
+    clean — the failure mode the freshness work exists to prevent. Both the
+    client card and the per-platform card carry it."""
+    js = _read("dashboard.js")
+    client_card = _function_body(js, "function buildClientCard(")
+    assert (
+        '(cardFresh.stale ? " is-stale" : "")' in client_card
+    ), "the client card's stale modifier no longer keys off the truthy case"
+    # The per-platform card carries its own, from the row's own freshness.
+    platform_foot = _function_body(js, "function buildReportCardFoot(")
+    assert (
+        '(fresh.stale ? " is-stale" : "")' in platform_foot
+    ), "the platform card's stale modifier no longer keys off the truthy case"
+    assert "reportsFreshnessLabel(platform.freshness)" in platform_foot
+    # The label always comes from the same object as the flag, so the text
+    # and the styling cannot disagree.
+    assert "fresh.textContent = cardFresh.text" in client_card
+    assert ".is-stale" in _read("app.css")
+
+
+@pytest.mark.unit
+def test_the_renderer_asks_the_logic_module_rather_than_re_deciding() -> None:
+    """The withholding must stay a property of the aggregate, not of the
+    card. A renderer that re-derived "is this double-counted?" from
+    ``platform_conflicts`` itself would drift from the tested condition the
+    first time the wire grows a third kind."""
+    js = _read("dashboard.js")
+    card = _function_body(js, "function buildClientCard(")
+    assert "aggregateClientKpis(summary)" in card
+    assert "reportsCardFreshness(summary)" in card
+    # The card reads the flag it was handed; it does not re-inspect kinds.
+    assert '"duplicate_account"' not in js
+    assert "REPORTS_CONFLICT_DUPLICATE_ACCOUNT" not in js
+
+
+@pytest.mark.unit
+def test_the_period_fallback_asks_hasfigures_not_the_rendered_values() -> None:
+    """``fetchClientCardSummary`` re-requests a different period window when
+    the selected one has no data. It must decide that on ``hasFigures`` —
+    the RAW presence of data — and never on the rendered values: a
+    conflicted client HAS figures, they are just withheld, and the conflict
+    is a property of the document rather than of the window, so re-fetching
+    would spin and then show a window the operator did not select.
+
+    Pinned separately from the card because ``aggregateClientKpis`` has two
+    call sites, and a structure pin on one of them says nothing about the
+    other."""
+    js = _read("dashboard.js")
+    fetch = _function_body(js, "async function fetchClientCardSummary(")
+    assert (
+        "aggregateClientKpis(summary)" in fetch
+    ), "the period fallback no longer consults the aggregate at all"
+    assert "if (!kpis.hasFigures && periods.length) {" in fetch, (
+        "the period fallback no longer branches on hasFigures — branching on "
+        "kpis.spend/conversions would re-fetch for every conflicted client"
+    )
+    # It must not re-decide from the withheld figures.
+    fallback = fetch.split("if (!kpis.hasFigures", 1)[1]
+    for withheld in ("kpis.spend", "kpis.conversions", "kpis.cpa"):
+        assert withheld not in fallback, f"the fallback reads {withheld}"

--- a/tests/test_web_assets_reports_order_and_archive.py
+++ b/tests/test_web_assets_reports_order_and_archive.py
@@ -1,8 +1,11 @@
 """Static-content guards for the Reports index reorder + archive controls.
 
-There is no JS build step and no JS test runner in this repo (#540), so —
-like ``test_web_assets_reports_conflicts.py`` — these read the bundled
-assets in ``mureo/_data/web/`` and pin the *shape* of what ships: that the
+There is still no JS build step, and the runner added in #540
+(``node --test tests/js/``) covers only the DOM-free Reports logic that was
+extracted into ``reports_logic.js``. The ordering and archive helpers below
+touch ``localStorage`` and the grid DOM and were NOT extracted, so — like
+``test_web_assets_reports_conflicts.py`` — these read the bundled assets in
+``mureo/_data/web/`` and pin the *shape* of what ships: that the
 identifiers, i18n keys, DOM hooks and CSS rules the feature depends on are
 present, in both locales, and that nothing here reintroduces ``innerHTML``.
 

--- a/tests/test_web_assets_reports_period_toggle.py
+++ b/tests/test_web_assets_reports_period_toggle.py
@@ -6,6 +6,11 @@ These tests pin the *shape* of the bundled web assets (no build step —
 read directly from ``mureo/_data/web/``) so a future refactor that drops
 the toggle wiring, the ``?period=`` request, or the default-window choice
 flips red here before an operator notices the regression.
+
+The toggle itself is rendering and has no runner. The KPI aggregation it
+re-requests moved to ``reports_logic.js`` in #540 and IS executed there, by
+``node --test tests/js/`` — so the pin below reads the aggregate helper from
+that file and only checks that ``dashboard.js`` still calls it.
 """
 
 from __future__ import annotations
@@ -154,7 +159,8 @@ def test_reports_index_detail_navigation() -> None:
     # JS builds the index, aggregates KPIs, opens detail, and toggles views.
     assert "function renderReportsIndex(" in js
     assert "function buildClientCard(" in js
-    assert "function aggregateClientKpis(" in js
+    assert "function aggregateClientKpis(" in _read("reports_logic.js")
+    assert "aggregateClientKpis(summary)" in js
     assert "function showReportsClientDetail(" in js
     assert "function setReportsView(" in js
     assert "renderReportsClientSelector" not in js


### PR DESCRIPTION
Closes #540.

## Why

`aggregateClientKpis` decides whether a client card renders a money figure **at all**. Since #533 it nulls spend / conversions / CPA when the document is known to double-count an ad account — that nulling is what stands between an operator and a figure mureo knows is wrong. `reportsCardFreshness` decides whether a card reads as stale.

**Neither was executed by any test.** The existing guards read the asset as text: they catch a deleted function name or string, but not an inverted condition, a wrong comparison, or a reordered branch. A regression in the nulling condition shipped green.

## The runner

`node --test`. No `package.json`, no lockfile, no install step, and **no third-party action in the supply chain of every CI run** — the job uses the Node preinstalled on `ubuntu-latest` and takes ~0.3s. The cost that normally makes a JS toolchain unattractive in a Python repo is zero here.

It runs in CI, deliberately **not** behind `needs: lint` — a Python formatting failure must not hide a broken money figure.

## Making the tests read what actually ships

Extracting logic for testability is worth nothing if the tests exercise a second copy. `mureo/_data/web/reports_logic.js` is a plain `<script>`-loaded asset publishing one global, the shape `amazon_oauth.js` already used, and `browser_contract.test.js`:

- evaluates the **served bytes** with `vm`, in a context with no `module` / `exports` / `require`
- asserts exactly **one** name is added to the page globals
- loads `dashboard.js` on top and asserts its load-time footprint is still the three listeners
- asserts the Node and browser surfaces expose **identical keys**, so a drifted copy cannot pass

The extraction itself is a verified pure move: every moved block is byte-identical, with no residue left behind.

## Coverage established by sweeping, not by sampling

Every guard, branch and comparison in the module was mutated — 63, not a representative handful. That found **eight real gaps**, including:

- a contributor with a known `fetched_at` but `stale: null` silently ceasing to be "unknown", so a card read fresh for an aggregate whose staleness nobody established
- `hasFigures` as AND instead of OR — a spend-only client (no conversion tracking; common) reading as no-data
- **two raw-key fallbacks at different levels that were masking each other**: deleting either alone left the suite green, because testing only end-to-end always exercised the survivor. A conflict note reading "undefined is double-counted" was one deletion away.
- `typeof t.conversions === "number"`, whose sibling on `spend` *was* tested. `isFinite("5")` is true, so a numeric-string `conversions` corrupts the sum through `+=` coercion the moment a second platform contributes — `conversions: "053"`, `cpa: 0.566`. Symmetry with a tested sibling had been assumed rather than checked.

Four survivors were investigated with a differential run over the generated input space rather than declared equivalent — **which disproved two of those assumptions**. Two remain, both provably equivalent over ~20.5k comparisons, and no test can kill either.

## The seam

Structural pins in `tests/test_web_assets_reports_conflicts.py` cover what the logic tests cannot reach — the spend cell's polarity, that the withheld-figures warning is reachable **only** from the truthy branch, the stale modifier on both cards, that the renderer asks rather than re-deciding, and the period fallback (a hole the sweep itself exposed: `aggregateClientKpis` has two call sites and the first pin covered one).

They read source, not behaviour. **A renderer that satisfies every assertion and then drops the node on the floor still passes** — verified, and stated in the docstring rather than implied. Closing that needs a DOM runner, which this change deliberately did not buy.

## Also

`dashboard.js` throws an explicit error naming the missing global, the file, the allowlist and the required `<script>` order — and `browser_contract.test.js` *proves* nothing observable has happened when it fires (it asserts no listener is registered), so a future refactor that moves a listener above the guard fails.

Six `test_web_assets_*.py` docstrings said no JS runner exists in this repo; corrected, along with the Node floor (`node:test` was experimental until Node 20, not 18).

`dashboard.js` is still 3,875 lines — reduced, not fixed; tracked as #556.
