### PR TITLE
fix: keep an observed change out of the operator's open batch, and test the change-feed registry's discovery paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **An observed change no longer joins the operator's open batch** (#545 x
+  #549). "Imports never join a batch" is stated in `docs/change-import.md`
+  without qualification, but it was enforced in one place: the polled
+  importer, which opts out by hand with `join_active_batch=False`. The
+  hosted-connector route — an agent recording what it read from a connector
+  mureo cannot poll, through `mureo_state_action_log_append` — went through
+  the default path and was stamped with whatever batch happened to be open.
+
+  Nothing dishonest came of it: `plan_rollback` still refused the entry and
+  the batch still reported the coverage gap. What it cost was sense. An
+  operator's fully-reversible Monday cleanup could report `partial` because
+  an unrelated UI edit was imported while the batch was open.
+
+  The rule now lives in `stamp_batch`, next to the membership decision
+  itself. #549 put that decision at the one point every recording path
+  converges on precisely so no caller has to know about batches; fixing this
+  in the handler instead would have left the next recording path to
+  rediscover it. An explicit `batch_id` still wins and is still validated, so
+  a deliberate backfill into its own declared batch remains possible — and
+  that batch correctly reports it as a gap.
+
 ### Added
 
 - **Delivery-collapse detection and diagnosis, across all platforms** (#546).

--- a/mureo/context/batch.py
+++ b/mureo/context/batch.py
@@ -241,6 +241,28 @@ def stamp_batch(entry: ActionLogEntry, batch: BatchRecord | None) -> ActionLogEn
     """
     if batch is None or entry.batch_id is not None:
         return entry
+    # An observed change is not a member of the operator's change set (#545 x
+    # #549). A batch is "what I did on Monday"; a UI edit mureo merely read
+    # out of a platform's change history is by definition not that, and
+    # letting it join drops the whole batch's rollback coverage to ``partial``
+    # for no reason other than that the batch happened to be open when the
+    # change was recorded.
+    #
+    # This lives here, not in a caller, for the reason membership itself does:
+    # #549 put the decision at the one point every recording path converges on
+    # precisely so no caller has to know about batches. The polled importer
+    # already opted out by hand with ``join_active_batch=False``, but the
+    # hosted-connector route — an agent recording what it read from a
+    # connector mureo cannot poll, through ``mureo_state_action_log_append`` —
+    # went through the default path and joined. Fixing that in the handler
+    # would leave the next recording path to rediscover it; fixing it here
+    # means there is no next time.
+    #
+    # An explicit ``batch_id`` still wins, above: a deliberate backfill into
+    # its own declared batch is a real use, and it is still validated against
+    # the declared batches by ``ensure_joinable``.
+    if entry.is_external:
+        return entry
     return replace(entry, batch_id=batch.batch_id)
 
 

--- a/tests/test_batch_revertible_unit.py
+++ b/tests/test_batch_revertible_unit.py
@@ -299,6 +299,25 @@ def _fully_populated_entry() -> ActionLogEntry:
     return ActionLogEntry(**_ENTRY_FIELD_VALUES)
 
 
+#: The provenance trio, which only an OBSERVED change carries.
+_PROVENANCE_FIELDS = ("origin", "external_id", "occurred_at")
+
+
+def _fully_populated_own_entry() -> ActionLogEntry:
+    """The same entry, minus provenance: a change mureo itself made.
+
+    Only this kind reaches ``stamp_batch``'s rewrite at all. An observed
+    change is returned untouched (see
+    ``TestJoiningABatchPreservesTheEntry.test_an_observed_change_is_left_out``),
+    so driving the field-preservation check off an external entry would
+    assert on a code path it no longer takes and pass for the wrong reason.
+    """
+    values = {k: v for k, v in _ENTRY_FIELD_VALUES.items()}
+    for name in _PROVENANCE_FIELDS:
+        values[name] = None
+    return ActionLogEntry(**values)
+
+
 @pytest.mark.unit
 class TestJoiningABatchPreservesTheEntry:
     """Joining a batch must change ``batch_id`` and nothing else.
@@ -318,7 +337,7 @@ class TestJoiningABatchPreservesTheEntry:
 
     def test_stamp_batch_changes_only_batch_id(self) -> None:
         """The pure function, so a failure localizes here and not in the codec."""
-        entry = _fully_populated_entry()
+        entry = _fully_populated_own_entry()
         record = BatchRecord(
             batch_id="batch-x", label="pass", started_at="2026-08-07T09:00:00+09:00"
         )
@@ -343,7 +362,7 @@ class TestJoiningABatchPreservesTheEntry:
         """
         state_file = workspace / "STATE.json"
         batch = begin_batch(state_file, label="preserve everything")
-        entry = _fully_populated_entry()
+        entry = _fully_populated_own_entry()
         append_action_log(state_file, entry)
 
         stored = read_state_file(state_file).action_log[0]
@@ -351,10 +370,55 @@ class TestJoiningABatchPreservesTheEntry:
         for field in fields(ActionLogEntry):
             if field.name == "batch_id":
                 continue
-            assert getattr(stored, field.name) == _ENTRY_FIELD_VALUES[field.name], (
+            expected = (
+                None
+                if field.name in _PROVENANCE_FIELDS
+                else _ENTRY_FIELD_VALUES[field.name]
+            )
+            assert getattr(stored, field.name) == expected, (
                 f"{field.name!r} did not survive append_action_log with an open "
                 "batch — check stamp_batch and both halves of state_codec."
             )
+
+    def test_an_observed_change_is_left_out_of_the_batch(self) -> None:
+        """An imported change is not part of what the operator did.
+
+        A batch is a declared change set — "what I did on Monday". A UI edit
+        mureo merely read out of a platform's change history is not that, and
+        stamping it on would drop the batch's coverage to ``partial`` for no
+        reason but that the batch was open when the change was recorded.
+
+        The decision lives in ``stamp_batch`` rather than in a caller for the
+        same reason membership itself does (#549): every recording path
+        converges here, so no caller has to know. The polled importer opts
+        out by hand as well; the hosted-connector route, which records
+        through ``mureo_state_action_log_append``, has only this.
+        """
+        entry = _fully_populated_entry()
+        assert entry.is_external, "fixture must be an observed change"
+        record = BatchRecord(
+            batch_id="batch-x", label="pass", started_at="2026-08-07T09:00:00+09:00"
+        )
+
+        stamped = stamp_batch(entry, record)
+
+        assert stamped.batch_id is None
+        for field in fields(ActionLogEntry):
+            assert getattr(stamped, field.name) == getattr(entry, field.name)
+
+    def test_an_explicit_batch_id_still_wins_for_an_observed_change(self) -> None:
+        """Opting out of the implicit stamp is not a ban on deliberate ones.
+
+        A backfill that declares its own batch and records into it by id is a
+        real use, and the id is still validated against the declared batches
+        by ``ensure_joinable``. Only the silent join is withheld.
+        """
+        entry = ActionLogEntry(**{**_ENTRY_FIELD_VALUES, "batch_id": "batch-declared"})
+        record = BatchRecord(
+            batch_id="batch-open", label="pass", started_at="2026-08-07T09:00:00+09:00"
+        )
+
+        assert stamp_batch(entry, record).batch_id == "batch-declared"
 
 
 @pytest.mark.unit

--- a/tests/test_change_import.py
+++ b/tests/test_change_import.py
@@ -14,6 +14,7 @@ worth anything:
 from __future__ import annotations
 
 import json
+from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
@@ -37,6 +38,7 @@ from mureo.change_import import (
     get_change_feed,
     import_external_changes,
     list_change_feed_platforms,
+    plugin_source,
     register_change_feed,
     to_action_log_entry,
 )
@@ -780,16 +782,21 @@ class TestProvenanceSurvivesBatchStamping:
     ``stamp_batch`` at all. A hosted connector does: mureo holds no
     credentials for TikTok and dispatches nothing, so an agent records what it
     read from the connector's own change history through
-    ``mureo_state_action_log_append`` — the ordinary append path, where joining
-    the open batch is the DEFAULT.
+    ``mureo_state_action_log_append`` — the ordinary append path.
 
-    That is where a batch-stamping bug reaches the provenance fields, and the
-    failure mode is silent in the worst way: a dropped ``origin`` reads as
-    "mureo made this change", which flips ``is_external`` to False and lets
-    ``plan_rollback`` accept a ``reversible_params`` hint that came from
-    outside mureo entirely. These tests pin the whole chain rather than the
-    stamping function, so a future regression anywhere along it is caught here
-    too.
+    That path used to stamp the open batch onto the entry. It cost nothing in
+    honesty (``plan_rollback`` refused the entry either way, and the batch
+    still reported the coverage gap) but it contradicted the rule the docs
+    state without qualification: an imported change is not part of the
+    operator's declared change set. ``stamp_batch`` now declines to stamp an
+    observed change, so the rule holds for every recording path rather than
+    only the polled one.
+
+    What these tests are really guarding is the chain underneath: a dropped
+    ``origin`` reads as "mureo made this change", which flips ``is_external``
+    to False and lets ``plan_rollback`` accept a ``reversible_params`` hint
+    that came from outside mureo entirely — and ``is_external`` is now also
+    what keeps the entry out of the batch, so losing it costs twice.
     """
 
     def _forged_hint(self) -> dict[str, Any]:
@@ -816,23 +823,58 @@ class TestProvenanceSurvivesBatchStamping:
             reversible_params=self._forged_hint(),
         )
 
-    def test_provenance_survives_an_append_that_joins_a_batch(
+    def test_an_open_batch_does_not_capture_an_observed_change(
         self, tmp_path: Path
     ) -> None:
+        """The ordinary append path, with a batch open, on a hosted connector.
+
+        This is the route the polled importer does not take, and the one the
+        "imports never join a batch" rule used to miss.
+        """
         path = _write_state(tmp_path, {"tiktok_ads": "tt1"})
-        batch = begin_batch(path, label="monday exclusions")
+        begin_batch(path, label="monday exclusions")
         entry = self._external_entry()
 
         append_action_log(path, entry)
 
         stored = read_state_file(path).action_log[-1]
-        # It DID join the batch — this is the ordinary path, not the importer's.
-        assert stored.batch_id == batch.batch_id
-        # ...and joining cost it nothing.
+        assert stored.batch_id is None
+        # ...and staying out cost it nothing.
         assert stored.origin == EXTERNAL_ORIGIN
         assert stored.external_id == entry.external_id
         assert stored.occurred_at == entry.occurred_at
         assert stored.is_external
+
+    def test_an_operators_own_batch_stays_fully_revertible(
+        self, tmp_path: Path
+    ) -> None:
+        """The consequence an operator actually feels.
+
+        A reversible change of their own, recorded while an unrelated UI edit
+        was imported, must still report full coverage — the import is not
+        theirs and is no longer counted against them.
+        """
+        path = _write_state(tmp_path, {"tiktok_ads": "tt1", "google_ads": "111"})
+        batch = begin_batch(path, label="monday exclusions")
+        append_action_log(
+            path,
+            ActionLogEntry(
+                timestamp=NOW.isoformat(),
+                action="google_ads_campaigns_update_status",
+                platform="google_ads",
+                campaign_id="111",
+                reversible_params={
+                    "operation": "google_ads_campaigns_update_status",
+                    "params": {"campaign_id": "111", "status": "ENABLED"},
+                },
+            ),
+        )
+        append_action_log(path, self._external_entry())
+
+        plan = plan_batch_rollback(read_state_file(path), batch.batch_id)
+
+        assert plan.coverage.value == "full"
+        assert len(plan.apply_order) == 1
 
     def test_rollback_still_refuses_a_batch_stamped_external_entry(
         self, tmp_path: Path
@@ -849,14 +891,24 @@ class TestProvenanceSurvivesBatchStamping:
         assert plan.status is RollbackStatus.NOT_SUPPORTED
         assert "outside mureo" in plan.notes
 
-    def test_the_batch_plan_reports_it_as_a_gap(self, tmp_path: Path) -> None:
-        """A batch holding it must not read as fully revertible."""
+    def test_a_deliberately_backfilled_entry_is_still_a_gap(
+        self, tmp_path: Path
+    ) -> None:
+        """Declining the implicit join is not a way to hide an import.
+
+        An operator who deliberately records an observed change INTO a batch,
+        by naming its id, gets what they asked for — and the plan says the
+        batch cannot be fully reverted, because that member genuinely cannot.
+        """
         path = _write_state(tmp_path, {"tiktok_ads": "tt1"})
         batch = begin_batch(path, label="monday exclusions")
-        append_action_log(path, self._external_entry())
+        entry = replace(self._external_entry(), batch_id=batch.batch_id)
 
+        append_action_log(path, entry)
+
+        stored = read_state_file(path).action_log[-1]
+        assert stored.batch_id == batch.batch_id
         plan = plan_batch_rollback(read_state_file(path), batch.batch_id)
-
         assert plan.coverage.value == "none"
         assert plan.apply_order == ()
 
@@ -1145,6 +1197,138 @@ class TestChangeFeedAbi:
 
         with pytest.warns(ChangeFeedWarning):
             assert discover_change_feeds(refresh=True, loader=_boom) == ()
+
+
+@pytest.mark.unit
+class TestChangeFeedDiscoveryRejectsBadPlugins:
+    """Every way ``_collect_one`` can refuse an entry point, through discover().
+
+    This registry is deliberately modelled on ``mureo.analytics.registry`` so
+    plugin authors meet one set of rules, and that sibling pins each of these
+    refusals. The equivalents here were only ever reached by calling
+    ``register()`` directly, which skips ``_collect_one`` entirely — so the
+    load-isolation, not-a-class, not-instantiable, protocol-check, first-wins
+    and breadcrumb branches had no regression protection on the path a real
+    plugin actually takes.
+
+    Every case drives ``discover(loader=...)``, which is that path.
+    """
+
+    @staticmethod
+    def _ep(name: str, value: Any) -> Any:
+        class _EntryPoint:
+            def __init__(self) -> None:
+                self.name = name
+                self.dist = None
+
+            def load(self) -> Any:
+                return value
+
+        return _EntryPoint()
+
+    def _discover(self, *eps: Any) -> tuple[str, ...]:
+        return default_change_feed_registry().discover(
+            refresh=True, loader=lambda group: list(eps)
+        )
+
+    def test_an_entry_point_that_is_not_a_class_is_skipped(self) -> None:
+        with pytest.warns(ChangeFeedWarning, match="must yield a class"):
+            assert self._discover(self._ep("inst", _StubFeed("a_ads", None))) == ()
+        assert get_change_feed("a_ads") is None
+
+    def test_a_class_needing_constructor_arguments_is_skipped(self) -> None:
+        class _NeedsArgs:
+            platform = "a_ads"
+
+            def __init__(self, required: str) -> None:  # no no-arg form
+                self.required = required
+
+        with pytest.warns(ChangeFeedWarning, match="not instantiable"):
+            assert self._discover(self._ep("needsargs", _NeedsArgs)) == ()
+
+    def test_a_constructor_that_raises_is_isolated(self) -> None:
+        class _Explodes:
+            platform = "a_ads"
+
+            def __init__(self) -> None:
+                raise RuntimeError("boom")
+
+        with pytest.warns(ChangeFeedWarning, match="not instantiable"):
+            assert self._discover(self._ep("explodes", _Explodes)) == ()
+
+    def test_a_class_that_fails_the_protocol_check_is_skipped(self) -> None:
+        """Structurally close, but missing the method that does the work."""
+
+        class _NoFetch:
+            platform = "a_ads"
+
+        with pytest.warns(ChangeFeedWarning):
+            assert self._discover(self._ep("nofetch", _NoFetch)) == ()
+        assert get_change_feed("a_ads") is None
+
+    def test_one_bad_plugin_does_not_cost_a_good_one(self) -> None:
+        """Fault isolation is per entry point, not per group."""
+
+        class _Good:
+            platform = "good_ads"
+
+            async def fetch_change_events(self, **kwargs: Any) -> ChangeFeedResult:
+                return ChangeFeedResult(changes=())
+
+        class _Bad:
+            platform = "bad_ads"
+
+        with pytest.warns(ChangeFeedWarning):
+            registered = self._discover(self._ep("bad", _Bad), self._ep("good", _Good))
+        assert registered == ("good_ads",)
+        assert get_change_feed("good_ads") is not None
+
+    def test_first_plugin_wins_a_platform_collision(self) -> None:
+        class _First:
+            platform = "dup_ads"
+
+            async def fetch_change_events(self, **kwargs: Any) -> ChangeFeedResult:
+                return ChangeFeedResult(changes=())
+
+        class _Second(_First):
+            pass
+
+        with pytest.warns(ChangeFeedWarning, match="already registered"):
+            registered = self._discover(
+                self._ep("first", _First), self._ep("second", _Second)
+            )
+        assert registered == ("dup_ads",)
+        assert isinstance(get_change_feed("dup_ads"), _First)
+        assert not isinstance(get_change_feed("dup_ads"), _Second)
+
+    def test_the_source_distribution_breadcrumb_is_recorded(self) -> None:
+        """``plugin_source`` is public and had no test at all.
+
+        It is how an operator finds out which pip package supplied a feed
+        that reported something odd, so an empty answer is a support problem.
+        """
+
+        class _Dist:
+            name = "acme-mureo-plugin"
+
+        class _Feed:
+            platform = "acme_ads"
+
+            async def fetch_change_events(self, **kwargs: Any) -> ChangeFeedResult:
+                return ChangeFeedResult(changes=())
+
+        ep = self._ep("acme", _Feed)
+        ep.dist = _Dist()
+
+        assert self._discover(ep) == ("acme_ads",)
+        feed = get_change_feed("acme_ads")
+        assert feed is not None
+        assert plugin_source(feed) == "acme-mureo-plugin"
+
+    def test_a_feed_registered_by_hand_reports_no_distribution(self) -> None:
+        feed = _StubFeed("hand_ads", ChangeFeedResult(changes=()))
+        register_change_feed(feed)
+        assert plugin_source(feed) == ""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_change_import.py
+++ b/tests/test_change_import.py
@@ -876,10 +876,16 @@ class TestProvenanceSurvivesBatchStamping:
         assert plan.coverage.value == "full"
         assert len(plan.apply_order) == 1
 
-    def test_rollback_still_refuses_a_batch_stamped_external_entry(
+    def test_rollback_refuses_an_external_entry_whether_batched_or_not(
         self, tmp_path: Path
     ) -> None:
-        """The consequence, asserted where an operator would feel it."""
+        """The refusal does not depend on the batch, and never did.
+
+        The name used to say "batch stamped", from when an observed change
+        recorded through this path acquired the open batch. It no longer
+        does, and the refusal is unaffected either way: ``plan_rollback``
+        keys on ``is_external``, not on membership.
+        """
         path = _write_state(tmp_path, {"tiktok_ads": "tt1"})
         begin_batch(path, label="monday exclusions")
 


### PR DESCRIPTION
Both findings come from a post-merge review of #575, which was merged without the usual review gate. Neither is a correctness bug — no plan ever over-promised — so this is not urgent, but both are worth closing while the context is fresh.

## 1. An observed change no longer joins the operator's open batch

`docs/change-import.md` states the rule without qualification:

> An imported change is never stamped with the open batch id (#549). A batch is the operator's declared change set — "what I did on Monday" — and a change mureo merely observed is by definition not something they did through mureo.

It was enforced in exactly one place: the polled importer, which opts out by hand with `join_active_batch=False`. The hosted-connector route — an agent recording what it read from a connector mureo cannot poll, through `mureo_state_action_log_append`, which the docs name as the way to do it — went through the default path and was stamped with whatever batch happened to be open.

**Nothing dishonest came of it.** `plan_rollback` still refused the entry, and the batch still reported the coverage gap. What it cost was sense: an operator's fully-reversible Monday cleanup could report `partial` because an unrelated UI edit was imported while the batch was open. A coverage verdict that moves for a reason unrelated to the operator's own work is one they learn to ignore, and the point of #549 is that they should not have to.

### Where the fix lives, and why that matters more than the fix

In `stamp_batch`, beside the membership decision — not in the handler.

That placement is #549's own argument for membership itself: the decision sits at the one point every recording path converges on, so no caller has to know batches exist. Fixing this in the handler would have worked today and left the next recording path to rediscover the same gap.

An explicit `batch_id` still wins, above the new check, and is still validated by `ensure_joinable`. A deliberate backfill into its own declared batch stays possible — and a test pins that such a batch still reports `none` coverage, because that member genuinely cannot be reverted. Declining the implicit join is not a way to hide an import.

### Three tests changed premise rather than being deleted

The behaviour they pinned is the behaviour being changed, so each was rewritten to pin the new rule and the reason for it:

- The append-with-open-batch case now asserts the entry stays **out**, and still asserts the provenance survives — losing `origin` now costs twice, since it is both what refuses the rollback and what keeps the entry out of the batch.
- The batch-plan case is replaced by the one an operator actually feels: their own reversible change reports `full` coverage even though an import landed during the batch. The deliberate-backfill case above covers the other direction.
- The field-preservation tests are driven off an entry mureo made, because an observed one no longer reaches `stamp_batch`'s rewrite at all. Left as they were, they would have asserted on a path the entry no longer takes and passed for the wrong reason.

## 2. The change-feed registry's discovery paths now have tests

`mureo/change_import/registry.py` is deliberately modelled on `mureo.analytics.registry` so plugin authors meet one set of rules, and the sibling pins every way an entry point can be refused. Here those branches were only ever reached by calling `register()` directly, which skips `_collect_one` entirely — so the path a real plugin actually takes had no regression protection.

Each refusal now goes through `discover(loader=...)`: not-a-class, not instantiable with no arguments, a constructor that raises, failing the protocol check, first-wins on a platform collision, one bad plugin not costing a good one, and the source-distribution breadcrumb. `plugin_source` is public, is how an operator finds out which pip package supplied a feed that reported something odd, and had no test at all.

Coverage of `registry.py`: **74% → 91%**, with the previously unreached `_collect_one` body now exercised.

## Verification

- `tests/test_change_import.py`, `tests/test_batch_revertible_unit.py`, `tests/test_mcp_tools_mureo_context.py`, `tests/test_rollback.py` — all pass.
- Full suite: 8697 passed, no regressions beyond the 12 tests that fail on any machine with provider plugins installed and no live credentials.
- `ruff`, `black`, `mypy` clean.
