### PR TITLE
test: freeze the clock in the tests that compare two clock reads (#562)

### DIFF
--- a/tests/test_byod_date_rebase.py
+++ b/tests/test_byod_date_rebase.py
@@ -31,19 +31,42 @@ def _write(path: Path, text: str) -> None:
 # ---------------------------------------------------------------------------
 
 
+_PINNED_TODAY = date(2026, 6, 15)
+
+
+@pytest.fixture
+def pinned_today(monkeypatch: pytest.MonkeyPatch) -> date:
+    """Pin the ``date.today()`` that ``_period_to_range`` reads.
+
+    The legacy branch reads the wall clock itself, so a test that also
+    reads it compares two independent clock reads and breaks on a run
+    that straddles midnight (#562). Pin the module's ``date`` instead —
+    the assertion then measures the window arithmetic, not the clock."""
+    from mureo.byod import clients
+
+    class _PinnedDate(date):
+        @classmethod
+        def today(cls) -> date:
+            return _PINNED_TODAY
+
+    monkeypatch.setattr(clients, "date", _PinnedDate)
+    return _PINNED_TODAY
+
+
 @pytest.mark.unit
 class TestPeriodToRangeAnchor:
-    def test_anchor_none_preserves_legacy_today_behaviour(self) -> None:
+    def test_anchor_none_preserves_legacy_today_behaviour(
+        self, pinned_today: date
+    ) -> None:
         from mureo.byod.clients import _period_to_range
 
-        today = date.today()
         assert _period_to_range("LAST_7_DAYS") == (
-            today - timedelta(days=7),
-            today - timedelta(days=1),
+            pinned_today - timedelta(days=7),
+            pinned_today - timedelta(days=1),
         )
         assert _period_to_range("LAST_30_DAYS", anchor=None) == (
-            today - timedelta(days=30),
-            today - timedelta(days=1),
+            pinned_today - timedelta(days=30),
+            pinned_today - timedelta(days=1),
         )
 
     def test_anchor_rebases_window_end_to_anchor(self) -> None:

--- a/tests/test_mcp_tools_mureo_context.py
+++ b/tests/test_mcp_tools_mureo_context.py
@@ -1399,9 +1399,15 @@ def _write_mixed_state(root) -> None:
     (root / "STATE.json").write_text(json.dumps(state), encoding="utf-8")
 
 
-async def test_state_get_action_log_default_is_all_and_byte_identical(cwd_to_tmp):
+async def test_state_get_action_log_default_is_all_and_byte_identical(
+    cwd_to_tmp, frozen_clock
+):
     """Omitting ``action_log`` (and passing ``"all"``) is the historical
-    behaviour verbatim: the full log, no scope markers, byte-for-byte equal."""
+    behaviour verbatim: the full log, no scope markers, byte-for-byte equal.
+
+    The clock is frozen (#460 seam) because the two responses each carry
+    their own ``server_now`` stamp: unfrozen, "byte-for-byte" would only
+    hold while both calls land in the same wall-clock second (#562)."""
     _write_mixed_state(cwd_to_tmp)
     mod = _import_tools()
     default = (await mod.handle_tool("mureo_state_get", {}))[0].text
@@ -1447,9 +1453,15 @@ async def test_state_get_action_log_none_omits(cwd_to_tmp):
 
 
 @pytest.mark.parametrize("scope", ["pending", "none"])
-async def test_state_get_rest_of_response_unchanged_when_filtered(cwd_to_tmp, scope):
+async def test_state_get_rest_of_response_unchanged_when_filtered(
+    cwd_to_tmp, frozen_clock, scope
+):
     """Filtering the log must not touch anything else: platforms (incl.
-    campaigns), reports, last_synced_at and server_now are identical."""
+    campaigns), reports, last_synced_at and server_now are identical.
+
+    ``server_now`` is stamped per response, so the clock is frozen (#460
+    seam) — otherwise this compares two wall-clock reads, not the filter's
+    effect (#562)."""
     _write_mixed_state(cwd_to_tmp)
     mod = _import_tools()
     full = json.loads((await mod.handle_tool("mureo_state_get", {}))[0].text)


### PR DESCRIPTION
Fixes #562.

## Problem

`test_state_get_action_log_default_is_all_and_byte_identical` calls `mureo_state_get` twice and compares the two response bodies byte-for-byte. Every read response carries `server_now`, stamped from the wall clock at handler time (#460) — so the test compared two independent clock reads and passed only while both calls landed inside the same second. It failed on the `py3.10` job for PR #561 (a `dashboard.js`-only branch) and passed on a re-run.

## Fix

Freeze the clock through the seam #460 already provides — the `frozen_clock` fixture in the same file, which patches `mureo.core.clock.server_now`. The tests written for #460 use it; the `action_log`-scope tests added later did not.

Deliberately **not** done: adding a tolerance, or excluding `server_now` from the comparison. The point of this test is that the two payloads are byte-identical, so weakening the comparison deletes the property it exists to protect.

## Also fixed (same defect class)

Swept the suite for tests that produce an expected value from a live clock and assert exact equality. Two further sites, both fixed here:

- `test_state_get_rest_of_response_unchanged_when_filtered[pending|none]` — same file, `assert filtered["server_now"] == full["server_now"]` across two calls. Same mechanism, same one-second window.
- `tests/test_byod_date_rebase.py::TestPeriodToRangeAnchor::test_anchor_none_preserves_legacy_today_behaviour` — the test reads `date.today()` and `_period_to_range(anchor=None)` reads it again inside `mureo.byod.clients`. Day granularity, so it only breaks on a run that straddles midnight, but it is the same defect. Pinned the module's `date` so both reads see the same day; the assertion now measures the window arithmetic rather than the clock.

Threshold-style tests that feed a now-relative timestamp in and assert on a classification (`test_meta_token_refresh.py`, `test_amazon_manifest_staleness.py`, `test_web_status_collector.py`, `test_web_reports_conflicts.py`, `creative_studio/test_fonts.py`) were checked and left alone: day-scale margins, drifting in the safe direction.

## Verification

Reproduced deterministically rather than waiting for a boundary, with a throwaway pytest plugin (not committed) whose autouse fixtures advance `mureo.core.clock.server_now` by one second per call and make `mureo.byod.clients` see tomorrow's date:

```
FAILED tests/test_mcp_tools_mureo_context.py::test_state_get_action_log_default_is_all_and_byte_identical
E   assert '{"version": ...12:13+00:00"}' == '{"version": ...12:14+00:00"}'
FAILED tests/test_mcp_tools_mureo_context.py::test_state_get_rest_of_response_unchanged_when_filtered[pending]
FAILED tests/test_mcp_tools_mureo_context.py::test_state_get_rest_of_response_unchanged_when_filtered[none]
E   AssertionError: assert '2026-08-07T07:12:13+00:00' == '2026-08-07T07:12:12+00:00'
FAILED tests/test_byod_date_rebase.py::TestPeriodToRangeAnchor::test_anchor_none_preserves_legacy_today_behaviour
E   At index 0 diff: datetime.date(2026, 8, 1) != datetime.date(2026, 7, 31)
4 failed
```

All 4 pass under the same harness after the change — the fix removes the dependency rather than making it less likely.
