### PR TITLE
refactor: extract the Reports vocabulary and ordering from dashboard.js (#556)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -285,12 +285,23 @@ This rule was reinforced after PR #20 (2026-04-19, OAuth helper extraction — 6
 - **Browser assets** (`mureo/_data/web/`): they ship as plain
   `<script>`-loaded files, so nothing there may grow a bundler, a module
   system or a build step. Rendering is guarded by the substring pins in
-  `tests/test_web_assets_*.py`. DOM-free logic goes in
-  `mureo/_data/web/reports_logic.js` — which publishes
-  `window.MUREO_REPORTS_LOGIC` for the browser and carries an inert
-  `module.exports` tail so `node --test tests/js/*.test.js` executes the
-  exact bytes the browser is served. Put new decision logic there; a
-  grep-pin cannot catch an inverted condition.
+  `tests/test_web_assets_*.py`. DOM-free logic lives in its own asset next
+  to `dashboard.js`, one global per file:
+  - `reports_logic.js` → `window.MUREO_REPORTS_LOGIC` — the money-safety
+    decisions (KPI withholding, freshness aggregation, conflict routing).
+  - `reports_format.js` → `window.MUREO_REPORTS_FORMAT` — the display
+    vocabulary (flag labels and severities, param detail, numbers, periods).
+  - `reports_order.js` → `window.MUREO_REPORTS_ORDER` — the Reports index
+    card order (localStorage, and the two ways the grid is reordered).
+
+  Each carries an inert `module.exports` tail so `node --test
+  tests/js/*.test.js` executes the exact bytes the browser is served, and
+  each is listed in `_STATIC_ALLOWLIST` with its `<script>` ahead of
+  `dashboard.js` (which throws at load naming any that is missing).
+  `tests/js/browser_contract.test.js` asserts the shipping contract for
+  every module from one table — add a row when you add a module. Put new
+  decision logic in one of these rather than in `dashboard.js`; a grep-pin
+  cannot catch an inverted condition.
 
 ## Credential Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,64 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Two more DOM-free parts of `dashboard.js` are now executed by tests
+  rather than grepped for** (#556). `dashboard.js` was 3,877 lines against
+  the repo's 800-line budget, grown by feature accretion. Rather than chase
+  the number, two cohesive seams moved out **verbatim**, on the pattern #540
+  established and proved:
+
+  - `mureo/_data/web/reports_format.js` (`window.MUREO_REPORTS_FORMAT`) —
+    the Reports display vocabulary: a report flag's localized label and
+    severity chip, a flag's `params` rendered as a drill-down line, numbers
+    and CTR, and the period-toggle labels.
+  - `mureo/_data/web/reports_order.js` (`window.MUREO_REPORTS_ORDER`) — the
+    per-operator Reports index card order: where it is stored, how it is
+    applied to the server's rows, and the two ways the grid changes.
+
+  Both were previously covered only by substring pins, which see that a name
+  or a string is present and nothing more. What now runs: that the **longest**
+  registered flag base wins even when a shorter one is registered first — the
+  case that decides whether `search_console_no_property` is an informational
+  note or an amber warning with the wrong text — that an unlocalized flag code
+  degrades to a humanized token instead of putting a raw
+  `dashboard.reports_flag_…` key on screen, that an `info` or `positive` flag
+  is neither coloured nor sorted like an alarm, that CTR's
+  fraction-vs-percentage heuristic scales `0.034` and `3.4` to the same
+  figure, that an unusable stored order (storage disabled, corrupt JSON, junk
+  members) degrades to the **server's** order and never to an empty grid, that
+  a never-placed client lands **last**, and that a move off either end of the
+  grid is a no-op rather than a wrap-around.
+
+  The longest-base rule is checked against the shipped table rather than by
+  restating cases: the test derives every `_`-boundary prefix pair from
+  `REPORTS_FLAG_BASES` itself, so a base added anywhere in it is covered the
+  moment it ships.
+
+  `reports_order.js` is not DOM-free and does not claim to be — the grid is
+  the single source of truth for the order. What it never does is go
+  *looking* for a node: every node is handed in by the caller, nothing in it
+  touches `document`, creates an element or registers a listener. That is
+  what makes the rules executable against a fake grid. The drag handle, the
+  drag/drop listeners and the archive controls stayed in `dashboard.js`.
+
+  **Nothing about how mureo ships changed.** Both are plain
+  `<script>`-loaded assets, each publishing exactly one global, each on
+  `_STATIC_ALLOWLIST` with its tag ahead of `dashboard.js`. No bundler, no
+  module system, no build step, no `package.json`. `dashboard.js` still
+  refuses to run without them, and now names every module that is missing
+  rather than the first. `tests/js/browser_contract.test.js` asserts the same
+  contract for every module from one table, cross-checked against the
+  `reports_*.js` files actually shipped so a module cannot be added without
+  it. The move was verified mechanically against the base: every line of
+  each new module came from `dashboard.js` byte-for-byte apart from one
+  declared comment edit (a pointer that named a function the split had left
+  behind), and the only edited region in `dashboard.js` is the binding block
+  itself. `dashboard.js` is 3,563 lines — still well over budget, and the
+  remaining seams (the Creative Studio gallery, the credential-card wiring,
+  the report renderers) are untouched.
+
 ## [0.10.42] - 2026-08-07
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Thank you for your interest in contributing to mureo. This guide covers the deve
   (`node --test tests/js/*.test.js`). mureo ships no JavaScript
   dependencies, there is no `package.json` and no build step; Node is used
   purely as a test runner for the DOM-free logic in
-  `mureo/_data/web/reports_logic.js`. Skip it if you are not touching the
+  `mureo/_data/web/reports_*.js`. Skip it if you are not touching the
   configure UI — CI runs it either way.
 
 ### Clone and Install
@@ -74,20 +74,31 @@ files — no bundler, no module system, no build step. Most of it is guarded
 by the `tests/test_web_assets_*.py` pins, which grep the shipped asset for
 the names, strings and selectors a feature depends on.
 
-Grepping cannot catch an inverted condition, so the DOM-free logic behind
-the Reports dashboard's money figures lives in its own asset,
-`mureo/_data/web/reports_logic.js`, and is executed by Node's built-in test
-runner:
+Grepping cannot catch an inverted condition, so the DOM-free parts of the
+Reports dashboard live in their own assets and are executed by Node's
+built-in test runner:
 
 ```bash
 node --test tests/js/*.test.js
 ```
 
-No install step: no `package.json`, no dependencies, no lockfile. The
-module publishes `window.MUREO_REPORTS_LOGIC` for the browser and carries an
-inert `module.exports` tail so Node can require the exact bytes the browser
-is served. When you add DOM-free logic to the configure UI, put it there
-and test it; rendering stays in `dashboard.js` and stays pinned statically.
+| Asset | Global | What is in it |
+| --- | --- | --- |
+| `reports_logic.js` | `MUREO_REPORTS_LOGIC` | KPI withholding, freshness aggregation, conflict routing |
+| `reports_format.js` | `MUREO_REPORTS_FORMAT` | Flag labels and severities, param detail, numbers, period labels |
+| `reports_order.js` | `MUREO_REPORTS_ORDER` | The Reports index card order and how it is persisted |
+
+No install step: no `package.json`, no dependencies, no lockfile. Each
+module publishes exactly one global for the browser and carries an inert
+`module.exports` tail so Node can require the exact bytes the browser is
+served. A new module needs three things: an entry in `_STATIC_ALLOWLIST`
+(`mureo/web/handlers.py`), a `<script>` tag ahead of `dashboard.js` in
+`app.html`, and a row in the table at the top of
+`tests/js/browser_contract.test.js` — which then asserts the same shipping
+contract for it as for every other module.
+
+When you add DOM-free logic to the configure UI, put it in one of these and
+test it; rendering stays in `dashboard.js` and stays pinned statically.
 
 ### Test Framework
 

--- a/mureo/_data/web/app.html
+++ b/mureo/_data/web/app.html
@@ -459,9 +459,13 @@
   <script src="/static/amazon_oauth.js"></script>
   <script src="/static/auth_wizards_meta.js"></script>
   <script src="/static/auth_wizards.js"></script>
-  <!-- The Reports dashboard's pure logic (#540). dashboard.js binds it at
-       load, so it MUST come first. -->
+  <!-- The Reports dashboard's DOM-free halves: the money-safety logic
+       (#540), the display vocabulary and the card order (#556).
+       dashboard.js binds all three at load and throws naming the missing
+       one, so they MUST come first. -->
   <script src="/static/reports_logic.js"></script>
+  <script src="/static/reports_format.js"></script>
+  <script src="/static/reports_order.js"></script>
   <script src="/static/dashboard.js"></script>
   <script src="/static/extensions.js"></script>
 

--- a/mureo/_data/web/dashboard.js
+++ b/mureo/_data/web/dashboard.js
@@ -1782,28 +1782,51 @@
   // renders what it is told.
   // ----------------------------------------------------------------------
 
-  // The pure half of this section — the KPI-withholding condition, the
-  // freshness aggregation and the conflict-kind routing — lives in
-  // reports_logic.js (#540) so a test runner can execute it. Nothing about
-  // it needs a DOM; everything below still does. Bound here by their
+  // The parts of this section that need no DOM live in their own plain
+  // `<script>` modules, loaded ahead of this file (see app.html):
+  //
+  //   reports_logic.js  (#540) — the KPI-withholding condition, the
+  //     freshness aggregation and the conflict-kind routing.
+  //   reports_format.js (#556) — the display vocabulary: a flag's label and
+  //     severity, a param's detail line, a number's and a period's text.
+  //   reports_order.js  (#556) — the operator's card order: where it is
+  //     stored, how it is applied, and the two ways it changes.
+  //
+  // Everything below still needs a DOM. The modules are bound here by their
   // original names so every call site downstream reads exactly as before.
-  // reports_logic.js is a plain `<script>` loaded ahead of this file (see
-  // app.html). Failing at load is deliberate — the alternative is a
-  // conflicted client's double-counted totals rendering because the
-  // withholding helper quietly became `undefined`. Everything above this
-  // point is declarations, so nothing observable has happened yet when this
-  // throws: no listener is registered, no fetch is issued, no node reaches
-  // the DOM. But it does take the whole configure UI with it, so it says
-  // what is missing and what fixes it rather than leaving whoever hits it
-  // to reverse-engineer a bare "cannot read properties of undefined".
-  if (!window.MUREO_REPORTS_LOGIC) {
+  //
+  // Failing at load is deliberate — the alternative is a conflicted client's
+  // double-counted totals rendering because the withholding helper quietly
+  // became `undefined`. Everything above this point is declarations, so
+  // nothing observable has happened yet when this throws: no listener is
+  // registered, no fetch is issued, no node reaches the DOM. But it does
+  // take the whole configure UI with it, so it names WHICH modules are
+  // missing and what fixes it rather than leaving whoever hits it to
+  // reverse-engineer a bare "cannot read properties of undefined".
+  //
+  // ALL of them, not the first: a deployment that dropped the whole block of
+  // <script> tags would otherwise be diagnosed one reload at a time.
+  const missingReportsModules = [
+    ["MUREO_REPORTS_LOGIC", "reports_logic.js"],
+    ["MUREO_REPORTS_FORMAT", "reports_format.js"],
+    ["MUREO_REPORTS_ORDER", "reports_order.js"],
+  ].filter(function (mod) {
+    return !window[mod[0]];
+  });
+  if (missingReportsModules.length) {
     throw new Error(
-      "dashboard.js: window.MUREO_REPORTS_LOGIC is missing. " +
-        "reports_logic.js must be served (see _STATIC_ALLOWLIST in " +
+      "dashboard.js: " +
+        missingReportsModules
+          .map(function (mod) {
+            return "window." + mod[0] + " (" + mod[1] + ")";
+          })
+          .join(", ") +
+        " is missing. Each must be served (see _STATIC_ALLOWLIST in " +
         "mureo/web/handlers.py) and its <script> tag must come BEFORE " +
         "dashboard.js in app.html."
     );
   }
+
   const REPORTS_LOGIC = window.MUREO_REPORTS_LOGIC;
   const relativeAge = REPORTS_LOGIC.relativeAge;
   const reportsPlatformLabels = REPORTS_LOGIC.reportsPlatformLabels;
@@ -1812,6 +1835,21 @@
   const reportsFreshnessLabel = REPORTS_LOGIC.reportsFreshnessLabel;
   const reportsCardFreshness = REPORTS_LOGIC.reportsCardFreshness;
   const aggregateClientKpis = REPORTS_LOGIC.aggregateClientKpis;
+
+  const REPORTS_FORMAT = window.MUREO_REPORTS_FORMAT;
+  const reportsPeriodLabel = REPORTS_FORMAT.reportsPeriodLabel;
+  const humanizeReportFlag = REPORTS_FORMAT.humanizeReportFlag;
+  const reportFlagKind = REPORTS_FORMAT.reportFlagKind;
+  const flagSeverityRank = REPORTS_FORMAT.flagSeverityRank;
+  const clientReportFlags = REPORTS_FORMAT.clientReportFlags;
+  const buildFlagDetail = REPORTS_FORMAT.buildFlagDetail;
+  const formatNumber = REPORTS_FORMAT.formatNumber;
+  const formatKpi = REPORTS_FORMAT.formatKpi;
+
+  const REPORTS_ORDER = window.MUREO_REPORTS_ORDER;
+  const orderReportsClients = REPORTS_ORDER.orderReportsClients;
+  const persistReportsOrderFromDom = REPORTS_ORDER.persistReportsOrderFromDom;
+  const moveReportsCard = REPORTS_ORDER.moveReportsCard;
 
   // Canonical secondary KPI vocabulary → i18n label key. Headline (spend)
   // is rendered separately. Order here is the on-card display order.
@@ -1822,218 +1860,6 @@
     clicks: "dashboard.reports_kpi_clicks",
     impressions: "dashboard.reports_kpi_impressions",
   };
-
-  // Canonical period token → i18n label key. Unknown tokens fall back to the
-  // raw token (so a future window still renders a button, just unlocalized).
-  const REPORTS_PERIOD_LABELS = {
-    YESTERDAY: "dashboard.reports_period_yesterday",
-    LAST_7_DAYS: "dashboard.reports_period_last_7_days",
-    LAST_30_DAYS: "dashboard.reports_period_last_30_days",
-  };
-
-  function reportsPeriodLabel(token) {
-    const key = REPORTS_PERIOD_LABELS[token];
-    return key ? MUREO.t(key) : String(token);
-  }
-
-  // Report flags (reports.daily.flags) are free-form snake_case tags the
-  // analysis skill authors (e.g. "cpa_over_target_logly"). Map the common
-  // bases to friendly localized labels; anything unknown is humanized
-  // generically so a raw snake_case token never reaches the operator. The
-  // LONGEST matching base wins. Only the base label is shown — the trailing
-  // remainder (a platform or a descriptor) is dropped: it was inconsistent
-  // across flags and read as distracting, ambiguous parentheses. Detail
-  // lives in the report narrative. The 3rd element is the chip severity
-  // (is-warn / is-danger / is-success) so flags read as coloured tags:
-  // off-target / setup gaps = warn (amber), data-integrity / runaway = danger
-  // (red), on-target = success (green).
-  const REPORTS_FLAG_BASES = [
-    ["cpa_over_target", "dashboard.reports_flag_cpa_over_target", "is-warn"],
-    ["cpa_under_target", "dashboard.reports_flag_cpa_under_target", "is-success"],
-    ["cv_below_target", "dashboard.reports_flag_cv_below_target", "is-warn"],
-    ["conversions_below_target", "dashboard.reports_flag_cv_below_target", "is-warn"],
-    ["cv_above_target", "dashboard.reports_flag_cv_above_target", "is-success"],
-    ["operation_mode_mismatch", "dashboard.reports_flag_operation_mode_mismatch", "is-warn"],
-    ["low_cvr_lp_conversion", "dashboard.reports_flag_low_cvr_lp", "is-warn"],
-    ["low_cvr", "dashboard.reports_flag_low_cvr", "is-warn"],
-    ["sparse_conversions_tracking_suspect", "dashboard.reports_flag_tracking_suspect", "is-danger"],
-    ["tracking_suspect", "dashboard.reports_flag_tracking_suspect", "is-danger"],
-    ["zero_conversions", "dashboard.reports_flag_zero_conversions", "is-danger"],
-    ["budget_overspend", "dashboard.reports_flag_budget_overspend", "is-danger"],
-    ["spend_spike", "dashboard.reports_flag_spend_spike", "is-warn"],
-    ["search_console_no", "dashboard.reports_flag_sc_no_property", "is-warn"],
-    // Canonical vocabulary (PR-A) — a bare-string flag emitted as one of these
-    // codes maps to the same localized label + severity as its object form.
-    ["invalid_traffic_suspected", "dashboard.reports_flag_invalid_traffic_suspected", "is-danger"],
-    ["cpa_spike", "dashboard.reports_flag_cpa_spike", "is-warn"],
-    ["zero_cv_adspots", "dashboard.reports_flag_zero_cv_adspots", "is-warn"],
-    ["budget_drift", "dashboard.reports_flag_budget_drift", "is-warn"],
-    ["goals_met", "dashboard.reports_flag_goals_met", "is-success"],
-    ["supply_tools_unconfigured", "dashboard.reports_flag_supply_tools_unconfigured", "is-info"],
-    ["anomaly_baseline_insufficient", "dashboard.reports_flag_anomaly_baseline_insufficient", "is-info"],
-    ["pending_observations", "dashboard.reports_flag_pending_observations", "is-info"],
-    ["search_console_no_property", "dashboard.reports_flag_search_console_no_property", "is-info"],
-    ["ga4_not_configured", "dashboard.reports_flag_ga4_not_configured", "is-info"],
-  ];
-
-  // snake_case tokens that read better upper-cased (metric acronyms).
-  const REPORTS_FLAG_ACRONYMS = {
-    cpa: "CPA",
-    cpc: "CPC",
-    cpm: "CPM",
-    ctr: "CTR",
-    cvr: "CVR",
-    cv: "CV",
-    roas: "ROAS",
-    roi: "ROI",
-    lp: "LP",
-    ga4: "GA4",
-    seo: "SEO",
-    url: "URL",
-  };
-
-  function humanizeFlagWords(token) {
-    const words = String(token == null ? "" : token)
-      .split("_")
-      .filter(Boolean)
-      .map(function (w) {
-        return REPORTS_FLAG_ACRONYMS[w] || w;
-      });
-    if (!words.length) return "";
-    const s = words.join(" ");
-    return s.charAt(0).toUpperCase() + s.slice(1);
-  }
-
-  // The longest base entry that a bare-string flag matches (or null).
-  function matchReportFlagBase(raw) {
-    let best = null;
-    for (let i = 0; i < REPORTS_FLAG_BASES.length; i++) {
-      const base = REPORTS_FLAG_BASES[i][0];
-      if (
-        (raw === base || raw.indexOf(base + "_") === 0) &&
-        (!best || base.length > best[0].length)
-      ) {
-        best = REPORTS_FLAG_BASES[i];
-      }
-    }
-    return best;
-  }
-
-  function humanizeReportFlag(flag) {
-    // Structured object flag: localize by its canonical code, or use the
-    // author-written label for a `custom` flag. Detail never appears here —
-    // it lives in `params` (rendered on drill-down) and the narrative.
-    if (flag && typeof flag === "object") {
-      if (flag.code === "custom") return pickLocalizedLabel(flag.label);
-      if (typeof flag.code === "string" && flag.code) {
-        const key = "dashboard.reports_flag_" + flag.code;
-        const label = MUREO.t(key);
-        return label !== key ? label : humanizeFlagWords(flag.code);
-      }
-      // Legacy object without a code: fall back to any author text it carries
-      // (label / message / level / kind), matching the pre-vocabulary render.
-      return String(flag.label || flag.message || flag.level || flag.kind || "");
-    }
-    const raw = String(flag == null ? "" : flag);
-    const best = matchReportFlagBase(raw);
-    // A matched base shows only its localized label (no trailing context).
-    return best ? MUREO.t(best[1]) : humanizeFlagWords(raw);
-  }
-
-  // A `custom` flag's label is either a plain string or a {locale: text} map.
-  // Pick the active configure-UI locale (mirrored onto <html lang>), falling
-  // back to English, then to any provided string.
-  function pickLocalizedLabel(label) {
-    if (typeof label === "string") return label;
-    if (label && typeof label === "object") {
-      const loc = document.documentElement.lang || "en";
-      if (typeof label[loc] === "string") return label[loc];
-      if (typeof label.en === "string") return label.en;
-      const first = Object.keys(label)
-        .map(function (k) {
-          return label[k];
-        })
-        .filter(function (v) {
-          return typeof v === "string" && v;
-        })[0];
-      return first || "";
-    }
-    return "";
-  }
-
-  // Canonical severity (action/watch/info/positive) → chip CSS class. Kept
-  // separate from the legacy keyword inference in flagChipKind so a positive
-  // ("goals met") or informational ("baseline not yet established") flag is
-  // never coloured like an alarm.
-  const SEVERITY_CHIP = {
-    action: "is-danger",
-    watch: "is-warn",
-    info: "is-info",
-    positive: "is-success",
-  };
-
-  // Severity class for a flag's coloured chip. An object flag carries an
-  // explicit canonical severity; a bare string uses its base entry's curated
-  // severity, falling back to keyword inference (flagChipKind) for unmapped
-  // flags.
-  function reportFlagKind(flag) {
-    if (flag && typeof flag === "object") {
-      const sev = flag.severity || flag.level || flag.kind;
-      return SEVERITY_CHIP[sev] || flagChipKind(sev);
-    }
-    const best = matchReportFlagBase(String(flag == null ? "" : flag));
-    return (best && best[2]) || flagChipKind(flag);
-  }
-
-  // Build the drill-down detail string for a structured flag from its
-  // `params` (adspot ids, yen, ctr, …). Returns "" when there is nothing to
-  // show — the chip then renders as a plain, non-interactive tag.
-  function buildFlagDetail(flag) {
-    if (!flag || typeof flag !== "object") return "";
-    const params = flag.params;
-    if (!params || typeof params !== "object") return "";
-    const parts = [];
-    Object.keys(params).forEach(function (key) {
-      const value = formatFlagParam(key, params[key]);
-      if (value === "") return;
-      parts.push(flagParamLabel(key) + ": " + value);
-    });
-    return parts.join(" · ");
-  }
-
-  // Localized label for a param key (dashboard.reports_param_<key>), humanized
-  // as a fallback so an unlocalized key never shows a raw i18n token.
-  function flagParamLabel(key) {
-    const k = "dashboard.reports_param_" + key;
-    const label = MUREO.t(k);
-    return label !== k ? label : humanizeFlagWords(key);
-  }
-
-  // Format a single param value: arrays join with commas, ctr renders as a
-  // percentage, other numbers get thousands separators (no currency symbol —
-  // the value may be any platform's spend), everything else is stringified.
-  function formatFlagParam(key, value) {
-    if (Array.isArray(value)) {
-      return value
-        .map(function (v) {
-          return formatFlagParam(key, v);
-        })
-        .filter(Boolean)
-        .join(", ");
-    }
-    if (typeof value === "boolean") {
-      return MUREO.t(
-        value ? "dashboard.reports_param_yes" : "dashboard.reports_param_no"
-      );
-    }
-    if (key === "ctr" && typeof value === "number" && Number.isFinite(value)) {
-      return formatKpi("ctr", value);
-    }
-    if (typeof value === "number" && Number.isFinite(value)) {
-      return formatNumber(value);
-    }
-    return value == null ? "" : String(value);
-  }
 
   // Build one flag chip element. A flag with drill-down detail becomes an
   // interactive <button> that toggles a detail line (an ARIA disclosure);
@@ -2106,31 +1932,6 @@
   // (locale change, client switch, period switch) must not let a stale
   // result append.
   let reportsRenderSeq = 0;
-
-  // Format a raw number with thousands separators (no currency symbol —
-  // the API returns raw numbers and we must not assume a currency). Non-
-  // numbers pass through as plain text.
-  function formatNumber(value) {
-    if (typeof value === "number" && Number.isFinite(value)) {
-      return value.toLocaleString();
-    }
-    return value == null ? "" : String(value);
-  }
-
-  // CTR is a ratio/percentage — render with up to 2 decimals + "%".
-  function formatKpi(key, value) {
-    if (key === "ctr" && typeof value === "number" && Number.isFinite(value)) {
-      // Heuristic: a value <= 1 is a fraction (0.034 → 3.4%); otherwise it
-      // is already a percentage figure from the platform. NOTE: totals are
-      // platform-agnostic (built-in + arbitrary plugin:<dist> bridges) with no
-      // guaranteed CTR-unit convention, so a bridge reporting "0.8" meaning
-      // 0.8% would render as 80%. The real fix is normalizing CTR units in the
-      // backend (PR-1) so the frontend doesn't guess; tracked as a follow-up.
-      const pct = value <= 1 ? value * 100 : value;
-      return pct.toLocaleString(undefined, { maximumFractionDigits: 2 }) + "%";
-    }
-    return formatNumber(value);
-  }
 
   // Build one KPI card for a single platform entry. `summary` is optional and
   // supplies the conflict context (the platform row itself carries none).
@@ -2238,18 +2039,6 @@
     freshEl.textContent = fresh.text;
     foot.appendChild(freshEl);
     return foot;
-  }
-
-  // Map a free-form flag (string) to a chip kind. Defensive: any field may
-  // be absent and the value may be an object with {level, label}.
-  function flagChipKind(level) {
-    const l = String(level || "").toLowerCase();
-    if (l.indexOf("danger") >= 0 || l.indexOf("critical") >= 0 || l.indexOf("error") >= 0)
-      return "is-danger";
-    if (l.indexOf("warn") >= 0 || l.indexOf("watch") >= 0) return "is-warn";
-    if (l.indexOf("ok") >= 0 || l.indexOf("good") >= 0 || l.indexOf("healthy") >= 0)
-      return "is-success";
-    return "";
   }
 
   // Render the "latest report" block from reports.{daily|weekly|goal}. The
@@ -2371,22 +2160,6 @@
     }
   }
 
-  // Flags from a client's latest report (daily → weekly → goal).
-  function clientReportFlags(summary) {
-    const reports =
-      summary && typeof summary.reports === "object" ? summary.reports : null;
-    if (!reports) return [];
-    const r = reports.daily || reports.weekly || reports.goal;
-    return r && Array.isArray(r.flags) ? r.flags : [];
-  }
-
-  // Sort flags danger → warn → success → info → neutral (most urgent first).
-  const REPORTS_FLAG_SEVERITY_ORDER = ["is-danger", "is-warn", "is-success", "is-info", ""];
-  function flagSeverityRank(flag) {
-    const idx = REPORTS_FLAG_SEVERITY_ORDER.indexOf(reportFlagKind(flag));
-    return idx === -1 ? REPORTS_FLAG_SEVERITY_ORDER.length : idx;
-  }
-
   // Fetch a client's summary for its overview card. Honours the period toggle,
   // and when the selected window has no totals (a period-bucketed client whose
   // passthrough rollup is blank) falls back to the first window with data.
@@ -2431,93 +2204,6 @@
     cell.appendChild(v);
     cell.appendChild(l);
     return cell;
-  }
-
-  // --------------------------------------------------------------------
-  // Index card order (per operator, in this browser)
-  //
-  // The order is PURELY visual: losing it breaks nothing, and two operators
-  // sharing one install reasonably want different orders. So it is
-  // localStorage, not server state — server state would impose one
-  // operator's arrangement on everyone. Archiving is the opposite kind of
-  // decision and is deliberately NOT stored here (see setReportsClientArchived).
-  // --------------------------------------------------------------------
-  const REPORTS_ORDER_KEY = "mureo.reports.client_order";
-
-  // The stored order, or [] on ANY problem (storage disabled, corrupt JSON,
-  // a non-array body, non-string members). An unusable order must degrade to
-  // the server's order — never to an empty grid.
-  function readReportsOrder() {
-    try {
-      const raw = window.localStorage.getItem(REPORTS_ORDER_KEY);
-      if (!raw) return [];
-      const parsed = JSON.parse(raw);
-      if (!Array.isArray(parsed)) return [];
-      return parsed.filter(function (s) {
-        return typeof s === "string" && s;
-      });
-    } catch (_e) {
-      return []; // storage unavailable or corrupt — fall back to server order
-    }
-  }
-
-  function writeReportsOrder(slugs) {
-    try {
-      window.localStorage.setItem(REPORTS_ORDER_KEY, JSON.stringify(slugs));
-    } catch (_e) {
-      /* storage unavailable — the order stays for this render only */
-    }
-  }
-
-  // Apply the stored order to `rows`. Stored slugs that no longer exist are
-  // simply never matched, so they cost nothing; clients the stored order has
-  // never seen keep their server order and are appended LAST.
-  //
-  // Last, not first: the grid is curated on purpose, and a client the
-  // operator has never placed must not displace the top of it on every
-  // onboarding. Its position is defined and findable, and one drag fixes it.
-  function orderReportsClients(rows) {
-    const order = readReportsOrder();
-    const placed = [];
-    const fresh = [];
-    rows.forEach(function (c) {
-      const slug = c && c.slug ? c.slug : "";
-      if (slug && order.indexOf(slug) !== -1) placed.push(c);
-      else fresh.push(c);
-    });
-    placed.sort(function (a, b) {
-      return order.indexOf(a.slug) - order.indexOf(b.slug);
-    });
-    return placed.concat(fresh);
-  }
-
-  // Persist the grid's CURRENT DOM order. The DOM is the single source of
-  // truth for both the drop handler and the keyboard path, so the two can
-  // never disagree. Only the cards on screen are recorded: an archived
-  // client leaves the stored order and returns as an unplaced (last) card
-  // when it is restored.
-  function persistReportsOrderFromDom(wrap) {
-    const slugs = [];
-    Array.prototype.forEach.call(wrap.children, function (node) {
-      const slug = node.getAttribute ? node.getAttribute("data-client") : null;
-      if (slug) slugs.push(slug);
-    });
-    writeReportsOrder(slugs);
-  }
-
-  // Move one card `delta` slots and persist. Moving the existing node (rather
-  // than re-rendering the grid) keeps focus on the control the operator is
-  // holding, so repeated arrow presses just work.
-  function moveReportsCard(node, delta) {
-    const wrap = node.parentNode;
-    if (!wrap) return;
-    const items = Array.prototype.slice.call(wrap.children);
-    const from = items.indexOf(node);
-    const to = from + delta;
-    if (from === -1 || to < 0 || to >= items.length) return;
-    if (delta < 0) wrap.insertBefore(node, items[to]);
-    else wrap.insertBefore(node, items[to].nextSibling);
-    persistReportsOrderFromDom(wrap);
   }
 
   // The card being dragged, held as the NODE (never as a slug fed back into

--- a/mureo/_data/web/reports_format.js
+++ b/mureo/_data/web/reports_format.js
@@ -1,0 +1,328 @@
+// reports_format.js — the Reports dashboard's display vocabulary (#556).
+//
+// Everything here turns a wire value into text or a CSS class: a report flag
+// into a localized label and a severity chip kind, a flag's `params` into a
+// drill-down line, a raw number into a thousands-separated string, a period
+// token into a button label. It was MOVED here verbatim from dashboard.js —
+// same reason as reports_logic.js (#540): these are decisions a substring pin
+// cannot check. Whether the LONGEST flag base wins, whether an unknown code
+// degrades to a humanized token instead of showing a raw i18n key, whether an
+// `is-info` flag sorts below an alarm — each is a comparison that can be
+// flipped silently, and `node --test tests/js/` can execute them.
+//
+// No node is built here: nothing calls document.createElement, and the chip
+// and card elements that consume these strings stay in dashboard.js. The one
+// thing that reads the document at all is pickLocalizedLabel, which takes the
+// active locale off <html lang> exactly as it did before — one attribute read,
+// at CALL time, not a rendering dependency.
+//
+// Shipping shape is unchanged: a plain `<script>`-loaded file publishing one
+// global, `window.MUREO_REPORTS_FORMAT`, the same way amazon_oauth.js
+// publishes `window.MUREO_AMAZON_OAUTH`, and it MUST load before dashboard.js.
+// The `module.exports` tail at the bottom is inert in a browser (`module` is
+// undefined there) and is what lets Node require the same bytes the browser
+// gets — the test never sees a re-implementation.
+//
+// `MUREO.t` is read from the global at CALL time, not captured at load time,
+// so this file has no load-order dependency on app.js and a test can supply
+// its own `t`.
+
+(function () {
+  "use strict";
+
+  // Canonical period token → i18n label key. Unknown tokens fall back to the
+  // raw token (so a future window still renders a button, just unlocalized).
+  const REPORTS_PERIOD_LABELS = {
+    YESTERDAY: "dashboard.reports_period_yesterday",
+    LAST_7_DAYS: "dashboard.reports_period_last_7_days",
+    LAST_30_DAYS: "dashboard.reports_period_last_30_days",
+  };
+
+  function reportsPeriodLabel(token) {
+    const key = REPORTS_PERIOD_LABELS[token];
+    return key ? MUREO.t(key) : String(token);
+  }
+
+  // Report flags (reports.daily.flags) are free-form snake_case tags the
+  // analysis skill authors (e.g. "cpa_over_target_logly"). Map the common
+  // bases to friendly localized labels; anything unknown is humanized
+  // generically so a raw snake_case token never reaches the operator. The
+  // LONGEST matching base wins. Only the base label is shown — the trailing
+  // remainder (a platform or a descriptor) is dropped: it was inconsistent
+  // across flags and read as distracting, ambiguous parentheses. Detail
+  // lives in the report narrative. The 3rd element is the chip severity
+  // (is-warn / is-danger / is-success) so flags read as coloured tags:
+  // off-target / setup gaps = warn (amber), data-integrity / runaway = danger
+  // (red), on-target = success (green).
+  const REPORTS_FLAG_BASES = [
+    ["cpa_over_target", "dashboard.reports_flag_cpa_over_target", "is-warn"],
+    ["cpa_under_target", "dashboard.reports_flag_cpa_under_target", "is-success"],
+    ["cv_below_target", "dashboard.reports_flag_cv_below_target", "is-warn"],
+    ["conversions_below_target", "dashboard.reports_flag_cv_below_target", "is-warn"],
+    ["cv_above_target", "dashboard.reports_flag_cv_above_target", "is-success"],
+    ["operation_mode_mismatch", "dashboard.reports_flag_operation_mode_mismatch", "is-warn"],
+    ["low_cvr_lp_conversion", "dashboard.reports_flag_low_cvr_lp", "is-warn"],
+    ["low_cvr", "dashboard.reports_flag_low_cvr", "is-warn"],
+    ["sparse_conversions_tracking_suspect", "dashboard.reports_flag_tracking_suspect", "is-danger"],
+    ["tracking_suspect", "dashboard.reports_flag_tracking_suspect", "is-danger"],
+    ["zero_conversions", "dashboard.reports_flag_zero_conversions", "is-danger"],
+    ["budget_overspend", "dashboard.reports_flag_budget_overspend", "is-danger"],
+    ["spend_spike", "dashboard.reports_flag_spend_spike", "is-warn"],
+    ["search_console_no", "dashboard.reports_flag_sc_no_property", "is-warn"],
+    // Canonical vocabulary (PR-A) — a bare-string flag emitted as one of these
+    // codes maps to the same localized label + severity as its object form.
+    ["invalid_traffic_suspected", "dashboard.reports_flag_invalid_traffic_suspected", "is-danger"],
+    ["cpa_spike", "dashboard.reports_flag_cpa_spike", "is-warn"],
+    ["zero_cv_adspots", "dashboard.reports_flag_zero_cv_adspots", "is-warn"],
+    ["budget_drift", "dashboard.reports_flag_budget_drift", "is-warn"],
+    ["goals_met", "dashboard.reports_flag_goals_met", "is-success"],
+    ["supply_tools_unconfigured", "dashboard.reports_flag_supply_tools_unconfigured", "is-info"],
+    ["anomaly_baseline_insufficient", "dashboard.reports_flag_anomaly_baseline_insufficient", "is-info"],
+    ["pending_observations", "dashboard.reports_flag_pending_observations", "is-info"],
+    ["search_console_no_property", "dashboard.reports_flag_search_console_no_property", "is-info"],
+    ["ga4_not_configured", "dashboard.reports_flag_ga4_not_configured", "is-info"],
+  ];
+
+  // snake_case tokens that read better upper-cased (metric acronyms).
+  const REPORTS_FLAG_ACRONYMS = {
+    cpa: "CPA",
+    cpc: "CPC",
+    cpm: "CPM",
+    ctr: "CTR",
+    cvr: "CVR",
+    cv: "CV",
+    roas: "ROAS",
+    roi: "ROI",
+    lp: "LP",
+    ga4: "GA4",
+    seo: "SEO",
+    url: "URL",
+  };
+
+  function humanizeFlagWords(token) {
+    const words = String(token == null ? "" : token)
+      .split("_")
+      .filter(Boolean)
+      .map(function (w) {
+        return REPORTS_FLAG_ACRONYMS[w] || w;
+      });
+    if (!words.length) return "";
+    const s = words.join(" ");
+    return s.charAt(0).toUpperCase() + s.slice(1);
+  }
+
+  // The longest base entry that a bare-string flag matches (or null).
+  function matchReportFlagBase(raw) {
+    let best = null;
+    for (let i = 0; i < REPORTS_FLAG_BASES.length; i++) {
+      const base = REPORTS_FLAG_BASES[i][0];
+      if (
+        (raw === base || raw.indexOf(base + "_") === 0) &&
+        (!best || base.length > best[0].length)
+      ) {
+        best = REPORTS_FLAG_BASES[i];
+      }
+    }
+    return best;
+  }
+
+  function humanizeReportFlag(flag) {
+    // Structured object flag: localize by its canonical code, or use the
+    // author-written label for a `custom` flag. Detail never appears here —
+    // it lives in `params` (rendered on drill-down) and the narrative.
+    if (flag && typeof flag === "object") {
+      if (flag.code === "custom") return pickLocalizedLabel(flag.label);
+      if (typeof flag.code === "string" && flag.code) {
+        const key = "dashboard.reports_flag_" + flag.code;
+        const label = MUREO.t(key);
+        return label !== key ? label : humanizeFlagWords(flag.code);
+      }
+      // Legacy object without a code: fall back to any author text it carries
+      // (label / message / level / kind), matching the pre-vocabulary render.
+      return String(flag.label || flag.message || flag.level || flag.kind || "");
+    }
+    const raw = String(flag == null ? "" : flag);
+    const best = matchReportFlagBase(raw);
+    // A matched base shows only its localized label (no trailing context).
+    return best ? MUREO.t(best[1]) : humanizeFlagWords(raw);
+  }
+
+  // A `custom` flag's label is either a plain string or a {locale: text} map.
+  // Pick the active configure-UI locale (mirrored onto <html lang>), falling
+  // back to English, then to any provided string.
+  function pickLocalizedLabel(label) {
+    if (typeof label === "string") return label;
+    if (label && typeof label === "object") {
+      const loc = document.documentElement.lang || "en";
+      if (typeof label[loc] === "string") return label[loc];
+      if (typeof label.en === "string") return label.en;
+      const first = Object.keys(label)
+        .map(function (k) {
+          return label[k];
+        })
+        .filter(function (v) {
+          return typeof v === "string" && v;
+        })[0];
+      return first || "";
+    }
+    return "";
+  }
+
+  // Canonical severity (action/watch/info/positive) → chip CSS class. Kept
+  // separate from the legacy keyword inference in flagChipKind so a positive
+  // ("goals met") or informational ("baseline not yet established") flag is
+  // never coloured like an alarm.
+  const SEVERITY_CHIP = {
+    action: "is-danger",
+    watch: "is-warn",
+    info: "is-info",
+    positive: "is-success",
+  };
+
+  // Severity class for a flag's coloured chip. An object flag carries an
+  // explicit canonical severity; a bare string uses its base entry's curated
+  // severity, falling back to keyword inference (flagChipKind) for unmapped
+  // flags.
+  function reportFlagKind(flag) {
+    if (flag && typeof flag === "object") {
+      const sev = flag.severity || flag.level || flag.kind;
+      return SEVERITY_CHIP[sev] || flagChipKind(sev);
+    }
+    const best = matchReportFlagBase(String(flag == null ? "" : flag));
+    return (best && best[2]) || flagChipKind(flag);
+  }
+
+  // Build the drill-down detail string for a structured flag from its
+  // `params` (adspot ids, yen, ctr, …). Returns "" when there is nothing to
+  // show — the chip then renders as a plain, non-interactive tag.
+  function buildFlagDetail(flag) {
+    if (!flag || typeof flag !== "object") return "";
+    const params = flag.params;
+    if (!params || typeof params !== "object") return "";
+    const parts = [];
+    Object.keys(params).forEach(function (key) {
+      const value = formatFlagParam(key, params[key]);
+      if (value === "") return;
+      parts.push(flagParamLabel(key) + ": " + value);
+    });
+    return parts.join(" · ");
+  }
+
+  // Localized label for a param key (dashboard.reports_param_<key>), humanized
+  // as a fallback so an unlocalized key never shows a raw i18n token.
+  function flagParamLabel(key) {
+    const k = "dashboard.reports_param_" + key;
+    const label = MUREO.t(k);
+    return label !== k ? label : humanizeFlagWords(key);
+  }
+
+  // Format a single param value: arrays join with commas, ctr renders as a
+  // percentage, other numbers get thousands separators (no currency symbol —
+  // the value may be any platform's spend), everything else is stringified.
+  function formatFlagParam(key, value) {
+    if (Array.isArray(value)) {
+      return value
+        .map(function (v) {
+          return formatFlagParam(key, v);
+        })
+        .filter(Boolean)
+        .join(", ");
+    }
+    if (typeof value === "boolean") {
+      return MUREO.t(
+        value ? "dashboard.reports_param_yes" : "dashboard.reports_param_no"
+      );
+    }
+    if (key === "ctr" && typeof value === "number" && Number.isFinite(value)) {
+      return formatKpi("ctr", value);
+    }
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return formatNumber(value);
+    }
+    return value == null ? "" : String(value);
+  }
+
+  // Format a raw number with thousands separators (no currency symbol —
+  // the API returns raw numbers and we must not assume a currency). Non-
+  // numbers pass through as plain text.
+  function formatNumber(value) {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value.toLocaleString();
+    }
+    return value == null ? "" : String(value);
+  }
+
+  // CTR is a ratio/percentage — render with up to 2 decimals + "%".
+  function formatKpi(key, value) {
+    if (key === "ctr" && typeof value === "number" && Number.isFinite(value)) {
+      // Heuristic: a value <= 1 is a fraction (0.034 → 3.4%); otherwise it
+      // is already a percentage figure from the platform. NOTE: totals are
+      // platform-agnostic (built-in + arbitrary plugin:<dist> bridges) with no
+      // guaranteed CTR-unit convention, so a bridge reporting "0.8" meaning
+      // 0.8% would render as 80%. The real fix is normalizing CTR units in the
+      // backend (PR-1) so the frontend doesn't guess; tracked as a follow-up.
+      const pct = value <= 1 ? value * 100 : value;
+      return pct.toLocaleString(undefined, { maximumFractionDigits: 2 }) + "%";
+    }
+    return formatNumber(value);
+  }
+
+  // Map a free-form flag (string) to a chip kind. Defensive: any field may
+  // be absent and the value may be an object with {level, label}.
+  function flagChipKind(level) {
+    const l = String(level || "").toLowerCase();
+    if (l.indexOf("danger") >= 0 || l.indexOf("critical") >= 0 || l.indexOf("error") >= 0)
+      return "is-danger";
+    if (l.indexOf("warn") >= 0 || l.indexOf("watch") >= 0) return "is-warn";
+    if (l.indexOf("ok") >= 0 || l.indexOf("good") >= 0 || l.indexOf("healthy") >= 0)
+      return "is-success";
+    return "";
+  }
+
+  // Flags from a client's latest report (daily → weekly → goal).
+  function clientReportFlags(summary) {
+    const reports =
+      summary && typeof summary.reports === "object" ? summary.reports : null;
+    if (!reports) return [];
+    const r = reports.daily || reports.weekly || reports.goal;
+    return r && Array.isArray(r.flags) ? r.flags : [];
+  }
+
+  // Sort flags danger → warn → success → info → neutral (most urgent first).
+  const REPORTS_FLAG_SEVERITY_ORDER = ["is-danger", "is-warn", "is-success", "is-info", ""];
+  function flagSeverityRank(flag) {
+    const idx = REPORTS_FLAG_SEVERITY_ORDER.indexOf(reportFlagKind(flag));
+    return idx === -1 ? REPORTS_FLAG_SEVERITY_ORDER.length : idx;
+  }
+
+  const api = {
+    // Exported for the invariant test in tests/js/reports_format.test.js,
+    // which derives its cases FROM this table rather than restating them:
+    // every base that is a `_`-boundary prefix of a longer one must lose to
+    // it, whatever order they are registered in. Read-only by convention —
+    // nothing in the browser build touches it.
+    REPORTS_FLAG_BASES: REPORTS_FLAG_BASES,
+    reportsPeriodLabel: reportsPeriodLabel,
+    humanizeFlagWords: humanizeFlagWords,
+    matchReportFlagBase: matchReportFlagBase,
+    humanizeReportFlag: humanizeReportFlag,
+    pickLocalizedLabel: pickLocalizedLabel,
+    flagChipKind: flagChipKind,
+    reportFlagKind: reportFlagKind,
+    flagSeverityRank: flagSeverityRank,
+    clientReportFlags: clientReportFlags,
+    buildFlagDetail: buildFlagDetail,
+    flagParamLabel: flagParamLabel,
+    formatFlagParam: formatFlagParam,
+    formatNumber: formatNumber,
+    formatKpi: formatKpi,
+  };
+
+  // Browser: the global the `<script>` tag exists to publish.
+  if (typeof window !== "undefined") window.MUREO_REPORTS_FORMAT = api;
+  // Node (test runner only): `module` does not exist in a browser, so this
+  // branch is dead code there and adds no runtime module system.
+  if (typeof module === "object" && module && module.exports) {
+    module.exports = api;
+  }
+})();

--- a/mureo/_data/web/reports_order.js
+++ b/mureo/_data/web/reports_order.js
@@ -1,0 +1,148 @@
+// reports_order.js — the Reports index card order (#556).
+//
+// One concern: the order the operator arranged the client grid in — where it
+// is stored, how it is applied to the server's rows, and the two ways it
+// changes. MOVED here verbatim from dashboard.js.
+//
+// This is not the DOM-free half of the split (reports_logic.js is) and does
+// not pretend to be: the grid itself is the single source of truth for the
+// order, so persistReportsOrderFromDom and moveReportsCard read and reorder
+// real element nodes. What they never do is go LOOKING for them — every node
+// is handed in by the caller, nothing here touches `document`, nothing here
+// creates an element or registers a listener. That is what makes the rules
+// executable: a fake node carrying `children` and `insertBefore` is enough to
+// prove that a corrupt stored order degrades to the server's, that a client
+// the operator has never placed lands LAST rather than displacing the top of
+// the grid, and that a move off either end is a no-op.
+//
+// What stayed in dashboard.js, and why — the reasons differ, so they are not
+// collapsed into one:
+//
+//   buildReportsDragHandle, wireReportsCardDrag, buildReportsArchiveButton
+//     create elements and register listeners. They need a document.
+//   setReportsClientArchived POSTs and re-renders. Archiving is server state,
+//     not a browser-local view preference — the process that stops collecting
+//     a client's figures cannot see a flag in someone's browser.
+//   isArchivedClient, visibleReportsClients, archivedReportsClients read the
+//     module-level `reportsClients` cache. The last two would have to take it
+//     as a parameter to move, which is a signature change, not a move — and
+//     isArchivedClient alone is a three-line predicate that does not earn a
+//     seam of its own.
+//
+// `window.localStorage` is read at CALL time, inside a try/catch: storage can
+// be disabled or hold someone else's corrupt value, and an unusable order
+// must degrade to the server's order rather than to an empty grid.
+//
+// Shipping shape is unchanged: a plain `<script>`-loaded file publishing one
+// global, `window.MUREO_REPORTS_ORDER`, and it MUST load before dashboard.js.
+// The `module.exports` tail is inert in a browser and is what lets Node
+// require the same bytes the browser gets.
+
+(function () {
+  "use strict";
+
+  // --------------------------------------------------------------------
+  // Index card order (per operator, in this browser)
+  //
+  // The order is PURELY visual: losing it breaks nothing, and two operators
+  // sharing one install reasonably want different orders. So it is
+  // localStorage, not server state — server state would impose one
+  // operator's arrangement on everyone. Archiving is the opposite kind of
+  // decision and is deliberately NOT stored here (see
+  // setReportsClientArchived in dashboard.js).
+  // --------------------------------------------------------------------
+  const REPORTS_ORDER_KEY = "mureo.reports.client_order";
+
+  // The stored order, or [] on ANY problem (storage disabled, corrupt JSON,
+  // a non-array body, non-string members). An unusable order must degrade to
+  // the server's order — never to an empty grid.
+  function readReportsOrder() {
+    try {
+      const raw = window.localStorage.getItem(REPORTS_ORDER_KEY);
+      if (!raw) return [];
+      const parsed = JSON.parse(raw);
+      if (!Array.isArray(parsed)) return [];
+      return parsed.filter(function (s) {
+        return typeof s === "string" && s;
+      });
+    } catch (_e) {
+      return []; // storage unavailable or corrupt — fall back to server order
+    }
+  }
+
+  function writeReportsOrder(slugs) {
+    try {
+      window.localStorage.setItem(REPORTS_ORDER_KEY, JSON.stringify(slugs));
+    } catch (_e) {
+      /* storage unavailable — the order stays for this render only */
+    }
+  }
+
+  // Apply the stored order to `rows`. Stored slugs that no longer exist are
+  // simply never matched, so they cost nothing; clients the stored order has
+  // never seen keep their server order and are appended LAST.
+  //
+  // Last, not first: the grid is curated on purpose, and a client the
+  // operator has never placed must not displace the top of it on every
+  // onboarding. Its position is defined and findable, and one drag fixes it.
+  function orderReportsClients(rows) {
+    const order = readReportsOrder();
+    const placed = [];
+    const fresh = [];
+    rows.forEach(function (c) {
+      const slug = c && c.slug ? c.slug : "";
+      if (slug && order.indexOf(slug) !== -1) placed.push(c);
+      else fresh.push(c);
+    });
+    placed.sort(function (a, b) {
+      return order.indexOf(a.slug) - order.indexOf(b.slug);
+    });
+    return placed.concat(fresh);
+  }
+
+  // Persist the grid's CURRENT DOM order. The DOM is the single source of
+  // truth for both the drop handler and the keyboard path, so the two can
+  // never disagree. Only the cards on screen are recorded: an archived
+  // client leaves the stored order and returns as an unplaced (last) card
+  // when it is restored.
+  function persistReportsOrderFromDom(wrap) {
+    const slugs = [];
+    Array.prototype.forEach.call(wrap.children, function (node) {
+      const slug = node.getAttribute ? node.getAttribute("data-client") : null;
+      if (slug) slugs.push(slug);
+    });
+    writeReportsOrder(slugs);
+  }
+
+  // Move one card `delta` slots and persist. Moving the existing node (rather
+  // than re-rendering the grid) keeps focus on the control the operator is
+  // holding, so repeated arrow presses just work.
+  function moveReportsCard(node, delta) {
+    const wrap = node.parentNode;
+    if (!wrap) return;
+    const items = Array.prototype.slice.call(wrap.children);
+    const from = items.indexOf(node);
+    const to = from + delta;
+    if (from === -1 || to < 0 || to >= items.length) return;
+    if (delta < 0) wrap.insertBefore(node, items[to]);
+    else wrap.insertBefore(node, items[to].nextSibling);
+    persistReportsOrderFromDom(wrap);
+  }
+
+  const api = {
+    REPORTS_ORDER_KEY: REPORTS_ORDER_KEY,
+    readReportsOrder: readReportsOrder,
+    writeReportsOrder: writeReportsOrder,
+    orderReportsClients: orderReportsClients,
+    persistReportsOrderFromDom: persistReportsOrderFromDom,
+    moveReportsCard: moveReportsCard,
+  };
+
+  // Browser: the global the `<script>` tag exists to publish.
+  if (typeof window !== "undefined") window.MUREO_REPORTS_ORDER = api;
+  // Node (test runner only): `module` does not exist in a browser, so this
+  // branch is dead code there and adds no runtime module system.
+  if (typeof module === "object" && module && module.exports) {
+    module.exports = api;
+  }
+})();

--- a/mureo/web/handlers.py
+++ b/mureo/web/handlers.py
@@ -287,6 +287,8 @@ _STATIC_ALLOWLIST: tuple[str, ...] = (
     "auth_wizards_meta.js",
     "auth_wizards.js",
     "reports_logic.js",
+    "reports_format.js",
+    "reports_order.js",
     "dashboard.js",
     "extensions.js",
     "i18n.json",

--- a/tests/js/browser_contract.test.js
+++ b/tests/js/browser_contract.test.js
@@ -1,20 +1,32 @@
-// The shipping contract for the extracted module (#540).
+// The shipping contract for the extracted modules (#540, #556).
 //
 // Run with:  node --test tests/js/
 //
-// reports_logic.test.js proves the LOGIC is right; this file proves the
-// split did not change how mureo SHIPS. mureo serves mureo/_data/web/*.js
+// The per-module suites (reports_logic.test.js, reports_format.test.js,
+// reports_order.test.js) prove the LOGIC is right; this file proves the
+// splits did not change how mureo SHIPS. mureo serves mureo/_data/web/*.js
 // as plain `<script>`-loaded assets — no bundler, no module system, no
 // build step — so the risk of "make it testable" is that the browser gets
-// a file it can no longer evaluate. reports_logic.js carries a
-// `module.exports` tail for the test runner; here the same bytes are
-// evaluated in a context that has NO module/exports/require, i.e. the
-// browser's, and asserted to publish window.MUREO_REPORTS_LOGIC anyway.
+// a file it can no longer evaluate. Each module carries a `module.exports`
+// tail for the test runner; here the same bytes are evaluated in a context
+// that has NO module/exports/require, i.e. the browser's, and asserted to
+// publish their global anyway.
 //
-// dashboard.js is then evaluated on top of it, in load order, against a
+// Every property below is asserted for EVERY module from one table, not
+// duplicated per file: publishes exactly one global, that global is the
+// same object Node sees, and dashboard.js binds it.
+//
+// The table is not the source of truth for WHICH modules exist — the
+// directory is. `MODULES` is cross-checked against every `reports_*.js`
+// actually shipped in mureo/_data/web/, so a module dropped in without a
+// row fails loudly here instead of quietly receiving none of these checks.
+// The row still carries what a glob cannot know: which names dashboard.js
+// binds, and which definitions must not have survived in it.
+//
+// dashboard.js is then evaluated on top of them, in load order, against a
 // stub DOM — which is what proves the binding block at the top of its
-// Reports section resolves against the real module rather than against a
-// name the extraction forgot to export.
+// Reports section resolves against the real modules rather than against
+// names an extraction forgot to export.
 
 const test = require("node:test");
 const assert = require("node:assert/strict");
@@ -24,16 +36,114 @@ const vm = require("node:vm");
 
 const WEB = path.join(__dirname, "..", "..", "mureo", "_data", "web");
 
-/** Every function the browser build of dashboard.js binds at load. */
-const BOUND_BY_DASHBOARD = [
-  "relativeAge",
-  "reportsPlatformLabels",
-  "reportsConflictText",
-  "reportsConflictsForKey",
-  "reportsFreshnessLabel",
-  "reportsCardFreshness",
-  "aggregateClientKpis",
+/**
+ * Every extracted module, in the <script> order app.html pins, with the
+ * functions the browser build of dashboard.js binds at load.
+ *
+ * `bound` is deliberately the exact bind list and not "everything the
+ * module exports": these are the names whose absence would leave
+ * dashboard.js holding `undefined` at render time.
+ */
+const MODULES = [
+  {
+    file: "reports_logic.js",
+    global: "MUREO_REPORTS_LOGIC",
+    bound: [
+      "relativeAge",
+      "reportsPlatformLabels",
+      "reportsConflictText",
+      "reportsConflictsForKey",
+      "reportsFreshnessLabel",
+      "reportsCardFreshness",
+      "aggregateClientKpis",
+    ],
+    // Definitions that must NOT survive in dashboard.js: a leftover copy
+    // would shadow the module and drift from it.
+    moved: [
+      "relativeAge",
+      "reportsPlatformLabels",
+      "reportsConflictText",
+      "reportsConflictsForKey",
+      "reportsFreshnessLabel",
+      "reportsCardFreshness",
+      "aggregateClientKpis",
+      "reportsHasDoubleCount",
+      "reportsConflictsOfKind",
+    ],
+  },
+  {
+    file: "reports_format.js",
+    global: "MUREO_REPORTS_FORMAT",
+    bound: [
+      "reportsPeriodLabel",
+      "humanizeReportFlag",
+      "reportFlagKind",
+      "flagSeverityRank",
+      "clientReportFlags",
+      "buildFlagDetail",
+      "formatNumber",
+      "formatKpi",
+    ],
+    moved: [
+      "reportsPeriodLabel",
+      "humanizeReportFlag",
+      "reportFlagKind",
+      "flagSeverityRank",
+      "clientReportFlags",
+      "buildFlagDetail",
+      "formatNumber",
+      "formatKpi",
+      "humanizeFlagWords",
+      "matchReportFlagBase",
+      "pickLocalizedLabel",
+      "flagChipKind",
+      "flagParamLabel",
+      "formatFlagParam",
+    ],
+  },
+  {
+    file: "reports_order.js",
+    global: "MUREO_REPORTS_ORDER",
+    bound: ["orderReportsClients", "persistReportsOrderFromDom", "moveReportsCard"],
+    moved: [
+      "orderReportsClients",
+      "persistReportsOrderFromDom",
+      "moveReportsCard",
+      "readReportsOrder",
+      "writeReportsOrder",
+    ],
+  },
 ];
+
+/** Every extracted module actually shipped, found rather than declared. */
+const SHIPPED_MODULES = fs
+  .readdirSync(WEB)
+  .filter(function (n) {
+    return /^reports_.*\.js$/.test(n);
+  })
+  .sort();
+
+test.describe("the module table covers what actually ships", function () {
+  test.it("has a row for every reports_*.js in the web directory", function () {
+    // Without this, adding mureo/_data/web/reports_something.js and
+    // forgetting the row here means it gets NONE of the checks below while
+    // the suite stays green and the header still claims otherwise.
+    assert.deepEqual(
+      MODULES.map(function (m) {
+        return m.file;
+      }).sort(),
+      SHIPPED_MODULES,
+      "MODULES and mureo/_data/web/reports_*.js disagree"
+    );
+  });
+
+  test.it("gives each module a distinct global", function () {
+    const globals = MODULES.map(function (m) {
+      return m.global;
+    });
+    assert.equal(new Set(globals).size, globals.length, "two modules share a global");
+  });
+});
 
 function read(name) {
   return fs.readFileSync(path.join(WEB, name), "utf-8");
@@ -66,6 +176,14 @@ function browserContext() {
     fetch: function () {
       throw new Error("fetch at load time");
     },
+    localStorage: {
+      getItem: function () {
+        throw new Error("localStorage at load time");
+      },
+      setItem: function () {
+        throw new Error("localStorage at load time");
+      },
+    },
     MUREO: {
       t: function (key) {
         return key;
@@ -84,52 +202,98 @@ function evaluate(context, name) {
   new vm.Script(read(name), { filename: name }).runInContext(context);
 }
 
-test.describe("reports_logic.js as a browser asset", function () {
-  test.it("publishes its global with no CommonJS in scope", function () {
-    const env = browserContext();
-    assert.equal(env.sandbox.module, undefined);
-    assert.equal(env.sandbox.exports, undefined);
-    assert.equal(env.sandbox.require, undefined);
+/** Load every module ahead of dashboard.js, skipping `except`. */
+function loadModules(context, except) {
+  for (const mod of MODULES) {
+    if (mod.file === except) continue;
+    evaluate(context, mod.file);
+  }
+}
 
-    evaluate(env.context, "reports_logic.js");
+for (const mod of MODULES) {
+  test.describe(mod.file + " as a browser asset", function () {
+    test.it("publishes its global with no CommonJS in scope", function () {
+      const env = browserContext();
+      assert.equal(env.sandbox.module, undefined);
+      assert.equal(env.sandbox.exports, undefined);
+      assert.equal(env.sandbox.require, undefined);
 
-    const api = env.sandbox.window.MUREO_REPORTS_LOGIC;
-    assert.ok(api, "window.MUREO_REPORTS_LOGIC was not published");
-    for (const name of BOUND_BY_DASHBOARD) {
-      assert.equal(typeof api[name], "function", `${name} is not exported`);
-    }
-    assert.equal(api.REPORTS_CONFLICT_DUPLICATE_ACCOUNT, "duplicate_account");
-  });
+      evaluate(env.context, mod.file);
 
-  test.it("does not leak anything else into the page", function () {
-    // A plain <script> shares one global scope with every other asset, so
-    // the module must add exactly one name.
-    const env = browserContext();
-    const before = new Set(Object.keys(env.sandbox));
-    evaluate(env.context, "reports_logic.js");
-    const added = Object.keys(env.sandbox).filter(function (k) {
-      return !before.has(k);
+      const api = env.sandbox.window[mod.global];
+      assert.ok(api, "window." + mod.global + " was not published");
+      for (const name of mod.bound) {
+        assert.equal(typeof api[name], "function", name + " is not exported");
+      }
     });
-    assert.deepEqual(added, ["MUREO_REPORTS_LOGIC"]);
-  });
 
-  test.it("works when required by Node and loaded by a browser alike", function () {
-    // Same bytes, both entry points — the test suite is never reading a
-    // copy that could drift from the served asset.
-    const env = browserContext();
-    evaluate(env.context, "reports_logic.js");
-    const required = require(path.join(WEB, "reports_logic.js"));
-    assert.deepEqual(
-      Object.keys(env.sandbox.window.MUREO_REPORTS_LOGIC).sort(),
-      Object.keys(required).sort()
-    );
+    test.it("does not leak anything else into the page", function () {
+      // A plain <script> shares one global scope with every other asset, so
+      // the module must add exactly one name.
+      const env = browserContext();
+      const before = new Set(Object.keys(env.sandbox));
+      evaluate(env.context, mod.file);
+      const added = Object.keys(env.sandbox).filter(function (k) {
+        return !before.has(k);
+      });
+      assert.deepEqual(added, [mod.global]);
+    });
+
+    test.it("works when required by Node and loaded by a browser alike", function () {
+      // Same bytes, both entry points — the test suite is never reading a
+      // copy that could drift from the served asset.
+      const env = browserContext();
+      evaluate(env.context, mod.file);
+      const required = require(path.join(WEB, mod.file));
+      assert.deepEqual(
+        Object.keys(env.sandbox.window[mod.global]).sort(),
+        Object.keys(required).sort()
+      );
+    });
+
+    test.it("keeps no copy of its logic in dashboard.js", function () {
+      // A leftover definition would shadow the module and drift from it.
+      const js = read("dashboard.js");
+      for (const name of mod.moved) {
+        assert.ok(
+          !js.includes("function " + name + "("),
+          name + " is still defined in dashboard.js"
+        );
+      }
+    });
+  });
+}
+
+test.describe("reports_logic.js constants", function () {
+  test.it("still names the two conflict kinds apart", function () {
+    const api = require(path.join(WEB, "reports_logic.js"));
+    assert.equal(api.REPORTS_CONFLICT_DUPLICATE_ACCOUNT, "duplicate_account");
+    assert.equal(api.REPORTS_CONFLICT_UNRECOGNIZED_KEY, "unrecognized_key");
   });
 });
 
 test.describe("dashboard.js still evaluates as a plain script", function () {
-  test.it("binds the extracted logic when loaded after it", function () {
+  test.it("names EVERY missing module, not just the first", function () {
+    // The <script> block is usually dropped or reordered as a block, so
+    // diagnosing it one reload at a time is the wrong shape of message.
     const env = browserContext();
-    evaluate(env.context, "reports_logic.js");
+    assert.throws(
+      function () {
+        evaluate(env.context, "dashboard.js");
+      },
+      function (err) {
+        for (const mod of MODULES) {
+          assert.match(err.message, new RegExp(mod.global));
+          assert.match(err.message, new RegExp(mod.file.replace(".", "\\.")));
+        }
+        return true;
+      }
+    );
+  });
+
+  test.it("binds the extracted modules when loaded after them", function () {
+    const env = browserContext();
+    loadModules(env.context, null);
     evaluate(env.context, "dashboard.js");
     // Its load-time side effects are unchanged: it only registers listeners.
     assert.deepEqual(env.listeners, [
@@ -139,47 +303,45 @@ test.describe("dashboard.js still evaluates as a plain script", function () {
     ]);
   });
 
-  test.it("fails loudly AND diagnosably if the module is missing", function () {
-    // The failure mode that must NOT exist: dashboard.js loading anyway and
-    // rendering a conflicted client's double-counted totals because the
-    // withholding helper quietly became undefined. So it throws — but this
-    // file IS the configure UI, so the throw blanks the whole dashboard,
-    // and whoever sees it must not have to reverse-engineer a bare "cannot
-    // read properties of undefined". The message names the missing module
-    // and the load order that fixes it.
-    const env = browserContext();
-    assert.throws(
-      function () {
-        evaluate(env.context, "dashboard.js");
-      },
-      function (err) {
-        // Raised inside the vm realm, so `instanceof` does not apply.
-        assert.equal(err.name, "Error");
-        assert.match(err.message, /MUREO_REPORTS_LOGIC/);
-        assert.match(err.message, /reports_logic\.js/);
-        assert.match(err.message, /BEFORE/);
-        return true;
-      }
-    );
-    // The guard is not literally the file's first statement — ~1800 lines of
-    // declarations precede it — but it does run before anything OBSERVABLE,
-    // which is the property that matters: a half-initialised dashboard with
-    // live listeners and no working KPI logic would be worse than none.
-    assert.deepEqual(env.listeners, [], "a listener was registered before the guard");
-  });
-
-  test.it("keeps no copy of the moved logic", function () {
-    // A leftover definition would shadow the module and drift from it.
-    const js = read("dashboard.js");
-    for (const name of BOUND_BY_DASHBOARD) {
-      assert.ok(
-        !js.includes("function " + name + "("),
-        name + " is still defined in dashboard.js"
+  for (const mod of MODULES) {
+    test.it("fails loudly AND diagnosably without " + mod.file, function () {
+      // The failure mode that must NOT exist: dashboard.js loading anyway and
+      // rendering a conflicted client's double-counted totals because the
+      // withholding helper quietly became undefined. So it throws — but this
+      // file IS the configure UI, so the throw blanks the whole dashboard,
+      // and whoever sees it must not have to reverse-engineer a bare "cannot
+      // read properties of undefined". The message names THE module that is
+      // missing — not just the first one anybody ever extracted — and the
+      // load order that fixes it.
+      const env = browserContext();
+      loadModules(env.context, mod.file);
+      assert.throws(
+        function () {
+          evaluate(env.context, "dashboard.js");
+        },
+        function (err) {
+          // Raised inside the vm realm, so `instanceof` does not apply.
+          assert.equal(err.name, "Error");
+          assert.match(err.message, new RegExp(mod.global));
+          assert.match(err.message, new RegExp(mod.file.replace(".", "\\.")));
+          assert.match(err.message, /BEFORE/);
+          for (const other of MODULES) {
+            if (other === mod) continue;
+            assert.ok(
+              !err.message.includes(other.global),
+              "the message names " + other.global + ", which IS loaded"
+            );
+          }
+          return true;
+        }
       );
-    }
-    assert.ok(!js.includes("function reportsHasDoubleCount("));
-    assert.ok(!js.includes("function reportsConflictsOfKind("));
-  });
+      // The guard is not literally the file's first statement — ~1800 lines of
+      // declarations precede it — but it does run before anything OBSERVABLE,
+      // which is the property that matters: a half-initialised dashboard with
+      // live listeners and no working KPI logic would be worse than none.
+      assert.deepEqual(env.listeners, [], "a listener was registered before the guard");
+    });
+  }
 });
 
 test.describe("every served asset parses", function () {
@@ -197,6 +359,8 @@ test.describe("every served asset parses", function () {
 
   test.it("covers the whole web directory", function () {
     assert.ok(scripts.includes("dashboard.js"));
-    assert.ok(scripts.includes("reports_logic.js"));
+    for (const name of SHIPPED_MODULES) {
+      assert.ok(scripts.includes(name), name + " is not in " + WEB);
+    }
   });
 });

--- a/tests/js/reports_format.test.js
+++ b/tests/js/reports_format.test.js
@@ -1,0 +1,448 @@
+// Behavioural tests for mureo/_data/web/reports_format.js (#556).
+//
+// Run with:  node --test tests/js/
+//
+// These EXECUTE the shipped bytes — `require` loads the same file the
+// browser gets over /static/reports_format.js, no build step and no copy.
+//
+// Everything here was previously guarded only by the substring pins in
+// tests/test_web_assets_report_flags_vocab.py, which can see that a name, a
+// string or an i18n key is present and nothing more. The decisions below are
+// exactly what a substring pin cannot read:
+//
+//   • the LONGEST flag base wins, so "sparse_conversions_tracking_suspect"
+//     is a tracking-integrity danger and not whatever a shorter prefix says.
+//   • an unknown code degrades to a humanized token, so a raw i18n key
+//     ("dashboard.reports_flag_…") never reaches an operator's screen.
+//   • a canonical severity beats the legacy keyword inference, so an
+//     `info` or `positive` flag is never coloured like an alarm — and
+//     ranks BELOW the alarms when the card sorts its chips.
+//   • CTR's fraction-vs-percentage heuristic scales 0.034 and 3.4 to the
+//     same figure. Flip that and a card reads 0.03% instead of 3.4%.
+//
+// i18n: MUREO.t returns the key it was handed unless TRANSLATED names it, so
+// assertions are on WHICH string was chosen and on which fallback branch was
+// taken, not on English wording.
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+
+const WEB = path.join(__dirname, "..", "..", "mureo", "_data", "web");
+
+/** Keys the stub "has a translation for"; everything else echoes the key. */
+const TRANSLATED = {
+  "dashboard.reports_flag_cpa_over_target": "CPA over target",
+  "dashboard.reports_flag_tracking_suspect": "Tracking suspect",
+  "dashboard.reports_flag_low_cvr": "Low CVR",
+  "dashboard.reports_flag_low_cvr_lp": "Low CVR on the LP",
+  "dashboard.reports_flag_goals_met": "Goals met",
+  "dashboard.reports_period_yesterday": "Yesterday",
+  "dashboard.reports_param_adspot": "Ad spot",
+  "dashboard.reports_param_yes": "yes",
+  "dashboard.reports_param_no": "no",
+};
+
+globalThis.MUREO = {
+  t: function (key) {
+    return Object.prototype.hasOwnProperty.call(TRANSLATED, key)
+      ? TRANSLATED[key]
+      : key;
+  },
+};
+
+// pickLocalizedLabel reads the active locale off <html lang> — one attribute,
+// at call time. Nothing else in the module touches the document.
+globalThis.document = { documentElement: { lang: "en" } };
+
+const fmt = require(path.join(WEB, "reports_format.js"));
+
+test.beforeEach(function () {
+  globalThis.document.documentElement.lang = "en";
+});
+
+// ---------------------------------------------------------------------------
+// Period labels
+// ---------------------------------------------------------------------------
+
+test.describe("reportsPeriodLabel", function () {
+  test.it("localizes a known window", function () {
+    assert.equal(fmt.reportsPeriodLabel("YESTERDAY"), "Yesterday");
+  });
+
+  test.it("renders an unknown window as its raw token", function () {
+    // A future window still gets a button, just unlocalized — never a blank
+    // one and never a raw i18n key.
+    assert.equal(fmt.reportsPeriodLabel("LAST_90_DAYS"), "LAST_90_DAYS");
+    assert.equal(fmt.reportsPeriodLabel(null), "null");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Humanizing
+// ---------------------------------------------------------------------------
+
+test.describe("humanizeFlagWords", function () {
+  test.it("upper-cases metric acronyms and sentence-cases the rest", function () {
+    assert.equal(fmt.humanizeFlagWords("cpa_over_target"), "CPA over target");
+    assert.equal(fmt.humanizeFlagWords("low_cvr_lp"), "Low CVR LP");
+  });
+
+  test.it("capitalizes a leading non-acronym word", function () {
+    assert.equal(fmt.humanizeFlagWords("budget_drift"), "Budget drift");
+  });
+
+  test.it("survives empty and null input", function () {
+    assert.equal(fmt.humanizeFlagWords(""), "");
+    assert.equal(fmt.humanizeFlagWords(null), "");
+    assert.equal(fmt.humanizeFlagWords("___"), "");
+  });
+});
+
+test.describe("matchReportFlagBase", function () {
+  test.it("prefers the LONGEST matching base", function () {
+    const best = fmt.matchReportFlagBase("sparse_conversions_tracking_suspect");
+    assert.equal(best[0], "sparse_conversions_tracking_suspect");
+
+    const lp = fmt.matchReportFlagBase("low_cvr_lp_conversion");
+    assert.equal(lp[0], "low_cvr_lp_conversion");
+    assert.equal(fmt.matchReportFlagBase("low_cvr")[0], "low_cvr");
+  });
+
+  test.it("prefers the longest even when the SHORTER base is registered first", function () {
+    // The case that matters, and the only pair in the shipped table where
+    // registration order and match length disagree: "search_console_no" is
+    // listed BEFORE "search_console_no_property". A first-registered-wins
+    // implementation passes every other test in this file and puts an
+    // amber "is-warn" chip with the wrong label in front of an operator
+    // where an informational "is-info" one belongs.
+    const best = fmt.matchReportFlagBase("search_console_no_property");
+    assert.equal(best[0], "search_console_no_property");
+    assert.equal(best[1], "dashboard.reports_flag_search_console_no_property");
+    assert.equal(best[2], "is-info");
+    assert.equal(fmt.reportFlagKind("search_console_no_property"), "is-info");
+    // …and the shorter base still resolves to its own entry.
+    assert.equal(fmt.matchReportFlagBase("search_console_no")[0], "search_console_no");
+    assert.equal(fmt.reportFlagKind("search_console_no"), "is-warn");
+  });
+
+  test.it("resolves EVERY prefix pair in the shipped table to the longer one", function () {
+    // Derived from the table rather than restated: a base added anywhere in
+    // REPORTS_FLAG_BASES that shadows or is shadowed by another is covered
+    // the moment it ships, without anyone remembering to add a case here.
+    // This is what makes longest-wins a property of the module rather than
+    // of where entries happen to sit in the array.
+    const bases = fmt.REPORTS_FLAG_BASES.map(function (entry) {
+      return entry[0];
+    });
+    const pairs = [];
+    for (const long of bases) {
+      for (const short of bases) {
+        if (short !== long && long.indexOf(short + "_") === 0) {
+          pairs.push([short, long]);
+        }
+      }
+    }
+    assert.ok(pairs.length > 0, "no prefix pairs found — did the table change shape?");
+    for (const [short, long] of pairs) {
+      const best = fmt.matchReportFlagBase(long);
+      assert.equal(
+        best && best[0],
+        long,
+        `"${long}" resolved to "${best && best[0]}"; "${short}" shadowed it`
+      );
+    }
+  });
+
+  test.it("gives every registered base a label key and a known severity", function () {
+    // (best && best[2]) is the whole severity for a bare-string flag: an
+    // entry with an empty third slot would silently fall through to the
+    // legacy keyword inference, which returns "" for every base we ship.
+    const KINDS = ["is-danger", "is-warn", "is-success", "is-info"];
+    for (const entry of fmt.REPORTS_FLAG_BASES) {
+      assert.equal(entry.length, 3, `${entry[0]} is not [base, labelKey, kind]`);
+      assert.ok(entry[1].startsWith("dashboard.reports_flag_"), entry[0]);
+      assert.ok(KINDS.includes(entry[2]), `${entry[0]} has severity "${entry[2]}"`);
+    }
+  });
+
+  test.it("matches a base followed by a descriptor, not a bare prefix", function () {
+    // "cpa_over_target_logly" is the base plus a client name…
+    assert.equal(fmt.matchReportFlagBase("cpa_over_target_logly")[0], "cpa_over_target");
+    // …but "cpa_over_targeting" only SHARES a prefix and must not match.
+    assert.equal(fmt.matchReportFlagBase("cpa_over_targeting"), null);
+  });
+
+  test.it("returns null for an unregistered flag", function () {
+    assert.equal(fmt.matchReportFlagBase("something_nobody_registered"), null);
+  });
+});
+
+test.describe("humanizeReportFlag", function () {
+  test.it("localizes a structured flag by its canonical code", function () {
+    assert.equal(fmt.humanizeReportFlag({ code: "goals_met" }), "Goals met");
+  });
+
+  test.it("never shows a raw i18n key for an unlocalized code", function () {
+    // The regression this exists to catch: MUREO.t echoes the key when there
+    // is no translation, and echoing THAT onto a chip is unreadable.
+    const label = fmt.humanizeReportFlag({ code: "brand_new_finding" });
+    assert.equal(label, "Brand new finding");
+    assert.ok(!label.includes("dashboard."));
+  });
+
+  test.it("uses the author's own label for a custom flag", function () {
+    assert.equal(
+      fmt.humanizeReportFlag({ code: "custom", label: "Budget parked" }),
+      "Budget parked"
+    );
+  });
+
+  test.it("falls back to any author text on a legacy object flag", function () {
+    assert.equal(fmt.humanizeReportFlag({ message: "something odd" }), "something odd");
+    assert.equal(fmt.humanizeReportFlag({ level: "warn" }), "warn");
+    assert.equal(fmt.humanizeReportFlag({}), "");
+  });
+
+  test.it("shows only the base label for a bare-string flag", function () {
+    // The trailing remainder ("_logly") is dropped on purpose — it read as
+    // distracting, ambiguous parentheses.
+    assert.equal(fmt.humanizeReportFlag("cpa_over_target_logly"), "CPA over target");
+  });
+
+  test.it("humanizes an unregistered bare-string flag", function () {
+    assert.equal(fmt.humanizeReportFlag("weird_new_ctr_thing"), "Weird new CTR thing");
+    assert.equal(fmt.humanizeReportFlag(null), "");
+  });
+});
+
+test.describe("pickLocalizedLabel", function () {
+  test.it("passes a plain string through", function () {
+    assert.equal(fmt.pickLocalizedLabel("Budget parked"), "Budget parked");
+  });
+
+  test.it("picks the active configure-UI locale", function () {
+    globalThis.document.documentElement.lang = "ja";
+    assert.equal(fmt.pickLocalizedLabel({ en: "Parked", ja: "停止中" }), "停止中");
+  });
+
+  test.it("falls back to English, then to any string it has", function () {
+    globalThis.document.documentElement.lang = "de";
+    assert.equal(fmt.pickLocalizedLabel({ en: "Parked", ja: "停止中" }), "Parked");
+    assert.equal(fmt.pickLocalizedLabel({ ja: "停止中" }), "停止中");
+  });
+
+  test.it("returns empty rather than throwing on junk", function () {
+    assert.equal(fmt.pickLocalizedLabel(null), "");
+    assert.equal(fmt.pickLocalizedLabel(42), "");
+    assert.equal(fmt.pickLocalizedLabel({ en: 7 }), "");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Severity — the colour an operator triages by
+// ---------------------------------------------------------------------------
+
+test.describe("flagChipKind", function () {
+  test.it("infers a kind from legacy free-form level words", function () {
+    assert.equal(fmt.flagChipKind("critical"), "is-danger");
+    assert.equal(fmt.flagChipKind("ERROR"), "is-danger");
+    assert.equal(fmt.flagChipKind("watch"), "is-warn");
+    assert.equal(fmt.flagChipKind("healthy"), "is-success");
+    assert.equal(fmt.flagChipKind("whatever"), "");
+    assert.equal(fmt.flagChipKind(null), "");
+  });
+});
+
+test.describe("reportFlagKind", function () {
+  test.it("maps the four canonical severities", function () {
+    assert.equal(fmt.reportFlagKind({ code: "x", severity: "action" }), "is-danger");
+    assert.equal(fmt.reportFlagKind({ code: "x", severity: "watch" }), "is-warn");
+    assert.equal(fmt.reportFlagKind({ code: "x", severity: "info" }), "is-info");
+    assert.equal(fmt.reportFlagKind({ code: "x", severity: "positive" }), "is-success");
+  });
+
+  test.it("does not colour an info or positive flag like an alarm", function () {
+    // "info" contains no danger/warn keyword, so the legacy inference would
+    // return "" — the canonical map must be consulted FIRST.
+    const info = fmt.reportFlagKind({ code: "pending_observations", severity: "info" });
+    assert.equal(info, "is-info");
+    assert.notEqual(info, "is-danger");
+    assert.notEqual(info, "is-warn");
+  });
+
+  test.it("falls back to keyword inference for an unmapped severity", function () {
+    assert.equal(fmt.reportFlagKind({ code: "x", severity: "critical" }), "is-danger");
+    assert.equal(fmt.reportFlagKind({ code: "x", level: "warn" }), "is-warn");
+  });
+
+  test.it("uses the curated severity of a bare string's base", function () {
+    // Every shipped base infers "" under the legacy keyword rule, so the
+    // curated severity is the only thing that can produce these.
+    assert.equal(fmt.reportFlagKind("zero_conversions"), "is-danger");
+    assert.equal(fmt.reportFlagKind("cpa_under_target"), "is-success");
+    assert.equal(fmt.reportFlagKind("goals_met"), "is-success");
+    assert.equal(fmt.reportFlagKind("ga4_not_configured"), "is-info");
+    assert.equal(fmt.reportFlagKind("nothing_registered"), "");
+  });
+
+  test.it("still infers a kind for an unregistered flag that carries one", function () {
+    // The fallback arm: dropping it would leave an agent-authored flag that
+    // says "critical" rendering as an uncoloured tag. No shipped base
+    // reaches this arm, so nothing else in this file would notice.
+    assert.equal(fmt.reportFlagKind("some_critical_thing"), "is-danger");
+    assert.equal(fmt.reportFlagKind("unregistered_warn_case"), "is-warn");
+  });
+});
+
+test.describe("flagSeverityRank", function () {
+  test.it("sorts most urgent first and puts info below the colours", function () {
+    const flags = [
+      "ga4_not_configured", // is-info
+      "goals_met", // is-success
+      "nothing_registered", // ""
+      "zero_conversions", // is-danger
+      "spend_spike", // is-warn
+    ];
+    const sorted = flags.slice().sort(function (a, b) {
+      return fmt.flagSeverityRank(a) - fmt.flagSeverityRank(b);
+    });
+    assert.deepEqual(sorted, [
+      "zero_conversions",
+      "spend_spike",
+      "goals_met",
+      "ga4_not_configured",
+      "nothing_registered",
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Which flags a client card shows
+// ---------------------------------------------------------------------------
+
+test.describe("clientReportFlags", function () {
+  test.it("prefers daily, then weekly, then goal", function () {
+    const summary = {
+      reports: {
+        daily: { flags: ["a"] },
+        weekly: { flags: ["b"] },
+        goal: { flags: ["c"] },
+      },
+    };
+    assert.deepEqual(fmt.clientReportFlags(summary), ["a"]);
+    delete summary.reports.daily;
+    assert.deepEqual(fmt.clientReportFlags(summary), ["b"]);
+    delete summary.reports.weekly;
+    assert.deepEqual(fmt.clientReportFlags(summary), ["c"]);
+  });
+
+  test.it("is empty rather than throwing when there is no report", function () {
+    assert.deepEqual(fmt.clientReportFlags(null), []);
+    assert.deepEqual(fmt.clientReportFlags({}), []);
+    assert.deepEqual(fmt.clientReportFlags({ reports: {} }), []);
+    assert.deepEqual(fmt.clientReportFlags({ reports: { daily: {} } }), []);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Figures
+// ---------------------------------------------------------------------------
+
+test.describe("formatNumber", function () {
+  test.it("groups a finite number", function () {
+    assert.equal(fmt.formatNumber(1234567), (1234567).toLocaleString());
+  });
+
+  test.it("passes non-numbers through as plain text, never 'null'", function () {
+    assert.equal(fmt.formatNumber(null), "");
+    assert.equal(fmt.formatNumber(undefined), "");
+    assert.equal(fmt.formatNumber("n/a"), "n/a");
+    assert.equal(fmt.formatNumber(NaN), "NaN");
+    assert.equal(fmt.formatNumber(Infinity), "Infinity");
+  });
+});
+
+test.describe("formatKpi", function () {
+  test.it("scales a CTR fraction and a CTR percentage to the same figure", function () {
+    // The heuristic: <= 1 is a fraction (0.034 → 3.4%). Locale-independent —
+    // it asserts the SCALING, not the separator.
+    assert.equal(fmt.formatKpi("ctr", 0.034), fmt.formatKpi("ctr", 3.4));
+    assert.equal(fmt.formatKpi("ctr", 1), fmt.formatKpi("ctr", 100));
+    assert.ok(fmt.formatKpi("ctr", 0.034).endsWith("%"));
+  });
+
+  test.it("does not percent-ize a non-CTR metric", function () {
+    assert.equal(fmt.formatKpi("clicks", 0.5), fmt.formatNumber(0.5));
+    assert.ok(!fmt.formatKpi("clicks", 0.5).includes("%"));
+  });
+
+  test.it("leaves a non-numeric CTR alone", function () {
+    assert.equal(fmt.formatKpi("ctr", null), "");
+    assert.equal(fmt.formatKpi("ctr", "—"), "—");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Flag params → the drill-down line
+// ---------------------------------------------------------------------------
+
+test.describe("flagParamLabel", function () {
+  test.it("localizes a known param key", function () {
+    assert.equal(fmt.flagParamLabel("adspot"), "Ad spot");
+  });
+
+  test.it("humanizes an unlocalized one rather than showing the i18n key", function () {
+    const label = fmt.flagParamLabel("pool_ratio");
+    assert.equal(label, "Pool ratio");
+    assert.ok(!label.includes("dashboard."));
+  });
+});
+
+test.describe("formatFlagParam", function () {
+  test.it("localizes booleans instead of shipping English true/false", function () {
+    assert.equal(fmt.formatFlagParam("unlogged", true), "yes");
+    assert.equal(fmt.formatFlagParam("unlogged", false), "no");
+  });
+
+  test.it("joins arrays and drops the empties", function () {
+    assert.equal(fmt.formatFlagParam("adspots", ["a", "b"]), "a, b");
+    assert.equal(fmt.formatFlagParam("adspots", ["a", null, "b"]), "a, b");
+    assert.equal(fmt.formatFlagParam("adspots", []), "");
+  });
+
+  test.it("routes ctr through the percentage rule", function () {
+    assert.equal(fmt.formatFlagParam("ctr", 0.034), fmt.formatKpi("ctr", 0.034));
+  });
+
+  test.it("groups other numbers and stringifies the rest", function () {
+    assert.equal(fmt.formatFlagParam("spend", 1234567), (1234567).toLocaleString());
+    assert.equal(fmt.formatFlagParam("note", null), "");
+    assert.equal(fmt.formatFlagParam("note", "raw"), "raw");
+  });
+});
+
+test.describe("buildFlagDetail", function () {
+  test.it("renders label: value pairs joined by a middot", function () {
+    const detail = fmt.buildFlagDetail({
+      code: "zero_cv_adspots",
+      params: { adspot: "A-1", spend: 12000 },
+    });
+    assert.equal(detail, "Ad spot: A-1 · Spend: " + (12000).toLocaleString());
+  });
+
+  test.it("skips params that format to nothing", function () {
+    const detail = fmt.buildFlagDetail({ params: { adspot: "A-1", note: null } });
+    assert.equal(detail, "Ad spot: A-1");
+  });
+
+  test.it("returns empty when there is nothing to drill into", function () {
+    // "" is what makes the chip render as a plain, non-interactive tag —
+    // an interactive chip that discloses nothing is a dead control.
+    assert.equal(fmt.buildFlagDetail("cpa_over_target"), "");
+    assert.equal(fmt.buildFlagDetail(null), "");
+    assert.equal(fmt.buildFlagDetail({ code: "x" }), "");
+    assert.equal(fmt.buildFlagDetail({ code: "x", params: {} }), "");
+    assert.equal(fmt.buildFlagDetail({ code: "x", params: "nope" }), "");
+  });
+});

--- a/tests/js/reports_order.test.js
+++ b/tests/js/reports_order.test.js
@@ -1,0 +1,311 @@
+// Behavioural tests for mureo/_data/web/reports_order.js (#556).
+//
+// Run with:  node --test tests/js/
+//
+// These EXECUTE the shipped bytes — `require` loads the same file the
+// browser gets over /static/reports_order.js, no build step and no copy.
+//
+// Until #556 the ordering rules were guarded only by the substring pins in
+// tests/test_web_assets_reports_order_and_archive.py, whose own docstring
+// says it "cannot prove that a drag actually reorders the grid, that a
+// corrupt stored order really degrades to the server order". It can now:
+// the module never goes LOOKING for a node — every node is handed in — so a
+// fake grid of ~20 lines drives the real code.
+//
+// What is being pinned:
+//
+//   • an unusable stored order (storage off, corrupt JSON, wrong type, junk
+//     members) degrades to the SERVER's order, never to an empty grid;
+//   • a client the operator has never placed lands LAST, keeping its server
+//     order — it must not displace the top of a curated grid on every
+//     onboarding;
+//   • the DOM is the single source of truth for what gets persisted, so the
+//     keyboard path and the drop handler cannot disagree;
+//   • a move off either end of the grid is a no-op, not a wrap-around and
+//     not an exception that leaves the arrow key dead.
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+
+const WEB = path.join(__dirname, "..", "..", "mureo", "_data", "web");
+
+const KEY = "mureo.reports.client_order";
+
+/** A localStorage that can be corrupt, or disabled the way Safari's is. */
+const storage = { items: {}, disabled: false };
+
+// Assigned BEFORE the require: in a browser `window` is the global, and the
+// module reads window.localStorage at CALL time.
+globalThis.window = {
+  localStorage: {
+    getItem: function (key) {
+      if (storage.disabled) throw new Error("storage is disabled");
+      return Object.prototype.hasOwnProperty.call(storage.items, key)
+        ? storage.items[key]
+        : null;
+    },
+    setItem: function (key, value) {
+      if (storage.disabled) throw new Error("storage is disabled");
+      storage.items[key] = value;
+    },
+  },
+};
+
+const order = require(path.join(WEB, "reports_order.js"));
+
+test.beforeEach(function () {
+  storage.items = {};
+  storage.disabled = false;
+});
+
+/** The stored slugs, parsed — i.e. what a later page load would read back. */
+function stored() {
+  return storage.items[KEY] === undefined ? undefined : JSON.parse(storage.items[KEY]);
+}
+
+/**
+ * A stand-in for the client grid: an element with `children`, whose members
+ * carry `data-client` and a live `nextSibling`, and a DOM-shaped
+ * `insertBefore` (a null reference appends, and re-inserting a node that is
+ * already a child moves it).
+ */
+function grid(slugs) {
+  const wrap = {
+    children: [],
+    insertBefore: function (node, ref) {
+      const at = wrap.children.indexOf(node);
+      if (at !== -1) wrap.children.splice(at, 1);
+      const to = ref === null ? -1 : wrap.children.indexOf(ref);
+      if (to === -1) wrap.children.push(node);
+      else wrap.children.splice(to, 0, node);
+      return node;
+    },
+  };
+  slugs.forEach(function (slug) {
+    const node = {
+      parentNode: wrap,
+      getAttribute: function (name) {
+        return name === "data-client" ? slug : null;
+      },
+    };
+    Object.defineProperty(node, "nextSibling", {
+      get: function () {
+        const i = wrap.children.indexOf(node);
+        return i >= 0 && i + 1 < wrap.children.length ? wrap.children[i + 1] : null;
+      },
+    });
+    wrap.children.push(node);
+  });
+  return wrap;
+}
+
+/** The slugs currently on screen, in grid order. */
+function slugsOf(wrap) {
+  return wrap.children.map(function (n) {
+    return n.getAttribute("data-client");
+  });
+}
+
+const client = function (slug) {
+  return { slug: slug, name: slug };
+};
+
+// ---------------------------------------------------------------------------
+// Reading the stored order
+// ---------------------------------------------------------------------------
+
+test.describe("readReportsOrder", function () {
+  test.it("returns what was stored", function () {
+    storage.items[KEY] = JSON.stringify(["b", "a"]);
+    assert.deepEqual(order.readReportsOrder(), ["b", "a"]);
+  });
+
+  test.it("is empty when nothing was ever stored", function () {
+    assert.deepEqual(order.readReportsOrder(), []);
+  });
+
+  test.it("degrades to empty — never throws — on anything unusable", function () {
+    // Every one of these reaches the grid as "use the server's order".
+    for (const raw of ["{not json", '"a string"', "42", "null", '{"a":1}']) {
+      storage.items[KEY] = raw;
+      assert.deepEqual(order.readReportsOrder(), [], raw);
+    }
+  });
+
+  test.it("drops junk members rather than the whole order", function () {
+    storage.items[KEY] = JSON.stringify(["a", 7, null, "", "b", { slug: "c" }]);
+    assert.deepEqual(order.readReportsOrder(), ["a", "b"]);
+  });
+
+  test.it("survives storage being disabled outright", function () {
+    storage.disabled = true;
+    assert.deepEqual(order.readReportsOrder(), []);
+  });
+});
+
+test.describe("writeReportsOrder", function () {
+  test.it("persists under the documented key", function () {
+    order.writeReportsOrder(["a", "b"]);
+    assert.equal(order.REPORTS_ORDER_KEY, KEY);
+    assert.deepEqual(stored(), ["a", "b"]);
+  });
+
+  test.it("swallows a disabled storage so the render still completes", function () {
+    storage.disabled = true;
+    assert.doesNotThrow(function () {
+      order.writeReportsOrder(["a"]);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Applying it to the server's rows
+// ---------------------------------------------------------------------------
+
+test.describe("orderReportsClients", function () {
+  test.it("applies the operator's order to the server's rows", function () {
+    storage.items[KEY] = JSON.stringify(["c", "a", "b"]);
+    const rows = [client("a"), client("b"), client("c")];
+    assert.deepEqual(
+      order.orderReportsClients(rows).map(function (c) {
+        return c.slug;
+      }),
+      ["c", "a", "b"]
+    );
+  });
+
+  test.it("appends a never-placed client LAST, in server order", function () {
+    // Last, not first: a curated grid must not be displaced at the top on
+    // every onboarding. The position is defined and findable, and one drag
+    // fixes it.
+    storage.items[KEY] = JSON.stringify(["c", "a"]);
+    const rows = [client("a"), client("new1"), client("c"), client("new2")];
+    assert.deepEqual(
+      order.orderReportsClients(rows).map(function (c) {
+        return c.slug;
+      }),
+      ["c", "a", "new1", "new2"]
+    );
+  });
+
+  test.it("costs nothing for a stored client that no longer exists", function () {
+    storage.items[KEY] = JSON.stringify(["gone", "b", "also_gone", "a"]);
+    const rows = [client("a"), client("b")];
+    assert.deepEqual(
+      order.orderReportsClients(rows).map(function (c) {
+        return c.slug;
+      }),
+      ["b", "a"]
+    );
+  });
+
+  test.it("keeps the server order when there is nothing stored", function () {
+    const rows = [client("a"), client("b"), client("c")];
+    assert.deepEqual(order.orderReportsClients(rows), rows);
+  });
+
+  test.it("keeps the server order when storage is unusable", function () {
+    // The failure that must NOT happen: an empty grid.
+    storage.disabled = true;
+    const rows = [client("a"), client("b")];
+    assert.deepEqual(
+      order.orderReportsClients(rows).map(function (c) {
+        return c.slug;
+      }),
+      ["a", "b"]
+    );
+  });
+
+  test.it("does not mutate the array it was handed", function () {
+    storage.items[KEY] = JSON.stringify(["b", "a"]);
+    const rows = [client("a"), client("b")];
+    order.orderReportsClients(rows);
+    assert.deepEqual(
+      rows.map(function (c) {
+        return c.slug;
+      }),
+      ["a", "b"]
+    );
+  });
+
+  test.it("tolerates a row with no slug", function () {
+    storage.items[KEY] = JSON.stringify(["b"]);
+    const rows = [client("a"), null, client("b")];
+    const out = order.orderReportsClients(rows);
+    assert.equal(out.length, 3);
+    assert.equal(out[0].slug, "b");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The two ways the order changes
+// ---------------------------------------------------------------------------
+
+test.describe("persistReportsOrderFromDom", function () {
+  test.it("records the grid itself, not a shadow list", function () {
+    const wrap = grid(["a", "b", "c"]);
+    order.persistReportsOrderFromDom(wrap);
+    assert.deepEqual(stored(), ["a", "b", "c"]);
+  });
+
+  test.it("records only cards that name a client", function () {
+    // An archived client leaves the stored order and comes back as an
+    // unplaced (last) card when it is restored.
+    const wrap = grid(["a", "b"]);
+    wrap.children.splice(1, 0, { getAttribute: function () { return null; } });
+    order.persistReportsOrderFromDom(wrap);
+    assert.deepEqual(stored(), ["a", "b"]);
+  });
+});
+
+test.describe("moveReportsCard", function () {
+  test.it("moves a card down one slot and persists the result", function () {
+    const wrap = grid(["a", "b", "c"]);
+    order.moveReportsCard(wrap.children[0], 1);
+    assert.deepEqual(slugsOf(wrap), ["b", "a", "c"]);
+    assert.deepEqual(stored(), ["b", "a", "c"]);
+  });
+
+  test.it("moves a card up one slot", function () {
+    const wrap = grid(["a", "b", "c"]);
+    order.moveReportsCard(wrap.children[2], -1);
+    assert.deepEqual(slugsOf(wrap), ["a", "c", "b"]);
+    assert.deepEqual(stored(), ["a", "c", "b"]);
+  });
+
+  test.it("moves to either end without wrapping around", function () {
+    const wrap = grid(["a", "b", "c"]);
+    order.moveReportsCard(wrap.children[2], -2);
+    assert.deepEqual(slugsOf(wrap), ["c", "a", "b"]);
+    order.moveReportsCard(wrap.children[0], 2);
+    assert.deepEqual(slugsOf(wrap), ["a", "b", "c"]);
+  });
+
+  test.it("is a no-op off either end — and persists nothing", function () {
+    // Holding the arrow key at the top of the grid must not wrap the card
+    // round to the bottom, and must not rewrite the stored order either.
+    const wrap = grid(["a", "b"]);
+    order.moveReportsCard(wrap.children[0], -1);
+    assert.deepEqual(slugsOf(wrap), ["a", "b"]);
+    order.moveReportsCard(wrap.children[1], 1);
+    assert.deepEqual(slugsOf(wrap), ["a", "b"]);
+    assert.equal(stored(), undefined, "an out-of-range move still wrote");
+  });
+
+  test.it("is a no-op for a card that is not in a grid", function () {
+    assert.doesNotThrow(function () {
+      order.moveReportsCard({ parentNode: null }, 1);
+    });
+    assert.equal(stored(), undefined);
+  });
+
+  test.it("keeps the grid and the stored order in step over many moves", function () {
+    const wrap = grid(["a", "b", "c", "d"]);
+    order.moveReportsCard(wrap.children[3], -1);
+    order.moveReportsCard(wrap.children[0], 1);
+    order.moveReportsCard(wrap.children[3], -3);
+    assert.deepEqual(stored(), slugsOf(wrap));
+    assert.deepEqual(slugsOf(wrap), ["c", "b", "a", "d"]);
+  });
+});

--- a/tests/test_web_assets_report_flags_vocab.py
+++ b/tests/test_web_assets_report_flags_vocab.py
@@ -7,6 +7,22 @@ its detail in ``params`` so the chip stays coarse and localizable while the
 detail moves to a drill-down. These tests pin the bundled web assets (no build
 step — read directly from ``mureo/_data/web/``) so a regression that drops the
 localized labels, the severity colouring, or the drill-down flips red here.
+
+**Read this with ``tests/js/reports_format.test.js``.** Since #556 the two
+halves are guarded differently, the same way #540 split the conflict logic:
+
+  - the DECISIONS — the longest base wins, an unknown code degrades to a
+    humanized token instead of a raw i18n key, a canonical severity beats the
+    legacy keyword inference, an ``is-info`` flag ranks below the alarms —
+    live in ``mureo/_data/web/reports_format.js`` and are *executed* by
+    ``node --test tests/js/``. An inverted comparison is caught there.
+  - the CHIP — the element, its ARIA disclosure, its CSS classes — stays in
+    ``dashboard.js``, still has no runner that can drive a DOM, and is
+    guarded below by pinning the *shape* of what ships.
+
+The pair ships as one behaviour, so the pins that do not care which of the two
+holds a string grep both as a single source (``_FLAG_ASSETS``), the way
+``test_web_assets_reports_conflicts.py`` does.
 """
 
 from __future__ import annotations
@@ -51,8 +67,16 @@ _PARAM_LABEL_KEYS = (
 )
 
 
+# The flag vocabulary module and the renderer that consumes it (#556).
+_FLAG_ASSETS = ("reports_format.js", "dashboard.js")
+
+
 def _read(name: str) -> str:
     return (_WEB / name).read_text(encoding="utf-8")
+
+
+def _read_flags() -> str:
+    return "\n".join(_read(name) for name in _FLAG_ASSETS)
 
 
 # ---------------------------------------------------------------------------
@@ -79,14 +103,17 @@ def test_param_label_keys_present_in_both_locales() -> None:
 
 
 # ---------------------------------------------------------------------------
-# dashboard.js — structured flag rendering
+# reports_format.js + dashboard.js — structured flag rendering
 # ---------------------------------------------------------------------------
 
 
 def test_object_flags_localized_by_code() -> None:
     """An object flag renders its label from ``dashboard.reports_flag_<code>``,
-    not the raw slug — so it is coarse and localized."""
-    js = _read("dashboard.js")
+    not the raw slug — so it is coarse and localized.
+
+    *Which* label an unlocalized code falls back to is executed by
+    ``tests/js/reports_format.test.js``."""
+    js = _read("reports_format.js")
     assert "function humanizeReportFlag(" in js
     assert '"dashboard.reports_flag_" + ' in js
     assert "flag.code" in js
@@ -94,8 +121,12 @@ def test_object_flags_localized_by_code() -> None:
 
 def test_custom_flag_label_is_locale_picked() -> None:
     """A ``custom`` flag carries an author label (string or {locale: text});
-    the frontend picks the active locale via documentElement.lang."""
-    js = _read("dashboard.js")
+    the frontend picks the active locale via documentElement.lang.
+
+    This is the one thing in reports_format.js that reads the document — a
+    single attribute, at call time — so it is pinned here as well as executed
+    under a stubbed ``document`` by the JS suite."""
+    js = _read("reports_format.js")
     assert "function pickLocalizedLabel(" in js
     assert "documentElement.lang" in js
 
@@ -104,19 +135,19 @@ def test_severity_maps_to_chip_class_including_info() -> None:
     """The four canonical severities map to chip classes, including the new
     neutral ``is-info`` bucket so info / positive flags are not styled as
     alarms."""
-    js = _read("dashboard.js")
+    js = _read("reports_format.js")
     assert "function reportFlagKind(" in js
     assert "flag.severity" in js
     assert '"is-info"' in js
     # The severity → chip mapping must cover all four buckets.
     for sev in ("action", "watch", "info", "positive"):
-        assert sev in js, f"severity {sev} not referenced in dashboard.js"
+        assert sev in js, f"severity {sev} not referenced in reports_format.js"
 
 
 def test_new_canonical_bases_registered() -> None:
     """The bare-string base map is aligned with the canonical vocabulary so a
     flag emitted as a plain code string still maps to its localized label."""
-    js = _read("dashboard.js")
+    js = _read("reports_format.js")
     for code in (
         "invalid_traffic_suspected",
         "budget_drift",
@@ -124,27 +155,32 @@ def test_new_canonical_bases_registered() -> None:
         "goals_met",
         "anomaly_baseline_insufficient",
     ):
-        assert code in js, f"canonical base {code} not in dashboard.js"
+        assert code in js, f"canonical base {code} not in reports_format.js"
 
 
 def test_flag_detail_drilldown_present() -> None:
     """Detail (adspot ids / yen / ctr) is rendered on a drill-down, never on
     the chip face: an interactive chip toggles a detail element built from
-    ``params``, wired as an ARIA disclosure (aria-expanded + aria-controls)."""
-    js = _read("dashboard.js")
-    assert "function buildFlagDetail(" in js
-    assert "function buildFlagChipElement(" in js
-    assert '"dashboard.reports_param_" + ' in js
-    assert "is-interactive" in js
-    assert "report-flag-detail" in js
-    assert 'setAttribute("aria-expanded"' in js
-    assert 'setAttribute("aria-controls"' in js
+    ``params``, wired as an ARIA disclosure (aria-expanded + aria-controls).
+
+    The detail STRING is built in reports_format.js and executed by the JS
+    suite; the disclosure ELEMENT is rendering and stays pinned here."""
+    detail = _read("reports_format.js")
+    assert "function buildFlagDetail(" in detail
+    assert '"dashboard.reports_param_" + ' in detail
+    chip = _read("dashboard.js")
+    assert "function buildFlagChipElement(" in chip
+    assert "buildFlagDetail(flag)" in chip
+    assert "is-interactive" in chip
+    assert "report-flag-detail" in chip
+    assert 'setAttribute("aria-expanded"' in chip
+    assert 'setAttribute("aria-controls"' in chip
 
 
 def test_boolean_params_are_localized() -> None:
     """A boolean param (e.g. budget_drift's ``unlogged``) renders a localized
     yes/no, not raw English ``true`` / ``false`` in the Japanese UI."""
-    js = _read("dashboard.js")
+    js = _read("reports_format.js")
     assert 'typeof value === "boolean"' in js
     data = json.loads(_read("i18n.json"))
     for key in ("dashboard.reports_param_yes", "dashboard.reports_param_no"):
@@ -155,12 +191,51 @@ def test_boolean_params_are_localized() -> None:
 def test_severity_order_includes_info() -> None:
     """The client-card sort order ranks the new ``is-info`` bucket (below the
     coloured severities) so info flags do not jump above alarms."""
-    js = _read("dashboard.js")
+    js = _read("reports_format.js")
     assert "REPORTS_FLAG_SEVERITY_ORDER" in js
     order_line = next(
         line for line in js.splitlines() if "REPORTS_FLAG_SEVERITY_ORDER =" in line
     )
     assert "is-info" in order_line
+
+
+def test_the_flag_vocabulary_is_not_re_implemented_in_the_renderer() -> None:
+    """One definition, executed by ``node --test tests/js/``. A copy left in
+    dashboard.js would shadow the tested one and drift from it silently —
+    the exact failure the split exists to end."""
+    dashboard = _read("dashboard.js")
+    fmt = _read("reports_format.js")
+    for fn in (
+        "humanizeReportFlag",
+        "humanizeFlagWords",
+        "matchReportFlagBase",
+        "pickLocalizedLabel",
+        "reportFlagKind",
+        "flagChipKind",
+        "flagSeverityRank",
+        "clientReportFlags",
+        "buildFlagDetail",
+        "flagParamLabel",
+        "formatFlagParam",
+        "formatNumber",
+        "formatKpi",
+        "reportsPeriodLabel",
+    ):
+        assert f"function {fn}(" in fmt, f"{fn} is not in reports_format.js"
+        assert f"function {fn}(" not in dashboard, f"{fn} is duplicated"
+    # It publishes itself the way amazon_oauth.js does — a global on `window`,
+    # not a module system the served page would have to grow.
+    assert "window.MUREO_REPORTS_FORMAT = api" in fmt
+    assert "MUREO_REPORTS_FORMAT" in dashboard
+
+
+def test_untrusted_flag_text_still_reaches_the_dom_via_text_content() -> None:
+    """Flag labels and params are agent-authored. Neither file ever ASSIGNS
+    innerHTML (#533)."""
+    for name in _FLAG_ASSETS:
+        js = _read(name)
+        assert ".innerHTML =" not in js, name
+        assert ".innerHTML=" not in js, name
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_web_assets_reports_conflicts.py
+++ b/tests/test_web_assets_reports_conflicts.py
@@ -210,18 +210,27 @@ def test_conflict_and_freshness_text_is_rendered_via_text_content() -> None:
 @pytest.mark.unit
 def test_the_pure_logic_is_served_and_loaded_before_its_consumer() -> None:
     """#540 split the money-safety logic into its own asset so a test runner
-    can execute it. That only holds if the browser still gets it: it has to
-    be on the static allow-list and its ``<script>`` has to come BEFORE
-    dashboard.js, which binds it at load. Miss either and the dashboard is
-    a blank page — so this pins the shipping half of the split."""
+    can execute it, and #556 split two more the same way. That only holds if
+    the browser still gets them: each has to be on the static allow-list and
+    its ``<script>`` has to come BEFORE dashboard.js, which binds all three at
+    load. Miss either and the dashboard is a blank page — so this pins the
+    shipping half of the splits.
+
+    The module list is DISCOVERED, not declared: every ``reports_*.js`` in
+    ``mureo/_data/web/`` must satisfy this. A module extracted but never
+    served is the failure being guarded, and a hand-maintained list is
+    exactly what a person forgets to add the new name to."""
     from mureo.web.handlers import _STATIC_ALLOWLIST
 
-    assert "reports_logic.js" in _STATIC_ALLOWLIST
+    modules = sorted(p.name for p in _WEB.glob("reports_*.js"))
+    assert modules, "no reports_*.js modules found — did the layout change?"
     html = _read("app.html")
-    position = html.index("/static/reports_logic.js")
-    assert position < html.index("/static/dashboard.js")
-    # It stays a plain <script>: no type="module", no bundler entry point.
-    assert 'src="/static/reports_logic.js"></script>' in html
+    for name in modules:
+        assert name in _STATIC_ALLOWLIST, f"{name} is not served"
+        assert html.index(f"/static/{name}") < html.index("/static/dashboard.js")
+        # It stays a plain <script>: no type="module", no bundler entry point.
+        assert f'src="/static/{name}"></script>' in html
+    assert 'type="module"' not in html
 
 
 @pytest.mark.unit

--- a/tests/test_web_assets_reports_order_and_archive.py
+++ b/tests/test_web_assets_reports_order_and_archive.py
@@ -1,29 +1,32 @@
 """Static-content guards for the Reports index reorder + archive controls.
 
-There is still no JS build step, and the runner added in #540
-(``node --test tests/js/``) covers only the DOM-free Reports logic that was
-extracted into ``reports_logic.js``. The ordering and archive helpers below
-touch ``localStorage`` and the grid DOM and were NOT extracted, so — like
-``test_web_assets_reports_conflicts.py`` — these read the bundled assets in
-``mureo/_data/web/`` and pin the *shape* of what ships: that the
-identifiers, i18n keys, DOM hooks and CSS rules the feature depends on are
-present, in both locales, and that nothing here reintroduces ``innerHTML``.
+There is still no JS build step. Since #556 the ORDERING half of this feature
+is no longer guarded from here at all: ``readReportsOrder``,
+``writeReportsOrder``, ``orderReportsClients``, ``persistReportsOrderFromDom``
+and ``moveReportsCard`` moved verbatim into ``mureo/_data/web/reports_order.js``
+and are *executed* by ``tests/js/reports_order.test.js``. The module never goes
+looking for a node — every node is handed in by the caller — so a fake grid
+drives the real code, and the two claims this file used to admit it could not
+make ("a drag actually reorders the grid", "a corrupt stored order really
+degrades to the server order") are now assertions there.
 
-Two of them go past presence and read *structure*: the routing condition
-must mention the archived clients, and the archive click handler's source
-must confirm-then-return-then-POST in that order. Both would otherwise pass
-against an implementation that had regressed to the obvious wrong thing.
+What stays here is what still has no runner:
 
-**What they do NOT cover.** They execute no JavaScript. They cannot prove
-that a drag actually reorders the grid, that a corrupt stored order really
-degrades to the server order, that `await` genuinely suspends before the
-POST, or that the routing branch is reached with the state it is written
-for. Reading source order is not the same as observing behaviour: a
-handler could satisfy the ordering pin and still, say, ignore the confirm's
-resolved value. Those behaviours are argued in the code comments and were
-verified by hand (plus, for the ordering rules, by running the extracted
-helpers under node); treat these as anti-regression pins on the contract's
-surface, not as behavioural tests.
+  - the DOM wiring the module is bound to — the drag handle button, the
+    dragstart/dragover/drop listeners, the keyboard equivalent;
+  - the archive controls, which are server state rather than a browser-local
+    view preference, and whose click handler is pinned on *structure*
+    (confirm → bail-on-no → POST, in that order) rather than presence;
+  - the routing condition, which must count archived clients;
+  - i18n keys in both locales, CSS rules, and that nothing reintroduces
+    ``innerHTML``.
+
+**What they do NOT cover.** They execute no JavaScript. They cannot prove that
+`await` genuinely suspends before the POST, or that the routing branch is
+reached with the state it is written for. Reading source order is not the same
+as observing behaviour: a handler could satisfy the ordering pin and still,
+say, ignore the confirm's resolved value. Treat these as anti-regression pins
+on the contract's surface, not as behavioural tests.
 """
 
 from __future__ import annotations
@@ -54,6 +57,11 @@ def _function_body(js: str, signature: str) -> str:
 
 # ---------------------------------------------------------------------------
 # Ordering — per-operator, browser-local, degrades to the server order
+#
+# The RULES moved to reports_order.js in #556 and are executed by
+# tests/js/reports_order.test.js. What is left to pin from here is the
+# shipping seam: the module is served, it loads before dashboard.js, and no
+# copy of it stayed behind to shadow the tested one.
 # ---------------------------------------------------------------------------
 
 
@@ -62,35 +70,48 @@ def test_card_order_is_stored_per_operator_in_the_browser() -> None:
     """The order is purely visual: losing it breaks nothing and two operators
     reasonably want different ones, so it is localStorage — never server
     state that one operator's arrangement would impose on everyone."""
-    js = _read("dashboard.js")
+    js = _read("reports_order.js")
     assert "mureo.reports.client_order" in js
     assert "localStorage" in js
     assert "function readReportsOrder(" in js
     assert "function writeReportsOrder(" in js
+    # Browser-local means browser-local: no endpoint records the arrangement.
+    assert "/api/reports/clients/order" not in _read("dashboard.js")
 
 
 @pytest.mark.unit
-def test_a_stored_order_is_reconciled_rather_than_trusted() -> None:
-    """A stored order naming clients that no longer exist, missing clients
-    that now do, or corrupt JSON must all render a sane grid — the ordering
-    helper filters and merges instead of indexing blindly."""
-    js = _read("dashboard.js")
-    assert "function orderReportsClients(" in js
-    # Corrupt JSON / storage-disabled path: readReportsOrder swallows and
-    # returns [] so the grid falls back to the server's order.
-    body = js.split("function readReportsOrder(", 1)[1].split("\n  }", 1)[0]
-    assert "JSON.parse" in body
-    assert "catch" in body
-    assert "Array.isArray" in body
+def test_the_ordering_rules_are_not_re_implemented_in_the_renderer() -> None:
+    """One definition, executed by ``node --test tests/js/``. A copy left in
+    dashboard.js would shadow the tested one and drift from it silently."""
+    dashboard = _read("dashboard.js")
+    order = _read("reports_order.js")
+    for fn in (
+        "readReportsOrder",
+        "writeReportsOrder",
+        "orderReportsClients",
+        "persistReportsOrderFromDom",
+        "moveReportsCard",
+    ):
+        assert f"function {fn}(" in order, f"{fn} is not in reports_order.js"
+        assert f"function {fn}(" not in dashboard, f"{fn} is duplicated"
+    assert "window.MUREO_REPORTS_ORDER = api" in order
+    assert "MUREO_REPORTS_ORDER" in dashboard
 
 
 @pytest.mark.unit
-def test_reordering_persists_from_the_dom_not_from_a_shadow_list() -> None:
-    """One source of truth for the new order — the grid itself — so the
-    keyboard path and the drop handler can never disagree."""
+def test_the_renderer_still_asks_the_module_to_order_and_to_persist() -> None:
+    """The seam the JS suite cannot see: the module can be perfectly correct
+    and unreached. The grid must be ordered through it, and both mutation
+    paths — the drop handler and the keyboard handler — must end in it."""
     js = _read("dashboard.js")
-    assert "function persistReportsOrderFromDom(" in js
-    assert "function moveReportsCard(" in js
+    index = _function_body(js, "async function renderReportsIndex(")
+    assert "orderReportsClients(" in index
+
+    drop = _function_body(js, "function wireReportsCardDrag(")
+    assert "persistReportsOrderFromDom(wrap)" in drop
+
+    handle = _function_body(js, "function buildReportsDragHandle(")
+    assert "moveReportsCard(item, delta)" in handle
 
 
 @pytest.mark.unit
@@ -258,10 +279,11 @@ def test_order_and_archive_strings_are_localized_in_both_locales() -> None:
 def test_client_names_still_reach_the_dom_via_text_content() -> None:
     """Client names come from the Agency registry, which mureo does not
     control. The archived list renders them like every other untrusted
-    string — nothing in the file ever ASSIGNS innerHTML (#533)."""
-    js = _read("dashboard.js")
-    assert ".innerHTML =" not in js
-    assert ".innerHTML=" not in js
+    string — neither file ever ASSIGNS innerHTML (#533)."""
+    for name in ("dashboard.js", "reports_order.js"):
+        js = _read(name)
+        assert ".innerHTML =" not in js, name
+        assert ".innerHTML=" not in js, name
 
 
 @pytest.mark.unit

--- a/tests/test_web_assets_reports_period_toggle.py
+++ b/tests/test_web_assets_reports_period_toggle.py
@@ -7,10 +7,12 @@ read directly from ``mureo/_data/web/``) so a future refactor that drops
 the toggle wiring, the ``?period=`` request, or the default-window choice
 flips red here before an operator notices the regression.
 
-The toggle itself is rendering and has no runner. The KPI aggregation it
-re-requests moved to ``reports_logic.js`` in #540 and IS executed there, by
-``node --test tests/js/`` — so the pin below reads the aggregate helper from
-that file and only checks that ``dashboard.js`` still calls it.
+The toggle itself is rendering and has no runner. Two things it leans on do:
+the KPI aggregation it re-requests moved to ``reports_logic.js`` in #540, and
+the window/flag labelling moved to ``reports_format.js`` in #556. Both are
+executed by ``node --test tests/js/``, so the pins below read each helper from
+its own file and only check that ``dashboard.js`` still calls it — which is
+the half no runner can see.
 """
 
 from __future__ import annotations
@@ -74,9 +76,11 @@ def test_toggle_hidden_without_a_real_choice() -> None:
 @pytest.mark.unit
 def test_period_label_keys_referenced() -> None:
     """Window buttons are localized via the canonical period label keys."""
-    js = _read("dashboard.js")
+    js = _read("reports_format.js")
     assert "dashboard.reports_period_yesterday" in js
     assert "dashboard.reports_period_last_30_days" in js
+    # …and the button still gets its text from the labeller (#556).
+    assert "reportsPeriodLabel(token)" in _read("dashboard.js")
 
 
 @pytest.mark.unit
@@ -104,12 +108,17 @@ def test_report_flags_are_humanized_not_raw() -> None:
     """Free-form snake_case report flags (reports.daily.flags) must be mapped
     to friendly labels, not rendered raw. The dashboard humanizes them via a
     base→i18n-label map with a generic fallback, so a raw tag like
-    `cpa_over_target_logly` never reaches the operator."""
-    js = _read("dashboard.js")
+    `cpa_over_target_logly` never reaches the operator.
+
+    That the LONGEST base wins and that an unknown code degrades to a
+    humanized token rather than a raw i18n key is *executed* by
+    ``tests/js/reports_format.test.js``; this only pins that the helper
+    exists and that the chip text still goes through it."""
+    js = _read("reports_format.js")
     assert "function humanizeReportFlag(" in js
     assert "REPORTS_FLAG_BASES" in js
     # The chip text must go through the humanizer for bare-string flags.
-    assert "humanizeReportFlag(flag)" in js
+    assert "humanizeReportFlag(flag)" in _read("dashboard.js")
 
 
 @pytest.mark.unit
@@ -132,12 +141,16 @@ def test_report_flags_get_severity_colored_chips() -> None:
     """Flags render as coloured tags: each known base carries a severity
     (is-warn / is-danger / is-success) and the chip class comes from
     reportFlagKind(), not raw keyword inference alone — so issue flags are
-    not all neutral grey."""
-    js = _read("dashboard.js")
+    not all neutral grey.
+
+    Which severity each base carries is *executed* by
+    ``tests/js/reports_format.test.js``; this pins that the renderer asks
+    for a kind at all."""
+    js = _read("reports_format.js")
     assert "function reportFlagKind(" in js
-    assert "reportFlagKind(flag)" in js
     assert '"is-warn"' in js
     assert '"is-danger"' in js
+    assert "reportFlagKind(flag)" in _read("dashboard.js")
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Reduces #556. The file is still over budget after this change — see **Still over budget** below for what remains and why #556 is being closed anyway.

`dashboard.js` was 3,877 lines against the 800-line budget. #540 proved a browser asset can be split safely — one global per plain `<script>`-loaded module, verified as a pure move, with a contract test that evaluates the **shipped bytes** with no `module`/`exports`/`require` in scope and asserts the Node-visible and browser-visible surfaces carry identical keys. That answers the usual objection to splitting a served asset: you cannot otherwise tell whether the tests exercise what the page loads.

## What moved, and the rule that decided it

| module | contents |
|---|---|
| `reports_format.js` (328) | the Reports display vocabulary and its formatters |
| `reports_order.js` (148) | the `localStorage` ordering helpers |

The ordering helpers could move because they **never touch `document`, never create an element and never register a listener — every node arrives as a parameter**. The archive half could not, and the reason is the useful one: moving it would change signatures, which is the signal that a seam is wrong rather than an obstacle to work around.

The same rule ran in both directions: `REPORTS_PERIOD_LABELS` moved because its function did; `REPORTS_KPI_LABELS` stayed because its key order **is** the on-card display order and its only reader is a renderer — moving the data without the loop would split a hidden contract across files.

Rejected with reasons rather than forced: the Creative Studio gallery and the credential-card wiring (DOM-building end to end), and the render functions themselves (they *are* the rendering; extracting them needs a DOM runner, which #540 deliberately did not buy).

## Pure move, with one declared exception

Every body line is byte-identical to base — 264/264 and 86/86, in 4 and 1 contiguous runs. The single exception is a comment pointer requalified to name the module it now points across to, and **the verifier checks that exception rather than waiving it**: the base text must still exist in base, the replacement must exist in the shipped module, and the edit is undone before comparison so every other line still has to be verbatim. A negative-check script proves that gate is not vacuous.

## The pins were weaker than they read

The longest-base rule had **no test that could distinguish it from first-registered-wins**. Every pair the existing tests used already listed the longer entry first, and one pair did not even compete. The shipped table has exactly one pair where order and length disagree — `search_console_no` before `search_console_no_property` — and mutating `base.length > best[0].length` to `!best` left **all forty tests green** while `search_console_no_property` silently resolved to the wrong severity colour and the wrong label.

Rather than reorder the table — right by an arrangement nothing enforces, and one an obvious future insertion would quietly break — **the rule now checks itself against the shipped data**: a test derives every boundary-prefix pair from the table and asserts the longer wins. It covers today's pair and any future one, wherever it is inserted.

An 11-mutant sweep aimed at *shipped data* rather than merely *some input* killed all 11, and turned up an arm nothing reaches: no shipped base contains a `danger`/`warn`/`ok` keyword, so deleting the severity fallback was invisible. An agent-authored flag saying "critical" would have started rendering uncoloured. Two mutants are recorded as unkillable because no input distinguishes them, with the argument for each.

## Hardening

`MODULES` is now cross-checked against the files that actually ship, at both ends — the JS contract globs `reports_*.js` and asserts the table matches exactly, and the Python pins derive from the same glob, so a new module must also be allowlisted and ordered ahead of `dashboard.js`. A module added without a row now fails loudly instead of quietly receiving none of the four checks.

The load guard names **every** missing module at once; a deployment that dropped the whole `<script>` block was otherwise diagnosed one reload at a time.

## Still open

`dashboard.js` is **3,563** lines — still well over the 800-line budget. The remaining seams need either a DOM runner or renderers bent to fit, and recording that conclusion is worth more than three forced extractions.

#556 is closed with this PR as a deliberate call, not because the budget is met. The tractable seams — the ones that move without changing a signature — are now taken; what is left is a different piece of work (buy a DOM runner, or accept the renderers where they are), and it should be raised on its own terms rather than kept alive under a line-count target.

140 JS tests (was 133), full Python suite 7,491 passed, no new failures.

