### PR TITLE
test: derive the imports-cleanly check from the tree (#555)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -246,6 +246,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with the Node already on the runner. It is independent of the Python lint
   job on purpose: a formatting failure must not hide a broken money figure.
 
+### Fixed
+
+- **`import mureo.mcp.__main__` no longer starts an MCP server (#555).**
+  The module called `asyncio.run(main())` at module scope with no
+  `if __name__ == "__main__"` guard, so merely importing it opened the stdio
+  transport, read stdin to EOF and closed `sys.stdout` — taking the importing
+  process's stdout with it. `python -m mureo.mcp`, the documented launch
+  path, runs the file as `__main__` and is unchanged; `mureo/__main__.py`
+  already had the guard.
+
+  It surfaced because the clean-import test now reaches the module at all.
+  **`tests/test_imports.py` derives its module list from a walk of `mureo/`
+  instead of hand-maintaining one.** The old `_ALL_MODULES` named 46 of the
+  288 modules and had no exclusion policy written anywhere — `mcp`, `web`,
+  `core`, `cli`, `analytics`, `creative_studio`, `amazon_ads` and eight other
+  packages had no clean-import coverage at all. That was drift, not a
+  decision: the list simply stopped being extended, while the DB/LLM import
+  ban in the same file had always walked the tree.
+
+  A derived list cannot fall behind the tree, so the omission mode is gone
+  rather than merely corrected — but it introduces one of its own, a walk
+  that yields nothing and collects zero tests while staying green. Three
+  assertions close it: the package root resolves, every `.py` file yields
+  exactly one unique module name, and every name round-trips back to the file
+  it came from. None of them hard-codes a count that would need maintaining.
+
+  `mureo.mcp.__main__` was the only module of the 288 that did not import
+  standalone, and it was fixed rather than excluded. There is no exclusion
+  list; the file states that a future one must carry its reason beside it.
+
+  **The cost is amortised in a full run and real when the file is run
+  alone.** `pytest tests/` gains 245 tests with no measurable change in wall
+  time (two back-to-back A/B runs put the branch at or just under the base),
+  because the heavy transitive imports — `mcp`, `google-ads`,
+  `facebook-business` — are already paid by other tests.
+  `pytest tests/test_imports.py` on its own pays them by itself: 47 → 292
+  tests, roughly 2x the wall time and about +40MB peak RSS. Running that one
+  file is what someone debugging an import problem does, which is exactly
+  who meets the 2x, so it is stated rather than left to be discovered.
+
+  The file also now restores `sys.excepthook` and `warnings.filters` around
+  its own tests. Importing this much of the tree drags in dependencies that
+  move both on import (the `exceptiongroup` backport, `google-ads` /
+  `requests`). Today the restore is a measured no-op — pytest's warnings
+  plugin already brackets every item, and `exceptiongroup` is a hard pytest
+  dependency on Python 3.10 so its hook is installed before collection even
+  begins — but both are pytest internals, and the second does not exist on
+  3.11+. A test that imports 288 modules should leave the interpreter as it
+  found it on its own terms, not because something earlier happened to.
+
 ## [0.10.41] - 2026-08-06
 
 ### Fixed

--- a/mureo/mcp/__main__.py
+++ b/mureo/mcp/__main__.py
@@ -1,7 +1,15 @@
-"""Entry point to start the MCP server via python -m mureo.mcp."""
+"""Entry point to start the MCP server via python -m mureo.mcp.
+
+The ``if __name__ == "__main__"`` guard is load-bearing, not decoration:
+without it ``import mureo.mcp.__main__`` *starts the stdio server*, which
+reads stdin to EOF and closes ``sys.stdout``. ``python -m mureo.mcp`` runs
+this file as ``__main__``, so the documented launch path is unaffected.
+Mirrors :mod:`mureo.__main__`.
+"""
 
 import asyncio
 
 from mureo.mcp.server import main
 
-asyncio.run(main())
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,27 +1,42 @@
 """Import verification tests.
 
-Two checks with deliberately different reach. The difference matters when you
-read a green run, so it is stated here rather than left to be inferred:
+Two checks, both reaching the whole package, and both getting their reach
+from the same source: a walk of ``mureo/``. That is stated here because a
+green run means nothing without knowing the set it ran over.
 
 - **The DB/LLM import ban covers everything.** ``TestNoForbiddenImports``
-  walks ``mureo/`` with ``rglob``, so every module in the package is checked,
-  including any added since this file was last touched.
-- **The clean-import check does not.** ``TestModuleImports`` iterates
-  ``_ALL_MODULES``, a hand-maintained list naming 46 of the 288 importable
-  modules under ``mureo/``.
+  walks ``mureo/`` with ``rglob`` and AST-parses every ``.py`` file.
+- **The clean-import check covers everything.** ``TestModuleImports``
+  parametrises over ``_discover_modules()``, which turns that same walk into
+  dotted module names. There is no list to extend: a module is under test
+  the moment its file exists, and stops being under test when the file is
+  deleted. Omission is not unlikely — it is unreachable, because nothing is
+  written down that could disagree with the tree.
 
-That subset is **drift, not policy**. No exclusion rule was ever written for
-the list; it simply stopped being extended, and whole packages — ``mcp``,
-``web``, ``core``, ``cli``, ``analytics``, ``creative_studio``,
-``amazon_ads``, ``adapters``, ``byod``, ``demo``, ``providers``, ``policy``,
-``rollback``, ``learning``, ``search_console`` — have no clean-import
-coverage here at all, while ``google_ads`` / ``meta_ads`` / ``analysis`` are
-covered only in part. So do **not** read a green ``TestModuleImports`` as
-"every module imports cleanly"; read it as "these 46 do".
+This replaces (#555) a hand-maintained ``_ALL_MODULES`` that had drifted to
+46 of the 288 modules, leaving ``mcp``, ``web``, ``core``, ``cli``,
+``analytics``, ``creative_studio``, ``amazon_ads`` and eight other packages
+with no clean-import coverage at all. Deriving the list retires the failure
+mode instead of correcting one instance of it.
 
-Closing the gap is tracked in #555 and is deliberately its own change: a
-module that legitimately cannot import standalone has to be found and judged,
-not swept into a list.
+**There are no exclusions.** All 288 modules under ``mureo/`` import
+standalone. Widening the check turned up exactly one that did not:
+``mureo.mcp.__main__`` ran ``asyncio.run(main())`` at module scope with no
+``if __name__ == "__main__"`` guard, so importing it *started the stdio MCP
+server*, which read stdin to EOF and closed ``sys.stdout``. That was a
+defect and was fixed, not skipped. If some future module genuinely cannot
+import standalone, its exclusion belongs in this file with the reason
+written beside it — an exclusion nobody has to justify is how the old list
+got to 46.
+
+**Cost.** In a full run the imports are amortised — the heavy transitive
+deps (``mcp``, ``google-ads``, ``facebook-business``) are already loaded by
+other tests, and the suite total does not move. Run this file *by itself*
+and you pay them alone: roughly 2x the wall time and ~40MB more RSS than
+the 46-module version. That is the workflow of someone debugging an import
+problem, so it is written down rather than left to be discovered.
+``_leave_interpreter_globals_as_found`` keeps the process state this file
+touches from leaking into the rest of a session.
 """
 
 from __future__ import annotations
@@ -29,6 +44,9 @@ from __future__ import annotations
 import ast
 import importlib
 import pathlib
+import sys
+import warnings
+from collections.abc import Iterator
 from typing import Any
 
 import pytest
@@ -57,55 +75,68 @@ _FORBIDDEN_MODULES: frozenset[str] = frozenset(
     }
 )
 
-# Modules under test
-_ALL_MODULES: list[str] = [
-    "mureo",
-    "mureo.google_ads",
-    "mureo.google_ads.client",
-    "mureo.google_ads.mappers",
-    "mureo.google_ads._ads",
-    "mureo.google_ads._keywords",
-    "mureo.google_ads._analysis",
-    "mureo.google_ads._analysis_constants",
-    "mureo.google_ads._analysis_performance",
-    "mureo.google_ads._analysis_search_terms",
-    "mureo.google_ads._analysis_keywords",
-    "mureo.google_ads._analysis_budget",
-    "mureo.google_ads._analysis_rsa",
-    "mureo.google_ads._analysis_auction",
-    "mureo.google_ads._analysis_btob",
-    "mureo.google_ads._extensions",
-    "mureo.google_ads._diagnostics",
-    "mureo.google_ads._monitoring",
-    "mureo.google_ads._creative",
-    "mureo.google_ads._rsa_validator",
-    "mureo.google_ads._rsa_insights",
-    "mureo.google_ads._intent_classifier",
-    "mureo.google_ads._message_match",
-    "mureo.meta_ads",
-    "mureo.meta_ads.client",
-    "mureo.meta_ads.mappers",
-    "mureo.meta_ads._campaigns",
-    "mureo.meta_ads._ad_sets",
-    "mureo.meta_ads._ads",
-    "mureo.meta_ads._creatives",
-    "mureo.meta_ads._videos",
-    "mureo.meta_ads._audiences",
-    "mureo.meta_ads._pixels",
-    "mureo.meta_ads._insights",
-    "mureo.meta_ads._analysis",
-    "mureo.analysis",
-    "mureo.analysis.lp_analyzer",
-    "mureo.context",
-    "mureo.context.conversion_overrides",
-    "mureo.context.errors",
-    "mureo.context.models",
-    "mureo.context.platform_accounts",
-    "mureo.context.platform_guards",
-    "mureo.context.state",
-    "mureo.context.state_codec",
-    "mureo.context.strategy",
-]
+
+def _collect_py_files() -> list[pathlib.Path]:
+    """Every ``.py`` file under ``mureo/``, sorted for a stable test order."""
+    return sorted(_MUREO_ROOT.rglob("*.py"))
+
+
+def _module_name(filepath: pathlib.Path) -> str:
+    """Dotted module name for a file under ``mureo/``.
+
+    ``mureo/mcp/server.py`` -> ``mureo.mcp.server``;
+    ``mureo/mcp/__init__.py`` -> ``mureo.mcp``.
+    """
+    parts = list(filepath.relative_to(_MUREO_ROOT.parent).parts)
+    parts[-1] = parts[-1].removesuffix(".py")
+    if parts[-1] == "__init__":
+        parts.pop()
+    return ".".join(parts)
+
+
+def _discover_modules() -> list[str]:
+    """The modules under test, derived from the tree rather than listed.
+
+    One name per ``.py`` file, no filtering. Nothing here can fall behind
+    ``mureo/`` because nothing here is written down separately from it.
+    """
+    return [_module_name(path) for path in _collect_py_files()]
+
+
+# Modules under test — derived, never hand-maintained. See the module
+# docstring for why there is no exclusion list.
+_ALL_MODULES: list[str] = _discover_modules()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _leave_interpreter_globals_as_found() -> Iterator[None]:
+    """Restore the process globals that importing 288 modules can move.
+
+    Importing this much of the tree pulls in transitive dependencies that
+    mutate interpreter state on import: ``google-ads``/``requests`` append
+    to ``warnings.filters``, and the ``exceptiongroup`` backport replaces
+    ``sys.excepthook``. Neither is mureo's doing and neither is a defect.
+
+    **Measured, this fixture is currently a no-op**, but not for a reason
+    worth relying on. ``warnings.filters`` is already restored around every
+    item by pytest's warnings plugin (which ``-p no:warnings`` switches
+    off), and ``sys.excepthook`` is already the backport's before collection
+    starts because ``exceptiongroup`` is a hard pytest dependency on Python
+    3.10 — ``import pytest`` alone installs it, with no mureo loaded. That
+    dependency is gone on 3.11+, where ``ExceptionGroup`` is a builtin. So
+    "we inherit a clean interpreter" rests on two pytest internals across
+    two Python versions, and this file would be the one to notice.
+
+    Snapshotting at module setup makes the restore incapable of harm: it
+    reverts only what moved *during* these tests and re-installs whatever
+    state the module inherited, so it can never strip a mutation another
+    test depends on. Nothing in ``mureo/`` or ``tests/`` reads
+    ``sys.excepthook``.
+    """
+    excepthook = sys.excepthook
+    with warnings.catch_warnings():
+        yield
+    sys.excepthook = excepthook
 
 
 def _collect_imports_from_file(filepath: pathlib.Path) -> list[str]:
@@ -125,8 +156,48 @@ def _collect_imports_from_file(filepath: pathlib.Path) -> list[str]:
 
 
 @pytest.mark.unit
+class TestModuleDiscovery:
+    """Guard the discovery itself, so a broken walk cannot pass as green.
+
+    A derived parametrisation removes the *drift* failure mode but adds one
+    of its own: if the walk silently yields nothing (wrong root, renamed
+    package), ``TestModuleImports`` collects zero tests and the run is still
+    green. These assertions turn that into a failure, and none of them
+    hard-code a count that would itself need maintaining.
+    """
+
+    def test_package_root_resolves(self) -> None:
+        """``_MUREO_ROOT`` points at the real package directory."""
+        assert _MUREO_ROOT.is_dir(), f"package root not found: {_MUREO_ROOT}"
+        assert (_MUREO_ROOT / "__init__.py").is_file()
+
+    def test_every_python_file_yields_exactly_one_module(self) -> None:
+        """The walk is a bijection: no file dropped, no name duplicated."""
+        py_files = _collect_py_files()
+        assert py_files, f"no .py files found under {_MUREO_ROOT}"
+        assert len(_ALL_MODULES) == len(py_files)
+        assert len(set(_ALL_MODULES)) == len(_ALL_MODULES), "duplicate module names"
+
+    def test_module_names_round_trip_to_the_walked_files(self) -> None:
+        """Every name maps back to a real file, and together they cover all.
+
+        This is the assertion the old hand-maintained list would have
+        failed — it named 46 files out of 288, omitting eight whole
+        packages (#555). Any successor list would fail it the same way.
+        """
+        rebuilt: set[pathlib.Path] = set()
+        for name in _ALL_MODULES:
+            relative = pathlib.Path(*name.split("."))
+            package_init = _MUREO_ROOT.parent / relative / "__init__.py"
+            module_file = _MUREO_ROOT.parent / relative.with_suffix(".py")
+            rebuilt.add(package_init if package_init.is_file() else module_file)
+
+        assert rebuilt == set(_collect_py_files())
+
+
+@pytest.mark.unit
 class TestModuleImports:
-    """Verify that all modules can be imported."""
+    """Verify that every module under ``mureo/`` can be imported."""
 
     @pytest.mark.parametrize("module_name", _ALL_MODULES)
     def test_import_succeeds(self, module_name: str) -> None:
@@ -139,15 +210,11 @@ class TestModuleImports:
 class TestNoForbiddenImports:
     """Verify no DB/LLM imports are present, using AST analysis."""
 
-    def _collect_all_py_files(self) -> list[pathlib.Path]:
-        """Collect all .py files under mureo/."""
-        return sorted(_MUREO_ROOT.rglob("*.py"))
-
     def test_no_forbidden_imports_in_package(self) -> None:
         """No forbidden imports in any file under mureo/."""
         violations: list[str] = []
 
-        for py_file in self._collect_all_py_files():
+        for py_file in _collect_py_files():
             imports = _collect_imports_from_file(py_file)
             for imp in imports:
                 # Compare on top-level module name
@@ -161,6 +228,6 @@ class TestNoForbiddenImports:
                             f"import {imp}"
                         )
 
-        assert (
-            violations == []
-        ), "Forbidden DB/LLM imports detected:\n" + "\n".join(violations)
+        assert violations == [], "Forbidden DB/LLM imports detected:\n" + "\n".join(
+            violations
+        )


### PR DESCRIPTION
Closes #555.

## The gap

`tests/test_imports.py` has two halves and only one covered the tree. `TestNoForbiddenImports` walked `mureo/` with `rglob`, so the DB/LLM import ban genuinely applied everywhere. The **imports-cleanly** check next to it iterated a hand-maintained `_ALL_MODULES`:

```
listed          : 46
importable      : 288
stale entries   :  0    (pure omission, not rot)
exist, unlisted : 242
```

`mcp` (43 modules), `web` (32), `core` (31), `cli` (21), `analytics` (12), `creative_studio` (11), `amazon_ads` (10) and eight other packages had **no** clean-import coverage. There was no exclusion rule anywhere — the list simply stopped being extended.

## The mechanism

Both halves now share one walk. A file added under `mureo/` is parametrised the moment it exists; a deleted one leaves with it. There is no second source of truth, and **no exclusions** — not one of the 288 needed one.

A derived list trades drift for a different silent failure: a walk that yields nothing collects zero tests and stays green. `TestModuleDiscovery` closes it with three assertions, none hard-coding a count — the root resolves, files and module names form a bijection with no duplicates and non-empty, and every name maps back to a real walked file. The old 46-name list fails the last of those, as would any successor list.

Review forced a namespace package, a dotfile, a symlink, a non-identifier filename and a stray file in `__pycache__` through the walk: all are picked up, none silently skipped. (`pathlib.rglob` does not skip dotfiles the way a shell glob would — worth knowing.)

## It found a defect

`mureo/mcp/__main__.py` ran `asyncio.run(main())` at module scope with **no `if __name__ == "__main__"` guard**. Importing it started the stdio MCP server, read stdin to EOF, and closed the importing process's stdout — anything writing afterwards got `ValueError: I/O operation on closed file`.

The old 46-module list never covered it. A subprocess sweep did not catch it either — exit code zero — only a probe of interpreter state after each import did.

`python -m mureo.mcp`, the documented launch path in the README, `docs/mcp-server.md`, `docs/authentication.md`, `docs/integrations.md` and the CLI setup modules, runs the file as `__main__` and is unaffected; review verified it still starts, stays alive with stdin held open and exits 0 on EOF. The sibling `mureo/__main__.py` already had the guard.

## Leaving the interpreter as it found it

The suite now imports 288 modules in-process, so it snapshots and restores `sys.excepthook` and `warnings.filters` around itself.

Under pytest today neither is actually dirtied — but not for the reason first assumed. The excepthook comes from **importing pytest itself** (`exceptiongroup` is a pytest dependency on 3.10), not from any mureo module, and the warnings plugin restores filters per item. Both are pytest internals rather than declared contracts, one of them absent on 3.11+ where `ExceptionGroup` is a builtin, and neither holds in a bare interpreter — where both mutations were observed. A test that imports the world should not rest on who happened to dirty it first.

The fixture cannot strip a mutation another test depends on: the snapshot is taken at module setup, so it reverts only what moved during these tests.

## Cost, stated both ways

Amortised in a full run — the heavy libraries are already imported by the rest of the suite. Real when this file is run alone, which is what someone iterating on an import problem will do: **roughly 2× the time and about +40MB resident** (47 → 292 tests).

Full-suite runtime is unchanged, measured as adjacent A/B pairs under matched load after an unexplained 1.8× outlier turned out to be a concurrent `pip` upgrade and Spotlight indexing rather than the change.

+245 tests, no new failures.
