### PR TITLE
fix: send Meta the lead-form fields it actually requires and reads back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Every Meta lead-form create was a guaranteed 400, and duplicating a
+  form silently lost its intro cover photo.** Two defects hit against
+  Graph API v21.0.
+
+  `follow_up_action_url` was typed optional, but Meta requires it: a
+  create without it returns HTTP 400 `error_subcode 1892085` /
+  `"Missing field(s): FollowUpActionURL"`. Any caller following mureo's
+  own schema — `meta_ads_lead_forms_create` included — therefore failed
+  on every call. It is now a **required** parameter of
+  `create_lead_form` and of the MCP tool schema, so the call fails at
+  the call site with the field named instead of after a Meta
+  round-trip. It is deliberately not defaulted from the privacy-policy
+  host: silently deriving it would send real leads to a URL nobody
+  chose. `thank_you_page` adds a richer completion screen but does not
+  remove the requirement — the docs and tool descriptions that claimed
+  it "replaces" / "supersedes" `follow_up_action_url` were wrong and
+  are corrected.
+
+  The intro card's cover photo is write/read asymmetric: creation takes
+  `context_card.cover_photo_id`, but Meta reads it back as
+  `context_card.cover_photo: {id, created_time}`, and requesting
+  `context_card{cover_photo_id}` is rejected with `(#100) Tried
+  accessing nonexisting field (cover_photo_id)`. `duplicate_lead_form`
+  re-posted the read-back shape verbatim, so a duplicate either lost
+  the cover or 400d. It now normalizes the card before re-posting
+  (`cover_photo.id` → `cover_photo_id`, read-only `cover_photo` / `id`
+  dropped, every other key preserved) without mutating the source
+  record. `get_lead_form` still returns Meta's raw shape — mureo's
+  passthrough convention — and the asymmetry is documented on both
+  sides instead. `duplicate_lead_form` also fails fast with a
+  `ValueError` when the source form has no `follow_up_action_url`,
+  mirroring the existing `privacy_policy.url` check, and the
+  `meta_ads_lead_forms_duplicate` description no longer claims the
+  intro / thank-you / conditional-branch fields are uncopied (they have
+  been copied since PR 4).
+
 - **Google Ads enum fields emitted the raw number, not the name every
   consumer keys on** (#588). Twenty reads across the row mappers, the
   campaign diagnostic, the bid-adjustment and ad-schedule listings, the

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -419,7 +419,7 @@ Which publishers, Audience Network app categories and content types an ad set mu
 |------|-------------|-------------------|
 | `meta_ads_lead_forms_list` | List lead forms (per page) | `account_id`, `page_id` |
 | `meta_ads_lead_forms_get` | Get lead form details | `account_id`, `form_id` |
-| `meta_ads_lead_forms_create` | Create a lead form | `account_id`, `page_id`, `name`, `questions`, `privacy_policy_url` |
+| `meta_ads_lead_forms_create` | Create a lead form | `account_id`, `page_id`, `name`, `questions`, `privacy_policy_url`, `follow_up_action_url` |
 | `meta_ads_lead_forms_update` | Update lead form status (ACTIVE / ARCHIVED) | `account_id`, `form_id`, `status` |
 | `meta_ads_lead_forms_duplicate` | Duplicate a lead form under a Page with a new name | `account_id`, `form_id`, `page_id`, `new_name` |
 | `meta_ads_leads_export_csv` | Export form leads to a local CSV file | `account_id`, `form_id`, `output_path` |

--- a/mureo/_data/skills/_mureo-meta-ads/SKILL.md
+++ b/mureo/_data/skills/_mureo-meta-ads/SKILL.md
@@ -553,13 +553,18 @@ different one.
 
 - `create` -- Create a lead form. **Requires user confirmation.**
   ```
-  Required: account_id, page_id, name, questions (array), privacy_policy_url
+  Required: account_id, page_id, name, questions (array),
+    privacy_policy_url, follow_up_action_url
   Optional advanced: locale, context_card (intro screen),
     thank_you_page (custom completion screen), is_higher_intent
     (3-step input→review→submit form), conditional_questions_choices
-    (branching logic), follow_up_action_url (simple redirect; superseded
-    by thank_you_page when both present)
+    (branching logic)
   ```
+
+  `follow_up_action_url` is required by Meta — omitting it fails with
+  `error_subcode 1892085` / "Missing field(s): FollowUpActionURL". It is
+  the URL behind the completion screen's button; `thank_you_page` adds a
+  richer completion screen on top of it, it does not replace it.
 
   When to use `is_higher_intent=true`: trims junk submissions, lowers
   total volume — pick when CV quality matters more than CV volume
@@ -567,7 +572,10 @@ different one.
 
   When to use `context_card`: lifts conversion rate measurably. Always
   worth a `{title, content, style=PARAGRAPH_STYLE}` minimum for any
-  campaign that survives past a 1-week test.
+  campaign that survives past a 1-week test. `cover_photo_id` (a PAGE
+  photo id from `meta_ads_pages_upload_photo`) is write-only — Meta reads
+  it back as `context_card.cover_photo.id`, so asking for
+  `context_card{cover_photo_id}` returns a 400.
 
   When to use `conditional_questions_choices`: when a follow-up
   question is only relevant given a prior answer (e.g. "How many
@@ -581,7 +589,12 @@ different one.
   ```
 
 - `duplicate` -- Copy an existing form (questions / privacy_policy /
-  follow_up_action_url / locale) under a new name on the given Page.
+  follow_up_action_url / locale / context_card / thank_you_page /
+  is_higher_intent / conditional_questions_choices) under a new name on
+  the given Page. The intro card's cover photo is re-mapped from the
+  read shape (`cover_photo.id`) to the write shape (`cover_photo_id`).
+  Fails fast when the source form has no `privacy_policy.url` or no
+  `follow_up_action_url` — Meta requires both at creation time.
   Source form is untouched. **Requires user confirmation.**
   ```
   Required: account_id, form_id, page_id, new_name
@@ -824,7 +837,7 @@ Step 3: Create a dynamic creative (multi-asset optimization) (CONFIRM WITH USER)
 
 ```
 Step 1: Create the Instant Form (CONFIRM WITH USER)
-  -> meta_ads_lead_forms_create {account_id, page_id, name, questions, privacy_policy_url}
+  -> meta_ads_lead_forms_create {account_id, page_id, name, questions, privacy_policy_url, follow_up_action_url}
   Returns: { id: "<form_id>", ... }
 
 Step 2: Create a Lead Ad creative attached to the form

--- a/mureo/_data/skills/lead-form-create/SKILL.md
+++ b/mureo/_data/skills/lead-form-create/SKILL.md
@@ -52,9 +52,10 @@ Skip a step only when the answer is unambiguous from STATE.json / STRATEGY.md (e
      - **IMPORTANT — `cover_photo_id` needs a PAGE photo id, not an ad-account `image_hash`.** Do **not** use `meta_ads_images_upload_file` / `meta_ads_creatives_upload_image` here — those upload to the ad account and return an `image_hash`, which Meta rejects for a form cover photo (this previously failed silently).
      - If the user wants a cover image: call **`meta_ads_pages_upload_photo`** with the form's `page_id` and either a `file_path` (local image) or `image_url`. Capture the returned **`photo_id`** and pass it as `context_card.cover_photo_id`.
        - This needs the `pages_manage_posts` permission. If the call fails with a permissions error (e.g. `(#200)` / `pages_manage_posts`), tell the user to re-run Meta auth (`mureo` Meta login) so the access token picks up the scope, then retry. As a fallback they can upload the cover manually in **Ads Manager → form builder → intro screen**.
+       - `cover_photo_id` is write-only: Meta reads the id back as `context_card.cover_photo.id`. Verify there (`meta_ads_lead_forms_get`) — requesting `context_card{cover_photo_id}` returns a 400.
      - If the user does not want a cover image, omit `cover_photo_id` entirely.
 
-6. **Post-submission behaviour**: Ask which of three options the user wants — (a) Meta's default confirmation (no extra config), (b) a simple redirect to a URL after submission (the lightweight `follow_up_action_url` field, common case for "send them to my thank-you page"), or (c) a full custom completion screen with title / body / CTA button. If (b), capture the URL. If (c), collect — one question per step: `title`, `body`, `button_type` (`VIEW_WEBSITE` / `CALL_BUSINESS` / `MESSAGE_BUSINESS` / `DOWNLOAD` / `DOWNLOAD_APP`), `website_url`, `button_text`. Note: `thank_you_page` supersedes `follow_up_action_url` when both are set, so do not collect both — pick one based on the user's choice.
+6. **Post-submission behaviour**: `follow_up_action_url` is **always required** by Meta (omitting it fails with `error_subcode 1892085` / "Missing field(s): FollowUpActionURL"), so always ask for the completion-screen URL — "Where should the form send people after they submit?" Default it from STRATEGY.md or the site's thank-you page so the user can accept in one word, and never invent one silently. Then ask whether they also want a full custom completion screen with title / body / CTA button (`thank_you_page`). That is an optional add-on *on top of* `follow_up_action_url`, not a replacement — if yes, collect one question per step: `title`, `body`, `button_type` (`VIEW_WEBSITE` / `CALL_BUSINESS` / `MESSAGE_BUSINESS` / `DOWNLOAD` / `DOWNLOAD_APP`), `website_url`, `button_text`.
 
 7. **Higher-intent (3-step) mode?**: Explain the trade-off in one sentence: "Higher-intent mode adds a review step before submit. It improves lead quality and trims junk submissions, but it costs total volume." Then ask yes/no. Default is `false` (single-step) unless the operator's STRATEGY.md flags quality over volume.
 
@@ -62,7 +63,7 @@ Skip a step only when the answer is unambiguous from STATE.json / STRATEGY.md (e
 
 ### Confirm before mutating
 
-Once every answer is collected, summarise the full payload in a short bulleted list (form name, questions, privacy URL, intro card on/off, thank-you on/off, higher-intent on/off, locale) and **ask the user to confirm** before calling the tool. Do not call `meta_ads_lead_forms_create` until the user gives an explicit go-ahead.
+Once every answer is collected, summarise the full payload in a short bulleted list (form name, questions, privacy URL, follow-up action URL, intro card on/off, thank-you on/off, higher-intent on/off, locale) and **ask the user to confirm** before calling the tool. Do not call `meta_ads_lead_forms_create` until the user gives an explicit go-ahead.
 
 ### Create the form
 

--- a/mureo/mcp/_handlers_meta_ads.py
+++ b/mureo/mcp/_handlers_meta_ads.py
@@ -735,9 +735,9 @@ async def handle_lead_forms_create(args: dict[str, Any]) -> list[TextContent]:
         "name": _require(args, "name"),
         "questions": _require(args, "questions"),
         "privacy_policy_url": _require(args, "privacy_policy_url"),
+        "follow_up_action_url": _require(args, "follow_up_action_url"),
     }
     for key in (
-        "follow_up_action_url",
         "locale",
         "context_card",
         "thank_you_page",

--- a/mureo/mcp/_tools_meta_ads_leads.py
+++ b/mureo/mcp/_tools_meta_ads_leads.py
@@ -65,6 +65,10 @@ TOOLS: list[Tool] = [
             "(``{url, link_text?}``) and the legacy "
             "``privacy_policy_url`` flat field, "
             "follow_up_action_url, leads_count, and created_time. "
+            "context_card comes back with the intro cover photo as "
+            "``cover_photo: {id, created_time}`` — NOT the "
+            "``cover_photo_id`` you pass on create; requesting "
+            "``context_card{cover_photo_id}`` is rejected by Meta. "
             "Read-only. Call this before designing downstream CRM sync "
             "so you know the exact field keys to map."
         ),
@@ -94,7 +98,7 @@ TOOLS: list[Tool] = [
             "(FULL_NAME, EMAIL, PHONE_NUMBER, COMPANY_NAME, JOB_TITLE, "
             "CITY, STATE, ZIP_CODE, COUNTRY, DATE_OF_BIRTH) or CUSTOM "
             "(requires key, label, and options for dropdowns). Meta "
-            "requires a privacy_policy_url by policy."
+            "requires both privacy_policy_url and follow_up_action_url."
         ),
         inputSchema={
             "type": "object",
@@ -175,10 +179,12 @@ TOOLS: list[Tool] = [
                 "follow_up_action_url": {
                     "type": "string",
                     "description": (
-                        "Optional URL the user is redirected to after "
-                        "submission (e.g. thank-you page). Omit to show "
-                        "Meta's default confirmation only. Superseded by "
-                        "thank_you_page when both are supplied."
+                        "URL the user is sent to from the completion "
+                        "screen (e.g. thank-you page). Required by Meta "
+                        "— omitting it fails with error_subcode 1892085 "
+                        "'Missing field(s): FollowUpActionURL'. "
+                        "thank_you_page adds a richer completion screen "
+                        "but does not replace this field."
                     ),
                 },
                 "locale": {
@@ -194,15 +200,21 @@ TOOLS: list[Tool] = [
                         "Optional intro / welcome screen shown before "
                         "the form. Lifts conversion rate measurably when "
                         "supplied. Expected keys: title, content, style "
-                        "(PARAGRAPH_STYLE or LIST_STYLE), cover_photo_id."
+                        "(PARAGRAPH_STYLE or LIST_STYLE), cover_photo_id. "
+                        "cover_photo_id is a PAGE photo id from "
+                        "meta_ads_pages_upload_photo and is write-only: "
+                        "Meta reads it back as context_card.cover_photo.id "
+                        "({id, created_time}), and asking for "
+                        "context_card{cover_photo_id} is rejected."
                     ),
                 },
                 "thank_you_page": {
                     "type": "object",
                     "description": (
                         "Optional custom completion screen with a CTA. "
-                        "Replaces follow_up_action_url's simple "
-                        "redirect when supplied. Expected keys: title, "
+                        "Richer than follow_up_action_url's plain "
+                        "redirect, but does not replace it — Meta still "
+                        "requires follow_up_action_url. Expected keys: title, "
                         "body, button_type (VIEW_WEBSITE / "
                         "CALL_BUSINESS / MESSAGE_BUSINESS / DOWNLOAD / "
                         "DOWNLOAD_APP), website_url, button_text."
@@ -234,6 +246,7 @@ TOOLS: list[Tool] = [
                 "name",
                 "questions",
                 "privacy_policy_url",
+                "follow_up_action_url",
             ],
             "additionalProperties": False,
         },
@@ -280,16 +293,22 @@ TOOLS: list[Tool] = [
         description=(
             "Duplicates a lead form under the same (or another) Page. "
             "Meta has no native copy endpoint, so this fetches the "
-            "source form's questions, privacy_policy, optional "
-            "follow_up_action_url and locale, then creates a fresh "
-            "form with the supplied new_name. Returns the new form's "
+            "source form's questions, privacy_policy, "
+            "follow_up_action_url, locale, context_card, "
+            "thank_you_page, is_higher_intent and "
+            "conditional_questions_choices, then creates a fresh "
+            "form with the supplied new_name. The copied context_card "
+            "is normalized (Meta reads the intro cover photo back as "
+            "cover_photo.id but only accepts cover_photo_id on write). "
+            "Fails fast with a ValueError when the source form has no "
+            "follow_up_action_url or no privacy_policy.url — Meta "
+            "requires both. Returns the new form's "
             "id. Source form is untouched. Mutating, reversible via "
             "meta_ads_lead_forms_update {status: ARCHIVED} on the new "
-            "form's id. **Lossy:** advanced fields on the source "
-            "(legal_content_id, gdpr_required / custom_disclaimer, "
-            "question_page_custom_headline, intro/thank-you screens, "
-            "conditional question branches) are NOT copied; re-create "
-            "them on the new form manually if needed."
+            "form's id. **Lossy:** legal_content_id, gdpr_required / "
+            "custom_disclaimer and question_page_custom_headline are "
+            "NOT copied; re-create them on the new form manually if "
+            "needed."
         ),
         inputSchema={
             "type": "object",
@@ -451,6 +470,10 @@ TOOLS: list[Tool] = [
             "cover photo; Meta requires a Page photo id). Typical flow: "
             "upload here → take `photo_id` → pass it as "
             "`context_card.cover_photo_id` to meta_ads_lead_forms_create. "
+            "The write field is one-way: meta_ads_lead_forms_get reads the "
+            "same id back under `context_card.cover_photo.id`, so verify "
+            "there rather than asking for `context_card{cover_photo_id}` "
+            "(which Meta rejects). "
             "Provide exactly one of `file_path` (local image) or "
             "`image_url`. The photo is uploaded UNPUBLISHED (not shown on "
             "the page timeline). Requires the `pages_manage_posts` "

--- a/mureo/meta_ads/_leads.py
+++ b/mureo/meta_ads/_leads.py
@@ -49,6 +49,29 @@ _CSV_INJECTION_PREFIXES: tuple[str, ...] = ("=", "+", "-", "@", "\t", "\r")
 _MAX_LEAD_PAGES = 10_000
 
 
+def _context_card_for_write(card: dict[str, Any]) -> dict[str, Any]:
+    """Turn a read-back ``context_card`` into one Meta accepts on write.
+
+    The intro card's cover photo is write/read asymmetric: creation
+    takes ``cover_photo_id`` (a PAGE photo id), but Meta reads the card
+    back as ``cover_photo: {"id": ..., "created_time": ...}`` — and
+    requesting ``context_card{cover_photo_id}`` is rejected outright
+    with ``(#100) Tried accessing nonexisting field (cover_photo_id)``.
+    Re-posting the read-back shape therefore either loses the cover or
+    fails, so the read shape is converted back to the write shape here.
+
+    Returns a NEW dict; the input is never mutated. The server-assigned
+    ``id`` is dropped (read-only), ``cover_photo`` is converted to
+    ``cover_photo_id`` when it carries an id and dropped either way, and
+    every other key is preserved untouched.
+    """
+    out = {k: v for k, v in card.items() if k not in ("id", "cover_photo")}
+    cover = card.get("cover_photo")
+    if isinstance(cover, dict) and cover.get("id"):
+        out["cover_photo_id"] = cover["id"]
+    return out
+
+
 def _csv_safe(value: str) -> str:
     """Escape leading characters that would otherwise be interpreted
     as a spreadsheet formula. Idempotent — re-escaping the result is
@@ -105,6 +128,14 @@ class LeadsMixin:
     async def get_lead_form(self, form_id: str) -> dict[str, Any]:
         """Get lead form details
 
+        Meta's raw shape is returned unchanged. Note the intro card's
+        cover photo reads back as ``context_card.cover_photo``
+        (``{"id": ..., "created_time": ...}``) even though creation
+        takes ``cover_photo_id`` — asking Meta for
+        ``context_card{cover_photo_id}`` fails with ``(#100) Tried
+        accessing nonexisting field (cover_photo_id)``. Use
+        :func:`_context_card_for_write` before re-posting a card.
+
         Args:
             form_id: Lead form ID
 
@@ -120,8 +151,8 @@ class LeadsMixin:
         name: str,
         questions: list[dict[str, Any]],
         privacy_policy_url: str,
+        follow_up_action_url: str,
         *,
-        follow_up_action_url: str | None = None,
         locale: str | None = None,
         context_card: dict[str, Any] | None = None,
         thank_you_page: dict[str, Any] | None = None,
@@ -141,8 +172,12 @@ class LeadsMixin:
                 ``label``, and (for dropdowns) ``options``.
             privacy_policy_url: HTTPS URL of the advertiser's
                 privacy policy. Required by Meta policy.
-            follow_up_action_url: Optional redirect URL shown after
-                submission. Omit for Meta's default confirmation.
+            follow_up_action_url: URL the user is sent to from the
+                completion screen's button. **Required by Meta** —
+                omitting it fails with HTTP 400 ``error_subcode
+                1892085`` / "Missing field(s): FollowUpActionURL".
+                ``thank_you_page`` adds a richer completion screen but
+                does not remove this requirement.
             locale: Optional form locale (e.g. ``"ja_JP"``).
             context_card: Optional intro / welcome screen shown
                 before the form. Expected shape:
@@ -150,13 +185,20 @@ class LeadsMixin:
                 "style": "PARAGRAPH_STYLE" | "LIST_STYLE",
                 "cover_photo_id": "..."}``. Meta lifts conversion
                 rates measurably when an intro is supplied.
+                ``cover_photo_id`` is a PAGE photo id (see
+                :meth:`upload_page_photo`) and is write-only: Meta
+                reads the card back as ``cover_photo: {"id": ...,
+                "created_time": ...}``, and requesting
+                ``context_card{cover_photo_id}`` is a 400.
             thank_you_page: Optional custom completion screen with
                 a CTA. Expected shape (subset):
                 ``{"title": "...", "body": "...",
                 "button_type": "VIEW_WEBSITE" | "CALL_BUSINESS" |
                 "MESSAGE_BUSINESS" | "DOWNLOAD" | "DOWNLOAD_APP",
                 "website_url": "...", "button_text": "..."}``.
-                Replaces ``follow_up_action_url``'s simple redirect.
+                Richer than the plain ``follow_up_action_url``
+                redirect, but does not replace it — Meta still
+                requires ``follow_up_action_url``.
             is_higher_intent: When ``True``, Meta renders a 3-step
                 form (input → review → submit) which trims junk
                 submissions at the cost of total leads volume.
@@ -176,10 +218,9 @@ class LeadsMixin:
             "name": name,
             "questions": json.dumps(questions),
             "privacy_policy": json.dumps({"url": privacy_policy_url}),
+            "follow_up_action_url": follow_up_action_url,
         }
 
-        if follow_up_action_url is not None:
-            data["follow_up_action_url"] = follow_up_action_url
         if locale is not None:
             data["locale"] = locale
         if context_card is not None:
@@ -252,7 +293,12 @@ class LeadsMixin:
         **Copied fields**: ``questions``, ``privacy_policy``,
         ``follow_up_action_url``, ``locale``, ``context_card``,
         ``thank_you_page``, ``is_higher_intent``,
-        ``conditional_questions_choices``.
+        ``conditional_questions_choices``. The ``context_card`` is
+        normalized on the way out by :func:`_context_card_for_write`
+        — Meta reads the intro cover photo back as
+        ``cover_photo: {id, created_time}`` but only accepts
+        ``cover_photo_id`` on write, so re-posting the read-back
+        shape verbatim would drop the cover (or 400).
 
         **NOT copied** (lossy by design — Meta either makes them
         immutable post-creation or they require separate setup on
@@ -277,7 +323,9 @@ class LeadsMixin:
                 ``privacy_policy`` is present but its ``url`` is
                 empty / missing — falls through to the same fail
                 path so the operator gets one clear error rather
-                than a Meta 400 later.
+                than a Meta 400 later. Also raised when the source
+                form has no ``follow_up_action_url``; Meta requires
+                it at creation time (``error_subcode 1892085``).
         """
         source = await self.get_lead_form(form_id)
         policy = source.get("privacy_policy")
@@ -291,13 +339,19 @@ class LeadsMixin:
                 "Meta requires one for lead form creation"
             )
 
+        follow_up_url = source.get("follow_up_action_url")
+        if not follow_up_url:
+            raise ValueError(
+                f"source form {form_id!r} has no follow_up_action_url; "
+                "Meta requires one for lead form creation"
+            )
+
         data: dict[str, Any] = {
             "name": new_name,
             "questions": json.dumps(source.get("questions", [])),
             "privacy_policy": json.dumps({"url": privacy_url}),
+            "follow_up_action_url": follow_up_url,
         }
-        if source.get("follow_up_action_url"):
-            data["follow_up_action_url"] = source["follow_up_action_url"]
         if source.get("locale"):
             data["locale"] = source["locale"]
 
@@ -307,7 +361,9 @@ class LeadsMixin:
         # duplicate. JSON-encode dict / list fields the same way
         # create_lead_form does.
         if source.get("context_card"):
-            data["context_card"] = json.dumps(source["context_card"])
+            data["context_card"] = json.dumps(
+                _context_card_for_write(source["context_card"])
+            )
         if source.get("thank_you_page"):
             data["thank_you_page"] = json.dumps(source["thank_you_page"])
         if source.get("is_higher_intent"):

--- a/skills/_mureo-meta-ads/SKILL.md
+++ b/skills/_mureo-meta-ads/SKILL.md
@@ -553,13 +553,18 @@ different one.
 
 - `create` -- Create a lead form. **Requires user confirmation.**
   ```
-  Required: account_id, page_id, name, questions (array), privacy_policy_url
+  Required: account_id, page_id, name, questions (array),
+    privacy_policy_url, follow_up_action_url
   Optional advanced: locale, context_card (intro screen),
     thank_you_page (custom completion screen), is_higher_intent
     (3-step input→review→submit form), conditional_questions_choices
-    (branching logic), follow_up_action_url (simple redirect; superseded
-    by thank_you_page when both present)
+    (branching logic)
   ```
+
+  `follow_up_action_url` is required by Meta — omitting it fails with
+  `error_subcode 1892085` / "Missing field(s): FollowUpActionURL". It is
+  the URL behind the completion screen's button; `thank_you_page` adds a
+  richer completion screen on top of it, it does not replace it.
 
   When to use `is_higher_intent=true`: trims junk submissions, lowers
   total volume — pick when CV quality matters more than CV volume
@@ -567,7 +572,10 @@ different one.
 
   When to use `context_card`: lifts conversion rate measurably. Always
   worth a `{title, content, style=PARAGRAPH_STYLE}` minimum for any
-  campaign that survives past a 1-week test.
+  campaign that survives past a 1-week test. `cover_photo_id` (a PAGE
+  photo id from `meta_ads_pages_upload_photo`) is write-only — Meta reads
+  it back as `context_card.cover_photo.id`, so asking for
+  `context_card{cover_photo_id}` returns a 400.
 
   When to use `conditional_questions_choices`: when a follow-up
   question is only relevant given a prior answer (e.g. "How many
@@ -581,7 +589,12 @@ different one.
   ```
 
 - `duplicate` -- Copy an existing form (questions / privacy_policy /
-  follow_up_action_url / locale) under a new name on the given Page.
+  follow_up_action_url / locale / context_card / thank_you_page /
+  is_higher_intent / conditional_questions_choices) under a new name on
+  the given Page. The intro card's cover photo is re-mapped from the
+  read shape (`cover_photo.id`) to the write shape (`cover_photo_id`).
+  Fails fast when the source form has no `privacy_policy.url` or no
+  `follow_up_action_url` — Meta requires both at creation time.
   Source form is untouched. **Requires user confirmation.**
   ```
   Required: account_id, form_id, page_id, new_name
@@ -824,7 +837,7 @@ Step 3: Create a dynamic creative (multi-asset optimization) (CONFIRM WITH USER)
 
 ```
 Step 1: Create the Instant Form (CONFIRM WITH USER)
-  -> meta_ads_lead_forms_create {account_id, page_id, name, questions, privacy_policy_url}
+  -> meta_ads_lead_forms_create {account_id, page_id, name, questions, privacy_policy_url, follow_up_action_url}
   Returns: { id: "<form_id>", ... }
 
 Step 2: Create a Lead Ad creative attached to the form

--- a/skills/lead-form-create/SKILL.md
+++ b/skills/lead-form-create/SKILL.md
@@ -52,9 +52,10 @@ Skip a step only when the answer is unambiguous from STATE.json / STRATEGY.md (e
      - **IMPORTANT — `cover_photo_id` needs a PAGE photo id, not an ad-account `image_hash`.** Do **not** use `meta_ads_images_upload_file` / `meta_ads_creatives_upload_image` here — those upload to the ad account and return an `image_hash`, which Meta rejects for a form cover photo (this previously failed silently).
      - If the user wants a cover image: call **`meta_ads_pages_upload_photo`** with the form's `page_id` and either a `file_path` (local image) or `image_url`. Capture the returned **`photo_id`** and pass it as `context_card.cover_photo_id`.
        - This needs the `pages_manage_posts` permission. If the call fails with a permissions error (e.g. `(#200)` / `pages_manage_posts`), tell the user to re-run Meta auth (`mureo` Meta login) so the access token picks up the scope, then retry. As a fallback they can upload the cover manually in **Ads Manager → form builder → intro screen**.
+       - `cover_photo_id` is write-only: Meta reads the id back as `context_card.cover_photo.id`. Verify there (`meta_ads_lead_forms_get`) — requesting `context_card{cover_photo_id}` returns a 400.
      - If the user does not want a cover image, omit `cover_photo_id` entirely.
 
-6. **Post-submission behaviour**: Ask which of three options the user wants — (a) Meta's default confirmation (no extra config), (b) a simple redirect to a URL after submission (the lightweight `follow_up_action_url` field, common case for "send them to my thank-you page"), or (c) a full custom completion screen with title / body / CTA button. If (b), capture the URL. If (c), collect — one question per step: `title`, `body`, `button_type` (`VIEW_WEBSITE` / `CALL_BUSINESS` / `MESSAGE_BUSINESS` / `DOWNLOAD` / `DOWNLOAD_APP`), `website_url`, `button_text`. Note: `thank_you_page` supersedes `follow_up_action_url` when both are set, so do not collect both — pick one based on the user's choice.
+6. **Post-submission behaviour**: `follow_up_action_url` is **always required** by Meta (omitting it fails with `error_subcode 1892085` / "Missing field(s): FollowUpActionURL"), so always ask for the completion-screen URL — "Where should the form send people after they submit?" Default it from STRATEGY.md or the site's thank-you page so the user can accept in one word, and never invent one silently. Then ask whether they also want a full custom completion screen with title / body / CTA button (`thank_you_page`). That is an optional add-on *on top of* `follow_up_action_url`, not a replacement — if yes, collect one question per step: `title`, `body`, `button_type` (`VIEW_WEBSITE` / `CALL_BUSINESS` / `MESSAGE_BUSINESS` / `DOWNLOAD` / `DOWNLOAD_APP`), `website_url`, `button_text`.
 
 7. **Higher-intent (3-step) mode?**: Explain the trade-off in one sentence: "Higher-intent mode adds a review step before submit. It improves lead quality and trims junk submissions, but it costs total volume." Then ask yes/no. Default is `false` (single-step) unless the operator's STRATEGY.md flags quality over volume.
 
@@ -62,7 +63,7 @@ Skip a step only when the answer is unambiguous from STATE.json / STRATEGY.md (e
 
 ### Confirm before mutating
 
-Once every answer is collected, summarise the full payload in a short bulleted list (form name, questions, privacy URL, intro card on/off, thank-you on/off, higher-intent on/off, locale) and **ask the user to confirm** before calling the tool. Do not call `meta_ads_lead_forms_create` until the user gives an explicit go-ahead.
+Once every answer is collected, summarise the full payload in a short bulleted list (form name, questions, privacy URL, follow-up action URL, intro card on/off, thank-you on/off, higher-intent on/off, locale) and **ask the user to confirm** before calling the tool. Do not call `meta_ads_lead_forms_create` until the user gives an explicit go-ahead.
 
 ### Create the form
 

--- a/tests/test_meta_ads_lead_form_contract.py
+++ b/tests/test_meta_ads_lead_form_contract.py
@@ -1,0 +1,284 @@
+"""Contract tests for two Meta Graph API v21.0 lead-form defects (2026-08-12).
+
+1. ``follow_up_action_url`` was typed optional, but Meta requires it.
+   Creating a form without it always fails with HTTP 400
+   ``error_subcode 1892085`` / "Missing field(s): FollowUpActionURL", so
+   every caller that followed mureo's schema hit a server round-trip
+   failure. It is now a required parameter that fails at the call site.
+
+2. The intro card's cover photo is write/read asymmetric. Create accepts
+   ``context_card.cover_photo_id``, but Meta reads it back as
+   ``context_card.cover_photo.id`` (``{id, created_time}``) — and asking
+   for ``context_card{cover_photo_id}`` is rejected with
+   ``(#100) Tried accessing nonexisting field (cover_photo_id)``. So
+   ``duplicate_lead_form`` must normalize the read-back shape before
+   re-posting it, or the duplicate loses its cover photo (or 400s).
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mureo.meta_ads._leads import LeadsMixin
+
+
+def _make_mock_client() -> LeadsMixin:
+    """Build a LeadsMixin instance with mocked _get/_post/_ad_account_id."""
+
+    class MockClient(LeadsMixin):
+        def __init__(self) -> None:
+            self._ad_account_id = "act_123"
+            self._get = AsyncMock(return_value={"data": []})
+            self._post = AsyncMock(return_value={"id": "new_id"})
+
+    return MockClient()
+
+
+def _import_meta_ads_tools():
+    from mureo.mcp import tools_meta_ads
+
+    return tools_meta_ads
+
+
+def _import_handlers():
+    from mureo.mcp import _handlers_meta_ads
+
+    return _handlers_meta_ads
+
+
+@pytest.fixture(autouse=True)
+def _standalone_meta_ads():
+    """Pin the handler test below to STANDALONE (untenanted) Meta Ads.
+
+    Same reason as ``tests/test_meta_ads_leads.py``: a dev box carrying a
+    ``mureo.runtime_context_factory`` plugin with a shared-auth
+    multi-account store would fail-close every account_id and break the
+    assertion for reasons unrelated to this contract.
+    """
+    with patch(
+        "mureo.mcp._handlers_meta_ads.runtime_meta_account_ids",
+        return_value=None,
+    ):
+        yield
+
+
+# ===========================================================================
+# Defect 1 — follow_up_action_url is required by Meta
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestFollowUpActionUrlRequired:
+    @pytest.fixture()
+    def client(self) -> LeadsMixin:
+        return _make_mock_client()
+
+    def test_signature_has_no_default(self) -> None:
+        """The parameter must have no default at all.
+
+        A default (even ``None``) means a caller can omit it and only
+        learn about ``error_subcode 1892085`` after a Meta round-trip.
+        """
+        param = inspect.signature(LeadsMixin.create_lead_form).parameters[
+            "follow_up_action_url"
+        ]
+        assert param.default is inspect.Parameter.empty
+
+    @pytest.mark.asyncio
+    async def test_omitting_it_raises_type_error(self, client: LeadsMixin) -> None:
+        """Omitting it fails at the call site, not at Meta."""
+        with pytest.raises(TypeError):
+            await client.create_lead_form(  # type: ignore[call-arg]
+                page_id="page_123",
+                name="no follow-up",
+                questions=[{"type": "EMAIL"}],
+                privacy_policy_url="https://example.com/privacy",
+            )
+        client._post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_always_emitted_into_payload(self, client: LeadsMixin) -> None:
+        """A normal create always sends the field Meta demands."""
+        await client.create_lead_form(
+            page_id="page_123",
+            name="basic",
+            questions=[{"type": "EMAIL"}],
+            privacy_policy_url="https://example.com/privacy",
+            follow_up_action_url="https://example.com/thanks",
+        )
+        data = client._post.call_args[0][1]
+        assert data["follow_up_action_url"] == "https://example.com/thanks"
+
+    def test_tool_schema_lists_it_as_required(self) -> None:
+        """The MCP schema must not advertise an optional field Meta rejects."""
+        mod = _import_meta_ads_tools()
+        tool = next(t for t in mod.TOOLS if t.name == "meta_ads_lead_forms_create")
+        assert "follow_up_action_url" in tool.inputSchema["required"]
+
+    async def test_handler_rejects_missing_follow_up_action_url(self) -> None:
+        """``_require`` raises ValueError, which ``api_error_handler``
+        re-raises untouched, so the caller sees a named-parameter error
+        instead of a Meta 400."""
+        mod = _import_meta_ads_tools()
+        handlers = _import_handlers()
+        client = AsyncMock()
+        creds = MagicMock()
+
+        with (
+            patch.object(handlers, "load_meta_ads_credentials", return_value=creds),
+            patch.object(handlers, "create_meta_ads_client", return_value=client),
+            pytest.raises(ValueError, match="follow_up_action_url"),
+        ):
+            await mod.handle_tool(
+                "meta_ads_lead_forms_create",
+                {
+                    "account_id": "act_123",
+                    "page_id": "page_456",
+                    "name": "contract form",
+                    "questions": [{"type": "EMAIL"}],
+                    "privacy_policy_url": "https://example.com/privacy",
+                },
+            )
+
+        client.create_lead_form.assert_not_awaited()
+
+
+# ===========================================================================
+# Defect 1 (duplicate path) — a source form without the field cannot be copied
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestDuplicateRequiresFollowUpActionUrl:
+    @pytest.fixture()
+    def client(self) -> LeadsMixin:
+        return _make_mock_client()
+
+    @pytest.mark.asyncio
+    async def test_missing_follow_up_action_url_raises(
+        self, client: LeadsMixin
+    ) -> None:
+        """Mirrors the existing ``privacy_policy.url`` fail-fast: Meta
+        requires the field at creation time, so the duplicate would 400
+        server-side anyway."""
+        source = {
+            "id": "form_1",
+            "name": "source form",
+            "questions": [{"type": "EMAIL"}],
+            "privacy_policy": {"url": "https://example.com/policy"},
+        }
+        client._get = AsyncMock(return_value=source)
+
+        with pytest.raises(ValueError) as excinfo:
+            await client.duplicate_lead_form(
+                "form_1", page_id="page_123", new_name="Copy"
+            )
+        message = str(excinfo.value)
+        assert "follow_up_action_url" in message
+        assert "requires" in message
+        client._post.assert_not_called()
+
+
+# ===========================================================================
+# Defect 2 — context_card cover photo write/read asymmetry
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestDuplicateNormalizesContextCard:
+    @pytest.fixture()
+    def client(self) -> LeadsMixin:
+        return _make_mock_client()
+
+    @staticmethod
+    def _source_with_cover() -> dict:
+        return {
+            "id": "form_1",
+            "name": "source form",
+            "questions": [{"type": "EMAIL"}],
+            "privacy_policy": {"url": "https://example.com/policy"},
+            "follow_up_action_url": "https://example.com/thanks",
+            "context_card": {
+                "title": "t",
+                "content": "c",
+                "style": "PARAGRAPH_STYLE",
+                "cover_photo": {
+                    "id": "122104778757409237",
+                    "created_time": "2026-08-12T00:00:00+0000",
+                },
+                "id": "999",
+            },
+        }
+
+    @pytest.mark.asyncio
+    async def test_cover_photo_converted_to_cover_photo_id(
+        self, client: LeadsMixin
+    ) -> None:
+        """Meta reads back ``cover_photo: {id, ...}`` but only accepts
+        ``cover_photo_id`` on write."""
+        client._get = AsyncMock(return_value=self._source_with_cover())
+        client._post = AsyncMock(return_value={"id": "form_2"})
+
+        await client.duplicate_lead_form("form_1", page_id="page_123", new_name="Copy")
+
+        card = json.loads(client._post.call_args[0][1]["context_card"])
+        assert card["cover_photo_id"] == "122104778757409237"
+        assert "cover_photo" not in card
+        # The server-assigned card id is read-only — re-posting it 400s.
+        assert "id" not in card
+        assert card["title"] == "t"
+        assert card["content"] == "c"
+        assert card["style"] == "PARAGRAPH_STYLE"
+
+    @pytest.mark.asyncio
+    async def test_source_dict_is_not_mutated(self, client: LeadsMixin) -> None:
+        """The normalization returns a new dict — the caller's read-back
+        record stays exactly as Meta returned it."""
+        source = self._source_with_cover()
+        client._get = AsyncMock(return_value=source)
+        client._post = AsyncMock(return_value={"id": "form_2"})
+
+        await client.duplicate_lead_form("form_1", page_id="page_123", new_name="Copy")
+
+        assert source["context_card"] == {
+            "title": "t",
+            "content": "c",
+            "style": "PARAGRAPH_STYLE",
+            "cover_photo": {
+                "id": "122104778757409237",
+                "created_time": "2026-08-12T00:00:00+0000",
+            },
+            "id": "999",
+        }
+
+    @pytest.mark.asyncio
+    async def test_card_without_cover_photo_still_copied(
+        self, client: LeadsMixin
+    ) -> None:
+        """No cover photo on the source means no ``cover_photo_id`` key —
+        the rest of the card still travels."""
+        source = {
+            "id": "form_1",
+            "name": "source form",
+            "questions": [{"type": "EMAIL"}],
+            "privacy_policy": {"url": "https://example.com/policy"},
+            "follow_up_action_url": "https://example.com/thanks",
+            "context_card": {
+                "title": "t",
+                "content": "c",
+                "style": "LIST_STYLE",
+                "id": "999",
+            },
+        }
+        client._get = AsyncMock(return_value=source)
+        client._post = AsyncMock(return_value={"id": "form_2"})
+
+        await client.duplicate_lead_form("form_1", page_id="page_123", new_name="Copy")
+
+        card = json.loads(client._post.call_args[0][1]["context_card"])
+        assert card == {"title": "t", "content": "c", "style": "LIST_STYLE"}
+        assert "cover_photo_id" not in card

--- a/tests/test_meta_ads_leads.py
+++ b/tests/test_meta_ads_leads.py
@@ -150,6 +150,7 @@ class TestCreateLeadForm:
             name="問い合わせフォーム",
             questions=questions,
             privacy_policy_url="https://example.com/privacy",
+            follow_up_action_url="https://example.com/thanks",
         )
 
         assert result["id"] == "form_new"
@@ -428,6 +429,7 @@ class TestLeadsApiError:
                 name="テスト",
                 questions=[{"type": "EMAIL"}],
                 privacy_policy_url="https://example.com/privacy",
+                follow_up_action_url="https://example.com/thanks",
             )
 
     @pytest.mark.asyncio
@@ -524,6 +526,7 @@ class TestLeadFormsMcpHandlers:
                     "name": "テストフォーム",
                     "questions": [{"type": "EMAIL"}],
                     "privacy_policy_url": "https://example.com/privacy",
+                    "follow_up_action_url": "https://example.com/thanks",
                 },
             )
 
@@ -631,7 +634,13 @@ class TestLeadAdsToolDefinitions:
             ("meta_ads_lead_forms_get", ["form_id"]),
             (
                 "meta_ads_lead_forms_create",
-                ["page_id", "name", "questions", "privacy_policy_url"],
+                [
+                    "page_id",
+                    "name",
+                    "questions",
+                    "privacy_policy_url",
+                    "follow_up_action_url",
+                ],
             ),
             ("meta_ads_lead_forms_update", ["form_id", "status"]),
             (
@@ -774,15 +783,21 @@ class TestDuplicateLeadForm:
         assert post_data["locale"] == "ja_JP"
 
     @pytest.mark.asyncio
-    async def test_duplicate_lead_form_handles_missing_optional_fields(
+    async def test_duplicate_lead_form_handles_missing_locale(
         self, client: LeadsMixin
     ) -> None:
-        """Works even when source omits follow_up_action_url / locale."""
+        """Works even when the source omits the optional ``locale``.
+
+        ``follow_up_action_url`` is no longer optional — Meta requires
+        it, so a source without one fails fast instead (see
+        tests/test_meta_ads_lead_form_contract.py).
+        """
         source = {
             "id": "form_1",
             "name": "原本",
             "questions": [{"type": "EMAIL"}],
             "privacy_policy": {"url": "https://example.com/policy"},
+            "follow_up_action_url": "https://example.com/thanks",
         }
         client._get = AsyncMock(return_value=source)
         client._post = AsyncMock(return_value={"id": "form_2"})
@@ -790,9 +805,10 @@ class TestDuplicateLeadForm:
         await client.duplicate_lead_form("form_1", page_id="page_123", new_name="Copy")
 
         post_data = client._post.call_args[0][1]
-        # Optional fields are not added.
-        assert "follow_up_action_url" not in post_data
+        # The optional field is not added.
         assert "locale" not in post_data
+        # The required one is always carried over.
+        assert post_data["follow_up_action_url"] == "https://example.com/thanks"
 
     @pytest.mark.asyncio
     async def test_duplicate_lead_form_accepts_string_privacy_policy_url(
@@ -804,6 +820,7 @@ class TestDuplicateLeadForm:
             "name": "原本",
             "questions": [{"type": "EMAIL"}],
             "privacy_policy_url": "https://example.com/policy",
+            "follow_up_action_url": "https://example.com/thanks",
         }
         client._get = AsyncMock(return_value=source)
         client._post = AsyncMock(return_value={"id": "form_2"})
@@ -825,6 +842,7 @@ class TestDuplicateLeadForm:
             "name": "オリジナル",
             "questions": [{"type": "EMAIL"}],
             "privacy_policy": {"url": "https://example.com/policy"},
+            "follow_up_action_url": "https://example.com/thanks",
         }
         client._get = AsyncMock(return_value=source)
         client._post = AsyncMock(return_value={"id": "form_2"})
@@ -918,6 +936,7 @@ class TestDuplicateLeadForm:
             "name": "原本",
             "questions": [{"type": "EMAIL"}],
             "privacy_policy": {"url": "https://example.com/policy"},
+            "follow_up_action_url": "https://example.com/thanks",
             "context_card": {
                 "title": "資料請求",
                 "content": "60秒で完了",
@@ -965,6 +984,7 @@ class TestDuplicateLeadForm:
             "name": "原本",
             "questions": [{"type": "EMAIL"}],
             "privacy_policy": {"url": "https://example.com/policy"},
+            "follow_up_action_url": "https://example.com/thanks",
         }
         client._get = AsyncMock(return_value=source)
         client._post = AsyncMock(return_value={"id": "form_2"})
@@ -989,6 +1009,7 @@ class TestDuplicateLeadForm:
             "name": "原本",
             "questions": [{"type": "EMAIL"}],
             "privacy_policy": {"url": "https://example.com/policy"},
+            "follow_up_action_url": "https://example.com/thanks",
             "is_higher_intent": False,
         }
         client._get = AsyncMock(return_value=source)
@@ -1023,6 +1044,7 @@ class TestCreateLeadFormAdvanced:
             name="basic",
             questions=[{"type": "EMAIL"}],
             privacy_policy_url="https://example.com/policy",
+            follow_up_action_url="https://example.com/thanks",
         )
         data = client._post.call_args[0][1]
         # The new fields are not sent.
@@ -1047,6 +1069,7 @@ class TestCreateLeadFormAdvanced:
             name="intro form",
             questions=[{"type": "EMAIL"}],
             privacy_policy_url="https://example.com/policy",
+            follow_up_action_url="https://example.com/thanks",
             context_card=card,
         )
         data = client._post.call_args[0][1]
@@ -1069,6 +1092,7 @@ class TestCreateLeadFormAdvanced:
             name="ty form",
             questions=[{"type": "EMAIL"}],
             privacy_policy_url="https://example.com/policy",
+            follow_up_action_url="https://example.com/thanks",
             thank_you_page=page,
         )
         data = client._post.call_args[0][1]
@@ -1088,6 +1112,7 @@ class TestCreateLeadFormAdvanced:
             name="HI form",
             questions=[{"type": "EMAIL"}],
             privacy_policy_url="https://example.com/policy",
+            follow_up_action_url="https://example.com/thanks",
             is_higher_intent=True,
         )
         data = client._post.call_args[0][1]
@@ -1104,6 +1129,7 @@ class TestCreateLeadFormAdvanced:
             name="standard form",
             questions=[{"type": "EMAIL"}],
             privacy_policy_url="https://example.com/policy",
+            follow_up_action_url="https://example.com/thanks",
         )
         data = client._post.call_args[0][1]
         assert "is_higher_intent" not in data
@@ -1125,6 +1151,7 @@ class TestCreateLeadFormAdvanced:
             name="branching form",
             questions=[{"type": "EMAIL"}],
             privacy_policy_url="https://example.com/policy",
+            follow_up_action_url="https://example.com/thanks",
             conditional_questions_choices=choices,
         )
         data = client._post.call_args[0][1]


### PR DESCRIPTION
Two Meta lead-form defects, both hit while driving Graph API v21.0 on a live account.

## 1. `follow_up_action_url` was optional in mureo, required by Meta

Creating a form without it always fails:

```json
{"error":{"message":"Invalid parameter","code":100,"error_subcode":1892085,
 "error_user_title":"Missing Fields","error_user_msg":"Missing field(s): FollowUpActionURL"}}
```

`create_lead_form()` declared `follow_up_action_url: str | None = None` and the
`meta_ads_lead_forms_create` tool schema did not list it as required, so **every caller that
followed mureo's own schema failed on every call**.

It is now a required parameter of `create_lead_form` and of the tool schema — the call fails at
the call site with the field named, instead of after a Meta round-trip.

Why required rather than defaulted to the `privacy_policy_url` host: the field is the URL behind
the completion screen's button, i.e. where real leads land. Deriving it silently would send people
to a page nobody chose. `thank_you_page` adds a richer completion screen but does not remove the
requirement, so the tool/skill text claiming it "supersedes" the field is corrected too.

`duplicate_lead_form` now fails fast with a `ValueError` when the source form has no
`follow_up_action_url`, mirroring the existing `privacy_policy.url` check.

## 2. The created form cannot be read back via `cover_photo_id`

Create accepts `context_card.cover_photo_id`, but Meta reads it back as
`context_card.cover_photo.id`:

```
GET /{form_id}?fields=context_card{cover_photo_id}
-> 400 (#100) Tried accessing nonexisting field (cover_photo_id)
```

Verified read shape:

```json
{"context_card": {"title": "...", "cover_photo": {"id": "1221047787...", "created_time": "..."}, "id": "..."}}
```

`duplicate_lead_form` re-posted that read-back shape verbatim, so a duplicated form either lost its
intro cover photo or 400d. It now normalizes the card first via `_context_card_for_write`:
`cover_photo.id` -> `cover_photo_id`, read-only `cover_photo` / `id` dropped, every other key
preserved, source record never mutated.

`get_lead_form` still returns Meta's raw shape (mureo's passthrough convention); the asymmetry is
documented on both the write and read side instead — tool descriptions, docstrings,
`docs/mcp-server.md`, and both skills trees.

While correcting the `meta_ads_lead_forms_duplicate` description, its "NOT copied" list was also
stale: intro / thank-you / higher-intent / conditional-branch fields have been copied since PR 4.

## Tests

TDD — `tests/test_meta_ads_lead_form_contract.py` (new, 9 tests) was written first and 7 of them
failed against the old code:

- `follow_up_action_url` has no default in the signature; omitting it raises `TypeError` before any
  POST; it is always in the payload
- the MCP tool schema lists it in `required`; the handler raises a `ValueError` naming the field and
  never reaches the client
- `duplicate_lead_form` raises on a source form without it
- `duplicate_lead_form` converts `cover_photo` -> `cover_photo_id`, drops the server-assigned card
  `id`, keeps the rest, does not mutate the source, and handles a card with no cover photo

Existing tests that encoded the old contract were updated. `pytest tests/ -q` is green apart from 12
failures that reproduce byte-identically on a clean `origin/main` worktree (live-credential
`AccountNotAvailableError` cases and tool-count assertions affected by a locally installed plugin).
ruff / black / mypy clean.
