### PR TITLE
fix: resolve Google Ads enums to their name, not their number

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ mureo/
 ├── google_ads/          # Google Ads API client (Mixin composition)
 │   ├── client.py        # GoogleAdsApiClient (main entry)
 │   ├── mappers.py       # Response mapping to structured dicts
+│   ├── _enum_names.py   # map_enum_name + SDK-derived int->name maps (raw protobuf has no .name, #588)
 │   ├── _placement_mappers.py # Negative-placement + group_placement_view row mappers (#544/#547)
 │   ├── _ads.py          # AdsMixin (RSA create/update/status/list)
 │   ├── _ads_display.py  # DisplayAdsMixin (RDA create + RDAUploadError)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,127 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Google Ads enum fields emitted the raw number, not the name every
+  consumer keys on** (#588). Twenty reads across the row mappers, the
+  campaign diagnostic, the bid-adjustment and ad-schedule listings, the
+  placement-performance view, the RSA asset analysis, the device analysis and
+  the keyword-suggestion tool stringified an enum
+  field with a bare `str()`. mureo
+  builds its client with the SDK default `use_proto_plus=False`, so the SDK's
+  response interceptor converts every row to raw protobuf before a mapper sees
+  it — and on raw protobuf an enum field is a plain `int` with no `.name`.
+  Every one of those reads therefore emitted `"2"`, on every Python version.
+  They now emit `"AD"`, so **the observable output of these fields changes**:
+  `change_resource_type`, `resource_change_operation` and `client_type` on
+  `google_ads_change_history_list`, the conversion-action `type` and
+  `category`, the conversion tag-snippet `type`, the recommendation `type`,
+  the `match_type` of both the keyword and the negative-keyword mapper,
+  the criterion `type` on `google_ads_bid_adjustments_get`, the
+  `placement_type` — with the `type` derived from it — on every
+  `group_placement_view` row, the `day_of_week`, `start_minute` and
+  `end_minute` of `google_ads_schedule_targeting_list`, the `device_type` of
+  `google_ads_device_analyze`, the `competition` of
+  `google_ads_keywords_suggest`, and the `performance_label` of
+  `google_ads_rsa_assets_analyze` / `_audit`.
+
+  The cost was not cosmetic, and everywhere but the third bullet it was
+  silent:
+
+  - `change_import` classifies a change by exact match on that string —
+    `_RESOURCE_KINDS`, `_AD_LEVEL_RESOURCE_TYPES`, `_CRITERION_RESOURCE_TYPES`
+    and `_OPERATION_ALIASES` all key on names like `"AD"` — so **the
+    classification had never worked**. Every imported external change fell
+    through to kind `""` and lost its ad-level identity, with no exception
+    raised and nothing logged, and the dedupe that keys on the kind stopped
+    matching with it.
+  - Keyword match types were mis-comparing the same way: `_analysis_keywords`
+    tests `match_type == "BROAD"` / `== "PHRASE"` and
+    `exclusion_impact.matching` tests `== "EXACT"` / `== "PHRASE"`, and `"2"`
+    equals none of them.
+  - The adapter boundary did not fail silently, it failed loudly: the
+    Google Ads provider adapter coerces `match_type` against
+    `{EXACT, PHRASE, BROAD}` and raises otherwise, so every live
+    `list_keywords` through it raised `ValueError: unknown keyword
+    match_type: '2'`.
+  - The rarely-served-keyword warning in `campaigns.diagnose` was dead code:
+    it tests `"RARELY_SERVED" in str(system_serving_status)` against `"3"`,
+    so a live account could never trigger it.
+  - Placement-attributed delivery was always empty. The `type` of a
+    `group_placement_view` row is derived from `placement_type`, and
+    `exclusion_sources` tests it for membership of
+    `{website, mobile_application}` before a row can be attributed — a digit
+    string is in neither, so **no placement row was ever attributable**. Both
+    the exclusion-impact preview (#547) and the delivery-collapse diagnosis
+    (#572) read that basis, and both saw nothing, with no exception raised and
+    nothing logged.
+  - **RSA asset analysis returned nothing, and always had.**
+    `google_ads_rsa_assets_analyze` sorts each asset into `headlines` or
+    `descriptions` by `field_type == "HEADLINE"` / `== "DESCRIPTION"`, which
+    `"2"` and `"3"` never satisfied, so both lists came back empty for every
+    live account — and with them `best_headlines`, `worst_headlines` and the
+    whole of `google_ads_rsa_assets_audit`, which reads them. The tool
+    answered "asset-level performance data has not yet been accumulated" to
+    accounts with years of it. The `performance_label == "BEST"` and
+    `in ("LOW", "POOR")` filters could not have matched either.
+  - Device analysis named devices by number, and could not find the desktop.
+    `google_ads_device_analyze` wrote insights like `"2 has 0 conversions
+    with 40000 yen in cost"`. Its mobile-vs-desktop CTR comparison fared
+    worse: the digit fallbacks written beside the names found mobile under
+    `"2"` but looked for desktop under `"1"` — DESKTOP is `4`, `1` is
+    UNKNOWN — so that comparison could never fire. Those fallbacks are
+    deleted rather than corrected: they existed only to paper over the
+    unresolved enum.
+  - Four tool contracts documented the name and shipped the number: the
+    `google_ads_bid_adjustments_get` description promises `type` as a
+    "CriterionType enum string, e.g. 'DEVICE'" and returned `"6"`;
+    `google_ads_change_history_list` promises `change_resource_type` as an
+    enum string; `google_ads_keywords_suggest` promises
+    `competition (LOW / MEDIUM / HIGH)` and shipped `"2"` / `"3"` / `"4"`;
+    and `google_ads_schedule_targeting_list` promises `day_of_week` as "the
+    string form of the DayOfWeek enum, e.g. 'MONDAY'..'SUNDAY'" and
+    `start_minute` / `end_minute` as `'ZERO'`, `'FIFTEEN'`, `'THIRTY'` or
+    `'FORTY_FIVE'` — the day it returned as `"2"` is also the spelling
+    `google_ads_schedule_targeting_update` takes back, so a read could not be
+    round-tripped into a write. The descriptions were right; the code was not.
+
+  The reads now resolve through the existing `map_enum_name(value, mapping)`,
+  against maps derived from the vendored SDK enums rather than transcribed, so
+  they cannot go stale against the API version. Resolver and maps moved
+  together into `mureo/google_ads/_enum_names.py`, because `mappers.py` is at
+  the 800-line budget a test enforces on it. It resolves the raw `int` through
+  the mapping and never reads `.name` off the value — a `MagicMock` answers
+  `.name` with a truthy stand-in, which is how a `.name`-based reading of this
+  bug looked correct while changing nothing. Every fixed surface gained a test
+  driven through
+  `convert_proto_plus_to_protobuf`, the shape the interceptor really
+  delivers, beside the mock-driven test that had been masking it; the mapper
+  assertions are parametrized across the proto-plus shape as well, so a future
+  flip of `use_proto_plus` cannot silently break them either.
+
+  `map_keyword` is fixed alongside its sibling `map_negative_keyword` — they
+  read the same `KeywordMatchType` off the same proto, so fixing one alone
+  would have introduced a fresh inconsistency — and a test pins the two to the
+  same spelling for every member of the enum, in both shapes.
+
+  Two reads that were already right are consolidated onto the same resolver
+  rather than left as the only two of their kind: the keyword system-serving
+  status, which carried its own hand-transcribed map, and the
+  network-performance ad-network type, whose hardcoded digit fallbacks
+  happened to be correct. So are the hand-written match-type and
+  criterion-status maps the keyword analysis reads, which are now aliases of
+  the SDK-derived ones. That makes twenty-three `map_enum_name` call sites in
+  total: the twenty broken reads, plus one because the criterion-type read
+  spends a call on each branch of its ternary, plus those two.
+
+  The count above is twenty because the first pass found thirteen and a
+  descriptor sweep of the whole package then found seven more. There is no
+  third pass: `tests/test_google_ads_enum_reads.py` extracts every
+  `str(<attribute chain>)` under `mureo/google_ads/`, resolves the chain
+  against the vendored v23 descriptors, and fails on any that lands on a
+  `TYPE_ENUM` field. Its subject-to-message bindings are asserted against the
+  sweep in both directions, so a new subject forces a decision and a departed
+  one cannot linger, and its extraction is pinned against an independent
+  tokenizer count so it cannot decay into a green no-op.
 - **A read written mureo's own way is now recognised as a read, in the one
   place that can safely act on it** (#549 follow-up). mureo's tools put the
   verb LAST (`google_ads_campaigns_list`); the shared read vocabulary only

--- a/mureo/google_ads/_analysis_auction.py
+++ b/mureo/google_ads/_analysis_auction.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
+from mureo.google_ads._enum_names import DEVICE_MAP, map_enum_name
+
 if TYPE_CHECKING:
     from google.ads.googleads.client import GoogleAdsClient
 
@@ -72,7 +74,7 @@ class _AuctionAnalysisMixin:
 
         devices: list[dict[str, Any]] = []
         for row in rows:
-            device_type = str(row.segments.device).split(".")[-1]
+            device_type = map_enum_name(row.segments.device, DEVICE_MAP)
             cost = float(row.metrics.cost_micros) / 1_000_000
             conversions = float(row.metrics.conversions)
             cpa = round(cost / conversions, 0) if conversions > 0 else None
@@ -136,11 +138,12 @@ class _AuctionAnalysisMixin:
                         f"Consider lowering bid adjustments for {worst['device_type']}."
                     )
 
-        # Mobile vs Desktop CTR comparison
-        mobile = next((d for d in devices if d["device_type"] in ("MOBILE", "2")), None)
-        desktop = next(
-            (d for d in devices if d["device_type"] in ("DESKTOP", "1")), None
-        )
+        # Mobile vs Desktop CTR comparison. The digit fallbacks these two
+        # lookups used to carry ("2" for mobile, "1" for desktop) existed only
+        # to paper over the unresolved enum above, and the desktop one was
+        # wrong anyway — DESKTOP is 4, 1 is UNKNOWN (#588).
+        mobile = next((d for d in devices if d["device_type"] == "MOBILE"), None)
+        desktop = next((d for d in devices if d["device_type"] == "DESKTOP"), None)
         if mobile and desktop and desktop["ctr"] > 0:
             ctr_ratio = mobile["ctr"] / desktop["ctr"]
             if ctr_ratio < 0.5:

--- a/mureo/google_ads/_analysis_constants.py
+++ b/mureo/google_ads/_analysis_constants.py
@@ -6,6 +6,9 @@ import logging
 from datetime import date, timedelta
 from typing import Any
 
+from mureo.google_ads._enum_names import KEYWORD_MATCH_TYPE_MAP
+from mureo.google_ads.mappers import AD_GROUP_CRITERION_STATUS_MAP
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -20,23 +23,15 @@ _PERIOD_DAYS: dict[str, int] = {
 
 # ---------------------------------------------------------------------------
 # Common mapping constants (eliminate duplicate definitions)
+#
+# Both were transcribed by hand and both happened to be right; they are now
+# aliases of the SDK-derived maps so they cannot drift from the API version
+# (#588). The names are kept because the analysis modules read them.
 # ---------------------------------------------------------------------------
 
-_MATCH_TYPE_MAP: dict[int, str] = {
-    0: "UNSPECIFIED",
-    1: "UNKNOWN",
-    2: "EXACT",
-    3: "PHRASE",
-    4: "BROAD",
-}
+_MATCH_TYPE_MAP: dict[int, str] = KEYWORD_MATCH_TYPE_MAP
 
-_STATUS_MAP: dict[int, str] = {
-    0: "UNSPECIFIED",
-    1: "UNKNOWN",
-    2: "ENABLED",
-    3: "PAUSED",
-    4: "REMOVED",
-}
+_STATUS_MAP: dict[int, str] = AD_GROUP_CRITERION_STATUS_MAP
 
 # ---------------------------------------------------------------------------
 # Informational query patterns. Japanese tokens that signal informational

--- a/mureo/google_ads/_analysis_rsa.py
+++ b/mureo/google_ads/_analysis_rsa.py
@@ -5,6 +5,12 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
+from mureo.google_ads._enum_names import (
+    ASSET_FIELD_TYPE_MAP,
+    ASSET_PERFORMANCE_LABEL_MAP,
+    map_enum_name,
+)
+
 if TYPE_CHECKING:
     from google.ads.googleads.client import GoogleAdsClient
 
@@ -62,9 +68,18 @@ class _RsaAnalysisMixin:
         for row in response:
             view = row.ad_group_ad_asset_view
             asset_text = row.asset.text_asset.text if row.asset.text_asset else ""
-            field_type = str(view.field_type).split(".")[-1] if view.field_type else ""
+            # The falsiness guards are kept deliberately: on raw protobuf an
+            # unset enum field is the int 0 (UNSPECIFIED), and these two
+            # fallbacks — "" for a field type that names no slot, "UNKNOWN"
+            # for the label bucket the audit's learning heuristic counts —
+            # are the answers the rest of this module is written against.
+            field_type = (
+                map_enum_name(view.field_type, ASSET_FIELD_TYPE_MAP)
+                if view.field_type
+                else ""
+            )
             perf_label = (
-                str(view.performance_label).split(".")[-1]
+                map_enum_name(view.performance_label, ASSET_PERFORMANCE_LABEL_MAP)
                 if view.performance_label
                 else "UNKNOWN"
             )

--- a/mureo/google_ads/_diagnostics.py
+++ b/mureo/google_ads/_diagnostics.py
@@ -4,6 +4,11 @@ import logging
 from datetime import date
 from typing import TYPE_CHECKING, Any
 
+from mureo.google_ads._enum_names import (
+    CRITERION_SYSTEM_SERVING_STATUS_MAP,
+    KEYWORD_MATCH_TYPE_MAP,
+    map_enum_name,
+)
 from mureo.google_ads.mappers import (
     map_ad_type,
     map_approval_status,
@@ -324,15 +329,22 @@ class _DiagnosticsMixin:
         for row in kw_response:
             kw = row.ad_group_criterion
             approval = map_criterion_approval_status(kw.approval_status)
+            # Both enums arrive as plain ints on the raw-protobuf path this
+            # client runs on, so ``str()`` gave "3" and the RARELY_SERVED test
+            # below could never fire — the warning was dead code (#588).
             sys_status = (
-                str(kw.system_serving_status)
+                map_enum_name(
+                    kw.system_serving_status, CRITERION_SYSTEM_SERVING_STATUS_MAP
+                )
                 if hasattr(kw, "system_serving_status")
                 else ""
             )
             enabled_kws.append(
                 {
                     "text": kw.keyword.text,
-                    "match_type": str(kw.keyword.match_type),
+                    "match_type": map_enum_name(
+                        kw.keyword.match_type, KEYWORD_MATCH_TYPE_MAP
+                    ),
                     "approval_status": approval,
                     "system_serving_status": sys_status,
                 }

--- a/mureo/google_ads/_enum_names.py
+++ b/mureo/google_ads/_enum_names.py
@@ -1,0 +1,153 @@
+"""Enum-name resolution: the one resolver and the SDK-derived maps it reads.
+
+mureo builds its Google Ads client with the SDK default
+``use_proto_plus=False`` (``GoogleAdsClient(...)`` in
+:mod:`mureo.google_ads.client` passes no such argument), so the SDK's response
+interceptor converts every row to raw protobuf before a mapper sees it and an
+enum field arrives as a plain ``int`` with no ``.name``. A bare ``str()`` on
+that field yields "2", which no consumer keys on; ``map_enum_name`` recovers
+the API spelling from these maps (#588).
+
+Every map is derived from the vendored SDK enum rather than transcribed by
+hand, so it cannot go stale against the API version. The maps that predate
+#588 still live beside their mappers in :mod:`mureo.google_ads.mappers`, which
+is at its 800-line budget; new ones belong here.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from google.ads.googleads.v23.enums.types.ad_network_type import AdNetworkTypeEnum
+from google.ads.googleads.v23.enums.types.asset_field_type import AssetFieldTypeEnum
+from google.ads.googleads.v23.enums.types.asset_performance_label import (
+    AssetPerformanceLabelEnum,
+)
+from google.ads.googleads.v23.enums.types.change_client_type import ChangeClientTypeEnum
+from google.ads.googleads.v23.enums.types.change_event_resource_type import (
+    ChangeEventResourceTypeEnum,
+)
+from google.ads.googleads.v23.enums.types.conversion_action_category import (
+    ConversionActionCategoryEnum,
+)
+from google.ads.googleads.v23.enums.types.conversion_action_type import (
+    ConversionActionTypeEnum,
+)
+from google.ads.googleads.v23.enums.types.criterion_system_serving_status import (
+    CriterionSystemServingStatusEnum,
+)
+from google.ads.googleads.v23.enums.types.day_of_week import DayOfWeekEnum
+from google.ads.googleads.v23.enums.types.device import DeviceEnum
+from google.ads.googleads.v23.enums.types.keyword_match_type import (
+    KeywordMatchTypeEnum,
+)
+from google.ads.googleads.v23.enums.types.keyword_plan_competition_level import (
+    KeywordPlanCompetitionLevelEnum,
+)
+from google.ads.googleads.v23.enums.types.minute_of_hour import MinuteOfHourEnum
+from google.ads.googleads.v23.enums.types.placement_type import PlacementTypeEnum
+from google.ads.googleads.v23.enums.types.recommendation_type import (
+    RecommendationTypeEnum,
+)
+from google.ads.googleads.v23.enums.types.resource_change_operation import (
+    ResourceChangeOperationEnum,
+)
+from google.ads.googleads.v23.enums.types.tracking_code_type import (
+    TrackingCodeTypeEnum,
+)
+
+
+def map_enum_name(value: Any, mapping: dict[int, str]) -> str:
+    """Convert a proto enum value to its bare name, whatever its shape.
+
+    Handles every representation the google-ads client can produce:
+    raw protobuf ints (use_proto_plus=False — the production path),
+    proto-plus members stringifying as 'EnumClass.NAME' (Python <= 3.10),
+    and members stringifying as the bare number (IntEnum on Python 3.11+).
+
+    The name is never read off the value: a proto-plus member *is* an ``int``,
+    so the mapping resolves it too, and ``getattr(value, "name", None)`` would
+    answer with a truthy stand-in for any ``MagicMock`` a test hands in (#588).
+    """
+    if isinstance(value, int) and not isinstance(value, bool):
+        return mapping.get(value, str(value))
+    s = str(value)
+    if s.isdigit():
+        return mapping.get(int(s), s)
+    return s.rsplit(".", 1)[-1]
+
+
+KEYWORD_MATCH_TYPE_MAP: dict[int, str] = {
+    member.value: member.name for member in KeywordMatchTypeEnum.KeywordMatchType  # type: ignore[attr-defined]
+}
+
+CONVERSION_ACTION_TYPE_MAP: dict[int, str] = {
+    member.value: member.name
+    for member in ConversionActionTypeEnum.ConversionActionType  # type: ignore[attr-defined]
+}
+
+CONVERSION_ACTION_CATEGORY_MAP: dict[int, str] = {
+    member.value: member.name
+    for member in ConversionActionCategoryEnum.ConversionActionCategory  # type: ignore[attr-defined]
+}
+
+TRACKING_CODE_TYPE_MAP: dict[int, str] = {
+    member.value: member.name for member in TrackingCodeTypeEnum.TrackingCodeType  # type: ignore[attr-defined]
+}
+
+RECOMMENDATION_TYPE_MAP: dict[int, str] = {
+    member.value: member.name for member in RecommendationTypeEnum.RecommendationType  # type: ignore[attr-defined]
+}
+
+CHANGE_EVENT_RESOURCE_TYPE_MAP: dict[int, str] = {
+    member.value: member.name
+    for member in ChangeEventResourceTypeEnum.ChangeEventResourceType  # type: ignore[attr-defined]
+}
+
+RESOURCE_CHANGE_OPERATION_MAP: dict[int, str] = {
+    member.value: member.name
+    for member in ResourceChangeOperationEnum.ResourceChangeOperation  # type: ignore[attr-defined]
+}
+
+CHANGE_CLIENT_TYPE_MAP: dict[int, str] = {
+    member.value: member.name for member in ChangeClientTypeEnum.ChangeClientType  # type: ignore[attr-defined]
+}
+
+CRITERION_SYSTEM_SERVING_STATUS_MAP: dict[int, str] = {
+    member.value: member.name
+    for member in CriterionSystemServingStatusEnum.CriterionSystemServingStatus  # type: ignore[attr-defined]
+}
+
+PLACEMENT_TYPE_MAP: dict[int, str] = {
+    member.value: member.name for member in PlacementTypeEnum.PlacementType  # type: ignore[attr-defined]
+}
+
+ASSET_FIELD_TYPE_MAP: dict[int, str] = {
+    member.value: member.name for member in AssetFieldTypeEnum.AssetFieldType  # type: ignore[attr-defined]
+}
+
+ASSET_PERFORMANCE_LABEL_MAP: dict[int, str] = {
+    member.value: member.name
+    for member in AssetPerformanceLabelEnum.AssetPerformanceLabel  # type: ignore[attr-defined]
+}
+
+DEVICE_MAP: dict[int, str] = {
+    member.value: member.name for member in DeviceEnum.Device  # type: ignore[attr-defined]
+}
+
+KEYWORD_PLAN_COMPETITION_LEVEL_MAP: dict[int, str] = {
+    member.value: member.name
+    for member in KeywordPlanCompetitionLevelEnum.KeywordPlanCompetitionLevel  # type: ignore[attr-defined]
+}
+
+DAY_OF_WEEK_MAP: dict[int, str] = {
+    member.value: member.name for member in DayOfWeekEnum.DayOfWeek  # type: ignore[attr-defined]
+}
+
+MINUTE_OF_HOUR_MAP: dict[int, str] = {
+    member.value: member.name for member in MinuteOfHourEnum.MinuteOfHour  # type: ignore[attr-defined]
+}
+
+AD_NETWORK_TYPE_MAP: dict[int, str] = {
+    member.value: member.name for member in AdNetworkTypeEnum.AdNetworkType  # type: ignore[attr-defined]
+}

--- a/mureo/google_ads/_extensions_targeting.py
+++ b/mureo/google_ads/_extensions_targeting.py
@@ -14,6 +14,11 @@ from typing import TYPE_CHECKING, Any
 
 from google.protobuf.field_mask_pb2 import FieldMask as PbFieldMask
 
+from mureo.google_ads._enum_names import (
+    DAY_OF_WEEK_MAP,
+    MINUTE_OF_HOUR_MAP,
+    map_enum_name,
+)
 from mureo.google_ads.client import _wrap_mutate_error
 from mureo.google_ads.mappers import (
     AD_GROUP_CRITERION_STATUS_MAP,
@@ -23,7 +28,6 @@ from mureo.google_ads.mappers import (
     INCOME_RANGE_TYPE_MAP,
     PARENTAL_STATUS_TYPE_MAP,
     map_change_event,
-    map_enum_name,
     map_recommendation,
 )
 
@@ -470,10 +474,14 @@ class _TargetingMixin:
         return [
             {
                 "criterion_id": str(row.campaign_criterion.criterion_id),
+                # The criterion type arrives as a plain int on the raw-protobuf
+                # path this client runs on, so ``str()`` returned "6" where the
+                # tool contract promises "DEVICE" (#588). The ``type_``/``type``
+                # fallback stays: it covers the proto-plus naming difference.
                 "type": (
-                    str(row.campaign_criterion.type_)
+                    map_enum_name(row.campaign_criterion.type_, CRITERION_TYPE_MAP)
                     if hasattr(row.campaign_criterion, "type_")
-                    else str(row.campaign_criterion.type)
+                    else map_enum_name(row.campaign_criterion.type, CRITERION_TYPE_MAP)
                 ),
                 "bid_modifier": float(row.campaign_criterion.bid_modifier),
                 "device_type": (
@@ -673,11 +681,17 @@ class _TargetingMixin:
         return [
             {
                 "criterion_id": str(row.campaign_criterion.criterion_id),
-                "day_of_week": str(row.campaign_criterion.ad_schedule.day_of_week),
+                "day_of_week": map_enum_name(
+                    row.campaign_criterion.ad_schedule.day_of_week, DAY_OF_WEEK_MAP
+                ),
                 "start_hour": int(row.campaign_criterion.ad_schedule.start_hour),
                 "end_hour": int(row.campaign_criterion.ad_schedule.end_hour),
-                "start_minute": str(row.campaign_criterion.ad_schedule.start_minute),
-                "end_minute": str(row.campaign_criterion.ad_schedule.end_minute),
+                "start_minute": map_enum_name(
+                    row.campaign_criterion.ad_schedule.start_minute, MINUTE_OF_HOUR_MAP
+                ),
+                "end_minute": map_enum_name(
+                    row.campaign_criterion.ad_schedule.end_minute, MINUTE_OF_HOUR_MAP
+                ),
                 "bid_modifier": (
                     float(row.campaign_criterion.bid_modifier)
                     if hasattr(row.campaign_criterion, "bid_modifier")

--- a/mureo/google_ads/_keywords.py
+++ b/mureo/google_ads/_keywords.py
@@ -13,6 +13,10 @@ from typing import TYPE_CHECKING, Any
 from google.ads.googleads.errors import GoogleAdsException
 from google.protobuf.field_mask_pb2 import FieldMask as PbFieldMask
 
+from mureo.google_ads._enum_names import (
+    KEYWORD_PLAN_COMPETITION_LEVEL_MAP,
+    map_enum_name,
+)
 from mureo.google_ads.client import _wrap_mutate_error
 from mureo.google_ads.mappers import (
     map_keyword,
@@ -343,7 +347,10 @@ class _KeywordsMixin:
             {
                 "keyword": idea.text,
                 "avg_monthly_searches": idea.keyword_idea_metrics.avg_monthly_searches,
-                "competition": str(idea.keyword_idea_metrics.competition),
+                "competition": map_enum_name(
+                    idea.keyword_idea_metrics.competition,
+                    KEYWORD_PLAN_COMPETITION_LEVEL_MAP,
+                ),
             }
             for idea in response.results[:20]
         ]

--- a/mureo/google_ads/_media.py
+++ b/mureo/google_ads/_media.py
@@ -10,7 +10,8 @@ import logging
 from typing import Any
 
 from mureo._image_validation import validate_image_file
-from mureo.google_ads.mappers import ASSET_TYPE_MAP, MIME_TYPE_MAP, map_enum_name
+from mureo.google_ads._enum_names import map_enum_name
+from mureo.google_ads.mappers import ASSET_TYPE_MAP, MIME_TYPE_MAP
 
 logger = logging.getLogger(__name__)
 

--- a/mureo/google_ads/_placement_mappers.py
+++ b/mureo/google_ads/_placement_mappers.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from mureo.google_ads._enum_names import PLACEMENT_TYPE_MAP, map_enum_name
 from mureo.google_ads.mappers import (
     CRITERION_TYPE_MAP,
     _HasIdAndName,
@@ -29,7 +30,6 @@ from mureo.google_ads.mappers import (
     _safe_float,
     _safe_int,
     _safe_str,
-    map_enum_name,
 )
 
 # === Negative Placements (delivery-surface exclusions, #544) ===
@@ -107,7 +107,9 @@ def map_placement_performance(row: Any) -> dict[str, Any]:
     """
     view = row.group_placement_view if hasattr(row, "group_placement_view") else row
     metrics = row.metrics if hasattr(row, "metrics") else row
-    raw_type = str(getattr(view, "placement_type", "")).rsplit(".", 1)[-1].upper()
+    raw_type = map_enum_name(
+        getattr(view, "placement_type", ""), PLACEMENT_TYPE_MAP
+    ).upper()
     return {
         "placement": _safe_str(view, "placement"),
         "display_name": _safe_str(view, "display_name"),

--- a/mureo/google_ads/client.py
+++ b/mureo/google_ads/client.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
 from mureo.google_ads._analysis import _AnalysisMixin
 from mureo.google_ads._creative import _CreativeMixin
 from mureo.google_ads._diagnostics import _DiagnosticsMixin
+from mureo.google_ads._enum_names import AD_NETWORK_TYPE_MAP, map_enum_name
 from mureo.google_ads._gaql_validator import (
     escape_string_literal as _gaql_escape_string_literal,
 )
@@ -43,7 +44,6 @@ from mureo.google_ads.mappers import (
     map_bidding_strategy_type,
     map_campaign,
     map_entity_status,
-    map_enum_name,
     map_performance_report,
 )
 
@@ -1091,11 +1091,11 @@ class GoogleAdsApiClient(  # type: ignore[misc]
 
         results: list[dict[str, Any]] = []
         for row in response:
-            network_type = str(row.segments.ad_network_type).replace(
-                "AdNetworkType.", ""
+            network_type = map_enum_name(
+                row.segments.ad_network_type, AD_NETWORK_TYPE_MAP
             )
             # SEARCH = Google Search, SEARCH_PARTNERS = Search Partners, skip others
-            if network_type not in ("SEARCH", "SEARCH_PARTNERS", "2", "3"):
+            if network_type not in ("SEARCH", "SEARCH_PARTNERS"):
                 continue
             cost_micros = row.metrics.cost_micros
             conversions = float(row.metrics.conversions)
@@ -1105,14 +1105,10 @@ class GoogleAdsApiClient(  # type: ignore[misc]
                 {
                     "campaign_id": str(row.campaign.id),
                     "campaign_name": str(row.campaign.name),
-                    "network_type": (
-                        "SEARCH"
-                        if network_type in ("SEARCH", "2")
-                        else "SEARCH_PARTNERS"
-                    ),
+                    "network_type": network_type,
                     "network_label": (
                         "Google Search"
-                        if network_type in ("SEARCH", "2")
+                        if network_type == "SEARCH"
                         else "Search Partners"
                     ),
                     "impressions": int(row.metrics.impressions),

--- a/mureo/google_ads/mappers.py
+++ b/mureo/google_ads/mappers.py
@@ -42,6 +42,19 @@ from google.ads.googleads.v23.enums.types.policy_topic_entry_type import (
     PolicyTopicEntryTypeEnum,
 )
 
+from mureo.google_ads._enum_names import (
+    CHANGE_CLIENT_TYPE_MAP,
+    CHANGE_EVENT_RESOURCE_TYPE_MAP,
+    CONVERSION_ACTION_CATEGORY_MAP,
+    CONVERSION_ACTION_TYPE_MAP,
+    CRITERION_SYSTEM_SERVING_STATUS_MAP,
+    KEYWORD_MATCH_TYPE_MAP,
+    RECOMMENDATION_TYPE_MAP,
+    RESOURCE_CHANGE_OPERATION_MAP,
+    TRACKING_CODE_TYPE_MAP,
+    map_enum_name,
+)
+
 
 class _HasIdAndName(Protocol):
     id: int
@@ -213,22 +226,6 @@ def _map_enum(value: Any, mapping: dict[int, str]) -> str:
     if isinstance(value, int):
         return mapping.get(value, str(value))
     return str(value)
-
-
-def map_enum_name(value: Any, mapping: dict[int, str]) -> str:
-    """Convert a proto enum value to its bare name, whatever its shape.
-
-    Handles every representation the google-ads client can produce:
-    raw protobuf ints (use_proto_plus=False — the production path),
-    proto-plus members stringifying as 'EnumClass.NAME' (Python <= 3.10),
-    and members stringifying as the bare number (IntEnum on Python 3.11+).
-    """
-    if isinstance(value, int) and not isinstance(value, bool):
-        return mapping.get(value, str(value))
-    s = str(value)
-    if s.isdigit():
-        return mapping.get(int(s), s)
-    return s.rsplit(".", 1)[-1]
 
 
 # ---------------------------------------------------------------------------
@@ -422,19 +419,9 @@ def map_keyword_quality_info(
         hasattr(criterion, "system_serving_status")
         and criterion.system_serving_status is not None
     ):
-        raw = criterion.system_serving_status
-        if isinstance(raw, int):
-            serving_map: dict[int, str] = {
-                0: "UNSPECIFIED",
-                1: "UNKNOWN",
-                2: "ELIGIBLE",
-                3: "RARELY_SERVED",
-            }
-            result["system_serving_status"] = serving_map.get(raw, str(raw))
-        elif hasattr(raw, "name"):
-            result["system_serving_status"] = str(raw.name)
-        else:
-            result["system_serving_status"] = str(raw)
+        result["system_serving_status"] = map_enum_name(
+            criterion.system_serving_status, CRITERION_SYSTEM_SERVING_STATUS_MAP
+        )
 
     # quality_info
     qi = getattr(criterion, "quality_info", None)
@@ -474,7 +461,9 @@ def map_keyword(
         ),
         "text": keyword.keyword.text if hasattr(keyword, "keyword") else str(keyword),
         "match_type": (
-            str(keyword.keyword.match_type) if hasattr(keyword, "keyword") else None
+            map_enum_name(keyword.keyword.match_type, KEYWORD_MATCH_TYPE_MAP)
+            if hasattr(keyword, "keyword")
+            else None
         ),
         "status": (
             map_entity_status(keyword.status) if hasattr(keyword, "status") else None
@@ -586,7 +575,9 @@ def map_negative_keyword(criterion: Any) -> dict[str, Any]:
             criterion.keyword.text if hasattr(criterion, "keyword") else None
         ),
         "match_type": (
-            str(criterion.keyword.match_type) if hasattr(criterion, "keyword") else None
+            map_enum_name(criterion.keyword.match_type, KEYWORD_MATCH_TYPE_MAP)
+            if hasattr(criterion, "keyword")
+            else None
         ),
     }
 
@@ -672,18 +663,30 @@ def map_conversion_action(action: Any) -> dict[str, Any]:
     return {
         "id": str(action.id) if hasattr(action, "id") else None,
         "name": _safe_str(action, "name"),
-        "type": str(action.type_) if hasattr(action, "type_") else None,
+        "type": (
+            map_enum_name(action.type_, CONVERSION_ACTION_TYPE_MAP)
+            if hasattr(action, "type_")
+            else None
+        ),
         "status": (
             map_entity_status(action.status) if hasattr(action, "status") else None
         ),
-        "category": str(action.category) if hasattr(action, "category") else None,
+        "category": (
+            map_enum_name(action.category, CONVERSION_ACTION_CATEGORY_MAP)
+            if hasattr(action, "category")
+            else None
+        ),
     }
 
 
 def map_tag_snippet(snippet: Any) -> dict[str, Any]:
     """Format conversion tag snippet."""
     return {
-        "type": str(snippet.type_) if hasattr(snippet, "type_") else None,
+        "type": (
+            map_enum_name(snippet.type_, TRACKING_CODE_TYPE_MAP)
+            if hasattr(snippet, "type_")
+            else None
+        ),
         # The v23 proto spells the page-header snippet ``global_site_tag``;
         # the response key stays ``page_header`` for backward compatibility
         # with the documented google_ads_conversions_tag tool contract.
@@ -701,7 +704,11 @@ def map_recommendation(rec: Any) -> dict[str, Any]:
         "resource_name": (
             str(rec.resource_name) if hasattr(rec, "resource_name") else None
         ),
-        "type": str(rec.type_) if hasattr(rec, "type_") else None,
+        "type": (
+            map_enum_name(rec.type_, RECOMMENDATION_TYPE_MAP)
+            if hasattr(rec, "type_")
+            else None
+        ),
         "impact": (
             {
                 "base_metrics": {
@@ -755,13 +762,15 @@ def map_change_event(event: Any) -> dict[str, Any]:
         "resource_name": _safe_str(event, "resource_name"),
         "change_date_time": _safe_str(event, "change_date_time"),
         "change_resource_type": (
-            str(event.change_resource_type)
+            map_enum_name(event.change_resource_type, CHANGE_EVENT_RESOURCE_TYPE_MAP)
             if hasattr(event, "change_resource_type")
             else None
         ),
         "change_resource_name": _safe_str(event, "change_resource_name"),
         "resource_change_operation": (
-            str(event.resource_change_operation)
+            map_enum_name(
+                event.resource_change_operation, RESOURCE_CHANGE_OPERATION_MAP
+            )
             if hasattr(event, "resource_change_operation")
             else None
         ),
@@ -772,7 +781,9 @@ def map_change_event(event: Any) -> dict[str, Any]:
             else []
         ),
         "client_type": (
-            str(event.client_type) if hasattr(event, "client_type") else None
+            map_enum_name(event.client_type, CHANGE_CLIENT_TYPE_MAP)
+            if hasattr(event, "client_type")
+            else None
         ),
         "user_email": _safe_str(event, "user_email"),
         "campaign": _safe_str(event, "campaign"),

--- a/mureo/mcp/_tools_google_ads_extensions.py
+++ b/mureo/mcp/_tools_google_ads_extensions.py
@@ -1031,7 +1031,7 @@ TOOLS: list[Tool] = [
             "coercion is applied, so callers should parse "
             "defensively), change_resource_type (enum string e.g. "
             "'CAMPAIGN', 'CAMPAIGN_BUDGET', 'AD_GROUP', 'AD', "
-            "'CAMPAIGN_BID_MODIFIER'), resource_change_operation "
+            "'AD_GROUP_BID_MODIFIER'), resource_change_operation "
             "('CREATE'|'UPDATE'|'REMOVE' as enum string), "
             "changed_fields (list of dotted field paths), "
             "user_email}]. Read-only. Defaults to the last 14 days "

--- a/tests/adapters/google_ads/test_mappers.py
+++ b/tests/adapters/google_ads/test_mappers.py
@@ -227,6 +227,38 @@ def test_to_keyword_match_type_strings_are_mapped(
 
 
 @pytest.mark.unit
+def test_a_live_keyword_row_survives_the_adapter_boundary() -> None:
+    """``list_keywords`` -> ``to_keyword`` on the row the API really returns.
+
+    ``_coerce`` raises for anything outside {EXACT, PHRASE, BROAD}, and the
+    upstream mapper used to emit a bare ``str()`` of the enum. mureo builds
+    its client with the SDK default ``use_proto_plus=False``, so that field is
+    a plain ``int`` and the string was "2" — every live ``list_keywords``
+    through this adapter raised ``ValueError: unknown keyword match_type:
+    '2'`` (#588). The dict-driven tests around this one cannot see that: they
+    start from a name that is already spelled correctly.
+    """
+    from google.ads.googleads import util
+    from google.ads.googleads.v23.services.types.google_ads_service import GoogleAdsRow
+
+    from mureo.google_ads.mappers import map_keyword
+
+    row = GoogleAdsRow()
+    row.ad_group_criterion.criterion_id = 42
+    row.ad_group_criterion.keyword.text = "buy widgets"
+    row.ad_group_criterion.keyword.match_type = 2  # EXACT
+    row.ad_group_criterion.status = 2  # ENABLED
+    raw = util.convert_proto_plus_to_protobuf(row)
+
+    legacy = map_keyword(raw.ad_group_criterion, raw.campaign, raw.ad_group)
+    out = to_keyword(legacy, account_id=_ACCOUNT_ID, campaign_id="111")
+
+    assert out.match_type == KeywordMatchType.EXACT
+    assert out.status == KeywordStatus.ENABLED
+    assert out.text == "buy widgets"
+
+
+@pytest.mark.unit
 def test_to_keyword_unknown_match_type_raises() -> None:
     row = {
         "id": "k1",

--- a/tests/test_change_import_google_ads.py
+++ b/tests/test_change_import_google_ads.py
@@ -262,6 +262,57 @@ class TestRowMapping:
         move the watermark past changes never seen."""
         assert _row_to_change(_row(change_date_time="")) is None
 
+    def test_a_real_change_event_row_classifies_end_to_end(self) -> None:
+        """The whole path, from the row the API returns to the kind (#588).
+
+        Every test above starts from a hand-written row dict, which is where
+        this feed's worst defect hid: the mapper emitted a bare ``str()`` of
+        the enum field, and mureo builds its Google Ads client with the SDK
+        default ``use_proto_plus=False``, so that field is a plain ``int`` and
+        the string was "2" — while every consumer keys on "AD". Classification
+        missed every time and each imported change fell through to kind ``""``
+        with nothing raised and nothing logged.
+
+        So this drives ``map_change_event`` with the RAW PROTOBUF the search
+        interceptor hands back — ``convert_proto_plus_to_protobuf`` is exactly
+        what the SDK does — and asserts the kind at the far end. Building the
+        proto-plus object and passing it straight in would test a shape
+        production never produces, which is how the first attempt at this fix
+        passed while changing nothing.
+        """
+        from google.ads.googleads import util
+        from google.ads.googleads.v23.resources.types.change_event import ChangeEvent
+
+        from mureo.change_import.dedupe import (
+            _OPERATION_ALIASES,
+            KIND_AD,
+            change_kind,
+        )
+        from mureo.google_ads.mappers import map_change_event
+
+        event = ChangeEvent(
+            resource_name="customers/1/changeEvents/2026-08-05~1~2",
+            change_date_time="2026-08-05 09:14:00",
+            change_resource_name="customers/1/ads/999",
+            campaign="customers/1/campaigns/111",
+            ad_group="customers/1/adGroups/222",
+        )
+        event.change_resource_type = 2  # AD
+        event.resource_change_operation = 3  # UPDATE
+        event.changed_fields.paths.append("ad.final_urls")
+        raw = util.convert_proto_plus_to_protobuf(event)
+        assert isinstance(raw.change_resource_type, int)  # the production shape
+
+        change = _row_to_change(map_change_event(raw))
+
+        assert change is not None
+        assert change.resource_type == "AD"
+        # The point of the fix: the kind resolves instead of being "".
+        assert change_kind(change) == KIND_AD
+        assert _OPERATION_ALIASES.get(change.operation) == "update"
+        # And the ad-level identity, which is keyed on the same string.
+        assert change.ad_id == "999"
+
 
 @pytest.mark.unit
 class TestGoogleFeed:

--- a/tests/test_gaql_field_names.py
+++ b/tests/test_gaql_field_names.py
@@ -238,7 +238,6 @@ _UNBOUND_MAPPER_SUBJECTS: dict[str, str] = {
     "keyword": "carries deliberate non-proto fallbacks (keyword.id, str(keyword))",
     "member": "an enum member, not a message",
     "qi": "the quality_info of the unbound 'criterion'",
-    "raw": "an enum value or a plain int, not a message",
     "value": "an enum value or a plain int, not a message",
 }
 

--- a/tests/test_google_ads_analysis.py
+++ b/tests/test_google_ads_analysis.py
@@ -1395,6 +1395,83 @@ class TestRsaAnalysisMixin:
             ),
         )
 
+    @staticmethod
+    def _make_real_asset_row(
+        text: str,
+        field_type: int,
+        performance_label: int,
+        impressions: int = 1000,
+        clicks: int = 100,
+        conversions: float = 5.0,
+        cost_micros: int = 3_000_000,
+    ) -> Any:
+        """One ``ad_group_ad_asset_view`` row in the shape ``_search`` returns.
+
+        ``_make_asset_row`` above builds a double whose ``__str__`` answers
+        "FieldType.HEADLINE", which production never produces: mureo builds its
+        client with the SDK default ``use_proto_plus=False``, so the row is raw
+        protobuf and ``field_type`` is the plain int 2. ``str()`` made that
+        "2", ``"2" == "HEADLINE"`` is False, and ``headlines`` /
+        ``descriptions`` came back empty on every live account (#588).
+        """
+        from google.ads.googleads import util
+        from google.ads.googleads.v23.services.types.google_ads_service import (
+            GoogleAdsRow,
+        )
+
+        row = GoogleAdsRow()
+        row.ad_group_ad_asset_view.field_type = field_type
+        row.ad_group_ad_asset_view.performance_label = performance_label
+        row.asset.text_asset.text = text
+        row.metrics.impressions = impressions
+        row.metrics.clicks = clicks
+        row.metrics.conversions = conversions
+        row.metrics.cost_micros = cost_micros
+        raw_row = util.convert_proto_plus_to_protobuf(row)
+        assert isinstance(  # the shape the interceptor delivers
+            raw_row.ad_group_ad_asset_view.field_type, int
+        )
+        return raw_row
+
+    @pytest.mark.unit
+    async def test_analyze_rsa_assets_on_the_real_row_shape(self) -> None:
+        """The same analysis, driven by the row ``_search`` actually returns."""
+        client = self._make_client()
+        client._search.return_value = [
+            # HEADLINE / BEST, HEADLINE / LOW, DESCRIPTION / BEST
+            self._make_real_asset_row("Best Headline", 2, 6, impressions=1000),
+            self._make_real_asset_row("Low Headline", 2, 4, impressions=500),
+            self._make_real_asset_row("Best Desc", 3, 6, impressions=800),
+        ]
+
+        result = await client.analyze_rsa_assets("123")
+
+        assert [h["text"] for h in result["headlines"]] == [
+            "Best Headline",
+            "Low Headline",
+        ]
+        assert [d["text"] for d in result["descriptions"]] == ["Best Desc"]
+        assert [h["text"] for h in result["best_headlines"]] == ["Best Headline"]
+        assert [h["text"] for h in result["worst_headlines"]] == ["Low Headline"]
+        assert [d["text"] for d in result["best_descriptions"]] == ["Best Desc"]
+        assert result["headlines"][0]["performance_label"] == "BEST"
+
+    @pytest.mark.unit
+    async def test_audit_rsa_assets_on_the_real_row_shape(self) -> None:
+        """The audit reads the analysis, so it was dead for the same reason."""
+        client = self._make_client()
+        client._search.return_value = [
+            self._make_real_asset_row("Low Headline", 2, 4),
+            self._make_real_asset_row("Poor Desc", 3, 4),
+        ]
+
+        result = await client.audit_rsa_assets("123")
+
+        assert result["label_distribution"] == {"LOW": 2}
+        rec_types = [r["type"] for r in result["recommendations"]]
+        assert "replace_headline" in rec_types
+        assert "replace_description" in rec_types
+
     @pytest.mark.unit
     async def test_analyze_rsa_assets_basic(self) -> None:
         client = self._make_client()
@@ -1523,6 +1600,57 @@ class TestAuctionAnalysisMixin:
                 average_cpc=average_cpc,
             ),
         )
+
+    @staticmethod
+    def _make_real_device_row(
+        device: int,
+        impressions: int,
+        clicks: int,
+        cost_micros: int,
+        conversions: float,
+        ctr: float,
+        average_cpc: int = 50_000,
+    ) -> Any:
+        """One device-segmented row in the shape ``_search`` returns.
+
+        ``_make_device_row`` above builds a double whose ``__str__`` answers
+        "Device.MOBILE"; the real row is raw protobuf and ``segments.device``
+        is the plain int 2. ``str()`` made that "2", so every device insight
+        named the device by number and the desktop lookup — which searched for
+        "1", while DESKTOP is 4 — matched nothing (#588).
+        """
+        from google.ads.googleads import util
+        from google.ads.googleads.v23.services.types.google_ads_service import (
+            GoogleAdsRow,
+        )
+
+        row = GoogleAdsRow()
+        row.segments.device = device
+        row.metrics.impressions = impressions
+        row.metrics.clicks = clicks
+        row.metrics.cost_micros = cost_micros
+        row.metrics.conversions = conversions
+        row.metrics.ctr = ctr
+        row.metrics.average_cpc = average_cpc
+        raw_row = util.convert_proto_plus_to_protobuf(row)
+        assert isinstance(raw_row.segments.device, int)  # the delivered shape
+        return raw_row
+
+    @pytest.mark.unit
+    async def test_analyze_device_performance_on_the_real_row_shape(self) -> None:
+        """Devices are named, and the mobile-vs-desktop comparison can fire."""
+        client = self._make_client()
+        client.get_campaign.return_value = {"name": "Test Campaign"}
+        client._search.return_value = [
+            self._make_real_device_row(4, 1000, 100, 5_000_000, 5.0, 0.10),  # DESKTOP
+            self._make_real_device_row(2, 4000, 80, 4_000_000, 0.0, 0.02),  # MOBILE
+        ]
+
+        result = await client.analyze_device_performance("123")
+
+        assert [d["device_type"] for d in result["devices"]] == ["DESKTOP", "MOBILE"]
+        assert any(i.startswith("MOBILE has 0 conversions") for i in result["insights"])
+        assert any("Mobile CTR" in i for i in result["insights"])
 
     @pytest.mark.unit
     async def test_analyze_device_performance_basic(self) -> None:

--- a/tests/test_google_ads_client.py
+++ b/tests/test_google_ads_client.py
@@ -1355,6 +1355,52 @@ class TestGetNetworkPerformanceReport:
         assert result[0]["network_label"] == "Google Search"
 
     @pytest.mark.asyncio
+    async def test_network_type_on_the_real_row_shape(self) -> None:
+        """The same split, driven by the row ``_search`` actually returns.
+
+        The MagicMock tests here assign the string "SEARCH"; the real row is
+        raw protobuf and ``segments.ad_network_type`` is a plain int. This read
+        worked in production only because it carried hardcoded digit fallbacks
+        ("2", "3") beside the names; it now resolves the enum instead, so the
+        fallbacks are gone and this pins the behaviour they used to carry
+        (#588).
+        """
+        from google.ads.googleads import util
+        from google.ads.googleads.v23.services.types.google_ads_service import (
+            GoogleAdsRow,
+        )
+
+        def _raw_row(network: int) -> Any:
+            row = GoogleAdsRow()
+            row.campaign.id = 111
+            row.campaign.name = "テスト"
+            row.segments.ad_network_type = network
+            row.metrics.impressions = 1000
+            row.metrics.clicks = 50
+            row.metrics.cost_micros = 5000_000_000
+            row.metrics.conversions = 5.0
+            row.metrics.ctr = 0.05
+            row.metrics.average_cpc = 100_000_000
+            return util.convert_proto_plus_to_protobuf(row)
+
+        client = _make_client()
+        rows = [
+            _raw_row(2),
+            _raw_row(3),
+            _raw_row(4),
+        ]  # SEARCH, SEARCH_PARTNERS, CONTENT
+        assert isinstance(rows[0].segments.ad_network_type, int)  # delivered shape
+
+        with patch.object(client, "_search", return_value=rows):
+            result = await client.get_network_performance_report()
+
+        assert [r["network_type"] for r in result] == ["SEARCH", "SEARCH_PARTNERS"]
+        assert [r["network_label"] for r in result] == [
+            "Google Search",
+            "Search Partners",
+        ]
+
+    @pytest.mark.asyncio
     async def test_DISPLAY等はスキップ(self) -> None:
         client = _make_client()
         row = MagicMock()

--- a/tests/test_google_ads_diagnostics.py
+++ b/tests/test_google_ads_diagnostics.py
@@ -530,6 +530,53 @@ class TestDiagnoseCampaignDeliveryAdditional:
         assert any("RARELY_SERVED" in w for w in result["warnings"])
 
     @pytest.mark.asyncio
+    async def test_rarely_served_warning_fires_on_the_real_row_shape(
+        self, client: _MockDiagClient
+    ) -> None:
+        """The same warning, driven by the row ``_search`` actually returns.
+
+        The MagicMock test above hands the diagnostic the string
+        "RARELY_SERVED", so it passes whatever the code does with the enum.
+        mureo builds its client with the SDK default ``use_proto_plus=False``,
+        so the real row is raw protobuf and ``system_serving_status`` is the
+        plain ``int`` 3 — ``str()`` made it "3", ``"RARELY_SERVED" in "3"`` is
+        False, and this warning could never fire on a live account (#588).
+        """
+        from google.ads.googleads import util
+        from google.ads.googleads.v23.services.types.google_ads_service import (
+            GoogleAdsRow,
+        )
+
+        campaign = self._make_base_campaign()
+        client.get_campaign = AsyncMock(return_value=campaign)
+        client.list_ad_groups = AsyncMock(return_value=[{"id": "1"}])
+
+        row = GoogleAdsRow()
+        row.ad_group_criterion.keyword.text = "rare keyword"
+        row.ad_group_criterion.keyword.match_type = 4  # BROAD
+        row.ad_group_criterion.approval_status = 2  # APPROVED
+        row.ad_group_criterion.system_serving_status = 3  # RARELY_SERVED
+        raw_row = util.convert_proto_plus_to_protobuf(row)
+        assert isinstance(  # the shape the interceptor delivers
+            raw_row.ad_group_criterion.system_serving_status, int
+        )
+
+        client._search = AsyncMock(
+            side_effect=[
+                [raw_row],  # keywords
+                [],  # ads
+                [],  # locations
+                [],  # billing
+                [],  # impression share
+            ]
+        )
+
+        result = await client.diagnose_campaign_delivery("123")
+
+        assert any("RARELY_SERVED" in w for w in result["warnings"])
+        assert any("rare keyword" in w for w in result["warnings"])
+
+    @pytest.mark.asyncio
     async def test_disapproved_ads_issue(self, client: _MockDiagClient) -> None:
         """Disapproved-ad issue (line 431)."""
         campaign = self._make_base_campaign()

--- a/tests/test_google_ads_enum_reads.py
+++ b/tests/test_google_ads_enum_reads.py
@@ -1,0 +1,334 @@
+"""No Google Ads proto enum field may be read with a bare ``str()``.
+
+**Why this file exists.** mureo builds its Google Ads client with the SDK
+default ``use_proto_plus=False``, so the SDK's response interceptor converts
+every row to raw protobuf before mureo sees it, and an enum field arrives as a
+plain ``int``. ``str()`` on it yields ``"2"``, and the ``.split(".")[-1]`` /
+``.rsplit(".", 1)`` that usually follows is a no-op on a digit string. The
+result is a tool that returns numbers where its own description promises names,
+and comparisons like ``field_type == "HEADLINE"`` that can never be true.
+
+That failure is silent in production and invisible in the suite: the tests hand
+in doubles whose ``__str__`` returns ``"FieldType.HEADLINE"``, a shape the
+production path never produces, so the split works in the test and nowhere
+else. #588 found thirteen such reads; a descriptor sweep of the whole package
+then found seven more, two of them in the RSA asset analysis, which had
+therefore never returned a single headline or description, plus one read that
+worked only because someone had written the digits in beside the names. This
+file exists so there is no third sweep: the reads
+are extracted from source and resolved against the vendored protobuf
+descriptors, and any that lands on a ``TYPE_ENUM`` field fails.
+
+Two properties worth keeping when editing this file, the same two
+``test_gaql_field_names.py`` states:
+
+- **Derived, never enumerated.** The reads come from the tree and their types
+  from the SDK descriptors. Only the subject-to-message bindings are written by
+  hand, because a guessed binding would invent failures on correct code — and
+  they are asserted against the sweep in both directions, so a new subject
+  forces a decision and a departed one cannot linger.
+- **Extraction is asserted, not assumed.**
+  ``test_extraction_covers_every_str_call`` pins the AST sweep against an
+  independent tokenizer count of ``str(`` call sites. An extractor that quietly
+  stopped matching would otherwise turn this whole file into a green no-op.
+
+**Scope, and the two exclusions the #588 review cleared.** The sweep covers
+``mureo/google_ads/`` — the only tree that reads Google Ads protos.
+``mureo/analysis/tracking/sources.py`` stringifies mureo's own ``AdStatus``
+dataclass enum, not a protobuf, and is out of the swept root for that reason.
+``client.py`` reads ``.name`` off ``GoogleAdsException.failure``, which the SDK
+always hands back as proto-plus regardless of the flag, so ``.name`` is correct
+there; it is also not a ``str()`` read, and ``.name`` on raw protobuf raises
+rather than lying, which is why this sweep is about ``str()`` alone.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import io
+import pathlib
+import tokenize
+
+import pytest
+from google.protobuf.descriptor import FieldDescriptor
+
+from tests.test_gaql_field_names import (
+    _API_VERSION,
+    _MAPPER_SUBJECTS,
+    _UNBOUND_MAPPER_SUBJECTS,
+    _dotted,
+    _imported_names,
+)
+
+_SOURCE_ROOT = pathlib.Path(__file__).resolve().parent.parent / "mureo" / "google_ads"
+
+#: The proto packages a subject can be bound to.
+_PROTO_PACKAGES = ("resources", "common", "services", "errors")
+
+
+@pytest.fixture(scope="module")
+def proto_packages() -> dict[str, object]:
+    return {
+        name: importlib.import_module(f"google.ads.googleads.{_API_VERSION}.{name}")
+        for name in _PROTO_PACKAGES
+    }
+
+
+#: ``(module file name, subject variable)`` -> the proto message it holds, as
+#: ``(package, class name)``. Keyed by file because the same variable name
+#: holds different messages in different modules (``asset`` is a bare ``Asset``
+#: in ``_media.py`` and a row in ``mappers.py``). ``mappers.py`` is absent on
+#: purpose: its subjects are already bound in ``test_gaql_field_names.py`` and
+#: are reused from there rather than re-declared.
+_STR_READ_SUBJECTS: dict[tuple[str, str], tuple[str, str]] = {
+    ("_ads.py", "row"): ("services", "GoogleAdsRow"),
+    ("_ads.py", "entry"): ("common", "PolicyTopicEntry"),
+    ("_analysis_auction.py", "row"): ("services", "GoogleAdsRow"),
+    ("_analysis_keywords.py", "row"): ("services", "GoogleAdsRow"),
+    ("_analysis_performance.py", "row"): ("services", "GoogleAdsRow"),
+    ("_creative.py", "ad"): ("resources", "Ad"),
+    ("_diagnostics.py", "row"): ("services", "GoogleAdsRow"),
+    ("_diagnostics.py", "ad"): ("resources", "AdGroupAd"),
+    ("_diagnostics.py", "cc"): ("resources", "CampaignCriterion"),
+    ("_extensions_conversions.py", "row"): ("services", "GoogleAdsRow"),
+    ("_extensions_targeting.py", "row"): ("services", "GoogleAdsRow"),
+    ("_extensions_targeting.py", "crit"): ("resources", "AdGroupCriterion"),
+    ("_media.py", "asset"): ("resources", "Asset"),
+    ("_media.py", "image"): ("common", "ImageAsset"),
+    ("_placement_mappers.py", "campaign"): ("resources", "Campaign"),
+    ("_placement_mappers.py", "ad_group"): ("resources", "AdGroup"),
+    ("accounts.py", "child"): ("resources", "CustomerClient"),
+    ("client.py", "row"): ("services", "GoogleAdsRow"),
+    ("client.py", "budget"): ("resources", "CampaignBudget"),
+    ("client.py", "error"): ("errors", "GoogleAdsError"),
+}
+
+#: Subjects deliberately left unchecked, each with the reason it cannot be
+#: bound to one message. Asserted below in both directions so the sweep can
+#: never quietly shrink to nothing by "skipping" everything.
+_UNRESOLVABLE_STR_READ_SUBJECTS: dict[tuple[str, str], str] = {
+    (
+        "_placement_mappers.py",
+        "criterion",
+    ): "AdGroupCriterion or CampaignCriterion — the mapper serves both levels",
+}
+
+
+def _field_at(message: object, segments: list[str]) -> FieldDescriptor | None:
+    """The descriptor of the field ``segments`` names, or ``None``.
+
+    ``test_gaql_field_names._walk`` answers whether a path exists; this needs
+    the field itself to ask what type it is, which is why it descends rather
+    than reusing that helper. Both spellings of a mangled name are accepted:
+    the descriptor carries the API name (``type``) while the attribute read
+    uses proto-plus's mangling (``type_``).
+    """
+    fields = {f.name: f for f in message.pb(message()).DESCRIPTOR.fields}  # type: ignore[attr-defined]
+    field: FieldDescriptor | None = None
+    for segment in segments:
+        field = (
+            fields.get(segment)
+            or fields.get(segment.removesuffix("_"))
+            or fields.get(segment + "_")
+        )
+        if field is None:
+            return None
+        fields = (
+            {f.name: f for f in field.message_type.fields}
+            if field.message_type is not None
+            else {}
+        )
+    return field
+
+
+def _str_attribute_reads() -> list[tuple[str, int, str]]:
+    """Every ``str(<attribute chain>)`` in the package.
+
+    Returned as ``(module file name, line number, dotted path)``. A bare
+    ``str(name)`` is not a field read and a chain rooted at an imported name is
+    not an instance, so neither is returned.
+    """
+    reads: list[tuple[str, int, str]] = []
+    for path in sorted(_SOURCE_ROOT.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        imported = _imported_names(tree)
+        for node in ast.walk(tree):
+            if not (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "str"
+                and len(node.args) == 1
+            ):
+                continue
+            dotted = _dotted(node.args[0])
+            if dotted is None or "." not in dotted:
+                continue
+            if dotted.split(".")[0] in imported:
+                continue
+            reads.append((path.name, node.lineno, dotted))
+    return reads
+
+
+def _str_call_sites(source: str) -> int:
+    """``str(`` call sites in ``source``, counted by the tokenizer.
+
+    Independent of the AST sweep on purpose — this is what pins it. A regex
+    would count the ``str()`` written in a docstring; the tokenizer classifies
+    strings and comments for us, and several of this package's ``str()``
+    mentions are prose about this very bug.
+    """
+    count = 0
+    previous: tokenize.TokenInfo | None = None
+    ignored = {
+        tokenize.NL,
+        tokenize.NEWLINE,
+        tokenize.COMMENT,
+        tokenize.INDENT,
+        tokenize.DEDENT,
+    }
+    for token in tokenize.generate_tokens(io.StringIO(source).readline):
+        if (
+            token.type == tokenize.OP
+            and token.string == "("
+            and previous is not None
+            and previous.type == tokenize.NAME
+            and previous.string == "str"
+        ):
+            count += 1
+        if token.type not in ignored:
+            previous = token
+    return count
+
+
+def _binding_for(module: str, subject: str) -> tuple[str, str] | None:
+    """The proto message bound to ``subject`` in ``module``, if any."""
+    if module == "mappers.py":
+        return _MAPPER_SUBJECTS.get(subject)
+    return _STR_READ_SUBJECTS.get((module, subject))
+
+
+def _skip_reason(module: str, subject: str) -> str | None:
+    """Why ``subject`` in ``module`` cannot be bound to one message, if so."""
+    if module == "mappers.py":
+        return _UNBOUND_MAPPER_SUBJECTS.get(subject)
+    return _UNRESOLVABLE_STR_READ_SUBJECTS.get((module, subject))
+
+
+def _message_for(binding: tuple[str, str], packages: dict[str, object]) -> object:
+    package, class_name = binding
+    return getattr(packages[package], class_name)
+
+
+@pytest.mark.unit
+def test_extraction_covers_every_str_call() -> None:
+    """The AST sweep must see every ``str(...)`` call site in the package.
+
+    Not every one is a field read — most take a plain name — but if the sweep
+    stopped seeing ``str`` calls at all it would pass by checking nothing, and
+    that is the one failure this file cannot afford.
+    """
+    swept = 0
+    tokenized = 0
+    for path in sorted(_SOURCE_ROOT.rglob("*.py")):
+        source = path.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        swept += sum(
+            1
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "str"
+        )
+        tokenized += _str_call_sites(source)
+    assert swept == tokenized, (
+        f"the AST sweep saw {swept} str() call site(s) but the tokenizer "
+        f"counted {tokenized}. Reconcile the two before trusting this file's "
+        "result."
+    )
+
+
+@pytest.mark.unit
+def test_every_str_read_subject_is_classified() -> None:
+    """Every ``str(x.y)`` subject is either bound to a proto or skipped.
+
+    Both directions: a new subject forces a decision, and a subject that
+    disappears cannot leave a stale binding behind pretending the sweep still
+    covers it. ``mappers.py`` is checked one-way only, because its bindings are
+    owned by ``test_gaql_field_names.py`` and cover more subjects than reach a
+    ``str()``.
+    """
+    subjects = {
+        (module, path.split(".")[0]) for module, _, path in _str_attribute_reads()
+    }
+    unclassified = sorted(
+        key
+        for key in subjects
+        if _binding_for(*key) is None and _skip_reason(*key) is None
+    )
+    assert not unclassified, (
+        "these str() read subjects are bound to nothing. Bind each to its proto "
+        "message in _STR_READ_SUBJECTS, or list it in "
+        f"_UNRESOLVABLE_STR_READ_SUBJECTS with the reason: {unclassified}"
+    )
+    declared = set(_STR_READ_SUBJECTS) | set(_UNRESOLVABLE_STR_READ_SUBJECTS)
+    assert not sorted(declared - subjects), (
+        "these entries name a subject this package no longer reads through "
+        f"str(), so they verify nothing: {sorted(declared - subjects)}"
+    )
+
+
+@pytest.mark.unit
+def test_every_bound_str_read_resolves_on_the_proto(
+    proto_packages: dict[str, object],
+) -> None:
+    """A binding that resolves nothing would make the enum sweep below inert."""
+    problems: list[str] = []
+    for module, lineno, path in _str_attribute_reads():
+        binding = _binding_for(module, path.split(".")[0])
+        if binding is None:
+            continue
+        message = _message_for(binding, proto_packages)
+        if _field_at(message, path.split(".")[1:]) is None:
+            problems.append(f"{module}:{lineno}: {path} — not a field of {binding[1]}")
+    assert not problems, (
+        f"{len(problems)} str() read(s) name nothing on the {_API_VERSION} "
+        "proto they are bound to. Either the binding is wrong, or the read is "
+        "— and an unresolvable read is one the enum sweep cannot check:\n  "
+        + "\n  ".join(problems)
+    )
+
+
+@pytest.mark.unit
+def test_every_bound_subject_contributes_a_read() -> None:
+    """A binding no read reaches verifies nothing."""
+    reached = {
+        (module, path.split(".")[0]) for module, _, path in _str_attribute_reads()
+    }
+    silent = sorted(set(_STR_READ_SUBJECTS) - reached)
+    assert not silent, f"these bindings are reached by no str() read: {silent}"
+
+
+@pytest.mark.unit
+def test_no_bare_str_is_taken_on_a_proto_enum_field(
+    proto_packages: dict[str, object],
+) -> None:
+    """The sweep itself. A failure here is #588 happening again."""
+    problems: list[str] = []
+    for module, lineno, path in _str_attribute_reads():
+        binding = _binding_for(module, path.split(".")[0])
+        if binding is None:
+            continue
+        field = _field_at(_message_for(binding, proto_packages), path.split(".")[1:])
+        if field is not None and field.type == FieldDescriptor.TYPE_ENUM:
+            problems.append(
+                f"mureo/google_ads/{module}:{lineno}: str({path}) reads the "
+                f"{field.enum_type.name} enum"
+            )
+    assert not problems, (
+        f"{len(problems)} enum field(s) are read with a bare str(). On the "
+        "raw-protobuf path this client runs on that yields the number, not the "
+        "name, and any .split('.') after it is a no-op. Resolve them through "
+        "mureo.google_ads._enum_names.map_enum_name against an SDK-derived "
+        "map:\n  " + "\n  ".join(problems)
+    )

--- a/tests/test_google_ads_extensions.py
+++ b/tests/test_google_ads_extensions.py
@@ -537,6 +537,38 @@ class TestGetBidAdjustments:
         assert result[0]["device_type"] == "DESKTOP"
 
     @pytest.mark.asyncio
+    async def test_type_is_the_enum_name_on_the_real_row_shape(
+        self, client: _MockExtensionsClient
+    ) -> None:
+        """``type`` is the bare enum name on the row ``_search`` returns.
+
+        The MagicMock test above assigns the string "DEVICE" to ``type_``, so
+        it passes whatever the code does with the enum. mureo builds its client
+        with the SDK default ``use_proto_plus=False``, so the real row is raw
+        protobuf and ``campaign_criterion.type_`` is the plain ``int`` 6 —
+        ``str()`` made it "6", while the tool contract for
+        ``google_ads_bid_adjustments_get`` promises "DEVICE" (#588).
+        """
+        from google.ads.googleads import util
+        from google.ads.googleads.v23.services.types.google_ads_service import (
+            GoogleAdsRow,
+        )
+
+        row = GoogleAdsRow()
+        row.campaign_criterion.criterion_id = 1
+        row.campaign_criterion.type_ = 6  # DEVICE
+        row.campaign_criterion.bid_modifier = 1.2
+        row.campaign_criterion.device.type_ = 2  # MOBILE
+        raw_row = util.convert_proto_plus_to_protobuf(row)
+        assert isinstance(raw_row.campaign_criterion.type_, int)  # interceptor shape
+
+        client._search = AsyncMock(return_value=[raw_row])
+        result = await client.get_bid_adjustments("123")
+
+        assert result[0]["type"] == "DEVICE"
+        assert result[0]["device_type"] == "MOBILE"
+
+    @pytest.mark.asyncio
     async def test_empty_adjustments(self, client: _MockExtensionsClient) -> None:
         client._search = AsyncMock(return_value=[])
         result = await client.get_bid_adjustments("123")
@@ -699,6 +731,47 @@ class TestListScheduleTargeting:
         result = await client.list_schedule_targeting("123")
         assert len(result) == 1
         assert result[0]["day_of_week"] == "MONDAY"
+        assert result[0]["start_hour"] == 9
+        assert result[0]["end_hour"] == 18
+
+    @pytest.mark.asyncio
+    async def test_enum_names_on_the_real_row_shape(
+        self, client: _MockExtensionsClient
+    ) -> None:
+        """Day and minute are enum names on the row ``_search`` returns.
+
+        The MagicMock test above assigns the strings "MONDAY" and "ZERO", so it
+        passes whatever the code does with the enums. mureo builds its client
+        with the SDK default ``use_proto_plus=False``, so the real row is raw
+        protobuf and both fields are plain ints — ``str()`` made them "2",
+        while the ``google_ads_schedule_targeting_list`` description promises
+        "the string form of the DayOfWeek enum" and of MinuteOfHour, and
+        ``google_ads_schedule_targeting_update`` takes the day back by name
+        (#588).
+        """
+        from google.ads.googleads import util
+        from google.ads.googleads.v23.services.types.google_ads_service import (
+            GoogleAdsRow,
+        )
+
+        row = GoogleAdsRow()
+        row.campaign_criterion.criterion_id = 1
+        row.campaign_criterion.ad_schedule.day_of_week = 2  # MONDAY
+        row.campaign_criterion.ad_schedule.start_hour = 9
+        row.campaign_criterion.ad_schedule.end_hour = 18
+        row.campaign_criterion.ad_schedule.start_minute = 3  # FIFTEEN
+        row.campaign_criterion.ad_schedule.end_minute = 4  # THIRTY
+        raw_row = util.convert_proto_plus_to_protobuf(row)
+        assert isinstance(  # the shape the interceptor delivers
+            raw_row.campaign_criterion.ad_schedule.day_of_week, int
+        )
+
+        client._search = AsyncMock(return_value=[raw_row])
+        result = await client.list_schedule_targeting("123")
+
+        assert result[0]["day_of_week"] == "MONDAY"
+        assert result[0]["start_minute"] == "FIFTEEN"
+        assert result[0]["end_minute"] == "THIRTY"
         assert result[0]["start_hour"] == 9
         assert result[0]["end_hour"] == 18
 

--- a/tests/test_google_ads_keywords.py
+++ b/tests/test_google_ads_keywords.py
@@ -433,6 +433,53 @@ class TestSuggestKeywords:
         assert result[0]["avg_monthly_searches"] == 1000
 
     @pytest.mark.asyncio
+    async def test_competition_on_the_real_response_shape(self) -> None:
+        """The tool contract promises LOW / MEDIUM / HIGH; it shipped digits.
+
+        The MagicMock tests above set ``competition`` to the string "MEDIUM",
+        so they pass whatever the code does with the enum. mureo builds its
+        client with the SDK default ``use_proto_plus=False``, so the SDK
+        converts the response to raw protobuf and ``competition`` is the plain
+        int 3 — ``str()`` made that "3", against a description that documents
+        ``competition (LOW / MEDIUM / HIGH)`` (#588).
+        """
+        from google.ads.googleads import util
+        from google.ads.googleads.v23.common.types.keyword_plan_common import (
+            KeywordPlanHistoricalMetrics,
+        )
+        from google.ads.googleads.v23.services.types.keyword_plan_idea_service import (
+            GenerateKeywordIdeaResponse,
+            GenerateKeywordIdeaResult,
+        )
+
+        response = GenerateKeywordIdeaResponse()
+        for text, competition, searches in (("KW高", 4, 900), ("KW中", 3, 500)):
+            response.results.append(
+                GenerateKeywordIdeaResult(
+                    text=text,
+                    keyword_idea_metrics=KeywordPlanHistoricalMetrics(
+                        competition=competition,
+                        avg_monthly_searches=searches,
+                    ),
+                )
+            )
+        raw_response = util.convert_proto_plus_to_protobuf(response)
+        assert isinstance(  # the shape the interceptor delivers
+            raw_response.results[0].keyword_idea_metrics.competition, int
+        )
+
+        client = _make_client()
+        mock_service = MagicMock()
+        mock_service.generate_keyword_ideas.return_value = raw_response
+        client._client.get_service.return_value = mock_service
+        client._client.get_type.return_value = MagicMock()
+
+        result = await client.suggest_keywords(["テスト"])
+
+        assert [r["competition"] for r in result] == ["HIGH", "MEDIUM"]
+        assert [r["keyword"] for r in result] == ["KW高", "KW中"]
+
+    @pytest.mark.asyncio
     async def test_20件上限(self) -> None:
         client = _make_client()
         ideas = []

--- a/tests/test_google_ads_mappers.py
+++ b/tests/test_google_ads_mappers.py
@@ -6,12 +6,30 @@ conversions.
 
 from __future__ import annotations
 
+import inspect
+from collections.abc import Callable
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
+from google.ads.googleads import util
+from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.v23.common import TagSnippet
+from google.ads.googleads.v23.enums.types.keyword_match_type import (
+    KeywordMatchTypeEnum,
+)
+from google.ads.googleads.v23.resources.types.ad_group_criterion import (
+    AdGroupCriterion,
+)
 from google.ads.googleads.v23.resources.types.campaign import Campaign
+from google.ads.googleads.v23.resources.types.change_event import ChangeEvent
+from google.ads.googleads.v23.resources.types.conversion_action import ConversionAction
+from google.ads.googleads.v23.resources.types.recommendation import Recommendation
 
+from mureo.google_ads._enum_names import (
+    CHANGE_EVENT_RESOURCE_TYPE_MAP,
+    map_enum_name,
+)
 from mureo.google_ads.mappers import (
     _BIDDING_STRATEGY_MAP,
     _micros_to_currency,
@@ -41,6 +59,68 @@ from mureo.google_ads.mappers import (
     map_sitelink,
     map_tag_snippet,
 )
+
+# ---------------------------------------------------------------------------
+# The two shapes a mapper can be handed — and which one production uses
+# ---------------------------------------------------------------------------
+
+
+def _raw(message: Any) -> Any:
+    """The shape ``GoogleAdsApiClient._search`` actually delivers.
+
+    mureo builds its client with the SDK default ``use_proto_plus=False``, so
+    the SDK's response interceptor converts every row to raw protobuf before a
+    mapper sees it — and on raw protobuf an enum field is a plain ``int`` with
+    no ``.name``. Handing a mapper a proto-plus object is therefore testing a
+    shape production never produces; see ``TestWhyTheRawShapeIsTheRealOne``.
+    """
+    return util.convert_proto_plus_to_protobuf(message)
+
+
+def _proto_plus(message: Any) -> Any:
+    """The shape a ``use_proto_plus=True`` client would deliver."""
+    return message
+
+
+# Every enum assertion runs through both, so the mappers stay pinned under
+# either client setting and a future flip of that flag cannot silently break
+# them. ``raw-protobuf`` is the one that reflects production today.
+SHAPES: list[Callable[[Any], Any]] = [_raw, _proto_plus]
+SHAPE_IDS = ["raw-protobuf", "proto-plus"]
+
+
+@pytest.mark.unit
+class TestWhyTheRawShapeIsTheRealOne:
+    """Why every enum test below is driven through ``_raw`` (#588).
+
+    The original fix for #588 read ``.name`` off the value and was verified
+    against proto-plus objects built in the test. It passed and changed
+    nothing in production, because production never sees that shape. These two
+    assertions are the load-bearing premise; if either stops holding, the
+    parametrization above needs revisiting rather than deleting.
+    """
+
+    def test_mureo_builds_its_client_on_the_raw_protobuf_default(self) -> None:
+        """``GoogleAdsApiClient`` passes no ``use_proto_plus``, and it is False."""
+        from mureo.google_ads.client import GoogleAdsApiClient
+
+        source = inspect.getsource(GoogleAdsApiClient.__init__)
+        assert "use_proto_plus" not in source
+        default = inspect.signature(GoogleAdsClient.__init__).parameters[
+            "use_proto_plus"
+        ]
+        assert default.default is False
+
+    def test_a_raw_protobuf_enum_field_is_a_plain_int_with_no_name(self) -> None:
+        """The whole reason ``str()`` on these fields emitted "2"."""
+        event = ChangeEvent()
+        event.change_resource_type = 2  # AD
+
+        value = _raw(event).change_resource_type
+
+        assert isinstance(value, int)
+        assert not hasattr(value, "name")
+
 
 # ---------------------------------------------------------------------------
 # Helper functions
@@ -139,6 +219,57 @@ class TestEnumMappers:
     def test_map_primary_status_reason_int(self) -> None:
         result = map_primary_status_reason(0)
         assert result == "UNSPECIFIED"
+
+
+@pytest.mark.unit
+class TestMapEnumNameOnEveryShape:
+    """The one resolver every enum read goes through (#588).
+
+    It resolves a name from the SDK-derived mapping instead of reading
+    ``.name`` off the value, which is what makes it work on the raw-protobuf
+    path where there is no ``.name`` to read.
+    """
+
+    def test_the_raw_protobuf_int_resolves_to_its_name(self) -> None:
+        """The production path: a plain ``int``, no ``.name``, was "2"."""
+        event = ChangeEvent()
+        event.change_resource_type = 2  # AD
+
+        value = _raw(event).change_resource_type
+
+        assert map_enum_name(value, CHANGE_EVENT_RESOURCE_TYPE_MAP) == "AD"
+
+    def test_a_proto_plus_member_resolves_to_the_same_name(self) -> None:
+        """A ``use_proto_plus=True`` client must produce the same string."""
+        event = ChangeEvent()
+        event.change_resource_type = 2  # AD
+
+        resolved = map_enum_name(
+            event.change_resource_type, CHANGE_EVENT_RESOURCE_TYPE_MAP
+        )
+
+        assert resolved == "AD"
+
+    def test_an_out_of_range_int_falls_back_to_its_digits(self) -> None:
+        """An enum member newer than the vendored SDK must not raise."""
+        assert map_enum_name(9999, CHANGE_EVENT_RESOURCE_TYPE_MAP) == "9999"
+
+    def test_a_string_passes_through_unchanged(self) -> None:
+        """What the MagicMock-driven tests in this file feed the mappers."""
+        assert map_enum_name("EXACT", CHANGE_EVENT_RESOURCE_TYPE_MAP) == "EXACT"
+
+    def test_a_value_that_merely_claims_a_name_does_not_get_it(self) -> None:
+        """Only the mapping decides; ``.name`` is never consulted.
+
+        A MagicMock answers every attribute, so ``getattr(value, "name",
+        None)`` hands back a truthy stand-in and a ``.name``-based helper
+        looks correct for any input at all — the exact reason #588's first fix
+        passed a green suite while changing nothing in production.
+        """
+        mock = MagicMock()
+        mock.name = "AD"
+
+        assert map_enum_name(mock, CHANGE_EVENT_RESOURCE_TYPE_MAP) != "AD"
 
 
 # ---------------------------------------------------------------------------
@@ -379,6 +510,27 @@ class TestMapKeyword:
         assert result["ad_group_id"] == "200"
         assert result["ad_group_name"] == "AG200"
 
+    @pytest.mark.parametrize("shape", SHAPES, ids=SHAPE_IDS)
+    def test_match_type_is_the_bare_enum_name(
+        self, shape: Callable[[Any], Any]
+    ) -> None:
+        """A real proto, in both shapes — ``raw-protobuf`` is production.
+
+        Every ``match_type`` test above feeds the mapper a string that is
+        already a name, so none of them can see what the mapper does with the
+        value the client actually delivers: a plain ``int``, which bare
+        ``str()`` turned into "2". Consumers key on the bare name —
+        ``_analysis_keywords`` compares against "BROAD"/"PHRASE",
+        ``exclusion_impact.matching`` against "EXACT"/"PHRASE" — so "2" is a
+        silent mis-comparison at every one of them (#588).
+        """
+        criterion = AdGroupCriterion()
+        criterion.criterion_id = 66666
+        criterion.keyword.text = "running shoes"
+        criterion.keyword.match_type = 2  # EXACT
+
+        assert map_keyword(shape(criterion))["match_type"] == "EXACT"
+
 
 @pytest.mark.unit
 class TestMapKeywordQualityInfo:
@@ -402,6 +554,20 @@ class TestMapKeywordQualityInfo:
         assert result["post_click_quality_score"] == "ABOVE_AVERAGE"
         assert result["search_predicted_ctr"] == "BELOW_AVERAGE"
         assert result["system_serving_status"] == "ELIGIBLE"
+
+    @pytest.mark.parametrize("shape", SHAPES, ids=SHAPE_IDS)
+    def test_system_serving_status_is_the_bare_enum_name(
+        self, shape: Callable[[Any], Any]
+    ) -> None:
+        """``_keywords`` compares this against "RARELY_SERVED" exactly."""
+        criterion = AdGroupCriterion()
+        criterion.criterion_id = 55555
+        criterion.keyword.text = "shoes"
+        criterion.system_serving_status = 3  # RARELY_SERVED
+
+        result = map_keyword_quality_info(shape(criterion))
+
+        assert result["system_serving_status"] == "RARELY_SERVED"
 
     def test_品質情報なし(self) -> None:
         keyword = MagicMock(spec=["criterion_id", "keyword", "status"])
@@ -452,6 +618,51 @@ class TestMapNegativeKeyword:
         assert result["criterion_id"] == "77777"
         assert result["keyword_text"] == "無料"
         assert result["match_type"] == "EXACT"
+
+    @pytest.mark.parametrize("shape", SHAPES, ids=SHAPE_IDS)
+    def test_match_type_is_the_bare_enum_name(
+        self, shape: Callable[[Any], Any]
+    ) -> None:
+        """A real proto, in both shapes — ``raw-protobuf`` is production.
+
+        On the raw shape the field is the plain ``int`` 2, which bare
+        ``str()`` emitted as "2"; the mock test above cannot see that because
+        it feeds the mapper a string that is already a name.
+        """
+        criterion = AdGroupCriterion()
+        criterion.criterion_id = 77777
+        criterion.keyword.text = "free"
+        criterion.keyword.match_type = 2  # EXACT
+
+        assert map_negative_keyword(shape(criterion))["match_type"] == "EXACT"
+
+
+@pytest.mark.unit
+class TestKeywordMatchTypeSpelling:
+    """The two mappers that read ``KeywordMatchType`` may not drift apart.
+
+    ``map_keyword`` and ``map_negative_keyword`` read the same field off the
+    same proto and feed consumers that compare on the bare name, so a fix
+    applied to one and not the other is its own defect: for a while #588 was
+    scoped to the negative-keyword site alone, which would have shipped
+    ``map_negative_keyword`` returning "EXACT" next to ``map_keyword``
+    returning "2". This pins them together, member by member.
+    """
+
+    @pytest.mark.parametrize("shape", SHAPES, ids=SHAPE_IDS)
+    def test_both_mappers_spell_every_member_the_same_bare_way(
+        self, shape: Callable[[Any], Any]
+    ) -> None:
+        for member in KeywordMatchTypeEnum.KeywordMatchType:
+            criterion = AdGroupCriterion()
+            criterion.keyword.text = "shoes"
+            criterion.keyword.match_type = member.value
+            row = shape(criterion)
+
+            positive = map_keyword(row)["match_type"]
+            negative = map_negative_keyword(row)["match_type"]
+
+            assert positive == negative == member.name
 
 
 @pytest.mark.unit
@@ -520,6 +731,23 @@ class TestMapConversionAction:
         assert result["name"] == "購入完了"
         assert result["status"] == "ENABLED"
 
+    @pytest.mark.parametrize("shape", SHAPES, ids=SHAPE_IDS)
+    def test_type_and_category_are_bare_enum_names(
+        self, shape: Callable[[Any], Any]
+    ) -> None:
+        """Real proto in both shapes; on the production one these were "8"/"4"."""
+        action = ConversionAction()
+        action.id = 10001
+        action.name = "Purchase"
+        action.status = 2  # ENABLED
+        action.type_ = 8  # WEBPAGE
+        action.category = 4  # PURCHASE
+
+        result = map_conversion_action(shape(action))
+
+        assert result["type"] == "WEBPAGE"
+        assert result["category"] == "PURCHASE"
+
 
 @pytest.mark.unit
 class TestMapTagSnippet:
@@ -527,19 +755,22 @@ class TestMapTagSnippet:
     # so the previous mock-based test passed against ``page_header``, a field
     # the v23 TagSnippet does not have. The key was therefore always empty.
 
-    def test_global_site_tag_populates_the_page_header_key(self) -> None:
+    @pytest.mark.parametrize("shape", SHAPES, ids=SHAPE_IDS)
+    def test_global_site_tag_populates_the_page_header_key(
+        self, shape: Callable[[Any], Any]
+    ) -> None:
         """The global site tag is returned under the ``page_header`` key."""
         snippet = TagSnippet()
         snippet.type_ = 2  # WEBPAGE
         snippet.global_site_tag = "<script>gtag</script>"
         snippet.event_snippet = "<script>event</script>"
 
-        result = map_tag_snippet(snippet)
+        result = map_tag_snippet(shape(snippet))
 
-        # ``type`` is deliberately not pinned to a literal: the mapper returns
-        # ``str(snippet.type_)``, and proto-plus enums are stdlib IntEnum,
-        # whose ``__str__`` CPython changed in 3.11 — "TrackingCodeType.WEBPAGE"
-        # on 3.10, "2" on 3.11+. This test is about the snippet fields.
+        # ``type`` IS pinned to the bare enum name: the mapper resolves it
+        # through ``map_enum_name``, so the "2" that bare ``str()`` emitted on
+        # the raw-protobuf path production runs on is a failure here.
+        assert result["type"] == "WEBPAGE"
         assert result["page_header"] == "<script>gtag</script>"
         assert result["event_snippet"] == "<script>event</script>"
 
@@ -580,6 +811,15 @@ class TestMapRecommendation:
         assert result["resource_name"] == "customers/123/recommendations/456"
         assert result["impact"]["base_metrics"]["impressions"] == 1000.0
 
+    @pytest.mark.parametrize("shape", SHAPES, ids=SHAPE_IDS)
+    def test_type_is_the_bare_enum_name(self, shape: Callable[[Any], Any]) -> None:
+        """Real proto in both shapes; on the production one this was "3"."""
+        rec = Recommendation()
+        rec.resource_name = "customers/123/recommendations/456"
+        rec.type_ = 3  # KEYWORD
+
+        assert map_recommendation(shape(rec))["type"] == "KEYWORD"
+
 
 @pytest.mark.unit
 class TestMapChangeEvent:
@@ -610,10 +850,6 @@ class TestMapChangeEvent:
         A real protobuf raises ``AttributeError`` for a name it does not have,
         so every key this asserts is a name the vendored SDK actually defines.
         """
-        from google.ads.googleads.v23.resources.types.change_event import (
-            ChangeEvent,
-        )
-
         event = ChangeEvent(
             resource_name="customers/1/changeEvents/2026-08-05~1~2",
             change_date_time="2026-08-05 09:14:00",
@@ -638,6 +874,29 @@ class TestMapChangeEvent:
         assert result["resource_change_operation"] is not None
         assert result["client_type"] is not None
 
+    @pytest.mark.parametrize("shape", SHAPES, ids=SHAPE_IDS)
+    def test_the_three_enum_fields_are_bare_names(
+        self, shape: Callable[[Any], Any]
+    ) -> None:
+        """The names ``change_import`` keys on, in both client shapes.
+
+        On the raw-protobuf shape production runs, these fields are the plain
+        ints 2/3/6 and bare ``str()`` emitted "2"/"3"/"6", while the consumers
+        look the value up by exact match on "AD" — so the classification
+        missed every time. See ``tests/test_change_import_google_ads.py`` for
+        the end-to-end proof (#588).
+        """
+        event = ChangeEvent(change_date_time="2026-08-05 09:14:00")
+        event.change_resource_type = 2  # AD
+        event.resource_change_operation = 3  # UPDATE
+        event.client_type = 6  # GOOGLE_ADS_API
+
+        result = map_change_event(shape(event))
+
+        assert result["change_resource_type"] == "AD"
+        assert result["resource_change_operation"] == "UPDATE"
+        assert result["client_type"] == "GOOGLE_ADS_API"
+
     def test_every_mapped_key_exists_on_the_proto(self) -> None:
         """No key the mapper emits may name a field the proto does not have.
 
@@ -645,10 +904,6 @@ class TestMapChangeEvent:
         moment someone adds a field name by hand rather than from the proto.
         Keys the mapper renames deliberately are listed as exceptions.
         """
-        from google.ads.googleads.v23.resources.types.change_event import (
-            ChangeEvent,
-        )
-
         declared = {f.name for f in ChangeEvent.pb(ChangeEvent()).DESCRIPTOR.fields}
         emitted = set(map_change_event(ChangeEvent()))
         assert emitted <= declared, (

--- a/tests/test_google_ads_negative_placements.py
+++ b/tests/test_google_ads_negative_placements.py
@@ -9,11 +9,15 @@ the handler wiring.
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
+from google.ads.googleads import util
+from google.ads.googleads.v23.services.types.google_ads_service import GoogleAdsRow
 
+from mureo.google_ads._placement_mappers import map_placement_performance
 from mureo.google_ads.client import GoogleAdsApiClient
 
 PLACEMENT = 3  # CriterionTypeEnum.PLACEMENT
@@ -494,6 +498,17 @@ def _placement_perf_row(
     placement_type: str = "PlacementType.WEBSITE",
     impressions: int = 1000,
 ) -> MagicMock:
+    """A query-shaping stand-in — NOT the shape production delivers.
+
+    ``placement_type`` here is the string "PlacementType.WEBSITE", which the
+    client never produces: mureo builds it with the SDK default
+    ``use_proto_plus=False``, so the row is raw protobuf and the field is a
+    plain ``int``. Every assertion this helper feeds therefore passes whatever
+    the mapper does with a real enum, which is how #588 hid here. The rows are
+    kept for the GAQL / scoping tests they serve; anything about
+    ``placement_type`` is pinned on the real shape in
+    ``TestPlacementPerformanceOnTheRealRowShape`` below.
+    """
     row = MagicMock()
     view = row.group_placement_view
     view.placement = placement
@@ -562,3 +577,122 @@ class TestPlacementPerformance:
         client._search = _search  # type: ignore[method-assign]
         with pytest.raises(ValueError):
             await client.get_placement_performance(campaign_id="100 OR 1=1")
+
+
+# ---------------------------------------------------------------------------
+# The two shapes a mapper can be handed — and which one production uses
+# ---------------------------------------------------------------------------
+
+
+def _raw(message: Any) -> Any:
+    """The shape ``GoogleAdsApiClient._search`` actually delivers.
+
+    mureo builds its client with the SDK default ``use_proto_plus=False``, so
+    the SDK's response interceptor converts every row to raw protobuf before a
+    mapper sees it — and on raw protobuf an enum field is a plain ``int`` with
+    no ``.name``.
+    """
+    return util.convert_proto_plus_to_protobuf(message)
+
+
+def _proto_plus(message: Any) -> Any:
+    """The shape a ``use_proto_plus=True`` client would deliver."""
+    return message
+
+
+# Both shapes, so the mapper stays pinned under either client setting and a
+# future flip of that flag cannot silently break it. ``raw-protobuf`` is the
+# one that reflects production today.
+SHAPES: list[Callable[[Any], Any]] = [_raw, _proto_plus]
+SHAPE_IDS = ["raw-protobuf", "proto-plus"]
+
+WEBSITE = 2  # PlacementTypeEnum.PlacementType
+MOBILE_APPLICATION_PLACEMENT = 4
+
+
+def _placement_perf_proto(placement_type: int = WEBSITE) -> GoogleAdsRow:
+    """A real ``group_placement_view`` row, enum field and all."""
+    row = GoogleAdsRow()
+    row.group_placement_view.placement = "example.com"
+    row.group_placement_view.display_name = "Example"
+    row.group_placement_view.target_url = "https://example.com"
+    row.group_placement_view.placement_type = placement_type
+    row.metrics.impressions = 1000
+    row.metrics.clicks = 10
+    row.metrics.cost_micros = 5_000_000
+    row.metrics.conversions = 2.0
+    return row
+
+
+@pytest.mark.unit
+class TestPlacementPerformanceOnTheRealRowShape:
+    """``placement_type`` on the row ``_search`` really returns (#588).
+
+    The ``_placement_perf_row`` tests above assign the string
+    "PlacementType.WEBSITE", so they pass whatever the mapper does with the
+    enum. On the raw-protobuf path the field is the plain ``int`` 2, which
+    bare ``str()`` turned into "2" — and every placement row then failed the
+    ``_PLACEMENT_ATTRIBUTABLE`` membership test in
+    :mod:`mureo.mcp.exclusion_sources`, so placement-attributed delivery was
+    silently always empty for the exclusion-impact preview and for the
+    delivery-collapse diagnosis.
+    """
+
+    def test_a_raw_protobuf_placement_type_is_a_plain_int(self) -> None:
+        """The premise: the interceptor shape has no ``.name`` to read."""
+        value = _raw(_placement_perf_proto()).group_placement_view.placement_type
+
+        assert isinstance(value, int)
+        assert not hasattr(value, "name")
+
+    @pytest.mark.parametrize("shape", SHAPES, ids=SHAPE_IDS)
+    def test_placement_type_is_the_bare_enum_name(
+        self, shape: Callable[[Any], Any]
+    ) -> None:
+        result = map_placement_performance(shape(_placement_perf_proto()))
+
+        assert result["placement_type"] == "WEBSITE"
+        assert result["type"] == "website"
+
+    @pytest.mark.parametrize("shape", SHAPES, ids=SHAPE_IDS)
+    def test_a_website_row_is_attributable_delivery(
+        self, shape: Callable[[Any], Any]
+    ) -> None:
+        """Asserted against the real set, so the two cannot drift apart.
+
+        ``_placement_records`` copies this ``type`` into
+        ``DeliveryRecord.entity_type``, which is what the attributable test
+        keys on.
+        """
+        from mureo.mcp.exclusion_sources import _PLACEMENT_ATTRIBUTABLE
+
+        result = map_placement_performance(shape(_placement_perf_proto()))
+
+        assert result["type"] in _PLACEMENT_ATTRIBUTABLE
+
+    @pytest.mark.parametrize("shape", SHAPES, ids=SHAPE_IDS)
+    def test_a_mobile_application_row_is_attributable_delivery(
+        self, shape: Callable[[Any], Any]
+    ) -> None:
+        from mureo.mcp.exclusion_sources import _PLACEMENT_ATTRIBUTABLE
+
+        result = map_placement_performance(
+            shape(_placement_perf_proto(MOBILE_APPLICATION_PLACEMENT))
+        )
+
+        assert result["placement_type"] == "MOBILE_APPLICATION"
+        assert result["type"] == "mobile_application"
+        assert result["type"] in _PLACEMENT_ATTRIBUTABLE
+
+    @pytest.mark.parametrize("shape", SHAPES, ids=SHAPE_IDS)
+    def test_a_kind_no_exclusion_can_name_keeps_its_lower_cased_name(
+        self, shape: Callable[[Any], Any]
+    ) -> None:
+        """A YouTube channel row stays readable and stays non-attributable."""
+        from mureo.mcp.exclusion_sources import _PLACEMENT_ATTRIBUTABLE
+
+        result = map_placement_performance(shape(_placement_perf_proto(6)))
+
+        assert result["placement_type"] == "YOUTUBE_CHANNEL"
+        assert result["type"] == "youtube_channel"
+        assert result["type"] not in _PLACEMENT_ATTRIBUTABLE


### PR DESCRIPTION
Fixes #588.

## The defect

mureo builds its Google Ads client with the SDK default `use_proto_plus=False`, so the SDK's response interceptor converts every row to **raw protobuf** before a mapper sees it — and on raw protobuf an enum field is a plain `int` with no `.name`. Twenty reads across the tree stringified such a field with a bare `str()`, so they emitted `"2"` where every consumer keys on `"AD"`.

```
raw field value : 2  (int)
has .name?      : False
mapper emitted  : '2'
CLASSIFIES?     : <<MISS -> unknown>>
```

The 3.11 `IntEnum.__str__` change that opened the issue turned out to be a red herring: on the real path the value was the bare integer on **every** Python version. The issue body was corrected in a [follow-up comment](https://github.com/logly/mureo/issues/588#issuecomment-5263735097).

## What was silently broken

Everything below failed with no exception and nothing logged, except where noted:

- **`change_import` classification had never worked.** `_RESOURCE_KINDS`, `_AD_LEVEL_RESOURCE_TYPES`, `_CRITERION_RESOURCE_TYPES` and `_OPERATION_ALIASES` all key on names like `"AD"`. Every imported external change fell through to kind `""`, lost its ad-level identity, and took the dedupe that keys on the kind down with it.
- **RSA asset analysis returned nothing, and always had.** `google_ads_rsa_assets_analyze` sorts assets by `field_type == "HEADLINE"` / `"DESCRIPTION"`, which `"2"`/`"3"` never satisfied — both lists came back empty for every live account, and with them `best_headlines`, `worst_headlines`, and all of `google_ads_rsa_assets_audit`. The tool told accounts with years of data that none had accumulated.
- **Placement-attributed delivery was always empty.** `exclusion_sources` tests `type` for membership of `{website, mobile_application}`; a digit string is in neither, so no placement row was ever attributable. Both the exclusion-impact preview (#547) and the delivery-collapse diagnosis (#572) read that basis and saw nothing.
- **The adapter failed loudly, not silently.** The provider adapter coerces `match_type` against `{EXACT, PHRASE, BROAD}` and raises otherwise, so every live `list_keywords` through it raised `ValueError: unknown keyword match_type: '2'`.
- **The rarely-served-keyword warning was dead code** — `"RARELY_SERVED" in "3"` is never true.
- Keyword match types mis-compared in `_analysis_keywords` (`== "BROAD"`) and `exclusion_impact.matching` (`== "EXACT"`).
- Auction/device insight strings read `"2 has 0 conversions…"`, and the hand-written fallback was itself wrong (`DESKTOP` is 4, not 1 — that lookup was dead regardless).
- `google_ads_keywords_suggest` shipped digits against a description promising `LOW / MEDIUM / HIGH`; `google_ads_bid_adjustments_get` shipped `"6"` against a contract promising `DEVICE`.
- `google_ads_schedule_targeting_list` emitted `"2"` for the day while the update path takes day **names**, so read → write could not round-trip.

## The fix

Resolution goes through the existing `map_enum_name(value, MAP)`, which never reads `.name` and resolves a raw int through a map. The maps live in a new `mureo/google_ads/_enum_names.py` and are **derived** from the SDK enum types by comprehension — never hand-transcribed, so they cannot go stale. (`mappers.py` sits at 791/800 lines against its budget test, which forced the new module rather than in-lining.)

`map_enum_name` call sites: **10 at HEAD → 33 now, +23.** Of those 23, 20 replaced a read that produced a digit in production, 1 is the second branch of an existing ternary, and 2 are consolidations of code that already worked (`system_serving_status`, `ad_network_type`) onto the shared derived maps.

## The guard — why this converged

Three review passes each found more instances after the previous "complete" fix. So this PR adds `tests/test_google_ads_enum_reads.py`, which AST-sweeps `str(<attribute chain>)` across `mureo/google_ads/`, resolves each chain against the live v23 descriptors, and fails when the field is `TYPE_ENUM`. It follows the two properties `tests/test_gaql_field_names.py` states: **derived, never enumerated**, and **extraction is asserted, not assumed** (the sweep is pinned by a tokenizer-based count, and every read subject must be bound to a proto message or listed as unbindable with a reason — asserted as a set in both directions).

It earned its place immediately: **the ad-schedule surface above was found by the guard, not by review.**

Verified load-bearing: reintroducing a bare `str()` on a fixed site turns it red; restoring turns it green.

Documented blind spot, stated in the module docstring: a chain first assigned to a bare local (`raw = crit.status; str(raw)`) escapes the sweep, and it only covers `mureo/google_ads/`. A manual sweep of the rest of `mureo/` found no further instances — the defect class is specific to the Google Ads SDK's raw-protobuf interceptor; no other platform adapter touches protobuf.

## Tests

Every assertion runs against the **raw-protobuf shape the client actually delivers**, via `google.ads.googleads.util.convert_proto_plus_to_protobuf`, and is parametrized over both shapes (`raw-protobuf` / `proto-plus`) so a future `use_proto_plus` flip cannot silently break it. `TestWhyTheRawShapeIsTheRealOne` pins the premise — the client passes no `use_proto_plus`, the SDK default is `False`, a raw field is an `int` with no `.name` — so nobody "simplifies" these back to direct proto-plus construction.

That distinction is the whole point: the pre-existing tests passed against doubles whose `__str__` returned `"FieldType.HEADLINE"`, a shape production never produces. Those legacy tests are kept alongside the real-shape ones, each annotated with why it cannot see the bug.

## Verification

- `python3 -m pytest` — 8841 passed, 12 failed, 8 skipped. The 12 are exactly this machine's known environmental baseline (9 live-client tests needing credentials, 3 tool-count tests inflated by a locally installed plugin); none touch files this PR modifies.
- `python3 -m mypy mureo/ --ignore-missing-imports` — `Success: no issues found in 338 source files`
- `ruff check .` — `All checks passed!`
- `black --check .` — `682 files would be left unchanged`

Four code-review passes. Pass 1 raised a CRITICAL — the first attempt resolved via `.name`, which does nothing on the raw-protobuf path — and the approach was reworked to be mapping-based. Passes 2 and 3 each surfaced further instances, now fixed. Pass 4 is clean.

## Follow-ups, not in this PR

- `_analysis_rsa.py` filters `performance_label in ("LOW", "POOR")`, but `POOR` is not a member of `AssetPerformanceLabel` in v23 — now that the labels resolve, that arm is permanently dead. Pre-existing, unrelated to the enum defect.
- `google_ads_schedule_targeting_list` emits `day_of_week` while the update path takes `day`, so the list output still can't be passed straight back in without renaming the key.
- Two enum resolvers now coexist (`map_enum_name`, and `_resolve_enum` in `_analysis_constants.py`). Unifying them needs a decision about `_resolve_enum`'s `.name` branch, which `map_enum_name` deliberately does not have. Its two hand-maintained maps were aliased onto the SDK-derived ones here; the resolver itself was left alone as provably not behaviour-preserving to migrate.
