### PR TITLE
fix: stop the Bash credential guard firing on mureo's own identifiers

### DIFF
--- a/mureo/credential_guard.py
+++ b/mureo/credential_guard.py
@@ -23,10 +23,32 @@ Two guards are installed:
   ``~/.mureo/credentials.json`` that is itself a symlink pointing OUT — its
   realpath escapes the dir, but the requested path is still under it). Both
   cover every file in the directory, not just ``credentials.json``.
-* Bash guard: denies any command whose text references ``.mureo``.  A
-  substring check is all a command string allows, but anchoring on the
-  directory name (not ``credentials``) also catches wildcard forms like
-  ``cat ~/.mureo/cred*``.
+* Bash guard: denies any command whose text references ``.mureo`` as a
+  complete path component — the substring must not be followed by an
+  identifier character (``[A-Za-z0-9_]``).  A substring check is all a
+  command string allows, but anchoring on the directory name (not
+  ``credentials``) also catches wildcard forms like ``cat ~/.mureo/cred*``.
+
+  The boundary costs nothing against *plain path syntax*, which is what a
+  text guard can see: naming ``~/.mureo`` requires the component to end
+  there, and every way a shell continues a word after it — ``/``, quote,
+  ``$``, backtick, ``{``, ``*``, backslash, whitespace, end of string — is
+  a non-identifier character.  A letter, digit or underscore instead spells
+  a *different* component (``~/.mureoX``), which the path guard likewise
+  treats as outside the protected tree.  What it buys is that mureo's own
+  public browser namespace — ``window.MUREO_REPORTS_FORMAT`` and friends,
+  case-folded to ``.mureo_...`` — stops tripping the guard in commit
+  messages, release notes and greps.
+
+  Two properties of the boundary are deliberate.  It is one-sided: the
+  character *before* the match is not examined, because an unquoted
+  variable holding the parent (``D=~/; cat $D.mureo/...``) puts an
+  identifier character there while still resolving into ``~/.mureo``.  And
+  it no longer blocks a *symlink* whose own name starts with ``.mureo``
+  (``~/.mureoLINK -> ~/.mureo``); that was never a property to rely on,
+  since a symlink under any other name (``~/link``) evaded the old check
+  too — the path guard's realpath resolution is what actually covers
+  symlinks.
 
 Both comparisons are case-folded: macOS and Windows filesystems are
 case-insensitive by default, so ``~/.MUREO/credentials.json`` opens the
@@ -95,11 +117,11 @@ _PATH_GUARD_CODE = (
 )
 
 _BASH_GUARD_CODE = (
-    "import sys,json; "
+    "import sys,json,re; "
     "d=json.loads(sys.stdin.read() or '{}'); "
     "c=str((d.get('tool_input') or {}).get('command') or ''); "
     + _deny_expr("mureo credential guard: commands referencing .mureo are blocked")
-    + " if '.mureo' in c.lower() else None"
+    + " if re.search('[.]mureo[^A-Za-z0-9_]', c.lower()+' ') else None"
 )
 
 

--- a/mureo/credential_guard.py
+++ b/mureo/credential_guard.py
@@ -23,32 +23,44 @@ Two guards are installed:
   ``~/.mureo/credentials.json`` that is itself a symlink pointing OUT — its
   realpath escapes the dir, but the requested path is still under it). Both
   cover every file in the directory, not just ``credentials.json``.
-* Bash guard: denies any command whose text references ``.mureo`` as a
-  complete path component — the substring must not be followed by an
-  identifier character (``[A-Za-z0-9_]``).  A substring check is all a
-  command string allows, but anchoring on the directory name (not
-  ``credentials``) also catches wildcard forms like ``cat ~/.mureo/cred*``.
+* Bash guard: denies any command whose text references ``.mureo`` where a
+  path component could *start*.  A substring check is all a command string
+  allows, but anchoring on the directory name (not ``credentials``) also
+  catches wildcard forms like ``cat ~/.mureo/cred*``.
 
-  The boundary costs nothing against *plain path syntax*, which is what a
-  text guard can see: naming ``~/.mureo`` requires the component to end
-  there, and every way a shell continues a word after it — ``/``, quote,
-  ``$``, backtick, ``{``, ``*``, backslash, whitespace, end of string — is
-  a non-identifier character.  A letter, digit or underscore instead spells
-  a *different* component (``~/.mureoX``), which the path guard likewise
-  treats as outside the protected tree.  What it buys is that mureo's own
-  public browser namespace — ``window.MUREO_REPORTS_FORMAT`` and friends,
-  case-folded to ``.mureo_...`` — stops tripping the guard in commit
-  messages, release notes and greps.
+  A bare substring test over-blocks badly, because case-folded ``.mureo``
+  is also a prefix of things that are emphatically not the directory:
+  mureo's own browser globals (``window.MUREO_REPORTS_FORMAT``) and every
+  hostname under the project's domain (``pkgs.mureo.jp``,
+  ``docs.mureo.jp``).  Naming either one in a commit message, a release
+  note or a PR body was denied outright.
 
-  Two properties of the boundary are deliberate.  It is one-sided: the
-  character *before* the match is not examined, because an unquoted
-  variable holding the parent (``D=~/; cat $D.mureo/...``) puts an
-  identifier character there while still resolving into ``~/.mureo``.  And
-  it no longer blocks a *symlink* whose own name starts with ``.mureo``
-  (``~/.mureoLINK -> ~/.mureo``); that was never a property to rely on,
-  since a symlink under any other name (``~/link``) evaded the old check
-  too — the path guard's realpath resolution is what actually covers
-  symlinks.
+  What separates those from a real reference is what comes *before*: a
+  path component named ``.mureo`` always starts at a boundary — after
+  ``/``, ``~``, a quote, whitespace, or the start of the string — whereas
+  the false positives are preceded by an identifier character that belongs
+  to a longer name (``window``, ``pkgs``).  So the guard denies when the
+  substring is at the start of the command or preceded by a non-identifier
+  character.
+
+  That test alone would be too weak, because an identifier character can
+  also be the tail of a *substitution* that supplies the parent directory:
+  with ``D=~/``, the command ``cat $D.mureo/credentials.json`` resolves
+  into the protected directory while putting ``D`` immediately before the
+  name.  Of all the ways a shell can splice text, only ``$NAME`` and
+  ``$1`` end in an identifier character — ``${...}``, ``$(...)``,
+  backticks and brace expansion all close with punctuation, which the
+  boundary test already catches.  The same applies one level up, to
+  format specifiers consumed by a program (``printf '%s.mureo/...' ~/``).
+  So the guard additionally denies when the identifier run before the
+  substring is itself introduced by ``$`` or ``%``.
+
+  Note ``$`` cannot appear literally in the payload (see the NOTE below),
+  hence ``chr(36)``.
+
+  Nothing that names the directory in plain path syntax is admitted by
+  this: sibling directories (``~/.mureoX``, ``~/.mureo_backup``) still
+  deny, since only the text before the name is consulted.
 
 Both comparisons are case-folded: macOS and Windows filesystems are
 case-insensitive by default, so ``~/.MUREO/credentials.json`` opens the
@@ -119,9 +131,11 @@ _PATH_GUARD_CODE = (
 _BASH_GUARD_CODE = (
     "import sys,json,re; "
     "d=json.loads(sys.stdin.read() or '{}'); "
-    "c=str((d.get('tool_input') or {}).get('command') or ''); "
+    "c=str((d.get('tool_input') or {}).get('command') or '').lower(); "
+    "b=re.search('(^|[^a-z0-9_])[.]mureo', c) or "
+    "re.search('[' + chr(36) + '%][a-z0-9_]*[.]mureo', c); "
     + _deny_expr("mureo credential guard: commands referencing .mureo are blocked")
-    + " if re.search('[.]mureo[^A-Za-z0-9_]', c.lower()+' ') else None"
+    + " if b else None"
 )
 
 

--- a/tests/test_credential_guard.py
+++ b/tests/test_credential_guard.py
@@ -218,27 +218,43 @@ class TestBashGuardBehavior:
             # filesystems, so it must stay blocked.
             "cat ~/.Mureo/credentials.json",
             "ls ~/.MUREO",
-            # An expansion right after the directory name never starts with an
-            # identifier character, so the boundary rule still sees the match.
+            # Anything at all may follow the directory name — the rule only
+            # consults what comes before it.
             "cat ~/.mureo$SUFFIX/credentials.json",
             "cat ~/.mureo{,}/credentials.json",
             "cat ~/.mureo*/credentials.json",
-            # A variable holding the parent puts an identifier character
-            # *before* the directory name — the rule must not key on that.
-            "D=~/; cat $D.mureo/credentials.json",
-            # A sibling directory name is not a match, but the traversal back
-            # into the real directory is a second occurrence that is.
             "cat ~/.mureoX/../.mureo/credentials.json",
+            # Sibling names are blocked too: only the text before the name is
+            # consulted, so ``.mureoX`` — which may well be a symlink INTO the
+            # protected directory — is not admitted.
+            "cat ~/.mureoX/credentials.json",
+            "ls ~/.mureo_backup",
+            # A substitution supplying the parent directory leaves an
+            # identifier character immediately before the name. These are the
+            # forms that make a naive preceded-by test unsafe: each one
+            # resolves into ~/.mureo.
+            "D=~/; cat $D.mureo/credentials.json",
+            "D=~/; cat $D.MUREO/credentials.json",
+            "set -- ~/; cat $1.mureo/credentials.json",
+            "D=~/; E=; cat $D$E.mureo/credentials.json",
+            "cat $(printf '%s.mureo/credentials.json' ~/)",
+            "python3 -c \"print(open('%s.mureo/credentials.json' % h).read())\"",
+            # ...while every other splice closes with punctuation, which the
+            # boundary test catches on its own.
+            "D=~/; cat ${D}.mureo/credentials.json",
+            'D=~/; cat "$D".mureo/credentials.json',
+            "cat $(printf '%s' ~/).mureo/credentials.json",
+            "python3 -c \"print(open('{}.mureo/x'.format(h)).read())\"",
         ],
     )
     def test_denies_every_spelling_of_the_mureo_dir(
         self, fake_home: Path, command: str
     ) -> None:
-        """The identifier-boundary rule must not shrink what is blocked.
+        """The boundary rule must not shrink what is blocked.
 
-        Every form here reaches ``~/.mureo`` with plain path syntax; the
-        character after the directory name is never an identifier character,
-        because shell expansions and quoting all start with something else.
+        Every form here resolves into ``~/.mureo`` — verified by expanding
+        each one with a real shell against a throwaway ``$HOME`` — and every
+        one of them was blocked by the previous bare-substring check.
         """
         proc = run_guard(
             _bash_guard_command(), {"command": command}, fake_home, tool_name="Bash"
@@ -255,41 +271,29 @@ class TestBashGuardBehavior:
 
     @pytest.mark.parametrize(
         "command",
-        ["cat ~/.mureoX/credentials.json", "ls ~/.mureo_backup"],
-    )
-    def test_allows_sibling_dirs_whose_name_merely_starts_with_mureo(
-        self, fake_home: Path, command: str
-    ) -> None:
-        """``~/.mureoX`` is a different directory, and is not protected.
-
-        This mirrors the path guard, which already allows sibling names
-        (``test_allows_similarly_named_sibling_dir``). Blocking them was the
-        same behavior that blocked ``window.MUREO_REPORTS_FORMAT`` — a prefix
-        match cannot tell the two apart, so the boundary is drawn where the
-        path guard already draws it: at the end of the directory name.
-        """
-        proc = run_guard(
-            _bash_guard_command(), {"command": command}, fake_home, tool_name="Bash"
-        )
-        assert proc.returncode == 0
-        assert proc.stdout.strip() == "", command
-
-    @pytest.mark.parametrize(
-        "command",
         [
+            # mureo's own public browser namespace, case-folding to `.mureo_`.
             "gh release create v0.10.43 --notes 'adds window.MUREO_REPORTS_FORMAT'",
             "git commit -m 'feat: reorder via window.MUREO_REPORTS_ORDER'",
             "grep -rn window.MUREO_WIZARD mureo/_data/web/",
             "node --test tests/js/reports_format.test.js # window.MUREO_AUTH_META",
+            # Hostnames under the project's domain, case-folding to `.mureo.`.
+            "gh pr create --body 'published to pkgs.mureo.jp'",
+            "pip install --index-url https://pkgs.mureo.jp/simple/ mureo-agency",
+            "curl -sS https://pkgs.mureo.jp/simple/index.html",
+            "open https://docs.mureo.jp/byod",
+            "echo www.mureo.jp",
         ],
     )
-    def test_allows_mureo_browser_globals(self, fake_home: Path, command: str) -> None:
-        """``window.MUREO_*`` is mureo's own public browser namespace.
+    def test_allows_mureo_own_identifiers(self, fake_home: Path, command: str) -> None:
+        """mureo's browser globals and hostnames are not the directory.
 
-        Case-folded, ``.MUREO_REPORTS_FORMAT`` contains ``.mureo`` — but the
-        next character continues an identifier, so it can never be the
-        ``~/.mureo`` directory name. Release notes, commit messages and greps
-        naming these globals must not be blocked.
+        Both false positives were observed for real: the ``gh release
+        create`` call for v0.10.43 was denied over ``window.MUREO_REPORTS_*``
+        in its notes, and a ``gh pr create`` was denied over
+        ``pkgs.mureo.jp`` in its body. In each the substring is preceded by
+        an identifier character belonging to a longer name, so it cannot be
+        the start of a ``.mureo`` path component.
         """
         proc = run_guard(
             _bash_guard_command(), {"command": command}, fake_home, tool_name="Bash"

--- a/tests/test_credential_guard.py
+++ b/tests/test_credential_guard.py
@@ -202,6 +202,49 @@ class TestBashGuardBehavior:
         )
         assert deny_decision(proc) == "deny"
 
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # End of the command string: nothing follows the directory name.
+            "ls -la ~/.mureo",
+            "tar cf /tmp/x.tar ~/.mureo",
+            # Trailing separator, and every quoting form of the same path.
+            "ls ~/.mureo/",
+            'cat "$HOME/.mureo/credentials.json"',
+            "cat '~/.mureo/credentials.json'",
+            "cat ~/'.mureo'/credentials.json",
+            'cat ~/.mureo""/credentials.json',
+            # Mixed case still opens the real file on case-insensitive
+            # filesystems, so it must stay blocked.
+            "cat ~/.Mureo/credentials.json",
+            "ls ~/.MUREO",
+            # An expansion right after the directory name never starts with an
+            # identifier character, so the boundary rule still sees the match.
+            "cat ~/.mureo$SUFFIX/credentials.json",
+            "cat ~/.mureo{,}/credentials.json",
+            "cat ~/.mureo*/credentials.json",
+            # A variable holding the parent puts an identifier character
+            # *before* the directory name — the rule must not key on that.
+            "D=~/; cat $D.mureo/credentials.json",
+            # A sibling directory name is not a match, but the traversal back
+            # into the real directory is a second occurrence that is.
+            "cat ~/.mureoX/../.mureo/credentials.json",
+        ],
+    )
+    def test_denies_every_spelling_of_the_mureo_dir(
+        self, fake_home: Path, command: str
+    ) -> None:
+        """The identifier-boundary rule must not shrink what is blocked.
+
+        Every form here reaches ``~/.mureo`` with plain path syntax; the
+        character after the directory name is never an identifier character,
+        because shell expansions and quoting all start with something else.
+        """
+        proc = run_guard(
+            _bash_guard_command(), {"command": command}, fake_home, tool_name="Bash"
+        )
+        assert deny_decision(proc) == "deny", command
+
     @pytest.mark.parametrize("command", ["echo hello", "ls -la", "git status"])
     def test_allows_unrelated_commands(self, fake_home: Path, command: str) -> None:
         proc = run_guard(
@@ -209,6 +252,50 @@ class TestBashGuardBehavior:
         )
         assert proc.returncode == 0
         assert proc.stdout.strip() == ""
+
+    @pytest.mark.parametrize(
+        "command",
+        ["cat ~/.mureoX/credentials.json", "ls ~/.mureo_backup"],
+    )
+    def test_allows_sibling_dirs_whose_name_merely_starts_with_mureo(
+        self, fake_home: Path, command: str
+    ) -> None:
+        """``~/.mureoX`` is a different directory, and is not protected.
+
+        This mirrors the path guard, which already allows sibling names
+        (``test_allows_similarly_named_sibling_dir``). Blocking them was the
+        same behavior that blocked ``window.MUREO_REPORTS_FORMAT`` — a prefix
+        match cannot tell the two apart, so the boundary is drawn where the
+        path guard already draws it: at the end of the directory name.
+        """
+        proc = run_guard(
+            _bash_guard_command(), {"command": command}, fake_home, tool_name="Bash"
+        )
+        assert proc.returncode == 0
+        assert proc.stdout.strip() == "", command
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "gh release create v0.10.43 --notes 'adds window.MUREO_REPORTS_FORMAT'",
+            "git commit -m 'feat: reorder via window.MUREO_REPORTS_ORDER'",
+            "grep -rn window.MUREO_WIZARD mureo/_data/web/",
+            "node --test tests/js/reports_format.test.js # window.MUREO_AUTH_META",
+        ],
+    )
+    def test_allows_mureo_browser_globals(self, fake_home: Path, command: str) -> None:
+        """``window.MUREO_*`` is mureo's own public browser namespace.
+
+        Case-folded, ``.MUREO_REPORTS_FORMAT`` contains ``.mureo`` — but the
+        next character continues an identifier, so it can never be the
+        ``~/.mureo`` directory name. Release notes, commit messages and greps
+        naming these globals must not be blocked.
+        """
+        proc = run_guard(
+            _bash_guard_command(), {"command": command}, fake_home, tool_name="Bash"
+        )
+        assert proc.returncode == 0
+        assert proc.stdout.strip() == "", command
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The Bash credential guard denies a command when its text contains the protected directory name as a bare substring:

```python
... if '.mureo' in c.lower() else None
```

Case-folded, that substring is also a prefix of things that are emphatically **not** the directory. Two separate false positives were observed in real use:

| text | what it actually is | how it was hit |
|---|---|---|
| `window.MUREO_REPORTS_FORMAT` | mureo's own public browser global, published by `mureo/_data/web/reports_format.js` and documented in `AGENTS.md` | `gh release create` for v0.10.43 — the release notes named it, so the release was denied |
| `pkgs.mureo.jp` | the package index hostname | `gh pr create` — the PR body named it, so the PR was denied |

The second one generalises: **every** hostname under the project's domain (`docs.mureo.jp`, `www.mureo.jp`) trips the guard, as does every `window.MUREO_*` global. Commit messages, release notes, PR bodies and greps that mention any of them are blocked.

## What separates a real reference from these

Not what follows the substring — `.MUREO_REPORTS_FORMAT` is followed by `_`, but `pkgs.mureo.jp` is followed by `.`, and `.` is exactly what follows the name in a legitimate path too.

What separates them is what comes **before**. A path component named `.mureo` always starts at a boundary: after `/`, `~`, a quote, whitespace, or the start of the string. The false positives are preceded by an identifier character that belongs to a longer name (`window`, `pkgs`).

## Fix

```python
c = str(...).lower()
b = (re.search('(^|[^a-z0-9_])[.]mureo', c)
     or re.search('[' + chr(36) + '%][a-z0-9_]*[.]mureo', c))
```

**First clause — the boundary test.** Deny when the substring starts the command or is preceded by a non-identifier character. This covers every plain path spelling.

**Second clause — substitutions.** The boundary test alone is not safe, because an identifier character can also be the *tail of a substitution supplying the parent directory*. With `D=~/`, the command `cat $D.mureo/credentials.json` resolves into the protected directory while putting `D` immediately before the name. Of all the ways a shell can splice text, only `$NAME` and `$1` end in an identifier character — `${...}`, `$(...)`, backticks and brace expansion all close with punctuation, which the first clause already catches. The same reasoning applies one level up to format specifiers consumed by a program (`printf '%s.mureo/...' ~/`, `'%s.mureo/x' % h`). So the second clause denies when the identifier run before the name is introduced by `$` or `%`.

`$` cannot appear literally in the payload — it is interpolated inside double quotes on a `python3 -c` command line — hence `chr(36)`. Note also `[$]` as a character class rather than a bare `$`, which regex would read as an end-of-string anchor. Explicit `[a-z0-9_]` rather than `\w` and `[.]` rather than an escaped dot, because the payload may not contain backslashes either (enforced by `tests/hook_guard_runner.extract_python_code`).

## Evidence that nothing protected was given up

Argument is not enough here, so this was measured. Each of **43 candidate forms** was expanded by a real `bash` against a throwaway `$HOME`, and the expansion checked for whether it actually lands inside the protected directory. Each rule's verdict was then compared against that ground truth.

**Result: the new rule blocks every form that reaches the directory, with no exceptions, and blocks everything the original bare-substring check blocked.** It admits both false-positive shapes.

Forms confirmed still blocked include: bare name and trailing separator; `$HOME/`, `${HOME}/` and literal `/Users/<name>/` parents; every quoting form (`"$HOME/..."`, `'~/...'`, `~/'.mureo'/...`, `~/.mureo""/...`); mixed case (`.MUREO`, `.Mureo`, `.MuReO`) — which matters because case-insensitive filesystems open the real file; wildcards and brace/var expansions after the name; `.` and `..` segments; traversal back in through a sibling; and every substitution-supplied parent (`$D.`, `$1.`, `$D$E.`, `${D}.`, `"$D".`, `$(...)` , backticks, `printf '%s.'`, `'%s.' % h`, `'{}.'.format(h)`, `f'{h}.'`).

Dropping the followed-by clause that was in the first commit of this PR **restores** coverage: sibling names such as `~/.mureoX` and `~/.mureo_backup` deny again. That matters, because `~/.mureoX` may itself be a symlink pointing into the protected directory.

The single reaching form the new rule does not block — a parent directory held entirely in a variable set by an *earlier* command (`P=~/.mureo` in one call, `cat $P/credentials.json` in the next) — contains no literal `.mureo` in its text and was missed by the original check too. It is the shell-indirection class the module docstring already scopes out; real safety there comes from filesystem permissions.

## Tests

TDD. The allow-cases were written first and failed against the old rule; the deny-cases pass before *and* after, which is the invariant that matters. No existing evasion test was weakened or removed. `test_denies_every_spelling_of_the_mureo_dir` now pins 24 spellings, including all the substitution-supplied-parent forms that make a naive preceded-by test unsafe.

## Path guard

Checked and unaffected. It compares `realpath`/`abspath`-resolved paths against the resolved protected directory, so a textual collision cannot arise. Verified directly: reading `mureo/_data/web/reports_format.js`, and a `Grep` whose *pattern* is `window.MUREO_REPORTS_FORMAT`, both pass; every path under the protected directory, including the `~/.MUREO` case form, is still denied.

## Upgrading an existing install

The hook is a literal string in `~/.claude/settings.json` (and `~/.codex/hooks.json`), so an already-installed hook keeps the old rule until it is rewritten. After this ships, re-run the installer for the host in use — `mureo setup claude-code` / `mureo setup codex` — which replaces the tagged `[mureo-credential-guard]` entries in place. No hooks were rewritten as part of this PR.

## Gates

- `ruff check .` — passed
- `black --check .` — passed (606 files)
- `mypy mureo --ignore-missing-imports` — passed (288 source files)
- `python -m pytest` — 7770 passed, 12 failed, 7 skipped. The 12 are pre-existing local-environment failures unrelated to this change (9 in `tests/analytics/builtin/test_live_clients.py`, 3 tool-registry counts); CI is green.
