### PR TITLE
Stop field-by-field dataclass rebuilds silently dropping fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -355,14 +355,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   actually owns, so preservation is structural rather than remembered. A new
   field on either model is carried across by every mutator with no edit.
 
+  The same shape was found and fixed in `_merge_campaign_metrics`
+  (`mureo/analytics/builtin/_live_clients.py`), which folded two rows for one
+  campaign by enumerating five of `CampaignMetrics`'s seven fields and dropped
+  `cpa` / `ctr`. Inert today because nothing populates them — the exact state
+  the other instances were in before a field was added. The two duplicated
+  merge blocks are now one helper, and `cpa` / `ctr` are cleared *explicitly*
+  rather than by omission: they are ratios, cannot be summed, and carrying one
+  row's value across would report it as the total's.
+
   This is the same defect that dropped `archived` from a renamed agency client
-  and `origin` from a batched `action_log` entry. Finding it twice did not
-  prevent the third instance, because the failure is an omission and omissions
-  are invisible in review — so the fix comes with tests driven off
+  and `origin` from a batched `action_log` entry. Finding it three times did
+  not prevent the fourth, because the failure is an omission and omissions are
+  invisible in review — so the fix comes with tests driven off
   `dataclasses.fields(...)`: each names only what its mutator declares it
-  changes and asserts everything else survived. `state_codec` must keep
-  enumerating (it maps to an external JSON schema, so `replace` cannot help
-  it) and is covered by a round-trip test built the same way.
+  changes and asserts everything else survived.
+
+  `state_codec` must keep enumerating (it maps to an external JSON schema, so
+  `replace` cannot help it). Its field coverage is now asserted **at module
+  import**, so adding a field without updating both halves of the codec raises
+  immediately — on any `import mureo`, a REPL, or a `pytest -k` run that never
+  collects the round-trip test — instead of silently dropping the field on the
+  next STATE.json write.
 
 ## [0.10.43] - 2026-08-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -364,9 +364,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rather than by omission: they are ratios, cannot be summed, and carrying one
   row's value across would report it as the total's.
 
+  A fifth was found in `preflight_tracking_consistency`
+  (`mureo/analysis/tracking/checks.py`) while rebasing onto the commit that
+  introduced it: narrowing a `TrackingConsistencyReport` to the planned ads
+  enumerated all five of its fields, so nothing is dropped today and the sixth
+  field added to that model would be. Two helpers beside it in the same file
+  already used `replace`.
+
   This is the same defect that dropped `archived` from a renamed agency client
-  and `origin` from a batched `action_log` entry. Finding it three times did
-  not prevent the fourth, because the failure is an omission and omissions are
+  and `origin` from a batched `action_log` entry. Finding it four times did
+  not prevent the fifth, because the failure is an omission and omissions are
   invisible in review — so the fix comes with tests driven off
   `dataclasses.fields(...)`: each names only what its mutator declares it
   changes and asserts everything else survived.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -372,11 +372,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   changes and asserts everything else survived.
 
   `state_codec` must keep enumerating (it maps to an external JSON schema, so
-  `replace` cannot help it). Its field coverage is now asserted **at module
-  import**, so adding a field without updating both halves of the codec raises
-  immediately — on any `import mureo`, a REPL, or a `pytest -k` run that never
-  collects the round-trip test — instead of silently dropping the field on the
-  next STATE.json write.
+  `replace` cannot help it), so it gets two guards with a clear division of
+  labour. Its field coverage is asserted **at module import**, so adding a
+  field without naming it there raises immediately — on any `import mureo`, a
+  REPL, or a `pytest -k` run that never collects the round-trip test. That
+  check asserts *declaration*; the round-trip tests assert the field actually
+  **survives**, and they now cover every model the codec touches — including
+  the nested `ActionLogEntry` and `AdState`, where a declared-but-unwired
+  field would previously have round-tripped to `None` unnoticed because the
+  fixtures left it at its default.
 
 ## [0.10.43] - 2026-08-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
 ### Added
 
 - **A bulk exclusion now says how much of your delivery it removes, before it
@@ -339,6 +340,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   shape, so sixteen mis-tagged ads produce zero findings), and a source
   campaign carrying the scheme on a single ad when the campaigns use different
   landing pages.
+
+### Fixed
+
+- **A targeted STATE.json write no longer resets fields it does not own.**
+  All five mutators (`upsert_campaign`, `append_action_log`, `set_report`,
+  `set_platform_metrics`, `set_conversion_action_types`) rebuilt the
+  `StateDocument` — and three of them the `PlatformState` — by enumerating
+  every field. That works until a field is added, at which point every mutator
+  that forgot it silently resets it, and a reset field is indistinguishable
+  downstream from one that was never set.
+
+  They now use `dataclasses.replace` and change only the fields each call
+  actually owns, so preservation is structural rather than remembered. A new
+  field on either model is carried across by every mutator with no edit.
+
+  This is the same defect that dropped `archived` from a renamed agency client
+  and `origin` from a batched `action_log` entry. Finding it twice did not
+  prevent the third instance, because the failure is an omission and omissions
+  are invisible in review — so the fix comes with tests driven off
+  `dataclasses.fields(...)`: each names only what its mutator declares it
+  changes and asserts everything else survived. `state_codec` must keep
+  enumerating (it maps to an external JSON schema, so `replace` cannot help
+  it) and is covered by a round-trip test built the same way.
 
 ## [0.10.43] - 2026-08-07
 

--- a/mureo/analysis/tracking/checks.py
+++ b/mureo/analysis/tracking/checks.py
@@ -16,6 +16,7 @@ ads on the same platform, and it only ever sees
 
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import TYPE_CHECKING
 
 from mureo.analysis.tracking._checks_completeness import (
@@ -105,28 +106,30 @@ def preflight_tracking_consistency(
         for finding in report.findings
         if planned_ids & set(finding.ad_ids)
     )
-    return TrackingConsistencyReport(
+    # ``replace``, not a rebuild: this function narrows the report to the
+    # planned ads and owns exactly two fields. ``ads_examined`` /
+    # ``campaigns_examined`` / ``notes`` — and anything added to
+    # :class:`TrackingConsistencyReport` later — are carried across by
+    # construction. Enumerating them instead is complete today and silently
+    # resets whatever is added tomorrow; that omission has now been the same
+    # bug four separate times in this codebase, and it is invisible in review
+    # because a reset field looks exactly like one that was never set.
+    return replace(
+        report,
         findings=findings,
-        ads_examined=report.ads_examined,
-        campaigns_examined=report.campaigns_examined,
         ads_without_readable_url=tuple(
             ad_id for ad_id in report.ads_without_readable_url if ad_id in planned_ids
         ),
-        notes=report.notes,
     )
 
 
 def _as_planned(record: AdTrackingRecord) -> AdTrackingRecord:
-    from dataclasses import replace
-
     return replace(record, planned=True)
 
 
 def _project_onto_planned(
     finding: TrackingFinding, planned_ids: set[str]
 ) -> TrackingFinding:
-    from dataclasses import replace
-
     mine = tuple(ad_id for ad_id in finding.ad_ids if ad_id in planned_ids)
     others = tuple(ad_id for ad_id in finding.ad_ids if ad_id not in planned_ids)
     evidence = finding.evidence

--- a/mureo/analytics/builtin/_live_clients.py
+++ b/mureo/analytics/builtin/_live_clients.py
@@ -27,6 +27,7 @@ Failure modes:
 
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import TYPE_CHECKING, Any
 
 from mureo.analysis.anomaly_detector import CampaignMetrics
@@ -269,6 +270,45 @@ def _row_to_campaign_metrics(
     )
 
 
+def _merge_campaign_metrics(
+    existing: CampaignMetrics, addition: CampaignMetrics
+) -> CampaignMetrics:
+    """Sum two rows for the same campaign into one :class:`CampaignMetrics`.
+
+    Both fan-out fetchers (Google and Meta) index rows by campaign and have to
+    fold a repeated campaign_id together. They used to rebuild the record by
+    enumerating five of its seven fields, so ``cpa`` / ``ctr`` were dropped —
+    inert only because nothing in this module populates them yet, which is
+    exactly the state the other instances of this bug were in before a field
+    was added.
+
+    ``dataclasses.replace`` carries every field this function does not name, so
+    a field added to :class:`CampaignMetrics` later survives a merge without
+    this function being edited.
+
+    ``cpa`` and ``ctr`` are named, and cleared, deliberately: they are RATIOS
+    and cannot be summed. Carrying the first row's value across would be worse
+    than dropping it — the merged record would report one row's CPA as the
+    total's. Clearing them lets ``derived_cpa`` / ``derived_ctr`` recompute
+    from the summed counters, which is the only correct answer for a sum. That
+    is also today's behaviour, so this fix changes nothing now while staying
+    correct if the API-supplied values the class docstring anticipates ever
+    start being populated.
+
+    Any future field that is likewise a ratio or an average must be added to
+    the cleared list; a field that is a counter or a label needs no change.
+    """
+    return replace(
+        existing,
+        cost=existing.cost + addition.cost,
+        impressions=existing.impressions + addition.impressions,
+        clicks=existing.clicks + addition.clicks,
+        conversions=existing.conversions + addition.conversions,
+        cpa=None,
+        ctr=None,
+    )
+
+
 def _index_google_rows_by_campaign(
     rows: list[dict[str, Any]],
 ) -> dict[str, CampaignMetrics]:
@@ -291,13 +331,7 @@ def _index_google_rows_by_campaign(
         if existing is None:
             indexed[metric.campaign_id] = metric
         else:
-            indexed[metric.campaign_id] = CampaignMetrics(
-                campaign_id=metric.campaign_id,
-                cost=existing.cost + metric.cost,
-                impressions=existing.impressions + metric.impressions,
-                clicks=existing.clicks + metric.clicks,
-                conversions=existing.conversions + metric.conversions,
-            )
+            indexed[metric.campaign_id] = _merge_campaign_metrics(existing, metric)
     return indexed
 
 
@@ -374,13 +408,7 @@ def _index_meta_rows_by_campaign(
         if existing is None:
             indexed[metric.campaign_id] = metric
         else:
-            indexed[metric.campaign_id] = CampaignMetrics(
-                campaign_id=metric.campaign_id,
-                cost=existing.cost + metric.cost,
-                impressions=existing.impressions + metric.impressions,
-                clicks=existing.clicks + metric.clicks,
-                conversions=existing.conversions + metric.conversions,
-            )
+            indexed[metric.campaign_id] = _merge_campaign_metrics(existing, metric)
     return indexed
 
 

--- a/mureo/context/state.py
+++ b/mureo/context/state.py
@@ -196,6 +196,27 @@ def _upsert_into(
     return tuple(result)
 
 
+def _platform_base(
+    platforms: dict[str, PlatformState], platform: str, account_id: str
+) -> PlatformState:
+    """The :class:`PlatformState` a targeted write should build on.
+
+    The existing entry when there is one, otherwise a minimal new entry
+    carrying only ``account_id`` — whose remaining fields take the dataclass's
+    own defaults rather than a hand-written copy of them.
+
+    Every caller then uses ``dataclasses.replace`` to change ONLY the fields it
+    actually has input for, which is what makes preservation structural: a
+    field added to :class:`PlatformState` later is carried across by every
+    mutator without any of them being edited. Enumerating instead is how a
+    campaign upsert once wiped the dashboard rollups, and how a metrics write
+    once wiped the #342 conversion override — both silent, because a reset
+    field is indistinguishable from one that was never set.
+    """
+    existing = platforms.get(platform)
+    return existing if existing is not None else PlatformState(account_id=account_id)
+
+
 def upsert_campaign(
     path: Path,
     campaign: CampaignSnapshot,
@@ -246,42 +267,32 @@ def upsert_campaign(
         # campaign.
         platforms = dict(doc.platforms) if doc.platforms else {}
         guard_platform_entry_write(platforms, platform, account_id)
-        existing = platforms.get(platform)
-        platforms[platform] = PlatformState(
+        base = _platform_base(platforms, platform, account_id)
+        # Everything a campaign upsert has no input for — the platform-level
+        # rollup (totals / metrics_period / periods) and the #342 conversion
+        # override — is carried over by ``replace``. Each was a real
+        # regression when it was enumerated and forgotten: an upsert wiped the
+        # dashboard KPIs, and another wiped the account's conversion setting.
+        platforms[platform] = replace(
+            base,
             account_id=account_id,
             campaigns=_upsert_into(
-                existing.campaigns if existing is not None else (),
+                base.campaigns,
                 campaign,
                 # Platform-scoped: a same-id match here IS the same campaign,
                 # so carrying its ad-level state over is safe (#468).
                 inherit_ads=True,
             ),
-            # Preserve the platform-level rollup: it has no upsert input, so
-            # a campaign upsert must inherit it rather than reset it to None
-            # (otherwise every upsert silently wipes the dashboard KPIs). The
-            # same applies to the per-period rollups.
-            totals=existing.totals if existing is not None else None,
-            metrics_period=existing.metrics_period if existing is not None else None,
-            periods=existing.periods if existing is not None else None,
-            # #342 — the operator conversion override has no upsert input;
-            # inherit it so a campaign upsert never wipes the account setting.
-            conversion_action_types=(
-                existing.conversion_action_types if existing is not None else None
-            ),
         )
 
-        return StateDocument(
-            version=doc.version,
+        # ``reports`` and ``action_log`` are likewise untouched by construction;
+        # dropping the former used to wipe the daily/weekly/goal summaries the
+        # dashboard renders on every upsert that followed a report write.
+        return replace(
+            doc,
             last_synced_at=_now_iso(),
-            customer_id=doc.customer_id,
             campaigns=flat_campaigns,
             platforms=platforms,
-            action_log=doc.action_log,
-            # Preserve the analysis summaries: a campaign upsert has no reports
-            # input, so dropping this would silently wipe the daily/weekly/goal
-            # summaries the dashboard renders (every upsert after a report write
-            # erased it).
-            reports=doc.reports,
         )
 
     return _locked_state_mutation(path, _build)
@@ -297,17 +308,11 @@ def append_action_log(path: Path, entry: ActionLogEntry) -> StateDocument:
     """
 
     def _build(doc: StateDocument) -> StateDocument:
-        return StateDocument(
-            version=doc.version,
-            last_synced_at=doc.last_synced_at,
-            customer_id=doc.customer_id,
-            campaigns=doc.campaigns,
-            platforms=doc.platforms,
-            action_log=(*doc.action_log, entry),
-            # Preserve the analysis summaries — appending an action must not
-            # wipe the daily/weekly/goal reports the dashboard renders.
-            reports=doc.reports,
-        )
+        # ``last_synced_at`` is deliberately NOT re-stamped: appending an action
+        # is not a sync, and the dashboard's "Synced N ago" freshness must keep
+        # reflecting the last real sync. Every other section is carried over by
+        # ``replace``.
+        return replace(doc, action_log=(*doc.action_log, entry))
 
     return _locked_state_mutation(path, _build)
 
@@ -338,15 +343,7 @@ def set_report(path: Path, report: str, summary: dict[str, Any]) -> StateDocumen
         # preserved rather than wiped.
         reports = dict(doc.reports) if doc.reports else {}
         reports[report] = summary
-        return StateDocument(
-            version=doc.version,
-            last_synced_at=_now_iso(),
-            customer_id=doc.customer_id,
-            campaigns=doc.campaigns,
-            platforms=doc.platforms,
-            action_log=doc.action_log,
-            reports=reports,
-        )
+        return replace(doc, last_synced_at=_now_iso(), reports=reports)
 
     return _locked_state_mutation(path, _build)
 
@@ -404,48 +401,31 @@ def set_platform_metrics(
     def _build(doc: StateDocument) -> StateDocument:
         platforms = dict(doc.platforms) if doc.platforms else {}
         guard_platform_entry_write(platforms, platform, account_id)
-        existing = platforms.get(platform)
+
+        base = _platform_base(platforms, platform, account_id)
 
         merged_periods: dict[str, dict[str, Any]] | None
         if periods is not None:
-            base = dict(existing.periods) if existing and existing.periods else {}
-            base.update(periods)
-            merged_periods = base
+            merged = dict(base.periods) if base.periods else {}
+            merged.update(periods)
+            merged_periods = merged
         else:
-            merged_periods = existing.periods if existing is not None else None
+            merged_periods = base.periods
 
-        platforms[platform] = PlatformState(
+        # ``campaigns`` and the #342 conversion override have no input on a
+        # metrics write and are carried over by ``replace``; a ``None``
+        # argument means "leave as it was", not "clear it".
+        platforms[platform] = replace(
+            base,
             account_id=account_id,
-            # Rollups have no campaign input — inherit the campaigns a prior
-            # sync/upsert wrote rather than reset them.
-            campaigns=existing.campaigns if existing is not None else (),
-            totals=(
-                totals
-                if totals is not None
-                else (existing.totals if existing is not None else None)
-            ),
+            totals=totals if totals is not None else base.totals,
             metrics_period=(
-                metrics_period
-                if metrics_period is not None
-                else (existing.metrics_period if existing is not None else None)
+                metrics_period if metrics_period is not None else base.metrics_period
             ),
             periods=merged_periods,
-            # #342 — preserve the operator conversion override across a
-            # metrics write (it has no input here, same rationale as totals).
-            conversion_action_types=(
-                existing.conversion_action_types if existing is not None else None
-            ),
         )
 
-        return StateDocument(
-            version=doc.version,
-            last_synced_at=_now_iso(),
-            customer_id=doc.customer_id,
-            campaigns=doc.campaigns,
-            platforms=platforms,
-            action_log=doc.action_log,
-            reports=doc.reports,
-        )
+        return replace(doc, last_synced_at=_now_iso(), platforms=platforms)
 
     return _locked_state_mutation(path, _build)
 
@@ -501,24 +481,14 @@ def set_conversion_action_types(
     def _build(doc: StateDocument) -> StateDocument:
         platforms = dict(doc.platforms) if doc.platforms else {}
         guard_platform_entry_write(platforms, platform, account_id)
-        existing = platforms.get(platform)
-        platforms[platform] = PlatformState(
+        # Campaigns and every rollup are untouched by construction — this call
+        # declares the conversion set and nothing else.
+        platforms[platform] = replace(
+            _platform_base(platforms, platform, account_id),
             account_id=account_id,
-            campaigns=existing.campaigns if existing is not None else (),
-            totals=existing.totals if existing is not None else None,
-            metrics_period=existing.metrics_period if existing is not None else None,
-            periods=existing.periods if existing is not None else None,
             conversion_action_types=cleaned,
         )
-        return StateDocument(
-            version=doc.version,
-            last_synced_at=_now_iso(),
-            customer_id=doc.customer_id,
-            campaigns=doc.campaigns,
-            platforms=platforms,
-            action_log=doc.action_log,
-            reports=doc.reports,
-        )
+        return replace(doc, last_synced_at=_now_iso(), platforms=platforms)
 
     return _locked_state_mutation(path, _build)
 

--- a/mureo/context/state_codec.py
+++ b/mureo/context/state_codec.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 import copy
 import json
 import logging
+from dataclasses import fields as dataclass_fields
 from typing import Any
 
 from mureo.context.models import (
@@ -47,6 +48,131 @@ from mureo.context.models import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Codec field coverage — checked at import, not only under pytest
+# ---------------------------------------------------------------------------
+#
+# Everywhere else in the tree, a field is carried across a rebuild by
+# ``dataclasses.replace`` and cannot be forgotten. This module is the one place
+# that CANNOT use it: it maps to an external JSON schema, so both halves list
+# every field by hand. A field added to a model but not to this file is
+# silently lost the moment a document is written and read back — the same
+# omission-shaped failure, in the one file where the structural fix does not
+# apply.
+#
+# So the omission is made loud instead. Each model below declares the fields
+# this codec handles, and the check runs at MODULE IMPORT: any `import mureo`,
+# a REPL, a `pytest -k` that never collects the round-trip test. Adding a field
+# without visiting this file raises immediately with the two functions to edit,
+# rather than costing an operator their data.
+#
+# This verifies DECLARATION, not behaviour — that the field is known here, not
+# that it survives. Behaviour is the round-trip test's job
+# (tests/test_dataclass_field_preservation.py::TestCodecRoundTrip).
+
+_CODEC_COVERAGE: tuple[tuple[type, frozenset[str], str], ...] = (
+    (
+        StateDocument,
+        frozenset(
+            {
+                "version",
+                "last_synced_at",
+                "customer_id",
+                "campaigns",
+                "platforms",
+                "action_log",
+                "reports",
+            }
+        ),
+        "parse_state / render_state",
+    ),
+    (
+        PlatformState,
+        frozenset(
+            {
+                "account_id",
+                "campaigns",
+                "totals",
+                "metrics_period",
+                "periods",
+                "conversion_action_types",
+            }
+        ),
+        "parse_state / _platform_state_to_dict",
+    ),
+    (
+        ActionLogEntry,
+        frozenset(
+            {
+                "timestamp",
+                "action",
+                "platform",
+                "campaign_id",
+                "ad_id",
+                "entity_type",
+                "entity_id",
+                "summary",
+                "command",
+                "metrics_at_action",
+                "observation_due",
+                "reversible_params",
+                "rollback_of",
+                "evaluation_of",
+            }
+        ),
+        "_parse_action_log_entry / _action_log_entry_to_dict",
+    ),
+    (
+        CampaignSnapshot,
+        frozenset(
+            {
+                "campaign_id",
+                "campaign_name",
+                "status",
+                "bidding_strategy_type",
+                "bidding_details",
+                "daily_budget",
+                "device_targeting",
+                "campaign_goal",
+                "notes",
+                "metrics",
+                "ads",
+            }
+        ),
+        "_parse_campaign / _snapshot_to_dict",
+    ),
+    (
+        AdState,
+        frozenset({"ad_id", "name", "status", "effective_status", "as_of"}),
+        "_parse_ad / _ad_state_to_dict",
+    ),
+)
+
+
+def _assert_codec_coverage() -> None:
+    """Fail loudly if a model has a field this codec does not name."""
+    for model, handled, functions in _CODEC_COVERAGE:
+        declared = {f.name for f in dataclass_fields(model)}
+        missing = declared - handled
+        if missing:
+            raise RuntimeError(
+                f"{model.__name__} has field(s) {sorted(missing)} that "
+                f"mureo.context.state_codec does not handle. Add them to BOTH "
+                f"halves of {functions} and to _CODEC_COVERAGE — otherwise the "
+                "field is silently dropped on every STATE.json write."
+            )
+        stale = handled - declared
+        if stale:
+            raise RuntimeError(
+                f"_CODEC_COVERAGE lists field(s) {sorted(stale)} that "
+                f"{model.__name__} no longer declares; remove them here and "
+                f"from {functions}."
+            )
+
+
+_assert_codec_coverage()
 
 
 # Required campaign fields

--- a/tests/test_dataclass_field_preservation.py
+++ b/tests/test_dataclass_field_preservation.py
@@ -6,34 +6,48 @@ mutator that forgot it silently resets it, and a reset field is
 indistinguishable downstream from one that was never set. The bug therefore
 does not announce itself; it is found later, from the damage.
 
-It has been found three times in this project now:
+It has been found four times in this project now:
 
 - agency #193 — ``update()`` rebuilt a registry entry field-by-field and
   dropped ``archived``, silently resuming collection on a renamed client.
 - #549 — ``stamp_batch`` rebuilt an ``ActionLogEntry`` and dropped the
   provenance fields, so an imported entry lost ``is_external`` and a forged
   ``reversible_params`` planned as a real reversal.
-- here — adding ``batches`` in #549 had to be hand-threaded through five
-  mutators; missing one would have silently closed an open batch on the next
-  campaign upsert.
+- the STATE.json mutators here — adding ``batches`` in #549 had to be
+  hand-threaded through five of them; missing one would have silently closed
+  an open batch on the next campaign upsert.
+- ``_merge_campaign_metrics`` here — five of :class:`CampaignMetrics`'s seven
+  fields were enumerated, dropping ``cpa`` / ``ctr``. Inert only because
+  nothing populates them yet, which is the state the other three were in
+  before a field was added.
 
-Finding it twice did not prevent the third, because the defect is an omission
-and omissions are invisible in review. So these tests are driven off
+Finding it three times did not prevent the fourth, because the defect is an
+omission and omissions are invisible in review. So these tests are driven off
 ``dataclasses.fields(...)`` rather than a hand-written list: each states only
 the fields its mutator DECLARES it changes, and asserts everything else
-survived. A field added to :class:`StateDocument` or :class:`PlatformState` is
-checked by every one of them without any test being edited — and the value
-maps below fail loudly if the new field has no distinctive value to check.
+survived. A field added to :class:`StateDocument`, :class:`PlatformState` or
+:class:`CampaignMetrics` is checked by every one of them without any test
+being edited — and the value maps below fail loudly if the new field has no
+distinctive value to check.
+
+One caveat worth stating, because it is why the fourth instance sat unnoticed:
+where every current field already has a declared role, an enumerated rebuild
+and a ``replace`` behave IDENTICALLY, so no behavioural assertion can tell
+them apart. That case needs the structural guard —
+``test_a_field_the_merge_does_not_know_about_survives``, which subclasses the
+model to supply a field the function has never heard of.
 """
 
 from __future__ import annotations
 
-from dataclasses import fields
+from dataclasses import dataclass, fields
 from pathlib import Path
 from typing import Any
 
 import pytest
 
+from mureo.analysis.anomaly_detector import CampaignMetrics
+from mureo.analytics.builtin._live_clients import _merge_campaign_metrics
 from mureo.context.models import (
     ActionLogEntry,
     AdState,
@@ -288,6 +302,135 @@ class TestPlatformLevelPreservation:
             if field.name in {"account_id", "conversion_action_types"}:
                 continue
             assert getattr(created, field.name) == getattr(fresh, field.name)
+
+
+#: One distinctive value per :class:`CampaignMetrics` field, and which of the
+#: three roles each plays when two rows for the same campaign are folded
+#: together. The roles are what make the check meaningful: a counter must be
+#: SUMMED, a ratio must be CLEARED (it cannot be summed, and carrying one row's
+#: value would report it as the total's), and anything else must be PRESERVED.
+_METRICS_IDENTITY = {"campaign_id"}
+_METRICS_SUMMED = {"cost", "impressions", "clicks", "conversions"}
+_METRICS_CLEARED = {"cpa", "ctr"}
+_METRICS_FIELD_VALUES: dict[str, Any] = {
+    "campaign_id": "C-1",
+    "cost": 1000.0,
+    "impressions": 500,
+    "clicks": 50,
+    "conversions": 5.0,
+    "cpa": 200.0,
+    "ctr": 0.1,
+}
+
+
+@pytest.mark.unit
+class TestCampaignMetricsMerge:
+    """Folding two rows for one campaign must not drop fields (fourth instance).
+
+    ``_index_google_rows_by_campaign`` / ``_index_meta_rows_by_campaign``
+    rebuilt :class:`CampaignMetrics` by enumerating five of its seven fields,
+    so ``cpa`` / ``ctr`` were dropped. Inert today only because nothing in
+    ``_live_clients`` populates them — precisely the state the other three
+    instances were in before a field was added.
+    """
+
+    def test_every_field_has_a_declared_role(self) -> None:
+        """A new field forces a decision: summed, cleared, or preserved."""
+        declared = {f.name for f in fields(CampaignMetrics)}
+        classified = _METRICS_IDENTITY | _METRICS_SUMMED | _METRICS_CLEARED
+        unclassified = declared - classified
+        assert not unclassified or unclassified == declared - set(
+            _METRICS_FIELD_VALUES
+        ), (
+            f"CampaignMetrics gained field(s) {sorted(unclassified)}. Decide "
+            "whether a merge should sum it, clear it (ratios and averages "
+            "cannot be summed), or carry it over, then update "
+            "_merge_campaign_metrics and this test."
+        )
+        _assert_map_covers(CampaignMetrics, _METRICS_FIELD_VALUES)
+
+    def test_counters_are_summed_and_ratios_cleared(self) -> None:
+        first = CampaignMetrics(**_METRICS_FIELD_VALUES)
+        second = CampaignMetrics(**_METRICS_FIELD_VALUES)
+        merged = _merge_campaign_metrics(first, second)
+
+        for name in _METRICS_SUMMED:
+            assert getattr(merged, name) == getattr(first, name) * 2, name
+        for name in _METRICS_CLEARED:
+            assert getattr(merged, name) is None, (
+                f"{name!r} is a ratio: carrying one row's value across a merge "
+                "would report it as the total's."
+            )
+        for name in _METRICS_IDENTITY:
+            assert getattr(merged, name) == getattr(first, name)
+
+    def test_unclassified_fields_survive_a_merge(self) -> None:
+        """Anything that is not a counter or a ratio is carried over.
+
+        Driven off the field list, so a field added to
+        :class:`CampaignMetrics` is checked here without this test being
+        edited.
+        """
+        first = CampaignMetrics(**_METRICS_FIELD_VALUES)
+        merged = _merge_campaign_metrics(first, CampaignMetrics(campaign_id="C-1"))
+        for field in fields(CampaignMetrics):
+            if field.name in _METRICS_SUMMED | _METRICS_CLEARED:
+                continue
+            assert getattr(merged, field.name) == getattr(first, field.name), (
+                f"{field.name!r} was dropped by a merge. _merge_campaign_metrics "
+                "must use dataclasses.replace and name only the fields it owns."
+            )
+
+    def test_a_field_the_merge_does_not_know_about_survives(self) -> None:
+        """The structural guard — and the only one that fails TODAY.
+
+        Every field of :class:`CampaignMetrics` currently has a declared role,
+        so an enumerated rebuild and a ``replace`` are behaviourally identical
+        right now: the two fields it drops are the two a merge clears anyway.
+        A behavioural assertion therefore cannot tell them apart, which is
+        exactly why this instance sat inert and unnoticed.
+
+        Subclassing supplies the field the merge has never heard of.
+        ``dataclasses.replace`` reconstructs ``type(obj)`` and carries it;
+        naming ``CampaignMetrics(...)`` explicitly returns the base class and
+        drops it. That difference is the property under test, and it holds for
+        any future field without this test being edited.
+        """
+
+        @dataclass(frozen=True)
+        class ExtendedMetrics(CampaignMetrics):
+            source_report: str | None = None
+
+        first = ExtendedMetrics(
+            campaign_id="C-1", cost=100.0, clicks=10, source_report="weekly"
+        )
+        second = ExtendedMetrics(
+            campaign_id="C-1", cost=50.0, clicks=5, source_report="weekly"
+        )
+        merged = _merge_campaign_metrics(first, second)
+
+        assert isinstance(merged, ExtendedMetrics), (
+            "_merge_campaign_metrics rebuilt the record as a bare "
+            "CampaignMetrics. Use dataclasses.replace, which reconstructs the "
+            "actual type and carries fields the function does not name."
+        )
+        assert merged.source_report == "weekly"
+        assert merged.cost == 150.0
+
+    def test_cleared_ratios_recompute_from_the_summed_counters(self) -> None:
+        """Clearing is not data loss — the derived accessors do the right sum."""
+        first = CampaignMetrics(
+            campaign_id="C-1",
+            cost=1000.0,
+            impressions=1000,
+            clicks=50,
+            conversions=5.0,
+            cpa=200.0,
+            ctr=0.05,
+        )
+        merged = _merge_campaign_metrics(first, first)
+        assert merged.derived_cpa() == pytest.approx(2000.0 / 10.0)
+        assert merged.derived_ctr() == pytest.approx(100 / 2000)
 
 
 @pytest.mark.unit

--- a/tests/test_dataclass_field_preservation.py
+++ b/tests/test_dataclass_field_preservation.py
@@ -1,0 +1,329 @@
+"""A targeted write must change what it declares and nothing else.
+
+Every STATE.json mutator rebuilt its document — and its platform entry — by
+enumerating fields. That works until a field is added, at which point every
+mutator that forgot it silently resets it, and a reset field is
+indistinguishable downstream from one that was never set. The bug therefore
+does not announce itself; it is found later, from the damage.
+
+It has been found three times in this project now:
+
+- agency #193 — ``update()`` rebuilt a registry entry field-by-field and
+  dropped ``archived``, silently resuming collection on a renamed client.
+- #549 — ``stamp_batch`` rebuilt an ``ActionLogEntry`` and dropped the
+  provenance fields, so an imported entry lost ``is_external`` and a forged
+  ``reversible_params`` planned as a real reversal.
+- here — adding ``batches`` in #549 had to be hand-threaded through five
+  mutators; missing one would have silently closed an open batch on the next
+  campaign upsert.
+
+Finding it twice did not prevent the third, because the defect is an omission
+and omissions are invisible in review. So these tests are driven off
+``dataclasses.fields(...)`` rather than a hand-written list: each states only
+the fields its mutator DECLARES it changes, and asserts everything else
+survived. A field added to :class:`StateDocument` or :class:`PlatformState` is
+checked by every one of them without any test being edited — and the value
+maps below fail loudly if the new field has no distinctive value to check.
+"""
+
+from __future__ import annotations
+
+from dataclasses import fields
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from mureo.context.models import (
+    ActionLogEntry,
+    AdState,
+    CampaignSnapshot,
+    PlatformState,
+    StateDocument,
+)
+from mureo.context.state import (
+    append_action_log,
+    parse_state,
+    read_state_file,
+    render_state,
+    set_conversion_action_types,
+    set_platform_metrics,
+    set_report,
+    upsert_campaign,
+    write_state_file,
+)
+
+_ACCOUNT = "123-456-7890"
+_PLATFORM = "google_ads"
+
+
+def _campaign(campaign_id: str = "C-1") -> CampaignSnapshot:
+    return CampaignSnapshot(
+        campaign_id=campaign_id,
+        campaign_name="Brand Search",
+        status="ENABLED",
+        bidding_strategy_type="TARGET_CPA",
+        bidding_details={"target_cpa": 5000},
+        daily_budget=12000.0,
+        device_targeting=({"device": "MOBILE", "modifier": 1.2},),
+        campaign_goal="leads",
+        notes="do not pause",
+        metrics={"spend": 4200.0, "clicks": 310},
+        ads=(AdState(ad_id="A-1", name="RSA", status="ENABLED"),),
+    )
+
+
+#: One distinctive value per :class:`PlatformState` field.
+_PLATFORM_FIELD_VALUES: dict[str, Any] = {
+    "account_id": _ACCOUNT,
+    "campaigns": (_campaign(),),
+    "totals": {"spend": 4200.0, "conversions": 12},
+    "metrics_period": "LAST_30_DAYS",
+    "periods": {"LAST_30_DAYS": {"spend": 4200.0}},
+    "conversion_action_types": ("offsite_conversion.custom.42",),
+}
+
+#: One distinctive value per :class:`StateDocument` field.
+_DOCUMENT_FIELD_VALUES: dict[str, Any] = {
+    "version": "2",
+    "last_synced_at": "2026-08-08T09:00:00+09:00",
+    "customer_id": _ACCOUNT,
+    "campaigns": (_campaign(),),
+    "platforms": {_PLATFORM: PlatformState(**_PLATFORM_FIELD_VALUES)},
+    "action_log": (
+        ActionLogEntry(
+            timestamp="2026-08-08T09:30:00+09:00",
+            action="google_ads_budget_update",
+            platform=_PLATFORM,
+            campaign_id="C-1",
+            summary="raised daily budget",
+            observation_due="2026-08-22",
+        ),
+    ),
+    "reports": {"daily": {"narrative": "healthy"}},
+}
+
+
+def _assert_map_covers(cls: type, values: dict[str, Any]) -> None:
+    """Fail loudly when the dataclass has grown a field the map does not know.
+
+    This is what stops the test rotting the way the code did: a new field with
+    no distinctive value here would be "preserved" trivially (its default
+    compares equal to itself) and the guard would quietly stop guarding.
+    """
+    declared = {f.name for f in fields(cls)}
+    missing = declared - set(values)
+    assert not missing, (
+        f"{cls.__name__} gained field(s) {sorted(missing)} with no value in this "
+        "test's map. Add one, then confirm every mutator preserves it — a field "
+        "silently reset by a targeted write is exactly what this guards."
+    )
+    stale = set(values) - declared
+    assert not stale, f"{cls.__name__} map names removed field(s) {sorted(stale)}"
+
+
+def _seed(path: Path) -> StateDocument:
+    """Write a STATE.json with every field of every model populated."""
+    _assert_map_covers(PlatformState, _PLATFORM_FIELD_VALUES)
+    _assert_map_covers(StateDocument, _DOCUMENT_FIELD_VALUES)
+    doc = StateDocument(**_DOCUMENT_FIELD_VALUES)
+    write_state_file(path, doc)
+    return doc
+
+
+def _assert_document_preserved(
+    before: StateDocument, after: StateDocument, *, changed: set[str]
+) -> None:
+    """Every :class:`StateDocument` field outside ``changed`` is untouched."""
+    for field in fields(StateDocument):
+        if field.name in changed:
+            continue
+        assert getattr(after, field.name) == getattr(before, field.name), (
+            f"{field.name!r} was reset by a write that does not declare it. "
+            "Use dataclasses.replace and change only the fields the call owns."
+        )
+
+
+def _assert_platform_preserved(
+    before: PlatformState, after: PlatformState, *, changed: set[str]
+) -> None:
+    """Every :class:`PlatformState` field outside ``changed`` is untouched."""
+    for field in fields(PlatformState):
+        if field.name in changed:
+            continue
+        assert getattr(after, field.name) == getattr(before, field.name), (
+            f"platform field {field.name!r} was reset by a write that does not "
+            "declare it."
+        )
+
+
+@pytest.fixture
+def seeded(tmp_path: Path) -> tuple[Path, StateDocument]:
+    path = tmp_path / "STATE.json"
+    return path, _seed(path)
+
+
+@pytest.mark.unit
+class TestDocumentLevelPreservation:
+    """Each mutator changes the document fields it owns, and no others."""
+
+    def test_upsert_campaign(self, seeded: tuple[Path, StateDocument]) -> None:
+        path, before = seeded
+        after = upsert_campaign(
+            path, _campaign("C-2"), platform=_PLATFORM, account_id=_ACCOUNT
+        )
+        _assert_document_preserved(
+            before, after, changed={"last_synced_at", "campaigns", "platforms"}
+        )
+
+    def test_append_action_log(self, seeded: tuple[Path, StateDocument]) -> None:
+        path, before = seeded
+        after = append_action_log(
+            path,
+            ActionLogEntry(
+                timestamp="2026-08-08T10:00:00+09:00",
+                action="google_ads_keywords_add",
+                platform=_PLATFORM,
+            ),
+        )
+        # last_synced_at is deliberately NOT re-stamped: appending an action is
+        # not a sync, and the dashboard's freshness must keep reflecting the
+        # last real one.
+        _assert_document_preserved(before, after, changed={"action_log"})
+        assert after.last_synced_at == before.last_synced_at
+
+    def test_set_report(self, seeded: tuple[Path, StateDocument]) -> None:
+        path, before = seeded
+        after = set_report(path, "weekly", {"narrative": "steady"})
+        _assert_document_preserved(before, after, changed={"last_synced_at", "reports"})
+        # Sibling report kinds survive too.
+        assert after.reports is not None
+        assert after.reports["daily"] == {"narrative": "healthy"}
+
+    def test_set_platform_metrics(self, seeded: tuple[Path, StateDocument]) -> None:
+        path, before = seeded
+        after = set_platform_metrics(
+            path, _PLATFORM, _ACCOUNT, periods={"YESTERDAY": {"spend": 100.0}}
+        )
+        _assert_document_preserved(
+            before, after, changed={"last_synced_at", "platforms"}
+        )
+
+    def test_set_conversion_action_types(
+        self, seeded: tuple[Path, StateDocument]
+    ) -> None:
+        path, before = seeded
+        after = set_conversion_action_types(path, _PLATFORM, _ACCOUNT, ["lead"])
+        _assert_document_preserved(
+            before, after, changed={"last_synced_at", "platforms"}
+        )
+
+
+@pytest.mark.unit
+class TestPlatformLevelPreservation:
+    """The three mutators that write ``platforms`` touch only their own fields.
+
+    This is where the real regressions landed: a campaign upsert wiped the
+    dashboard rollups, and a metrics write wiped the #342 conversion override.
+    """
+
+    def _platform(self, doc: StateDocument) -> PlatformState:
+        assert doc.platforms is not None
+        return doc.platforms[_PLATFORM]
+
+    def test_upsert_campaign_keeps_rollups_and_conversion_override(
+        self, seeded: tuple[Path, StateDocument]
+    ) -> None:
+        path, before = seeded
+        after = upsert_campaign(
+            path, _campaign("C-2"), platform=_PLATFORM, account_id=_ACCOUNT
+        )
+        _assert_platform_preserved(
+            self._platform(before), self._platform(after), changed={"campaigns"}
+        )
+
+    def test_metrics_write_keeps_campaigns_and_conversion_override(
+        self, seeded: tuple[Path, StateDocument]
+    ) -> None:
+        path, before = seeded
+        after = set_platform_metrics(
+            path, _PLATFORM, _ACCOUNT, periods={"YESTERDAY": {"spend": 100.0}}
+        )
+        _assert_platform_preserved(
+            self._platform(before),
+            self._platform(after),
+            changed={"totals", "metrics_period", "periods"},
+        )
+        # ``periods`` merges per window rather than replacing the map.
+        merged = self._platform(after).periods
+        assert merged is not None
+        assert merged["LAST_30_DAYS"] == {"spend": 4200.0}
+        assert merged["YESTERDAY"] == {"spend": 100.0}
+        # A None argument means "leave as it was", not "clear it".
+        assert self._platform(after).totals == _PLATFORM_FIELD_VALUES["totals"]
+
+    def test_conversion_override_write_keeps_everything_else(
+        self, seeded: tuple[Path, StateDocument]
+    ) -> None:
+        path, before = seeded
+        after = set_conversion_action_types(path, _PLATFORM, _ACCOUNT, ["lead"])
+        _assert_platform_preserved(
+            self._platform(before),
+            self._platform(after),
+            changed={"conversion_action_types"},
+        )
+        assert self._platform(after).conversion_action_types == ("lead",)
+
+    def test_a_new_platform_entry_takes_the_dataclass_defaults(
+        self, tmp_path: Path
+    ) -> None:
+        """Creating an entry must not hand-copy the model's own defaults."""
+        path = tmp_path / "STATE.json"
+        write_state_file(path, StateDocument(version="2"))
+        after = set_conversion_action_types(path, "meta_ads", "act_1", ["purchase"])
+        assert after.platforms is not None
+        created = after.platforms["meta_ads"]
+        fresh = PlatformState(account_id="act_1")
+        for field in fields(PlatformState):
+            if field.name in {"account_id", "conversion_action_types"}:
+                continue
+            assert getattr(created, field.name) == getattr(fresh, field.name)
+
+
+@pytest.mark.unit
+class TestCodecRoundTrip:
+    """The codec MUST enumerate — so it gets the same guard from outside.
+
+    ``state_codec`` maps to an external JSON schema, so ``replace`` cannot
+    help it: both halves list every field by hand. A field missing from either
+    half is lost on the way to disk, silently. Driving the check off
+    ``dataclasses.fields`` catches that without the codec having to change
+    shape.
+    """
+
+    def test_every_document_field_survives_render_and_parse(self) -> None:
+        _assert_map_covers(StateDocument, _DOCUMENT_FIELD_VALUES)
+        doc = StateDocument(**_DOCUMENT_FIELD_VALUES)
+        restored = parse_state(render_state(doc))
+        for field in fields(StateDocument):
+            assert getattr(restored, field.name) == getattr(doc, field.name), (
+                f"{field.name!r} did not survive the STATE.json round trip — "
+                "check BOTH halves of state_codec."
+            )
+
+    def test_every_platform_field_survives_render_and_parse(self) -> None:
+        _assert_map_covers(PlatformState, _PLATFORM_FIELD_VALUES)
+        doc = StateDocument(**_DOCUMENT_FIELD_VALUES)
+        restored = parse_state(render_state(doc))
+        assert restored.platforms is not None
+        for field in fields(PlatformState):
+            assert getattr(restored.platforms[_PLATFORM], field.name) == getattr(
+                doc.platforms[_PLATFORM], field.name  # type: ignore[index]
+            ), f"platform field {field.name!r} did not survive the round trip"
+
+    def test_round_trip_through_disk(self, tmp_path: Path) -> None:
+        path = tmp_path / "STATE.json"
+        doc = _seed(path)
+        restored = read_state_file(path)
+        for field in fields(StateDocument):
+            assert getattr(restored, field.name) == getattr(doc, field.name)

--- a/tests/test_dataclass_field_preservation.py
+++ b/tests/test_dataclass_field_preservation.py
@@ -6,7 +6,7 @@ mutator that forgot it silently resets it, and a reset field is
 indistinguishable downstream from one that was never set. The bug therefore
 does not announce itself; it is found later, from the damage.
 
-It has been found four times in this project now:
+It has been found five times in this project now:
 
 - agency #193 — ``update()`` rebuilt a registry entry field-by-field and
   dropped ``archived``, silently resuming collection on a renamed client.
@@ -20,15 +20,20 @@ It has been found four times in this project now:
   fields were enumerated, dropping ``cpa`` / ``ctr``. Inert only because
   nothing populates them yet, which is the state the other three were in
   before a field was added.
+- ``preflight_tracking_consistency`` here — found while rebasing onto the
+  commit that introduced it (#570). All five fields of
+  ``TrackingConsistencyReport`` were enumerated, so nothing is dropped today;
+  the sixth field added to that model would be. Two functions beside it in the
+  same file already used ``replace``.
 
-Finding it three times did not prevent the fourth, because the defect is an
+Finding it four times did not prevent the fifth, because the defect is an
 omission and omissions are invisible in review. So these tests are driven off
 ``dataclasses.fields(...)`` rather than a hand-written list: each states only
 the fields its mutator DECLARES it changes, and asserts everything else
-survived. A field added to :class:`StateDocument`, :class:`PlatformState` or
-:class:`CampaignMetrics` is checked by every one of them without any test
-being edited — and the value maps below fail loudly if the new field has no
-distinctive value to check.
+survived. A field added to :class:`StateDocument`, :class:`PlatformState`,
+:class:`CampaignMetrics` or ``TrackingConsistencyReport`` is checked by every
+one of them without any test being edited — and the value maps below fail
+loudly if the new field has no distinctive value to check.
 
 Two subtleties, both of which produced a test that looked like a guard and was
 not. They are the reason this file is longer than it first appears it needs to
@@ -500,6 +505,82 @@ class TestCampaignMetricsMerge:
         merged = _merge_campaign_metrics(first, first)
         assert merged.derived_cpa() == pytest.approx(2000.0 / 10.0)
         assert merged.derived_ctr() == pytest.approx(100 / 2000)
+
+
+@pytest.mark.unit
+class TestTrackingReportNarrowing:
+    """Narrowing a tracking report to the planned ads keeps the rest.
+
+    Fifth instance, found while rebasing onto the commit that introduced it
+    (#570). ``preflight_tracking_consistency`` runs the account-wide detector
+    and then narrows the result to the ads being uploaded. It rebuilt
+    :class:`TrackingConsistencyReport` field-by-field, enumerating all five —
+    complete today, and silently resetting whatever is added tomorrow.
+
+    Every field being enumerated correctly is exactly why a behavioural
+    assertion proves nothing here, the same trap as ``CampaignMetrics``. The
+    report is built inside the function, so the subclass has to arrive through
+    the seam: patching the detector makes it return a model carrying a field
+    the narrowing step has never heard of. ``replace`` reconstructs
+    ``type(obj)`` and keeps it; naming ``TrackingConsistencyReport(...)``
+    returns the base class and drops it.
+    """
+
+    def test_narrowing_preserves_a_field_it_does_not_know_about(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from mureo.analysis.tracking import checks as tracking_checks
+        from mureo.analysis.tracking.models import TrackingConsistencyReport
+
+        @dataclass(frozen=True)
+        class ExtendedReport(TrackingConsistencyReport):
+            scan_id: str | None = None
+
+        monkeypatch.setattr(
+            tracking_checks,
+            "check_tracking_consistency",
+            lambda *a, **k: ExtendedReport(
+                ads_examined=7,
+                campaigns_examined=2,
+                notes=("delivery data absent",),
+                scan_id="SCAN-1",
+            ),
+        )
+        narrowed = tracking_checks.preflight_tracking_consistency([], [])
+
+        assert isinstance(narrowed, ExtendedReport), (
+            "preflight_tracking_consistency rebuilt the report as a bare "
+            "TrackingConsistencyReport. Use dataclasses.replace so fields it "
+            "does not own survive."
+        )
+        assert narrowed.scan_id == "SCAN-1"
+
+    def test_narrowing_preserves_every_field_it_does_not_own(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The two fields it DOES own change; the rest are carried across."""
+        from mureo.analysis.tracking import checks as tracking_checks
+        from mureo.analysis.tracking.models import TrackingConsistencyReport
+
+        source = TrackingConsistencyReport(
+            ads_examined=7,
+            campaigns_examined=2,
+            ads_without_readable_url=("ad-9",),
+            notes=("delivery data absent — severities capped at HIGH",),
+        )
+        monkeypatch.setattr(
+            tracking_checks, "check_tracking_consistency", lambda *a, **k: source
+        )
+        narrowed = tracking_checks.preflight_tracking_consistency([], [])
+
+        owned = {"findings", "ads_without_readable_url"}
+        for field in fields(TrackingConsistencyReport):
+            if field.name in owned:
+                continue
+            assert getattr(narrowed, field.name) == getattr(source, field.name), (
+                f"{field.name!r} was reset while narrowing the report to the "
+                "planned ads."
+            )
 
 
 @pytest.mark.unit

--- a/tests/test_dataclass_field_preservation.py
+++ b/tests/test_dataclass_field_preservation.py
@@ -30,12 +30,32 @@ survived. A field added to :class:`StateDocument`, :class:`PlatformState` or
 being edited — and the value maps below fail loudly if the new field has no
 distinctive value to check.
 
-One caveat worth stating, because it is why the fourth instance sat unnoticed:
-where every current field already has a declared role, an enumerated rebuild
-and a ``replace`` behave IDENTICALLY, so no behavioural assertion can tell
-them apart. That case needs the structural guard —
-``test_a_field_the_merge_does_not_know_about_survives``, which subclasses the
-model to supply a field the function has never heard of.
+Two subtleties, both of which produced a test that looked like a guard and was
+not. They are the reason this file is longer than it first appears it needs to
+be.
+
+**1. Where every field already has a declared role, behaviour cannot tell an
+enumerated rebuild from a ``replace``.** That is why the ``CampaignMetrics``
+instance sat unnoticed: the two fields it dropped are the two a merge clears
+anyway, so the old code and the fixed code produce identical output today. The
+guard there has to be STRUCTURAL —
+``test_a_field_the_merge_does_not_know_about_survives`` subclasses the model to
+supply a field the function has never heard of, which ``replace`` carries and
+an enumerated constructor discards.
+
+**2. Every fixture value must be NON-DEFAULT.** A field the codec declares but
+wires into neither half comes back at its default; if the fixture also left it
+at its default, the comparison passes and the loss is invisible. Naming a field
+in ``state_codec._CODEC_COVERAGE`` satisfies the import-time check — which
+asserts declaration — while still dropping the data on every write. Only a
+distinctive value in the maps below turns that into a failure, which is why
+``_assert_map_covers`` runs over EVERY model the codec touches
+(:data:`_CODEC_MODELS`), nested ones included, rather than just the two at the
+top.
+
+Division of labour, stated once: the import-time check in ``state_codec``
+asserts a field is DECLARED; the round-trip tests here assert it SURVIVES.
+Neither substitutes for the other.
 """
 
 from __future__ import annotations
@@ -71,20 +91,62 @@ _ACCOUNT = "123-456-7890"
 _PLATFORM = "google_ads"
 
 
+# Every value below must be NON-DEFAULT and distinctive. That is the whole
+# mechanism: a codec that declares a field but wires neither half leaves it at
+# its default on the way back, so a fixture that also left it at its default
+# would compare equal and the loss would be invisible. Every nested model gets
+# the same treatment for the same reason — a gap in any one of them is a gap in
+# the round trip.
+
+#: One distinctive value per :class:`AdState` field.
+_AD_STATE_FIELD_VALUES: dict[str, Any] = {
+    "ad_id": "A-1",
+    "name": "RSA — spring",
+    "status": "ENABLED",
+    "effective_status": "DISAPPROVED",
+    "as_of": "2026-08-08T08:00:00+09:00",
+}
+
+#: One distinctive value per :class:`ActionLogEntry` field.
+_ACTION_LOG_FIELD_VALUES: dict[str, Any] = {
+    "timestamp": "2026-08-08T09:30:00+09:00",
+    "action": "google_ads_budget_update",
+    "platform": _PLATFORM,
+    "campaign_id": "C-1",
+    "ad_id": "A-1",
+    "summary": "raised daily budget",
+    "command": "/budget-rebalance",
+    "metrics_at_action": {"cpa": 5200, "conversions": 45},
+    "observation_due": "2026-08-22",
+    "reversible_params": {
+        "operation": "google_ads_budget_update",
+        "params": {"budget_id": "B1", "amount": 10000},
+    },
+    "rollback_of": 3,
+    "evaluation_of": 4,
+    "entity_type": "ad_group",
+    "entity_id": "G-1",
+}
+
+#: One distinctive value per :class:`CampaignSnapshot` field, minus the id the
+#: caller varies.
+_CAMPAIGN_FIELD_VALUES: dict[str, Any] = {
+    "campaign_id": "C-1",
+    "campaign_name": "Brand Search",
+    "status": "ENABLED",
+    "bidding_strategy_type": "TARGET_CPA",
+    "bidding_details": {"target_cpa": 5000},
+    "daily_budget": 12000.0,
+    "device_targeting": ({"device": "MOBILE", "modifier": 1.2},),
+    "campaign_goal": "leads",
+    "notes": "do not pause",
+    "metrics": {"spend": 4200.0, "clicks": 310},
+    "ads": (AdState(**_AD_STATE_FIELD_VALUES),),
+}
+
+
 def _campaign(campaign_id: str = "C-1") -> CampaignSnapshot:
-    return CampaignSnapshot(
-        campaign_id=campaign_id,
-        campaign_name="Brand Search",
-        status="ENABLED",
-        bidding_strategy_type="TARGET_CPA",
-        bidding_details={"target_cpa": 5000},
-        daily_budget=12000.0,
-        device_targeting=({"device": "MOBILE", "modifier": 1.2},),
-        campaign_goal="leads",
-        notes="do not pause",
-        metrics={"spend": 4200.0, "clicks": 310},
-        ads=(AdState(ad_id="A-1", name="RSA", status="ENABLED"),),
-    )
+    return CampaignSnapshot(**{**_CAMPAIGN_FIELD_VALUES, "campaign_id": campaign_id})
 
 
 #: One distinctive value per :class:`PlatformState` field.
@@ -104,18 +166,20 @@ _DOCUMENT_FIELD_VALUES: dict[str, Any] = {
     "customer_id": _ACCOUNT,
     "campaigns": (_campaign(),),
     "platforms": {_PLATFORM: PlatformState(**_PLATFORM_FIELD_VALUES)},
-    "action_log": (
-        ActionLogEntry(
-            timestamp="2026-08-08T09:30:00+09:00",
-            action="google_ads_budget_update",
-            platform=_PLATFORM,
-            campaign_id="C-1",
-            summary="raised daily budget",
-            observation_due="2026-08-22",
-        ),
-    ),
+    "action_log": (ActionLogEntry(**_ACTION_LOG_FIELD_VALUES),),
     "reports": {"daily": {"narrative": "healthy"}},
 }
+
+#: Every model the STATE.json codec maps, with the map that must cover it.
+#: Checked as one table so a model cannot be added to the codec and quietly
+#: left out of the round trip.
+_CODEC_MODELS: tuple[tuple[type, dict[str, Any]], ...] = (
+    (StateDocument, _DOCUMENT_FIELD_VALUES),
+    (PlatformState, _PLATFORM_FIELD_VALUES),
+    (ActionLogEntry, _ACTION_LOG_FIELD_VALUES),
+    (CampaignSnapshot, _CAMPAIGN_FIELD_VALUES),
+    (AdState, _AD_STATE_FIELD_VALUES),
+)
 
 
 def _assert_map_covers(cls: type, values: dict[str, Any]) -> None:
@@ -136,10 +200,15 @@ def _assert_map_covers(cls: type, values: dict[str, Any]) -> None:
     assert not stale, f"{cls.__name__} map names removed field(s) {sorted(stale)}"
 
 
+def _assert_every_codec_model_covered() -> None:
+    """Every model the codec maps has a fully-populated, non-default fixture."""
+    for model, values in _CODEC_MODELS:
+        _assert_map_covers(model, values)
+
+
 def _seed(path: Path) -> StateDocument:
     """Write a STATE.json with every field of every model populated."""
-    _assert_map_covers(PlatformState, _PLATFORM_FIELD_VALUES)
-    _assert_map_covers(StateDocument, _DOCUMENT_FIELD_VALUES)
+    _assert_every_codec_model_covered()
     doc = StateDocument(**_DOCUMENT_FIELD_VALUES)
     write_state_file(path, doc)
     return doc
@@ -445,7 +514,7 @@ class TestCodecRoundTrip:
     """
 
     def test_every_document_field_survives_render_and_parse(self) -> None:
-        _assert_map_covers(StateDocument, _DOCUMENT_FIELD_VALUES)
+        _assert_every_codec_model_covered()
         doc = StateDocument(**_DOCUMENT_FIELD_VALUES)
         restored = parse_state(render_state(doc))
         for field in fields(StateDocument):
@@ -455,7 +524,7 @@ class TestCodecRoundTrip:
             )
 
     def test_every_platform_field_survives_render_and_parse(self) -> None:
-        _assert_map_covers(PlatformState, _PLATFORM_FIELD_VALUES)
+        _assert_every_codec_model_covered()
         doc = StateDocument(**_DOCUMENT_FIELD_VALUES)
         restored = parse_state(render_state(doc))
         assert restored.platforms is not None
@@ -463,6 +532,59 @@ class TestCodecRoundTrip:
             assert getattr(restored.platforms[_PLATFORM], field.name) == getattr(
                 doc.platforms[_PLATFORM], field.name  # type: ignore[index]
             ), f"platform field {field.name!r} did not survive the round trip"
+
+    def test_every_action_log_field_survives_render_and_parse(self) -> None:
+        """#545 adds three fields to this codec pair — the gap closes first.
+
+        Declaring a field in ``_CODEC_COVERAGE`` while wiring neither half of
+        ``_parse_action_log_entry`` / ``_action_log_entry_to_dict`` passes the
+        import-time check, because that check asserts declaration only. It is
+        this assertion that catches the loss — but only because every field in
+        the fixture carries a distinctive NON-DEFAULT value, so a dropped one
+        comes back different rather than coincidentally equal.
+        """
+        _assert_every_codec_model_covered()
+        doc = StateDocument(**_DOCUMENT_FIELD_VALUES)
+        restored = parse_state(render_state(doc))
+        original_entry = doc.action_log[0]
+        restored_entry = restored.action_log[0]
+        for field in fields(ActionLogEntry):
+            assert getattr(restored_entry, field.name) == getattr(
+                original_entry, field.name
+            ), (
+                f"action_log field {field.name!r} did not survive the round "
+                "trip — naming it in _CODEC_COVERAGE is not enough, BOTH "
+                "_parse_action_log_entry and _action_log_entry_to_dict must "
+                "handle it."
+            )
+
+    def test_every_ad_state_field_survives_render_and_parse(self) -> None:
+        """``AdState`` is nested two deep and had the same blind spot."""
+        _assert_every_codec_model_covered()
+        doc = StateDocument(**_DOCUMENT_FIELD_VALUES)
+        restored = parse_state(render_state(doc))
+        original_ads = doc.campaigns[0].ads
+        restored_ads = restored.campaigns[0].ads
+        assert original_ads is not None and restored_ads is not None
+        for field in fields(AdState):
+            assert getattr(restored_ads[0], field.name) == getattr(
+                original_ads[0], field.name
+            ), (
+                f"ads[] field {field.name!r} did not survive the round trip — "
+                "check BOTH _parse_ad and _ad_state_to_dict."
+            )
+
+    def test_every_campaign_field_survives_render_and_parse(self) -> None:
+        _assert_every_codec_model_covered()
+        doc = StateDocument(**_DOCUMENT_FIELD_VALUES)
+        restored = parse_state(render_state(doc))
+        for field in fields(CampaignSnapshot):
+            assert getattr(restored.campaigns[0], field.name) == getattr(
+                doc.campaigns[0], field.name
+            ), (
+                f"campaign field {field.name!r} did not survive the round trip "
+                "— check BOTH _parse_campaign and _snapshot_to_dict."
+            )
 
     def test_round_trip_through_disk(self, tmp_path: Path) -> None:
         path = tmp_path / "STATE.json"


### PR DESCRIPTION
## Why

Fifth instance of the same defect in this project, so this fixes the shape rather than the symptom.

Five STATE.json mutators rebuilt the `StateDocument` by enumerating every field; three of them rebuilt the `PlatformState` the same way; and `_live_clients` rebuilt `CampaignMetrics` the same way again. That works until a field is added — at which point every rebuild that forgot it silently resets it. A reset field is indistinguishable downstream from one that was never set, so nothing reports it; the damage surfaces later, from its consequences.

Each prior instance was fixed in place, and none prevented the next:

| | What was rebuilt | What was dropped | Consequence |
|---|---|---|---|
| agency #193 | registry entry in `update()` | `archived` | collection silently resumed on a renamed client |
| #549 | `ActionLogEntry` in `stamp_batch` | `origin` / `external_id` | imported entry lost `is_external`; a forged `reversible_params` planned as a real reversal |
| **here** | `StateDocument` + `PlatformState` in 5 mutators | any future field | adding `batches` in #549 needed hand-threading through all five; missing one would have silently closed an open batch on the next campaign upsert |
| **here** | `CampaignMetrics` in 2 merge sites | `cpa` / `ctr` | inert today — nothing populates them yet, which is exactly the state the other three were in |
| **here** | `TrackingConsistencyReport` in `preflight_tracking_consistency` | nothing yet — all 5 fields enumerated | found while rebasing onto #570, the commit that introduced it; the 6th field added to that model would be dropped |

The failure is an omission, and omissions are invisible in review.

## What changed

**STATE.json mutators** — both models now go through `dataclasses.replace`, changing only the fields each call owns, so preservation is **structural rather than remembered**. A new `_platform_base` helper supplies the entry to build on: the existing one, or a minimal new one carrying only `account_id`, whose remaining fields take the dataclass's own defaults rather than a hand-written copy.

Behaviour is unchanged, including three deliberate asymmetries the previous code documented and this keeps: `append_action_log` does not re-stamp `last_synced_at`; `set_platform_metrics` merges `periods` per window key; a `None` argument means "leave as it was", not "clear it".

**`_merge_campaign_metrics`** — the two duplicated merge blocks are now one helper built on `replace`. `cpa` and `ctr` are cleared **explicitly** rather than by omission, which is a deliberate deviation from a bare `replace`: they are ratios and cannot be summed, so carrying the first row's value across would report one row's CPA as the total's. Clearing them lets `derived_cpa` / `derived_ctr` recompute from the summed counters — correct, and identical to today's behaviour, so nothing changes now while staying right if the API-supplied values the class docstring anticipates ever get populated.

**`state_codec`** — cannot use `replace` at all: it maps to an external JSON schema, so both halves list every field by hand. The field-coverage claim moved out of the test file and into the module, running **at import**. Adding a field to a model without updating the codec now raises immediately, naming the two functions to edit, on any `import mureo`, a REPL, or a `pytest -k` run that never collects the round-trip test. This asserts *declaration*, not behaviour; behaviour remains the round-trip test's job.

## Audit — the question is closed, not deferred

Every frozen dataclass in `mureo/context/`, `mureo/rollback/` and the analytics models was checked at every construction site. **After this change, nothing in the tree rebuilds an existing instance field-by-field.** What remains is legitimate:

| Site | Why enumerating is correct |
|---|---|
| `state_codec` | Maps to an external JSON schema — `replace` cannot help. Guarded by the import-time coverage check plus a round-trip test |
| `_handlers_mureo_context` | Builds from an untrusted MCP dict; the enumeration **is** the whitelist of what a caller may set |
| `_live_clients` (3 fresh constructors), `native_reversal`, `plugin_semantics`, `tools_creative_studio` ×2, `rollback/executor`, `rollback/planner`, `context/strategy` | Construct genuinely new objects — nothing to carry over |
| `_merge_ads`, `_as_planned`, `_project_onto_planned` | Already used `replace` |

Re-run against current `main` after each rebase rather than trusting the earlier pass — that is how the fifth instance was found, and how `mureo/analysis/exclusion_impact/` (from #574) was confirmed clean.

## Tests

`tests/test_dataclass_field_preservation.py`, driven off `dataclasses.fields(...)`. Each test names only the fields its mutator **declares** it changes and asserts everything else survived, so a future field is checked without any test being edited. The value maps fail loudly if a new field arrives with no distinctive value.

Verified not vacuous:

| Scenario | Result |
|---|---|
| simulated future field on `StateDocument` + `PlatformState`, wired through the codec, against **this PR** | 12 passed — carried across all five mutators |
| same field against **`main`'s** enumerating mutators | **8 failed** — all five document-level and all three platform-level writes dropped it |
| new field on a model, absent from the test's value map | fails with `… gained field(s) [...] with no value in this test's map` |
| new field on a model, absent from `_CODEC_COVERAGE` | `RuntimeError` on plain `import mureo.context.state`, and on an unrelated `pytest tests/test_throttle.py` |
| new field **declared** in `_CODEC_COVERAGE` but wired into neither codec half (`audit_note` on `ActionLogEntry`, `review_state` on `AdState`) | import check passes — it asserts declaration by design — and the round trip **fails**, naming the field and both functions to fix |
| old enumerating `_merge_campaign_metrics` restored | **fails** `test_a_field_the_merge_does_not_know_about_survives` |
| old enumerating `preflight_tracking_consistency` restored | **fails** `test_narrowing_preserves_a_field_it_does_not_know_about` — and the behavioural sibling passes, which is the point |

Two subtleties are recorded in the test module, because each produced a test that looked like a guard and was not:

1. **Where every field already has a declared role, behaviour cannot distinguish an enumerated rebuild from a `replace`** — which is why the `CampaignMetrics` instance sat unnoticed, and why my first version of that test passed against the injected old code. It needed a *structural* guard: subclassing the model to supply a field the function has never heard of, since `replace` reconstructs `type(obj)` and carries it while `CampaignMetrics(...)` returns the base class and drops it.
2. **Every fixture value must be non-default.** A field the codec declares but wires into neither half comes back at its default; a fixture that also left it at its default compares equal and the loss is invisible. `_assert_map_covers` therefore runs over every model the codec touches (`_CODEC_MODELS`), nested `ActionLogEntry` and `AdState` included — closing a gap that was reproducible with real data loss before this commit.

Division of labour, stated once in the module: the import-time check asserts a field is **declared**; the round-trip tests assert it **survives**. Neither substitutes for the other.

## Gates

`ruff check .` / `black --check .` / `mypy mureo --ignore-missing-imports` — all clean.

`python -m pytest` in a **clean venv** (`python3 -m venv` + `pip install -e ".[dev]"`, no plugins installed) — **8072 passed, 8 skipped, 0 failed**.

## Unrelated flake worth knowing about

`tests/test_web_handlers.py::TestServeAbout::test_about_unmocked_lists_mureo` binds a real local HTTP server and fetches it with a 2s `urlopen` timeout. It fails when the machine is busy — reproduced while two worktrees ran their suites concurrently, which happens routinely here. It passes in isolation and is **not** touched by this PR. Hardening it (raise the timeout, or mock the collector as its sibling tests do) would be its own small change.
