### PR TITLE
Enforce learning-period reset awareness as a pre-flight check, not prose

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,7 @@ mureo/
 │   ├── tools_analytics_registry.py        # mureo_analytics_modules_list / mureo_analytics_run (#440)
 │   ├── tools_creative_studio.py           # creative_studio_* (visual generation + compose)
 │   ├── tools_learning.py                  # mureo_learning_insights_get / mureo_consult_advisor
+│   ├── tools_learning_preflight.py        # mureo_learning_reset_preflight (#548)
 │   ├── tools_mureo_context.py             # STRATEGY.md / STATE.json + mureo_outcome_evaluate tools
 │   ├── _handlers_mureo_context.py         # Context (STRATEGY/STATE) handlers
 │   ├── _client_factory.py                 # Per-platform BYOD-vs-live client factory
@@ -133,6 +134,8 @@ mureo/
 ├── core/                # Extension Protocols + file-backed impls + RuntimeContext; provider & skill discovery
 ├── providers/           # Official MCP provider catalog + one-command install helpers (#86)
 ├── policy/              # Built-in policy gates (strategy_gate) — ship with OSS, run by default
+│   ├── learning_rules.py     # Per-platform learning-period facts + their first-party sources (#548)
+│   └── learning_reset.py     # Reset-class + learning-state pre-flight the gate refuses on
 ├── learning/            # Read-side /learn companion: insight federation across configured sources
 ├── creative_studio/     # Creator-grade ad-creative (image) generation via pluggable providers
 ├── byod/                # Bring Your Own Data — CSV-backed offline analysis (see BYOD Mode below)
@@ -227,6 +230,7 @@ These families are not tied to a single ad platform. Tool names are the exact MC
 | Analysis | `analysis_anomalies_check` |
 | Creative Studio | `creative_studio_providers_list`, `creative_studio_generate_visual`, `creative_studio_edit_visual`, `creative_studio_compose`, `creative_studio_brand_kit_get` |
 | Learning | `mureo_learning_insights_get`, `mureo_consult_advisor` |
+| Learning pre-flight (#548) | `mureo_learning_reset_preflight` |
 | mureo Context | `mureo_strategy_get`, `mureo_strategy_set`, `mureo_state_get`, `mureo_state_action_log_append`, `mureo_state_upsert_campaign`, `mureo_state_report_set`, `mureo_state_platform_metrics_set`, `mureo_state_set_conversion_events`, `mureo_outcome_evaluate` |
 
 ## Design Constraints

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,10 +97,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Hard refusal.** Two new STRATEGY.md `## Guardrails` rules, enforced by the
     existing built-in `StrategyPolicyGate` before dispatch (no second gate):
     `block_learning_resets` refuses every reset-triggering change;
-    `block_learning_resets_during_incident` refuses one unless the campaign is
-    *positively known* to be out of a learning period — so it also fires on an
-    unknown state, matching the gate's existing discipline of refusing what it
-    cannot verify. Both default off: with neither written, behaviour is
+    `block_learning_resets_during_incident` is narrower by name and in fact —
+    it refuses only a change that *identifies a campaign* which is not
+    positively known to be out of a learning period. An unknown state on an
+    identified campaign is refused (fail-closed, matching the gate's existing
+    discipline of refusing what it cannot verify); a change that identifies no
+    campaign at all has no subject and is not refused, since several
+    reset-triggering tools are account-level (`google_ads_conversions_*`) or
+    keyed on something other than a campaign (`google_ads_budget_update` takes
+    a `budget_id`) and would otherwise be blocked forever with no relation to
+    any incident. Both default off: with neither written, behaviour is
     unchanged and mureo neither reads STATE.json nor blocks anything.
   - **Pre-flight tool.** `mureo_learning_reset_preflight` (read-only, no
     platform API call) answers, *before* the change: is it reset-triggering,
@@ -131,9 +137,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   Reads and unrelated mutations are never flagged: a campaign rename through
   `google_ads_campaigns_update` is `no_reset` while the same tool carrying
-  `bidding_strategy` is `resets`, and pausing a campaign is `no_reset` while
-  re-enabling it is `resets`. A check that fires on everything is a check that
-  gets ignored.
+  `bidding_strategy` is `resets`; renaming a conversion action through
+  `google_ads_conversions_update` is `no_reset` while changing its category,
+  status, value or lookback window is `resets`; and pausing a campaign is
+  `no_reset` while re-enabling it is `resets`. A check that fires on everything
+  is a check that gets ignored — and one that blocks a rename is a check that
+  gets switched off.
+
+  The classification's known blind spots (a manual-CPC campaign has no bid
+  strategy to reset, so `budget_change` / `composition_change` / `reactivation`
+  are over-reported on one) travel with the **`resets`** verdict, not only with
+  `no_reset` — the operator stopped by a false positive is the one who needs
+  them.
 
 ## [0.10.43] - 2026-08-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,62 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   construction at the tool. Every other removal stays blocked, and both
   invariants are pinned by tests.
 
+- **Learning-period reset pre-flight — an enforced check, not prose** (#548).
+  `_mureo-shared/SKILL.md` documented "Learning Period Awareness" as a security
+  rule: warn before changes that reset the learning period, list the affected
+  operations, show the current bidding system status. Nothing in mureo actually
+  detected or blocked such a change at the moment it was dispatched — it was
+  advice addressed to a model, and models follow advice worst exactly when it
+  matters most. The incident behind this: a campaign whose delivery had already
+  collapsed was "fixed" by moving its bid ceiling, which put the bidding
+  strategy into a settings-change learning state and delayed recovery further.
+  Troubleshooting *means* making many changes quickly, which is why this needed
+  a mechanism.
+
+  Three surfaces of deliberately different strength — MCP has no interposed
+  confirmation step, so mureo either runs a call or refuses it:
+
+  - **Hard refusal.** Two new STRATEGY.md `## Guardrails` rules, enforced by the
+    existing built-in `StrategyPolicyGate` before dispatch (no second gate):
+    `block_learning_resets` refuses every reset-triggering change;
+    `block_learning_resets_during_incident` refuses one unless the campaign is
+    *positively known* to be out of a learning period — so it also fires on an
+    unknown state, matching the gate's existing discipline of refusing what it
+    cannot verify. Both default off: with neither written, behaviour is
+    unchanged and mureo neither reads STATE.json nor blocks anything.
+  - **Pre-flight tool.** `mureo_learning_reset_preflight` (read-only, no
+    platform API call) answers, *before* the change: is it reset-triggering,
+    with the first-party source that verdict rests on; what is the campaign's
+    current learning state; and would the operator's guardrails refuse it.
+    `would_block` is computed by the same function the gate uses, so the two
+    cannot drift.
+  - **Notice.** A reset-triggering call's own result carries a notice, so the
+    *next* change in a troubleshooting sequence is not made blind.
+
+  **Evidence, not folklore.** Every trigger carries the first-party source, the
+  retrieval date, and the sentence it rests on (`mureo/policy/learning_rules.py`).
+  Google Ads is complete because Google publishes the causes as the `LEARNING_*`
+  members of `BiddingStrategySystemStatus` — the same enum mureo reads the state
+  from. No other platform ships a trigger list: Meta documents that "significant
+  edits" restart the phase without enumerating them, so **every Meta mutation is
+  reported `unknown`, never `no_reset`**, and the same holds for the Amazon
+  bridge and plugin platforms until their plugin registers rules via
+  `register_platform_learning_rules`. The two figures the old prose asserted —
+  "budget changes > 20%" — had no first-party source and are gone rather than
+  reproduced. `unknown` and `unreportable` are never treated as safe: a false
+  "this resets nothing" converts a missing warning into implied approval.
+
+  The learning state is read **locally**, from
+  `bidding_details.bidding_strategy_system_status` on the campaign's STATE.json
+  snapshot, because a policy gate runs on every tool call and must not make
+  network calls. A missing observation reports `unknown`.
+
+  Reads and unrelated mutations are never flagged: a campaign rename through
+  `google_ads_campaigns_update` is `no_reset` while the same tool carrying
+  `bidding_strategy` is `resets`, and pausing a campaign is `no_reset` while
+  re-enabling it is `resets`. A check that fires on everything is a check that
+  gets ignored.
+
 ## [0.10.43] - 2026-08-07
 
 ### Changed

--- a/README.ja.md
+++ b/README.ja.md
@@ -270,7 +270,7 @@ STATE.jsonから接続媒体を検出:
 
 ### MCP サーバーとツール一覧
 
-mureo は **210 の MCP ツール** を stdio で公開します。Google広告（89）、Meta広告（90）、Search Console（10）に加え、rollback、異常検知、戦略と状態のコンテキスト、分析モジュールレジストリ、学習、Creative Studio を含みます。Amazon 広告を設定している場合は、ローカルのマニフェストからブリッジされた Amazon のツールがこれに加わります（ツール名も本数も Amazon 側のもので、mureo が定義するものではありません。詳細は [docs/amazon-ads.ja.md](docs/amazon-ads.ja.md)）。MCP 対応クライアントなら何からでも接続できます。
+mureo は **211 の MCP ツール** を stdio で公開します。Google広告（89）、Meta広告（90）、Search Console（10）に加え、rollback、異常検知、戦略と状態のコンテキスト、分析モジュールレジストリ、学習、学習期間リセットのプリフライト、Creative Studio を含みます。Amazon 広告を設定している場合は、ローカルのマニフェストからブリッジされた Amazon のツールがこれに加わります（ツール名も本数も Amazon 側のもので、mureo が定義するものではありません。詳細は [docs/amazon-ads.ja.md](docs/amazon-ads.ja.md)）。MCP 対応クライアントなら何からでも接続できます。
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ Why this matters: `link_click` vs `pixel_lead` optimization is a tracking distin
 
 ### MCP server & tool list
 
-mureo exposes **210 MCP tools** over stdio: Google Ads (89), Meta Ads (90), Search Console (10), plus rollback, anomaly detection, strategy/state context, analytics registry, learning, and Creative Studio. When Amazon Ads is configured, the bridged Amazon tools are added on top from the local manifest (their names and count are Amazon's, not mureo's — see [docs/amazon-ads.md](docs/amazon-ads.md)). Any MCP-compatible client can connect:
+mureo exposes **211 MCP tools** over stdio: Google Ads (89), Meta Ads (90), Search Console (10), plus rollback, anomaly detection, strategy/state context, analytics registry, learning, learning-period reset pre-flight, and Creative Studio. When Amazon Ads is configured, the bridged Amazon tools are added on top from the local manifest (their names and count are Amazon's, not mureo's — see [docs/amazon-ads.md](docs/amazon-ads.md)). Any MCP-compatible client can connect:
 
 ```json
 {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -449,7 +449,7 @@ The Amazon bridge is the reason mureo sits in the request path rather than letti
 
 ## Command-Based Workflow System
 
-In addition to the 210 individual MCP tools, mureo provides **workflow commands** as Claude Code native slash skills (deployed to `~/.claude/skills/`). These commands are **platform-agnostic orchestration instructions** that guide the AI agent to discover platforms, select tools, and synthesize cross-platform insights — all driven by the strategy context in `STRATEGY.md`.
+In addition to the 211 individual MCP tools, mureo provides **workflow commands** as Claude Code native slash skills (deployed to `~/.claude/skills/`). These commands are **platform-agnostic orchestration instructions** that guide the AI agent to discover platforms, select tools, and synthesize cross-platform insights — all driven by the strategy context in `STRATEGY.md`.
 
 ### How It Works
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -1,6 +1,6 @@
 # MCP Server Guide
 
-mureo exposes 210 tools via the [Model Context Protocol](https://modelcontextprotocol.io/) (MCP): 189 advertising and SEO operation tools across Google Ads (89), Meta Ads (90), and Search Console (10), 2 rollback tools, 1 cross-platform anomaly-detection tool, 9 mureo-context tools (strategy / state / reports / outcome evaluation), 2 analytics-registry tools, 2 learning tools (`mureo_learning_insights_get` for the operator's local `/learn` history and `mureo_consult_advisor` for federated retrieval against external advisor MCP servers — see [`docs/insight-federation.md`](insight-federation.md)), and 5 Creative Studio tools (text-free key-visual generation + banner composition). Any MCP-compatible client can connect and call these tools over stdio. Re-check this count when MCP tools are added or removed (`test_list_tools_returns_all_tools` pins the exact number). The count covers mureo's own tool families only — tools bridged from the official **Amazon Ads** MCP (and from any installed provider plugin) are appended on top at server start and vary per operator; see [Amazon Ads (official-MCP bridge)](#amazon-ads-official-mcp-bridge) below.
+mureo exposes 211 tools via the [Model Context Protocol](https://modelcontextprotocol.io/) (MCP): 189 advertising and SEO operation tools across Google Ads (89), Meta Ads (90), and Search Console (10), 2 rollback tools, 1 cross-platform anomaly-detection tool, 9 mureo-context tools (strategy / state / reports / outcome evaluation), 2 analytics-registry tools, 2 learning tools (`mureo_learning_insights_get` for the operator's local `/learn` history and `mureo_consult_advisor` for federated retrieval against external advisor MCP servers — see [`docs/insight-federation.md`](insight-federation.md)), 1 learning-period pre-flight tool (`mureo_learning_reset_preflight` — is a pending change reset-triggering, and is the campaign already learning; see [Learning-period reset pre-flight](#learning-period-reset-pre-flight)), and 5 Creative Studio tools (text-free key-visual generation + banner composition). Any MCP-compatible client can connect and call these tools over stdio. Re-check this count when MCP tools are added or removed (`test_list_tools_returns_all_tools` pins the exact number). The count covers mureo's own tool families only — tools bridged from the official **Amazon Ads** MCP (and from any installed provider plugin) are appended on top at server start and vary per operator; see [Amazon Ads (official-MCP bridge)](#amazon-ads-official-mcp-bridge) below.
 
 ## Starting the Server
 
@@ -572,6 +572,37 @@ Retrieve accumulated practitioner know-how before drawing diagnostic conclusions
 |------|-------------|-------------------|
 | `mureo_learning_insights_get` | Load every insight previously saved via `/learn` as raw Markdown | *(none)* |
 | `mureo_consult_advisor` | Query external advisor MCP servers (vector search) enriched with local campaign state; advisor responses are treated as untrusted external content | `question` |
+
+### Learning-period reset pre-flight
+
+Every automated-bidding system has a learning period, and a change that restarts it costs days of delivery — most damagingly while someone is troubleshooting a collapsed campaign, because troubleshooting means many changes in a row. This tool answers, *before* the change, whether it restarts learning and whether the campaign is already re-learning.
+
+| Tool | Description | Required Parameters |
+|------|-------------|-------------------|
+| `mureo_learning_reset_preflight` | Classify a pending change against the campaign's learning period: `reset_risk` (with the first-party source it rests on), `learning_state`, and whether `## Guardrails` would refuse it | `tool_name` |
+
+Read-only: it calls no platform API and changes nothing.
+
+**Three surfaces, of deliberately different strength.** MCP has no interposed confirmation step — mureo either runs a tool call or refuses it — so these are not interchangeable:
+
+| Surface | When | Strength |
+|---|---|---|
+| `## Guardrails` `block_learning_resets` / `block_learning_resets_during_incident` | before dispatch | **hard** — the call is refused by `StrategyPolicyGate`, before any API call |
+| `mureo_learning_reset_preflight` | before the change, when the agent calls it | advisory — as strong as the agent's compliance |
+| A notice appended to a reset-triggering call's own result | after that call | records the reset so the *next* change in the sequence is not made blind |
+
+**Per-platform coverage.** Reset triggers are sourced from first-party documentation only; where mureo has no such source it reports `unknown` and never `no_reset`, because a false "this resets nothing" turns a missing warning into implied approval.
+
+| Platform | Learning state readable by mureo? | Reset triggers known? |
+|---|---|---|
+| Google Ads | **Yes** — `bidding_details.bidding_strategy_system_status` on the campaign's STATE.json snapshot | **Yes** — Google's own `LEARNING_*` enum members ([`BiddingStrategySystemStatus`](https://developers.google.com/google-ads/api/reference/rpc/v23/BiddingStrategySystemStatusEnum.BiddingStrategySystemStatus)) |
+| Meta Ads | No — Meta exposes [`learning_stage_info`](https://developers.facebook.com/docs/marketing-api/reference/ad-campaign-learning-stage-info/) on the **ad set**; mureo's client does not request it and STATE.json is campaign-level | No — Meta documents that "significant edits" restart the phase without enumerating them |
+| Amazon Ads (official-MCP bridge) | No — no learning-state read exists on the bridged tool surface | No |
+| Yahoo / LINE / SmartNews / LOGLY (plugins) | No — unless the plugin registers rules | No — unless the plugin registers rules |
+
+A plugin or bridge advertises its own platform's rules through `mureo.policy.learning_rules.register_platform_learning_rules`, the same registry pattern the budget/bid declarations use.
+
+**The state read is local by design.** A policy gate runs on every tool call and must not make network calls, so the learning state comes from STATE.json rather than from the platform. Keep it fresh (`google_ads_campaigns_get` / `google_ads_campaigns_diagnose` → `mureo_state_upsert_campaign`); a missing observation is reported `unknown`, never `steady`.
 
 ### Creative Studio
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -588,6 +588,8 @@ Read-only: it calls no platform API and changes nothing.
 | Surface | When | Strength |
 |---|---|---|
 | `## Guardrails` `block_learning_resets` / `block_learning_resets_during_incident` | before dispatch | **hard** — the call is refused by `StrategyPolicyGate`, before any API call |
+
+`block_learning_resets` is an account-wide freeze: it refuses every reset-triggering change, with or without an identifiable campaign. `block_learning_resets_during_incident` is narrower by name and in fact — it refuses only a change that **identifies a campaign** which is not positively known to be out of a learning period. An unknown state on an identified campaign is refused (fail-closed); a change that identifies no campaign at all (`google_ads_conversions_*` is account-level, `google_ads_budget_update` is keyed on a `budget_id`) has no subject and is not refused, or the rule would permanently block editing a conversion action with no relation to any incident.
 | `mureo_learning_reset_preflight` | before the change, when the agent calls it | advisory — as strong as the agent's compliance |
 | A notice appended to a reset-triggering call's own result | after that call | records the reset so the *next* change in the sequence is not made blind |
 

--- a/mureo/_data/skills/_mureo-shared/SKILL.md
+++ b/mureo/_data/skills/_mureo-shared/SKILL.md
@@ -253,12 +253,54 @@ When adding or removing large numbers of keywords:
 - Show progress after each batch
 - Allow the user to stop between batches
 
-### 6. Learning Period Awareness
+### 6. Learning Period Awareness (mechanised — call the pre-flight tool)
 
-For Google Ads campaigns using smart bidding:
-- Warn before making changes that reset the learning period
-- Affected operations: bidding strategy changes, budget changes > 20%, conversion setting changes
-- Display the current bidding system status if available
+This used to be prose telling you to "warn before changes that reset the
+learning period". It is now a real check, because the rule was least likely to
+be followed exactly when it mattered most: troubleshooting a broken campaign
+means making many changes quickly, and that is precisely when stacking a second
+learning reset delays recovery instead of speeding it up.
+
+**Before any bid-strategy, budget, conversion-setting, keyword or re-enable
+change, call `mureo_learning_reset_preflight`** with the tool name and the
+arguments you are about to pass, and put its answer in your confirmation to the
+operator. It is read-only, calls no platform API, and returns:
+
+- `reset_risk` — `resets` / `no_reset` / `unknown`, with the **first-party
+  source** the verdict rests on (`reset_verdict.evidence`).
+- `learning_state` — `learning` / `steady` / `unknown` / `unreportable` for the
+  campaign, read from STATE.json.
+- `would_block` — whether the operator's STRATEGY.md `## Guardrails` refuses
+  this call.
+
+**`unknown` and `unreportable` never mean safe.** They mean mureo has no
+answer: report them as "not known" to the operator rather than proceeding as if
+the change were harmless.
+
+Three surfaces, of deliberately different strength:
+
+| Surface | When | Strength |
+|---|---|---|
+| `## Guardrails` `block_learning_resets` / `block_learning_resets_during_incident` | before dispatch | **hard** — the call is refused |
+| `mureo_learning_reset_preflight` | before the change, when you call it | advisory — as strong as your compliance |
+| Automatic notice appended to a reset-triggering call's result | after that call | records the reset so the NEXT change is not made blind |
+
+MCP has no interposed confirmation step, so mureo cannot pause a call and ask.
+The guardrails are the only surface that stops one.
+
+**What mureo knows, per platform** (never claim more than this):
+
+| Platform | Learning state readable by mureo? | Reset triggers known? |
+|---|---|---|
+| Google Ads | Yes — `bidding_strategy_system_status` from the campaign snapshot in STATE.json | Yes — Google's own `LEARNING_*` enum members |
+| Meta Ads | No — Meta exposes `learning_stage_info` on the **ad set**, mureo does not fetch it and STATE.json is campaign-level | No — Meta documents "significant edits" without enumerating them |
+| Amazon Ads (bridge), Yahoo / LINE / SmartNews / LOGLY (plugins) | No — unless the plugin registers rules | No — unless the plugin registers rules |
+
+So the check is **complete on Google Ads and honest everywhere else**. For a
+Google campaign, keep `bidding_details.bidding_strategy_system_status` fresh in
+STATE.json (`google_ads_campaigns_get` / `google_ads_campaigns_diagnose` →
+`mureo_state_upsert_campaign`); without it the learning state is reported
+`unknown`, not `steady`.
 
 ## Diagnostic preamble (learning insights + advisor consult)
 

--- a/mureo/_data/skills/_mureo-strategy/SKILL.md
+++ b/mureo/_data/skills/_mureo-strategy/SKILL.md
@@ -273,14 +273,27 @@ keys (all optional):
 - `block_learning_resets` — every change mureo classifies as restarting an
   automated bid strategy's learning period is **refused**. The blunt rule: use
   it during a freeze, not day to day.
-- `block_learning_resets_during_incident` — the same refusal, but only when the
-  campaign is **not positively known to be out of** a learning period. Stacking
-  a second reset on a campaign that is already re-learning is almost never
-  intended, and is the exact shape of the incident this rule comes from
-  (a collapsed campaign "fixed" by moving its bid ceiling, which restarted
-  learning and delayed recovery). It therefore **also fires when the learning
-  state is unknown or unreportable** — consistent with the rest of this gate,
-  which refuses what it cannot verify rather than assuming the safe answer.
+- `block_learning_resets_during_incident` — the same refusal, but narrower by
+  name and in fact: *"during incident"* names **a specific campaign that is
+  known to be unstable**. It refuses only when the call (1) identifies a
+  campaign at all and (2) that campaign is **not positively known to be out
+  of** a learning period. Stacking a second reset on a campaign that is already
+  re-learning is almost never intended, and is the exact shape of the incident
+  this rule comes from (a collapsed campaign "fixed" by moving its bid ceiling,
+  which restarted learning and delayed recovery).
+
+  Condition (2) is **fail-closed**: an `unknown` or `unreportable` state on an
+  identified campaign is refused, not assumed steady. Condition (1) is what
+  keeps that from degenerating into a permanent block. Several
+  reset-triggering tools are **not campaign-scoped** —
+  `google_ads_conversions_*` is account-level and `google_ads_budget_update` is
+  keyed on a `budget_id` — so their campaign can never be resolved and their
+  state is always `unknown`. Without (1) this rule would refuse every one of
+  those calls forever, with no relation to any incident: an operator who
+  followed mureo's own advice to declare it would find conversion actions
+  permanently un-editable. A rule with no subject has nothing to refuse. Use
+  `block_learning_resets` when you want the account-wide freeze — that one is
+  honestly blunt and needs no subject.
 
   Coverage is honest rather than uniform. mureo classifies reset triggers from
   **first-party sources only**: Google Ads is complete (Google publishes the

--- a/mureo/_data/skills/_mureo-strategy/SKILL.md
+++ b/mureo/_data/skills/_mureo-strategy/SKILL.md
@@ -213,6 +213,8 @@ keys (all optional):
 - max_bid_amount_per_ad_set: 5000   # minor units: 5000 = $50.00 (USD) but ¥5,000 (JPY)
 - max_cpc_bid_per_ad_group: 100      # currency units: 100 = $100 (USD) or ¥100 (JPY)
 - blocked_operations: google_ads_keywords_remove, meta_ads_audiences_delete
+- block_learning_resets: false
+- block_learning_resets_during_incident: true
 ```
 
 - `max_daily_budget_per_campaign` — a budget mutation proposing more than this
@@ -268,10 +270,39 @@ keys (all optional):
   To target deletion, block a distinct destructive tool (e.g.
   `google_ads_keywords_remove`) instead.
 
+- `block_learning_resets` — every change mureo classifies as restarting an
+  automated bid strategy's learning period is **refused**. The blunt rule: use
+  it during a freeze, not day to day.
+- `block_learning_resets_during_incident` — the same refusal, but only when the
+  campaign is **not positively known to be out of** a learning period. Stacking
+  a second reset on a campaign that is already re-learning is almost never
+  intended, and is the exact shape of the incident this rule comes from
+  (a collapsed campaign "fixed" by moving its bid ceiling, which restarted
+  learning and delayed recovery). It therefore **also fires when the learning
+  state is unknown or unreportable** — consistent with the rest of this gate,
+  which refuses what it cannot verify rather than assuming the safe answer.
+
+  Coverage is honest rather than uniform. mureo classifies reset triggers from
+  **first-party sources only**: Google Ads is complete (Google publishes the
+  causes as the `LEARNING_*` members of `BiddingStrategySystemStatus`), and no
+  other platform ships a trigger list in mureo core — Meta documents that
+  "significant edits" restart the phase without enumerating them, so every Meta
+  mutation is reported `unknown`, never `no_reset`. Only a `resets` verdict is
+  ever refused, so these two rules are effectively Google-Ads rules today; a
+  plugin can register its own platform's rules via
+  `mureo.policy.learning_rules.register_platform_learning_rules`.
+
+  The **learning state** is read locally, from
+  `bidding_details.bidding_strategy_system_status` on the campaign's STATE.json
+  snapshot (a policy gate runs on every tool call and must not make network
+  calls). Keep it fresh or the answer is `unknown` — which these rules treat as
+  "refuse", not as "fine".
+
 Absent section (or an unparseable value) ⇒ no enforcement for that rule
-(fail-open); mureo never blocks on a rule the operator did not write. When a
-mutation is refused, the agent receives the guardrail's reason verbatim and
-should surface it to the operator rather than retrying.
+(fail-open); mureo never blocks on a rule the operator did not write. A boolean
+rule accepts `true` / `yes` / `on` / `1`; anything else (including a typo) reads
+as off. When a mutation is refused, the agent receives the guardrail's reason
+verbatim and should surface it to the operator rather than retrying.
 
 ## STATE.json
 
@@ -290,7 +321,8 @@ should surface it to the operator rather than retrying.
           "campaign_name": "Brand Search - Tokyo",
           "status": "ENABLED",
           "bidding_strategy_type": "MAXIMIZE_CONVERSIONS",
-          "bidding_details": {"target_cpa": 5000},
+          "bidding_details": {"target_cpa": 5000,
+                              "bidding_strategy_system_status": "LEARNING_BUDGET_CHANGE"},
           "daily_budget": 8000.0,
           "campaign_goal": "Lead generation for SaaS trial signups",
           "notes": "Learning period ends ~April 5. Do not change bids."

--- a/mureo/mcp/server.py
+++ b/mureo/mcp/server.py
@@ -81,6 +81,10 @@ from mureo.mcp.tools_google_ads import TOOLS as GOOGLE_ADS_TOOLS
 from mureo.mcp.tools_google_ads import handle_tool as handle_google_ads_tool
 from mureo.mcp.tools_learning import TOOLS as LEARNING_TOOLS
 from mureo.mcp.tools_learning import handle_tool as handle_learning_tool
+from mureo.mcp.tools_learning_preflight import TOOLS as LEARNING_PREFLIGHT_TOOLS
+from mureo.mcp.tools_learning_preflight import (
+    handle_tool as handle_learning_preflight_tool,
+)
 from mureo.mcp.tools_meta_ads import TOOLS as META_ADS_TOOLS
 from mureo.mcp.tools_meta_ads import handle_tool as handle_meta_ads_tool
 from mureo.mcp.tools_mureo_context import TOOLS as MUREO_CONTEXT_TOOLS
@@ -135,6 +139,7 @@ _ALL_TOOLS: list[Tool] = [
     *MUREO_CONTEXT_TOOLS,
     *ANALYTICS_REGISTRY_TOOLS,
     *LEARNING_TOOLS,
+    *LEARNING_PREFLIGHT_TOOLS,
     *(CREATIVE_STUDIO_TOOLS if _CREATIVE_STUDIO_ENABLED else []),
 ]
 _GOOGLE_ADS_NAMES: frozenset[str] = (
@@ -151,6 +156,9 @@ _ANALYTICS_REGISTRY_NAMES: frozenset[str] = frozenset(
     t.name for t in ANALYTICS_REGISTRY_TOOLS
 )
 _LEARNING_NAMES: frozenset[str] = frozenset(t.name for t in LEARNING_TOOLS)
+_LEARNING_PREFLIGHT_NAMES: frozenset[str] = frozenset(
+    t.name for t in LEARNING_PREFLIGHT_TOOLS
+)
 _CREATIVE_STUDIO_NAMES: frozenset[str] = (
     frozenset(t.name for t in CREATIVE_STUDIO_TOOLS)
     if _CREATIVE_STUDIO_ENABLED
@@ -900,6 +908,41 @@ async def _capture_plugin_reversal(
     return None
 
 
+def _maybe_append_learning_reset_notice(
+    name: str, arguments: dict[str, Any], result: list[Any]
+) -> list[Any]:
+    """Append the #548 learning-period notice to a reset-triggering call.
+
+    Fires ONLY when :func:`mureo.policy.learning_reset.classify_change` says
+    the call restarts an automated bid strategy's learning period — a small,
+    evidence-backed set — so an ordinary read or a rename appends nothing. An
+    UNKNOWN verdict appends nothing either: it would fire on every mutation of
+    every platform mureo has no trigger list for, and a notice that always
+    fires is a notice nobody reads (the pre-flight tool still reports UNKNOWN
+    honestly when asked).
+
+    This runs AFTER the call, so for the call it rides on it is a record, not
+    a veto — MCP gives mureo no interposed confirmation step. What it buys is
+    the NEXT change in a troubleshooting sequence: the agent now knows the
+    campaign has just re-entered learning. The before-the-change surfaces are
+    ``mureo_learning_reset_preflight`` and the ``## Guardrails`` refusal.
+
+    Best-effort and never raises: a notice must not break a tool call.
+    """
+    try:
+        from mcp.types import TextContent
+
+        from mureo.policy.learning_reset import load_preflight, preflight_notice
+
+        notice = preflight_notice(load_preflight(name, arguments))
+        if notice is None:
+            return result
+        return [*result, TextContent(type="text", text=notice)]
+    except Exception:  # noqa: BLE001 — never let a notice break a tool call
+        logger.debug("learning-reset notice failed for %r", name, exc_info=True)
+        return result
+
+
 # Once-per-process latch: the stale-version banner is appended to the first
 # tool result that detects the mismatch, not every call (avoid spamming a
 # read-heavy daily-check). A fresh process after restart starts False again.
@@ -963,6 +1006,10 @@ async def handle_call_tool(name: str, arguments: dict[str, Any]) -> list[Any]:
     # rejected before it can reach a live campaign.
     _validate_tool_input(name, arguments)
     result = await _dispatch_tool(name, arguments)
+    # #548: a change that restarts an automated bid strategy's learning period
+    # says so in its own result, so the next change in a troubleshooting
+    # sequence is not made blind. No-op for everything else.
+    result = _maybe_append_learning_reset_notice(name, arguments, result)
     # Push, not pull: if this MCP process is older than the mureo installed on
     # disk (operator upgraded but did not fully restart Claude), append a
     # one-time restart warning so the agent surfaces it WITHOUT having to ask
@@ -1011,6 +1058,8 @@ async def _dispatch_tool(name: str, arguments: dict[str, Any]) -> list[Any]:
         return await handle_analytics_registry_tool(name, arguments)
     if name in _LEARNING_NAMES:
         return await handle_learning_tool(name, arguments)
+    if name in _LEARNING_PREFLIGHT_NAMES:
+        return await handle_learning_preflight_tool(name, arguments)
     if name in _CREATIVE_STUDIO_NAMES:
         return await handle_creative_studio_tool(name, arguments)
     if name in _PLUGIN_NAMES:

--- a/mureo/mcp/tools_learning_preflight.py
+++ b/mureo/mcp/tools_learning_preflight.py
@@ -1,0 +1,151 @@
+"""The ``mureo_learning_reset_preflight`` MCP tool (#548).
+
+The read-only, before-the-change surface of the learning-period pre-flight:
+given the tool the agent is *about* to call and the arguments it is about to
+pass, it answers the two questions the operator's confirmation step needs —
+is this change reset-triggering, and is the campaign already in a learning
+period — plus whether the operator's STRATEGY.md would refuse it.
+
+``would_block`` is computed by the exact function the gate uses
+(:func:`mureo.policy.learning_reset.learning_reset_denial`), so the pre-flight
+and the enforcement cannot drift into disagreeing.
+
+Every answer is explicit about not knowing. ``reset_risk`` is ``unknown`` for
+a platform mureo has no first-party trigger list for, and
+``learning_state.state`` is ``unknown`` / ``unreportable`` rather than
+``steady`` when nothing was observed — a false "safe" here would convert a
+missing warning into implied approval.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from mcp.types import TextContent, Tool
+
+from mureo.policy.learning_reset import learning_reset_denial, load_preflight
+from mureo.policy.learning_rules import registered_platforms
+from mureo.policy.strategy_gate import Guardrails, guardrails_from_strategy_text
+
+TOOL_NAME = "mureo_learning_reset_preflight"
+
+TOOLS: list[Tool] = [
+    Tool(
+        name=TOOL_NAME,
+        description=(
+            "Pre-flight a pending ad-platform change against the target "
+            "campaign's learning period. Read-only — it changes nothing and "
+            "calls no platform API. Returns (1) whether mureo classifies the "
+            "change as restarting an automated bid strategy's learning "
+            "period, with the first-party source that classification rests "
+            "on; (2) the campaign's current learning state as recorded in "
+            "STATE.json; (3) whether STRATEGY.md ## Guardrails "
+            "(block_learning_resets / "
+            "block_learning_resets_during_incident) would refuse it. Call "
+            "this BEFORE a bid-strategy, budget, conversion-setting, keyword "
+            "or re-enable change and show the operator the answer in your "
+            "confirmation step. reset_risk='unknown' and "
+            "learning_state.state='unknown'/'unreportable' mean mureo does "
+            "not know — they never mean safe."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "tool_name": {
+                    "type": "string",
+                    "description": (
+                        "The tool you are about to call, e.g. "
+                        "'google_ads_campaigns_update'."
+                    ),
+                },
+                "arguments": {
+                    "type": "object",
+                    "description": (
+                        "The arguments you are about to pass. Needed because "
+                        "one tool can be both: "
+                        "google_ads_campaigns_update resets learning when it "
+                        "carries bidding_strategy and does not when it only "
+                        "renames the campaign."
+                    ),
+                    "additionalProperties": True,
+                },
+                "campaign_id": {
+                    "type": "string",
+                    "description": (
+                        "Campaign whose learning state to look up. Optional "
+                        "when 'arguments' already carries campaign_id; supply "
+                        "it for tools keyed on something else (e.g. "
+                        "google_ads_budget_update takes a budget_id), "
+                        "otherwise the learning state is reported unknown."
+                    ),
+                },
+            },
+            "required": ["tool_name"],
+            "additionalProperties": False,
+        },
+    ),
+]
+
+_TOOL_NAMES: frozenset[str] = frozenset(t.name for t in TOOLS)
+
+
+def _guardrails() -> Guardrails:
+    """The operator's guardrails, read fresh. Fail-open (empty) on any error."""
+    from mureo.policy.strategy_gate import _resolve_strategy_path
+
+    try:
+        path = _resolve_strategy_path()
+        text = path.read_text(encoding="utf-8") if path.exists() else ""
+        return guardrails_from_strategy_text(text)
+    except Exception:  # noqa: BLE001 — a read-only pre-flight never fails hard
+        return Guardrails()
+
+
+async def _handle_preflight(arguments: dict[str, Any]) -> list[TextContent]:
+    tool_name = arguments.get("tool_name")
+    if not isinstance(tool_name, str) or not tool_name.strip():
+        raise ValueError("tool_name is required")
+    pending = arguments.get("arguments") or {}
+    if not isinstance(pending, dict):
+        raise ValueError("arguments must be an object")
+    campaign_id = arguments.get("campaign_id")
+
+    pre = load_preflight(
+        tool_name.strip(),
+        pending,
+        str(campaign_id) if isinstance(campaign_id, str) and campaign_id else None,
+    )
+    guardrails = _guardrails()
+    denial = learning_reset_denial(
+        pre,
+        block_all=guardrails.block_learning_resets,
+        block_during_incident=guardrails.block_learning_resets_during_incident,
+    )
+    payload: dict[str, Any] = pre.to_dict()
+    payload["guardrails"] = {
+        "block_learning_resets": guardrails.block_learning_resets,
+        "block_learning_resets_during_incident": (
+            guardrails.block_learning_resets_during_incident
+        ),
+    }
+    payload["would_block"] = denial is not None
+    payload["block_reason"] = denial
+    payload["platforms_with_learning_rules"] = list(registered_platforms())
+    return [TextContent(type="text", text=json.dumps(payload, ensure_ascii=False))]
+
+
+_HANDLERS: dict[str, Any] = {TOOL_NAME: _handle_preflight}
+
+
+async def handle_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
+    """Dispatch a learning-pre-flight tool call to its handler."""
+    if name not in _TOOL_NAMES:
+        raise ValueError(f"Unknown tool: {name}")
+    handler = _HANDLERS.get(name)
+    if handler is None:
+        raise ValueError(f"Unknown tool: {name}")
+    return await handler(arguments)  # type: ignore[no-any-return]
+
+
+__all__ = ["TOOLS", "TOOL_NAME", "handle_tool"]

--- a/mureo/mcp/tools_mureo_context.py
+++ b/mureo/mcp/tools_mureo_context.py
@@ -212,7 +212,20 @@ _CAMPAIGN_PROPERTY = {
             ),
         },
         "bidding_strategy_type": {"type": "string"},
-        "bidding_details": {"type": "object"},
+        "bidding_details": {
+            "type": "object",
+            "description": (
+                "Free-form bidding detail (e.g. {'target_cpa': 5000}). One "
+                "key is read by mureo: for Google Ads, "
+                "'bidding_strategy_system_status' — the value "
+                "google_ads_campaigns_get / google_ads_campaigns_diagnose "
+                "returns — is what the learning-period pre-flight "
+                "(mureo_learning_reset_preflight, and the "
+                "block_learning_resets* guardrails) uses to tell whether the "
+                "campaign is already re-learning. Without it that state is "
+                "reported 'unknown', never 'steady'."
+            ),
+        },
         "daily_budget": {"type": "number"},
         "device_targeting": {"type": "array"},
         "campaign_goal": {"type": "string"},

--- a/mureo/policy/learning_reset.py
+++ b/mureo/policy/learning_reset.py
@@ -1,0 +1,539 @@
+"""The learning-period reset pre-flight check (#548).
+
+The decision half of the feature; the per-platform facts and their sources
+live in :mod:`mureo.policy.learning_rules`. Three questions, answered
+separately so a missing answer to one cannot fake an answer to another:
+
+1. **Is the pending change reset-triggering?** — :func:`classify_change`,
+   pure, table-driven, argument-aware (a campaign rename and a bid-strategy
+   switch are the same tool).
+2. **Is the campaign in a learning period right now?** —
+   :func:`read_learning_state`, reading the platform's own status string out
+   of the STATE.json campaign snapshot. A gate runs on every tool call and
+   must not do network I/O, so this is deliberately a local read; when there
+   is nothing local to read it answers UNKNOWN, never STEADY.
+3. **Does the operator's STRATEGY.md refuse this?** —
+   :func:`learning_reset_denial`, which the one built-in
+   :class:`~mureo.policy.strategy_gate.StrategyPolicyGate` turns into a real
+   pre-dispatch refusal.
+
+What is enforced and what is only surfaced
+------------------------------------------
+MCP has no interposed confirmation step: mureo either runs a tool call or
+refuses it. So the three surfaces differ in strength, and the difference is
+deliberate rather than glossed:
+
+- **Refusal (hard).** Only when the operator wrote ``block_learning_resets``
+  or ``block_learning_resets_during_incident`` in STRATEGY.md
+  ``## Guardrails``. This runs before dispatch and blocks the call. The gate
+  stays fail-open by default: with no such rule, nothing is refused.
+- **Pre-flight tool (before the change).** ``mureo_learning_reset_preflight``
+  answers all three questions for a change the agent is *about* to make, so
+  the operator's confirmation step has the facts. It is a tool the agent has
+  to call — the SKILL requires it — so it is as strong as the agent's
+  compliance, which is exactly the weakness that made prose insufficient.
+- **Notice (after dispatch).** :func:`preflight_notice` is appended by the
+  dispatcher to the result of a reset-triggering call, so the *next* change
+  in a troubleshooting sequence is made with the reset already visible. This
+  is after the fact for the call it rides on, and is not a substitute for the
+  first two.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from mureo.core.strategy_reminder import is_mutating_builtin_tool
+from mureo.core.tool_names import is_read_only_tool_name
+from mureo.policy.learning_rules import (
+    Evidence,
+    LearningState,
+    PlatformLearningRules,
+    ResetRisk,
+    platform_learning_rules,
+    rules_for_tool,
+)
+
+logger = logging.getLogger(__name__)
+
+#: Tool-name prefixes mureo owns. For these, the pinned mutating-tool
+#: classifier in :mod:`mureo.core.strategy_reminder` is authoritative, so a
+#: name it does not recognise is a read rather than an unknown mutation.
+_BUILTIN_PREFIXES = ("google_ads_", "meta_ads_", "search_console_", "mureo_")
+
+#: The argument key a campaign-scoped mutation carries. Tools keyed on
+#: something else (``google_ads_budget_update`` takes a ``budget_id``) yield
+#: no campaign, hence an UNKNOWN learning state — which is the honest answer,
+#: not a defect to be papered over with a guess.
+_CAMPAIGN_ID_KEY = "campaign_id"
+
+
+@dataclass(frozen=True)
+class LearningReading:
+    """What mureo knows about one campaign's learning period right now."""
+
+    state: LearningState
+    detail: str
+    source: str
+    evidence: Evidence | None = None
+
+    def is_known_not_learning(self) -> bool:
+        """True only for a positively observed non-learning state.
+
+        UNKNOWN and UNREPORTABLE are both False on purpose: a caller asking
+        "is it safe to stack another reset?" must not read absence of evidence
+        as evidence of absence.
+        """
+        return self.state is LearningState.STEADY
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "state": str(self.state),
+            "detail": self.detail,
+            "source": self.source,
+            "evidence": _evidence_dict(self.evidence),
+        }
+
+
+@dataclass(frozen=True)
+class ChangeAssessment:
+    """Whether the pending change is in the reset-triggering class."""
+
+    platform: str
+    risk: ResetRisk
+    change_class: str
+    detail: str
+    evidence: Evidence | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "risk": str(self.risk),
+            "change_class": self.change_class,
+            "detail": self.detail,
+            "evidence": _evidence_dict(self.evidence),
+        }
+
+
+@dataclass(frozen=True)
+class LearningPreflight:
+    """The full pre-flight answer for one pending tool call."""
+
+    tool_name: str
+    platform: str
+    campaign_id: str | None
+    change: ChangeAssessment
+    learning: LearningReading
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "tool_name": self.tool_name,
+            "platform": self.platform,
+            "campaign_id": self.campaign_id,
+            "reset_risk": str(self.change.risk),
+            "change_class": self.change.change_class,
+            "reset_verdict": self.change.to_dict(),
+            "learning_state": self.learning.to_dict(),
+        }
+
+
+def _evidence_dict(evidence: Evidence | None) -> dict[str, str] | None:
+    if evidence is None:
+        return None
+    return {
+        "source": evidence.source,
+        "retrieved": evidence.retrieved,
+        "quote": evidence.quote,
+    }
+
+
+# ---------------------------------------------------------------------------
+# (b) Is the pending change reset-triggering?
+# ---------------------------------------------------------------------------
+
+
+def _is_mutation(tool_name: str) -> bool:
+    """Does ``tool_name`` change platform state?
+
+    Reads are the one answer that needs no per-platform evidence: a read
+    cannot restart a learning period on any platform. Getting this right is
+    what keeps the check quiet — a check that fires on ``campaigns_list`` is
+    a check that gets ignored.
+    """
+    if is_mutating_builtin_tool(tool_name):
+        return True
+    if tool_name.startswith(_BUILTIN_PREFIXES):
+        return False
+    return not is_read_only_tool_name(tool_name)
+
+
+def classify_change(tool_name: str, arguments: dict[str, Any]) -> ChangeAssessment:
+    """Classify ``tool_name(arguments)`` against the per-platform rules.
+
+    ``NO_RESET`` is returned only for a read, or for a mutation on a platform
+    whose trigger list mureo has first-party evidence is enumerable
+    (``triggers_are_enumerated``). Everything else is ``UNKNOWN`` — mureo does
+    not guess in either direction.
+    """
+    rules = rules_for_tool(tool_name)
+    platform = rules.platform if rules is not None else ""
+    if not _is_mutation(tool_name):
+        return ChangeAssessment(
+            platform=platform,
+            risk=ResetRisk.NO_RESET,
+            change_class="",
+            detail="Read-only call; it cannot restart a learning period.",
+        )
+    if rules is not None:
+        for trigger in rules.triggers:
+            if trigger.matches(tool_name, arguments):
+                return ChangeAssessment(
+                    platform=platform,
+                    risk=ResetRisk.RESETS,
+                    change_class=trigger.change_class,
+                    detail=(
+                        f"{tool_name} is a {trigger.change_class} on "
+                        f"{platform}, which restarts the learning period."
+                    ),
+                    evidence=trigger.evidence,
+                )
+        if rules.triggers_are_enumerated:
+            return ChangeAssessment(
+                platform=platform,
+                risk=ResetRisk.NO_RESET,
+                change_class="",
+                detail=(
+                    f"{tool_name} is not in mureo's evidence-backed list of "
+                    f"{platform} reset-triggering changes. {rules.notes}"
+                ),
+            )
+    return _unknown_change(tool_name, platform, rules)
+
+
+def _unknown_change(
+    tool_name: str, platform: str, rules: PlatformLearningRules | None
+) -> ChangeAssessment:
+    """The honest non-answer for a mutation mureo cannot classify."""
+    if rules is None:
+        detail = (
+            f"{tool_name} belongs to a platform mureo has no learning-period "
+            f"rules for, so mureo cannot say whether it restarts a learning "
+            f"period. This is 'unknown', not 'safe'. A plugin or bridge can "
+            f"register rules via "
+            f"mureo.policy.learning_rules.register_platform_learning_rules."
+        )
+    else:
+        detail = (
+            f"mureo has no first-party enumeration of {platform}'s "
+            f"reset-triggering changes, so {tool_name} is unclassified rather "
+            f"than assumed safe. {rules.notes}"
+        )
+    return ChangeAssessment(
+        platform=platform,
+        risk=ResetRisk.UNKNOWN,
+        change_class="",
+        detail=detail,
+        evidence=rules.unreportable_evidence if rules is not None else None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# (a) Is the campaign in a learning period right now?
+# ---------------------------------------------------------------------------
+
+
+def _snapshot_status(
+    platform: str, campaign_id: str, doc: Any, snapshot_key: str
+) -> str | None:
+    """The platform's own learning-status string from the STATE.json snapshot."""
+    platforms = getattr(doc, "platforms", None) or {}
+    entry = platforms.get(platform)
+    campaigns = tuple(getattr(entry, "campaigns", ()) if entry is not None else ())
+    if not campaigns:
+        campaigns = tuple(getattr(doc, "campaigns", ()) or ())
+    for snapshot in campaigns:
+        if str(getattr(snapshot, "campaign_id", "")) != str(campaign_id):
+            continue
+        details = getattr(snapshot, "bidding_details", None)
+        if isinstance(details, dict):
+            value = details.get(snapshot_key)
+            if isinstance(value, str):
+                return value
+        return None
+    return None
+
+
+def read_learning_state(
+    platform: str, campaign_id: str | None, doc: Any
+) -> LearningReading:
+    """Read ``platform``/``campaign_id``'s current learning state from ``doc``.
+
+    ``doc`` is a :class:`~mureo.context.models.StateDocument`. Local by
+    design — see the module docstring. Never returns STEADY on absence.
+    """
+    rules = platform_learning_rules(platform) if platform else None
+    if rules is None or rules.observation is None:
+        return _unreportable(platform, rules)
+    observation = rules.observation
+    source = (
+        f"STATE.json platforms.{platform}.campaigns[].bidding_details."
+        f"{observation.snapshot_key}"
+    )
+    if not campaign_id:
+        return LearningReading(
+            state=LearningState.UNKNOWN,
+            detail=(
+                "This call names no campaign_id, so mureo cannot look up the "
+                "campaign's learning state. Unknown, not steady."
+            ),
+            source=source,
+            evidence=observation.evidence,
+        )
+    raw = _snapshot_status(platform, campaign_id, doc, observation.snapshot_key)
+    if raw is None or not raw.strip():
+        return LearningReading(
+            state=LearningState.UNKNOWN,
+            detail=(
+                f"No {observation.snapshot_key} recorded for campaign "
+                f"{campaign_id} in STATE.json. Refresh it (sync-state / "
+                f"daily-check) to get a real answer; until then this is "
+                f"unknown, not steady."
+            ),
+            source=source,
+            evidence=observation.evidence,
+        )
+    return _classify_status(raw, observation, campaign_id, source)
+
+
+def _classify_status(
+    raw: str, observation: Any, campaign_id: str, source: str
+) -> LearningReading:
+    value = raw.strip().upper()
+    if value in observation.unknown_values:
+        state = LearningState.UNKNOWN
+    elif value in observation.unreportable_values:
+        state = LearningState.UNREPORTABLE
+    elif value in observation.learning_values or value.startswith(
+        observation.learning_prefixes or ()
+    ):
+        state = LearningState.LEARNING
+    else:
+        state = LearningState.STEADY
+    return LearningReading(
+        state=state,
+        detail=(
+            f"Campaign {campaign_id} last recorded "
+            f"{observation.snapshot_key}={raw.strip()} in STATE.json."
+        ),
+        source=source,
+        evidence=observation.evidence,
+    )
+
+
+def _unreportable(
+    platform: str, rules: PlatformLearningRules | None
+) -> LearningReading:
+    if rules is not None and rules.unreportable_detail:
+        detail = rules.unreportable_detail
+        evidence = rules.unreportable_evidence
+    else:
+        detail = (
+            f"mureo has no way to read the current learning state for "
+            f"{platform or 'this platform'}. Treat this as no answer, not as "
+            f"'not learning'."
+        )
+        evidence = None
+    return LearningReading(
+        state=LearningState.UNREPORTABLE,
+        detail=detail,
+        source="mureo.policy.learning_rules",
+        evidence=evidence,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Assembly
+# ---------------------------------------------------------------------------
+
+
+def campaign_id_from(arguments: dict[str, Any]) -> str | None:
+    """The campaign this call targets, when its arguments name one."""
+    value = arguments.get(_CAMPAIGN_ID_KEY)
+    return str(value) if isinstance(value, (str, int)) and str(value) else None
+
+
+def build_preflight(
+    tool_name: str,
+    arguments: dict[str, Any],
+    doc: Any,
+    campaign_id: str | None = None,
+) -> LearningPreflight:
+    """Answer all three pre-flight questions for one pending call. Pure."""
+    change = classify_change(tool_name, arguments)
+    resolved = campaign_id or campaign_id_from(arguments)
+    learning = read_learning_state(change.platform, resolved, doc)
+    return LearningPreflight(
+        tool_name=tool_name,
+        platform=change.platform,
+        campaign_id=resolved,
+        change=change,
+        learning=learning,
+    )
+
+
+# ---------------------------------------------------------------------------
+# (d) The hard refusal, and the soft notice
+# ---------------------------------------------------------------------------
+
+_DENY_PREAMBLE = (
+    "Refusing '{tool}': mureo classifies it as a learning-period reset "
+    "({change_class}) on {platform}. {change_detail}"
+)
+
+_DENY_EVIDENCE = ' Source: {source} (retrieved {retrieved}) — "{quote}"'
+
+
+def learning_reset_denial(
+    pre: LearningPreflight, *, block_all: bool, block_during_incident: bool
+) -> str | None:
+    """The operator-facing refusal reason, or ``None`` to allow.
+
+    ``block_all`` refuses every reset-triggering change.
+    ``block_during_incident`` refuses one only when the campaign is not
+    positively known to be out of a learning period — so it fires on
+    LEARNING (stacking a second reset on an unstable campaign) and equally on
+    UNKNOWN / UNREPORTABLE, matching the rest of this gate's discipline of
+    refusing what it cannot verify rather than assuming the safe answer.
+    """
+    if pre.change.risk is not ResetRisk.RESETS:
+        return None
+    if not (block_all or block_during_incident):
+        return None
+    if not block_all and pre.learning.is_known_not_learning():
+        return None
+    rule = (
+        "block_learning_resets"
+        if block_all
+        else "block_learning_resets_during_incident"
+    )
+    reason = _DENY_PREAMBLE.format(
+        tool=pre.tool_name,
+        change_class=pre.change.change_class,
+        platform=pre.platform or "this platform",
+        change_detail=pre.change.detail,
+    )
+    if pre.change.evidence is not None:
+        reason += _DENY_EVIDENCE.format(
+            source=pre.change.evidence.source,
+            retrieved=pre.change.evidence.retrieved,
+            quote=pre.change.evidence.quote,
+        )
+    reason += (
+        f" Current learning state: {pre.learning.state} — {pre.learning.detail}"
+        f" The STRATEGY.md Guardrails rule '{rule}' refuses this."
+    )
+    return reason
+
+
+def preflight_notice(pre: LearningPreflight) -> str | None:
+    """The dispatcher-appended notice for a reset-triggering call.
+
+    Fires only on :data:`ResetRisk.RESETS`. UNKNOWN deliberately does not
+    append a notice: it would fire on every mutation of every platform mureo
+    has no trigger list for, and a warning that always fires is a warning
+    nobody reads. The pre-flight tool still reports UNKNOWN honestly when
+    asked.
+    """
+    if pre.change.risk is not ResetRisk.RESETS:
+        return None
+    lines = [
+        "(LEARNING-PERIOD NOTICE: mureo classifies this call as a "
+        f"learning-period reset — {pre.change.change_class} on "
+        f"{pre.platform or 'this platform'}.",
+        f"  Why: {pre.change.detail}",
+    ]
+    if pre.change.evidence is not None:
+        lines.append(
+            f"  Source: {pre.change.evidence.source} "
+            f"(retrieved {pre.change.evidence.retrieved})"
+        )
+    lines.append(
+        f"  Learning state before this call: {pre.learning.state} — "
+        f"{pre.learning.detail}"
+    )
+    lines.append(
+        "  Surface this to the operator before the NEXT change: stacking "
+        "another reset while a campaign is re-learning delays recovery "
+        "instead of speeding it up. Call "
+        "mureo_learning_reset_preflight before the next change, and declare "
+        "block_learning_resets / block_learning_resets_during_incident in "
+        "STRATEGY.md ## Guardrails to make mureo refuse them outright.)"
+    )
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# I/O layer — the STATE.json read, TTL-cached like the guardrail read
+# ---------------------------------------------------------------------------
+
+_CACHE_TTL_SECONDS = 5.0
+_state_cache: dict[str, tuple[float, Any]] = {}
+
+
+def _state_path() -> Path:
+    try:
+        from mureo.core.runtime_context import get_runtime_context
+
+        store = get_runtime_context().state_store
+        state_path = getattr(store, "state_path", None)
+        if state_path is not None:
+            return Path(state_path)
+    except Exception:  # noqa: BLE001 — never let resolution break dispatch
+        logger.debug("learning pre-flight: could not resolve STATE.json", exc_info=True)
+    return Path.cwd() / "STATE.json"
+
+
+def load_state_document() -> Any:
+    """Read STATE.json (TTL-cached). Returns an empty document on any error."""
+    from mureo.context.models import StateDocument
+
+    path = _state_path()
+    key = str(path)
+    now = time.monotonic()
+    cached = _state_cache.get(key)
+    if cached is not None and (now - cached[0]) < _CACHE_TTL_SECONDS:
+        return cached[1]
+    try:
+        from mureo.context.state import read_state_file
+
+        doc = read_state_file(path) if path.exists() else StateDocument()
+    except Exception:  # noqa: BLE001 — a pre-flight must never take mureo down
+        logger.debug("learning pre-flight: could not read STATE.json", exc_info=True)
+        doc = StateDocument()
+    _state_cache[key] = (now, doc)
+    return doc
+
+
+def load_preflight(
+    tool_name: str, arguments: dict[str, Any], campaign_id: str | None = None
+) -> LearningPreflight:
+    """:func:`build_preflight` against the workspace's STATE.json."""
+    return build_preflight(tool_name, arguments, load_state_document(), campaign_id)
+
+
+__all__ = [
+    "ChangeAssessment",
+    "LearningPreflight",
+    "LearningReading",
+    "build_preflight",
+    "campaign_id_from",
+    "classify_change",
+    "learning_reset_denial",
+    "load_preflight",
+    "load_state_document",
+    "preflight_notice",
+    "read_learning_state",
+]

--- a/mureo/policy/learning_reset.py
+++ b/mureo/policy/learning_reset.py
@@ -194,9 +194,16 @@ def classify_change(tool_name: str, arguments: dict[str, Any]) -> ChangeAssessme
                     platform=platform,
                     risk=ResetRisk.RESETS,
                     change_class=trigger.change_class,
+                    # The caveats travel with the RESETS verdict, not only
+                    # with NO_RESET. The operator who is *blocked* by a false
+                    # positive is the one person who needs to know the
+                    # classification has known blind spots; putting the note
+                    # only on the quiet path is honesty filed where nobody
+                    # reads it.
                     detail=(
                         f"{tool_name} is a {trigger.change_class} on "
-                        f"{platform}, which restarts the learning period."
+                        f"{platform}, which restarts the learning period. "
+                        f"Known limits of this classification: {rules.notes}"
                     ),
                     evidence=trigger.evidence,
                 )
@@ -401,19 +408,37 @@ def learning_reset_denial(
 ) -> str | None:
     """The operator-facing refusal reason, or ``None`` to allow.
 
-    ``block_all`` refuses every reset-triggering change.
-    ``block_during_incident`` refuses one only when the campaign is not
-    positively known to be out of a learning period — so it fires on
-    LEARNING (stacking a second reset on an unstable campaign) and equally on
-    UNKNOWN / UNREPORTABLE, matching the rest of this gate's discipline of
-    refusing what it cannot verify rather than assuming the safe answer.
+    ``block_all`` refuses every reset-triggering change, whatever the state
+    and whether or not a campaign can be identified. It is a freeze, and it
+    is honestly blunt.
+
+    ``block_during_incident`` is narrower by name and must be narrower in
+    fact: "during incident" names *a specific campaign that is known to be
+    unstable*. So it refuses only when
+
+    1. this call identifies a campaign at all, and
+    2. that campaign is not positively known to be out of a learning period.
+
+    (2) is fail-closed on purpose — UNKNOWN is refused, not assumed steady —
+    but (1) is what keeps that from degenerating. Several reset-triggering
+    tools are not campaign-scoped (``google_ads_conversions_*`` is
+    account-level; ``google_ads_budget_update`` is keyed on a ``budget_id``),
+    so their campaign is always unresolvable and their state always UNKNOWN.
+    Without (1) this rule would refuse every one of those calls forever, with
+    no relation to any incident or any campaign — the operator who followed
+    mureo's own advice to declare it would find conversion actions
+    permanently un-editable, and would turn the feature off. A rule with no
+    subject has nothing to refuse.
     """
     if pre.change.risk is not ResetRisk.RESETS:
         return None
     if not (block_all or block_during_incident):
         return None
-    if not block_all and pre.learning.is_known_not_learning():
-        return None
+    if not block_all:
+        if pre.campaign_id is None:
+            return None
+        if pre.learning.is_known_not_learning():
+            return None
     rule = (
         "block_learning_resets"
         if block_all

--- a/mureo/policy/learning_rules.py
+++ b/mureo/policy/learning_rules.py
@@ -1,0 +1,414 @@
+"""Per-platform learning-period rules, and where each one comes from (#548).
+
+Every automated-bidding system has a learning period, and a change that
+restarts it costs days of delivery. mureo used to carry that as prose in
+``_mureo-shared/SKILL.md`` — "warn before changes that reset the learning
+period" — which is advice to a model, not a check. This module is the data
+half of the check: what *counts* as a reset-triggering change on each
+platform, and how mureo can observe whether a campaign is in a learning
+period right now.
+
+Evidence, not folklore
+----------------------
+"Which changes reset learning" is a per-platform fact that changes over
+time, so every entry here carries an :class:`Evidence` record naming the
+**first-party** source it was read from (platform help / API reference), the
+date it was retrieved, and the sentence it rests on. Nothing is listed on
+recollection: where mureo has no first-party enumeration, the platform is
+marked ``triggers_are_enumerated=False`` and every mutation on it is
+classified :data:`ResetRisk.UNKNOWN` rather than guessed either way. A false
+"this resets nothing" is worse than no answer, because it turns a missing
+warning into implied approval.
+
+The same discipline applies to the *state* read. A platform mureo cannot ask
+"are you learning right now?" reports :data:`LearningState.UNREPORTABLE`, and
+a platform it can ask but has no observation for reports
+:data:`LearningState.UNKNOWN`. Neither is ``STEADY``.
+
+Where mureo reads the state from
+--------------------------------
+A :class:`~mureo.core.policy.PolicyGate` runs on every tool call and must be
+pure and fast, so the pre-flight cannot make a network call to ask the
+platform. It reads what mureo already has locally: the campaign snapshot in
+STATE.json, written by the operator's sync/daily-check workflow through
+``mureo_state_upsert_campaign``. :class:`StateObservation` names the
+``bidding_details`` key that carries the platform's own status string and how
+to read its values.
+
+Plugins and bridges
+-------------------
+Third-party platforms register their own rules through
+:func:`register_platform_learning_rules`, the same shape the built-ins use
+and the same registry pattern as
+:func:`mureo.policy.declarations.register_budget_declaration`. mureo core
+ships rules only for the platforms it can source first-party evidence for;
+everything else is honestly unknown until its plugin says otherwise.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass, field
+from enum import Enum
+
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:  # pragma: no cover - exercised on 3.10 only
+
+    class StrEnum(str, Enum):
+        """Minimal 3.10 shim, mirroring
+        :class:`mureo.core.providers.capabilities.StrEnum`."""
+
+        def __str__(self) -> str:
+            return str(self._value_)
+
+
+class LearningState(StrEnum):
+    """What mureo knows about a campaign's current learning period."""
+
+    #: The platform (or mureo's local snapshot of it) reports an active
+    #: learning / adjustment period.
+    LEARNING = "learning"
+    #: The platform reports a non-learning status.
+    STEADY = "steady"
+    #: mureo *can* read this platform's learning state, but has no
+    #: observation for this campaign. Not "safe".
+    UNKNOWN = "unknown"
+    #: mureo has no way to read this platform's learning state at all.
+    #: Not "safe" either — see the module docstring.
+    UNREPORTABLE = "unreportable"
+
+
+class ResetRisk(StrEnum):
+    """Whether the pending change is in the reset-triggering class."""
+
+    RESETS = "resets"
+    NO_RESET = "no_reset"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class Evidence:
+    """Where a rule in this module comes from.
+
+    ``source`` is a first-party URL (the platform's own API reference or help
+    centre). ``retrieved`` is the ISO date it was read. ``quote`` is the
+    sentence the rule rests on, kept verbatim so a reviewer can check the
+    rule against the source without re-deriving it.
+    """
+
+    source: str
+    retrieved: str
+    quote: str
+
+
+@dataclass(frozen=True)
+class ResetTrigger:
+    """One class of change that restarts a platform's learning period.
+
+    ``tools`` are the exact mureo tool names that perform the change.
+    ``requires_arguments`` narrows the match to calls that actually carry the
+    field: ``google_ads_campaigns_update`` resets learning when it changes the
+    bidding strategy and does not when it only renames the campaign, and the
+    two are the same tool. ``argument_equals`` narrows further to a specific
+    value (re-enabling a campaign restarts learning; pausing it does not).
+    """
+
+    change_class: str
+    tools: frozenset[str]
+    evidence: Evidence
+    requires_arguments: frozenset[str] = frozenset()
+    argument_equals: tuple[str, frozenset[str]] | None = None
+
+    def matches(self, tool_name: str, arguments: dict[str, object]) -> bool:
+        """Does this trigger apply to ``tool_name(arguments)``?"""
+        if tool_name not in self.tools:
+            return False
+        if self.requires_arguments and not any(
+            arguments.get(key) is not None for key in self.requires_arguments
+        ):
+            return False
+        if self.argument_equals is not None:
+            key, accepted = self.argument_equals
+            value = arguments.get(key)
+            if not isinstance(value, str) or value.upper() not in accepted:
+                return False
+        return True
+
+
+@dataclass(frozen=True)
+class StateObservation:
+    """How mureo reads one platform's learning state out of STATE.json.
+
+    ``snapshot_key`` is the key inside ``CampaignSnapshot.bidding_details``
+    that carries the platform's own status string. The three value sets are
+    matched case-insensitively in order: learning, unreportable, unknown;
+    anything else that is a non-empty string counts as steady.
+    """
+
+    snapshot_key: str
+    learning_values: frozenset[str]
+    evidence: Evidence
+    unreportable_values: frozenset[str] = frozenset()
+    unknown_values: frozenset[str] = frozenset()
+    learning_prefixes: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class PlatformLearningRules:
+    """Everything mureo knows about one platform's learning period.
+
+    ``tool_prefix`` is how a tool name is attributed to this platform.
+    ``triggers_are_enumerated`` is the honesty switch: ``True`` means the
+    trigger list below is complete enough that a mutation *absent* from it can
+    be reported as :data:`ResetRisk.NO_RESET`; ``False`` means mureo has no
+    first-party enumeration for this platform, so every mutation on it is
+    :data:`ResetRisk.UNKNOWN`.
+    """
+
+    platform: str
+    tool_prefix: str
+    observation: StateObservation | None
+    triggers: tuple[ResetTrigger, ...]
+    triggers_are_enumerated: bool
+    notes: str
+    #: Named when the platform HAS a learning-state concept mureo cannot read.
+    #: Surfaced verbatim so "unreportable" says *why*, and names the field a
+    #: future contributor would have to plumb through.
+    unreportable_detail: str = ""
+    unreportable_evidence: Evidence | None = field(default=None)
+
+
+# ---------------------------------------------------------------------------
+# Google Ads
+# ---------------------------------------------------------------------------
+
+#: Google publishes the reset causes as an ENUM, not as prose: every
+#: ``LEARNING_*`` member of ``BiddingStrategySystemStatus`` names the change
+#: class that caused the strategy to re-enter learning. That makes the enum
+#: both the state read AND the trigger list, from one first-party source —
+#: and the exact enum ships inside the ``google-ads`` client this repo already
+#: depends on (``google.ads.googleads.v23.enums.types
+#: .bidding_strategy_system_status``), so the quotes below are checkable
+#: offline.
+_GOOGLE_ENUM_URL = (
+    "https://developers.google.com/google-ads/api/reference/rpc/v23/"
+    "BiddingStrategySystemStatusEnum.BiddingStrategySystemStatus"
+)
+_GOOGLE_RETRIEVED = "2026-08-07"
+
+
+def _google_evidence(quote: str) -> Evidence:
+    return Evidence(source=_GOOGLE_ENUM_URL, retrieved=_GOOGLE_RETRIEVED, quote=quote)
+
+
+GOOGLE_ADS_RULES = PlatformLearningRules(
+    platform="google_ads",
+    tool_prefix="google_ads_",
+    observation=StateObservation(
+        snapshot_key="bidding_strategy_system_status",
+        learning_values=frozenset({"MULTIPLE_LEARNING"}),
+        learning_prefixes=("LEARNING_",),
+        unreportable_values=frozenset({"UNAVAILABLE"}),
+        unknown_values=frozenset({"UNKNOWN", "UNSPECIFIED", ""}),
+        evidence=_google_evidence(
+            "UNAVAILABLE: This bid strategy currently does not support status "
+            "reporting."
+        ),
+    ),
+    triggers=(
+        ResetTrigger(
+            change_class="bidding_strategy_change",
+            tools=frozenset({"google_ads_campaigns_update"}),
+            requires_arguments=frozenset({"bidding_strategy"}),
+            evidence=_google_evidence(
+                "LEARNING_SETTING_CHANGE: The bid strategy is learning because "
+                "of a recent setting change."
+            ),
+        ),
+        ResetTrigger(
+            change_class="budget_change",
+            tools=frozenset({"google_ads_budget_update"}),
+            evidence=_google_evidence(
+                "LEARNING_BUDGET_CHANGE: The bid strategy is learning because "
+                "of a recent budget change."
+            ),
+        ),
+        ResetTrigger(
+            change_class="composition_change",
+            tools=frozenset(
+                {
+                    "google_ads_keywords_add",
+                    "google_ads_keywords_remove",
+                    "google_ads_ad_groups_create",
+                }
+            ),
+            evidence=_google_evidence(
+                "LEARNING_COMPOSITION_CHANGE: The bid strategy is learning "
+                "because of recent change in number of campaigns, ad groups or "
+                "keywords attached to it."
+            ),
+        ),
+        ResetTrigger(
+            change_class="conversion_settings_change",
+            tools=frozenset(
+                {
+                    "google_ads_conversions_create",
+                    "google_ads_conversions_update",
+                    "google_ads_conversions_remove",
+                }
+            ),
+            evidence=_google_evidence(
+                "LEARNING_CONVERSION_SETTING_CHANGE: The bid strategy depends "
+                "on conversion reporting and the customer recently changed "
+                "their conversion settings."
+            ),
+        ),
+        ResetTrigger(
+            change_class="reactivation",
+            tools=frozenset({"google_ads_campaigns_update_status"}),
+            argument_equals=("status", frozenset({"ENABLED"})),
+            evidence=_google_evidence(
+                "LEARNING_NEW: The bid strategy is learning because it has been "
+                "recently created or recently reactivated."
+            ),
+        ),
+    ),
+    triggers_are_enumerated=True,
+    notes=(
+        "Trigger classes are Google's own LEARNING_* enum members, mapped to "
+        "the mureo tools that perform each change. Two limits are deliberate "
+        "and not papered over: (1) LEARNING_SETTING_CHANGE says 'a recent "
+        "setting change' without enumerating which settings, so mureo maps it "
+        "only to the bidding-strategy field it can see in a tool argument — a "
+        "campaign setting changed through another tool is not classified; "
+        "(2) LEARNING_BUDGET_CHANGE names no magnitude threshold, so mureo "
+        "applies none (the '>20%' figure the old SKILL prose used has no "
+        "first-party source). Only campaigns on an automated bid strategy have "
+        "a bid strategy to reset; mureo does not consult the campaign's "
+        "strategy type before classifying, so a budget change on a manual-CPC "
+        "campaign is reported as reset-triggering when it is not."
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# Meta Ads
+# ---------------------------------------------------------------------------
+
+_META_LEARNING_STAGE_URL = (
+    "https://developers.facebook.com/docs/marketing-api/reference/"
+    "ad-campaign-learning-stage-info/"
+)
+
+META_ADS_RULES = PlatformLearningRules(
+    platform="meta_ads",
+    tool_prefix="meta_ads_",
+    # Meta exposes the state, mureo does not read it — see below.
+    observation=None,
+    triggers=(),
+    triggers_are_enumerated=False,
+    unreportable_detail=(
+        "Meta reports an ad set's learning phase in the Marketing API field "
+        "learning_stage_info (status: LEARNING / SUCCESS / FAIL). mureo does "
+        "not read it: the field lives on the AD SET node while mureo's "
+        "STATE.json snapshot is campaign-level, and mureo's Meta client does "
+        "not request the field today. So mureo reports 'unreportable' rather "
+        "than implying a Meta ad set is out of learning."
+    ),
+    unreportable_evidence=Evidence(
+        source=_META_LEARNING_STAGE_URL,
+        retrieved="2026-08-07",
+        quote=(
+            "status: Learning Phase progress for the ad set. Values: LEARNING "
+            "- The ad set is still learning. SUCCESS - The ad set exited the "
+            "learning phase. FAIL - The ad set isn't generating enough results "
+            "to exit the learning phase."
+        ),
+    ),
+    notes=(
+        "Meta's own reference states that 'Significant edits cause ad sets to "
+        "reenter the learning phase' and exposes last_sig_edit_ts, but does "
+        "not enumerate which edits are significant, and the Business Help "
+        "Centre article that does is not machine-readable. mureo therefore "
+        "ships NO Meta trigger list and classifies every Meta mutation as "
+        "unknown rather than inventing one. The same reference documents that "
+        "learning_stage_info is returned only for active ad sets, never for "
+        "Dynamic Creative ad sets, and not for every ad account — so even a "
+        "future reader would have honest gaps to report."
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+_BUILTIN_RULES: tuple[PlatformLearningRules, ...] = (GOOGLE_ADS_RULES, META_ADS_RULES)
+
+_RULES: dict[str, PlatformLearningRules] = {r.platform: r for r in _BUILTIN_RULES}
+
+
+def register_platform_learning_rules(rules: PlatformLearningRules) -> None:
+    """Register (or replace) one platform's learning rules.
+
+    The hook a bridge or plugin uses to advertise learning-period support for
+    a platform mureo core knows nothing about, mirroring
+    :func:`mureo.policy.declarations.register_budget_declaration`. A plugin
+    that registers rules with ``triggers_are_enumerated=False`` still helps:
+    its mutations become "unknown" for a *named* platform instead of an
+    anonymous one.
+    """
+    if not rules.platform:
+        raise ValueError("platform learning rules need a non-empty platform key")
+    if not rules.tool_prefix:
+        raise ValueError("platform learning rules need a non-empty tool_prefix")
+    _RULES[rules.platform] = rules
+
+
+def reset_platform_learning_rules() -> None:
+    """Restore the built-in registry. Intended for tests."""
+    _RULES.clear()
+    _RULES.update({r.platform: r for r in _BUILTIN_RULES})
+
+
+def platform_learning_rules(platform: str) -> PlatformLearningRules | None:
+    """Return the registered rules for ``platform``, or ``None``."""
+    return _RULES.get(platform)
+
+
+def rules_for_tool(tool_name: str) -> PlatformLearningRules | None:
+    """Return the rules whose ``tool_prefix`` claims ``tool_name``.
+
+    Longest prefix wins, so a plugin registering a more specific prefix than
+    an existing one is not shadowed by it.
+    """
+    best: PlatformLearningRules | None = None
+    for rules in _RULES.values():
+        if not tool_name.startswith(rules.tool_prefix):
+            continue
+        if best is None or len(rules.tool_prefix) > len(best.tool_prefix):
+            best = rules
+    return best
+
+
+def registered_platforms() -> tuple[str, ...]:
+    """Every platform key with registered learning rules, sorted."""
+    return tuple(sorted(_RULES))
+
+
+__all__ = [
+    "Evidence",
+    "GOOGLE_ADS_RULES",
+    "LearningState",
+    "META_ADS_RULES",
+    "PlatformLearningRules",
+    "ResetRisk",
+    "ResetTrigger",
+    "StateObservation",
+    "platform_learning_rules",
+    "register_platform_learning_rules",
+    "registered_platforms",
+    "reset_platform_learning_rules",
+    "rules_for_tool",
+]

--- a/mureo/policy/learning_rules.py
+++ b/mureo/policy/learning_rules.py
@@ -249,13 +249,43 @@ GOOGLE_ADS_RULES = PlatformLearningRules(
                 "keywords attached to it."
             ),
         ),
+        # Google exposes TWO conversion causes, and mapping them to separate
+        # triggers is what keeps a cosmetic edit out of the reset class.
+        # Adding or archiving an action changes the set of conversion TYPES;
+        # editing an existing action changes its SETTINGS — but only for the
+        # fields that are settings. ``google_ads_conversions_update`` also
+        # renames, and a rename resets nothing, so the settings trigger names
+        # the fields it needs (same discipline as
+        # ``google_ads_campaigns_update``, where a rename is NO_RESET).
         ResetTrigger(
-            change_class="conversion_settings_change",
+            change_class="conversion_type_change",
             tools=frozenset(
                 {
                     "google_ads_conversions_create",
-                    "google_ads_conversions_update",
                     "google_ads_conversions_remove",
+                }
+            ),
+            evidence=_google_evidence(
+                "LEARNING_CONVERSION_TYPE_CHANGE: The bid strategy depends on "
+                "conversion reporting and the customer recently modified "
+                "conversion types that were relevant to the bid strategy."
+            ),
+        ),
+        ResetTrigger(
+            change_class="conversion_settings_change",
+            tools=frozenset({"google_ads_conversions_update"}),
+            # Every updatable field of google_ads_conversions_update EXCEPT
+            # ``name``. ``status`` belongs here: HIDDEN / REMOVED / ENABLED
+            # decides whether the action counts toward "Conversions", which is
+            # the reporting the bid strategy depends on.
+            requires_arguments=frozenset(
+                {
+                    "category",
+                    "status",
+                    "default_value",
+                    "always_use_default_value",
+                    "click_through_lookback_window_days",
+                    "view_through_lookback_window_days",
                 }
             ),
             evidence=_google_evidence(
@@ -277,17 +307,19 @@ GOOGLE_ADS_RULES = PlatformLearningRules(
     triggers_are_enumerated=True,
     notes=(
         "Trigger classes are Google's own LEARNING_* enum members, mapped to "
-        "the mureo tools that perform each change. Two limits are deliberate "
-        "and not papered over: (1) LEARNING_SETTING_CHANGE says 'a recent "
-        "setting change' without enumerating which settings, so mureo maps it "
-        "only to the bidding-strategy field it can see in a tool argument — a "
-        "campaign setting changed through another tool is not classified; "
-        "(2) LEARNING_BUDGET_CHANGE names no magnitude threshold, so mureo "
-        "applies none (the '>20%' figure the old SKILL prose used has no "
-        "first-party source). Only campaigns on an automated bid strategy have "
-        "a bid strategy to reset; mureo does not consult the campaign's "
-        "strategy type before classifying, so a budget change on a manual-CPC "
-        "campaign is reported as reset-triggering when it is not."
+        "the mureo tools that perform each change. Three known limits, stated "
+        "so a verdict is never read as more than it is: (1) only a campaign on "
+        "an AUTOMATED bid strategy has a learning period to reset, and mureo "
+        "does not consult the campaign's strategy type before classifying — so "
+        "budget_change, composition_change AND reactivation are all "
+        "over-reported on a manual-CPC campaign; (2) LEARNING_BUDGET_CHANGE "
+        "names no magnitude threshold, so mureo applies none (the '>20%' "
+        "figure the old SKILL prose used has no first-party source); "
+        "(3) LEARNING_SETTING_CHANGE says 'a recent setting change' without "
+        "enumerating which settings, so mureo maps only the bidding-strategy "
+        "field it can see in a tool argument — a campaign setting changed "
+        "through another tool is not classified at all, which is an "
+        "under-report rather than an over-report."
     ),
 )
 

--- a/mureo/policy/strategy_gate.py
+++ b/mureo/policy/strategy_gate.py
@@ -118,6 +118,16 @@ from mureo.policy.declarations import (
     reset_bid_declarations,
     reset_budget_declarations,
 )
+
+# The learning-period pre-flight (#548) — "is this change reset-triggering,
+# and is the campaign already learning?". Its own module because the
+# per-platform facts it rests on carry provenance and change over time; this
+# module only turns its answer into a refusal.
+from mureo.policy.learning_reset import (
+    LearningPreflight,
+    learning_reset_denial,
+    load_preflight,
+)
 from mureo.policy.pattern_scan import (
     SCAN_EXHAUSTED_NODES,
     has_pattern_fallback,
@@ -136,7 +146,10 @@ logger = logging.getLogger(__name__)
 __all__ = [
     "GUARDRAILS_HEADING",
     "Guardrails",
+    "LearningPreflight",
     "StrategyPolicyGate",
+    "learning_reset_denial",
+    "load_preflight",
     "evaluate_guardrails",
     "guardrails_from_strategy_text",
     "parse_guardrails",
@@ -236,6 +249,15 @@ class Guardrails:
     max_bid_amount_per_ad_set: float | None = None
     max_cpc_bid_per_ad_group: float | None = None
     blocked_operations: frozenset[str] = field(default_factory=frozenset)
+    #: Learning-period reset refusals (#548). ``block_learning_resets``
+    #: refuses every change mureo classifies as restarting an automated bid
+    #: strategy's learning period. ``block_learning_resets_during_incident``
+    #: refuses one only when the campaign is not positively known to be out
+    #: of a learning period — the "stop stacking resets on an unstable
+    #: campaign" rule, which therefore also fires when the state is unknown.
+    #: Both default off, so the gate stays fail-open.
+    block_learning_resets: bool = False
+    block_learning_resets_during_incident: bool = False
 
     def is_empty(self) -> bool:
         return (
@@ -246,6 +268,8 @@ class Guardrails:
             and self.max_bid_amount_per_ad_set is None
             and self.max_cpc_bid_per_ad_group is None
             and not self.blocked_operations
+            and not self.block_learning_resets
+            and not self.block_learning_resets_during_incident
         )
 
 
@@ -254,6 +278,16 @@ def _to_float(value: str) -> float | None:
         return float(value.replace(",", "").replace("_", "").strip())
     except (ValueError, AttributeError):
         return None
+
+
+#: Accepted spellings of "on" for a boolean guardrail. Anything else — including
+#: a typo — reads as OFF, matching the numeric rules' "a malformed value drops
+#: that one rule" behaviour rather than silently enabling a refusal.
+_TRUE_WORDS = frozenset({"true", "yes", "on", "1"})
+
+
+def _to_bool(value: str) -> bool:
+    return value.strip().lower() in _TRUE_WORDS
 
 
 def parse_guardrails(content: str) -> Guardrails:
@@ -270,6 +304,8 @@ def parse_guardrails(content: str) -> Guardrails:
     max_bid_amount: float | None = None
     max_cpc_bid: float | None = None
     blocked: set[str] = set()
+    block_resets = False
+    block_resets_incident = False
 
     for line in content.splitlines():
         m = _BULLET_RE.match(line)
@@ -291,6 +327,10 @@ def parse_guardrails(content: str) -> Guardrails:
             max_cpc_bid = _to_float(raw)
         elif key == "blocked_operations":
             blocked = {op.strip() for op in raw.split(",") if op.strip()}
+        elif key == "block_learning_resets":
+            block_resets = _to_bool(raw)
+        elif key == "block_learning_resets_during_incident":
+            block_resets_incident = _to_bool(raw)
 
     return Guardrails(
         max_daily_budget_per_campaign=max_per_campaign,
@@ -300,6 +340,8 @@ def parse_guardrails(content: str) -> Guardrails:
         max_bid_amount_per_ad_set=max_bid_amount,
         max_cpc_bid_per_ad_group=max_cpc_bid,
         blocked_operations=frozenset(blocked),
+        block_learning_resets=block_resets,
+        block_learning_resets_during_incident=block_resets_incident,
     )
 
 
@@ -322,6 +364,7 @@ def evaluate_guardrails(
     budget_declaration: BudgetDeclaration | None = None,
     bid_declaration: BidDeclaration | None = None,
     pattern_fallback: bool = False,
+    learning: LearningPreflight | None = None,
 ) -> PolicyDecision:
     """Pure decision: does ``tool_name(arguments)`` violate ``guardrails``?
 
@@ -354,9 +397,24 @@ def evaluate_guardrails(
     runs and the larger figure wins. Per-family, so declaring a budget does not
     switch the bid fallback off (or vice versa). Default ``False`` ⇒ every
     existing caller is byte-identical.
+
+    ``learning`` (#548) is the pre-flight answer for this call — is the change
+    reset-triggering, and is the campaign already in a learning period. Only
+    the two ``block_learning_resets*`` rules consult it, and omitting it (the
+    pure-layer default) simply means no learning refusal: this function stays
+    I/O-free, and the STATE.json reading is done by the gate below.
     """
     if guardrails.is_empty():
         return PolicyDecision(allowed=True)
+
+    if learning is not None:
+        learning_reason = learning_reset_denial(
+            learning,
+            block_all=guardrails.block_learning_resets,
+            block_during_incident=guardrails.block_learning_resets_during_incident,
+        )
+        if learning_reason is not None:
+            return PolicyDecision(allowed=False, reason=learning_reason)
 
     if tool_name in guardrails.blocked_operations:
         return PolicyDecision(
@@ -572,12 +630,30 @@ class StrategyPolicyGate:
     by default; abstains (allows) whenever no guardrail applies.
     """
 
+    @staticmethod
+    def _learning_preflight(
+        tool_name: str, arguments: dict[str, Any], guardrails: Guardrails
+    ) -> LearningPreflight | None:
+        """The #548 pre-flight reading, or ``None`` when nothing needs it.
+
+        Skipped entirely unless the operator declared one of the two learning
+        rules, so an operator who wrote no such rule pays neither the
+        STATE.json read nor any behaviour change.
+        """
+        if not (
+            guardrails.block_learning_resets
+            or guardrails.block_learning_resets_during_incident
+        ):
+            return None
+        return load_preflight(tool_name, arguments)
+
     def evaluate(self, tool_name: str, arguments: dict[str, Any]) -> PolicyDecision:
         try:
+            guardrails = _load_guardrails()
             return evaluate_guardrails(
                 tool_name,
                 arguments,
-                _load_guardrails(),
+                guardrails,
                 # #414: a plugin tool that declared its budget keys is now
                 # enforced by THIS gate — no hand-rolled per-plugin gate.
                 budget_declaration=budget_declaration_for(tool_name),
@@ -588,6 +664,11 @@ class StrategyPolicyGate:
                 # surface cannot) falls back to the best-effort key-shape scan
                 # rather than to no enforcement at all.
                 pattern_fallback=has_pattern_fallback(tool_name),
+                # #548: the learning-period pre-flight. Read (from STATE.json,
+                # TTL-cached — no network, this runs on every call) only when
+                # the operator actually wrote one of the two rules, so the
+                # default path costs nothing.
+                learning=self._learning_preflight(tool_name, arguments, guardrails),
             )
         except Exception:  # noqa: BLE001 — abstain on any unexpected error
             logger.debug("StrategyPolicyGate: abstaining on error", exc_info=True)

--- a/skills/_mureo-shared/SKILL.md
+++ b/skills/_mureo-shared/SKILL.md
@@ -253,12 +253,54 @@ When adding or removing large numbers of keywords:
 - Show progress after each batch
 - Allow the user to stop between batches
 
-### 6. Learning Period Awareness
+### 6. Learning Period Awareness (mechanised — call the pre-flight tool)
 
-For Google Ads campaigns using smart bidding:
-- Warn before making changes that reset the learning period
-- Affected operations: bidding strategy changes, budget changes > 20%, conversion setting changes
-- Display the current bidding system status if available
+This used to be prose telling you to "warn before changes that reset the
+learning period". It is now a real check, because the rule was least likely to
+be followed exactly when it mattered most: troubleshooting a broken campaign
+means making many changes quickly, and that is precisely when stacking a second
+learning reset delays recovery instead of speeding it up.
+
+**Before any bid-strategy, budget, conversion-setting, keyword or re-enable
+change, call `mureo_learning_reset_preflight`** with the tool name and the
+arguments you are about to pass, and put its answer in your confirmation to the
+operator. It is read-only, calls no platform API, and returns:
+
+- `reset_risk` — `resets` / `no_reset` / `unknown`, with the **first-party
+  source** the verdict rests on (`reset_verdict.evidence`).
+- `learning_state` — `learning` / `steady` / `unknown` / `unreportable` for the
+  campaign, read from STATE.json.
+- `would_block` — whether the operator's STRATEGY.md `## Guardrails` refuses
+  this call.
+
+**`unknown` and `unreportable` never mean safe.** They mean mureo has no
+answer: report them as "not known" to the operator rather than proceeding as if
+the change were harmless.
+
+Three surfaces, of deliberately different strength:
+
+| Surface | When | Strength |
+|---|---|---|
+| `## Guardrails` `block_learning_resets` / `block_learning_resets_during_incident` | before dispatch | **hard** — the call is refused |
+| `mureo_learning_reset_preflight` | before the change, when you call it | advisory — as strong as your compliance |
+| Automatic notice appended to a reset-triggering call's result | after that call | records the reset so the NEXT change is not made blind |
+
+MCP has no interposed confirmation step, so mureo cannot pause a call and ask.
+The guardrails are the only surface that stops one.
+
+**What mureo knows, per platform** (never claim more than this):
+
+| Platform | Learning state readable by mureo? | Reset triggers known? |
+|---|---|---|
+| Google Ads | Yes — `bidding_strategy_system_status` from the campaign snapshot in STATE.json | Yes — Google's own `LEARNING_*` enum members |
+| Meta Ads | No — Meta exposes `learning_stage_info` on the **ad set**, mureo does not fetch it and STATE.json is campaign-level | No — Meta documents "significant edits" without enumerating them |
+| Amazon Ads (bridge), Yahoo / LINE / SmartNews / LOGLY (plugins) | No — unless the plugin registers rules | No — unless the plugin registers rules |
+
+So the check is **complete on Google Ads and honest everywhere else**. For a
+Google campaign, keep `bidding_details.bidding_strategy_system_status` fresh in
+STATE.json (`google_ads_campaigns_get` / `google_ads_campaigns_diagnose` →
+`mureo_state_upsert_campaign`); without it the learning state is reported
+`unknown`, not `steady`.
 
 ## Diagnostic preamble (learning insights + advisor consult)
 

--- a/skills/_mureo-strategy/SKILL.md
+++ b/skills/_mureo-strategy/SKILL.md
@@ -273,14 +273,27 @@ keys (all optional):
 - `block_learning_resets` — every change mureo classifies as restarting an
   automated bid strategy's learning period is **refused**. The blunt rule: use
   it during a freeze, not day to day.
-- `block_learning_resets_during_incident` — the same refusal, but only when the
-  campaign is **not positively known to be out of** a learning period. Stacking
-  a second reset on a campaign that is already re-learning is almost never
-  intended, and is the exact shape of the incident this rule comes from
-  (a collapsed campaign "fixed" by moving its bid ceiling, which restarted
-  learning and delayed recovery). It therefore **also fires when the learning
-  state is unknown or unreportable** — consistent with the rest of this gate,
-  which refuses what it cannot verify rather than assuming the safe answer.
+- `block_learning_resets_during_incident` — the same refusal, but narrower by
+  name and in fact: *"during incident"* names **a specific campaign that is
+  known to be unstable**. It refuses only when the call (1) identifies a
+  campaign at all and (2) that campaign is **not positively known to be out
+  of** a learning period. Stacking a second reset on a campaign that is already
+  re-learning is almost never intended, and is the exact shape of the incident
+  this rule comes from (a collapsed campaign "fixed" by moving its bid ceiling,
+  which restarted learning and delayed recovery).
+
+  Condition (2) is **fail-closed**: an `unknown` or `unreportable` state on an
+  identified campaign is refused, not assumed steady. Condition (1) is what
+  keeps that from degenerating into a permanent block. Several
+  reset-triggering tools are **not campaign-scoped** —
+  `google_ads_conversions_*` is account-level and `google_ads_budget_update` is
+  keyed on a `budget_id` — so their campaign can never be resolved and their
+  state is always `unknown`. Without (1) this rule would refuse every one of
+  those calls forever, with no relation to any incident: an operator who
+  followed mureo's own advice to declare it would find conversion actions
+  permanently un-editable. A rule with no subject has nothing to refuse. Use
+  `block_learning_resets` when you want the account-wide freeze — that one is
+  honestly blunt and needs no subject.
 
   Coverage is honest rather than uniform. mureo classifies reset triggers from
   **first-party sources only**: Google Ads is complete (Google publishes the

--- a/skills/_mureo-strategy/SKILL.md
+++ b/skills/_mureo-strategy/SKILL.md
@@ -213,6 +213,8 @@ keys (all optional):
 - max_bid_amount_per_ad_set: 5000   # minor units: 5000 = $50.00 (USD) but ¥5,000 (JPY)
 - max_cpc_bid_per_ad_group: 100      # currency units: 100 = $100 (USD) or ¥100 (JPY)
 - blocked_operations: google_ads_keywords_remove, meta_ads_audiences_delete
+- block_learning_resets: false
+- block_learning_resets_during_incident: true
 ```
 
 - `max_daily_budget_per_campaign` — a budget mutation proposing more than this
@@ -268,10 +270,39 @@ keys (all optional):
   To target deletion, block a distinct destructive tool (e.g.
   `google_ads_keywords_remove`) instead.
 
+- `block_learning_resets` — every change mureo classifies as restarting an
+  automated bid strategy's learning period is **refused**. The blunt rule: use
+  it during a freeze, not day to day.
+- `block_learning_resets_during_incident` — the same refusal, but only when the
+  campaign is **not positively known to be out of** a learning period. Stacking
+  a second reset on a campaign that is already re-learning is almost never
+  intended, and is the exact shape of the incident this rule comes from
+  (a collapsed campaign "fixed" by moving its bid ceiling, which restarted
+  learning and delayed recovery). It therefore **also fires when the learning
+  state is unknown or unreportable** — consistent with the rest of this gate,
+  which refuses what it cannot verify rather than assuming the safe answer.
+
+  Coverage is honest rather than uniform. mureo classifies reset triggers from
+  **first-party sources only**: Google Ads is complete (Google publishes the
+  causes as the `LEARNING_*` members of `BiddingStrategySystemStatus`), and no
+  other platform ships a trigger list in mureo core — Meta documents that
+  "significant edits" restart the phase without enumerating them, so every Meta
+  mutation is reported `unknown`, never `no_reset`. Only a `resets` verdict is
+  ever refused, so these two rules are effectively Google-Ads rules today; a
+  plugin can register its own platform's rules via
+  `mureo.policy.learning_rules.register_platform_learning_rules`.
+
+  The **learning state** is read locally, from
+  `bidding_details.bidding_strategy_system_status` on the campaign's STATE.json
+  snapshot (a policy gate runs on every tool call and must not make network
+  calls). Keep it fresh or the answer is `unknown` — which these rules treat as
+  "refuse", not as "fine".
+
 Absent section (or an unparseable value) ⇒ no enforcement for that rule
-(fail-open); mureo never blocks on a rule the operator did not write. When a
-mutation is refused, the agent receives the guardrail's reason verbatim and
-should surface it to the operator rather than retrying.
+(fail-open); mureo never blocks on a rule the operator did not write. A boolean
+rule accepts `true` / `yes` / `on` / `1`; anything else (including a typo) reads
+as off. When a mutation is refused, the agent receives the guardrail's reason
+verbatim and should surface it to the operator rather than retrying.
 
 ## STATE.json
 
@@ -290,7 +321,8 @@ should surface it to the operator rather than retrying.
           "campaign_name": "Brand Search - Tokyo",
           "status": "ENABLED",
           "bidding_strategy_type": "MAXIMIZE_CONVERSIONS",
-          "bidding_details": {"target_cpa": 5000},
+          "bidding_details": {"target_cpa": 5000,
+                              "bidding_strategy_system_status": "LEARNING_BUDGET_CHANGE"},
           "daily_budget": 8000.0,
           "campaign_goal": "Lead generation for SaaS trial signups",
           "notes": "Learning period ends ~April 5. Do not change bids."

--- a/tests/test_learning_reset_preflight.py
+++ b/tests/test_learning_reset_preflight.py
@@ -139,6 +139,53 @@ class TestChangeClassification:
         assert enable.risk is ResetRisk.RESETS
         assert pause.risk is ResetRisk.NO_RESET
 
+    def test_conversion_rename_is_not_a_reset(self) -> None:
+        """Review finding: a cosmetic rename of a conversion action classified
+        the same as changing its value, so an operator who declared
+        block_learning_resets_during_incident could never rename one."""
+        a = classify_change(
+            "google_ads_conversions_update",
+            {"conversion_action_id": "CA1", "name": "Renamed"},
+        )
+        assert a.risk is ResetRisk.NO_RESET
+
+    @pytest.mark.parametrize(
+        "field,value",
+        [
+            ("category", "PURCHASE"),
+            ("status", "REMOVED"),
+            ("default_value", 5000),
+            ("always_use_default_value", True),
+            ("click_through_lookback_window_days", 30),
+            ("view_through_lookback_window_days", 1),
+        ],
+    )
+    def test_conversion_setting_edits_are_resets(self, field: str, value: Any) -> None:
+        a = classify_change(
+            "google_ads_conversions_update",
+            {"conversion_action_id": "CA1", field: value},
+        )
+        assert a.risk is ResetRisk.RESETS
+        assert a.change_class == "conversion_settings_change"
+
+    @pytest.mark.parametrize(
+        "tool", ["google_ads_conversions_create", "google_ads_conversions_remove"]
+    )
+    def test_conversion_type_changes_stay_resets(self, tool: str) -> None:
+        """create / remove have no cosmetic-only mode, so they stay
+        unconditional — narrowing must not become under-reporting."""
+        a = classify_change(tool, {"conversion_action_id": "CA1"})
+        assert a.risk is ResetRisk.RESETS
+        assert a.change_class == "conversion_type_change"
+
+    def test_reset_verdict_carries_the_classification_caveats(self) -> None:
+        """The caveats must reach the person who is BLOCKED, not only the one
+        who is waved through."""
+        a = classify_change("google_ads_budget_update", {"amount": 1})
+        assert "manual-CPC" in a.detail
+        for change_class in ("budget_change", "composition_change", "reactivation"):
+            assert change_class in a.detail
+
     @pytest.mark.parametrize(
         "tool",
         [
@@ -277,6 +324,35 @@ class TestGateEnforcement:
         reason = learning_reset_denial(pre, block_all=False, block_during_incident=True)
         assert reason is not None
         assert "LEARNING_BUDGET_CHANGE" in reason
+
+    def test_incident_guardrail_needs_a_campaign_subject(self) -> None:
+        """'During incident' names a specific unstable campaign. An
+        account-level change identifies none, so the rule has no subject and
+        must not refuse — otherwise editing a conversion action is refused
+        forever, with no relation to any incident."""
+        pre = self._pre(
+            "google_ads_conversions_update",
+            {"conversion_action_id": "CA1", "status": "REMOVED"},
+            "LEARNING_NEW",
+        )
+        assert pre.campaign_id is None
+        assert pre.change.risk is ResetRisk.RESETS
+        assert (
+            learning_reset_denial(pre, block_all=False, block_during_incident=True)
+            is None
+        )
+
+    def test_block_all_still_refuses_without_a_campaign_subject(self) -> None:
+        """The blunt rule stays blunt: a freeze needs no subject."""
+        pre = self._pre(
+            "google_ads_conversions_update",
+            {"conversion_action_id": "CA1", "status": "REMOVED"},
+            "LEARNING_NEW",
+        )
+        assert (
+            learning_reset_denial(pre, block_all=True, block_during_incident=False)
+            is not None
+        )
 
     def test_incident_guardrail_allows_when_steady(self) -> None:
         pre = self._pre(

--- a/tests/test_learning_reset_preflight.py
+++ b/tests/test_learning_reset_preflight.py
@@ -1,0 +1,495 @@
+"""Tests for the learning-period reset pre-flight check (#548).
+
+Four properties matter more than coverage here, and each has its own class:
+
+- a reset-triggering dispatch SURFACES the current learning state and the
+  reset verdict (``TestDispatchSurfacing``);
+- a ``## Guardrails`` refusal actually BLOCKS rather than merely reporting
+  (``TestGateEnforcement``);
+- a change that resets nothing is NOT warned about (``TestChangeClassification``
+  / ``TestDispatchSurfacing.test_non_reset_dispatch_appends_no_notice``);
+- a platform whose learning state mureo cannot read says so, and never says
+  "safe" (``TestLearningStateReading``, ``TestPreflightTool``).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from mureo.context.models import CampaignSnapshot, PlatformState, StateDocument
+from mureo.context.state import write_state_file
+from mureo.core.runtime_context import reset_runtime_context
+from mureo.policy.learning_reset import (
+    LearningReading,
+    build_preflight,
+    classify_change,
+    learning_reset_denial,
+    read_learning_state,
+)
+from mureo.policy.learning_rules import (
+    LearningState,
+    ResetRisk,
+    platform_learning_rules,
+    reset_platform_learning_rules,
+)
+from mureo.policy.strategy_gate import (
+    Guardrails,
+    StrategyPolicyGate,
+    evaluate_guardrails,
+    parse_guardrails,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _state_with(status: str | None, campaign_id: str = "C1") -> StateDocument:
+    """A STATE.json document whose Google campaign carries ``status``."""
+    details: dict[str, Any] | None = (
+        None if status is None else {"bidding_strategy_system_status": status}
+    )
+    return StateDocument(
+        version="2",
+        platforms={
+            "google_ads": PlatformState(
+                account_id="1234567890",
+                campaigns=(
+                    CampaignSnapshot(
+                        campaign_id=campaign_id,
+                        campaign_name="Brand Search",
+                        status="ENABLED",
+                        bidding_details=details,
+                    ),
+                ),
+            )
+        },
+    )
+
+
+@pytest.fixture
+def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """An isolated cwd with a fresh runtime context and gate cache."""
+    from mureo.policy import strategy_gate
+
+    monkeypatch.chdir(tmp_path)
+    reset_runtime_context()
+    strategy_gate._cache.clear()
+    yield tmp_path
+    reset_runtime_context()
+    strategy_gate._cache.clear()
+
+
+def _write_strategy(path: Path, guardrails: str) -> None:
+    (path / "STRATEGY.md").write_text(
+        f"## Persona\nSMB\n\n## Guardrails\n{guardrails}\n", encoding="utf-8"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (b) is the pending change in the reset-triggering class?
+# ---------------------------------------------------------------------------
+
+
+class TestChangeClassification:
+    def test_google_budget_update_is_reset_triggering(self) -> None:
+        a = classify_change("google_ads_budget_update", {"budget_id": "B", "amount": 1})
+        assert a.risk is ResetRisk.RESETS
+        assert a.change_class == "budget_change"
+
+    def test_google_campaign_update_with_bidding_strategy_is_reset(self) -> None:
+        a = classify_change(
+            "google_ads_campaigns_update",
+            {"campaign_id": "C1", "bidding_strategy": "TARGET_CPA"},
+        )
+        assert a.risk is ResetRisk.RESETS
+        assert a.change_class == "bidding_strategy_change"
+
+    def test_google_campaign_rename_is_not_a_reset(self) -> None:
+        """A rename through the SAME tool must not inherit the bid verdict."""
+        a = classify_change(
+            "google_ads_campaigns_update", {"campaign_id": "C1", "name": "New name"}
+        )
+        assert a.risk is ResetRisk.NO_RESET
+
+    def test_google_keyword_add_is_composition_change(self) -> None:
+        a = classify_change(
+            "google_ads_keywords_add", {"ad_group_id": "A", "keywords": ["x"]}
+        )
+        assert a.risk is ResetRisk.RESETS
+        assert a.change_class == "composition_change"
+
+    def test_google_reactivation_is_reset_but_pause_is_not(self) -> None:
+        enable = classify_change(
+            "google_ads_campaigns_update_status",
+            {"campaign_id": "C1", "status": "ENABLED"},
+        )
+        pause = classify_change(
+            "google_ads_campaigns_update_status",
+            {"campaign_id": "C1", "status": "PAUSED"},
+        )
+        assert enable.risk is ResetRisk.RESETS
+        assert pause.risk is ResetRisk.NO_RESET
+
+    @pytest.mark.parametrize(
+        "tool",
+        [
+            "google_ads_campaigns_list",
+            "google_ads_campaigns_get",
+            "google_ads_performance_report",
+            "google_ads_search_terms_report",
+            "meta_ads_insights_report",
+            "campaign_management-query_campaign",
+        ],
+    )
+    def test_reads_never_warn(self, tool: str) -> None:
+        assert classify_change(tool, {}).risk is ResetRisk.NO_RESET
+
+    def test_meta_mutation_is_unknown_not_safe(self) -> None:
+        """Meta has a learning phase but mureo has no first-party trigger
+        list for it, so the verdict is UNKNOWN — never NO_RESET."""
+        a = classify_change("meta_ads_ad_sets_update", {"ad_set_id": "S1"})
+        assert a.risk is ResetRisk.UNKNOWN
+
+    def test_bridged_amazon_mutation_is_unknown(self) -> None:
+        a = classify_change("campaign_management-update_campaign_budget", {"body": {}})
+        assert a.risk is ResetRisk.UNKNOWN
+
+    def test_every_trigger_cites_first_party_evidence(self) -> None:
+        rules = platform_learning_rules("google_ads")
+        assert rules is not None
+        assert rules.triggers
+        for trigger in rules.triggers:
+            assert trigger.evidence.source.startswith("https://")
+            assert trigger.evidence.retrieved
+            assert trigger.evidence.quote
+
+
+# ---------------------------------------------------------------------------
+# (a) what is the campaign's current learning state?
+# ---------------------------------------------------------------------------
+
+
+class TestLearningStateReading:
+    def test_google_learning_status_is_read(self) -> None:
+        r = read_learning_state(
+            "google_ads", "C1", _state_with("LEARNING_SETTING_CHANGE")
+        )
+        assert r.state is LearningState.LEARNING
+        assert "LEARNING_SETTING_CHANGE" in r.detail
+
+    def test_google_enabled_status_is_steady(self) -> None:
+        r = read_learning_state("google_ads", "C1", _state_with("ENABLED"))
+        assert r.state is LearningState.STEADY
+
+    def test_google_unavailable_is_unreportable(self) -> None:
+        """Google's own enum says UNAVAILABLE means the strategy does not
+        support status reporting — that is not 'steady'."""
+        r = read_learning_state("google_ads", "C1", _state_with("UNAVAILABLE"))
+        assert r.state is LearningState.UNREPORTABLE
+
+    def test_no_observation_is_unknown_not_steady(self) -> None:
+        r = read_learning_state("google_ads", "C1", _state_with(None))
+        assert r.state is LearningState.UNKNOWN
+
+    def test_no_campaign_id_is_unknown(self) -> None:
+        r = read_learning_state("google_ads", None, _state_with("ENABLED"))
+        assert r.state is LearningState.UNKNOWN
+
+    def test_meta_is_unreportable_by_mureo(self) -> None:
+        r = read_learning_state("meta_ads", "C1", StateDocument())
+        assert r.state is LearningState.UNREPORTABLE
+        assert "learning_stage_info" in r.detail
+
+    def test_unknown_platform_is_unreportable(self) -> None:
+        r = read_learning_state("plugin:mureo-x-bridge:x", "C1", StateDocument())
+        assert r.state is LearningState.UNREPORTABLE
+
+    def test_reading_never_claims_safe_without_evidence(self) -> None:
+        for state in (LearningState.UNKNOWN, LearningState.UNREPORTABLE):
+            reading = LearningReading(state=state, detail="d", source="s")
+            assert reading.is_known_not_learning() is False
+
+
+# ---------------------------------------------------------------------------
+# (d) the hard refusal in STRATEGY.md ## Guardrails
+# ---------------------------------------------------------------------------
+
+
+class TestGuardrailParsing:
+    def test_parses_both_learning_keys(self) -> None:
+        g = parse_guardrails(
+            "- block_learning_resets: true\n"
+            "- block_learning_resets_during_incident: yes\n"
+        )
+        assert g.block_learning_resets is True
+        assert g.block_learning_resets_during_incident is True
+
+    def test_absent_keys_default_false_and_stay_empty(self) -> None:
+        g = parse_guardrails("- some_other_rule: 3")
+        assert g.block_learning_resets is False
+        assert g.block_learning_resets_during_incident is False
+        assert g.is_empty()
+
+    def test_learning_key_alone_makes_guardrails_non_empty(self) -> None:
+        assert not parse_guardrails("- block_learning_resets: true").is_empty()
+
+    def test_false_value_is_not_enabled(self) -> None:
+        g = parse_guardrails("- block_learning_resets: false")
+        assert g.block_learning_resets is False
+
+
+class TestGateEnforcement:
+    def _pre(self, tool: str, args: dict[str, Any], status: str | None):
+        return build_preflight(tool, args, _state_with(status))
+
+    def test_denial_when_block_learning_resets(self) -> None:
+        pre = self._pre(
+            "google_ads_budget_update", {"budget_id": "B", "amount": 1}, "ENABLED"
+        )
+        reason = learning_reset_denial(pre, block_all=True, block_during_incident=False)
+        assert reason is not None
+        assert "budget_change" in reason
+
+    def test_no_denial_for_non_reset_change(self) -> None:
+        pre = self._pre(
+            "google_ads_campaigns_update", {"campaign_id": "C1", "name": "x"}, "ENABLED"
+        )
+        assert (
+            learning_reset_denial(pre, block_all=True, block_during_incident=True)
+            is None
+        )
+
+    def test_incident_guardrail_denies_when_already_learning(self) -> None:
+        pre = self._pre(
+            "google_ads_campaigns_update",
+            {"campaign_id": "C1", "bidding_strategy": "TARGET_CPA"},
+            "LEARNING_BUDGET_CHANGE",
+        )
+        reason = learning_reset_denial(pre, block_all=False, block_during_incident=True)
+        assert reason is not None
+        assert "LEARNING_BUDGET_CHANGE" in reason
+
+    def test_incident_guardrail_allows_when_steady(self) -> None:
+        pre = self._pre(
+            "google_ads_campaigns_update",
+            {"campaign_id": "C1", "bidding_strategy": "TARGET_CPA"},
+            "ENABLED",
+        )
+        assert (
+            learning_reset_denial(pre, block_all=False, block_during_incident=True)
+            is None
+        )
+
+    def test_incident_guardrail_denies_when_state_unknown(self) -> None:
+        """Unverifiable is refused, not treated as steady."""
+        pre = self._pre(
+            "google_ads_campaigns_update",
+            {"campaign_id": "C1", "bidding_strategy": "TARGET_CPA"},
+            None,
+        )
+        reason = learning_reset_denial(pre, block_all=False, block_during_incident=True)
+        assert reason is not None
+        assert "unknown" in reason.lower()
+
+    def test_gate_denies_end_to_end_via_strategy_md(self, workspace: Path) -> None:
+        _write_strategy(workspace, "- block_learning_resets: true")
+        write_state_file(workspace / "STATE.json", _state_with("ENABLED"))
+        decision = StrategyPolicyGate().evaluate(
+            "google_ads_budget_update", {"budget_id": "B", "amount": 1000}
+        )
+        assert decision.allowed is False
+
+    def test_gate_allows_without_the_guardrail(self, workspace: Path) -> None:
+        _write_strategy(workspace, "- max_daily_budget_per_campaign: 999999")
+        write_state_file(workspace / "STATE.json", _state_with("ENABLED"))
+        decision = StrategyPolicyGate().evaluate(
+            "google_ads_budget_update", {"budget_id": "B", "amount": 1000}
+        )
+        assert decision.allowed is True
+
+    def test_evaluate_guardrails_ignores_learning_without_reading(self) -> None:
+        """The pure layer stays pure: no learning preflight ⇒ no learning
+        denial, even with the guardrail set."""
+        g = Guardrails(block_learning_resets=True)
+        d = evaluate_guardrails("google_ads_budget_update", {"amount": 1}, g)
+        assert d.allowed is True
+
+
+# ---------------------------------------------------------------------------
+# (c) surfaced at dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchSurfacing:
+    async def _dispatch(self, tool: str, args: dict[str, Any]) -> list[Any]:
+        """Run the real dispatcher with the platform handler stubbed out.
+
+        The gate and the notice hook are what is under test; the Google
+        handler's credential / tenant resolution is not, and stubbing it keeps
+        this test independent of what the local machine has configured.
+        """
+        from mcp.types import TextContent
+
+        from mureo.mcp import server as mod
+
+        stub = AsyncMock(
+            return_value=[TextContent(type="text", text=json.dumps({"id": "C1"}))]
+        )
+        with patch.object(mod, "_dispatch_tool", stub):
+            return await mod.handle_call_tool(tool, args)
+
+    async def test_reset_triggering_dispatch_surfaces_state_and_verdict(
+        self, workspace: Path
+    ) -> None:
+        write_state_file(
+            workspace / "STATE.json", _state_with("LEARNING_SETTING_CHANGE")
+        )
+        result = await self._dispatch(
+            "google_ads_campaigns_update",
+            {
+                "customer_id": "1234567890",
+                "campaign_id": "C1",
+                "bidding_strategy": "TARGET_CPA",
+            },
+        )
+        blob = "\n".join(r.text for r in result)
+        assert "bidding_strategy_change" in blob  # the reset verdict
+        assert "LEARNING_SETTING_CHANGE" in blob  # the current learning state
+
+    async def test_non_reset_dispatch_appends_no_notice(self, workspace: Path) -> None:
+        write_state_file(
+            workspace / "STATE.json", _state_with("LEARNING_SETTING_CHANGE")
+        )
+        result = await self._dispatch(
+            "google_ads_campaigns_update",
+            {"customer_id": "1234567890", "campaign_id": "C1", "name": "Renamed"},
+        )
+        blob = "\n".join(r.text for r in result)
+        assert "learning" not in blob.lower()
+
+    async def test_guardrail_refusal_reaches_the_agent(self, workspace: Path) -> None:
+        _write_strategy(workspace, "- block_learning_resets: true")
+        write_state_file(workspace / "STATE.json", _state_with("ENABLED"))
+        result = await self._dispatch(
+            "google_ads_campaigns_update",
+            {
+                "customer_id": "1234567890",
+                "campaign_id": "C1",
+                "bidding_strategy": "TARGET_CPA",
+            },
+        )
+        blob = "\n".join(r.text for r in result)
+        assert "refused by policy gate" in blob
+        assert "bidding_strategy_change" in blob
+
+
+# ---------------------------------------------------------------------------
+# The pre-flight MCP tool
+# ---------------------------------------------------------------------------
+
+
+class TestPreflightTool:
+    async def _run(self, args: dict[str, Any]) -> dict[str, Any]:
+        from mureo.mcp import server as mod
+
+        result = await mod.handle_call_tool("mureo_learning_reset_preflight", args)
+        return json.loads(result[0].text)
+
+    async def test_tool_is_registered(self) -> None:
+        from mureo.mcp import server as mod
+
+        names = {t.name for t in await mod.handle_list_tools()}
+        assert "mureo_learning_reset_preflight" in names
+
+    async def test_reports_state_and_verdict(self, workspace: Path) -> None:
+        write_state_file(workspace / "STATE.json", _state_with("LEARNING_NEW"))
+        out = await self._run(
+            {
+                "tool_name": "google_ads_budget_update",
+                "arguments": {"budget_id": "B", "amount": 1},
+                "campaign_id": "C1",
+            }
+        )
+        assert out["reset_risk"] == "resets"
+        assert out["change_class"] == "budget_change"
+        assert out["learning_state"]["state"] == "learning"
+        assert out["would_block"] is False
+
+    async def test_unreadable_platform_says_unknown_not_safe(
+        self, workspace: Path
+    ) -> None:
+        out = await self._run(
+            {
+                "tool_name": "campaign_management-update_campaign_budget",
+                "arguments": {"body": {}},
+            }
+        )
+        assert out["reset_risk"] == "unknown"
+        assert out["learning_state"]["state"] == "unreportable"
+        # It must NOT claim the change is safe.
+        assert out["reset_risk"] != "no_reset"
+
+    async def test_would_block_agrees_with_the_gate(self, workspace: Path) -> None:
+        _write_strategy(workspace, "- block_learning_resets: true")
+        write_state_file(workspace / "STATE.json", _state_with("ENABLED"))
+        args = {"budget_id": "B", "amount": 1}
+        out = await self._run(
+            {
+                "tool_name": "google_ads_budget_update",
+                "arguments": args,
+                "campaign_id": "C1",
+            }
+        )
+        gate = StrategyPolicyGate().evaluate("google_ads_budget_update", args)
+        assert out["would_block"] is True
+        assert gate.allowed is False
+
+
+# ---------------------------------------------------------------------------
+# Plugin / bridge registration hook
+# ---------------------------------------------------------------------------
+
+
+class TestPluginRegistration:
+    def teardown_method(self) -> None:
+        reset_platform_learning_rules()
+
+    def test_plugin_can_advertise_its_own_rules(self) -> None:
+        from mureo.policy.learning_rules import (
+            Evidence,
+            PlatformLearningRules,
+            ResetTrigger,
+            register_platform_learning_rules,
+        )
+
+        register_platform_learning_rules(
+            PlatformLearningRules(
+                platform="plugin:mureo-demo-bridge:demo",
+                tool_prefix="demo_",
+                observation=None,
+                triggers=(
+                    ResetTrigger(
+                        change_class="target_change",
+                        tools=frozenset({"demo_update_target"}),
+                        evidence=Evidence(
+                            source="https://example.invalid/docs",
+                            retrieved="2026-08-07",
+                            quote="target changes restart the adjustment period",
+                        ),
+                    ),
+                ),
+                triggers_are_enumerated=True,
+                notes="demo",
+            )
+        )
+        assert classify_change("demo_update_target", {}).risk is ResetRisk.RESETS
+        assert classify_change("demo_update_name", {}).risk is ResetRisk.NO_RESET

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -65,13 +65,14 @@ class TestListTools:
     async def test_list_tools_returns_all_tools(self) -> None:
         """list_tools returns all tools (Google Ads 89 + Meta Ads 90 + Search Console 10
         + Rollback 2 + Analysis 1 + Mureo Context 9 + Analytics Registry 2
-        + Learning 2 + Creative Studio 5 = 210).
+        + Learning 2 + Learning pre-flight 1 + Creative Studio 5 = 211).
 
         Analytics Registry is 2: mureo_analytics_modules_list +
-        mureo_analytics_run (#440)."""
+        mureo_analytics_run (#440). Learning pre-flight is 1:
+        mureo_learning_reset_preflight (#548)."""
         mod = _import_server_module()
         tools = await mod.handle_list_tools()
-        assert len(tools) == 210
+        assert len(tools) == 211
 
     async def test_list_tools_contains_google_and_meta(self) -> None:
         """Google Ads and Meta Ads tools are included."""


### PR DESCRIPTION
Closes #548

## What was wrong

`_mureo-shared/SKILL.md` carried "Learning Period Awareness" as a **security rule**: warn before changes that reset the learning period, list the affected operations, show the current bidding system status. Nothing in mureo detected — let alone blocked — a learning-resetting change at the moment it was dispatched.

A prose rule is followed worst exactly when it matters most. The incident behind #548: a campaign whose delivery had already collapsed was "fixed" by moving its bid ceiling, which put the bidding strategy into a settings-change learning state and delayed recovery further. Troubleshooting *means* making many changes quickly.

## Three surfaces, of deliberately different strength

MCP has no interposed confirmation step — mureo either runs a tool call or refuses it — so these are not interchangeable, and the PR does not pretend they are.

| Surface | When | Strength |
|---|---|---|
| `## Guardrails` `block_learning_resets` / `block_learning_resets_during_incident` | before dispatch | **hard** — refused by the existing `StrategyPolicyGate`, before any API call |
| `mureo_learning_reset_preflight` (new tool, read-only) | before the change, when the agent calls it | advisory — as strong as the agent's compliance |
| Notice appended to a reset-triggering call's own result | after that call | records the reset so the *next* change in the sequence is not made blind |

It runs on the **one existing gate**, not a parallel mechanism: `evaluate_guardrails` gained an optional `learning=` argument and stays I/O-free; the gate does the STATE.json read, and only when the operator actually wrote one of the two rules. Both default off, so the fail-open contract is intact — with no rule written, behaviour is byte-identical and no STATE.json read happens.

`would_block` in the pre-flight tool is computed by the same `learning_reset_denial` the gate calls, so the report and the enforcement cannot drift.

## Evidence, not folklore

Reset triggers are **not hardcoded from recollection**. `mureo/policy/learning_rules.py` carries, per trigger: the first-party source URL, the retrieval date, and the sentence it rests on.

Google Ads is complete because Google publishes the causes as an **enum**: every `LEARNING_*` member of [`BiddingStrategySystemStatus`](https://developers.google.com/google-ads/api/reference/rpc/v23/BiddingStrategySystemStatusEnum.BiddingStrategySystemStatus) names the change class that caused re-entry — and that exact enum ships inside the `google-ads` client this repo already depends on, so the quotes are checkable offline. The same enum is the state read, including `UNAVAILABLE` → *"does not support status reporting"* → reported `unreportable`, not `steady`.

The old prose's `budget changes > 20%` threshold has **no** first-party source. It is gone rather than reproduced; Google's enum says "a recent budget change" with no magnitude, so mureo applies none. That, and the other honest limits, are written down in the rules table's `notes` rather than smoothed over.

## Per-platform coverage — what is real

| Platform | Learning state readable by mureo? | Reset triggers known? |
|---|---|---|
| **Google Ads** | **Yes** — `bidding_details.bidding_strategy_system_status` on the campaign's STATE.json snapshot | **Yes** — Google's `LEARNING_*` enum members |
| **Meta Ads** | **No** — Meta exposes [`learning_stage_info`](https://developers.facebook.com/docs/marketing-api/reference/ad-campaign-learning-stage-info/) on the **ad set**; mureo's client does not request it and STATE.json is campaign-level | **No** — Meta documents that "significant edits" restart the phase, and exposes `last_sig_edit_ts`, but does not enumerate which edits are significant |
| **Amazon Ads** (`plugin:mureo-amazon-ads-bridge`) | **No** — no learning-state read exists anywhere on the bridged tool surface mureo knows (checked against `amazon_ads/reversal.py`, `amazon_ads/money_paths.py`, `docs/amazon-ads.md`) | **No** |
| **Yahoo / LINE / SmartNews / LOGLY** (plugins) | **No** — unless the plugin registers rules | **No** — unless the plugin registers rules |

So the check is **complete on Google Ads and honest everywhere else**. A platform mureo cannot classify reports `unknown`; a platform whose state it cannot read reports `unreportable`. Neither is ever `no_reset` / `steady` — a false "this resets nothing" converts a missing warning into implied approval, which is worse than no answer.

Bridges and plugins advertise their own rules through `register_platform_learning_rules`, the same registry pattern the budget/bid declarations already use.

## Not a false-alarm generator

A check that fires on everything gets ignored, so the classifier is argument-aware and read-aware:

- `google_ads_campaigns_update` with `name` → `no_reset`; the **same tool** with `bidding_strategy` → `resets`.
- `google_ads_campaigns_update_status` with `PAUSED` → `no_reset`; with `ENABLED` (reactivation) → `resets`.
- Every read on every platform → `no_reset` (needs no per-platform evidence).
- The appended notice fires **only** on `resets`, never on `unknown` — otherwise it would fire on every Meta and Amazon mutation. The pre-flight tool still reports `unknown` honestly when asked.

## Where the state comes from, and why

A `PolicyGate` runs on every tool call and must be pure and fast, so the pre-flight **cannot** ask the platform. It reads what mureo already has locally: the STATE.json campaign snapshot (`google_ads_campaigns_get` / `_diagnose` → `mureo_state_upsert_campaign`). A stale or missing observation is reported `unknown`, and `block_learning_resets_during_incident` treats `unknown` as "refuse" rather than "fine".

## Tests

42 new tests in `tests/test_learning_reset_preflight.py`, organised around the four properties that matter: the reset verdict and learning state are surfaced at dispatch; a `## Guardrails` refusal actually **blocks** (end-to-end through `StrategyPolicyGate` and through `handle_call_tool`); a non-resetting change is **not** warned about; an unreadable platform says so.

Not vacuous — five regressions were injected and each was caught:

| Injected bug | Tests that failed |
|---|---|
| unknown learning state counted as "not learning" | 2 |
| guardrail reports but never blocks | 6 |
| notice fires on every mutation | 1 |
| unclassifiable platform reported `no_reset` | 3 |
| trigger matching ignores arguments (rename warned) | 3 |

## Docs

Updated with the code: `_mureo-shared/SKILL.md` §6 rewritten from prose rule into a description of the mechanism (including the per-platform coverage table and the explicit statement that `unknown` never means safe), `_mureo-strategy/SKILL.md` guardrail reference, `docs/mcp-server.md` (new section + tool count 205 → 206), `docs/architecture.md`, both READMEs, `AGENTS.md`, `CHANGELOG.md`, and the `bidding_details` schema description in `mureo_state_upsert_campaign` so the convention is discoverable from the tool itself. Both skill copies (`skills/` and `mureo/_data/skills/`) stay in sync.

## Gates

`ruff check .` clean · `black --check .` clean · `mypy mureo --ignore-missing-imports` clean · `pytest` 7815 passed, 12 pre-existing local-environment failures only (9 × `test_live_clients.py`, 3 × tool-registry counts caused by extra plugins installed on the dev machine), no new failures.
