### PR TITLE
fix: stop the remaining Google Ads log lines from writing the exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,27 @@
   kept out of `action_log` — it would otherwise have been recorded as a
   change that never happened, complete with an `observation_due`.
 
+- **A Google Ads tool failure could write the developer token and the
+  `authorization` header to the log** (#603). 36 call sites under
+  `mureo/google_ads/` logged SDK exceptions with `exc_info=True`, which writes
+  `traceback.format_exception()` and so `str(exc)`. `GoogleAdsException` does
+  not curate its `__str__`: it never passes a message to `super().__init__()`,
+  so formatting it prints the underlying `grpc.Call` repr — which carries
+  `debug_error_string()`, and with it the request metadata. Chaining meant a
+  `RuntimeError` caught one level up printed the same bytes, because a
+  traceback follows `__cause__`. The three sites reachable from the configure
+  server were fixed in #581; these are the rest, on MCP tool paths, where the
+  exposure depends on what the host process has switched on.
+
+  Each site now logs the exception class, or — for the three that wrap a GAQL
+  search directly — the curated server-side `failure.errors[0].message` via
+  `_extract_error_detail`, which is both safe and more useful than a bare class
+  name. `_extract_error_detail` no longer falls back to `str(exc)` when the
+  failure carries no errors, since that fallback was the same leak in the
+  function offered as the safe alternative. `tests/test_google_ads_log_exc_info.py`
+  fails on a new `exc_info=` or `logger.exception()` anywhere under
+  `mureo/google_ads/`, so the 37th cannot be written.
+
 ### Added
 
 - **A Meta token expiry notice and a re-authenticate control on the Meta

--- a/mureo/google_ads/_ads.py
+++ b/mureo/google_ads/_ads.py
@@ -492,16 +492,19 @@ class _AdsMixin:
                             " Please pause existing ads before enabling."
                         ),
                     }
-            except Exception:
+            except Exception as exc:
                 # Advisory guard only — Google still enforces the RSA limit
                 # server-side. But do not silently bypass it: log at WARNING and
                 # thread a caveat into the result so the caller knows the
-                # friendly pre-check did not run for this call.
+                # friendly pre-check did not run for this call. Class name only:
+                # a traceback would print the GoogleAdsException repr, which
+                # carries the request metadata (developer token, authorization
+                # header) — see mureo/google_ads/accounts.py (#603).
                 logger.warning(
-                    "RSA-limit pre-check failed for ad_group %s; proceeding "
+                    "RSA-limit pre-check failed for ad_group %s (%s); proceeding "
                     "(Google Ads still enforces the limit server-side).",
                     ad_group_id,
-                    exc_info=True,
+                    type(exc).__name__,
                 )
                 precheck_skipped = True
 

--- a/mureo/google_ads/_analysis_btob.py
+++ b/mureo/google_ads/_analysis_btob.py
@@ -75,11 +75,15 @@ class _BtoBAnalysisMixin:
         """B2B optimization check for ad schedule."""
         try:
             schedules = await self.list_schedule_targeting(campaign_id)
-        except Exception:
+        except Exception as exc:
+            # Class name only. A traceback would print the GoogleAdsException
+            # repr, which carries the request metadata (developer token,
+            # authorization header) — see mureo/google_ads/accounts.py for the
+            # full reasoning (#603).
             logger.warning(
-                "B2B schedule check failed for campaign %s",
+                "B2B schedule check failed for campaign %s (%s)",
                 campaign_id,
-                exc_info=True,
+                type(exc).__name__,
             )
             return
 
@@ -120,11 +124,11 @@ class _BtoBAnalysisMixin:
         """B2B optimization check for device CPA."""
         try:
             device_result = await self.analyze_device_performance(campaign_id, period)
-        except Exception:
+        except Exception as exc:
             logger.warning(
-                "B2B device check failed for campaign %s",
+                "B2B device check failed for campaign %s (%s)",
                 campaign_id,
-                exc_info=True,
+                type(exc).__name__,
             )
             return
 
@@ -183,11 +187,11 @@ class _BtoBAnalysisMixin:
             search_terms = await self.get_search_terms_report(
                 campaign_id=campaign_id, period=period
             )
-        except Exception:
+        except Exception as exc:
             logger.warning(
-                "B2B search terms check failed for campaign %s",
+                "B2B search terms check failed for campaign %s (%s)",
                 campaign_id,
-                exc_info=True,
+                type(exc).__name__,
             )
             return
 

--- a/mureo/google_ads/_analysis_budget.py
+++ b/mureo/google_ads/_analysis_budget.py
@@ -54,11 +54,15 @@ class _BudgetAnalysisMixin:
                 m = _safe_metrics(perf)
                 cost = float(m.get("cost", 0))
                 convs = float(m.get("conversions", 0))
-            except Exception:
+            except Exception as exc:
+                # Class name only. A traceback would print the GoogleAdsException
+                # repr, which carries the request metadata (developer token,
+                # authorization header) — see mureo/google_ads/accounts.py for the
+                # full reasoning (#603).
                 logger.warning(
-                    "Failed to retrieve performance for campaign %s",
+                    "Failed to retrieve performance for campaign %s (%s)",
                     cid,
-                    exc_info=True,
+                    type(exc).__name__,
                 )
                 failed_campaigns.append(cid)
                 continue
@@ -184,9 +188,11 @@ class _BudgetAnalysisMixin:
                     budget_info.get("daily_budget", 0) if budget_info else 0
                 )
                 camp["budget_id"] = budget_info.get("id", "") if budget_info else ""
-            except Exception:
+            except Exception as exc:
                 logger.warning(
-                    "Failed to retrieve budget for campaign %s", cid, exc_info=True
+                    "Failed to retrieve budget for campaign %s (%s)",
+                    cid,
+                    type(exc).__name__,
                 )
                 camp["current_daily_budget"] = 0
                 camp["budget_id"] = ""

--- a/mureo/google_ads/_analysis_performance.py
+++ b/mureo/google_ads/_analysis_performance.py
@@ -286,8 +286,14 @@ class _PerformanceAnalysisMixin:
             )
             insights.extend(perf_insights)
             result.update(cpa_info)
-        except Exception:
-            logger.warning("Failed to retrieve performance comparison", exc_info=True)
+        except Exception as exc:
+            # Class name only. A traceback would print the GoogleAdsException
+            # repr, which carries the request metadata (developer token,
+            # authorization header) — see mureo/google_ads/accounts.py for the
+            # full reasoning (#603).
+            logger.warning(
+                "Failed to retrieve performance comparison (%s)", type(exc).__name__
+            )
             result["performance_current"] = "Retrieval failed"
 
         # 3. Top 20 search terms
@@ -301,8 +307,10 @@ class _PerformanceAnalysisMixin:
                 reverse=True,
             )
             result["top_search_terms"] = sorted_terms[:20]
-        except Exception:
-            logger.warning("Failed to retrieve search terms report", exc_info=True)
+        except Exception as exc:
+            logger.warning(
+                "Failed to retrieve search terms report (%s)", type(exc).__name__
+            )
             result["top_search_terms"] = "Retrieval failed"
 
         # 4. Google recommendations
@@ -311,16 +319,18 @@ class _PerformanceAnalysisMixin:
             result["recommendations_from_google"] = recommendations[:10]
             if recommendations:
                 recs.append(f"Google has {len(recommendations)} recommendations")
-        except Exception:
-            logger.warning("Failed to retrieve recommendations", exc_info=True)
+        except Exception as exc:
+            logger.warning(
+                "Failed to retrieve recommendations (%s)", type(exc).__name__
+            )
             result["recommendations_from_google"] = "Retrieval failed"
 
         # 5. Recent change history
         try:
             changes_history = await self.list_change_history()
             result["recent_changes"] = changes_history[:10]
-        except Exception:
-            logger.warning("Failed to retrieve change history", exc_info=True)
+        except Exception as exc:
+            logger.warning("Failed to retrieve change history (%s)", type(exc).__name__)
             result["recent_changes"] = "Retrieval failed"
 
         # 6. Analysis summary
@@ -355,8 +365,10 @@ class _PerformanceAnalysisMixin:
             result["performance_current_7d"] = current_m
             result["performance_previous_7d"] = previous_m
             result["changes"] = changes
-        except Exception:
-            logger.warning("Failed to retrieve performance comparison", exc_info=True)
+        except Exception as exc:
+            logger.warning(
+                "Failed to retrieve performance comparison (%s)", type(exc).__name__
+            )
             result["performance_current_7d"] = "Retrieval failed"
 
         # 2. Cost increase breakdown (CPC increase vs click increase)
@@ -373,8 +385,8 @@ class _PerformanceAnalysisMixin:
             result["wasteful_search_terms"] = term_analysis["wasteful_search_terms"]
             if term_analysis["finding"]:
                 findings.append(term_analysis["finding"])
-        except Exception:
-            logger.warning("Search term analysis failed", exc_info=True)
+        except Exception as exc:
+            logger.warning("Search term analysis failed (%s)", type(exc).__name__)
             result["new_search_terms"] = "Retrieval failed"
             result["wasteful_search_terms"] = "Retrieval failed"
 
@@ -397,8 +409,8 @@ class _PerformanceAnalysisMixin:
                 findings.append(
                     f"There are {len(bid_budget_changes)} recent bid/budget-related changes"
                 )
-        except Exception:
-            logger.warning("Failed to retrieve change history", exc_info=True)
+        except Exception as exc:
+            logger.warning("Failed to retrieve change history (%s)", type(exc).__name__)
             result["bid_budget_changes"] = "Retrieval failed"
 
         # 5. Negative keyword candidates
@@ -476,8 +488,8 @@ class _PerformanceAnalysisMixin:
                         f"There are {len(neg_candidates)} search terms with cost but no conversions. "
                         "Consider adding them as negative keywords"
                     )
-        except Exception:
-            logger.warning("Negative keyword analysis failed", exc_info=True)
+        except Exception as exc:
+            logger.warning("Negative keyword analysis failed (%s)", type(exc).__name__)
             result["negative_keyword_candidates"] = "Retrieval failed"
 
     # =================================================================
@@ -540,11 +552,11 @@ class _PerformanceAnalysisMixin:
                         "recommendations": diag.get("recommendations", []),
                     }
                 )
-            except Exception:
+            except Exception as exc:
                 logger.warning(
-                    "Failed to run detailed diagnostics for campaign %s",
+                    "Failed to run detailed diagnostics for campaign %s (%s)",
                     cid,
-                    exc_info=True,
+                    type(exc).__name__,
                 )
                 detailed_diagnostics.append(
                     {

--- a/mureo/google_ads/_creative.py
+++ b/mureo/google_ads/_creative.py
@@ -101,8 +101,12 @@ class _CreativeMixin:
             result["existing_ads"] = await self._fetch_existing_ads(
                 campaign_id, ad_group_id
             )
-        except Exception:
-            logger.warning("Failed to retrieve existing ads", exc_info=True)
+        except Exception as exc:
+            # Class name only. A traceback would print the GoogleAdsException
+            # repr, which carries the request metadata (developer token,
+            # authorization header) — see mureo/google_ads/accounts.py for the
+            # full reasoning (#603).
+            logger.warning("Failed to retrieve existing ads (%s)", type(exc).__name__)
             result["existing_ads"] = "fetch_failed"
 
         # --- 3. Search term insights ---
@@ -110,8 +114,10 @@ class _CreativeMixin:
             result["search_term_insights"] = await self._extract_search_term_insights(
                 campaign_id, ad_group_id
             )
-        except Exception:
-            logger.warning("Failed to retrieve search term insights", exc_info=True)
+        except Exception as exc:
+            logger.warning(
+                "Failed to retrieve search term insights (%s)", type(exc).__name__
+            )
             result["search_term_insights"] = "fetch_failed"
 
         # --- 4. Keyword suggestions ---
@@ -121,8 +127,10 @@ class _CreativeMixin:
                 result["keyword_suggestions"] = await self.suggest_keywords(seeds)
             else:
                 result["keyword_suggestions"] = []
-        except Exception:
-            logger.warning("Failed to retrieve keyword suggestions", exc_info=True)
+        except Exception as exc:
+            logger.warning(
+                "Failed to retrieve keyword suggestions (%s)", type(exc).__name__
+            )
             result["keyword_suggestions"] = "fetch_failed"
 
         # --- 5. Existing keywords ---
@@ -130,8 +138,10 @@ class _CreativeMixin:
             result["existing_keywords"] = await self.list_keywords(
                 campaign_id=campaign_id
             )
-        except Exception:
-            logger.warning("Failed to retrieve existing keywords", exc_info=True)
+        except Exception as exc:
+            logger.warning(
+                "Failed to retrieve existing keywords (%s)", type(exc).__name__
+            )
             result["existing_keywords"] = "fetch_failed"
 
         # --- 6. Context summary for LLM ---

--- a/mureo/google_ads/_diagnostics.py
+++ b/mureo/google_ads/_diagnostics.py
@@ -521,8 +521,12 @@ class _DiagnosticsMixin:
         try:
             sitelinks = await self.list_sitelinks(campaign_id)
             result["sitelinks_count"] = len(sitelinks)
-        except Exception:
-            logger.debug("Failed to retrieve sitelink count", exc_info=True)
+        except Exception as exc:
+            # Class name only. A traceback would print the GoogleAdsException
+            # repr, which carries the request metadata (developer token,
+            # authorization header) — see mureo/google_ads/accounts.py for the
+            # full reasoning (#603).
+            logger.debug("Failed to retrieve sitelink count (%s)", type(exc).__name__)
             result["sitelinks_count"] = 0
 
         # 8. Billing setup check
@@ -610,10 +614,17 @@ class _DiagnosticsMixin:
             # Sort by CV count descending
             conversion_actions_detail.sort(key=lambda x: x["conversions"], reverse=True)
             result["conversion_actions_detail"] = conversion_actions_detail
-        except Exception:
-            logger.debug(
-                "Failed to retrieve conversion action performance", exc_info=True
+        except Exception as exc:
+            # Never the exception itself (see above). This one wraps a GAQL
+            # search, so the curated server-side failure message is both safe
+            # and the thing worth reading; anything else falls back to the
+            # class name.
+            detail = (
+                self._extract_error_detail(exc)  # type: ignore[attr-defined]
+                if hasattr(exc, "failure")
+                else type(exc).__name__
             )
+            logger.debug("Failed to retrieve conversion action performance: %s", detail)
             result["conversion_actions_detail"] = []
 
         # --- NEW: 9. Impression share check ---
@@ -655,8 +666,14 @@ class _DiagnosticsMixin:
                             f"of impressions due to insufficient ad rank"
                         )
                 break  # First row only
-        except Exception:
-            logger.debug("Failed to retrieve impression share", exc_info=True)
+        except Exception as exc:
+            # GAQL search again — curated detail, class name otherwise.
+            detail = (
+                self._extract_error_detail(exc)  # type: ignore[attr-defined]
+                if hasattr(exc, "failure")
+                else type(exc).__name__
+            )
+            logger.debug("Failed to retrieve impression share: %s", detail)
 
         # Generate recommended actions
         if bidding.get("strategy") == "TARGET_IMPRESSION_SHARE":

--- a/mureo/google_ads/_extensions_sitelinks.py
+++ b/mureo/google_ads/_extensions_sitelinks.py
@@ -89,8 +89,20 @@ class _SitelinksMixin:
                     mapped["level"] = "account"
                     results.append(mapped)
                     seen_ids.add(mapped.get("id"))
-        except Exception:
-            logger.debug("Failed to retrieve account-level sitelinks", exc_info=True)
+        except Exception as exc:
+            # Never the exception itself: a traceback would print the
+            # GoogleAdsException repr, which carries the request metadata
+            # (developer token, authorization header) — see
+            # mureo/google_ads/accounts.py for the full reasoning (#603). This
+            # wraps a GAQL search, so the curated server-side failure message
+            # is both safe and the thing worth reading; anything else falls
+            # back to the class name.
+            detail = (
+                self._extract_error_detail(exc)  # type: ignore[attr-defined]
+                if hasattr(exc, "failure")
+                else type(exc).__name__
+            )
+            logger.debug("Failed to retrieve account-level sitelinks: %s", detail)
 
         return results
 

--- a/mureo/google_ads/_monitoring.py
+++ b/mureo/google_ads/_monitoring.py
@@ -52,16 +52,24 @@ class _MonitoringMixin:
         campaign: dict[str, Any] | None = None
         try:
             campaign = await self.get_campaign(campaign_id)
-        except Exception:
-            logger.warning("Failed to retrieve campaign information", exc_info=True)
+        except Exception as exc:
+            # Class name only. A traceback would print the GoogleAdsException
+            # repr, which carries the request metadata (developer token,
+            # authorization header) — see mureo/google_ads/accounts.py for the
+            # full reasoning (#603).
+            logger.warning(
+                "Failed to retrieve campaign information (%s)", type(exc).__name__
+            )
         result["campaign"] = campaign
 
         # 2. Delivery diagnostics
         diagnosis: dict[str, Any] = {}
         try:
             diagnosis = await self.diagnose_campaign_delivery(campaign_id)
-        except Exception:
-            logger.warning("Failed to retrieve delivery diagnostics", exc_info=True)
+        except Exception as exc:
+            logger.warning(
+                "Failed to retrieve delivery diagnostics (%s)", type(exc).__name__
+            )
             issues.append("Failed to retrieve delivery diagnostics")
         result["diagnosis"] = diagnosis
 
@@ -71,8 +79,10 @@ class _MonitoringMixin:
             performance = await self.get_performance_report(
                 campaign_id=campaign_id, period="YESTERDAY"
             )
-        except Exception:
-            logger.warning("Failed to retrieve previous day performance", exc_info=True)
+        except Exception as exc:
+            logger.warning(
+                "Failed to retrieve previous day performance (%s)", type(exc).__name__
+            )
             issues.append("Failed to retrieve previous day performance")
         result["performance"] = performance
 
@@ -156,8 +166,10 @@ class _MonitoringMixin:
             perf = await self.get_performance_report(
                 campaign_id=campaign_id, period="LAST_7_DAYS"
             )
-        except Exception:
-            logger.warning("Failed to retrieve performance report", exc_info=True)
+        except Exception as exc:
+            logger.warning(
+                "Failed to retrieve performance report (%s)", type(exc).__name__
+            )
             issues.append("Failed to retrieve performance report")
 
         metrics = perf[0].get("metrics", {}) if perf else {}
@@ -179,8 +191,8 @@ class _MonitoringMixin:
         cost_analysis: dict[str, Any] = {}
         try:
             cost_analysis = await self.investigate_cost_increase(campaign_id)
-        except Exception:
-            logger.warning("Failed to retrieve cost analysis", exc_info=True)
+        except Exception as exc:
+            logger.warning("Failed to retrieve cost analysis (%s)", type(exc).__name__)
             issues.append("Failed to retrieve cost analysis")
         result["cost_analysis"] = cost_analysis
 
@@ -270,8 +282,10 @@ class _MonitoringMixin:
             perf = await self.get_performance_report(
                 campaign_id=campaign_id, period="LAST_7_DAYS"
             )
-        except Exception:
-            logger.warning("Failed to retrieve performance report", exc_info=True)
+        except Exception as exc:
+            logger.warning(
+                "Failed to retrieve performance report (%s)", type(exc).__name__
+            )
             issues.append("Failed to retrieve performance report")
 
         metrics = perf[0].get("metrics", {}) if perf else {}
@@ -287,8 +301,10 @@ class _MonitoringMixin:
         performance_analysis: dict[str, Any] = {}
         try:
             performance_analysis = await self.analyze_performance(campaign_id)
-        except Exception:
-            logger.warning("Failed to retrieve performance analysis", exc_info=True)
+        except Exception as exc:
+            logger.warning(
+                "Failed to retrieve performance analysis (%s)", type(exc).__name__
+            )
             issues.append("Failed to retrieve performance analysis")
         result["performance_analysis"] = performance_analysis
 
@@ -393,15 +409,19 @@ class _MonitoringMixin:
         campaign: dict[str, Any] | None = None
         try:
             campaign = await self.get_campaign(campaign_id)
-        except Exception:
-            logger.warning("Failed to retrieve campaign information", exc_info=True)
+        except Exception as exc:
+            logger.warning(
+                "Failed to retrieve campaign information (%s)", type(exc).__name__
+            )
 
         # 2. Conversion tracking configuration
         cv_actions: list[dict[str, Any]] = []
         try:
             cv_actions = await self.list_conversion_actions()
-        except Exception:
-            logger.warning("Failed to retrieve conversion action list", exc_info=True)
+        except Exception as exc:
+            logger.warning(
+                "Failed to retrieve conversion action list (%s)", type(exc).__name__
+            )
             issues.append("Failed to retrieve conversion action list")
 
         total_actions = len(cv_actions)
@@ -447,8 +467,10 @@ class _MonitoringMixin:
             perf = await self.get_performance_report(
                 campaign_id=campaign_id, period="LAST_7_DAYS"
             )
-        except Exception:
-            logger.warning("Failed to retrieve performance report", exc_info=True)
+        except Exception as exc:
+            logger.warning(
+                "Failed to retrieve performance report (%s)", type(exc).__name__
+            )
             issues.append("Failed to retrieve performance report")
 
         metrics = perf[0].get("metrics", {}) if perf else {}
@@ -485,8 +507,10 @@ class _MonitoringMixin:
         diagnosis: dict[str, Any] = {}
         try:
             diagnosis = await self.diagnose_campaign_delivery(campaign_id)
-        except Exception:
-            logger.warning("Failed to retrieve delivery diagnostics", exc_info=True)
+        except Exception as exc:
+            logger.warning(
+                "Failed to retrieve delivery diagnostics (%s)", type(exc).__name__
+            )
             issues.append("Failed to retrieve delivery diagnostics")
 
         result["delivery_diagnosis"] = {
@@ -528,8 +552,10 @@ class _MonitoringMixin:
                         f"Zero-CV search terms account for "
                         f"{round(zero_cv_cost / cost * 100, 1)}% of total cost"
                     )
-            except Exception:
-                logger.warning("Failed to retrieve search terms report", exc_info=True)
+            except Exception as exc:
+                logger.warning(
+                    "Failed to retrieve search terms report (%s)", type(exc).__name__
+                )
                 issues.append("Failed to retrieve search terms report")
         result["search_term_quality"] = search_term_quality
 

--- a/mureo/google_ads/client.py
+++ b/mureo/google_ads/client.py
@@ -362,11 +362,20 @@ class GoogleAdsApiClient(  # type: ignore[misc]
 
     @staticmethod
     def _extract_error_detail(exc: GoogleAdsException) -> str:
-        """Extract the first error message from GoogleAdsException."""
+        """Extract the first error message from GoogleAdsException.
+
+        The returned string is logged and embedded in the errors callers see,
+        so it must never be ``str(exc)``: ``GoogleAdsException`` does not
+        curate its ``__str__``, and formatting it prints the underlying
+        ``grpc.Call`` repr — which carries ``debug_error_string()``, and with
+        it the request metadata (developer token, ``authorization`` header).
+        The server-side ``failure.errors[0].message`` is curated; an empty
+        ``errors`` leaves only the class name (#603).
+        """
         for error in exc.failure.errors:
             if hasattr(error, "message"):
                 return str(error.message)
-        return str(exc)
+        return type(exc).__name__
 
     @staticmethod
     def _has_error_code(

--- a/tests/test_google_ads_client.py
+++ b/tests/test_google_ads_client.py
@@ -242,6 +242,17 @@ class TestExtractErrorDetail:
         result = GoogleAdsApiClient._extract_error_detail(exc)
         assert isinstance(result, str)
 
+    def test_no_errors_falls_back_to_the_class_name(self) -> None:
+        """Never ``str(exc)``: its args carry the request metadata (#603)."""
+        exc = _make_google_ads_exception()
+        exc._failure.errors = []
+        exc.args = ("developer-token: s3cret, authorization: Bearer s3cret",)
+
+        result = GoogleAdsApiClient._extract_error_detail(exc)
+
+        assert result == "GoogleAdsException"
+        assert "s3cret" not in result
+
 
 @pytest.mark.unit
 class TestHasErrorCode:

--- a/tests/test_google_ads_log_exc_info.py
+++ b/tests/test_google_ads_log_exc_info.py
@@ -1,0 +1,135 @@
+"""No Google Ads log line may write the exception itself (#603).
+
+**Why this file exists.** ``exc_info=True`` writes
+``traceback.format_exception()``, which includes ``str(exc)``.
+``GoogleAdsException`` does not curate its ``__str__``: its
+``__init__(self, error, call, failure, request_id)`` never passes a message to
+``super().__init__()``, so ``BaseException`` keeps the raw constructor args and
+formatting the exception prints the underlying ``grpc.Call`` repr — which
+carries ``debug_error_string()``, and with it the request metadata: the
+developer token and the ``authorization`` header. The chained ``raise ... from
+exc`` inside this package means a ``RuntimeError`` caught one level up prints
+the same thing, because a traceback follows ``__cause__``.
+
+Nothing in the package installed a logging handler, so those lines were
+discarded at runtime until #581 installed one. #603 converted the 36 remaining
+call sites under ``mureo/google_ads/`` to log the exception *class* — or the
+curated server-side ``failure.errors[0].message`` via ``_extract_error_detail``
+— instead. This file is what stops the 37th from being written.
+
+Two properties worth keeping when editing this file:
+
+- **Derived, never enumerated.** The call sites come from the tree, not from a
+  list here, so a new module is covered the moment it is added.
+- **Extraction is asserted, not assumed.** ``test_the_sweep_still_matches``
+  runs the extractor over planted source, so a sweep that quietly stopped
+  matching cannot turn this file into a green no-op.
+
+``logger.exception()`` is swept alongside ``exc_info``: it sets
+``exc_info=True`` itself, so it leaks the same bytes without naming the
+keyword.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+
+_SOURCE_ROOT = pathlib.Path(__file__).resolve().parent.parent / "mureo" / "google_ads"
+
+#: Logging methods that accept an ``exc_info`` keyword.
+_LOG_METHODS = frozenset(
+    {
+        "critical",
+        "debug",
+        "error",
+        "fatal",
+        "info",
+        "log",
+        "warn",
+        "warning",
+    }
+)
+
+
+def _traceback_log_calls(source: str, module: str) -> list[tuple[str, int, str]]:
+    """Every logging call in ``source`` that would write the exception.
+
+    Returned as ``(module file name, line number, what was found)``. Matched on
+    the method name rather than the receiver, so ``self._logger.warning`` and a
+    module-level ``logger.warning`` are both covered.
+    """
+    found: list[tuple[str, int, str]] = []
+    for node in ast.walk(ast.parse(source)):
+        if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)):
+            continue
+        method = node.func.attr
+        if method == "exception":
+            found.append((module, node.lineno, "logger.exception()"))
+            continue
+        if method not in _LOG_METHODS:
+            continue
+        found.extend(
+            (module, node.lineno, "exc_info=")
+            for keyword in node.keywords
+            if keyword.arg == "exc_info"
+        )
+    return found
+
+
+def _sweep() -> list[tuple[str, int, str]]:
+    """Every offending logging call under ``mureo/google_ads/``."""
+    found: list[tuple[str, int, str]] = []
+    for path in sorted(_SOURCE_ROOT.rglob("*.py")):
+        found.extend(_traceback_log_calls(path.read_text(encoding="utf-8"), path.name))
+    return found
+
+
+@pytest.mark.unit
+def test_no_google_ads_log_line_writes_the_exception() -> None:
+    """The whole package logs a class name or a curated detail, never a traceback."""
+    offenders = _sweep()
+    assert not offenders, (
+        "these Google Ads log calls write the exception itself, which for a "
+        "GoogleAdsException prints the grpc.Call repr and with it the "
+        "developer token and authorization header:\n"
+        + "\n".join(f"  {module}:{line}: {what}" for module, line, what in offenders)
+        + "\nLog type(exc).__name__, or _extract_error_detail(exc) where the "
+        "server-side failure message is what you need."
+    )
+
+
+@pytest.mark.unit
+def test_the_sweep_still_matches() -> None:
+    """Planted source is caught — an extractor that stopped matching passes nothing."""
+    planted = (
+        "logger.warning('a', exc_info=True)\n"
+        "logger.debug('b', exc_info=exc)\n"
+        "self._logger.error('c', 1, exc_info=True)\n"
+        "logger.exception('d')\n"
+    )
+    assert [line for _, line, _ in _traceback_log_calls(planted, "planted.py")] == [
+        1,
+        2,
+        3,
+        4,
+    ]
+
+
+@pytest.mark.unit
+def test_the_sweep_does_not_invent_offenders() -> None:
+    """The safe replacements, and prose about the bug, are not matched.
+
+    ``accounts.py`` carries a comment naming ``exc_info=True`` as the thing it
+    is avoiding; a text scan would fail on it forever.
+    """
+    planted = (
+        "# exc_info=True would put the developer token in the log.\n"
+        "'''exc_info=True is what this docstring warns against.'''\n"
+        "logger.warning('a (%s)', type(exc).__name__)\n"
+        "logger.error('b: %s', self._extract_error_detail(exc))\n"
+        "some.exc_info = True\n"
+    )
+    assert _traceback_log_calls(planted, "planted.py") == []


### PR DESCRIPTION
## What

The 36 remaining `exc_info=True` logging calls under `mureo/google_ads/` no longer write the exception itself.

`exc_info=True` writes `traceback.format_exception()`, which includes `str(exc)`. `GoogleAdsException` does not curate its `__str__`: its `__init__(self, error, call, failure, request_id)` never passes a message to `super().__init__()`, so `BaseException` keeps the raw constructor args and formatting the exception prints the underlying `grpc.Call` repr — which carries `debug_error_string()`, and with it the request metadata: the developer token and the `authorization` header. Chaining means a `RuntimeError` caught one level up prints the same bytes, because a traceback follows `__cause__`.

Nothing in the package installed a logging handler until #581, so these lines were discarded at runtime. #581 fixed the three sites reachable from the configure server; this is the rest. They sit on MCP tool paths, so today the exposure depends on what the host process has switched on rather than on mureo — lower urgency than the three already fixed, not safe.

## How each site was decided

- **33 sites → `type(exc).__name__`.** Every one is a generic `except Exception` around one of mureo's *own* high-level methods (`self.get_performance_report`, `self.list_ads`, `self.diagnose_campaign_delivery`, …). What arrives is a `RuntimeError` mureo raised itself, or anything else, so there is no `failure` to read — only the class can be named. This is the pattern `mureo/cli/web_auth.py`, `mureo/amazon_ads/lwa.py` and `mureo/google_ads/accounts.py` already use.
- **3 sites → `_extract_error_detail`.** Account-level sitelinks, conversion-action performance and impression share each wrap a `self._search(...)` GAQL call directly, so the failure is a `GoogleAdsException` whose curated server-side `failure.errors[0].message` ("Invalid field in query", a resource error) is the diagnostic worth keeping — safe *and* more useful than a class name. The surrounding `except` stays broad, so they fall back to the class name for anything without a `.failure`, following the shape already in `_extensions_targeting.py`.

Comment style follows the existing one: `accounts.py` keeps the full explanation, and each module carries one short pointer to it at its first site rather than repeating it 36 times.

## One thing found on the way

`_extract_error_detail` — the function offered as the safe alternative — ended in `return str(exc)` when `failure.errors` was empty. That is the same leak, in the fallback, and it also reaches callers: the string is embedded in the `RuntimeError` messages `_wrap_mutate_error` raises. It now falls back to the class name, with a test that plants a revealing `args` tuple and asserts it does not survive.

## Regression guard

`tests/test_google_ads_log_exc_info.py` parses every module under `mureo/google_ads/` and fails on any logging call carrying an `exc_info` keyword, or any `logger.exception()` (which sets `exc_info=True` itself). Modelled on `tests/test_google_ads_enum_reads.py`, with the two properties that file states:

- **Derived, never enumerated** — the call sites come from the tree, so a new module is covered the moment it is added.
- **Extraction is asserted, not assumed** — `test_the_sweep_still_matches` runs the extractor over planted source, so a sweep that quietly stopped matching cannot turn the file into a green no-op. A third test pins the other direction: the AST sweep does not fire on the `exc_info=True` written in `accounts.py`'s *comment*, which is why this is not a text grep.

## Verification

- `pytest tests/test_google_ads_log_exc_info.py` — red at 36 sites before the fix, green after.
- `pytest` — 8968 passed. The 12 failures are pre-existing local plugin-discovery noise (`test_live_clients.py`, `test_mcp_server.py`, `test_mcp_server_plugin_wiring.py`, `test_mcp_tool_provider.py`) and are unchanged by this branch.
- `black --check mureo/ tests/`, `ruff check mureo/ tests/`, `mypy mureo/` — clean (mypy's 14 remaining errors are all missing third-party stubs, unchanged).

Closes #603
