### PR TITLE
fix: return the selected account_id from the Meta setup wizard

### DIFF
--- a/mureo/auth_setup.py
+++ b/mureo/auth_setup.py
@@ -1415,11 +1415,16 @@ async def setup_meta_ads(
 
     account_id: str = selected["id"]
 
-    # Save to credentials.json (using shared save_credentials function)
+    # Save to credentials.json (using shared save_credentials function).
+    # ``account_id`` is carried on the returned object as well as persisted:
+    # a caller that trusts the return value must see the same ad account that
+    # was written to disk, exactly as setup_google_ads returns its selected
+    # customer_id.
     meta_creds = MetaAdsCredentials(
         access_token=oauth_result.access_token,
         app_id=app_id,
         app_secret=app_secret,
+        account_id=account_id,
     )
 
     save_credentials(

--- a/tests/test_auth_setup.py
+++ b/tests/test_auth_setup.py
@@ -1812,6 +1812,7 @@ async def test_setup_meta_ads_flow(tmp_path: Path) -> None:
     data = json.loads(cred_path.read_text(encoding="utf-8"))
     assert data["meta_ads"]["access_token"] == "long-lived-token"
     assert data["meta_ads"]["account_id"] == "act_222"
+    assert result.account_id == data["meta_ads"]["account_id"]
 
 
 @pytest.mark.unit
@@ -1850,13 +1851,12 @@ async def test_setup_meta_ads_single_account(tmp_path: Path) -> None:
 
     data = json.loads(cred_path.read_text(encoding="utf-8"))
     assert data["meta_ads"]["account_id"] == "act_111"
-    # The returned credentials carry the OAuth result, not a re-read of the
-    # file. NB: ``account_id`` is deliberately NOT asserted here — the wizard
-    # persists it via ``save_credentials`` but leaves it unset on the returned
-    # object, and no caller reads the return value today. Pinning either value
-    # would bless a shape this PR did not decide on.
+    # The returned credentials must describe the same account that was
+    # persisted: a caller that trusts the return value would otherwise target
+    # a different (or no) ad account than the one on disk.
     assert result.access_token == "long-lived-token"
     assert result.app_id == "test-app-id"
+    assert result.account_id == data["meta_ads"]["account_id"]
 
 
 @pytest.mark.unit
@@ -1930,9 +1930,8 @@ async def test_setup_meta_ads_cancel_selection(tmp_path: Path) -> None:
     data = json.loads(cred_path.read_text(encoding="utf-8"))
     # On cancel, the first account is the default.
     assert data["meta_ads"]["account_id"] == "act_111"
-    # See test_setup_meta_ads_single_account for why account_id is not
-    # asserted on the returned object.
     assert result.access_token == "long-lived-token"
+    assert result.account_id == data["meta_ads"]["account_id"]
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Problem

`setup_meta_ads` selects an ad account, saves it through `save_credentials(..., account_id=account_id)`, and then returns a `MetaAdsCredentials` built without `account_id`. Since the field defaults to `None`, the returned object always disagreed with the file that was just written — and only the file was right.

This is an omission, not a design choice: the sibling wizard `setup_google_ads` in the same module puts the selected `customer_id` / `login_customer_id` on the `GoogleAdsCredentials` it returns. Meta was the only one dropping it.

No user is broken today — all five call sites (`cli/setup_cmd.py` x4, `cli/auth_cmd.py` x1) run `asyncio.run(setup_meta_ads())` and discard the result. The first caller to actually read the return value would have silently operated against no account.

## Change

- `mureo/auth_setup.py`: pass `account_id=account_id` when constructing the returned `MetaAdsCredentials`. All three selection paths (single-account auto-select, picker, cancel-to-default) already funnel through the same `account_id` variable, so one line covers them.
- `tests/test_auth_setup.py`: the three Meta wizard tests already read `account_id` out of the written file; they now also assert the returned object carries the same value, so the two cannot drift apart again. The note left by #564 explaining why `account_id` was *not* asserted is removed — it described the bug, and the bug is gone.

Written test-first: the new assertions fail on the parent commit with `AssertionError: assert None == 'act_111'`.

## Scope check

Looked for the same save-but-do-not-return shape elsewhere and found none:

- `auth_setup.py` has exactly two credential-returning wizards, `setup_google_ads` and `setup_meta_ads`. Google was already correct.
- Amazon has no interactive wizard of this shape — `amazon_ads` credentials are loaded from the secret store or env vars (`_amazon_ads_from_mapping`, which already carries `profile_id` / `account_id` / `manager_account_id`), and `cli/amazon_cmd.py` only mints and saves tokens.
- The browser wizard's Meta picker (`cli/web_auth.py`) already sets `account_id=chosen_id` on the credentials object; it is an HTTP handler and returns nothing, so there is no return value to diverge.
- `web/handlers.py` builds a `MetaAdsCredentials` purely as an argument to `save_credentials` and never returns it.

## Base branch

Based on `chore/lint-gate-tests-scripts` (#564), which is concurrently editing `tests/test_auth_setup.py` — including the comment removed here. Merge #564 first.

## Verification

- `ruff check .` — pass
- `black --check .` — pass
- `mypy mureo` — unchanged (14 pre-existing missing-stub errors, identical count on the parent commit)
- `python -m pytest` — 7736 passed. The 12 failures are pre-existing local-environment noise (`test_live_clients.py` x9 plus 3 tool-registry tests affected by a locally installed plugin), identical before and after this change.
