### PR TITLE
fix: keep a hand-entered Meta token off the auto-refresh clock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A Meta token pasted into the advanced credentials form was overwritten on
+  the next API call** (#578). The Setup tab's *mureo Credentials (advanced)*
+  form writes one field at a time, and that field-wise merge left the previous
+  token's `token_obtained_at` in place. `_should_refresh` ages the token
+  against that stamp — which was already past the 53-day threshold, since a
+  stale token is why the operator was pasting a new one — so the very next
+  Meta tool call handed the brand-new token to Graph's `fb_exchange_token`
+  endpoint under the stored `app_id` / `app_secret`. Both outcomes were
+  silent: an exchange that succeeded replaced a never-expiring system-user
+  token with a ~60-day one, and an exchange that failed (the common case,
+  where the token was minted under a different app) was swallowed, leaving
+  the operator to conclude the paste "didn't take" while it was retried on
+  every subsequent call. Writing `META_ADS_ACCESS_TOKEN` now clears
+  `token_obtained_at`, so a hand-entered token short-circuits the refresh
+  check the same way the dedicated paste card does. `app_id`, `app_secret`
+  and `account_id` are kept — updating a token should not cost the operator
+  their app secret — and writes to other `meta_ads` fields leave the stamp
+  alone, since it still describes the token on disk.
+
 ## [0.10.44] - 2026-08-12
 
 ### Fixed

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -255,6 +255,11 @@ account, then **Save**. Because the token never expires, mureo stores it
 **without** `app_id` / `app_secret`, which keeps it out of the auto-refresh path
 below — nothing to rotate, nothing to expire.
 
+Prefer that card. Saving `META_ADS_ACCESS_TOKEN` through the Setup tab's
+**mureo Credentials (advanced)** form also works — a hand-entered token is
+stored as entered and stays off the auto-refresh clock — but it writes one
+field, so it neither validates the token nor lets you pick an ad account.
+
 System User tokens do not expire.
 
 ### App ID and App Secret

--- a/mureo/web/env_var_writer.py
+++ b/mureo/web/env_var_writer.py
@@ -178,6 +178,37 @@ def _resolve_credentials_path(credentials_path: Path | None) -> Path:
     return Path.home() / ".mureo" / "credentials.json"
 
 
+def _clear_stale_refresh_clock(name: str, section_payload: dict[str, Any]) -> None:
+    """Drop ``token_obtained_at`` when a Meta token is written by hand (#578).
+
+    This writer merges field-wise, which is right for most fields and wrong
+    for a credential that another field describes. ``meta_ads`` keeps
+    ``token_obtained_at`` to age the token: :func:`mureo.auth._should_refresh`
+    compares it against ``_TOKEN_REFRESH_THRESHOLD_DAYS`` and, past that,
+    every Meta tool call hands the token to Graph's ``fb_exchange_token``
+    endpoint under the stored ``app_id``/``app_secret``.
+
+    A hand-pasted token therefore inherited the *previous* token's stamp —
+    already past the threshold, since that is why it was being replaced — so
+    the refresh fired on the very next call. Either the exchange succeeded and
+    overwrote a never-expiring system-user token with a ~60-day one, or the
+    token belonged to a different app, Graph rejected it, and the failure was
+    swallowed.
+
+    Clearing the stamp makes ``_should_refresh`` short-circuit on its
+    "no stamp" branch, which is what the dedicated paste card achieves by
+    dropping ``app_id``/``app_secret`` outright. We keep those: an operator
+    updating a token did not ask to lose the app secret, and the missing
+    stamp alone is enough to stay off the clock. Any path that legitimately
+    mints or refreshes a token re-stamps it.
+
+    Only the token write clears the stamp — writing ``META_ADS_ACCOUNT_ID``,
+    say, leaves the token untouched, so its stamp still describes it.
+    """
+    if name == "META_ADS_ACCESS_TOKEN":
+        section_payload.pop("token_obtained_at", None)
+
+
 def write_credential_env_var(
     name: str,
     value: str,
@@ -228,6 +259,7 @@ def write_credential_env_var(
         dict(section_payload_raw) if isinstance(section_payload_raw, dict) else {}
     )
     section_payload[target.field] = value
+    _clear_stale_refresh_clock(name, section_payload)
     merged: dict[str, Any] = dict(existing)
     merged[target.section] = section_payload
 

--- a/tests/test_web_env_var_meta_token.py
+++ b/tests/test_web_env_var_meta_token.py
@@ -1,0 +1,127 @@
+"""A Meta token pasted into the advanced form must not enter the refresh clock.
+
+Regression tests for #578. The advanced "mureo Credentials (advanced)" form
+writes one field at a time through :func:`write_credential_env_var`, which
+merges field-wise. For ``META_ADS_ACCESS_TOKEN`` that merge used to leave the
+previous token's ``token_obtained_at`` in place, so the very next Meta call saw
+a brand-new token as an aged one, handed it to the Graph token-exchange
+endpoint under the stale ``app_id``/``app_secret``, and wrote the result over
+it (or failed silently).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING
+
+import pytest
+
+from mureo.auth import _should_refresh, load_meta_ads_credentials
+from mureo.web.env_var_writer import write_credential_env_var
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+#: Older than ``mureo.auth._TOKEN_REFRESH_THRESHOLD_DAYS`` (53) by a margin, so
+#: the surviving stamp is unambiguously past the refresh threshold.
+_STALE_STAMP = (datetime.now(tz=timezone.utc) - timedelta(days=90)).isoformat()
+
+
+def _write_stale_meta_section(path: Path) -> None:
+    """Seed the on-disk state an operator with an expired token actually has."""
+    path.write_text(
+        json.dumps(
+            {
+                "meta_ads": {
+                    "access_token": "EXPIRED-USER-TOKEN",
+                    "app_id": "111111111111111",
+                    "app_secret": "stale-app-secret",
+                    "account_id": "act_222",
+                    "token_obtained_at": _STALE_STAMP,
+                },
+                # A second provider must survive the single-field write.
+                "google_ads": {"developer_token": "dev-token"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.unit
+class TestMetaAccessTokenLeavesRefreshClock:
+    def test_pasted_token_is_not_due_for_refresh(self, tmp_path: Path) -> None:
+        """The exact assertion #578 asks for: no refresh after a hand paste."""
+        path = tmp_path / "credentials.json"
+        _write_stale_meta_section(path)
+
+        write_credential_env_var(
+            "META_ADS_ACCESS_TOKEN", "SYSTEM-USER-TOKEN", credentials_path=path
+        )
+
+        creds = load_meta_ads_credentials(path)
+        assert creds is not None
+        assert creds.access_token == "SYSTEM-USER-TOKEN"
+        assert _should_refresh(creds) is False
+
+    def test_stale_token_obtained_at_is_dropped(self, tmp_path: Path) -> None:
+        """The stamp belongs to the token being replaced, so it must not survive."""
+        path = tmp_path / "credentials.json"
+        _write_stale_meta_section(path)
+
+        write_credential_env_var(
+            "META_ADS_ACCESS_TOKEN", "SYSTEM-USER-TOKEN", credentials_path=path
+        )
+
+        meta = json.loads(path.read_text(encoding="utf-8"))["meta_ads"]
+        assert "token_obtained_at" not in meta
+
+    def test_app_credentials_and_account_are_preserved(self, tmp_path: Path) -> None:
+        """Only the refresh clock is cleared — no other field is destroyed.
+
+        Dropping ``app_secret`` would make an operator who only meant to
+        refresh a token re-fetch it from Meta, so the fix clears the stamp
+        instead: ``_should_refresh`` already short-circuits without one.
+        """
+        path = tmp_path / "credentials.json"
+        _write_stale_meta_section(path)
+
+        write_credential_env_var(
+            "META_ADS_ACCESS_TOKEN", "SYSTEM-USER-TOKEN", credentials_path=path
+        )
+
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        assert payload["meta_ads"]["app_id"] == "111111111111111"
+        assert payload["meta_ads"]["app_secret"] == "stale-app-secret"
+        assert payload["meta_ads"]["account_id"] == "act_222"
+        assert payload["google_ads"] == {"developer_token": "dev-token"}
+
+    def test_writing_another_meta_field_keeps_the_stamp(self, tmp_path: Path) -> None:
+        """Only the token write clears the clock.
+
+        Saving ``META_ADS_ACCOUNT_ID`` does not replace the token, so the
+        stamp still describes the token on disk and must be left alone.
+        """
+        path = tmp_path / "credentials.json"
+        _write_stale_meta_section(path)
+
+        write_credential_env_var(
+            "META_ADS_ACCOUNT_ID", "act_999", credentials_path=path
+        )
+
+        meta = json.loads(path.read_text(encoding="utf-8"))["meta_ads"]
+        assert meta["token_obtained_at"] == _STALE_STAMP
+        assert meta["account_id"] == "act_999"
+
+    def test_no_stamp_to_clear_is_not_an_error(self, tmp_path: Path) -> None:
+        """A first-time paste has no prior section; the write still succeeds."""
+        path = tmp_path / "credentials.json"
+
+        write_credential_env_var(
+            "META_ADS_ACCESS_TOKEN", "SYSTEM-USER-TOKEN", credentials_path=path
+        )
+
+        creds = load_meta_ads_credentials(path)
+        assert creds is not None
+        assert creds.access_token == "SYSTEM-USER-TOKEN"
+        assert _should_refresh(creds) is False


### PR DESCRIPTION
Closes #578.

## The bug

The Setup tab's *mureo Credentials (advanced)* form writes one field at a time through `write_credential_env_var`, which merges field-wise. For `META_ADS_ACCESS_TOKEN` that left the **previous** token's `token_obtained_at` in place.

`_should_refresh` ages the token against that stamp. It was already past the 53-day threshold — a stale token is precisely why the operator was pasting a new one — so the refresh fired on the *next* Meta tool call, not eventually. mureo then handed the brand-new token to Graph's `fb_exchange_token` endpoint under the stored `app_id`/`app_secret`.

Both outcomes were silent:

- **Same app** — the exchange succeeded and a never-expiring system-user token was replaced on disk by a ~60-day one. The operator escaped the token treadmill and was put straight back on it.
- **Different app** (the common case, per the report) — Graph rejected it, `refresh_meta_token_if_needed` swallowed the failure, and nothing installs a logging handler on an interactive `mureo configure` run. The operator saw nothing, concluded the paste "didn't take", and the exchange was retried on every subsequent call.

## The fix

Writing `META_ADS_ACCESS_TOKEN` clears `token_obtained_at`, so `_should_refresh` short-circuits on its "no stamp" branch — the same end state the dedicated paste card reaches by dropping `app_id`/`app_secret` outright.

**Why clear the stamp rather than the app credentials.** The issue offered both. Dropping `app_secret` would make an operator who only meant to update a token re-fetch it from Meta, and it is not needed: the missing stamp alone keeps the token off the clock. Every path that legitimately mints or refreshes a token re-stamps it, so this does not decay.

**Why not re-stamp to now.** That only moves the failure 53 days out, at which point a system-user token is exchanged anyway.

Only the token write clears the stamp. Writing `META_ADS_ACCOUNT_ID` leaves the token untouched, so its stamp still describes it.

## Tests

`tests/test_web_env_var_meta_token.py` — 5 unit tests, no browser:

- the assertion #578 asked for: `_should_refresh` is `False` after a hand paste over a stale section
- the stale `token_obtained_at` is gone from disk
- `app_id` / `app_secret` / `account_id` and other providers' sections survive
- writing `META_ADS_ACCOUNT_ID` keeps the stamp
- a first-time paste with no prior section works

Both new assertions fail on `main` and pass here.

## Also

- `docs/authentication.md` — points at the purpose-built paste card and notes the advanced form is safe but does not validate the token or let you pick an ad account.
