### PR TITLE
Size a bulk exclusion against the account's own delivery before applying it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,8 +92,11 @@ mureo/
 │   ├── _handlers_search_console.py        # Search Console handlers
 │   ├── tools_rollback.py                  # rollback_plan_get / rollback_apply
 │   ├── _handlers_rollback.py              # Rollback handlers (lazy-resolve dispatcher)
-│   ├── tools_analysis.py                  # analysis_anomalies_check
+│   ├── tools_analysis.py                  # analysis_anomalies_check / analysis_exclusion_impact_preview
 │   ├── _handlers_analysis.py              # Anomaly detector composition handler
+│   ├── _handlers_exclusion_impact.py      # analysis_exclusion_impact_preview handler (#547)
+│   ├── exclusion_preflight.py             # Pre-dispatch exclusion sizing + refusal + notice (#547)
+│   ├── exclusion_sources.py               # Built-in per-platform delivery sources for the above (#547)
 │   ├── tools_analytics_registry.py        # mureo_analytics_modules_list / mureo_analytics_run (#440)
 │   ├── tools_creative_studio.py           # creative_studio_* (visual generation + compose)
 │   ├── tools_learning.py                  # mureo_learning_insights_get / mureo_consult_advisor
@@ -124,7 +127,13 @@ mureo/
 │   └── errors.py        # Context-specific errors
 ├── analysis/            # Analysis utilities
 │   ├── lp_analyzer.py   # Landing page analyzer
-│   └── anomaly_detector.py  # Zero-spend / CPA-spike / CTR-drop detection (pure, sample-size-gated)
+│   ├── anomaly_detector.py  # Zero-spend / CPA-spike / CTR-drop detection (pure, sample-size-gated)
+│   └── exclusion_impact/    # Delivery-impact preview for bulk exclusions (#547; pure)
+│       ├── models.py        # DeliveryRecord / ExclusionTarget / ExclusionImpact + coverage verdicts
+│       ├── matching.py      # Per-entity-kind match rules (host, app id, negative keyword match type)
+│       ├── estimator.py     # The share itself — incremental and cumulative
+│       ├── rules.py         # ## Guardrails exclusion keys + the one refusal decision
+│       └── surfaces.py      # Which tools are exclusion surfaces (mureo's + plugin-registered)
 ├── rollback/            # Rollback feature (allow-list gated, append-only audit trail)
 │   ├── models.py        # RollbackStatus enum + RollbackPlan dataclass
 │   ├── planner.py       # plan_rollback(ActionLogEntry) -> RollbackPlan | None
@@ -169,6 +178,7 @@ docs/integrations.md          # Platform discovery + external MCP integration gu
 | Keywords | `keywords.list`, `keywords.add`, `keywords.remove`, `keywords.suggest`, `keywords.diagnose`, `keywords.pause`, `keywords.audit`, `keywords.cross_adgroup_duplicates` |
 | Negative Keywords | `negative_keywords.list`, `negative_keywords.add`, `negative_keywords.remove`, `negative_keywords.add_to_ad_group`, `negative_keywords.suggest` |
 | Negative Placements | `negative_placements.list`, `negative_placements.add`, `negative_placements.remove` |
+| Placement Performance | (read used by `analysis_exclusion_impact_preview`: `group_placement_view` via `get_placement_performance`) |
 | Budget | `budget.get`, `budget.update`, `budget.create` |
 | Accounts | `accounts.list` |
 | Search Terms | `search_terms.report`, `search_terms.analyze` |
@@ -227,7 +237,7 @@ These families are not tied to a single ad platform. Tool names are the exact MC
 |--------|-------|
 | Analytics Registry (#440) | `mureo_analytics_modules_list`, `mureo_analytics_run` |
 | Rollback | `rollback_plan_get`, `rollback_apply` |
-| Analysis | `analysis_anomalies_check` |
+| Analysis | `analysis_anomalies_check`, `analysis_exclusion_impact_preview` |
 | Creative Studio | `creative_studio_providers_list`, `creative_studio_generate_visual`, `creative_studio_edit_visual`, `creative_studio_compose`, `creative_studio_brand_kit_get` |
 | Learning | `mureo_learning_insights_get`, `mureo_consult_advisor` |
 | Learning pre-flight (#548) | `mureo_learning_reset_preflight` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ mureo/
 ├── google_ads/          # Google Ads API client (Mixin composition)
 │   ├── client.py        # GoogleAdsApiClient (main entry)
 │   ├── mappers.py       # Response mapping to structured dicts
+│   ├── _placement_mappers.py # Negative-placement + group_placement_view row mappers (#544/#547)
 │   ├── _ads.py          # AdsMixin (RSA create/update/status/list)
 │   ├── _ads_display.py  # DisplayAdsMixin (RDA create + RDAUploadError)
 │   ├── _keywords.py     # KeywordsMixin (add/remove/suggest/diagnose)
@@ -132,7 +133,7 @@ mureo/
 │       ├── models.py        # DeliveryRecord / ExclusionTarget / ExclusionImpact + coverage verdicts
 │       ├── matching.py      # Per-entity-kind match rules (host, app id, negative keyword match type)
 │       ├── estimator.py     # The share itself — incremental and cumulative
-│       ├── rules.py         # ## Guardrails exclusion keys + the one refusal decision
+│       ├── rules.py         # ## Guardrails exclusion keys, the one refusal decision, inert-rule reporting
 │       └── surfaces.py      # Which tools are exclusion surfaces (mureo's + plugin-registered)
 ├── rollback/            # Rollback feature (allow-list gated, append-only audit trail)
 │   ├── models.py        # RollbackStatus enum + RollbackPlan dataclass

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   dispatcher enforces, so the advertised verdict and the enforced one cannot
   drift.
 
+  **A rule that cannot fire says so.** The cumulative figure is withheld on
+  ad-group-scoped writes, so `max_cumulative_delivery_share_removed_pct`
+  enforces nothing there — the scope the incident happened at. Rather than
+  leave that to a document, mureo names the inert rule at the moment it cannot
+  fire: `unevaluated_rules` in the preview tool's response, and a `NOT ENFORCED
+  on this call:` line naming the backstop to add in the notice on the
+  exclusion's own result.
+
   New `## Guardrails` keys (all optional, all default off):
   `max_delivery_share_removed_pct`,
   `max_cumulative_delivery_share_removed_pct`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,76 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A bulk exclusion now says how much of your delivery it removes, before it
+  is applied — and a threshold in `STRATEGY.md` can refuse it** (#547). mureo
+  would happily apply an exclusion / block / negative-keyword batch without
+  telling the operator that the inventory it is about to remove carried 94% of
+  the last 30 days of impressions. Of everything filed from the incident
+  post-mortem behind #544–#551, this is the only item that prevents the
+  originating mistake rather than shortening the recovery from it: the
+  operator's intent was reasonable and the direction was correct — the
+  magnitude was not visible at the moment of the decision.
+
+  Three surfaces, of deliberately different strength, because MCP has no
+  interposed confirmation step to put the number in:
+
+  | Surface | When | Strength |
+  |---|---|---|
+  | `## Guardrails` `max_delivery_share_removed_pct` / `max_cumulative_delivery_share_removed_pct` / `block_exclusions_without_impact_data` | before dispatch | **hard** — the call is refused before any API request |
+  | `analysis_exclusion_impact_preview` (new tool, read-only) | whenever the agent asks | advisory — as strong as the agent's compliance |
+  | Notice appended to an allowed exclusion's own result | after that call | records the measured size, so the **next** pass in an incremental sequence is not made blind |
+
+  **Enforced in the dispatcher, not in `StrategyPolicyGate`.** Sizing an
+  exclusion needs one *awaited* read of the account's own recent delivery, and
+  the `PolicyGate` v1 ABI is synchronous by design and must stay pure and fast
+  because it runs on every tool call. So the rules are parsed by the gate's own
+  parser — one `## Guardrails` vocabulary, one parser — and enforced in
+  `mureo/mcp/exclusion_preflight.py`, which runs before `_dispatch_tool`. With
+  none of the three keys written the pre-flight returns before it builds a
+  client: no report request is issued and behaviour is byte-identical.
+  `MUREO_DISABLE_EXCLUSION_PREFLIGHT=1` turns it off.
+
+  **It catches the incremental case, which is the one that did the damage.**
+  The estimate reports both the share this batch removes and the share the
+  account's **whole** standing exclusion set removes once it lands. An entity
+  excluded a week ago still carries its pre-exclusion impressions inside a
+  30-day window, so a fortnight of individually-small passes shows up in the
+  cumulative figure even when no single pass trips the incremental cap. The
+  honest limit: an exclusion older than the window contributed nothing to it
+  and is invisible, so the cumulative share is a lower bound — and it is
+  withheld entirely (never reported as zero) where mureo cannot list the
+  standing set.
+
+  **Per-platform, and honest where it cannot answer:**
+
+  | Surface | Attributable? |
+  |---|---|
+  | `google_ads_negative_placements_add` | **Yes** — new `group_placement_view` read (`get_placement_performance`). A `mobile_app_category` in the same batch is not attributable (a category is not a placement that serves), so a mixed batch reports `partial` |
+  | `google_ads_negative_keywords_add` / `_add_to_ad_group` | **Yes** — `search_term_view`, matched per `EXACT` / `PHRASE` / `BROAD`. Negative keywords do not match close variants and neither does the estimate, so it is a lower bound |
+  | `meta_ads_excluded_placements_set` | **No** — no Meta insights breakdown attributes past delivery to publisher categories, publisher block lists or brand-safety content types (`publisher_platform` / `platform_position` are a different exclusion surface). Reported `unknown` |
+  | Yahoo / LINE / SmartNews / LOGLY / Amazon | **Provider-declared** — a plugin or bridge registers its own surface via `register_exclusion_surface`; mureo registers nothing on their behalf rather than guessing a bridged tool's argument shape |
+
+  `unknown` is an acceptable output; a silent "no impact" is not. Coverage is
+  `measured` / `partial` / `unknown`, `incremental` is `null` rather than a row
+  of zeroes when nothing can be attributed, and a window that served nothing
+  reports `share_pct: null` rather than `0`. An operator who would rather
+  refuse than proceed blind sets `block_exclusions_without_impact_data: true`.
+
+  `analysis_exclusion_impact_preview` also takes `excluded_entities` +
+  `delivery_records` directly, in which case it **reaches no platform API at
+  all** — so a Yahoo placement URL list, a LOGLY adspot block or an Amazon
+  negative-targeting batch is auditable whenever the agent can pull that
+  platform's own report. Its `would_block` is computed by the same function the
+  dispatcher enforces, so the advertised verdict and the enforced one cannot
+  drift.
+
+  New `## Guardrails` keys (all optional, all default off):
+  `max_delivery_share_removed_pct`,
+  `max_cumulative_delivery_share_removed_pct`,
+  `exclusion_impact_window_days` (default 30),
+  `exclusion_impact_metrics` (default `impressions`),
+  `block_exclusions_without_impact_data`.
+
 - **Delivery-surface exclusions are now an operation mureo can perform, and
   therefore one it can guard, record and reverse** (#544). Google Ads
   campaign / ad-group **negative placement criteria** — excluded websites,

--- a/README.ja.md
+++ b/README.ja.md
@@ -270,7 +270,7 @@ STATE.jsonから接続媒体を検出:
 
 ### MCP サーバーとツール一覧
 
-mureo は **211 の MCP ツール** を stdio で公開します。Google広告（89）、Meta広告（90）、Search Console（10）に加え、rollback、異常検知、戦略と状態のコンテキスト、分析モジュールレジストリ、学習、学習期間リセットのプリフライト、Creative Studio を含みます。Amazon 広告を設定している場合は、ローカルのマニフェストからブリッジされた Amazon のツールがこれに加わります（ツール名も本数も Amazon 側のもので、mureo が定義するものではありません。詳細は [docs/amazon-ads.ja.md](docs/amazon-ads.ja.md)）。MCP 対応クライアントなら何からでも接続できます。
+mureo は **212 の MCP ツール** を stdio で公開します。Google広告（89）、Meta広告（90）、Search Console（10）に加え、rollback、異常検知、除外の配信インパクトプレビュー、戦略と状態のコンテキスト、分析モジュールレジストリ、学習、学習期間リセットのプリフライト、Creative Studio を含みます。Amazon 広告を設定している場合は、ローカルのマニフェストからブリッジされた Amazon のツールがこれに加わります（ツール名も本数も Amazon 側のもので、mureo が定義するものではありません。詳細は [docs/amazon-ads.ja.md](docs/amazon-ads.ja.md)）。MCP 対応クライアントなら何からでも接続できます。
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ Why this matters: `link_click` vs `pixel_lead` optimization is a tracking distin
 
 ### MCP server & tool list
 
-mureo exposes **211 MCP tools** over stdio: Google Ads (89), Meta Ads (90), Search Console (10), plus rollback, anomaly detection, strategy/state context, analytics registry, learning, learning-period reset pre-flight, and Creative Studio. When Amazon Ads is configured, the bridged Amazon tools are added on top from the local manifest (their names and count are Amazon's, not mureo's — see [docs/amazon-ads.md](docs/amazon-ads.md)). Any MCP-compatible client can connect:
+mureo exposes **212 MCP tools** over stdio: Google Ads (89), Meta Ads (90), Search Console (10), plus rollback, anomaly detection, exclusion delivery-impact preview, strategy/state context, analytics registry, learning, learning-period reset pre-flight, and Creative Studio. When Amazon Ads is configured, the bridged Amazon tools are added on top from the local manifest (their names and count are Amazon's, not mureo's — see [docs/amazon-ads.md](docs/amazon-ads.md)). Any MCP-compatible client can connect:
 
 ```json
 {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -449,7 +449,7 @@ The Amazon bridge is the reason mureo sits in the request path rather than letti
 
 ## Command-Based Workflow System
 
-In addition to the 211 individual MCP tools, mureo provides **workflow commands** as Claude Code native slash skills (deployed to `~/.claude/skills/`). These commands are **platform-agnostic orchestration instructions** that guide the AI agent to discover platforms, select tools, and synthesize cross-platform insights — all driven by the strategy context in `STRATEGY.md`.
+In addition to the 212 individual MCP tools, mureo provides **workflow commands** as Claude Code native slash skills (deployed to `~/.claude/skills/`). These commands are **platform-agnostic orchestration instructions** that guide the AI agent to discover platforms, select tools, and synthesize cross-platform insights — all driven by the strategy context in `STRATEGY.md`.
 
 ### How It Works
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -1,6 +1,6 @@
 # MCP Server Guide
 
-mureo exposes 211 tools via the [Model Context Protocol](https://modelcontextprotocol.io/) (MCP): 189 advertising and SEO operation tools across Google Ads (89), Meta Ads (90), and Search Console (10), 2 rollback tools, 1 cross-platform anomaly-detection tool, 9 mureo-context tools (strategy / state / reports / outcome evaluation), 2 analytics-registry tools, 2 learning tools (`mureo_learning_insights_get` for the operator's local `/learn` history and `mureo_consult_advisor` for federated retrieval against external advisor MCP servers — see [`docs/insight-federation.md`](insight-federation.md)), 1 learning-period pre-flight tool (`mureo_learning_reset_preflight` — is a pending change reset-triggering, and is the campaign already learning; see [Learning-period reset pre-flight](#learning-period-reset-pre-flight)), and 5 Creative Studio tools (text-free key-visual generation + banner composition). Any MCP-compatible client can connect and call these tools over stdio. Re-check this count when MCP tools are added or removed (`test_list_tools_returns_all_tools` pins the exact number). The count covers mureo's own tool families only — tools bridged from the official **Amazon Ads** MCP (and from any installed provider plugin) are appended on top at server start and vary per operator; see [Amazon Ads (official-MCP bridge)](#amazon-ads-official-mcp-bridge) below.
+mureo exposes 212 tools via the [Model Context Protocol](https://modelcontextprotocol.io/) (MCP): 189 advertising and SEO operation tools across Google Ads (89), Meta Ads (90), and Search Console (10), 2 rollback tools, 2 cross-platform analysis tools (anomaly detection and the exclusion delivery-impact preview), 9 mureo-context tools (strategy / state / reports / outcome evaluation), 2 analytics-registry tools, 2 learning tools (`mureo_learning_insights_get` for the operator's local `/learn` history and `mureo_consult_advisor` for federated retrieval against external advisor MCP servers — see [`docs/insight-federation.md`](insight-federation.md)), 1 learning-period pre-flight tool (`mureo_learning_reset_preflight` — is a pending change reset-triggering, and is the campaign already learning; see [Learning-period reset pre-flight](#learning-period-reset-pre-flight)), and 5 Creative Studio tools (text-free key-visual generation + banner composition). Any MCP-compatible client can connect and call these tools over stdio. Re-check this count when MCP tools are added or removed (`test_list_tools_returns_all_tools` pins the exact number). The count covers mureo's own tool families only — tools bridged from the official **Amazon Ads** MCP (and from any installed provider plugin) are appended on top at server start and vary per operator; see [Amazon Ads (official-MCP bridge)](#amazon-ads-official-mcp-bridge) below.
 
 ## Starting the Server
 
@@ -529,11 +529,68 @@ Both tools accept an optional `state_file` argument (default `STATE.json`), whic
 
 ### Analysis
 
-Cross-platform anomaly detection that operates on STATE.json's `action_log` history rather than a platform API directly.
+Cross-platform analysis that operates on data the caller supplies (or, for the exclusion preview, on the account's own report) rather than on a platform API the tool picks for itself.
 
 | Tool | Description | Required Parameters |
 |------|-------------|-------------------|
 | `analysis_anomalies_check` | Compare a campaign's current metrics against a median-based baseline built from `action_log` history. Returns severity-ordered anomalies — zero spend (CRITICAL), CPA spike (HIGH/CRITICAL, gated by 30+ conversions), CTR drop (HIGH/CRITICAL, gated by 1000+ impressions). | `current` (`current.campaign_id` and `current.cost` required) |
+| `analysis_exclusion_impact_preview` | Size a bulk exclusion / block / negative-keyword batch before applying it: what share of the recent window's impressions, clicks, cost and conversions the excluded entities carried, incrementally and cumulatively. Returns `would_block` from the same rule the dispatcher enforces. | either `tool` (+ `arguments`) or `excluded_entities` |
+
+#### `analysis_exclusion_impact_preview` (#547)
+
+Applying an exclusion batch without knowing its size is how a Display campaign
+goes to zero impressions. This tool answers "how much of *my current delivery*
+does this remove", from the account's own recent performance — never a platform
+reach estimator.
+
+Two calling conventions:
+
+- **`tool` + `arguments`** — the exact call you are about to make. mureo reads
+  the excluded entities out of the arguments and fetches the matching report
+  for that scope.
+- **`excluded_entities` + `delivery_records`** — you supply both sides. This
+  form **reaches no platform API**, so a platform mureo does not model is still
+  auditable whenever you can pull its own report.
+
+`window_days` defaults to STRATEGY.md's `exclusion_impact_window_days` (else
+30). `standing_exclusions` is optional; omit it (rather than passing `[]`) when
+the standing set is unknown — an empty list means "there are none", and the
+cumulative figure is withheld rather than understated when it is unknown.
+
+Coverage is `measured`, `partial` (some entity kinds are structurally
+unattributable on that basis) or `unknown`. `unknown` never means "no impact",
+and `incremental` is `null` rather than a row of zeroes. A window that served
+nothing reports `share_pct: null`, not `0`.
+
+Per-surface attribution:
+
+| Surface | Delivery source | Attributable |
+|---|---|---|
+| `google_ads_negative_placements_add` | `group_placement_view` over the window | Yes for `website` / `mobile_application`; `mobile_app_category` is not a placement that serves, so a mixed batch reports `partial` |
+| `google_ads_negative_keywords_add` / `_add_to_ad_group` | `search_term_view` over the window, matched per `EXACT` / `PHRASE` / `BROAD` | Yes. Negative keywords do not match close variants and neither does the estimate, so it is a lower bound |
+| `meta_ads_excluded_placements_set` | — | **No.** No insights breakdown attributes past delivery to publisher categories, publisher block lists or brand-safety content types. Reported `unknown` |
+| Plugin / bridged surfaces (Yahoo, LINE, SmartNews, LOGLY, Amazon) | Whatever the provider registers via `register_exclusion_surface`, else caller-supplied `delivery_records` | Provider-declared |
+
+**Cumulative tightening.** `cumulative` is the share attributable to the whole
+standing exclusion set once this batch lands, which is what catches a fortnight
+of individually-small passes: an entity excluded a week ago still carries its
+pre-exclusion impressions inside a 30-day window. Its limit is the window — an
+exclusion older than the window contributed nothing to it and is invisible — so
+the cumulative figure is a lower bound. It is withheld (`null` with a reason)
+for an ad-group-level Google placement write, because campaign-level exclusions
+also cover that ad group and are not reachable from the call's arguments, and
+for `google_ads_negative_keywords_add_to_ad_group`, because Google Ads exposes
+no ad-group-level negative keyword listing.
+
+**Enforcement.** The three `STRATEGY.md` `## Guardrails` keys
+`max_delivery_share_removed_pct`,
+`max_cumulative_delivery_share_removed_pct` and
+`block_exclusions_without_impact_data` are enforced in the dispatcher before an
+exclusion tool runs. They are *not* in `StrategyPolicyGate`: the check needs one
+awaited platform read and the `PolicyGate` v1 ABI is synchronous by design and
+must stay pure and fast. With none of them written the check does no I/O at all
+and behaviour is unchanged. `MUREO_DISABLE_EXCLUSION_PREFLIGHT=1` turns it off
+entirely.
 
 `had_prior_spend` (default `true`) suppresses the zero-spend alert for fresh campaigns. `min_baseline_entries` (default `7`) controls how many history entries are required before a baseline is built; below this, `baseline` is `null` and only zero-spend is evaluated. Numeric fields accept int / float / numeric-string and reject `"N/A"` or booleans. `state_file` is sandboxed the same way as for the rollback tools. A parseable-but-corrupt `STATE.json` produces a `baseline_warning` in the response without silencing live zero-spend detection.
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -582,6 +582,15 @@ also cover that ad group and are not reachable from the call's arguments, and
 for `google_ads_negative_keywords_add_to_ad_group`, because Google Ads exposes
 no ad-group-level negative keyword listing.
 
+**An inert rule says so.** Because the cumulative figure is withheld on those
+scopes, `max_cumulative_delivery_share_removed_pct` enforces **nothing** there
+— and that is the scope the motivating incident happened at. Pair it with
+`max_delivery_share_removed_pct`, which is per-batch and needs no standing
+list. When a rule the operator wrote could not be evaluated for a call, mureo
+names it rather than letting it pass silently: `unevaluated_rules` in this
+tool's response, and a `NOT ENFORCED on this call:` line (with the backstop to
+add) in the notice appended to the exclusion's own result.
+
 **Enforcement.** The three `STRATEGY.md` `## Guardrails` keys
 `max_delivery_share_removed_pct`,
 `max_cumulative_delivery_share_removed_pct` and

--- a/mureo/_data/skills/_mureo-google-ads/SKILL.md
+++ b/mureo/_data/skills/_mureo-google-ads/SKILL.md
@@ -334,6 +334,15 @@ kills delivery can be tied to a date and undone, instead of being reconstructed 
 - `add` -- Exclude websites / apps / app categories. **Requires user confirmation.** Always
   show the count and the level before writing — a large batch can take a Display campaign
   to zero impressions.
+
+  **Size it first (#547).** Call `analysis_exclusion_impact_preview` with
+  `tool="google_ads_negative_placements_add"` and the exact `arguments` you are about to
+  send. It reports the share of the last N days' impressions / clicks / cost / conversions
+  those placements carried, both for this batch and cumulatively for every standing
+  exclusion once it lands, plus `would_block`. Show the operator the share, not just the
+  count. If STRATEGY.md `## Guardrails` carries `max_delivery_share_removed_pct` (or
+  `max_cumulative_delivery_share_removed_pct`), an over-cap batch is **refused before it
+  reaches the API** and the refusal names the measured share.
   ```
   Required: customer_id (string), exactly one of campaign_id / ad_group_id (string),
             placements (array of {type: "website" | "mobile_application" | "mobile_app_category",

--- a/mureo/_data/skills/_mureo-meta-ads/SKILL.md
+++ b/mureo/_data/skills/_mureo-meta-ads/SKILL.md
@@ -254,6 +254,18 @@ indistinguishable from any other targeting edit.
             excluded_brand_safety_content_types (arrays of string; at least one required)
   ```
 
+  **Delivery impact is not measurable here, and mureo says so (#547).** None of Meta's
+  insights breakdowns attribute past delivery to publisher categories, publisher block
+  lists or brand-safety content types — `publisher_platform` / `platform_position` are a
+  different exclusion surface (ad-set targeting). So
+  `analysis_exclusion_impact_preview` reports `coverage: "unknown"` for this tool, never
+  "no impact", and the call's own result carries the same verdict. Tell the operator the
+  size is unknown rather than implying it is small. An operator who would rather refuse
+  than proceed blind sets `block_exclusions_without_impact_data: true` in STRATEGY.md
+  `## Guardrails`, which refuses this tool outright. To size such a change from real
+  data, pull the ad set's delivery yourself and pass it to the preview tool as
+  `delivery_records`.
+
 ### insights
 
 - `report` -- Get performance metrics for the account or specific campaign.

--- a/mureo/_data/skills/_mureo-shared/SKILL.md
+++ b/mureo/_data/skills/_mureo-shared/SKILL.md
@@ -240,6 +240,42 @@ When pausing or removing multiple entities:
 - Show total impact (e.g., "This will pause 5 campaigns with 1,200 clicks/day")
 - Require explicit confirmation
 
+### 3b. Bulk Exclusions: Size Them Before Applying (#547)
+
+An exclusion / block / negative-keyword batch removes **inventory**, and the
+share of delivery it removes is not visible from the count of entities. Before
+any such call, run:
+
+```
+analysis_exclusion_impact_preview
+  tool: "<the exclusion tool you are about to call>"
+  arguments: { …exactly the arguments you will send… }
+```
+
+It returns the share of the recent window's impressions / clicks / cost /
+conversions those entities carried — **incrementally** (this batch) and
+**cumulatively** (every standing exclusion once this batch lands). Show the
+operator the share, not just the count. The cumulative figure is the one that
+matters for a sequence of small passes: each pass can look harmless while the
+set as a whole takes delivery to zero.
+
+For a platform mureo does not model — Yahoo Ads placement URL lists, LINE /
+SmartNews placement restrictions, LOGLY adspot blocks, Amazon negative
+targeting — the tool still works: pull that platform's own per-placement /
+per-adspot report yourself and pass `excluded_entities` + `delivery_records`.
+In that form it reaches no API at all.
+
+`coverage: "unknown"` is an honest answer and **never** means "no impact". Say
+"the size of this exclusion cannot be measured" rather than proceeding as if it
+were small.
+
+**LOGLY specifically:** the account's own numbers cannot tell "bad inventory"
+apart from "my creative mismatches this inventory". Before blocking an adspot,
+also check `logly_supply_adspot_summary` (all-advertiser CTR / CPC for the
+slot) and `logly_supply_adspot_cv_by_category` (whether other advertisers
+convert there). The delivery-impact preview sizes the loss; the supply-side
+view is what says whether the loss is worth taking.
+
 ### 4. Never Expose Raw Credentials
 
 - Never include token values from `credentials.json` in responses

--- a/mureo/_data/skills/_mureo-strategy/SKILL.md
+++ b/mureo/_data/skills/_mureo-strategy/SKILL.md
@@ -332,6 +332,20 @@ request and behaves exactly as before.
   **whole** standing exclusion set, including this batch, is over the cap. The
   incident behind #547 was two weeks of individually-small passes, none of
   which would have tripped the incremental cap.
+
+  **Do not write this one alone.** It needs the standing exclusion set, and
+  mureo cannot read that for an **ad group-scoped** write: campaign-level
+  exclusions also cover the ad group and are not reachable from the call's
+  arguments, and Google Ads exposes no ad group-level negative keyword
+  listing at all. On those calls the cumulative figure is withheld (`null`
+  with a reason) and this rule therefore enforces **nothing** — which is
+  exactly the scope the motivating incident happened at. Always pair it with
+  `max_delivery_share_removed_pct`, which is evaluated per batch, needs no
+  standing list, and so still fires there. When a rule you wrote could not be
+  evaluated, mureo says so on the call itself (`NOT ENFORCED on this call:`
+  in the appended notice, `unevaluated_rules` in
+  `analysis_exclusion_impact_preview`) — treat that line as a gap to close,
+  not as a pass.
 - `exclusion_impact_window_days` — the recent window (default 30, max 365).
 - `exclusion_impact_metrics` — which of `impressions` / `clicks` / `cost` /
   `conversions` the caps apply to. Default `impressions`; any listed metric

--- a/mureo/_data/skills/_mureo-strategy/SKILL.md
+++ b/mureo/_data/skills/_mureo-strategy/SKILL.md
@@ -215,6 +215,11 @@ keys (all optional):
 - blocked_operations: google_ads_keywords_remove, meta_ads_audiences_delete
 - block_learning_resets: false
 - block_learning_resets_during_incident: true
+- max_delivery_share_removed_pct: 25
+- max_cumulative_delivery_share_removed_pct: 60
+- exclusion_impact_window_days: 30
+- exclusion_impact_metrics: impressions, cost
+- block_exclusions_without_impact_data: false
 ```
 
 - `max_daily_budget_per_campaign` — a budget mutation proposing more than this
@@ -310,6 +315,40 @@ keys (all optional):
   snapshot (a policy gate runs on every tool call and must not make network
   calls). Keep it fresh or the answer is `unknown` — which these rules treat as
   "refuse", not as "fine".
+
+### Exclusion delivery-impact rules (#547)
+
+The five keys below govern **bulk exclusions / blocks / negative keywords** —
+the operation that removes inventory rather than money. Before such a call is
+dispatched, mureo computes how much of the account's OWN recent delivery the
+batch removes and refuses it when it is over the cap. All five are optional and
+all default to off; with none of them written mureo issues no extra report
+request and behaves exactly as before.
+
+- `max_delivery_share_removed_pct` — refuse an exclusion batch whose entities
+  accounted for more than this share of the recent window. This is the rule
+  that stops "I tightened placements and delivery went to zero".
+- `max_cumulative_delivery_share_removed_pct` — refuse when the account's
+  **whole** standing exclusion set, including this batch, is over the cap. The
+  incident behind #547 was two weeks of individually-small passes, none of
+  which would have tripped the incremental cap.
+- `exclusion_impact_window_days` — the recent window (default 30, max 365).
+- `exclusion_impact_metrics` — which of `impressions` / `clicks` / `cost` /
+  `conversions` the caps apply to. Default `impressions`; any listed metric
+  over the cap refuses.
+- `block_exclusions_without_impact_data` — refuse an exclusion mureo cannot
+  size (coverage `unknown` or `partial`) instead of applying it blind. Default
+  `false`, because several real exclusion surfaces are structurally
+  unattributable (Meta publisher categories / block lists / brand-safety
+  content types have no insights breakdown). Even with it off, the measured —
+  or unmeasurable — verdict is appended to the call's own result, so an
+  exclusion is never applied *silently*.
+
+Call `analysis_exclusion_impact_preview` **before** any bulk exclusion to see
+the same numbers without applying anything. It also works for platforms mureo
+does not model: pass `excluded_entities` + `delivery_records` you fetched from
+that platform's own report and it reaches no API at all. Its `would_block`
+field is computed by the same rule the dispatcher enforces.
 
 Absent section (or an unparseable value) ⇒ no enforcement for that rule
 (fail-open); mureo never blocks on a rule the operator did not write. A boolean

--- a/mureo/analysis/exclusion_impact/__init__.py
+++ b/mureo/analysis/exclusion_impact/__init__.py
@@ -52,8 +52,10 @@ from mureo.analysis.exclusion_impact.rules import (
     DEFAULT_WINDOW_DAYS,
     MAX_WINDOW_DAYS,
     ExclusionImpactRules,
+    UnevaluatedRule,
     evaluate_exclusion_impact,
     exclusion_impact_rules,
+    unevaluated_rules,
 )
 from mureo.analysis.exclusion_impact.surfaces import (
     DeliverySample,
@@ -83,6 +85,7 @@ __all__ = [
     "ExclusionSurface",
     "ExclusionTarget",
     "MetricShare",
+    "UnevaluatedRule",
     "estimate_exclusion_impact",
     "evaluate_exclusion_impact",
     "exclusion_impact_rules",
@@ -94,4 +97,5 @@ __all__ = [
     "reset_exclusion_surfaces",
     "target_matches",
     "tokenize",
+    "unevaluated_rules",
 ]

--- a/mureo/analysis/exclusion_impact/__init__.py
+++ b/mureo/analysis/exclusion_impact/__init__.py
@@ -1,0 +1,97 @@
+"""Delivery-impact preview for bulk exclusions / blocks / negatives (#547).
+
+mureo used to apply an exclusion batch without saying how much of the
+account's delivery it removes. Every other item filed from the same
+incident post-mortem shortens the recovery; this one is the only mechanism
+that stops the mistake being made.
+
+The package is pure and platform-neutral:
+
+- :mod:`~mureo.analysis.exclusion_impact.models` — the vocabulary
+  (delivery rows, exclusion targets, the three coverage verdicts).
+- :mod:`~mureo.analysis.exclusion_impact.matching` — does excluding this
+  entity stop that row delivering, per entity kind.
+- :mod:`~mureo.analysis.exclusion_impact.estimator` — the share itself,
+  incremental and cumulative.
+- :mod:`~mureo.analysis.exclusion_impact.rules` — the ``## Guardrails``
+  keys, and the one function that decides a refusal.
+- :mod:`~mureo.analysis.exclusion_impact.surfaces` — which tools are
+  exclusion surfaces and where their numbers come from (mureo's own, plus
+  whatever a plugin registers).
+
+The I/O lives outside it, in :mod:`mureo.mcp.exclusion_sources` (the
+built-in Google/Meta data sources) and :mod:`mureo.mcp.exclusion_preflight`
+(the dispatcher hook).
+"""
+
+from __future__ import annotations
+
+from mureo.analysis.exclusion_impact.estimator import estimate_exclusion_impact
+from mureo.analysis.exclusion_impact.matching import (
+    normalize_app,
+    normalize_website,
+    target_matches,
+    tokenize,
+)
+from mureo.analysis.exclusion_impact.models import (
+    COVERAGE_MEASURED,
+    COVERAGE_PARTIAL,
+    COVERAGE_UNKNOWN,
+    ENTITY_MOBILE_APP_CATEGORY,
+    ENTITY_MOBILE_APPLICATION,
+    ENTITY_SEARCH_TERM,
+    ENTITY_WEBSITE,
+    METRICS,
+    DeliveryRecord,
+    ExclusionImpact,
+    ExclusionTarget,
+    MetricShare,
+)
+from mureo.analysis.exclusion_impact.rules import (
+    DEFAULT_METRICS,
+    DEFAULT_WINDOW_DAYS,
+    MAX_WINDOW_DAYS,
+    ExclusionImpactRules,
+    evaluate_exclusion_impact,
+    exclusion_impact_rules,
+)
+from mureo.analysis.exclusion_impact.surfaces import (
+    DeliverySample,
+    ExclusionSurface,
+    exclusion_surface_for,
+    register_exclusion_surface,
+    registered_exclusion_tools,
+    reset_exclusion_surfaces,
+)
+
+__all__ = [
+    "COVERAGE_MEASURED",
+    "COVERAGE_PARTIAL",
+    "COVERAGE_UNKNOWN",
+    "DEFAULT_METRICS",
+    "DEFAULT_WINDOW_DAYS",
+    "ENTITY_MOBILE_APPLICATION",
+    "ENTITY_MOBILE_APP_CATEGORY",
+    "ENTITY_SEARCH_TERM",
+    "ENTITY_WEBSITE",
+    "MAX_WINDOW_DAYS",
+    "METRICS",
+    "DeliveryRecord",
+    "DeliverySample",
+    "ExclusionImpact",
+    "ExclusionImpactRules",
+    "ExclusionSurface",
+    "ExclusionTarget",
+    "MetricShare",
+    "estimate_exclusion_impact",
+    "evaluate_exclusion_impact",
+    "exclusion_impact_rules",
+    "exclusion_surface_for",
+    "normalize_app",
+    "normalize_website",
+    "register_exclusion_surface",
+    "registered_exclusion_tools",
+    "reset_exclusion_surfaces",
+    "target_matches",
+    "tokenize",
+]

--- a/mureo/analysis/exclusion_impact/estimator.py
+++ b/mureo/analysis/exclusion_impact/estimator.py
@@ -1,0 +1,208 @@
+"""The estimate itself: how much of MY delivery does this exclusion remove?
+
+Pure and I/O-free. The caller supplies the account's own recent delivery
+rows and the entities a batch is about to exclude; this module answers with
+a share per metric, and with an explicit verdict about what it could not
+see.
+
+Two figures, deliberately:
+
+``incremental``
+    The share attributable to the entities in THIS call.
+``cumulative``
+    The share attributable to the whole standing exclusion set once this
+    call lands — the entities already excluded plus the new ones. This is
+    the figure that catches incremental tightening, because an entity
+    excluded a week ago still carries its pre-exclusion impressions inside
+    a 30-day window. Its limit is the window: an exclusion older than the
+    window contributed nothing to it and is therefore invisible. The
+    cumulative share is a lower bound for that reason.
+
+Zero total is not zero impact. When the window served nothing at all the
+share is ``None``, not ``0.0`` — the batch may still be removing all of a
+future recovery, and a printed ``0%`` reads as "safe".
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from mureo.analysis.exclusion_impact.matching import target_matches
+from mureo.analysis.exclusion_impact.models import (
+    COVERAGE_MEASURED,
+    COVERAGE_PARTIAL,
+    COVERAGE_UNKNOWN,
+    METRICS,
+    DeliveryRecord,
+    ExclusionImpact,
+    ExclusionTarget,
+    MetricShare,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Collection, Iterable, Sequence
+
+
+def _matched_indices(
+    targets: Sequence[ExclusionTarget], records: Sequence[DeliveryRecord]
+) -> tuple[set[int], set[int]]:
+    """Return (record indices covered, target indices that covered something)."""
+    covered: set[int] = set()
+    hitting: set[int] = set()
+    for t_index, target in enumerate(targets):
+        for r_index, record in enumerate(records):
+            if target_matches(target, record):
+                covered.add(r_index)
+                hitting.add(t_index)
+    return covered, hitting
+
+
+def _shares(
+    records: Sequence[DeliveryRecord], covered: Collection[int]
+) -> tuple[MetricShare, ...]:
+    shares: list[MetricShare] = []
+    for metric in METRICS:
+        total = sum(record.metric(metric) for record in records)
+        removed = sum(records[i].metric(metric) for i in covered)
+        share = (removed / total * 100.0) if total > 0 else None
+        shares.append(
+            MetricShare(
+                metric=metric,
+                total=total,
+                removed=removed,
+                share_pct=share,
+            )
+        )
+    return tuple(shares)
+
+
+def _split_targets(
+    targets: Iterable[ExclusionTarget], attributable_types: Collection[str]
+) -> tuple[list[ExclusionTarget], list[ExclusionTarget]]:
+    attributable: list[ExclusionTarget] = []
+    unattributable: list[ExclusionTarget] = []
+    for target in targets:
+        bucket = (
+            attributable if target.entity_type in attributable_types else unattributable
+        )
+        bucket.append(target)
+    return attributable, unattributable
+
+
+def _coverage(
+    attributable: Sequence[ExclusionTarget],
+    unattributable: Sequence[ExclusionTarget],
+) -> str:
+    if not attributable:
+        return COVERAGE_UNKNOWN
+    return COVERAGE_PARTIAL if unattributable else COVERAGE_MEASURED
+
+
+def _unattributable_reason(
+    unattributable: Sequence[ExclusionTarget], basis: str
+) -> str:
+    kinds = sorted({t.entity_type for t in unattributable})
+    return (
+        f"{len(unattributable)} of the excluded entities are of a kind "
+        f"({', '.join(kinds)}) that '{basis}' does not attribute past "
+        f"delivery to, so the reported share is a lower bound."
+    )
+
+
+def estimate_exclusion_impact(
+    *,
+    targets: Iterable[ExclusionTarget],
+    records: Sequence[DeliveryRecord] | None,
+    attributable_types: Collection[str],
+    basis: str,
+    window_days: int,
+    standing: Iterable[ExclusionTarget] | None = None,
+    coverage_reason: str = "",
+    cumulative_reason: str = "",
+) -> ExclusionImpact:
+    """Compute the delivery share a batch of exclusions removes.
+
+    Args:
+        targets: The entities this call excludes.
+        records: The account's own delivery in the window, or ``None`` when
+            the platform cannot attribute delivery to these entities at
+            all. ``None`` yields ``coverage='unknown'``; an EMPTY sequence
+            is a measured "the window served nothing".
+        attributable_types: Entity kinds ``records`` can speak about. A
+            target outside this set is reported, never silently dropped.
+        basis: What the denominator is, named for the operator (e.g.
+            ``google_ads_group_placement_view``). Never "the campaign" —
+            a placement report totals placement-attributed delivery only.
+        window_days: The window ``records`` covers.
+        standing: Entities already excluded on this scope, for the
+            cumulative figure. ``None`` (not ``()``) means mureo could not
+            list them, and the cumulative figure is withheld rather than
+            reported as equal to the incremental one.
+        coverage_reason: Why ``records`` is ``None``, in operator words.
+        cumulative_reason: Why ``standing`` is ``None``, in operator words.
+    """
+    target_list = list(targets)
+    attributable, unattributable = _split_targets(target_list, attributable_types)
+    unattributable_values = tuple(t.value for t in unattributable)
+
+    if records is None:
+        return ExclusionImpact(
+            coverage=COVERAGE_UNKNOWN,
+            basis=basis,
+            window_days=window_days,
+            incremental=None,
+            cumulative=None,
+            unattributable_targets=unattributable_values,
+            coverage_reason=coverage_reason
+            or f"'{basis}' does not attribute past delivery to these entities.",
+            cumulative_reason=cumulative_reason,
+        )
+
+    coverage = _coverage(attributable, unattributable)
+    if coverage == COVERAGE_UNKNOWN:
+        return ExclusionImpact(
+            coverage=COVERAGE_UNKNOWN,
+            basis=basis,
+            window_days=window_days,
+            incremental=None,
+            cumulative=None,
+            unattributable_targets=unattributable_values,
+            coverage_reason=coverage_reason
+            or _unattributable_reason(unattributable, basis),
+            cumulative_reason=cumulative_reason,
+        )
+
+    covered, hitting = _matched_indices(attributable, records)
+    incremental = _shares(records, covered)
+    matched = tuple(dict.fromkeys(records[i].entity for i in sorted(covered)))
+    unmatched = tuple(
+        target.value
+        for index, target in enumerate(attributable)
+        if index not in hitting
+    )
+
+    cumulative: tuple[MetricShare, ...] | None = None
+    if standing is not None:
+        standing_attributable, _ = _split_targets(standing, attributable_types)
+        standing_covered, _ = _matched_indices(standing_attributable, records)
+        cumulative = _shares(records, covered | standing_covered)
+
+    reason = coverage_reason
+    if coverage == COVERAGE_PARTIAL and not reason:
+        reason = _unattributable_reason(unattributable, basis)
+
+    return ExclusionImpact(
+        coverage=coverage,
+        basis=basis,
+        window_days=window_days,
+        incremental=incremental,
+        cumulative=cumulative,
+        matched=matched,
+        unmatched_targets=unmatched,
+        unattributable_targets=unattributable_values,
+        coverage_reason=reason,
+        cumulative_reason=cumulative_reason if cumulative is None else "",
+    )
+
+
+__all__ = ["estimate_exclusion_impact"]

--- a/mureo/analysis/exclusion_impact/matching.py
+++ b/mureo/analysis/exclusion_impact/matching.py
@@ -1,0 +1,136 @@
+"""Does an exclusion target cover a delivery row? Pure, per entity kind.
+
+Every rule here errs toward **fewer** attributed impressions, because the
+estimate feeds a threshold that can refuse a write: over-attributing turns
+an ordinary hygiene pass into a refusal the operator learns to switch off.
+
+The documented limits:
+
+- **Websites** match on host, after dropping scheme, ``www.``, port, path
+  and query. Excluding ``example.com`` covers ``news.example.com`` (Google
+  excludes the site, not the one hostname) but excluding
+  ``news.example.com`` never claims ``example.com``. The label-boundary
+  check is what stops ``example.com`` from swallowing
+  ``notexample.com``.
+- **Mobile applications** match on the store-qualified app id, with the
+  report's ``mobileapp::`` prefix dropped from either side.
+- **Negative keywords** are matched by token sequence per match type.
+  Google does **not** apply close variants to negative keywords, so no
+  stemming, pluralisation or accent folding is applied here either — which
+  means a term that only differs by a plural is NOT counted, and the
+  estimate is a lower bound.
+- Any other entity kind matches on the exact string, case-folded and
+  stripped. A plugin surface that needs richer matching normalizes its own
+  values before handing them over.
+"""
+
+from __future__ import annotations
+
+import re
+from urllib.parse import urlsplit
+
+from mureo.analysis.exclusion_impact.models import (
+    ENTITY_MOBILE_APPLICATION,
+    ENTITY_SEARCH_TERM,
+    ENTITY_WEBSITE,
+    DeliveryRecord,
+    ExclusionTarget,
+)
+
+#: Google Ads placement reports prefix a mobile app id with this.
+_MOBILE_APP_PREFIX = "mobileapp::"
+
+#: Everything that is not a word character or a space becomes a separator
+#: when a search term is tokenized. Unicode-aware so Japanese terms survive.
+_TOKEN_SPLIT = re.compile(r"[^\w]+", re.UNICODE)
+
+_EXACT = "EXACT"
+_PHRASE = "PHRASE"
+_BROAD = "BROAD"
+
+
+def normalize_website(value: str) -> str:
+    """``https://WWW.Example.com/a?b=1`` → ``example.com``."""
+    text = str(value or "").strip().lower().rstrip(".")
+    if not text:
+        return ""
+    if "//" not in text:
+        # urlsplit only fills ``netloc`` when a scheme separator is present.
+        text = f"//{text}"
+    host = urlsplit(text).netloc or ""
+    host = host.rsplit("@", 1)[-1]
+    if host.startswith("["):  # IPv6 literal — keep the brackets, drop the port
+        host = host.split("]", 1)[0] + "]"
+    else:
+        host = host.split(":", 1)[0]
+    if host.startswith("www."):
+        host = host[4:]
+    return host.rstrip(".")
+
+
+def normalize_app(value: str) -> str:
+    """Drop the report's ``mobileapp::`` prefix and case-fold."""
+    text = str(value or "").strip().lower()
+    if text.startswith(_MOBILE_APP_PREFIX):
+        text = text[len(_MOBILE_APP_PREFIX) :]
+    return text
+
+
+def tokenize(value: str) -> tuple[str, ...]:
+    """Split a search term / keyword into comparable tokens."""
+    return tuple(t for t in _TOKEN_SPLIT.split(str(value or "").casefold()) if t)
+
+
+def _covers_host(excluded: str, served: str) -> bool:
+    """True when ``served`` is ``excluded`` or a subdomain of it."""
+    if not excluded or not served:
+        return False
+    return served == excluded or served.endswith(f".{excluded}")
+
+
+def _contains_subsequence(haystack: tuple[str, ...], needle: tuple[str, ...]) -> bool:
+    if not needle or len(needle) > len(haystack):
+        return False
+    limit = len(haystack) - len(needle)
+    return any(haystack[i : i + len(needle)] == needle for i in range(limit + 1))
+
+
+def _keyword_matches(target: ExclusionTarget, record: DeliveryRecord) -> bool:
+    term = tokenize(record.entity)
+    keyword = tokenize(target.value)
+    if not keyword:
+        return False
+    match_type = (target.match_type or _BROAD).strip().upper()
+    if match_type == _EXACT:
+        return term == keyword
+    if match_type == _PHRASE:
+        return _contains_subsequence(term, keyword)
+    # BROAD (and anything unrecognized, handled as the widest documented
+    # form): every token present, order-free.
+    return set(keyword).issubset(set(term))
+
+
+def target_matches(target: ExclusionTarget, record: DeliveryRecord) -> bool:
+    """True when excluding ``target`` stops ``record`` from delivering."""
+    if target.entity_type != record.entity_type:
+        return False
+    if target.entity_type == ENTITY_WEBSITE:
+        return _covers_host(
+            normalize_website(target.value), normalize_website(record.entity)
+        )
+    if target.entity_type == ENTITY_MOBILE_APPLICATION:
+        return normalize_app(target.value) == normalize_app(record.entity)
+    if target.entity_type == ENTITY_SEARCH_TERM:
+        return _keyword_matches(target, record)
+    return (
+        str(target.value or "").strip().casefold()
+        == str(record.entity or "").strip().casefold()
+    )
+
+
+__all__ = [
+    "normalize_app",
+    "normalize_website",
+    "target_matches",
+    "tokenize",
+]

--- a/mureo/analysis/exclusion_impact/models.py
+++ b/mureo/analysis/exclusion_impact/models.py
@@ -1,0 +1,174 @@
+"""Platform-neutral value types for the exclusion delivery-impact preview.
+
+One vocabulary for every inventory-restriction surface mureo touches —
+excluded placements, excluded apps, negative keywords, blocked adspots,
+publisher block lists — so the estimator itself never learns a platform.
+
+Three coverage verdicts, and the distinction between them is the point of
+the feature:
+
+``measured``
+    Every entity in the batch is of a kind this delivery basis can
+    attribute. The reported shares are the account's own numbers.
+``partial``
+    Some entities are of a kind the basis cannot attribute at all (a
+    Google Ads *mobile app category* against a placement report, say —
+    categories are not themselves placements that serve). The shares are
+    real but are a LOWER bound on what the batch removes.
+``unknown``
+    Nothing in the batch can be attributed. Reported honestly; never
+    rendered as "0% impact", because a false "this removes nothing" is
+    read as approval.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+#: The four metrics a share is computed for. Order is the reporting order.
+METRICS: tuple[str, ...] = ("impressions", "clicks", "cost", "conversions")
+
+COVERAGE_MEASURED = "measured"
+COVERAGE_PARTIAL = "partial"
+COVERAGE_UNKNOWN = "unknown"
+
+#: Entity kinds mureo names itself. A plugin may use any other string; the
+#: estimator compares kinds, it does not enumerate them.
+ENTITY_WEBSITE = "website"
+ENTITY_MOBILE_APPLICATION = "mobile_application"
+ENTITY_MOBILE_APP_CATEGORY = "mobile_app_category"
+ENTITY_SEARCH_TERM = "search_term"
+
+
+@dataclass(frozen=True)
+class DeliveryRecord:
+    """One row of the account's OWN recent delivery, keyed by entity.
+
+    ``entity`` is whatever the platform's report calls the placement /
+    search term / adspot; normalization happens at match time, so a row is
+    stored exactly as reported.
+    """
+
+    entity: str
+    entity_type: str
+    impressions: float = 0.0
+    clicks: float = 0.0
+    cost: float = 0.0
+    conversions: float = 0.0
+
+    def metric(self, name: str) -> float:
+        return float(getattr(self, name))
+
+
+@dataclass(frozen=True)
+class ExclusionTarget:
+    """One entity a batch is about to exclude, block, or negate.
+
+    ``match_type`` carries a negative keyword's ``EXACT`` / ``PHRASE`` /
+    ``BROAD``; it is ``None`` for every surface whose entities are matched
+    by identity rather than by text.
+    """
+
+    value: str
+    entity_type: str
+    match_type: str | None = None
+
+
+@dataclass(frozen=True)
+class MetricShare:
+    """How much of one metric a batch removes, in the measured window."""
+
+    metric: str
+    total: float
+    removed: float
+    share_pct: float | None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "total": self.total,
+            "removed": self.removed,
+            "share_pct": self.share_pct,
+        }
+
+
+def _shares_as_dict(
+    shares: tuple[MetricShare, ...] | None,
+) -> dict[str, Any] | None:
+    if shares is None:
+        return None
+    return {share.metric: share.as_dict() for share in shares}
+
+
+def _pct(shares: tuple[MetricShare, ...] | None, metric: str) -> float | None:
+    if shares is None:
+        return None
+    for share in shares:
+        if share.metric == metric:
+            return share.share_pct
+    return None
+
+
+@dataclass(frozen=True)
+class ExclusionImpact:
+    """What a batch of exclusions removes from the account's own delivery.
+
+    ``incremental`` is what THIS batch removes. ``cumulative`` is what the
+    account's whole standing exclusion set removes once this batch lands —
+    the figure the incremental one hides, because the incident that
+    motivated #547 was two weeks of individually-small passes.
+
+    Either may be ``None``, and ``None`` never means zero:
+    ``incremental is None`` ⇔ coverage is ``unknown``; ``cumulative is
+    None`` means the standing set could not be listed, with the reason in
+    ``cumulative_reason``.
+    """
+
+    coverage: str
+    basis: str
+    window_days: int
+    incremental: tuple[MetricShare, ...] | None
+    cumulative: tuple[MetricShare, ...] | None = None
+    matched: tuple[str, ...] = ()
+    unmatched_targets: tuple[str, ...] = ()
+    unattributable_targets: tuple[str, ...] = ()
+    coverage_reason: str = ""
+    cumulative_reason: str = ""
+
+    def share_pct(self, metric: str) -> float | None:
+        """Incremental share of ``metric``, or ``None`` when not computable."""
+        return _pct(self.incremental, metric)
+
+    def cumulative_share_pct(self, metric: str) -> float | None:
+        """Cumulative share of ``metric``, or ``None`` when not computable."""
+        return _pct(self.cumulative, metric)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "coverage": self.coverage,
+            "coverage_reason": self.coverage_reason,
+            "basis": self.basis,
+            "window_days": self.window_days,
+            "incremental": _shares_as_dict(self.incremental),
+            "cumulative": _shares_as_dict(self.cumulative),
+            "cumulative_reason": self.cumulative_reason,
+            "matched_entities": list(self.matched),
+            "unmatched_targets": list(self.unmatched_targets),
+            "unattributable_targets": list(self.unattributable_targets),
+        }
+
+
+__all__ = [
+    "COVERAGE_MEASURED",
+    "COVERAGE_PARTIAL",
+    "COVERAGE_UNKNOWN",
+    "ENTITY_MOBILE_APPLICATION",
+    "ENTITY_MOBILE_APP_CATEGORY",
+    "ENTITY_SEARCH_TERM",
+    "ENTITY_WEBSITE",
+    "METRICS",
+    "DeliveryRecord",
+    "ExclusionImpact",
+    "ExclusionTarget",
+    "MetricShare",
+]

--- a/mureo/analysis/exclusion_impact/rules.py
+++ b/mureo/analysis/exclusion_impact/rules.py
@@ -120,6 +120,56 @@ def _over_cap(
     return None
 
 
+@dataclass(frozen=True)
+class UnevaluatedRule:
+    """A rule the operator WROTE that could not be evaluated for this call."""
+
+    key: str
+    reason: str
+
+    def as_text(self) -> str:
+        return f"{self.key} could not be evaluated here — {self.reason}"
+
+
+def unevaluated_rules(
+    impact: ExclusionImpact, rules: ExclusionImpactRules
+) -> tuple[UnevaluatedRule, ...]:
+    """Rules that are silently inert for this particular call.
+
+    A rule that cannot fire has to say so **at the moment it cannot fire**,
+    not only in a document. The case that matters:
+    ``max_cumulative_delivery_share_removed_pct`` is the rule that catches
+    incremental tightening, and it is exactly the rule an operator writes
+    after reading an incident report — but mureo cannot list the standing
+    exclusion set for an ad-group-scoped write, so on those calls the rule
+    enforces nothing at all. An operator who wrote ONLY that rule would
+    have no enforcement on the very scope the incident happened at. Saying
+    so lets them add ``max_delivery_share_removed_pct`` as the backstop.
+    """
+    inert: list[UnevaluatedRule] = []
+    if rules.max_share_pct is not None and impact.incremental is None:
+        inert.append(
+            UnevaluatedRule(
+                key="max_delivery_share_removed_pct",
+                reason=(
+                    impact.coverage_reason
+                    or f"delivery coverage for this call is '{impact.coverage}'"
+                ),
+            )
+        )
+    if rules.max_cumulative_share_pct is not None and impact.cumulative is None:
+        inert.append(
+            UnevaluatedRule(
+                key="max_cumulative_delivery_share_removed_pct",
+                reason=(
+                    impact.cumulative_reason
+                    or "the standing exclusion set could not be read for this scope"
+                ),
+            )
+        )
+    return tuple(inert)
+
+
 def evaluate_exclusion_impact(
     impact: ExclusionImpact, rules: ExclusionImpactRules
 ) -> str | None:
@@ -151,6 +201,8 @@ __all__ = [
     "DEFAULT_WINDOW_DAYS",
     "MAX_WINDOW_DAYS",
     "ExclusionImpactRules",
+    "UnevaluatedRule",
     "evaluate_exclusion_impact",
     "exclusion_impact_rules",
+    "unevaluated_rules",
 ]

--- a/mureo/analysis/exclusion_impact/rules.py
+++ b/mureo/analysis/exclusion_impact/rules.py
@@ -1,0 +1,156 @@
+"""Turning ``## Guardrails`` into a refusal — the one enforcement decision.
+
+:func:`evaluate_exclusion_impact` is the single place that decides whether
+an exclusion batch is refused. The dispatcher pre-flight calls it to
+actually refuse, and ``analysis_exclusion_impact_preview`` calls the same
+function to report ``would_block``, so the advertised verdict and the
+enforced one cannot drift.
+
+Fail-open by the same contract as every other guardrail: with none of the
+five keys written, :meth:`ExclusionImpactRules.enabled` is ``False``, the
+pre-flight does no platform I/O at all, and behaviour is unchanged.
+
+Unknown coverage is NOT a refusal by default. A platform mureo cannot
+attribute delivery on (Meta's publisher-category exclusions, an
+un-declared plugin surface) would otherwise become unusable the moment an
+operator wrote a share cap for Google. ``block_exclusions_without_impact_data``
+is the opt-in for operators who would rather refuse than proceed blind —
+and the batch is never *silently* allowed either way: the measured (or
+unmeasurable) verdict is appended to the call's own result.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from mureo.analysis.exclusion_impact.models import (
+    COVERAGE_MEASURED,
+    METRICS,
+    ExclusionImpact,
+)
+
+if TYPE_CHECKING:
+    from mureo.policy.strategy_gate import Guardrails
+
+#: Recent-window length used when the operator did not name one.
+DEFAULT_WINDOW_DAYS = 30
+
+#: Metric the share cap applies to when the operator did not name any.
+#: Impressions, not cost: an exclusion removes *inventory*, and impressions
+#: are the first thing to collapse when too much of it is removed.
+DEFAULT_METRICS: tuple[str, ...] = ("impressions",)
+
+#: Upper bound on ``exclusion_impact_window_days``. Beyond this the report
+#: request stops being a "recent window" and starts being a slow scan.
+MAX_WINDOW_DAYS = 365
+
+
+@dataclass(frozen=True)
+class ExclusionImpactRules:
+    """The operator's exclusion-impact rules, resolved with defaults."""
+
+    max_share_pct: float | None = None
+    max_cumulative_share_pct: float | None = None
+    window_days: int = DEFAULT_WINDOW_DAYS
+    metrics: tuple[str, ...] = DEFAULT_METRICS
+    block_without_data: bool = False
+
+    def enabled(self) -> bool:
+        """True when the operator wrote at least one exclusion-impact rule.
+
+        False ⇒ the pre-flight makes no platform call and never refuses.
+        """
+        return (
+            self.max_share_pct is not None
+            or self.max_cumulative_share_pct is not None
+            or self.block_without_data
+        )
+
+
+def _clamp_window(days: int | None) -> int:
+    if days is None:
+        return DEFAULT_WINDOW_DAYS
+    return max(1, min(int(days), MAX_WINDOW_DAYS))
+
+
+def exclusion_impact_rules(guardrails: Guardrails) -> ExclusionImpactRules:
+    """Resolve the ``## Guardrails`` exclusion keys against the defaults."""
+    metrics = tuple(m for m in guardrails.exclusion_impact_metrics if m in METRICS)
+    return ExclusionImpactRules(
+        max_share_pct=guardrails.max_delivery_share_removed_pct,
+        max_cumulative_share_pct=(guardrails.max_cumulative_delivery_share_removed_pct),
+        window_days=_clamp_window(guardrails.exclusion_impact_window_days),
+        metrics=metrics or DEFAULT_METRICS,
+        block_without_data=guardrails.block_exclusions_without_impact_data,
+    )
+
+
+def _over_cap(
+    impact: ExclusionImpact,
+    cap: float | None,
+    metrics: tuple[str, ...],
+    *,
+    cumulative: bool,
+) -> str | None:
+    if cap is None:
+        return None
+    key = (
+        "max_cumulative_delivery_share_removed_pct"
+        if cumulative
+        else "max_delivery_share_removed_pct"
+    )
+    what = "already-excluded inventory plus this batch" if cumulative else "this batch"
+    for metric in metrics:
+        share = (
+            impact.cumulative_share_pct(metric)
+            if cumulative
+            else impact.share_pct(metric)
+        )
+        if share is None or share <= cap:
+            continue
+        return (
+            f"Refusing this exclusion batch: {what} accounted for "
+            f"{share:.1f}% of the last {impact.window_days} days of "
+            f"{metric} ({impact.basis}), over the STRATEGY.md Guardrails "
+            f"limit of {cap:g}% ({key}). Narrow the batch, raise the "
+            f"limit, or apply it in smaller passes and observe delivery "
+            f"between them."
+        )
+    return None
+
+
+def evaluate_exclusion_impact(
+    impact: ExclusionImpact, rules: ExclusionImpactRules
+) -> str | None:
+    """Return the refusal reason for ``impact``, or ``None`` to allow.
+
+    Order matters only for which reason surfaces first; any one of them is
+    a refusal.
+    """
+    if not rules.enabled():
+        return None
+    if rules.block_without_data and impact.coverage != COVERAGE_MEASURED:
+        detail = impact.coverage_reason or "no attributable delivery data"
+        return (
+            f"Refusing this exclusion batch: mureo could not measure how much "
+            f"of the last {impact.window_days} days of delivery it removes "
+            f"(coverage: {impact.coverage} — {detail}). STRATEGY.md Guardrails "
+            f"has block_exclusions_without_impact_data set, which refuses an "
+            f"exclusion mureo cannot size rather than applying it blind."
+        )
+    return _over_cap(
+        impact, rules.max_share_pct, rules.metrics, cumulative=False
+    ) or _over_cap(
+        impact, rules.max_cumulative_share_pct, rules.metrics, cumulative=True
+    )
+
+
+__all__ = [
+    "DEFAULT_METRICS",
+    "DEFAULT_WINDOW_DAYS",
+    "MAX_WINDOW_DAYS",
+    "ExclusionImpactRules",
+    "evaluate_exclusion_impact",
+    "exclusion_impact_rules",
+]

--- a/mureo/analysis/exclusion_impact/surfaces.py
+++ b/mureo/analysis/exclusion_impact/surfaces.py
@@ -1,0 +1,100 @@
+"""Which tool calls are exclusion surfaces, and where their numbers come from.
+
+A registry, in the shape the budget/bid declarations already use
+(:mod:`mureo.policy.declarations`): mureo registers the surfaces it owns
+the schema for, and a plugin or bridge registers its own through the same
+public function. A tool with no registration is not an exclusion surface as
+far as mureo is concerned, so the pre-flight skips it entirely and does no
+I/O — which is what keeps the check off the other ~200 tools.
+
+A surface is two callables:
+
+``targets``
+    Pure. Reads the tool's own arguments and returns the entities the call
+    is about to exclude.
+``delivery``
+    Awaited. Returns the account's own recent delivery for the scope those
+    entities live in — or :class:`DeliverySample` with ``records=None`` and
+    a ``reason``, which is how a platform says "I cannot attribute past
+    delivery to this kind of entity". Returning ``None`` records is a
+    supported, honest answer; returning empty records to mean the same
+    thing would print "0% impact" and read as approval.
+
+The provider ABI hook the issue asks for is exactly this: a bridge with a
+supply-side view registers a ``delivery`` that carries it, and the same
+preview then gates that platform's blocks too.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable, Iterable, Mapping
+
+    from mureo.analysis.exclusion_impact.models import DeliveryRecord, ExclusionTarget
+
+
+@dataclass(frozen=True)
+class DeliverySample:
+    """The account's own delivery for one exclusion scope.
+
+    ``records=None`` means "not attributable", with ``reason`` saying why.
+    ``standing=None`` means the standing exclusion set could not be listed,
+    with ``standing_reason`` saying why; the cumulative figure is then
+    withheld rather than understated.
+    """
+
+    records: tuple[DeliveryRecord, ...] | None
+    basis: str
+    attributable_types: frozenset[str] = frozenset()
+    reason: str = ""
+    standing: tuple[ExclusionTarget, ...] | None = None
+    standing_reason: str = ""
+
+
+@dataclass(frozen=True)
+class ExclusionSurface:
+    """One tool whose call removes inventory from delivery."""
+
+    tool: str
+    platform: str
+    targets: Callable[[Mapping[str, Any]], Iterable[ExclusionTarget]]
+    delivery: Callable[[Mapping[str, Any], int], Awaitable[DeliverySample]]
+    #: Human-readable note carried into the preview output, e.g. a known
+    #: limit of the platform's report.
+    note: str = field(default="")
+
+
+_SURFACES: dict[str, ExclusionSurface] = {}
+
+
+def register_exclusion_surface(surface: ExclusionSurface) -> None:
+    """Register (or replace) the exclusion surface for ``surface.tool``."""
+    _SURFACES[surface.tool] = surface
+
+
+def exclusion_surface_for(tool: str) -> ExclusionSurface | None:
+    """The registered surface for ``tool``, or ``None`` if it is not one."""
+    return _SURFACES.get(tool)
+
+
+def registered_exclusion_tools() -> frozenset[str]:
+    """Every tool name currently registered as an exclusion surface."""
+    return frozenset(_SURFACES)
+
+
+def reset_exclusion_surfaces() -> None:
+    """Drop every registration. Test-support; not part of the plugin ABI."""
+    _SURFACES.clear()
+
+
+__all__ = [
+    "DeliverySample",
+    "ExclusionSurface",
+    "exclusion_surface_for",
+    "register_exclusion_surface",
+    "registered_exclusion_tools",
+    "reset_exclusion_surfaces",
+]

--- a/mureo/google_ads/_placement_mappers.py
+++ b/mureo/google_ads/_placement_mappers.py
@@ -1,0 +1,125 @@
+"""Response mappers for the Google Ads placement surfaces.
+
+Split out of :mod:`mureo.google_ads.mappers` for the same reason
+:mod:`mureo.google_ads._placements` was split out of the client: the
+placement work is one coherent family, and `mappers.py` had grown past the
+project's 800-line file budget.
+
+Two rows are shaped here:
+
+- :func:`map_negative_placement` — a campaign / ad-group negative placement
+  criterion (an exclusion that EXISTS), #544.
+- :func:`map_placement_performance` — a ``group_placement_view`` row (what a
+  placement actually DELIVERED), the denominator for the #547 exclusion
+  delivery-impact preview.
+
+Both keep the raw Google Ads enum name alongside mureo's tool-facing
+vocabulary, so a row stays readable if Google adds a type mureo does not map
+yet.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mureo.google_ads.mappers import (
+    CRITERION_TYPE_MAP,
+    _HasIdAndName,
+    _micros_to_currency,
+    _safe_float,
+    _safe_int,
+    _safe_str,
+    map_enum_name,
+)
+
+# === Negative Placements (delivery-surface exclusions, #544) ===
+
+
+def map_negative_placement(
+    criterion: Any,
+    level: str,
+    campaign: _HasIdAndName | None = None,
+    ad_group: _HasIdAndName | None = None,
+) -> dict[str, Any]:
+    """Shape one negative placement / app / app-category criterion row.
+
+    ``level`` is ``"campaign"`` or ``"ad_group"`` — the two are separate
+    Google Ads resources and an operator has to know which one an exclusion
+    lives on before removing it. ``type`` is mureo's tool-facing exclusion
+    vocabulary; ``criterion_type`` keeps the raw Google Ads enum name so a
+    row is still readable if Google adds a type mureo does not map yet.
+    """
+    # Imported here rather than at module import time: the placements mixin
+    # imports this module, so a module-level import would close a cycle.
+    from mureo.google_ads._placements import CRITERION_TYPE_TO_KIND
+
+    criterion_type = map_enum_name(criterion.type_, CRITERION_TYPE_MAP)
+    kind = CRITERION_TYPE_TO_KIND.get(criterion_type)
+    if kind == "website":
+        value = _safe_str(criterion.placement, "url") or None
+    elif kind == "mobile_application":
+        value = _safe_str(criterion.mobile_application, "app_id") or None
+    elif kind == "mobile_app_category":
+        value = (
+            _safe_str(criterion.mobile_app_category, "mobile_app_category_constant")
+            or None
+        )
+    else:
+        value = None
+    app_name = _safe_str(criterion.mobile_application, "name") or None
+    result: dict[str, Any] = {
+        "level": level,
+        "criterion_id": str(criterion.criterion_id),
+        "type": kind,
+        "criterion_type": criterion_type,
+        "value": value,
+        "display_name": app_name if kind == "mobile_application" else value,
+        "negative": bool(getattr(criterion, "negative", True)),
+    }
+    if campaign is not None:
+        result["campaign_id"] = str(campaign.id)
+        result["campaign_name"] = campaign.name
+    if ad_group is not None:
+        result["ad_group_id"] = str(ad_group.id)
+        result["ad_group_name"] = ad_group.name
+    return result
+
+
+# === Placement performance (delivery-impact preview, #547) ===
+
+#: ``group_placement_view.placement_type`` → mureo's exclusion vocabulary.
+#: Only the three kinds an exclusion can name are translated; anything else
+#: keeps a lower-cased raw enum name so a YouTube channel row is still
+#: readable — and, since it matches no exclusion kind, contributes to the
+#: denominator without ever being claimed as removed.
+_PLACEMENT_TYPE_TO_KIND: dict[str, str] = {
+    "WEBSITE": "website",
+    "MOBILE_APPLICATION": "mobile_application",
+    "MOBILE_APP_CATEGORY": "mobile_app_category",
+}
+
+
+def map_placement_performance(row: Any) -> dict[str, Any]:
+    """Shape one ``group_placement_view`` row for the exclusion preview.
+
+    ``placement`` is the value an exclusion would name (a domain, or a
+    ``mobileapp::``-prefixed app id); ``display_name`` is the human label.
+    """
+    view = row.group_placement_view if hasattr(row, "group_placement_view") else row
+    metrics = row.metrics if hasattr(row, "metrics") else row
+    raw_type = str(getattr(view, "placement_type", "")).rsplit(".", 1)[-1].upper()
+    return {
+        "placement": _safe_str(view, "placement"),
+        "display_name": _safe_str(view, "display_name"),
+        "target_url": _safe_str(view, "target_url"),
+        "placement_type": raw_type,
+        "type": _PLACEMENT_TYPE_TO_KIND.get(raw_type, raw_type.lower()),
+        "impressions": _safe_int(metrics, "impressions"),
+        "clicks": _safe_int(metrics, "clicks"),
+        "cost_micros": _safe_int(metrics, "cost_micros"),
+        "cost": _micros_to_currency(_safe_int(metrics, "cost_micros")),
+        "conversions": _safe_float(metrics, "conversions"),
+    }
+
+
+__all__ = ["map_negative_placement", "map_placement_performance"]

--- a/mureo/google_ads/_placements.py
+++ b/mureo/google_ads/_placements.py
@@ -27,7 +27,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from mureo.google_ads.client import _wrap_mutate_error
-from mureo.google_ads.mappers import map_negative_placement
+from mureo.google_ads.mappers import map_negative_placement, map_placement_performance
 
 if TYPE_CHECKING:
     from google.ads.googleads.client import GoogleAdsClient
@@ -76,6 +76,7 @@ class _PlacementsMixin:
     @staticmethod
     def _validate_id(value: str, field_name: str) -> str: ...  # type: ignore[empty-body]
     def _get_service(self, service_name: str) -> Any: ...
+    def _period_to_date_clause(self, period: str) -> str: ...  # type: ignore[empty-body]
 
     # -- helpers -----------------------------------------------------------
 
@@ -208,6 +209,47 @@ class _PlacementsMixin:
             )
             for row in response
         ]
+
+    async def get_placement_performance(
+        self,
+        campaign_id: str | None = None,
+        ad_group_id: str | None = None,
+        period: str = "LAST_30_DAYS",
+    ) -> list[dict[str, Any]]:
+        """Delivery per placement over ``period`` — the exclusion denominator.
+
+        ``group_placement_view`` aggregates at the level an exclusion is
+        actually written at (a domain, an app), which is why it is the
+        source for the #547 impact preview rather than
+        ``detail_placement_view``'s per-URL rows.
+
+        The totals it returns are *placement-attributed* delivery only —
+        Search impressions, and any Display impression Google does not
+        attribute to a placement, are not in it. Callers name that as the
+        basis rather than calling it "the campaign's delivery".
+        """
+        date_clause = self._period_to_date_clause(period)
+        query = f"""
+            SELECT
+                group_placement_view.placement,
+                group_placement_view.display_name,
+                group_placement_view.target_url,
+                group_placement_view.placement_type,
+                metrics.impressions,
+                metrics.clicks,
+                metrics.cost_micros,
+                metrics.conversions
+            FROM group_placement_view
+            WHERE segments.date {date_clause}"""
+        if campaign_id:
+            self._validate_id(campaign_id, "campaign_id")
+            query += f"\n                AND campaign.id = {campaign_id}"
+        if ad_group_id:
+            self._validate_id(ad_group_id, "ad_group_id")
+            query += f"\n                AND ad_group.id = {ad_group_id}"
+        query += f"\n            LIMIT {_PLACEMENT_READ_LIMIT}"
+        response = await self._search(query)  # type: ignore[attr-defined]
+        return [map_placement_performance(row) for row in response]
 
     # -- writes ------------------------------------------------------------
 

--- a/mureo/google_ads/_placements.py
+++ b/mureo/google_ads/_placements.py
@@ -26,8 +26,11 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
+from mureo.google_ads._placement_mappers import (
+    map_negative_placement,
+    map_placement_performance,
+)
 from mureo.google_ads.client import _wrap_mutate_error
-from mureo.google_ads.mappers import map_negative_placement, map_placement_performance
 
 if TYPE_CHECKING:
     from google.ads.googleads.client import GoogleAdsClient

--- a/mureo/google_ads/mappers.py
+++ b/mureo/google_ads/mappers.py
@@ -623,6 +623,43 @@ def map_negative_placement(
     return result
 
 
+# === Placement performance (delivery-impact preview, #547) ===
+
+#: ``group_placement_view.placement_type`` → mureo's exclusion vocabulary.
+#: Only the three kinds an exclusion can name are translated; anything else
+#: keeps a lower-cased raw enum name so a YouTube channel row is still
+#: readable — and, since it matches no exclusion kind, contributes to the
+#: denominator without ever being claimed as removed.
+_PLACEMENT_TYPE_TO_KIND: dict[str, str] = {
+    "WEBSITE": "website",
+    "MOBILE_APPLICATION": "mobile_application",
+    "MOBILE_APP_CATEGORY": "mobile_app_category",
+}
+
+
+def map_placement_performance(row: Any) -> dict[str, Any]:
+    """Shape one ``group_placement_view`` row for the exclusion preview.
+
+    ``placement`` is the value an exclusion would name (a domain, or a
+    ``mobileapp::``-prefixed app id); ``display_name`` is the human label.
+    """
+    view = row.group_placement_view if hasattr(row, "group_placement_view") else row
+    metrics = row.metrics if hasattr(row, "metrics") else row
+    raw_type = str(getattr(view, "placement_type", "")).rsplit(".", 1)[-1].upper()
+    return {
+        "placement": _safe_str(view, "placement"),
+        "display_name": _safe_str(view, "display_name"),
+        "target_url": _safe_str(view, "target_url"),
+        "placement_type": raw_type,
+        "type": _PLACEMENT_TYPE_TO_KIND.get(raw_type, raw_type.lower()),
+        "impressions": _safe_int(metrics, "impressions"),
+        "clicks": _safe_int(metrics, "clicks"),
+        "cost_micros": _safe_int(metrics, "cost_micros"),
+        "cost": _micros_to_currency(_safe_int(metrics, "cost_micros")),
+        "conversions": _safe_float(metrics, "conversions"),
+    }
+
+
 # === Search Terms Report ===
 
 

--- a/mureo/google_ads/mappers.py
+++ b/mureo/google_ads/mappers.py
@@ -570,94 +570,12 @@ def map_negative_keyword(criterion: Any) -> dict[str, Any]:
     }
 
 
-# === Negative Placements (delivery-surface exclusions, #544) ===
-
-
-def map_negative_placement(
-    criterion: Any,
-    level: str,
-    campaign: _HasIdAndName | None = None,
-    ad_group: _HasIdAndName | None = None,
-) -> dict[str, Any]:
-    """Shape one negative placement / app / app-category criterion row.
-
-    ``level`` is ``"campaign"`` or ``"ad_group"`` — the two are separate
-    Google Ads resources and an operator has to know which one an exclusion
-    lives on before removing it. ``type`` is mureo's tool-facing exclusion
-    vocabulary; ``criterion_type`` keeps the raw Google Ads enum name so a
-    row is still readable if Google adds a type mureo does not map yet.
-    """
-    # Imported here rather than at module import time: the placements mixin
-    # imports this module, so a module-level import would close a cycle.
-    from mureo.google_ads._placements import CRITERION_TYPE_TO_KIND
-
-    criterion_type = map_enum_name(criterion.type_, CRITERION_TYPE_MAP)
-    kind = CRITERION_TYPE_TO_KIND.get(criterion_type)
-    if kind == "website":
-        value = _safe_str(criterion.placement, "url") or None
-    elif kind == "mobile_application":
-        value = _safe_str(criterion.mobile_application, "app_id") or None
-    elif kind == "mobile_app_category":
-        value = (
-            _safe_str(criterion.mobile_app_category, "mobile_app_category_constant")
-            or None
-        )
-    else:
-        value = None
-    app_name = _safe_str(criterion.mobile_application, "name") or None
-    result: dict[str, Any] = {
-        "level": level,
-        "criterion_id": str(criterion.criterion_id),
-        "type": kind,
-        "criterion_type": criterion_type,
-        "value": value,
-        "display_name": app_name if kind == "mobile_application" else value,
-        "negative": bool(getattr(criterion, "negative", True)),
-    }
-    if campaign is not None:
-        result["campaign_id"] = str(campaign.id)
-        result["campaign_name"] = campaign.name
-    if ad_group is not None:
-        result["ad_group_id"] = str(ad_group.id)
-        result["ad_group_name"] = ad_group.name
-    return result
-
-
-# === Placement performance (delivery-impact preview, #547) ===
-
-#: ``group_placement_view.placement_type`` → mureo's exclusion vocabulary.
-#: Only the three kinds an exclusion can name are translated; anything else
-#: keeps a lower-cased raw enum name so a YouTube channel row is still
-#: readable — and, since it matches no exclusion kind, contributes to the
-#: denominator without ever being claimed as removed.
-_PLACEMENT_TYPE_TO_KIND: dict[str, str] = {
-    "WEBSITE": "website",
-    "MOBILE_APPLICATION": "mobile_application",
-    "MOBILE_APP_CATEGORY": "mobile_app_category",
-}
-
-
-def map_placement_performance(row: Any) -> dict[str, Any]:
-    """Shape one ``group_placement_view`` row for the exclusion preview.
-
-    ``placement`` is the value an exclusion would name (a domain, or a
-    ``mobileapp::``-prefixed app id); ``display_name`` is the human label.
-    """
-    view = row.group_placement_view if hasattr(row, "group_placement_view") else row
-    metrics = row.metrics if hasattr(row, "metrics") else row
-    raw_type = str(getattr(view, "placement_type", "")).rsplit(".", 1)[-1].upper()
-    return {
-        "placement": _safe_str(view, "placement"),
-        "display_name": _safe_str(view, "display_name"),
-        "target_url": _safe_str(view, "target_url"),
-        "placement_type": raw_type,
-        "type": _PLACEMENT_TYPE_TO_KIND.get(raw_type, raw_type.lower()),
-        "impressions": _safe_int(metrics, "impressions"),
-        "clicks": _safe_int(metrics, "clicks"),
-        "cost_micros": _safe_int(metrics, "cost_micros"),
-        "cost": _micros_to_currency(_safe_int(metrics, "cost_micros")),
-        "conversions": _safe_float(metrics, "conversions"),
-    }
+# === Negative Placements / placement performance ===
+#
+# ``map_negative_placement`` (#544) and ``map_placement_performance``
+# (#547) live in :mod:`mureo.google_ads._placement_mappers`, split out
+# the way ``_placements.py`` was split out of the client once this module
+# reached the project's 800-line file budget. Import them from there.
 
 
 # === Search Terms Report ===

--- a/mureo/mcp/_handlers_exclusion_impact.py
+++ b/mureo/mcp/_handlers_exclusion_impact.py
@@ -1,0 +1,212 @@
+"""MCP handler for ``analysis_exclusion_impact_preview`` (#547).
+
+Read-only. Two ways to call it, and the second is why it exists for
+platforms mureo does not own:
+
+1. ``tool`` + ``arguments`` — "this is the call I am about to make".
+   mureo resolves the entities from the tool's own arguments and fetches
+   the account's own recent delivery for that scope. Available for every
+   registered exclusion surface (mureo's own, plus whatever a plugin
+   registered).
+2. ``excluded_entities`` + ``delivery_records`` — the caller supplies both
+   sides. Reaches no platform API at all, so a Yahoo placement URL list, a
+   LOGLY adspot block or an Amazon negative-targeting batch is auditable
+   whenever the agent can pull that platform's own report itself.
+
+``delivery_records`` may also be combined with ``tool``, which then reads
+the entities from the arguments and issues no platform request.
+
+``would_block`` is computed by the same
+:func:`~mureo.analysis.exclusion_impact.evaluate_exclusion_impact` the
+dispatcher pre-flight calls, against the same STRATEGY.md, so what this
+tool advertises and what the guardrail enforces cannot drift.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from mureo.analysis.exclusion_impact import (
+    DeliveryRecord,
+    DeliverySample,
+    ExclusionTarget,
+    estimate_exclusion_impact,
+    evaluate_exclusion_impact,
+    exclusion_impact_rules,
+    exclusion_surface_for,
+    registered_exclusion_tools,
+)
+from mureo.mcp._helpers import _json_result, _opt
+
+if TYPE_CHECKING:
+    from mcp.types import TextContent
+
+logger = logging.getLogger(__name__)
+
+_SUPPLIED_BASIS = "caller_supplied_delivery_records"
+
+
+def _number(value: Any) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float, str)):
+        return 0.0
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _records(raw: Any) -> tuple[DeliveryRecord, ...] | None:
+    """Caller-supplied delivery rows, or ``None`` when none were supplied.
+
+    An explicitly supplied EMPTY list is a measured "nothing served", so it
+    is kept distinct from the key being absent.
+    """
+    if raw is None:
+        return None
+    if not isinstance(raw, list):
+        raise ValueError("delivery_records must be a list of objects")
+    return tuple(
+        DeliveryRecord(
+            entity=str(row.get("entity") or ""),
+            entity_type=str(row.get("entity_type") or ""),
+            impressions=_number(row.get("impressions")),
+            clicks=_number(row.get("clicks")),
+            cost=_number(row.get("cost")),
+            conversions=_number(row.get("conversions")),
+        )
+        for row in raw
+        if isinstance(row, dict)
+    )
+
+
+def _targets(raw: Any) -> tuple[ExclusionTarget, ...]:
+    if not isinstance(raw, list):
+        raise ValueError("excluded_entities must be a list of objects")
+    return tuple(
+        ExclusionTarget(
+            value=str(row.get("value") or ""),
+            entity_type=str(row.get("entity_type") or ""),
+            match_type=(
+                str(row["match_type"]) if row.get("match_type") is not None else None
+            ),
+        )
+        for row in raw
+        if isinstance(row, dict) and row.get("value")
+    )
+
+
+def _supplied_sample(
+    records: tuple[DeliveryRecord, ...],
+    targets: tuple[ExclusionTarget, ...],
+    standing: tuple[ExclusionTarget, ...] | None,
+) -> DeliverySample:
+    """Every kind present in supplied rows is attributable by construction."""
+    return DeliverySample(
+        records=records,
+        basis=_SUPPLIED_BASIS,
+        attributable_types=frozenset(
+            {record.entity_type for record in records}
+            | {target.entity_type for target in targets}
+        ),
+        standing=standing,
+        standing_reason=(
+            "" if standing is not None else "No standing_exclusions were supplied."
+        ),
+    )
+
+
+async def _resolve(
+    arguments: dict[str, Any], window_days: int
+) -> tuple[tuple[ExclusionTarget, ...], DeliverySample, str]:
+    """Return (targets, sample, note) for either calling convention."""
+    tool = _opt(arguments, "tool")
+    supplied = _records(arguments.get("delivery_records"))
+    standing = (
+        _targets(arguments["standing_exclusions"])
+        if isinstance(arguments.get("standing_exclusions"), list)
+        else None
+    )
+    if tool:
+        surface = exclusion_surface_for(str(tool))
+        if surface is None:
+            raise ValueError(
+                f"'{tool}' is not a registered exclusion surface. Known "
+                f"surfaces: {', '.join(sorted(registered_exclusion_tools()))}. "
+                f"Pass excluded_entities + delivery_records instead to size an "
+                f"exclusion on a platform mureo does not model."
+            )
+        call_args = arguments.get("arguments") or {}
+        if not isinstance(call_args, dict):
+            raise ValueError("arguments must be an object")
+        targets = tuple(surface.targets(call_args))
+        if supplied is not None:
+            return targets, _supplied_sample(supplied, targets, standing), surface.note
+        return targets, await surface.delivery(call_args, window_days), surface.note
+    targets = _targets(arguments.get("excluded_entities") or [])
+    if not targets:
+        raise ValueError(
+            "Provide either 'tool' (+ 'arguments') or a non-empty "
+            "'excluded_entities' list."
+        )
+    if supplied is None:
+        return (
+            targets,
+            DeliverySample(
+                records=None,
+                basis=_SUPPLIED_BASIS,
+                reason=(
+                    "No delivery_records were supplied and no tool was named, "
+                    "so mureo has nothing to size this exclusion against."
+                ),
+            ),
+            "",
+        )
+    return targets, _supplied_sample(supplied, targets, standing), ""
+
+
+async def handle_exclusion_impact_preview(
+    arguments: dict[str, Any],
+) -> list[TextContent]:
+    """Size an exclusion batch without applying it."""
+    from mureo.policy.strategy_gate import load_guardrails
+
+    rules = exclusion_impact_rules(load_guardrails())
+    window_days = int(_opt(arguments, "window_days", rules.window_days))
+    if window_days < 1:
+        raise ValueError("window_days must be >= 1")
+    targets, sample, note = await _resolve(arguments, window_days)
+    impact = estimate_exclusion_impact(
+        targets=targets,
+        records=sample.records,
+        attributable_types=sample.attributable_types,
+        basis=sample.basis,
+        window_days=window_days,
+        standing=sample.standing,
+        coverage_reason=sample.reason,
+        cumulative_reason=sample.standing_reason,
+    )
+    block_reason = evaluate_exclusion_impact(impact, rules)
+    payload: dict[str, Any] = {
+        "tool": _opt(arguments, "tool"),
+        "excluded_entity_count": len(targets),
+        "impact": impact.as_dict(),
+        "guardrails": {
+            "enabled": rules.enabled(),
+            "max_delivery_share_removed_pct": rules.max_share_pct,
+            "max_cumulative_delivery_share_removed_pct": (
+                rules.max_cumulative_share_pct
+            ),
+            "exclusion_impact_window_days": rules.window_days,
+            "exclusion_impact_metrics": list(rules.metrics),
+            "block_exclusions_without_impact_data": rules.block_without_data,
+        },
+        "would_block": block_reason is not None,
+        "block_reason": block_reason,
+    }
+    if note:
+        payload["note"] = note
+    return _json_result(payload)
+
+
+__all__ = ["handle_exclusion_impact_preview"]

--- a/mureo/mcp/_handlers_exclusion_impact.py
+++ b/mureo/mcp/_handlers_exclusion_impact.py
@@ -36,6 +36,7 @@ from mureo.analysis.exclusion_impact import (
     exclusion_impact_rules,
     exclusion_surface_for,
     registered_exclusion_tools,
+    unevaluated_rules,
 )
 from mureo.mcp._helpers import _json_result, _opt
 
@@ -56,6 +57,25 @@ def _number(value: Any) -> float:
         return 0.0
 
 
+def _required_field(row: Any, key: str, field: str, index: int) -> str:
+    """A non-empty string field of one caller-supplied row, or raise.
+
+    Fail loudly rather than substituting ``""``. An entity with an empty
+    ``entity_type`` matches no delivery row and no target, so a single typo
+    would be reported as a measured **0% impact** — the one output this
+    feature must never produce. ``additionalProperties: false`` in the tool
+    schema catches a misspelled KEY; this catches a missing or blank VALUE.
+    """
+    if not isinstance(row, dict):
+        raise ValueError(f"{field}[{index}] must be an object")
+    value = row.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(
+            f"{field}[{index}].{key} is required and must be a non-empty string"
+        )
+    return value.strip()
+
+
 def _records(raw: Any) -> tuple[DeliveryRecord, ...] | None:
     """Caller-supplied delivery rows, or ``None`` when none were supplied.
 
@@ -68,31 +88,29 @@ def _records(raw: Any) -> tuple[DeliveryRecord, ...] | None:
         raise ValueError("delivery_records must be a list of objects")
     return tuple(
         DeliveryRecord(
-            entity=str(row.get("entity") or ""),
-            entity_type=str(row.get("entity_type") or ""),
+            entity=_required_field(row, "entity", "delivery_records", index),
+            entity_type=_required_field(row, "entity_type", "delivery_records", index),
             impressions=_number(row.get("impressions")),
             clicks=_number(row.get("clicks")),
             cost=_number(row.get("cost")),
             conversions=_number(row.get("conversions")),
         )
-        for row in raw
-        if isinstance(row, dict)
+        for index, row in enumerate(raw)
     )
 
 
-def _targets(raw: Any) -> tuple[ExclusionTarget, ...]:
+def _targets(raw: Any, field: str = "excluded_entities") -> tuple[ExclusionTarget, ...]:
     if not isinstance(raw, list):
-        raise ValueError("excluded_entities must be a list of objects")
+        raise ValueError(f"{field} must be a list of objects")
     return tuple(
         ExclusionTarget(
-            value=str(row.get("value") or ""),
-            entity_type=str(row.get("entity_type") or ""),
+            value=_required_field(row, "value", field, index),
+            entity_type=_required_field(row, "entity_type", field, index),
             match_type=(
                 str(row["match_type"]) if row.get("match_type") is not None else None
             ),
         )
-        for row in raw
-        if isinstance(row, dict) and row.get("value")
+        for index, row in enumerate(raw)
     )
 
 
@@ -123,7 +141,7 @@ async def _resolve(
     tool = _opt(arguments, "tool")
     supplied = _records(arguments.get("delivery_records"))
     standing = (
-        _targets(arguments["standing_exclusions"])
+        _targets(arguments["standing_exclusions"], "standing_exclusions")
         if isinstance(arguments.get("standing_exclusions"), list)
         else None
     )
@@ -203,6 +221,14 @@ async def handle_exclusion_impact_preview(
         },
         "would_block": block_reason is not None,
         "block_reason": block_reason,
+        # Rules the operator WROTE that cannot be evaluated for this call.
+        # An inert rule is not the same as a satisfied one, and the
+        # cumulative rule is inert on exactly the ad-group scopes the
+        # motivating incident happened at.
+        "unevaluated_rules": [
+            {"key": rule.key, "reason": rule.reason}
+            for rule in unevaluated_rules(impact, rules)
+        ],
     }
     if note:
         payload["note"] = note

--- a/mureo/mcp/exclusion_preflight.py
+++ b/mureo/mcp/exclusion_preflight.py
@@ -1,0 +1,281 @@
+"""The dispatcher hook that sizes an exclusion batch before it is applied.
+
+Why here and not in :class:`~mureo.policy.strategy_gate.StrategyPolicyGate`
+------------------------------------------------------------------------
+
+The gate is the natural home for a ``## Guardrails`` rule, and this one is
+not in it, deliberately. ``PolicyGate``'s v1 ABI is *synchronous by
+design* — "gates that need to await network I/O are out of scope for
+``mureo.policy_gates`` in 0.9.x" — and it "MUST be pure and fast" because
+it runs on **every** tool call. Sizing an exclusion needs one awaited read
+of the account's own recent delivery, which is neither. So the rule is
+parsed by the gate's parser (one ``## Guardrails`` vocabulary, one parser)
+and enforced here, at the first point in dispatch that has both an
+``await`` and the call's arguments — before ``_dispatch_tool``, so no
+mutation has reached the platform when the refusal is returned.
+
+There is also no confirmation step to put this in. MCP gives mureo two
+outcomes: run the call, or refuse it. So "surface it in the confirmation
+step" from the issue becomes three surfaces of deliberately different
+strength:
+
+===============================================  ==========  ================
+Surface                                          When        Strength
+===============================================  ==========  ================
+``## Guardrails`` ``max_delivery_share_removed_pct``,
+``max_cumulative_delivery_share_removed_pct``,
+``block_exclusions_without_impact_data``         before      **hard** — the
+                                                 dispatch    call is refused
+``analysis_exclusion_impact_preview``            whenever    advisory — as
+                                                 the agent   strong as the
+                                                 asks        agent's
+                                                             compliance
+Notice appended to the exclusion call's own      after       records what was
+result                                           that call   removed, so the
+                                                             NEXT pass in an
+                                                             incremental
+                                                             sequence is not
+                                                             made blind
+===============================================  ==========  ================
+
+The third one is what the motivating incident actually needed: the damage
+was done by two weeks of individually-small passes, and no single one of
+them was ever measured.
+
+Fail-open, and cheap when off
+-----------------------------
+
+With none of the three rules written the pre-flight returns before it
+builds a client, so no report request is issued and behaviour is
+byte-identical to today. A tool that is not a registered exclusion surface
+returns even earlier, without touching STRATEGY.md.
+
+Any error — an unreadable report, a client that cannot be built, a plugin
+surface that raises — becomes ``coverage: unknown`` with the reason
+attached. That never blocks unless the operator wrote
+``block_exclusions_without_impact_data``, and it is never rendered as
+"0% impact".
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from mureo.analysis.exclusion_impact import (
+    COVERAGE_MEASURED,
+    DeliverySample,
+    ExclusionImpact,
+    ExclusionImpactRules,
+    estimate_exclusion_impact,
+    evaluate_exclusion_impact,
+    exclusion_impact_rules,
+    exclusion_surface_for,
+)
+from mureo.core.control_flow import STOP_EXCEPTIONS
+
+# Importing the sources module registers the built-in surfaces.
+from mureo.mcp import exclusion_sources as _sources  # noqa: F401
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from mureo.analysis.exclusion_impact import ExclusionSurface
+
+logger = logging.getLogger(__name__)
+
+#: Env kill-switch, matching the other pre-dispatch checks. Set to ``1`` to
+#: skip the check entirely (the guardrail then enforces nothing).
+DISABLE_ENV_VAR = "MUREO_DISABLE_EXCLUSION_PREFLIGHT"
+
+
+@dataclass(frozen=True)
+class ExclusionPreflight:
+    """Outcome of the pre-dispatch sizing of one exclusion batch."""
+
+    tool: str
+    impact: ExclusionImpact | None = None
+    refusal_reason: str | None = None
+
+    @property
+    def checked(self) -> bool:
+        return self.impact is not None
+
+
+_NOT_A_SURFACE = ExclusionPreflight(tool="")
+
+
+async def _sample(
+    surface: ExclusionSurface, arguments: Mapping[str, Any], window_days: int
+) -> DeliverySample:
+    """Ask the surface for its delivery; any failure is 'unknown', not zero."""
+    try:
+        return await surface.delivery(arguments, window_days)
+    except STOP_EXCEPTIONS:
+        raise
+    except BaseException as exc:  # noqa: BLE001 — a read failure is not a refusal
+        logger.warning(
+            "exclusion delivery read failed for %r", surface.tool, exc_info=True
+        )
+        return DeliverySample(
+            records=None,
+            basis=f"{surface.platform}_unavailable",
+            reason=(
+                f"mureo could not read this account's recent delivery "
+                f"({type(exc).__name__}), so the size of this exclusion is "
+                f"unknown."
+            ),
+        )
+
+
+def _impact_for(
+    surface: ExclusionSurface,
+    arguments: Mapping[str, Any],
+    sample: DeliverySample,
+    window_days: int,
+) -> ExclusionImpact:
+    return estimate_exclusion_impact(
+        targets=surface.targets(arguments),
+        records=sample.records,
+        attributable_types=sample.attributable_types,
+        basis=sample.basis,
+        window_days=window_days,
+        standing=sample.standing,
+        coverage_reason=sample.reason,
+        cumulative_reason=sample.standing_reason,
+    )
+
+
+async def measure_exclusion_impact(
+    surface: ExclusionSurface,
+    arguments: Mapping[str, Any],
+    rules: ExclusionImpactRules,
+) -> ExclusionImpact:
+    """Size one exclusion batch against the account's own recent delivery."""
+    sample = await _sample(surface, arguments, rules.window_days)
+    return _impact_for(surface, arguments, sample, rules.window_days)
+
+
+async def exclusion_impact_preflight(
+    name: str, arguments: Mapping[str, Any]
+) -> ExclusionPreflight:
+    """Size ``name(arguments)`` if it is an exclusion, else do nothing.
+
+    Never raises: an unexpected failure degrades to "not checked", because
+    a broken pre-flight must not take the exclusion tools offline.
+    """
+    import os
+
+    surface = exclusion_surface_for(name)
+    if surface is None or os.environ.get(DISABLE_ENV_VAR) == "1":
+        return _NOT_A_SURFACE
+    try:
+        from mureo.policy.strategy_gate import load_guardrails
+
+        rules = exclusion_impact_rules(load_guardrails())
+        if not rules.enabled():
+            # No rule written ⇒ no platform read, no refusal, no notice.
+            return _NOT_A_SURFACE
+        impact = await measure_exclusion_impact(surface, arguments, rules)
+        return ExclusionPreflight(
+            tool=name,
+            impact=impact,
+            refusal_reason=evaluate_exclusion_impact(impact, rules),
+        )
+    except STOP_EXCEPTIONS:
+        raise
+    except BaseException:  # noqa: BLE001 — must never break a tool call
+        logger.warning("exclusion impact pre-flight failed for %r", name, exc_info=True)
+        return _NOT_A_SURFACE
+
+
+def refusal_content(preflight: ExclusionPreflight) -> list[Any]:
+    """The TextContent payload returned in place of a refused exclusion."""
+    from mcp.types import TextContent
+
+    reason = preflight.refusal_reason or ""
+    impact = preflight.impact
+    body = "Tool call refused by the exclusion delivery-impact guardrail.\n"
+    body += f"  Tool: {preflight.tool}\n  Reason: {reason}\n"
+    if impact is not None:
+        body += f"  Coverage: {impact.coverage} (basis: {impact.basis})\n"
+        body += _share_lines(impact)
+    return [TextContent(type="text", text=body)]
+
+
+def _share_lines(impact: ExclusionImpact) -> str:
+    lines: list[str] = []
+    for label, shares in (
+        ("this batch", impact.incremental),
+        ("all standing exclusions after this batch", impact.cumulative),
+    ):
+        if shares is None:
+            continue
+        rendered = ", ".join(
+            f"{share.metric} {share.share_pct:.1f}%"
+            for share in shares
+            if share.share_pct is not None
+        )
+        if rendered:
+            lines.append(
+                f"  Share of the last {impact.window_days} days removed by "
+                f"{label}: {rendered}\n"
+            )
+    if impact.cumulative is None and impact.cumulative_reason:
+        lines.append(f"  Cumulative share: not computed — {impact.cumulative_reason}\n")
+    return "".join(lines)
+
+
+def notice_text(preflight: ExclusionPreflight) -> str | None:
+    """The advisory block appended to an allowed exclusion's own result."""
+    impact = preflight.impact
+    if impact is None:
+        return None
+    header = (
+        f"[mureo] Delivery impact of {preflight.tool} "
+        f"(last {impact.window_days} days, basis {impact.basis}):\n"
+    )
+    if impact.coverage != COVERAGE_MEASURED:
+        header += (
+            f"  Coverage: {impact.coverage} — {impact.coverage_reason}\n"
+            f"  This exclusion was applied WITHOUT a measured size. Set "
+            f"block_exclusions_without_impact_data in STRATEGY.md "
+            f"## Guardrails to refuse this case instead.\n"
+        )
+    body = _share_lines(impact)
+    if not body and impact.coverage == COVERAGE_MEASURED:
+        body = (
+            "  The window served nothing on this basis, so no share could "
+            "be computed — this is not the same as 'removes nothing'.\n"
+        )
+    return header + body
+
+
+def append_notice(result: list[Any], preflight: ExclusionPreflight) -> list[Any]:
+    """Append the impact notice to an exclusion call's result. Never raises."""
+    try:
+        from mureo.mcp._helpers import is_error_result
+
+        if preflight.impact is None or is_error_result(result):
+            return result
+        text = notice_text(preflight)
+        if not text:
+            return result
+        from mcp.types import TextContent
+
+        return [*result, TextContent(type="text", text=text)]
+    except Exception:  # noqa: BLE001 — a notice must never break a tool call
+        logger.debug("exclusion impact notice failed", exc_info=True)
+        return result
+
+
+__all__ = [
+    "DISABLE_ENV_VAR",
+    "ExclusionPreflight",
+    "append_notice",
+    "exclusion_impact_preflight",
+    "measure_exclusion_impact",
+    "notice_text",
+    "refusal_content",
+]

--- a/mureo/mcp/exclusion_preflight.py
+++ b/mureo/mcp/exclusion_preflight.py
@@ -72,6 +72,7 @@ from mureo.analysis.exclusion_impact import (
     evaluate_exclusion_impact,
     exclusion_impact_rules,
     exclusion_surface_for,
+    unevaluated_rules,
 )
 from mureo.core.control_flow import STOP_EXCEPTIONS
 
@@ -97,6 +98,10 @@ class ExclusionPreflight:
     tool: str
     impact: ExclusionImpact | None = None
     refusal_reason: str | None = None
+    #: The resolved rules this call was measured against. Carried so the
+    #: notice can report a rule the operator WROTE but that could not be
+    #: evaluated for this particular call.
+    rules: ExclusionImpactRules | None = None
 
     @property
     def checked(self) -> bool:
@@ -182,6 +187,7 @@ async def exclusion_impact_preflight(
             tool=name,
             impact=impact,
             refusal_reason=evaluate_exclusion_impact(impact, rules),
+            rules=rules,
         )
     except STOP_EXCEPTIONS:
         raise
@@ -249,7 +255,36 @@ def notice_text(preflight: ExclusionPreflight) -> str | None:
             "  The window served nothing on this basis, so no share could "
             "be computed — this is not the same as 'removes nothing'.\n"
         )
-    return header + body
+    return header + body + _inert_rule_lines(preflight)
+
+
+def _inert_rule_lines(preflight: ExclusionPreflight) -> str:
+    """Name any rule the operator wrote that could not fire on this call.
+
+    Without this, an operator who wrote ONLY
+    ``max_cumulative_delivery_share_removed_pct`` — the natural rule to write
+    after reading the incident report — would get no enforcement at all on
+    ad-group-scoped exclusion writes, and nothing would ever tell them. The
+    line names the backstop to add.
+    """
+    impact, rules = preflight.impact, preflight.rules
+    if impact is None or rules is None:
+        return ""
+    inert = unevaluated_rules(impact, rules)
+    if not inert:
+        return ""
+    lines = [f"  NOT ENFORCED on this call: {rule.as_text()}\n" for rule in inert]
+    needs_backstop = rules.max_share_pct is None and any(
+        rule.key == "max_cumulative_delivery_share_removed_pct" for rule in inert
+    )
+    if needs_backstop:
+        lines.append(
+            "  Add max_delivery_share_removed_pct to STRATEGY.md ## Guardrails "
+            "as a backstop: it is evaluated per batch and needs no standing "
+            "exclusion list, so it still fires on the scopes the cumulative "
+            "rule cannot cover.\n"
+        )
+    return "".join(lines)
 
 
 def append_notice(result: list[Any], preflight: ExclusionPreflight) -> list[Any]:

--- a/mureo/mcp/exclusion_sources.py
+++ b/mureo/mcp/exclusion_sources.py
@@ -1,0 +1,453 @@
+"""Where the exclusion delivery-impact numbers come from, per platform (#547).
+
+The pure estimator lives in :mod:`mureo.analysis.exclusion_impact`. This
+module is the I/O half: for each exclusion tool mureo owns the schema for,
+it reads the entities the call is about to exclude out of the arguments,
+and fetches the account's own recent delivery for the scope those entities
+live in.
+
+Per-platform honesty, which is the whole point of the issue:
+
+======================================  =========================================
+Surface                                 Delivery attributable?
+======================================  =========================================
+``google_ads_negative_placements_add``  **Yes** — ``group_placement_view``
+                                        gives impressions / clicks / cost /
+                                        conversions per website and per mobile
+                                        app. A ``mobile_app_category`` entry in
+                                        the same batch is **not** attributable —
+                                        a category is not itself a placement
+                                        that serves — so a mixed batch reports
+                                        ``partial``.
+``google_ads_negative_keywords_add``    **Yes** — ``search_term_view`` over the
+``..._add_to_ad_group``                 same window, matched by the negative's
+                                        own match type.
+``meta_ads_excluded_placements_set``    **No** — the facets this tool writes
+                                        (publisher categories, publisher block
+                                        lists, brand-safety content types) have
+                                        no insights breakdown that attributes
+                                        past delivery to them. Meta breaks
+                                        delivery down by ``publisher_platform``
+                                        / ``platform_position``, which are a
+                                        different exclusion surface
+                                        (``meta_ads_ad_sets_update`` targeting).
+                                        Reported ``unknown``, never "no impact".
+Plugins / bridges                       Whatever they register. mureo registers
+(Yahoo, LINE, SmartNews, LOGLY,         nothing on their behalf: guessing a
+Amazon)                                 bridged tool's argument shape would
+                                        produce a confident wrong number.
+======================================  =========================================
+
+Everything here is best-effort by contract. A read that fails yields
+``records=None`` with the reason attached — which surfaces as ``unknown``,
+and refuses only if the operator asked for that with
+``block_exclusions_without_impact_data``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from mureo.analysis.exclusion_impact import (
+    ENTITY_MOBILE_APPLICATION,
+    ENTITY_SEARCH_TERM,
+    ENTITY_WEBSITE,
+    DeliveryRecord,
+    DeliverySample,
+    ExclusionSurface,
+    ExclusionTarget,
+    register_exclusion_surface,
+)
+from mureo.core import clock
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+logger = logging.getLogger(__name__)
+
+GOOGLE_PLACEMENTS_ADD = "google_ads_negative_placements_add"
+GOOGLE_NEGATIVE_KEYWORDS_ADD = "google_ads_negative_keywords_add"
+GOOGLE_NEGATIVE_KEYWORDS_ADD_AD_GROUP = "google_ads_negative_keywords_add_to_ad_group"
+META_EXCLUDED_PLACEMENTS_SET = "meta_ads_excluded_placements_set"
+
+#: What ``group_placement_view`` can attribute delivery to.
+_PLACEMENT_ATTRIBUTABLE = frozenset({ENTITY_WEBSITE, ENTITY_MOBILE_APPLICATION})
+_SEARCH_TERM_ATTRIBUTABLE = frozenset({ENTITY_SEARCH_TERM})
+
+_PLACEMENT_BASIS = "google_ads_group_placement_view"
+_SEARCH_TERM_BASIS = "google_ads_search_term_view"
+_META_BASIS = "meta_ads_ad_set_targeting"
+
+_META_UNATTRIBUTABLE = (
+    "Meta does not expose an insights breakdown that attributes past "
+    "delivery to publisher categories, publisher block lists or "
+    "brand-safety content types, so mureo cannot size this exclusion from "
+    "the account's own data. (publisher_platform / platform_position ARE "
+    "attributable, but they are a different exclusion surface — ad-set "
+    "targeting, not these facets.)"
+)
+
+_AD_GROUP_STANDING_UNKNOWN = (
+    "Standing exclusions were listed at the ad group level only; "
+    "campaign-level exclusions covering the same ad group are not visible "
+    "from this call's arguments, so the cumulative figure would understate."
+)
+
+_CAMPAIGN_NEGATIVES_ONLY = (
+    "Google Ads exposes no ad-group-level negative keyword listing, so the "
+    "standing negative set for this ad group cannot be read."
+)
+
+
+def _period(window_days: int) -> str:
+    """A ``BETWEEN 'start' AND 'end'`` clause covering the last N days.
+
+    Built off :func:`mureo.core.clock.server_now` (the operator's local
+    calendar day), not a GAQL ``LAST_30_DAYS`` constant, so an arbitrary
+    ``exclusion_impact_window_days`` is expressible.
+    """
+    from datetime import timedelta
+
+    end = clock.server_now().date()
+    start = end - timedelta(days=max(1, window_days) - 1)
+    return f"BETWEEN '{start.isoformat()}' AND '{end.isoformat()}'"
+
+
+# ---------------------------------------------------------------------------
+# Client access (patched wholesale in tests)
+# ---------------------------------------------------------------------------
+
+
+async def google_ads_client(arguments: Mapping[str, Any]) -> Any:
+    """A Google Ads client for this call's account, or ``None``."""
+    from mureo.mcp._handlers_google_ads import _get_client
+
+    return _get_client(dict(arguments))
+
+
+async def meta_ads_client(arguments: Mapping[str, Any]) -> Any:
+    """A Meta Ads client for this call's account, or ``None``."""
+    from mureo.mcp._handlers_meta_ads import _get_client
+
+    return await _get_client(dict(arguments))
+
+
+# ---------------------------------------------------------------------------
+# Google Ads — negative placements
+# ---------------------------------------------------------------------------
+
+
+def google_placement_targets(
+    arguments: Mapping[str, Any],
+) -> tuple[ExclusionTarget, ...]:
+    """The websites / apps / app categories this call excludes."""
+    placements = arguments.get("placements") or []
+    targets: list[ExclusionTarget] = []
+    for item in placements:
+        if not isinstance(item, dict):
+            continue
+        value = str(item.get("value") or "").strip()
+        kind = str(item.get("type") or "").strip()
+        if value and kind:
+            targets.append(ExclusionTarget(value=value, entity_type=kind))
+    return tuple(targets)
+
+
+def _placement_records(rows: Any) -> tuple[DeliveryRecord, ...]:
+    return tuple(
+        DeliveryRecord(
+            entity=str(row.get("placement") or ""),
+            entity_type=str(row.get("type") or ""),
+            impressions=float(row.get("impressions") or 0),
+            clicks=float(row.get("clicks") or 0),
+            cost=float(row.get("cost") or 0),
+            conversions=float(row.get("conversions") or 0),
+        )
+        for row in rows
+        if isinstance(row, dict)
+    )
+
+
+def _standing_placements(rows: Any) -> tuple[ExclusionTarget, ...]:
+    return tuple(
+        ExclusionTarget(
+            value=str(row.get("value") or ""),
+            entity_type=str(row.get("type") or ""),
+        )
+        for row in rows
+        if isinstance(row, dict) and row.get("value") and row.get("type")
+    )
+
+
+async def _standing_placement_set(
+    client: Any, campaign_id: Any, ad_group_id: Any
+) -> tuple[tuple[ExclusionTarget, ...] | None, str]:
+    """Standing exclusions on this scope, for the cumulative figure.
+
+    Withheld (``None``) for an ad-group-level write: campaign-level
+    exclusions cover the same ad group and are not reachable from this
+    call's arguments, so including only the ad group's own would report a
+    cumulative figure that is quietly too small.
+    """
+    if ad_group_id and not campaign_id:
+        return None, _AD_GROUP_STANDING_UNKNOWN
+    try:
+        rows = await client.list_negative_placements(
+            campaign_id=str(campaign_id) if campaign_id else None,
+            ad_group_id=str(ad_group_id) if ad_group_id else None,
+        )
+    except Exception:  # noqa: BLE001 — a missing cumulative is not a failure
+        logger.debug("standing negative placements unreadable", exc_info=True)
+        return None, "The standing exclusion list could not be read."
+    return _standing_placements(rows), ""
+
+
+async def google_placement_delivery(
+    arguments: Mapping[str, Any], window_days: int
+) -> DeliverySample:
+    """Placement-attributed delivery for the scope this call writes to."""
+    from mureo.mcp._helpers import _close_clients
+
+    campaign_id = arguments.get("campaign_id") or None
+    ad_group_id = arguments.get("ad_group_id") or None
+    client = await google_ads_client(arguments)
+    if client is None:
+        return DeliverySample(
+            records=None,
+            basis=_PLACEMENT_BASIS,
+            attributable_types=_PLACEMENT_ATTRIBUTABLE,
+            reason="No Google Ads credentials are configured for this account.",
+        )
+    try:
+        rows = await client.get_placement_performance(
+            campaign_id=str(campaign_id) if campaign_id else None,
+            ad_group_id=str(ad_group_id) if ad_group_id else None,
+            period=_period(window_days),
+        )
+        standing, standing_reason = await _standing_placement_set(
+            client, campaign_id, ad_group_id
+        )
+    finally:
+        await _close_clients([client])
+    return DeliverySample(
+        records=_placement_records(rows),
+        basis=_PLACEMENT_BASIS,
+        attributable_types=_PLACEMENT_ATTRIBUTABLE,
+        standing=standing,
+        standing_reason=standing_reason,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Google Ads — negative keywords
+# ---------------------------------------------------------------------------
+
+
+def google_negative_keyword_targets(
+    arguments: Mapping[str, Any],
+) -> tuple[ExclusionTarget, ...]:
+    keywords = arguments.get("keywords") or []
+    targets: list[ExclusionTarget] = []
+    for item in keywords:
+        if not isinstance(item, dict):
+            continue
+        text = str(item.get("text") or "").strip()
+        if text:
+            targets.append(
+                ExclusionTarget(
+                    value=text,
+                    entity_type=ENTITY_SEARCH_TERM,
+                    match_type=str(item.get("match_type") or "BROAD"),
+                )
+            )
+    return tuple(targets)
+
+
+def _search_term_records(rows: Any) -> tuple[DeliveryRecord, ...]:
+    records: list[DeliveryRecord] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        metrics = row.get("metrics") or {}
+        records.append(
+            DeliveryRecord(
+                entity=str(row.get("search_term") or ""),
+                entity_type=ENTITY_SEARCH_TERM,
+                impressions=float(metrics.get("impressions") or 0),
+                clicks=float(metrics.get("clicks") or 0),
+                cost=float(metrics.get("cost") or 0),
+                conversions=float(metrics.get("conversions") or 0),
+            )
+        )
+    return tuple(records)
+
+
+async def _standing_negative_keywords(
+    client: Any, campaign_id: Any
+) -> tuple[tuple[ExclusionTarget, ...] | None, str]:
+    if not campaign_id:
+        return None, _CAMPAIGN_NEGATIVES_ONLY
+    try:
+        rows = await client.list_negative_keywords(str(campaign_id))
+    except Exception:  # noqa: BLE001 — a missing cumulative is not a failure
+        logger.debug("standing negative keywords unreadable", exc_info=True)
+        return None, "The standing negative keyword list could not be read."
+    return (
+        tuple(
+            ExclusionTarget(
+                value=str(row.get("text") or row.get("keyword") or ""),
+                entity_type=ENTITY_SEARCH_TERM,
+                match_type=str(row.get("match_type") or "BROAD"),
+            )
+            for row in rows
+            if isinstance(row, dict)
+        ),
+        "",
+    )
+
+
+async def google_negative_keyword_delivery(
+    arguments: Mapping[str, Any], window_days: int
+) -> DeliverySample:
+    """Search-term delivery for the campaign / ad group being negated."""
+    from mureo.mcp._helpers import _close_clients
+
+    campaign_id = arguments.get("campaign_id") or None
+    ad_group_id = arguments.get("ad_group_id") or None
+    client = await google_ads_client(arguments)
+    if client is None:
+        return DeliverySample(
+            records=None,
+            basis=_SEARCH_TERM_BASIS,
+            attributable_types=_SEARCH_TERM_ATTRIBUTABLE,
+            reason="No Google Ads credentials are configured for this account.",
+        )
+    try:
+        rows = await client.get_search_terms_report(
+            campaign_id=str(campaign_id) if campaign_id else None,
+            ad_group_id=str(ad_group_id) if ad_group_id else None,
+            period=_period(window_days),
+        )
+        standing, standing_reason = await _standing_negative_keywords(
+            client, campaign_id
+        )
+    finally:
+        await _close_clients([client])
+    return DeliverySample(
+        records=_search_term_records(rows),
+        basis=_SEARCH_TERM_BASIS,
+        attributable_types=_SEARCH_TERM_ATTRIBUTABLE,
+        standing=standing,
+        standing_reason=standing_reason,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Meta Ads — ad-set publisher exclusions
+# ---------------------------------------------------------------------------
+
+#: Argument key → the entity kind mureo names it by. Kept in lockstep with
+#: ``mureo.meta_ads._placement_exclusions.EXCLUSION_KEYS``.
+_META_FACETS: dict[str, str] = {
+    "excluded_publisher_categories": "publisher_category",
+    "excluded_publisher_list_ids": "publisher_block_list",
+    "excluded_brand_safety_content_types": "brand_safety_content_type",
+}
+
+
+def meta_excluded_placement_targets(
+    arguments: Mapping[str, Any],
+) -> tuple[ExclusionTarget, ...]:
+    targets: list[ExclusionTarget] = []
+    for key, entity_type in _META_FACETS.items():
+        for value in arguments.get(key) or []:
+            text = str(value).strip()
+            if text:
+                targets.append(ExclusionTarget(value=text, entity_type=entity_type))
+    return tuple(targets)
+
+
+async def meta_excluded_placement_delivery(
+    arguments: Mapping[str, Any], window_days: int
+) -> DeliverySample:
+    """Always unknown — and it says so rather than reading nothing as zero."""
+    return DeliverySample(
+        records=None,
+        basis=_META_BASIS,
+        attributable_types=frozenset(),
+        reason=_META_UNATTRIBUTABLE,
+        standing_reason=_META_UNATTRIBUTABLE,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+_BUILTIN_SURFACES: tuple[ExclusionSurface, ...] = (
+    ExclusionSurface(
+        tool=GOOGLE_PLACEMENTS_ADD,
+        platform="google_ads",
+        targets=google_placement_targets,
+        delivery=google_placement_delivery,
+        note=(
+            "Denominator is placement-attributed delivery in the named "
+            "campaign / ad group, not the campaign's total delivery."
+        ),
+    ),
+    ExclusionSurface(
+        tool=GOOGLE_NEGATIVE_KEYWORDS_ADD,
+        platform="google_ads",
+        targets=google_negative_keyword_targets,
+        delivery=google_negative_keyword_delivery,
+        note=(
+            "Negative keywords do not match close variants, and neither "
+            "does this estimate — a term differing only by a plural is not "
+            "counted, so the share is a lower bound."
+        ),
+    ),
+    ExclusionSurface(
+        tool=GOOGLE_NEGATIVE_KEYWORDS_ADD_AD_GROUP,
+        platform="google_ads",
+        targets=google_negative_keyword_targets,
+        delivery=google_negative_keyword_delivery,
+        note=(
+            "Ad-group scope. Google Ads exposes no ad-group-level negative "
+            "keyword listing, so no cumulative figure is reported."
+        ),
+    ),
+    ExclusionSurface(
+        tool=META_EXCLUDED_PLACEMENTS_SET,
+        platform="meta_ads",
+        targets=meta_excluded_placement_targets,
+        delivery=meta_excluded_placement_delivery,
+        note=_META_UNATTRIBUTABLE,
+    ),
+)
+
+
+def register_builtin_exclusion_surfaces() -> None:
+    """Register every exclusion surface mureo owns the schema for."""
+    for surface in _BUILTIN_SURFACES:
+        register_exclusion_surface(surface)
+
+
+register_builtin_exclusion_surfaces()
+
+
+__all__ = [
+    "GOOGLE_NEGATIVE_KEYWORDS_ADD",
+    "GOOGLE_NEGATIVE_KEYWORDS_ADD_AD_GROUP",
+    "GOOGLE_PLACEMENTS_ADD",
+    "META_EXCLUDED_PLACEMENTS_SET",
+    "google_ads_client",
+    "google_negative_keyword_delivery",
+    "google_negative_keyword_targets",
+    "google_placement_delivery",
+    "google_placement_targets",
+    "meta_ads_client",
+    "meta_excluded_placement_delivery",
+    "meta_excluded_placement_targets",
+    "register_builtin_exclusion_surfaces",
+]

--- a/mureo/mcp/server.py
+++ b/mureo/mcp/server.py
@@ -52,6 +52,15 @@ if TYPE_CHECKING:
 
 from mureo.core.control_flow import STOP_EXCEPTIONS
 from mureo.mcp._helpers import is_error_result
+from mureo.mcp.exclusion_preflight import (
+    append_notice as append_exclusion_impact_notice,
+)
+from mureo.mcp.exclusion_preflight import (
+    exclusion_impact_preflight,
+)
+from mureo.mcp.exclusion_preflight import (
+    refusal_content as exclusion_refusal_content,
+)
 from mureo.mcp.native_reversal import capture_before_state, record_native_mutation
 from mureo.mcp.plugin_audit import record_plugin_call
 from mureo.mcp.plugin_semantics import (
@@ -1005,7 +1014,19 @@ async def handle_call_tool(name: str, arguments: dict[str, Any]) -> list[Any]:
     # capture, or real-spend API call — so an out-of-bounds budget/bid is
     # rejected before it can reach a live campaign.
     _validate_tool_input(name, arguments)
-    result = await _dispatch_tool(name, arguments)
+    # #547: size a bulk exclusion / block / negative-keyword batch against the
+    # account's own recent delivery before it is applied. Runs here rather than
+    # in a PolicyGate because it needs one AWAITED platform read and the gate
+    # ABI is synchronous by design; runs before _dispatch_tool so a refusal
+    # lands before any mutation. No-ops (and issues no read) for every tool
+    # that is not a registered exclusion surface, and for an operator who wrote
+    # no exclusion rule in STRATEGY.md ## Guardrails.
+    preflight = await exclusion_impact_preflight(name, arguments)
+    if preflight.refusal_reason is not None:
+        return exclusion_refusal_content(preflight)
+    result = append_exclusion_impact_notice(
+        await _dispatch_tool(name, arguments), preflight
+    )
     # #548: a change that restarts an automated bid strategy's learning period
     # says so in its own result, so the next change in a troubleshooting
     # sequence is not made blind. No-op for everything else.

--- a/mureo/mcp/tools_analysis.py
+++ b/mureo/mcp/tools_analysis.py
@@ -163,7 +163,10 @@ TOOLS: list[Tool] = [
             "or 'unknown'; 'unknown' is an honest answer and never means "
             "'no impact'. 'would_block' is computed by the same rule the "
             "dispatcher enforces from STRATEGY.md ## Guardrails, so it "
-            "cannot disagree with what will actually happen."
+            "cannot disagree with what will actually happen. "
+            "'unevaluated_rules' names any guardrail the operator wrote that "
+            "cannot be evaluated for this call — an inert rule is not a "
+            "satisfied one, so surface it to the operator."
         ),
         inputSchema={
             "type": "object",

--- a/mureo/mcp/tools_analysis.py
+++ b/mureo/mcp/tools_analysis.py
@@ -1,9 +1,14 @@
 """Cross-platform analysis MCP tool definitions and dispatcher.
 
-Exposes one tool: ``analysis_anomalies_check``. Given a current
-metrics snapshot for a campaign and (optionally) STATE.json's action
-log, returns a severity-ordered list of anomalies (zero-spend, CPA
-spike, CTR drop) the agent should surface to the operator.
+Two tools:
+
+- ``analysis_anomalies_check`` — given a current metrics snapshot for a
+  campaign and (optionally) STATE.json's action log, returns a
+  severity-ordered list of anomalies (zero-spend, CPA spike, CTR drop).
+- ``analysis_exclusion_impact_preview`` (#547) — given an exclusion /
+  block / negative-keyword batch, returns the share of the account's own
+  recent delivery it removes, and whether STRATEGY.md ``## Guardrails``
+  would refuse it.
 """
 
 from __future__ import annotations
@@ -13,6 +18,7 @@ from typing import TYPE_CHECKING, Any
 from mcp.types import Tool
 
 from mureo.mcp._handlers_analysis import handle_anomalies_check
+from mureo.mcp._handlers_exclusion_impact import handle_exclusion_impact_preview
 
 if TYPE_CHECKING:
     from mcp.types import TextContent
@@ -41,6 +47,51 @@ _CURRENT_PROPERTIES: dict[str, Any] = {
             "derived from clicks/impressions when omitted."
         ),
     },
+}
+
+_ENTITY_ITEM: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "value": {
+            "type": "string",
+            "description": "The excluded value — domain, app id, keyword text…",
+        },
+        "entity_type": {
+            "type": "string",
+            "description": (
+                "Kind of entity: website / mobile_application / "
+                "mobile_app_category / search_term, or any string a plugin "
+                "surface uses. Must equal the entity_type on the matching "
+                "delivery rows."
+            ),
+        },
+        "match_type": {
+            "type": "string",
+            "description": (
+                "Negative keyword match type (EXACT / PHRASE / BROAD). "
+                "Ignored for every other entity kind."
+            ),
+        },
+    },
+    "required": ["value", "entity_type"],
+    "additionalProperties": False,
+}
+
+_DELIVERY_ITEM: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "entity": {
+            "type": "string",
+            "description": "Entity key exactly as the platform's report names it.",
+        },
+        "entity_type": {"type": "string", "description": "Kind of entity."},
+        "impressions": {"type": "number"},
+        "clicks": {"type": "number"},
+        "cost": {"type": "number"},
+        "conversions": {"type": "number"},
+    },
+    "required": ["entity", "entity_type"],
+    "additionalProperties": False,
 }
 
 TOOLS: list[Tool] = [
@@ -95,12 +146,88 @@ TOOLS: list[Tool] = [
             "additionalProperties": False,
         },
     ),
+    Tool(
+        name="analysis_exclusion_impact_preview",
+        description=(
+            "Before applying a batch of exclusions / blocks / negative "
+            "keywords, report how much of the account's OWN recent delivery "
+            "(impressions, clicks, cost, conversions) it removes — both for "
+            "this batch and cumulatively for every standing exclusion once "
+            "it lands. Call it with 'tool' + 'arguments' to size the exact "
+            "call you are about to make on a surface mureo models (Google "
+            "Ads negative placements / negative keywords, Meta excluded "
+            "placements, plus any surface a plugin registered), or with "
+            "'excluded_entities' + 'delivery_records' to size a batch on any "
+            "other platform from a report you fetched yourself — that form "
+            "reaches no platform API. Returns coverage 'measured', 'partial' "
+            "or 'unknown'; 'unknown' is an honest answer and never means "
+            "'no impact'. 'would_block' is computed by the same rule the "
+            "dispatcher enforces from STRATEGY.md ## Guardrails, so it "
+            "cannot disagree with what will actually happen."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "tool": {
+                    "type": "string",
+                    "description": (
+                        "MCP tool name of the exclusion call being previewed, "
+                        "e.g. google_ads_negative_placements_add."
+                    ),
+                },
+                "arguments": {
+                    "type": "object",
+                    "description": (
+                        "The arguments that call would be made with. Required "
+                        "when 'tool' is given."
+                    ),
+                    "additionalProperties": True,
+                },
+                "excluded_entities": {
+                    "type": "array",
+                    "description": (
+                        "Entities being excluded, when no modelled 'tool' " "applies."
+                    ),
+                    "items": _ENTITY_ITEM,
+                },
+                "standing_exclusions": {
+                    "type": "array",
+                    "description": (
+                        "Entities already excluded on this scope, for the "
+                        "cumulative figure. Omit rather than pass an empty "
+                        "list when they are unknown — an empty list means "
+                        "'there are none'."
+                    ),
+                    "items": _ENTITY_ITEM,
+                },
+                "delivery_records": {
+                    "type": "array",
+                    "description": (
+                        "The account's own delivery over the window, one row "
+                        "per entity. Supplying this suppresses every platform "
+                        "read."
+                    ),
+                    "items": _DELIVERY_ITEM,
+                },
+                "window_days": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": (
+                        "Recent window in days. Defaults to STRATEGY.md's "
+                        "exclusion_impact_window_days, else 30."
+                    ),
+                },
+            },
+            "additionalProperties": False,
+        },
+    ),
 ]
 
 _TOOL_NAMES: frozenset[str] = frozenset(t.name for t in TOOLS)
 
 _HANDLERS: dict[str, Any] = {
     "analysis_anomalies_check": handle_anomalies_check,
+    "analysis_exclusion_impact_preview": handle_exclusion_impact_preview,
 }
 
 

--- a/mureo/policy/strategy_gate.py
+++ b/mureo/policy/strategy_gate.py
@@ -152,6 +152,7 @@ __all__ = [
     "load_preflight",
     "evaluate_guardrails",
     "guardrails_from_strategy_text",
+    "load_guardrails",
     "parse_guardrails",
     "ArgumentPaths",
     "BudgetDeclaration",
@@ -258,8 +259,31 @@ class Guardrails:
     #: Both default off, so the gate stays fail-open.
     block_learning_resets: bool = False
     block_learning_resets_during_incident: bool = False
+    #: Delivery-impact rules for bulk exclusions / blocks / negative
+    #: keywords (#547). Enforced by the dispatcher pre-flight
+    #: (:mod:`mureo.mcp.exclusion_preflight`) rather than by this gate: the
+    #: check needs one AWAITED platform read of the account's own recent
+    #: delivery, and the ``PolicyGate`` v1 contract is synchronous and
+    #: must stay pure and fast. They are parsed here so ``## Guardrails``
+    #: stays one vocabulary with one parser. Resolved against their
+    #: defaults by
+    #: :func:`mureo.analysis.exclusion_impact.exclusion_impact_rules`.
+    max_delivery_share_removed_pct: float | None = None
+    max_cumulative_delivery_share_removed_pct: float | None = None
+    exclusion_impact_window_days: int | None = None
+    exclusion_impact_metrics: tuple[str, ...] = ()
+    block_exclusions_without_impact_data: bool = False
 
     def is_empty(self) -> bool:
+        """True when THIS gate has nothing to enforce.
+
+        Deliberately blind to the ``exclusion_impact_*`` fields: they are
+        enforced by the dispatcher pre-flight, not here, and counting them
+        would switch on this gate's budget/bid scan — including the
+        best-effort pattern fallback and its fail-closed deny on an
+        exhausted scan — for an operator who wrote only an exclusion rule
+        and no money cap at all.
+        """
         return (
             self.max_daily_budget_per_campaign is None
             and self.max_daily_budget_increase_pct is None
@@ -280,6 +304,19 @@ def _to_float(value: str) -> float | None:
         return None
 
 
+def _to_int(value: str) -> int | None:
+    """Whole-number bullet value, or ``None`` when it is not one.
+
+    A fractional day count is dropped rather than truncated: silently
+    turning ``30.5`` into ``30`` would report a window the operator did not
+    write.
+    """
+    number = _to_float(value)
+    if number is None or number != int(number):
+        return None
+    return int(number)
+
+
 #: Accepted spellings of "on" for a boolean guardrail. Anything else — including
 #: a typo — reads as OFF, matching the numeric rules' "a malformed value drops
 #: that one rule" behaviour rather than silently enabling a refusal.
@@ -290,6 +327,27 @@ def _to_bool(value: str) -> bool:
     return value.strip().lower() in _TRUE_WORDS
 
 
+def _to_metrics(value: str) -> tuple[str, ...]:
+    """``impressions, cost`` → ``("impressions", "cost")``, order preserved.
+
+    Unknown names are dropped by
+    :func:`~mureo.analysis.exclusion_impact.exclusion_impact_rules`, which
+    owns the metric vocabulary; parsing stays a pure split so this module
+    keeps no import on the analysis package.
+    """
+    return tuple(item.strip().lower() for item in value.split(",") if item.strip())
+
+
+def _bullets(content: str) -> dict[str, str]:
+    """``- key: value`` bullets of a section body, last occurrence winning."""
+    found: dict[str, str] = {}
+    for line in content.splitlines():
+        match = _BULLET_RE.match(line)
+        if match is not None:
+            found[match.group(1).lower()] = match.group(2).strip()
+    return found
+
+
 def parse_guardrails(content: str) -> Guardrails:
     """Parse the body of a ``## Guardrails`` section into :class:`Guardrails`.
 
@@ -297,51 +355,42 @@ def parse_guardrails(content: str) -> Guardrails:
     compatibility). A malformed numeric value drops that one rule rather than
     failing the whole parse.
     """
-    max_per_campaign: float | None = None
-    max_increase_pct: float | None = None
-    max_total: float | None = None
-    max_lifetime: float | None = None
-    max_bid_amount: float | None = None
-    max_cpc_bid: float | None = None
-    blocked: set[str] = set()
-    block_resets = False
-    block_resets_incident = False
+    bullets = _bullets(content)
 
-    for line in content.splitlines():
-        m = _BULLET_RE.match(line)
-        if m is None:
-            continue
-        key = m.group(1).lower()
-        raw = m.group(2).strip()
-        if key == "max_daily_budget_per_campaign":
-            max_per_campaign = _to_float(raw)
-        elif key == "max_daily_budget_increase_pct":
-            max_increase_pct = _to_float(raw)
-        elif key == "max_total_daily_budget":
-            max_total = _to_float(raw)
-        elif key == "max_lifetime_budget_per_campaign":
-            max_lifetime = _to_float(raw)
-        elif key == "max_bid_amount_per_ad_set":
-            max_bid_amount = _to_float(raw)
-        elif key == "max_cpc_bid_per_ad_group":
-            max_cpc_bid = _to_float(raw)
-        elif key == "blocked_operations":
-            blocked = {op.strip() for op in raw.split(",") if op.strip()}
-        elif key == "block_learning_resets":
-            block_resets = _to_bool(raw)
-        elif key == "block_learning_resets_during_incident":
-            block_resets_incident = _to_bool(raw)
+    def number(key: str) -> float | None:
+        raw = bullets.get(key)
+        return None if raw is None else _to_float(raw)
 
+    window_raw = bullets.get("exclusion_impact_window_days")
     return Guardrails(
-        max_daily_budget_per_campaign=max_per_campaign,
-        max_daily_budget_increase_pct=max_increase_pct,
-        max_total_daily_budget=max_total,
-        max_lifetime_budget_per_campaign=max_lifetime,
-        max_bid_amount_per_ad_set=max_bid_amount,
-        max_cpc_bid_per_ad_group=max_cpc_bid,
-        blocked_operations=frozenset(blocked),
-        block_learning_resets=block_resets,
-        block_learning_resets_during_incident=block_resets_incident,
+        max_daily_budget_per_campaign=number("max_daily_budget_per_campaign"),
+        max_daily_budget_increase_pct=number("max_daily_budget_increase_pct"),
+        max_total_daily_budget=number("max_total_daily_budget"),
+        max_lifetime_budget_per_campaign=number("max_lifetime_budget_per_campaign"),
+        max_bid_amount_per_ad_set=number("max_bid_amount_per_ad_set"),
+        max_cpc_bid_per_ad_group=number("max_cpc_bid_per_ad_group"),
+        blocked_operations=frozenset(
+            op.strip()
+            for op in bullets.get("blocked_operations", "").split(",")
+            if op.strip()
+        ),
+        max_delivery_share_removed_pct=number("max_delivery_share_removed_pct"),
+        max_cumulative_delivery_share_removed_pct=number(
+            "max_cumulative_delivery_share_removed_pct"
+        ),
+        exclusion_impact_window_days=(
+            None if window_raw is None else _to_int(window_raw)
+        ),
+        exclusion_impact_metrics=_to_metrics(
+            bullets.get("exclusion_impact_metrics", "")
+        ),
+        block_exclusions_without_impact_data=_to_bool(
+            bullets.get("block_exclusions_without_impact_data", "")
+        ),
+        block_learning_resets=_to_bool(bullets.get("block_learning_resets", "")),
+        block_learning_resets_during_incident=_to_bool(
+            bullets.get("block_learning_resets_during_incident", "")
+        ),
     )
 
 
@@ -621,6 +670,18 @@ def _load_guardrails() -> Guardrails:
         guardrails = Guardrails()
     _cache[key] = (now, guardrails)
     return guardrails
+
+
+def load_guardrails() -> Guardrails:
+    """Public read of the operator's ``## Guardrails``, TTL-cached, fail-open.
+
+    Exists for the rules this file PARSES but does not enforce — the
+    exclusion delivery-impact keys (#547), enforced by the dispatcher
+    pre-flight because they need an awaited platform read. Calls through
+    :func:`_load_guardrails` rather than aliasing it so a test that patches
+    the loader patches both.
+    """
+    return _load_guardrails()
 
 
 class StrategyPolicyGate:

--- a/skills/_mureo-google-ads/SKILL.md
+++ b/skills/_mureo-google-ads/SKILL.md
@@ -334,6 +334,15 @@ kills delivery can be tied to a date and undone, instead of being reconstructed 
 - `add` -- Exclude websites / apps / app categories. **Requires user confirmation.** Always
   show the count and the level before writing — a large batch can take a Display campaign
   to zero impressions.
+
+  **Size it first (#547).** Call `analysis_exclusion_impact_preview` with
+  `tool="google_ads_negative_placements_add"` and the exact `arguments` you are about to
+  send. It reports the share of the last N days' impressions / clicks / cost / conversions
+  those placements carried, both for this batch and cumulatively for every standing
+  exclusion once it lands, plus `would_block`. Show the operator the share, not just the
+  count. If STRATEGY.md `## Guardrails` carries `max_delivery_share_removed_pct` (or
+  `max_cumulative_delivery_share_removed_pct`), an over-cap batch is **refused before it
+  reaches the API** and the refusal names the measured share.
   ```
   Required: customer_id (string), exactly one of campaign_id / ad_group_id (string),
             placements (array of {type: "website" | "mobile_application" | "mobile_app_category",

--- a/skills/_mureo-meta-ads/SKILL.md
+++ b/skills/_mureo-meta-ads/SKILL.md
@@ -254,6 +254,18 @@ indistinguishable from any other targeting edit.
             excluded_brand_safety_content_types (arrays of string; at least one required)
   ```
 
+  **Delivery impact is not measurable here, and mureo says so (#547).** None of Meta's
+  insights breakdowns attribute past delivery to publisher categories, publisher block
+  lists or brand-safety content types — `publisher_platform` / `platform_position` are a
+  different exclusion surface (ad-set targeting). So
+  `analysis_exclusion_impact_preview` reports `coverage: "unknown"` for this tool, never
+  "no impact", and the call's own result carries the same verdict. Tell the operator the
+  size is unknown rather than implying it is small. An operator who would rather refuse
+  than proceed blind sets `block_exclusions_without_impact_data: true` in STRATEGY.md
+  `## Guardrails`, which refuses this tool outright. To size such a change from real
+  data, pull the ad set's delivery yourself and pass it to the preview tool as
+  `delivery_records`.
+
 ### insights
 
 - `report` -- Get performance metrics for the account or specific campaign.

--- a/skills/_mureo-shared/SKILL.md
+++ b/skills/_mureo-shared/SKILL.md
@@ -240,6 +240,42 @@ When pausing or removing multiple entities:
 - Show total impact (e.g., "This will pause 5 campaigns with 1,200 clicks/day")
 - Require explicit confirmation
 
+### 3b. Bulk Exclusions: Size Them Before Applying (#547)
+
+An exclusion / block / negative-keyword batch removes **inventory**, and the
+share of delivery it removes is not visible from the count of entities. Before
+any such call, run:
+
+```
+analysis_exclusion_impact_preview
+  tool: "<the exclusion tool you are about to call>"
+  arguments: { …exactly the arguments you will send… }
+```
+
+It returns the share of the recent window's impressions / clicks / cost /
+conversions those entities carried — **incrementally** (this batch) and
+**cumulatively** (every standing exclusion once this batch lands). Show the
+operator the share, not just the count. The cumulative figure is the one that
+matters for a sequence of small passes: each pass can look harmless while the
+set as a whole takes delivery to zero.
+
+For a platform mureo does not model — Yahoo Ads placement URL lists, LINE /
+SmartNews placement restrictions, LOGLY adspot blocks, Amazon negative
+targeting — the tool still works: pull that platform's own per-placement /
+per-adspot report yourself and pass `excluded_entities` + `delivery_records`.
+In that form it reaches no API at all.
+
+`coverage: "unknown"` is an honest answer and **never** means "no impact". Say
+"the size of this exclusion cannot be measured" rather than proceeding as if it
+were small.
+
+**LOGLY specifically:** the account's own numbers cannot tell "bad inventory"
+apart from "my creative mismatches this inventory". Before blocking an adspot,
+also check `logly_supply_adspot_summary` (all-advertiser CTR / CPC for the
+slot) and `logly_supply_adspot_cv_by_category` (whether other advertisers
+convert there). The delivery-impact preview sizes the loss; the supply-side
+view is what says whether the loss is worth taking.
+
 ### 4. Never Expose Raw Credentials
 
 - Never include token values from `credentials.json` in responses

--- a/skills/_mureo-strategy/SKILL.md
+++ b/skills/_mureo-strategy/SKILL.md
@@ -332,6 +332,20 @@ request and behaves exactly as before.
   **whole** standing exclusion set, including this batch, is over the cap. The
   incident behind #547 was two weeks of individually-small passes, none of
   which would have tripped the incremental cap.
+
+  **Do not write this one alone.** It needs the standing exclusion set, and
+  mureo cannot read that for an **ad group-scoped** write: campaign-level
+  exclusions also cover the ad group and are not reachable from the call's
+  arguments, and Google Ads exposes no ad group-level negative keyword
+  listing at all. On those calls the cumulative figure is withheld (`null`
+  with a reason) and this rule therefore enforces **nothing** — which is
+  exactly the scope the motivating incident happened at. Always pair it with
+  `max_delivery_share_removed_pct`, which is evaluated per batch, needs no
+  standing list, and so still fires there. When a rule you wrote could not be
+  evaluated, mureo says so on the call itself (`NOT ENFORCED on this call:`
+  in the appended notice, `unevaluated_rules` in
+  `analysis_exclusion_impact_preview`) — treat that line as a gap to close,
+  not as a pass.
 - `exclusion_impact_window_days` — the recent window (default 30, max 365).
 - `exclusion_impact_metrics` — which of `impressions` / `clicks` / `cost` /
   `conversions` the caps apply to. Default `impressions`; any listed metric

--- a/skills/_mureo-strategy/SKILL.md
+++ b/skills/_mureo-strategy/SKILL.md
@@ -215,6 +215,11 @@ keys (all optional):
 - blocked_operations: google_ads_keywords_remove, meta_ads_audiences_delete
 - block_learning_resets: false
 - block_learning_resets_during_incident: true
+- max_delivery_share_removed_pct: 25
+- max_cumulative_delivery_share_removed_pct: 60
+- exclusion_impact_window_days: 30
+- exclusion_impact_metrics: impressions, cost
+- block_exclusions_without_impact_data: false
 ```
 
 - `max_daily_budget_per_campaign` — a budget mutation proposing more than this
@@ -310,6 +315,40 @@ keys (all optional):
   snapshot (a policy gate runs on every tool call and must not make network
   calls). Keep it fresh or the answer is `unknown` — which these rules treat as
   "refuse", not as "fine".
+
+### Exclusion delivery-impact rules (#547)
+
+The five keys below govern **bulk exclusions / blocks / negative keywords** —
+the operation that removes inventory rather than money. Before such a call is
+dispatched, mureo computes how much of the account's OWN recent delivery the
+batch removes and refuses it when it is over the cap. All five are optional and
+all default to off; with none of them written mureo issues no extra report
+request and behaves exactly as before.
+
+- `max_delivery_share_removed_pct` — refuse an exclusion batch whose entities
+  accounted for more than this share of the recent window. This is the rule
+  that stops "I tightened placements and delivery went to zero".
+- `max_cumulative_delivery_share_removed_pct` — refuse when the account's
+  **whole** standing exclusion set, including this batch, is over the cap. The
+  incident behind #547 was two weeks of individually-small passes, none of
+  which would have tripped the incremental cap.
+- `exclusion_impact_window_days` — the recent window (default 30, max 365).
+- `exclusion_impact_metrics` — which of `impressions` / `clicks` / `cost` /
+  `conversions` the caps apply to. Default `impressions`; any listed metric
+  over the cap refuses.
+- `block_exclusions_without_impact_data` — refuse an exclusion mureo cannot
+  size (coverage `unknown` or `partial`) instead of applying it blind. Default
+  `false`, because several real exclusion surfaces are structurally
+  unattributable (Meta publisher categories / block lists / brand-safety
+  content types have no insights breakdown). Even with it off, the measured —
+  or unmeasurable — verdict is appended to the call's own result, so an
+  exclusion is never applied *silently*.
+
+Call `analysis_exclusion_impact_preview` **before** any bulk exclusion to see
+the same numbers without applying anything. It also works for platforms mureo
+does not model: pass `excluded_entities` + `delivery_records` you fetched from
+that platform's own report and it reaches no API at all. Its `would_block`
+field is computed by the same rule the dispatcher enforces.
 
 Absent section (or an unparseable value) ⇒ no enforcement for that rule
 (fail-open); mureo never blocks on a rule the operator did not write. A boolean

--- a/tests/test_exclusion_impact_preview.py
+++ b/tests/test_exclusion_impact_preview.py
@@ -1,0 +1,804 @@
+"""Delivery-impact preview before bulk exclusions / blocks (#547).
+
+The incident this exists for: placement exclusions tightened incrementally
+over two weeks, then one larger pass, and delivery went to zero for a week.
+The direction was right; the *magnitude* was never shown at the moment of
+the decision.
+
+So these tests pin the four properties that decide whether the feature
+actually prevents that, rather than the shape of the code:
+
+1. The share of the recent window's delivery attributable to the entities
+   being excluded is **computed and surfaced** at the moment of the write.
+2. A threshold written in ``## Guardrails`` in STRATEGY.md **actually
+   blocks** the call — end to end through ``handle_call_tool``, before any
+   mutation reaches the platform.
+3. A small exclusion is **not** warned about and **not** blocked. A check
+   that fires on everything gets switched off.
+4. A surface whose delivery mureo cannot attribute reports **unknown** —
+   never a silent "no impact".
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from mureo.analysis.exclusion_impact import (
+    COVERAGE_MEASURED,
+    COVERAGE_PARTIAL,
+    COVERAGE_UNKNOWN,
+    DEFAULT_WINDOW_DAYS,
+    DeliveryRecord,
+    ExclusionTarget,
+    estimate_exclusion_impact,
+    evaluate_exclusion_impact,
+    exclusion_impact_rules,
+)
+from mureo.policy.strategy_gate import Guardrails, guardrails_from_strategy_text
+
+GOOGLE_ADD = "google_ads_negative_placements_add"
+GOOGLE_NEG_KW = "google_ads_negative_keywords_add"
+META_SET = "meta_ads_excluded_placements_set"
+
+_WEBSITE = "website"
+_APP = "mobile_application"
+_APP_CATEGORY = "mobile_app_category"
+_SEARCH_TERM = "search_term"
+
+_PLACEMENT_TYPES = frozenset({_WEBSITE, _APP})
+
+
+def _rec(entity: str, impressions: float, **kw: Any) -> DeliveryRecord:
+    return DeliveryRecord(
+        entity=entity,
+        entity_type=kw.pop("entity_type", _WEBSITE),
+        impressions=impressions,
+        clicks=kw.pop("clicks", 0.0),
+        cost=kw.pop("cost", 0.0),
+        conversions=kw.pop("conversions", 0.0),
+    )
+
+
+def _site(value: str) -> ExclusionTarget:
+    return ExclusionTarget(value=value, entity_type=_WEBSITE)
+
+
+# ---------------------------------------------------------------------------
+# 1. The share is computed and surfaced
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestShareIsComputed:
+    def test_dominant_entity_share_is_reported(self) -> None:
+        """Excluding what carried 94% of the window's impressions says 94%."""
+        records = [
+            _rec("bigsite.com", 9400, clicks=470, cost=94000, conversions=47),
+            _rec("small.example", 600, clicks=30, cost=6000, conversions=3),
+        ]
+        impact = estimate_exclusion_impact(
+            targets=[_site("bigsite.com")],
+            records=records,
+            attributable_types=_PLACEMENT_TYPES,
+            basis="google_ads_group_placement_view",
+            window_days=30,
+        )
+        assert impact.coverage == COVERAGE_MEASURED
+        assert impact.share_pct("impressions") == pytest.approx(94.0)
+        assert impact.share_pct("clicks") == pytest.approx(94.0)
+        assert impact.share_pct("cost") == pytest.approx(94.0)
+        assert impact.share_pct("conversions") == pytest.approx(94.0)
+        assert "bigsite.com" in impact.matched
+
+    def test_subdomains_of_an_excluded_domain_count(self) -> None:
+        impact = estimate_exclusion_impact(
+            targets=[_site("example.com")],
+            records=[
+                _rec("news.example.com", 700),
+                _rec("example.com", 200),
+                _rec("notexample.com", 100),
+            ],
+            attributable_types=_PLACEMENT_TYPES,
+            basis="b",
+            window_days=30,
+        )
+        assert impact.share_pct("impressions") == pytest.approx(90.0)
+
+    def test_excluding_a_subdomain_does_not_claim_the_parent(self) -> None:
+        impact = estimate_exclusion_impact(
+            targets=[_site("news.example.com")],
+            records=[_rec("news.example.com", 100), _rec("example.com", 900)],
+            attributable_types=_PLACEMENT_TYPES,
+            basis="b",
+            window_days=30,
+        )
+        assert impact.share_pct("impressions") == pytest.approx(10.0)
+
+    def test_url_forms_normalize_to_the_same_host(self) -> None:
+        impact = estimate_exclusion_impact(
+            targets=[_site("https://WWW.Example.com/section?a=1")],
+            records=[_rec("example.com", 500), _rec("other.jp", 500)],
+            attributable_types=_PLACEMENT_TYPES,
+            basis="b",
+            window_days=30,
+        )
+        assert impact.share_pct("impressions") == pytest.approx(50.0)
+
+    def test_mobile_app_placement_prefix_normalizes(self) -> None:
+        impact = estimate_exclusion_impact(
+            targets=[ExclusionTarget("1-com.example.app", _APP)],
+            records=[
+                _rec("mobileapp::1-com.example.app", 800, entity_type=_APP),
+                _rec("mobileapp::2-999", 200, entity_type=_APP),
+            ],
+            attributable_types=_PLACEMENT_TYPES,
+            basis="b",
+            window_days=30,
+        )
+        assert impact.share_pct("impressions") == pytest.approx(80.0)
+
+    def test_negative_keyword_match_types(self) -> None:
+        records = [
+            DeliveryRecord("cheap running shoes", _SEARCH_TERM, impressions=500),
+            DeliveryRecord("running shoes cheap", _SEARCH_TERM, impressions=300),
+            DeliveryRecord("running blue shoes", _SEARCH_TERM, impressions=200),
+        ]
+        common = {
+            "records": records,
+            "attributable_types": frozenset({_SEARCH_TERM}),
+            "basis": "google_ads_search_term_view",
+            "window_days": 30,
+        }
+        exact = estimate_exclusion_impact(
+            targets=[ExclusionTarget("cheap running shoes", _SEARCH_TERM, "EXACT")],
+            **common,
+        )
+        phrase = estimate_exclusion_impact(
+            targets=[ExclusionTarget("running shoes", _SEARCH_TERM, "PHRASE")],
+            **common,
+        )
+        broad = estimate_exclusion_impact(
+            targets=[ExclusionTarget("blue shoes", _SEARCH_TERM, "BROAD")],
+            **common,
+        )
+        # EXACT is the whole term, so only the first row.
+        assert exact.share_pct("impressions") == pytest.approx(50.0)
+        # "running shoes" is contiguous in rows 1 and 2, split in row 3.
+        assert phrase.share_pct("impressions") == pytest.approx(80.0)
+        # Both tokens present in row 3 only, order-free.
+        assert broad.share_pct("impressions") == pytest.approx(20.0)
+
+    def test_zero_delivery_is_not_reported_as_zero_percent(self) -> None:
+        """An empty window is 'no share to compute', not 'no impact'."""
+        impact = estimate_exclusion_impact(
+            targets=[_site("example.com")],
+            records=[],
+            attributable_types=_PLACEMENT_TYPES,
+            basis="b",
+            window_days=30,
+        )
+        assert impact.coverage == COVERAGE_MEASURED
+        assert impact.share_pct("impressions") is None
+        assert impact.as_dict()["incremental"]["impressions"]["share_pct"] is None
+
+
+# ---------------------------------------------------------------------------
+# 2. A `## Guardrails` threshold blocks
+# ---------------------------------------------------------------------------
+
+
+_STRATEGY_WITH_CAP = """# Strategy
+
+## Guardrails
+
+- max_delivery_share_removed_pct: 25
+- exclusion_impact_window_days: 30
+"""
+
+
+@pytest.mark.unit
+class TestGuardrailParsing:
+    def test_guardrail_keys_parse_from_strategy_text(self) -> None:
+        rails = guardrails_from_strategy_text(_STRATEGY_WITH_CAP)
+        assert rails.max_delivery_share_removed_pct == 25
+        assert rails.exclusion_impact_window_days == 30
+        rules = exclusion_impact_rules(rails)
+        assert rules.enabled() is True
+        assert rules.window_days == 30
+        assert rules.metrics == ("impressions",)
+
+    def test_defaults_are_not_hardcoded_at_the_call_site(self) -> None:
+        rules = exclusion_impact_rules(Guardrails(max_delivery_share_removed_pct=10.0))
+        assert rules.window_days == DEFAULT_WINDOW_DAYS
+        assert rules.metrics == ("impressions",)
+
+    def test_metrics_and_block_without_data_parse(self) -> None:
+        rails = guardrails_from_strategy_text(
+            "## Guardrails\n\n"
+            "- max_delivery_share_removed_pct: 40\n"
+            "- exclusion_impact_metrics: impressions, cost\n"
+            "- block_exclusions_without_impact_data: true\n"
+        )
+        rules = exclusion_impact_rules(rails)
+        assert rules.metrics == ("impressions", "cost")
+        assert rules.block_without_data is True
+
+    def test_no_exclusion_rule_written_means_disabled(self) -> None:
+        rules = exclusion_impact_rules(guardrails_from_strategy_text("# Strategy\n"))
+        assert rules.enabled() is False
+
+
+@pytest.mark.unit
+class TestEvaluationBlocks:
+    def _impact(self, share: float) -> Any:
+        return estimate_exclusion_impact(
+            targets=[_site("big.example")],
+            records=[
+                _rec("big.example", share),
+                _rec("rest.example", 100 - share),
+            ],
+            attributable_types=_PLACEMENT_TYPES,
+            basis="b",
+            window_days=30,
+        )
+
+    def test_over_threshold_produces_a_block_reason(self) -> None:
+        rules = exclusion_impact_rules(Guardrails(max_delivery_share_removed_pct=25.0))
+        reason = evaluate_exclusion_impact(self._impact(94), rules)
+        assert reason is not None
+        assert "94" in reason
+        assert "max_delivery_share_removed_pct" in reason
+
+    def test_under_threshold_does_not_block(self) -> None:
+        rules = exclusion_impact_rules(Guardrails(max_delivery_share_removed_pct=25.0))
+        assert evaluate_exclusion_impact(self._impact(3), rules) is None
+
+    def test_a_metric_not_listed_cannot_block(self) -> None:
+        impact = estimate_exclusion_impact(
+            targets=[_site("big.example")],
+            records=[
+                _rec("big.example", 1, cost=9000),
+                _rec("rest.example", 999, cost=1000),
+            ],
+            attributable_types=_PLACEMENT_TYPES,
+            basis="b",
+            window_days=30,
+        )
+        impressions_only = exclusion_impact_rules(
+            Guardrails(max_delivery_share_removed_pct=25.0)
+        )
+        with_cost = exclusion_impact_rules(
+            Guardrails(
+                max_delivery_share_removed_pct=25.0,
+                exclusion_impact_metrics=("impressions", "cost"),
+            )
+        )
+        assert evaluate_exclusion_impact(impact, impressions_only) is None
+        assert evaluate_exclusion_impact(impact, with_cost) is not None
+
+
+# ---------------------------------------------------------------------------
+# 3. Cumulative tightening
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCumulativeTightening:
+    def test_standing_exclusions_are_added_to_the_new_batch(self) -> None:
+        """Two weeks of small passes plus one more must show the total."""
+        records = [_rec(f"site{i}.example", 100) for i in range(10)]
+        impact = estimate_exclusion_impact(
+            targets=[_site("site9.example")],
+            records=records,
+            attributable_types=_PLACEMENT_TYPES,
+            basis="b",
+            window_days=30,
+            standing=[_site(f"site{i}.example") for i in range(8)],
+        )
+        assert impact.share_pct("impressions") == pytest.approx(10.0)
+        assert impact.cumulative_share_pct("impressions") == pytest.approx(90.0)
+
+    def test_cumulative_cap_blocks_when_incremental_does_not(self) -> None:
+        records = [_rec(f"site{i}.example", 100) for i in range(10)]
+        impact = estimate_exclusion_impact(
+            targets=[_site("site9.example")],
+            records=records,
+            attributable_types=_PLACEMENT_TYPES,
+            basis="b",
+            window_days=30,
+            standing=[_site(f"site{i}.example") for i in range(8)],
+        )
+        rules = exclusion_impact_rules(
+            Guardrails(
+                max_delivery_share_removed_pct=25.0,
+                max_cumulative_delivery_share_removed_pct=60.0,
+            )
+        )
+        reason = evaluate_exclusion_impact(impact, rules)
+        assert reason is not None
+        assert "max_cumulative_delivery_share_removed_pct" in reason
+
+    def test_unavailable_standing_list_is_not_reported_as_zero(self) -> None:
+        impact = estimate_exclusion_impact(
+            targets=[_site("a.example")],
+            records=[_rec("a.example", 10), _rec("b.example", 90)],
+            attributable_types=_PLACEMENT_TYPES,
+            basis="b",
+            window_days=30,
+            standing=None,
+            cumulative_reason="mureo cannot list ad-group-level standing exclusions",
+        )
+        assert impact.cumulative is None
+        assert impact.cumulative_share_pct("impressions") is None
+        assert impact.as_dict()["cumulative"] is None
+        assert "ad-group-level" in impact.as_dict()["cumulative_reason"]
+
+
+# ---------------------------------------------------------------------------
+# 4. Unknown coverage is never a silent pass
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestUnknownCoverage:
+    def test_no_records_is_unknown_not_zero(self) -> None:
+        impact = estimate_exclusion_impact(
+            targets=[ExclusionTarget("household", "publisher_category")],
+            records=None,
+            attributable_types=frozenset(),
+            basis="meta_ads_ad_set_targeting",
+            window_days=30,
+            coverage_reason=(
+                "Meta insights breakdowns do not attribute delivery to "
+                "publisher categories"
+            ),
+        )
+        assert impact.coverage == COVERAGE_UNKNOWN
+        assert impact.incremental is None
+        assert impact.share_pct("impressions") is None
+        payload = impact.as_dict()
+        assert payload["coverage"] == COVERAGE_UNKNOWN
+        assert payload["incremental"] is None
+        assert "publisher categories" in payload["coverage_reason"]
+
+    def test_block_without_data_refuses_an_unknown_batch(self) -> None:
+        impact = estimate_exclusion_impact(
+            targets=[ExclusionTarget("household", "publisher_category")],
+            records=None,
+            attributable_types=frozenset(),
+            basis="meta_ads_ad_set_targeting",
+            window_days=30,
+            coverage_reason="no attributable breakdown",
+        )
+        permissive = exclusion_impact_rules(
+            Guardrails(max_delivery_share_removed_pct=25.0)
+        )
+        strict = exclusion_impact_rules(
+            Guardrails(
+                max_delivery_share_removed_pct=25.0,
+                block_exclusions_without_impact_data=True,
+            )
+        )
+        assert evaluate_exclusion_impact(impact, permissive) is None
+        reason = evaluate_exclusion_impact(impact, strict)
+        assert reason is not None
+        assert "block_exclusions_without_impact_data" in reason
+
+    def test_a_target_type_the_basis_cannot_attribute_is_partial(self) -> None:
+        impact = estimate_exclusion_impact(
+            targets=[_site("a.example"), ExclusionTarget("60000", _APP_CATEGORY)],
+            records=[_rec("a.example", 10), _rec("b.example", 90)],
+            attributable_types=_PLACEMENT_TYPES,
+            basis="b",
+            window_days=30,
+        )
+        assert impact.coverage == COVERAGE_PARTIAL
+        assert impact.unattributable_targets == ("60000",)
+        assert impact.share_pct("impressions") == pytest.approx(10.0)
+
+    def test_a_target_that_simply_never_served_is_still_measured(self) -> None:
+        """Not the same as unattributable — it served nothing, and we know it."""
+        impact = estimate_exclusion_impact(
+            targets=[_site("never-served.example")],
+            records=[_rec("a.example", 100)],
+            attributable_types=_PLACEMENT_TYPES,
+            basis="b",
+            window_days=30,
+        )
+        assert impact.coverage == COVERAGE_MEASURED
+        assert impact.share_pct("impressions") == pytest.approx(0.0)
+        assert impact.unmatched_targets == ("never-served.example",)
+
+
+# ---------------------------------------------------------------------------
+# Surface registry — what mureo knows how to check
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSurfaceRegistry:
+    def test_the_mureo_owned_exclusion_tools_are_registered(self) -> None:
+        from mureo.mcp.exclusion_sources import register_builtin_exclusion_surfaces
+
+        register_builtin_exclusion_surfaces()
+        from mureo.analysis.exclusion_impact import exclusion_surface_for
+
+        for tool in (
+            GOOGLE_ADD,
+            GOOGLE_NEG_KW,
+            "google_ads_negative_keywords_add_to_ad_group",
+            META_SET,
+        ):
+            assert exclusion_surface_for(tool) is not None, tool
+
+    def test_a_non_exclusion_tool_has_no_surface(self) -> None:
+        from mureo.analysis.exclusion_impact import exclusion_surface_for
+
+        assert exclusion_surface_for("google_ads_budget_update") is None
+
+    def test_a_plugin_can_register_its_own_surface(self) -> None:
+        from mureo.analysis.exclusion_impact import (
+            DeliverySample,
+            ExclusionSurface,
+            exclusion_surface_for,
+            register_exclusion_surface,
+            reset_exclusion_surfaces,
+        )
+
+        async def _delivery(args: dict[str, Any], days: int) -> DeliverySample:
+            return DeliverySample(records=None, basis="x", reason="no supply view")
+
+        try:
+            register_exclusion_surface(
+                ExclusionSurface(
+                    tool="logly_ads_block_adspots",
+                    platform="logly",
+                    targets=lambda args: (
+                        ExclusionTarget(str(a), "adspot")
+                        for a in args.get("adspots", [])
+                    ),
+                    delivery=_delivery,
+                )
+            )
+            assert exclusion_surface_for("logly_ads_block_adspots") is not None
+        finally:
+            reset_exclusion_surfaces()
+            register_builtin = __import__(
+                "mureo.mcp.exclusion_sources", fromlist=["x"]
+            ).register_builtin_exclusion_surfaces
+            register_builtin()
+
+
+# ---------------------------------------------------------------------------
+# End to end: the guardrail refuses the call before the mutation
+# ---------------------------------------------------------------------------
+
+
+class _FakeGoogleClient:
+    def __init__(
+        self,
+        placements: list[dict[str, Any]],
+        standing: list[dict[str, Any]] | None = None,
+    ) -> None:
+        self._placements = placements
+        self._standing = standing or []
+        self.mutated = False
+
+    async def get_placement_performance(self, **kwargs: Any) -> list[dict[str, Any]]:
+        return self._placements
+
+    async def list_negative_placements(self, **kwargs: Any) -> list[dict[str, Any]]:
+        return self._standing
+
+    async def add_negative_placements(self, params: dict[str, Any]) -> dict[str, Any]:
+        self.mutated = True
+        return {"level": "campaign", "campaign_id": "100", "count": 1, "created": []}
+
+
+def _activate_workspace(
+    monkeypatch: pytest.MonkeyPatch, directory: Path, body: str
+) -> None:
+    """Make ``directory`` the workspace the guardrail loader reads.
+
+    ``RuntimeContext`` is a process singleton bound to the cwd of its first
+    resolution, so a bare ``chdir`` would leave the gate reading the repo's
+    own STRATEGY.md. Resetting it is the documented way to swap it.
+    """
+    import mureo.policy.strategy_gate as sg
+    from mureo.core.runtime_context import reset_runtime_context
+
+    (directory / "STRATEGY.md").write_text(body, encoding="utf-8")
+    monkeypatch.chdir(directory)
+    reset_runtime_context()
+    sg._cache.clear()
+
+
+@pytest.fixture(autouse=True)
+def _restore_workspace() -> Any:
+    """Undo the singleton swap so a later test file is unaffected."""
+    yield
+    import mureo.policy.strategy_gate as sg
+    from mureo.core.runtime_context import reset_runtime_context
+
+    reset_runtime_context()
+    sg._cache.clear()
+
+
+@pytest.mark.asyncio
+class TestDispatcherEnforcement:
+    async def _call(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        *,
+        strategy: str,
+        placements: list[dict[str, Any]],
+        excluded: str = "bigsite.com",
+    ) -> tuple[Any, _FakeGoogleClient]:
+        import mureo.mcp.exclusion_sources as sources
+        from mureo.mcp.server import handle_call_tool
+
+        _activate_workspace(monkeypatch, tmp_path, strategy)
+        monkeypatch.setattr("mureo.mcp.server._load_policy_gates", lambda: ())
+
+        client = _FakeGoogleClient(placements)
+
+        async def _fake_client(args: dict[str, Any]) -> Any:
+            return client
+
+        monkeypatch.setattr(sources, "google_ads_client", _fake_client)
+        monkeypatch.setattr(
+            "mureo.mcp._handlers_google_ads._get_client", lambda args: client
+        )
+        result = await handle_call_tool(
+            GOOGLE_ADD,
+            {
+                "customer_id": "1234567890",
+                "campaign_id": "100",
+                "placements": [{"type": "website", "value": excluded}],
+            },
+        )
+        return result, client
+
+    async def test_over_cap_exclusion_is_refused_before_the_mutation(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        result, client = await self._call(
+            monkeypatch,
+            tmp_path,
+            strategy=_STRATEGY_WITH_CAP,
+            placements=[
+                {"placement": "bigsite.com", "type": "website", "impressions": 9400},
+                {"placement": "small.example", "type": "website", "impressions": 600},
+            ],
+        )
+        text = "\n".join(getattr(c, "text", "") for c in result)
+        assert "94" in text
+        assert "refused" in text.lower()
+        assert client.mutated is False
+
+    async def test_small_exclusion_is_not_refused(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        result, client = await self._call(
+            monkeypatch,
+            tmp_path,
+            strategy=_STRATEGY_WITH_CAP,
+            placements=[
+                {"placement": "bigsite.com", "type": "website", "impressions": 30},
+                {"placement": "small.example", "type": "website", "impressions": 9970},
+            ],
+        )
+        text = "\n".join(getattr(c, "text", "") for c in result)
+        assert "refused" not in text.lower()
+        assert client.mutated is True
+
+    async def test_an_allowed_batch_still_reports_what_it_removed(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """The measured size is recorded so the NEXT pass is not made blind."""
+        result, client = await self._call(
+            monkeypatch,
+            tmp_path,
+            strategy=_STRATEGY_WITH_CAP,
+            placements=[
+                {"placement": "bigsite.com", "type": "website", "impressions": 30},
+                {"placement": "small.example", "type": "website", "impressions": 9970},
+            ],
+        )
+        text = "\n".join(getattr(c, "text", "") for c in result)
+        assert client.mutated is True
+        assert "[mureo] Delivery impact" in text
+        assert "impressions 0.3%" in text
+
+    async def test_no_guardrail_written_reaches_no_report_api(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Fail-open: with no rule written, the pre-dispatch check does no I/O."""
+        import mureo.mcp.exclusion_sources as sources
+        from mureo.mcp.server import handle_call_tool
+
+        _activate_workspace(monkeypatch, tmp_path, "# Strategy\n\n## Goals\n\n- grow\n")
+        monkeypatch.setattr("mureo.mcp.server._load_policy_gates", lambda: ())
+
+        calls: list[str] = []
+
+        async def _boom(args: dict[str, Any]) -> Any:
+            calls.append("client")
+            raise AssertionError("no client must be built with no guardrail written")
+
+        client = _FakeGoogleClient([])
+        monkeypatch.setattr(sources, "google_ads_client", _boom)
+        monkeypatch.setattr(
+            "mureo.mcp._handlers_google_ads._get_client", lambda args: client
+        )
+        await handle_call_tool(
+            GOOGLE_ADD,
+            {
+                "customer_id": "1234567890",
+                "campaign_id": "100",
+                "placements": [{"type": "website", "value": "x.example"}],
+            },
+        )
+        assert calls == []
+        assert client.mutated is True
+
+    async def test_a_read_failure_is_unknown_and_still_dispatches(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A broken report must not take the exclusion tools offline."""
+        import mureo.mcp.exclusion_sources as sources
+        from mureo.mcp.server import handle_call_tool
+
+        _activate_workspace(monkeypatch, tmp_path, _STRATEGY_WITH_CAP)
+        monkeypatch.setattr("mureo.mcp.server._load_policy_gates", lambda: ())
+
+        class _Broken(_FakeGoogleClient):
+            async def get_placement_performance(
+                self, **kwargs: Any
+            ) -> list[dict[str, Any]]:
+                raise RuntimeError("report unavailable")
+
+        client = _Broken([])
+
+        async def _fake_client(args: dict[str, Any]) -> Any:
+            return client
+
+        monkeypatch.setattr(sources, "google_ads_client", _fake_client)
+        monkeypatch.setattr(
+            "mureo.mcp._handlers_google_ads._get_client", lambda args: client
+        )
+        result = await handle_call_tool(
+            GOOGLE_ADD,
+            {
+                "customer_id": "1234567890",
+                "campaign_id": "100",
+                "placements": [{"type": "website", "value": "x.example"}],
+            },
+        )
+        text = "\n".join(getattr(c, "text", "") for c in result)
+        assert client.mutated is True
+        assert "Coverage: unknown" in text
+        assert "WITHOUT a measured size" in text
+
+    async def test_block_without_impact_data_refuses_the_meta_surface(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Meta's facets are unattributable; the opt-in rule refuses them."""
+        from mureo.mcp.server import handle_call_tool
+
+        _activate_workspace(
+            monkeypatch,
+            tmp_path,
+            "## Guardrails\n\n- block_exclusions_without_impact_data: true\n",
+        )
+        monkeypatch.setattr("mureo.mcp.server._load_policy_gates", lambda: ())
+
+        mutated: list[str] = []
+
+        class _FakeMetaClient:
+            async def set_excluded_placements(
+                self, ad_set_id: str, **facets: Any
+            ) -> dict[str, Any]:
+                mutated.append(ad_set_id)
+                return {"ad_set_id": ad_set_id}
+
+        async def _client(args: dict[str, Any]) -> Any:
+            return _FakeMetaClient()
+
+        monkeypatch.setattr("mureo.mcp._handlers_meta_ads._get_client", _client)
+        result = await handle_call_tool(
+            META_SET,
+            {
+                "ad_set_id": "1",
+                "excluded_publisher_categories": ["household"],
+            },
+        )
+        text = "\n".join(getattr(c, "text", "") for c in result)
+        assert mutated == []
+        assert "block_exclusions_without_impact_data" in text
+        assert "publisher categories" in text
+
+
+# ---------------------------------------------------------------------------
+# The read-only preview tool
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestPreviewTool:
+    async def test_tool_is_registered(self) -> None:
+        from mureo.mcp.tools_analysis import TOOLS
+
+        assert "analysis_exclusion_impact_preview" in {t.name for t in TOOLS}
+
+    async def test_preview_over_supplied_records_needs_no_platform(self) -> None:
+        from mureo.mcp.tools_analysis import handle_tool
+
+        result = await handle_tool(
+            "analysis_exclusion_impact_preview",
+            {
+                "excluded_entities": [
+                    {"value": "adspot-1", "entity_type": "adspot"},
+                ],
+                "delivery_records": [
+                    {"entity": "adspot-1", "entity_type": "adspot", "impressions": 800},
+                    {"entity": "adspot-2", "entity_type": "adspot", "impressions": 200},
+                ],
+            },
+        )
+        payload = json.loads(result[0].text)
+        assert payload["impact"]["coverage"] == COVERAGE_MEASURED
+        assert payload["impact"]["incremental"]["impressions"][
+            "share_pct"
+        ] == pytest.approx(80.0)
+
+    async def test_would_block_agrees_with_the_enforcement(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from mureo.mcp.tools_analysis import handle_tool
+
+        _activate_workspace(monkeypatch, tmp_path, _STRATEGY_WITH_CAP)
+        result = await handle_tool(
+            "analysis_exclusion_impact_preview",
+            {
+                "excluded_entities": [{"value": "a.example", "entity_type": "website"}],
+                "delivery_records": [
+                    {
+                        "entity": "a.example",
+                        "entity_type": "website",
+                        "impressions": 940,
+                    },
+                    {
+                        "entity": "b.example",
+                        "entity_type": "website",
+                        "impressions": 60,
+                    },
+                ],
+            },
+        )
+        payload = json.loads(result[0].text)
+        assert payload["would_block"] is True
+        assert "max_delivery_share_removed_pct" in payload["block_reason"]
+
+    async def test_unattributable_surface_reports_unknown(self) -> None:
+        from mureo.mcp.tools_analysis import handle_tool
+
+        result = await handle_tool(
+            "analysis_exclusion_impact_preview",
+            {
+                "tool": META_SET,
+                "arguments": {
+                    "ad_set_id": "1",
+                    "excluded_publisher_categories": ["household"],
+                },
+            },
+        )
+        payload = json.loads(result[0].text)
+        assert payload["impact"]["coverage"] == COVERAGE_UNKNOWN
+        assert payload["impact"]["coverage_reason"]
+        assert payload["impact"]["incremental"] is None

--- a/tests/test_exclusion_impact_preview.py
+++ b/tests/test_exclusion_impact_preview.py
@@ -93,7 +93,7 @@ class TestShareIsComputed:
         assert impact.share_pct("clicks") == pytest.approx(94.0)
         assert impact.share_pct("cost") == pytest.approx(94.0)
         assert impact.share_pct("conversions") == pytest.approx(94.0)
-        assert "bigsite.com" in impact.matched
+        assert impact.matched == ("bigsite.com",)
 
     def test_subdomains_of_an_excluded_domain_count(self) -> None:
         impact = estimate_exclusion_impact(

--- a/tests/test_exclusion_impact_preview.py
+++ b/tests/test_exclusion_impact_preview.py
@@ -37,6 +37,7 @@ from mureo.analysis.exclusion_impact import (
     estimate_exclusion_impact,
     evaluate_exclusion_impact,
     exclusion_impact_rules,
+    unevaluated_rules,
 )
 from mureo.policy.strategy_gate import Guardrails, guardrails_from_strategy_text
 
@@ -802,3 +803,233 @@ class TestPreviewTool:
         assert payload["impact"]["coverage"] == COVERAGE_UNKNOWN
         assert payload["impact"]["coverage_reason"]
         assert payload["impact"]["incremental"] is None
+
+
+# ---------------------------------------------------------------------------
+# A rule that cannot fire must say so at the moment it cannot fire
+# ---------------------------------------------------------------------------
+
+
+_STRATEGY_CUMULATIVE_ONLY = """# Strategy
+
+## Guardrails
+
+- max_cumulative_delivery_share_removed_pct: 60
+"""
+
+
+def _impact_without_standing() -> Any:
+    return estimate_exclusion_impact(
+        targets=[_site("a.example")],
+        records=[_rec("a.example", 10), _rec("b.example", 90)],
+        attributable_types=_PLACEMENT_TYPES,
+        basis="b",
+        window_days=30,
+        standing=None,
+        cumulative_reason="mureo cannot list ad-group-level standing exclusions",
+    )
+
+
+@pytest.mark.unit
+class TestInertRulesAreNamed:
+    def test_a_cumulative_only_rule_is_reported_as_unevaluated(self) -> None:
+        rules = exclusion_impact_rules(
+            Guardrails(max_cumulative_delivery_share_removed_pct=60.0)
+        )
+        impact = _impact_without_standing()
+        # It genuinely enforces nothing here — that is the defect being named.
+        assert evaluate_exclusion_impact(impact, rules) is None
+        inert = unevaluated_rules(impact, rules)
+        assert [r.key for r in inert] == ["max_cumulative_delivery_share_removed_pct"]
+        assert "ad-group-level" in inert[0].reason
+
+    def test_an_evaluable_rule_is_not_reported(self) -> None:
+        rules = exclusion_impact_rules(Guardrails(max_delivery_share_removed_pct=25.0))
+        impact = _impact_without_standing()
+        assert unevaluated_rules(impact, rules) == ()
+
+    def test_an_unmeasurable_batch_makes_the_incremental_rule_inert(self) -> None:
+        rules = exclusion_impact_rules(Guardrails(max_delivery_share_removed_pct=25.0))
+        impact = estimate_exclusion_impact(
+            targets=[ExclusionTarget("household", "publisher_category")],
+            records=None,
+            attributable_types=frozenset(),
+            basis="meta_ads_ad_set_targeting",
+            window_days=30,
+            coverage_reason="no attributable breakdown",
+        )
+        assert [r.key for r in unevaluated_rules(impact, rules)] == [
+            "max_delivery_share_removed_pct"
+        ]
+
+
+@pytest.mark.asyncio
+class TestInertRuleSurfacing:
+    async def test_the_notice_names_the_inert_rule_and_the_backstop(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """An ad-group-scoped write with only the cumulative rule written."""
+        import mureo.mcp.exclusion_sources as sources
+        from mureo.mcp.server import handle_call_tool
+
+        _activate_workspace(monkeypatch, tmp_path, _STRATEGY_CUMULATIVE_ONLY)
+        monkeypatch.setattr("mureo.mcp.server._load_policy_gates", lambda: ())
+
+        client = _FakeGoogleClient(
+            [
+                {"placement": "a.example", "type": "website", "impressions": 100},
+                {"placement": "b.example", "type": "website", "impressions": 900},
+            ]
+        )
+
+        async def _fake_client(args: dict[str, Any]) -> Any:
+            return client
+
+        monkeypatch.setattr(sources, "google_ads_client", _fake_client)
+        monkeypatch.setattr(
+            "mureo.mcp._handlers_google_ads._get_client", lambda args: client
+        )
+        result = await handle_call_tool(
+            GOOGLE_ADD,
+            {
+                "customer_id": "1234567890",
+                "ad_group_id": "200",
+                "placements": [{"type": "website", "value": "a.example"}],
+            },
+        )
+        text = "\n".join(getattr(c, "text", "") for c in result)
+        assert client.mutated is True
+        assert "NOT ENFORCED on this call" in text
+        assert "max_cumulative_delivery_share_removed_pct" in text
+        assert "Add max_delivery_share_removed_pct" in text
+
+    async def test_the_preview_tool_reports_the_same_inert_rule(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from mureo.mcp.tools_analysis import handle_tool
+
+        _activate_workspace(monkeypatch, tmp_path, _STRATEGY_CUMULATIVE_ONLY)
+        result = await handle_tool(
+            "analysis_exclusion_impact_preview",
+            {
+                "excluded_entities": [{"value": "a.example", "entity_type": "website"}],
+                "delivery_records": [
+                    {
+                        "entity": "a.example",
+                        "entity_type": "website",
+                        "impressions": 940,
+                    },
+                ],
+            },
+        )
+        payload = json.loads(result[0].text)
+        assert payload["would_block"] is False
+        assert [r["key"] for r in payload["unevaluated_rules"]] == [
+            "max_cumulative_delivery_share_removed_pct"
+        ]
+
+    async def test_no_inert_rules_when_everything_could_be_evaluated(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from mureo.mcp.tools_analysis import handle_tool
+
+        _activate_workspace(monkeypatch, tmp_path, _STRATEGY_WITH_CAP)
+        result = await handle_tool(
+            "analysis_exclusion_impact_preview",
+            {
+                "excluded_entities": [{"value": "a.example", "entity_type": "website"}],
+                "delivery_records": [
+                    {"entity": "a.example", "entity_type": "website", "impressions": 5},
+                    {
+                        "entity": "b.example",
+                        "entity_type": "website",
+                        "impressions": 95,
+                    },
+                ],
+            },
+        )
+        payload = json.loads(result[0].text)
+        assert payload["unevaluated_rules"] == []
+        assert payload["would_block"] is False
+
+
+# ---------------------------------------------------------------------------
+# A malformed caller payload must never read as "measured, 0% impact"
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestMalformedPayloadIsRefused:
+    async def test_an_entity_without_a_type_is_refused(self) -> None:
+        from mureo.mcp.tools_analysis import handle_tool
+
+        with pytest.raises(ValueError, match="entity_type"):
+            await handle_tool(
+                "analysis_exclusion_impact_preview",
+                {
+                    "excluded_entities": [{"value": "a.example"}],
+                    "delivery_records": [
+                        {
+                            "entity": "a.example",
+                            "entity_type": "website",
+                            "impressions": 100,
+                        }
+                    ],
+                },
+            )
+
+    async def test_an_entity_without_a_value_is_refused(self) -> None:
+        from mureo.mcp.tools_analysis import handle_tool
+
+        with pytest.raises(ValueError, match="value"):
+            await handle_tool(
+                "analysis_exclusion_impact_preview",
+                {"excluded_entities": [{"entity_type": "website"}]},
+            )
+
+    async def test_a_delivery_row_without_a_type_is_refused(self) -> None:
+        from mureo.mcp.tools_analysis import handle_tool
+
+        with pytest.raises(ValueError, match="entity_type"):
+            await handle_tool(
+                "analysis_exclusion_impact_preview",
+                {
+                    "excluded_entities": [
+                        {"value": "a.example", "entity_type": "website"}
+                    ],
+                    "delivery_records": [{"entity": "a.example", "impressions": 100}],
+                },
+            )
+
+    async def test_a_blank_standing_exclusion_is_refused(self) -> None:
+        from mureo.mcp.tools_analysis import handle_tool
+
+        with pytest.raises(ValueError, match="standing_exclusions"):
+            await handle_tool(
+                "analysis_exclusion_impact_preview",
+                {
+                    "excluded_entities": [
+                        {"value": "a.example", "entity_type": "website"}
+                    ],
+                    "standing_exclusions": [{"value": "", "entity_type": "website"}],
+                    "delivery_records": [],
+                },
+            )
+
+
+# ---------------------------------------------------------------------------
+# The placement mappers keep their own module (file-size budget)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_placement_mappers_live_outside_mappers_py() -> None:
+    from mureo.google_ads import _placement_mappers, mappers
+
+    assert hasattr(_placement_mappers, "map_negative_placement")
+    assert hasattr(_placement_mappers, "map_placement_performance")
+    assert not hasattr(mappers, "map_placement_performance")
+    root = Path(mappers.__file__).parent
+    for name in ("mappers.py", "_placement_mappers.py"):
+        lines = len((root / name).read_text(encoding="utf-8").splitlines())
+        assert lines <= 800, f"{name} is {lines} lines, over the 800-line budget"

--- a/tests/test_google_ads_negative_placements.py
+++ b/tests/test_google_ads_negative_placements.py
@@ -482,3 +482,83 @@ class TestHandlers:
             await h.HANDLERS["google_ads_negative_placements_remove"](
                 {"campaign_id": "100"}
             )
+
+
+# ---------------------------------------------------------------------------
+# Placement performance — the denominator for the #547 impact preview
+# ---------------------------------------------------------------------------
+
+
+def _placement_perf_row(
+    placement: str = "example.com",
+    placement_type: str = "PlacementType.WEBSITE",
+    impressions: int = 1000,
+) -> MagicMock:
+    row = MagicMock()
+    view = row.group_placement_view
+    view.placement = placement
+    view.display_name = "Example"
+    view.target_url = f"https://{placement}"
+    view.placement_type = placement_type
+    row.metrics.impressions = impressions
+    row.metrics.clicks = 10
+    row.metrics.cost_micros = 5_000_000
+    row.metrics.conversions = 2.0
+    return row
+
+
+@pytest.mark.unit
+class TestPlacementPerformance:
+    @pytest.mark.asyncio
+    async def test_reads_group_placement_view_scoped_to_the_campaign(self) -> None:
+        client = _make_client()
+        queries: list[str] = []
+
+        async def _search(query: str) -> list[Any]:
+            queries.append(query)
+            return [
+                _placement_perf_row(),
+                _placement_perf_row(
+                    "mobileapp::1-com.example.app",
+                    "PlacementType.MOBILE_APPLICATION",
+                    400,
+                ),
+            ]
+
+        client._search = _search  # type: ignore[method-assign]
+        rows = await client.get_placement_performance(
+            campaign_id="100", period="LAST_30_DAYS"
+        )
+
+        assert "FROM group_placement_view" in queries[0]
+        assert "AND campaign.id = 100" in queries[0]
+        assert "DURING LAST_30_DAYS" in queries[0]
+        assert rows[0]["placement"] == "example.com"
+        assert rows[0]["type"] == "website"
+        assert rows[0]["impressions"] == 1000
+        assert rows[0]["cost"] == 5.0
+        assert rows[1]["type"] == "mobile_application"
+
+    @pytest.mark.asyncio
+    async def test_a_between_window_is_validated_not_interpolated_raw(self) -> None:
+        client = _make_client()
+
+        async def _search(query: str) -> list[Any]:
+            return []
+
+        client._search = _search  # type: ignore[method-assign]
+        with pytest.raises(ValueError):
+            await client.get_placement_performance(
+                campaign_id="100", period="BETWEEN '2026-01-01' AND '; DROP'"
+            )
+
+    @pytest.mark.asyncio
+    async def test_a_non_numeric_scope_id_is_refused(self) -> None:
+        client = _make_client()
+
+        async def _search(query: str) -> list[Any]:
+            return []
+
+        client._search = _search  # type: ignore[method-assign]
+        with pytest.raises(ValueError):
+            await client.get_placement_performance(campaign_id="100 OR 1=1")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -64,15 +64,16 @@ class TestListTools:
 
     async def test_list_tools_returns_all_tools(self) -> None:
         """list_tools returns all tools (Google Ads 89 + Meta Ads 90 + Search Console 10
-        + Rollback 2 + Analysis 1 + Mureo Context 9 + Analytics Registry 2
-        + Learning 2 + Learning pre-flight 1 + Creative Studio 5 = 211).
+        + Rollback 2 + Analysis 2 + Mureo Context 9 + Analytics Registry 2
+        + Learning 2 + Learning pre-flight 1 + Creative Studio 5 = 212).
 
         Analytics Registry is 2: mureo_analytics_modules_list +
-        mureo_analytics_run (#440). Learning pre-flight is 1:
+        mureo_analytics_run (#440). Analysis is 2: analysis_anomalies_check +
+        analysis_exclusion_impact_preview (#547). Learning pre-flight is 1:
         mureo_learning_reset_preflight (#548)."""
         mod = _import_server_module()
         tools = await mod.handle_list_tools()
-        assert len(tools) == 211
+        assert len(tools) == 212
 
     async def test_list_tools_contains_google_and_meta(self) -> None:
         """Google Ads and Meta Ads tools are included."""


### PR DESCRIPTION
Closes #547

Based on `feat/placement-exclusion-tools` (#544) — this guards the exclusion tools that branch adds.

## What was wrong

mureo would apply an exclusion / block / negative-keyword batch without telling the operator that the inventory it was about to remove carried 94% of the last 30 days of impressions. Of everything filed from the incident post-mortem, **this is the only item that prevents the originating mistake rather than shortening the recovery from it**: the operator tightened Display placement exclusions over two weeks, then made one larger pass, and delivery went to zero for a week. The intent was reasonable and the direction was correct — the magnitude was never visible at the moment of the decision.

## The correction to the issue's premise

The issue asks for this "in the confirmation step that already exists for write operations". **There is no such step.** MCP gives mureo two outcomes — run the call or refuse it — and `PolicyDecision` has no allow-with-notice path (the `reason` is discarded when a gate allows). So the ask becomes three surfaces of deliberately different strength, and the PR does not pretend they are interchangeable:

| Surface | When | Strength |
|---|---|---|
| `## Guardrails` `max_delivery_share_removed_pct` / `max_cumulative_delivery_share_removed_pct` / `block_exclusions_without_impact_data` | before dispatch | **hard** — refused before any API request reaches the platform |
| `analysis_exclusion_impact_preview` (new tool, read-only) | whenever the agent asks | advisory — as strong as the agent's compliance |
| Notice appended to an allowed exclusion's own result | after that call | records the measured size, so the **next** pass in an incremental sequence is not made blind |

The third one is what the motivating incident actually needed. The damage was two weeks of individually-small passes and not one of them was ever measured.

## Where it is enforced, and why not in the gate

**In the dispatcher (`mureo/mcp/exclusion_preflight.py`), not in `StrategyPolicyGate`.** Sizing an exclusion needs one *awaited* read of the account's own recent delivery, and the `PolicyGate` v1 ABI is *synchronous by design* ("gates that need to await network I/O are out of scope for `mureo.policy_gates` in 0.9.x") and "MUST be pure and fast" because it runs on every tool call. So the keys are parsed by the gate's **own parser** — one `## Guardrails` vocabulary, one parser — and enforced at the first point in dispatch that has both an `await` and the arguments, before `_dispatch_tool`, so a refusal lands before any mutation.

`Guardrails.is_empty()` deliberately stays blind to the new fields: counting them would switch the gate's budget/bid pattern scan (and its fail-closed deny on an exhausted scan) on for an operator who wrote only an exclusion rule and no money cap at all.

**Fail-open and cheap when off.** With none of the three rules written the pre-flight returns before it builds a client: no report request is issued, behaviour is byte-identical. A tool that is not a registered exclusion surface returns even earlier, without touching STRATEGY.md. `MUREO_DISABLE_EXCLUSION_PREFLIGHT=1` turns it off entirely.

## Two figures, because one is not enough

`incremental` is what this batch removes. `cumulative` is what the account's **whole** standing exclusion set removes once this batch lands.

That is what catches the incremental tightening: an entity excluded a week ago still carries its pre-exclusion impressions inside a 30-day window, so a fortnight of small passes shows up cumulatively even when no single pass trips the incremental cap.

Its honest limit: **an exclusion older than the window contributed nothing to it and is invisible**, so the cumulative share is a lower bound. And where mureo cannot list the standing set it is **withheld** (`null` with a reason), never reported as zero — that happens for an ad-group-level Google placement write (campaign-level exclusions also cover that ad group and are not reachable from the call's arguments) and for `google_ads_negative_keywords_add_to_ad_group` (Google Ads exposes no ad-group-level negative keyword listing).

## Per-platform, and honest where it cannot answer

| Surface | Delivery source | Attributable? |
|---|---|---|
| `google_ads_negative_placements_add` | new `group_placement_view` read (`get_placement_performance`) | **Yes** for `website` / `mobile_application`. A `mobile_app_category` in the same batch is **not** — a category is not a placement that serves — so a mixed batch reports `partial`, not a confident number |
| `google_ads_negative_keywords_add` / `_add_to_ad_group` | `search_term_view` over the same window | **Yes**, matched per `EXACT` / `PHRASE` / `BROAD`. Negative keywords do not match close variants and neither does the estimate, so it is a lower bound |
| `meta_ads_excluded_placements_set` | — | **No.** No Meta insights breakdown attributes past delivery to publisher categories, publisher block lists or brand-safety content types. `publisher_platform` / `platform_position` *are* attributable but are a different exclusion surface (ad-set targeting). Reported `unknown` |
| Yahoo / LINE / SmartNews / LOGLY (plugins), Amazon (bridge) | whatever the provider registers via `register_exclusion_surface` | **Provider-declared.** mureo registers nothing on their behalf rather than guessing a bridged tool's argument shape and producing a confident wrong number |

`unknown` is an acceptable output; a silent "no impact" is not. Coverage is `measured` / `partial` / `unknown`; `incremental` is `null` rather than a row of zeroes when nothing can be attributed; a window that served nothing reports `share_pct: null` rather than `0`, because a printed `0%` reads as approval. Even when nothing blocks, the measured — or unmeasurable — verdict is appended to the call's own result, so an exclusion is never applied *silently*.

`analysis_exclusion_impact_preview` also takes `excluded_entities` + `delivery_records` directly, in which case it **reaches no platform API at all** — so a Yahoo placement URL list, a LOGLY adspot block or an Amazon negative-targeting batch is auditable whenever the agent can pull that platform's own report. `would_block` is computed by the same `evaluate_exclusion_impact` the pre-flight calls, so the advertised verdict and the enforced one cannot drift.

The LOGLY discipline the issue calls out (never block an adspot on your own campaign's numbers alone — check `logly_supply_adspot_summary` and `logly_supply_adspot_cv_by_category`) is written into `_mureo-shared/SKILL.md` next to the preview step: the impact preview sizes the loss, the supply-side view says whether the loss is worth taking. The `ExclusionSurface` registry is the ABI hook for a bridge that wants to contribute its own supply-side enrichment.

## Not a false-alarm generator

A check that fires on everything gets switched off, so every matching rule errs toward **fewer** attributed impressions:

1. Excluding `example.com` covers `news.example.com` (Google excludes the site), but excluding `news.example.com` never claims `example.com`, and the label-boundary check stops `example.com` swallowing `notexample.com`.
2. Negative keywords are matched by token sequence per match type, with **no** stemming, pluralisation or accent folding — Google does not apply close variants to negatives either.
3. Any other entity kind is exact-string, case-folded.
4. The cap applies only to the metrics the operator listed (`exclusion_impact_metrics`, default `impressions`).

## New `## Guardrails` keys

All optional, all default off:

```markdown
## Guardrails
- max_delivery_share_removed_pct: 25
- max_cumulative_delivery_share_removed_pct: 60
- exclusion_impact_window_days: 30
- exclusion_impact_metrics: impressions, cost
- block_exclusions_without_impact_data: false
```

## Tests

38 new in `tests/test_exclusion_impact_preview.py`, organised around the four properties that decide whether this works: the share is computed and surfaced; a `## Guardrails` threshold **actually blocks**, end to end through `handle_call_tool` and before the mutation; a small exclusion is neither warned about nor blocked; an unattributable surface says `unknown` rather than passing silently. Plus 4 in `tests/test_google_ads_negative_placements.py` for the new `group_placement_view` read (including GAQL-validator coverage of the scope id and the window).

Not vacuous — seven regressions were injected and each was caught:

| Injected bug | Tests that failed |
|---|---|
| share cap reports but never blocks | 5 |
| unknown / zero-total coverage rendered as `0%` | 1 |
| host match drops the label boundary | 1 |
| pre-flight reads the platform with no rule written | 1 |
| `block_exclusions_without_impact_data` ignored | 2 |
| missing standing list read as an empty one | 1 |
| unattributable entity kinds silently dropped | 1 |

Full suite green in a **clean venv** (7883 passed, 8 skipped) — this machine has plugins installed, so the local tool-count result is not evidence. `ruff check .`, `black --check .`, `mypy mureo --ignore-missing-imports` all clean.

## Tool count

210 → 211 (Analysis 1 → 2). README (both), `docs/mcp-server.md`, `docs/architecture.md`, `AGENTS.md`, the four foundation skills and their `_data` mirrors updated.
