### PR TITLE
fix: refuse a platform key mureo cannot resolve on create (#609)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 ### Fixed
 
+- **A platform key an agent invented was accepted on write, creating a phantom
+  duplicate** (#609). An agent operating through mureo wrote its snapshots
+  under `logly_ads` for a bridge whose provider is `logly_ads_context`. The
+  write guard checked the key's *shape* only — empty, padded, or a malformed
+  `plugin:` claim — so an arbitrary plausible string passed, and both keys
+  ended up in the same `platforms` map carrying the same ad account. The
+  reporting view sums every entry, so that account's spend, conversions and
+  CPA were double-counted, and the operator was told to repair it by hand.
+  This was the upstream cause of #606, which fixed the wording the two
+  conflict notes produced downstream but not the bad key being written.
+
+  Creating a platform entry now also refuses a key that names no platform
+  mureo can resolve. Three vocabularies are accepted: a built-in
+  (`google_ads` / `meta_ads` / `search_console` / `ga4` / `tiktok_ads`), a
+  platform an installed plugin registered under the `mureo.providers` or
+  `mureo.analytics` entry-point group, and a canonical
+  `plugin:<distribution>:<provider>` key — the last accepted without
+  requiring the distribution to be installed, so a snapshot from another
+  machine, an uninstalled bridge or a restored backup stays writable. The
+  refusal names the key and lists what would have been accepted, so an
+  agent's next attempt is informed rather than a second guess.
+
+  The check is deliberately narrow. It runs on **create through the targeted
+  writers only** — the paths where a caller named one platform
+  (`mureo_state_upsert_campaign`, `mureo_state_platform_metrics_set`,
+  `mureo_state_set_conversion_events`). Whole-document writes, restores,
+  imports and the tolerant parse are untouched, and an entry that already
+  exists keeps taking writes whatever its key: an operator holding a bad key
+  has to be able to keep syncing and repair it. If the installed-plugin set
+  cannot be read at all (corrupted metadata, an odd install layout) the check
+  logs and lets the write through — a broken environment is not evidence that
+  a key is wrong.
+
 - **Two conflict notes on the same platform card contradicted each other**
   (#606). A card could show `duplicate_account` — "one ad account is stored
   under two platform keys", certain, and the account identified — directly

--- a/docs/strategy-context.md
+++ b/docs/strategy-context.md
@@ -217,6 +217,25 @@ the reporting dashboard's label lookup, and `mureo_analytics_modules_list` /
 under another is a silent join failure; see
 `skills/_mureo-shared/SKILL.md` → *Canonical platform key*.
 
+**A key mureo cannot resolve is rejected on create.** Creating a `platforms`
+entry through `upsert_campaign` / `set_platform_metrics` /
+`set_conversion_action_types` (and so through the `mureo_state_*` tools)
+requires the key to be one of: a first-class ad-platform key; a platform an
+**installed** plugin registered (its provider / analytics entry-point name,
+e.g. `logly_ads_context`); or a `plugin:<dist>:<provider>` key, which is
+accepted whether or not that distribution is installed here — use it for a
+snapshot whose bridge lives on another machine. Anything else is refused with
+an error naming the key and listing what would have been accepted, because an
+invented key (`logly_ads` for a bridge whose provider is `logly_ads_context`)
+files an account under a key nothing joins with and double-counts it against
+the entry it really belongs to.
+
+The check is create-only and applies to the targeted writers only: a
+**whole-document** write (a restore, an import, a digest sync) still lands
+whatever keys it carries, and an entry that already exists keeps taking writes
+under its own key — an operator holding a bad key has to be able to sync and
+repair it.
+
 **One ad account has exactly one platform key.** The `platforms` map is keyed
 by a free-form string, so two spellings of the same platform would otherwise
 produce two entries for one real ad account — and the reporting view sums

--- a/mureo/_data/skills/_mureo-shared/SKILL.md
+++ b/mureo/_data/skills/_mureo-shared/SKILL.md
@@ -534,7 +534,13 @@ shows fewer campaigns than you wrote — get these exact names right:
   same rule is yours to honour, and a wholesale `Write` that lands a duplicate
   is logged as a warning rather than blocked. Pass the key exactly — a key with
   surrounding whitespace (`" google_ads"`) is a *different* key, and is
-  rejected on create rather than silently stripped. If a document already
+  rejected on create rather than silently stripped. **Never invent or
+  abbreviate a platform key**: creating an entry under a key that is neither a
+  first-class ad-platform key, nor a platform an installed plugin registered
+  (its entry-point name — `logly_ads_context`, not `logly_ads`), nor a
+  `plugin:<dist>:<provider>` key is rejected, with the accepted keys listed in
+  the error. Use the canonical `plugin:<dist>:<provider>` form when the bridge
+  that owns a snapshot is not installed on this machine. If a document already
   carries the duplicate pair, writes to the *existing* keys still succeed —
   mureo never merges or deletes an entry, because the two typically hold
   different partial figures; reconciling them is the operator's call. Changing

--- a/mureo/context/platform_guards.py
+++ b/mureo/context/platform_guards.py
@@ -26,8 +26,9 @@ duplicate just as surely. So the decision branches on what the entry already
 says:
 
 1. **The key does not exist.** A true create: validate the key's shape
-   (:func:`reject_unusable_platform_key`) and refuse if another key already
-   holds ``account_id``.
+   (:func:`reject_unusable_platform_key`), refuse a key naming no platform
+   mureo can resolve (:func:`reject_unknown_platform_key`), and refuse if
+   another key already holds ``account_id``.
 2. **The key exists and its stored id matches the incoming one.** A plain
    update — nothing about identity changes, so allow it. The match is
    ``act_``-tolerant, so re-writing ``123456`` as ``act_123456`` is still an
@@ -54,6 +55,35 @@ operator who already has one.** Nothing here deletes or merges an entry either
 — the two halves of a duplicate typically hold different *partial* figures, so
 the repair is the operator's call, informed by the read side.
 
+Which writers this applies to (#609)
+------------------------------------
+:func:`reject_unknown_platform_key` refuses a key naming no platform mureo
+can resolve, and it runs on branch (1) **only**. The split it follows is
+"did an agent name this platform, or did this document arrive from
+elsewhere?":
+
+- **An agent named it — refuse.** ``upsert_campaign``,
+  ``set_platform_metrics`` and ``set_conversion_action_types`` in
+  :mod:`mureo.context.state` (reached from the MCP tools
+  ``mureo_state_upsert_campaign`` / ``mureo_state_platform_metrics_set`` /
+  ``mureo_state_set_conversion_events``, and from bridges and out-of-tree
+  writers calling them directly). Each takes ONE key the caller chose, so
+  there is something to refuse and a caller to tell.
+- **The document arrived from elsewhere — never refuse.**
+  ``write_state_file`` and everything funnelling through it
+  (``FilesystemStateStore.write_state``, mureo-agency's digest sync, a
+  restored backup, an import), plus the tolerant parse in
+  :mod:`mureo.context.state_codec` and the demo installer, which renders a
+  scenario's STATE.json straight to disk. A whole document has no notion of
+  which entry is new, and refusing it would strand an operator holding state
+  they cannot otherwise repair — the same reason
+  :func:`warn_on_duplicate_accounts` only reports.
+
+A key that is legitimate but unresolvable **here** — a snapshot for a bridge
+this machine does not have installed — is not stranded either: the canonical
+``plugin:<distribution>:<provider>`` form names its own distribution and so
+is accepted without any registry to consult.
+
 One corner this does **not** defend: writing an explicit ``account_id=""``
 onto an entry that holds a known id silently reverts that entry to "unknown",
 because ``""`` is by contract free rather than taken. The MCP surface blocks
@@ -66,7 +96,7 @@ id, never ``""`` to mean "leave it alone".
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from mureo.context.platform_accounts import (
     DuplicateAccountEntry,
@@ -132,7 +162,9 @@ def reject_unusable_platform_key(platform: str) -> None:
     STATE.json and on the dashboard without saying so, which is the same class
     of silent divergence this guard exists to stop.
 
-    Create-only; see :func:`guard_platform_entry_write`.
+    Shape only — whether the key names a platform that EXISTS is
+    :func:`reject_unknown_platform_key`'s question (#609). Create-only; see
+    :func:`guard_platform_entry_write`.
     """
     # Imported lazily: ``mureo.core.__init__`` pulls in ``runtime_context`` ->
     # ``state_store`` -> ``mureo.context.state``, which imports this module —
@@ -161,6 +193,119 @@ def reject_unusable_platform_key(platform: str) -> None:
             f"or the older {PLUGIN_PLATFORM_PREFIX}<distribution> for a "
             f"distribution that provides a single platform"
         )
+
+
+def _provider_entry_points() -> tuple[Any, ...] | None:
+    """Return every entry point that registers a plugin platform.
+
+    Both groups a plugin can name a platform in: ``mureo.providers`` (the
+    provider itself) and ``mureo.analytics`` (an analytics module, whose
+    registry name is the same ``<provider>`` component — see
+    :mod:`mureo.core.platform_keys`). A distribution may ship only the latter,
+    and refusing its key would be a false rejection.
+
+    Entry points are **not loaded**: only ``ep.name`` is read. Loading would
+    import third-party code on a state write, which is neither this function's
+    business nor safe to do under the state lock.
+
+    ``None`` — distinct from an empty tuple — means the environment could not
+    be enumerated. ``importlib.metadata`` blowing up is rare but possible
+    (unusual install layout, corrupted metadata), and unlike the policy-gate
+    loader (:func:`mureo.mcp.server._policy_gate_entry_points`, which treats
+    the failure as "zero gates") this one cannot treat it as "zero providers":
+    that would turn a broken environment into a refusal of every plugin
+    platform key. A failure is not evidence the key is wrong, so the caller
+    fails open. Isolated as its own function so tests can pin the environment
+    rather than monkeypatching ``importlib.metadata``.
+    """
+    from importlib.metadata import entry_points
+
+    from mureo.analytics.registry import ANALYTICS_ENTRY_POINT_GROUP
+    from mureo.core.providers.registry import PROVIDERS_ENTRY_POINT_GROUP
+
+    found: list[Any] = []
+    for group in (PROVIDERS_ENTRY_POINT_GROUP, ANALYTICS_ENTRY_POINT_GROUP):
+        try:
+            found.extend(entry_points(group=group))
+        except Exception as exc:  # noqa: BLE001 — see docstring: fail open
+            logger.warning(
+                "platform key check: importlib.metadata.entry_points(group=%r) "
+                "failed (%s); accepting the key rather than refusing every "
+                "plugin platform",
+                group,
+                exc,
+            )
+            return None
+    return tuple(found)
+
+
+def _installed_platform_names() -> frozenset[str] | None:
+    """The platform names installed plugins registered, or ``None``.
+
+    ``None`` propagates :func:`_provider_entry_points`' "could not enumerate".
+    A nameless or blank entry point is dropped: it can never equal a key that
+    :func:`reject_unusable_platform_key` already let through.
+    """
+    eps = _provider_entry_points()
+    if eps is None:
+        return None
+    return frozenset(
+        name
+        for ep in eps
+        if isinstance(name := getattr(ep, "name", None), str) and name.strip()
+    )
+
+
+def reject_unknown_platform_key(platform: str) -> None:
+    """Reject a ``platform`` naming no platform mureo can resolve (#609).
+
+    Three vocabularies are accepted, and nothing else:
+
+    - a built-in key (:data:`~mureo.core.platform_keys.
+      BUILTIN_PLATFORM_DISPLAY_NAMES`), which includes the hosted connectors
+      that have no provider entry point at all;
+    - a platform an installed plugin registered (:func:`_installed_platform_names`);
+    - a canonical ``plugin:<distribution>:<provider>`` key (or the legacy
+      ``plugin:<distribution>``), accepted **without** checking that the
+      distribution is installed — it names its own distribution, so a snapshot
+      from another machine, an uninstalled bridge or a restored backup stays
+      writable.
+
+    Refusing is what stops an agent inventing a key: ``logly_ads`` for a bridge
+    whose provider is ``logly_ads_context`` produced a second entry holding the
+    same ad account, which the reporting view then summed (#609, the upstream
+    cause of #606). This is deliberately not a rewrite — canonicalizing an
+    unknown key would change the key the operator sees without saying so, which
+    is the silent divergence :func:`reject_unusable_platform_key` exists to
+    stop. The message therefore names the key AND what would have been
+    accepted, so the caller's next attempt is informed rather than a guess.
+
+    Create-only, and fails open on an unreadable environment; see this module's
+    docstring and :func:`guard_platform_entry_write`.
+    """
+    from mureo.core.platform_keys import (
+        BUILTIN_PLATFORM_DISPLAY_NAMES,
+        PLUGIN_PLATFORM_PREFIX,
+        is_plugin_platform_key,
+    )
+
+    if platform in BUILTIN_PLATFORM_DISPLAY_NAMES or is_plugin_platform_key(platform):
+        return
+    installed = _installed_platform_names()
+    if installed is None or platform in installed:
+        return
+    builtins = ", ".join(sorted(BUILTIN_PLATFORM_DISPLAY_NAMES))
+    plugins = ", ".join(sorted(installed)) if installed else "none installed here"
+    raise ValueError(
+        f"refusing to create platform {platform!r}: it is not a platform mureo "
+        f"can resolve, and storing it would file this account under a key "
+        f"nothing joins with — double-counting it against the key the account "
+        f"is really stored under. Accepted: a built-in ({builtins}); a platform "
+        f"an installed plugin registered ({plugins}); or a plugin platform key "
+        f"{PLUGIN_PLATFORM_PREFIX}<distribution>:<provider>, which is the form "
+        f"to use for a plugin whose package is not installed on this machine. "
+        f"Write to the key this account is already stored under if it has one."
+    )
 
 
 def _reject_account_already_taken(
@@ -218,6 +363,7 @@ def guard_platform_entry_write(
     existing = platforms.get(platform)
     if existing is None:  # (1) create
         reject_unusable_platform_key(platform)
+        reject_unknown_platform_key(platform)
         _reject_account_already_taken(platforms, platform, account_id, creating=True)
         return
     if account_ids_match(existing.account_id, account_id):  # (2) plain update
@@ -280,6 +426,7 @@ def warn_on_duplicate_accounts(path: Path, doc: StateDocument) -> None:
 
 __all__ = [
     "guard_platform_entry_write",
+    "reject_unknown_platform_key",
     "reject_unusable_platform_key",
     "warn_on_duplicate_accounts",
 ]

--- a/mureo/context/state.py
+++ b/mureo/context/state.py
@@ -260,7 +260,10 @@ def upsert_campaign(
         The updated :class:`StateDocument`.
 
     Raises:
-        ValueError: ``platform`` is not a usable platform key, or the write
+        ValueError: ``platform`` is not a usable platform key, names no
+            platform mureo can resolve (a built-in, an installed plugin's
+            platform, or a ``plugin:<dist>:<provider>`` key — checked on
+            CREATE only, so an existing entry stays writable), or the write
             would create a SECOND key for an account another key already
             holds (see
             :func:`mureo.context.platform_guards.guard_platform_entry_write`).
@@ -512,7 +515,10 @@ def set_platform_metrics(
         The updated :class:`StateDocument`.
 
     Raises:
-        ValueError: ``platform`` is not a usable platform key, or the write
+        ValueError: ``platform`` is not a usable platform key, names no
+            platform mureo can resolve (a built-in, an installed plugin's
+            platform, or a ``plugin:<dist>:<provider>`` key — checked on
+            CREATE only, so an existing entry stays writable), or the write
             would create a SECOND key for an account another key already
             holds (see
             :func:`mureo.context.platform_guards.guard_platform_entry_write`).
@@ -584,7 +590,10 @@ def set_conversion_action_types(
         The updated :class:`StateDocument`.
 
     Raises:
-        ValueError: ``platform`` is not a usable platform key, or the write
+        ValueError: ``platform`` is not a usable platform key, names no
+            platform mureo can resolve (a built-in, an installed plugin's
+            platform, or a ``plugin:<dist>:<provider>`` key — checked on
+            CREATE only, so an existing entry stays writable), or the write
             would create a SECOND key for an account another key already
             holds (see
             :func:`mureo.context.platform_guards.guard_platform_entry_write`).

--- a/mureo/core/platform_keys.py
+++ b/mureo/core/platform_keys.py
@@ -85,9 +85,27 @@ surfaces build different keys for one platform.
 This module is the single source of that convention. Everything that
 builds, recognises, or takes apart a plugin platform key goes through
 it rather than open-coding the ``"plugin:"`` literal.
+
+The built-in keys (#609)
+------------------------
+:data:`BUILTIN_PLATFORM_DISPLAY_NAMES` is the other half of the platform
+vocabulary — the keys that belong to no plugin. It lived in
+``mureo.web.reports`` while only the dashboard needed it; the write-time
+guard (:mod:`mureo.context.platform_guards`) now has to consult it to
+refuse a key an agent invented, and ``context`` must not import ``web``:
+that would put the configure UI's import graph on the state-write path,
+and it inverts the layering (a UI surface is a consumer of the
+vocabulary, not its owner). It is data with no dependencies, so it sits
+here beside the plugin half rather than in a module of its own.
 """
 
 from __future__ import annotations
+
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Final
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 PLUGIN_PLATFORM_PREFIX = "plugin:"
 """The prefix that marks a platform key as belonging to a plugin."""
@@ -99,6 +117,36 @@ Safe because the distribution half cannot contain it and the parse
 splits on the FIRST occurrence, so an unvalidated provider half
 round-trips — not because both halves are forbidden from containing one.
 See this module's docstring.
+"""
+
+BUILTIN_PLATFORM_DISPLAY_NAMES: Final[Mapping[str, str]] = MappingProxyType(
+    {
+        "google_ads": "Google Ads",
+        "meta_ads": "Meta Ads",
+        "search_console": "Search Console",
+        "ga4": "GA4",
+        # Hosted-connector platform (no native mureo tools, and no provider
+        # entry point — added as a Claude.ai connector). Skills write its
+        # snapshots under this key, so it is a built-in key even though
+        # nothing in the plugin registry will ever vouch for it.
+        "tiktok_ads": "TikTok Ads",
+    }
+)
+"""Built-in platform key → human display name.
+
+The complete set of ``platforms`` keys that belong to no plugin. Two
+surfaces read it and they must not drift apart:
+
+- the dashboard resolves a label from it
+  (:func:`mureo.web.reports.platform_display_name`) — a key missing here
+  resolves to itself, which is the ``unrecognized_key`` conflict signal;
+- the write guard accepts it without consulting the plugin registry
+  (:func:`mureo.context.platform_guards.reject_unknown_platform_key`) —
+  a key missing here is refused on create.
+
+Read-only (:class:`~types.MappingProxyType`): it is process-wide shared
+state now, and a surface that could mutate it would change what another
+accepts or renders.
 """
 
 
@@ -234,6 +282,7 @@ def plugin_platform_key_matches(key: str, distribution: str, provider: str) -> b
 
 
 __all__ = [
+    "BUILTIN_PLATFORM_DISPLAY_NAMES",
     "PLUGIN_PLATFORM_PREFIX",
     "PLUGIN_PLATFORM_SEPARATOR",
     "is_plugin_platform_key",

--- a/mureo/mcp/tools_mureo_context.py
+++ b/mureo/mcp/tools_mureo_context.py
@@ -257,12 +257,15 @@ _CAMPAIGN_PROPERTY = {
             "minLength": 1,
             "description": (
                 "Platform key this campaign belongs to, e.g. "
-                "``google_ads`` / ``meta_ads`` / ``tiktok_ads``, or a plugin "
-                "bridge ``plugin:<dist>``. Use the SAME key the account is "
-                "already stored under — one ad account has exactly one "
-                "platform key, and a second key for an account another key "
-                "already holds is REJECTED (the reporting view sums the "
-                "entries, so it would double-count)."
+                "``google_ads`` / ``meta_ads`` / ``tiktok_ads``, a platform "
+                "an installed plugin registered (its provider name), or a "
+                "plugin bridge ``plugin:<dist>:<provider>``. Use the SAME key "
+                "the account is already stored under — one ad account has "
+                "exactly one platform key, and a second key for an account "
+                "another key already holds is REJECTED (the reporting view "
+                "sums the entries, so it would double-count). A NEW key that "
+                "is none of the three is REJECTED too: do not invent or "
+                "abbreviate a platform name."
             ),
         },
         "account_id": {
@@ -526,12 +529,16 @@ TOOLS: list[Tool] = [
                     "description": (
                         "Platform key: a built-in (``google_ads`` / "
                         "``meta_ads`` / ``tiktok_ads`` / ``search_console`` / "
-                        "``ga4``) or a plugin bridge ``plugin:<dist>``. Use "
-                        "the SAME key the account is already stored under — "
-                        "one ad account has exactly one platform key, and a "
-                        "second key for an account another key already holds "
-                        "is REJECTED (the reporting view sums the entries, so "
-                        "it would double-count)."
+                        "``ga4``), a platform an installed plugin registered "
+                        "(its provider name), or a plugin bridge "
+                        "``plugin:<dist>:<provider>``. Use the SAME key the "
+                        "account is already stored under — one ad account has "
+                        "exactly one platform key, and a second key for an "
+                        "account another key already holds is REJECTED (the "
+                        "reporting view sums the entries, so it would "
+                        "double-count). A NEW key that is none of the three "
+                        "is REJECTED too: do not invent or abbreviate a "
+                        "platform name."
                     ),
                 },
                 "account_id": {
@@ -608,7 +615,8 @@ TOOLS: list[Tool] = [
                         "ad account has exactly one platform key, and a "
                         "second key for an account another key already holds "
                         "is REJECTED (the reporting view sums the entries, so "
-                        "it would double-count)."
+                        "it would double-count). A NEW key naming no platform "
+                        "mureo knows is REJECTED too."
                     ),
                 },
                 "account_id": {

--- a/mureo/web/reports.py
+++ b/mureo/web/reports.py
@@ -53,7 +53,11 @@ from mureo.context.platform_accounts import (
     normalize_account_id,
 )
 from mureo.context.state import read_state_file
-from mureo.core.platform_keys import is_plugin_platform_key, plugin_platform_parts
+from mureo.core.platform_keys import (
+    BUILTIN_PLATFORM_DISPLAY_NAMES,
+    is_plugin_platform_key,
+    plugin_platform_parts,
+)
 
 # The client seam. Imported (not re-implemented) and re-exported through
 # ``__all__`` so ``from mureo.web.reports import state_store_for_client``
@@ -153,16 +157,12 @@ _CANONICAL_TOTAL_KEYS: tuple[str, ...] = (
 
 # Built-in platform key → human display name. Plugin keys (``plugin:<dist>``)
 # and any unknown key are resolved by :func:`platform_display_name` instead.
-_BUILTIN_DISPLAY_NAMES: dict[str, str] = {
-    "google_ads": "Google Ads",
-    "meta_ads": "Meta Ads",
-    "search_console": "Search Console",
-    "ga4": "GA4",
-    # Hosted-connector platform (no native mureo tools; added as a Claude.ai
-    # connector). Skills write its snapshots under this key — give it a friendly
-    # dashboard label instead of falling back to the raw "tiktok_ads".
-    "tiktok_ads": "TikTok Ads",
-}
+#
+# The map itself lives in ``mureo.core.platform_keys`` (#609): the write-time
+# guard has to accept exactly these keys, and ``mureo.context`` cannot import
+# ``mureo.web``. This module keeps the local name because it is the read-side
+# resolver's own vocabulary and every reference below reads as one.
+_BUILTIN_DISPLAY_NAMES = BUILTIN_PLATFORM_DISPLAY_NAMES
 
 # Distribution → display name for OFFICIAL, in-tree bridges (audit #30).
 # These ride the ``plugin:<dist>`` dispatch path to reuse the plugin safety

--- a/skills/_mureo-shared/SKILL.md
+++ b/skills/_mureo-shared/SKILL.md
@@ -534,7 +534,13 @@ shows fewer campaigns than you wrote — get these exact names right:
   same rule is yours to honour, and a wholesale `Write` that lands a duplicate
   is logged as a warning rather than blocked. Pass the key exactly — a key with
   surrounding whitespace (`" google_ads"`) is a *different* key, and is
-  rejected on create rather than silently stripped. If a document already
+  rejected on create rather than silently stripped. **Never invent or
+  abbreviate a platform key**: creating an entry under a key that is neither a
+  first-class ad-platform key, nor a platform an installed plugin registered
+  (its entry-point name — `logly_ads_context`, not `logly_ads`), nor a
+  `plugin:<dist>:<provider>` key is rejected, with the accepted keys listed in
+  the error. Use the canonical `plugin:<dist>:<provider>` form when the bridge
+  that owns a snapshot is not installed on this machine. If a document already
   carries the duplicate pair, writes to the *existing* keys still succeed —
   mureo never merges or deletes an entry, because the two typically hold
   different partial figures; reconciling them is the operator's call. Changing

--- a/tests/test_mcp_tools_mureo_context.py
+++ b/tests/test_mcp_tools_mureo_context.py
@@ -833,6 +833,41 @@ async def test_platform_metrics_set_rejects_a_duplicate_account(cwd_to_tmp) -> N
     assert "act_1" in message
 
 
+async def test_platform_metrics_set_rejects_an_invented_platform_key(
+    cwd_to_tmp, monkeypatch
+) -> None:
+    """#609 — the tool surface an agent actually calls refuses a key it made
+    up, and tells it what would have been accepted.
+
+    The installed set is pinned: this machine has real bridges installed, and
+    a test that read the ambient environment would not be asserting the rule.
+    """
+    from types import SimpleNamespace
+
+    from mureo.context import platform_guards
+
+    monkeypatch.setattr(
+        platform_guards,
+        "_provider_entry_points",
+        lambda: (SimpleNamespace(name="logly_ads_context"),),
+    )
+    mod = _import_tools()
+    with pytest.raises(ValueError) as exc:
+        await mod.handle_tool(
+            "mureo_state_platform_metrics_set",
+            {
+                "platform": "logly_ads",
+                "account_id": "act_1",
+                "totals": {"spend": 1.0},
+            },
+        )
+    message = str(exc.value)
+    assert "logly_ads" in message
+    assert "logly_ads_context" in message
+    assert "google_ads" in message
+    assert not (cwd_to_tmp / "STATE.json").exists()
+
+
 async def test_platform_metrics_set_rejects_malformed_shapes(cwd_to_tmp) -> None:
     mod = _import_tools()
     base = {"platform": "google_ads", "account_id": "act_123"}

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -6,11 +6,13 @@ import dataclasses
 import json
 import logging
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch
 
 import pytest
 
+from mureo.context import platform_guards
 from mureo.context.errors import ContextFileError
 from mureo.context.models import (
     ActionLogEntry,
@@ -2007,8 +2009,21 @@ class TestDuplicateAccountEntryGuard:
         self, tmp_path: Path
     ) -> None:
         """The registry-name spelling and the canonical ``plugin:<dist>`` key
-        are two keys for one account — exactly the #533 ingress."""
-        path = self._seed(tmp_path, "mureo-logly-bridge", "act_1")
+        are two keys for one account — exactly the #533 ingress.
+
+        The bare distribution name is seeded through the whole-document path
+        because #609 refuses it on create (it is neither a built-in, nor an
+        installed provider, nor a plugin key). State that already carries it
+        still has to collide, and still has to stay repairable.
+        """
+        path = tmp_path / "STATE.json"
+        write_state_file(
+            path,
+            StateDocument(
+                version="2",
+                platforms={"mureo-logly-bridge": PlatformState(account_id="act_1")},
+            ),
+        )
         with pytest.raises(ValueError, match="mureo-logly-bridge"):
             set_platform_metrics(
                 path, "plugin:mureo-logly-bridge", "act_1", totals={"spend": 2.0}
@@ -2319,6 +2334,214 @@ class TestDuplicateAccountEntryGuard:
         )
         doc = set_platform_metrics(path, "plugin:", "123", totals={"spend": 1.0})
         assert doc.platforms["plugin:"].totals == {"spend": 1.0}
+
+
+# ---------------------------------------------------------------------------
+# #609 — a platform key an agent invented is refused on create
+# ---------------------------------------------------------------------------
+
+
+def _pin_installed_platforms(monkeypatch: pytest.MonkeyPatch, *names: str) -> None:
+    """Pin which plugin platforms the environment reports as installed.
+
+    Every test below pins this. The developer machine that reported #609 has
+    real bridges installed (``logly_ads_context``, ``yahoo_ads``, …), so a test
+    that leaned on the ambient environment would pass for a reason it did not
+    assert — and would flip on a machine with no plugins.
+    """
+    entries = tuple(SimpleNamespace(name=name) for name in names)
+    monkeypatch.setattr(platform_guards, "_provider_entry_points", lambda: entries)
+
+
+@pytest.mark.unit
+class TestUnknownPlatformKeyGuard:
+    """#609 — an agent can no longer invent a platform key mureo then stores.
+
+    The observed failure: an agent wrote LOGLY snapshots under ``logly_ads``
+    while the bridge's provider is ``logly_ads_context``. Both keys carried the
+    same ad account, so the reporting view summed them.
+
+    Refusing is create-only, exactly like every other key check here: a
+    document that ALREADY carries a bad key has to stay writable or the
+    operator can never repair it.
+    """
+
+    def test_an_invented_key_is_refused_on_create(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """And the message names the key plus what WOULD have been accepted,
+        so the agent's next attempt is correct rather than a second guess."""
+        _pin_installed_platforms(monkeypatch, "logly_ads_context")
+        path = tmp_path / "STATE.json"
+        with pytest.raises(ValueError) as exc:
+            set_platform_metrics(path, "logly_ads", "act_1", totals={"spend": 1.0})
+        message = str(exc.value)
+        assert "logly_ads" in message
+        # The three accepted vocabularies are all named.
+        assert "google_ads" in message  # a built-in
+        assert "logly_ads_context" in message  # an installed provider
+        assert "plugin:" in message  # the canonical plugin key form
+        # Fail-before-write: nothing landed.
+        assert not path.exists()
+
+    def test_an_installed_providers_name_is_accepted(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _pin_installed_platforms(monkeypatch, "logly_ads_context")
+        path = tmp_path / "STATE.json"
+        doc = set_platform_metrics(
+            path, "logly_ads_context", "act_1", totals={"spend": 1.0}
+        )
+        assert set(doc.platforms) == {"logly_ads_context"}
+
+    def test_the_logly_incident(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The reported case, pinned end to end: the invented key is refused,
+        the real provider name is accepted, and one account keeps one key."""
+        _pin_installed_platforms(monkeypatch, "logly_ads_context")
+        path = tmp_path / "STATE.json"
+        with pytest.raises(ValueError, match="logly_ads"):
+            set_platform_metrics(path, "logly_ads", "act_1", totals={"spend": 1.0})
+        doc = set_platform_metrics(
+            path, "logly_ads_context", "act_1", totals={"spend": 1.0}
+        )
+        assert set(doc.platforms) == {"logly_ads_context"}
+
+    def test_a_builtin_is_accepted_with_no_plugin_installed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Including ``tiktok_ads``, a hosted connector with no provider entry
+        point at all — its key is a built-in, not a plugin."""
+        from mureo.core.platform_keys import BUILTIN_PLATFORM_DISPLAY_NAMES
+
+        _pin_installed_platforms(monkeypatch)
+        path = tmp_path / "STATE.json"
+        for index, key in enumerate(sorted(BUILTIN_PLATFORM_DISPLAY_NAMES)):
+            set_platform_metrics(path, key, f"act_{index}", totals={"spend": 1.0})
+        assert set(read_state_file(path).platforms) == set(
+            BUILTIN_PLATFORM_DISPLAY_NAMES
+        )
+
+    def test_the_installed_set_is_read_from_the_environment(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Not from a list in the source: with nothing installed, a provider
+        name that IS installed on the reporting machine is refused."""
+        _pin_installed_platforms(monkeypatch)
+        path = tmp_path / "STATE.json"
+        with pytest.raises(ValueError, match="logly_ads_context"):
+            set_platform_metrics(
+                path, "logly_ads_context", "act_1", totals={"spend": 1.0}
+            )
+
+    def test_a_canonical_plugin_key_is_accepted_when_nothing_is_installed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The escape hatch for a snapshot whose bridge is not installed here
+        (another machine, an uninstalled bridge, a restored backup): the
+        canonical key names its own distribution, so it needs no registry."""
+        _pin_installed_platforms(monkeypatch)
+        path = tmp_path / "STATE.json"
+        doc = set_platform_metrics(
+            path,
+            "plugin:mureo-logly-bridge:logly_ads_context",
+            "act_1",
+            totals={"spend": 1.0},
+        )
+        assert set(doc.platforms) == {"plugin:mureo-logly-bridge:logly_ads_context"}
+
+    def test_uninstalling_a_provider_does_not_strand_its_entries(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Create-only means an existing entry keeps taking writes after its
+        bridge is uninstalled — otherwise `pip uninstall` freezes the state."""
+        _pin_installed_platforms(monkeypatch, "logly_ads_context")
+        path = tmp_path / "STATE.json"
+        set_platform_metrics(path, "logly_ads_context", "act_1", totals={"spend": 1.0})
+        _pin_installed_platforms(monkeypatch)
+        doc = set_platform_metrics(
+            path, "logly_ads_context", "act_1", totals={"spend": 2.0}
+        )
+        assert doc.platforms["logly_ads_context"].totals == {"spend": 2.0}
+
+    def test_an_existing_unknown_key_stays_writable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The repair path: the operator holding the bad key must be able to
+        keep syncing it (and to re-point it) while they decide what to do."""
+        _pin_installed_platforms(monkeypatch, "logly_ads_context")
+        path = tmp_path / "STATE.json"
+        path.write_text(
+            json.dumps(
+                {"version": "2", "platforms": {"logly_ads": {"account_id": "act_1"}}}
+            ),
+            encoding="utf-8",
+        )
+        doc = set_platform_metrics(path, "logly_ads", "act_1", totals={"spend": 1.0})
+        assert doc.platforms["logly_ads"].totals == {"spend": 1.0}
+
+    def test_a_whole_document_write_carrying_an_unknown_key_still_lands(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Detection, not enforcement, on the whole-document funnel — a
+        restore / import / digest sync must never be blocked by this check."""
+        _pin_installed_platforms(monkeypatch, "logly_ads_context")
+        path = tmp_path / "STATE.json"
+        write_state_file(
+            path,
+            StateDocument(
+                version="2",
+                platforms={"logly_ads": PlatformState(account_id="act_1")},
+            ),
+        )
+        assert set(read_state_file(path).platforms) == {"logly_ads"}
+
+    def test_an_unreadable_plugin_environment_fails_open(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """``importlib.metadata`` blowing up (odd install layout, corrupted
+        metadata) must not make every plugin platform unwritable — it is not
+        evidence the key is wrong. Log it and let the write through."""
+        path = tmp_path / "STATE.json"
+
+        def _boom(**_kwargs: Any) -> Any:
+            raise RuntimeError("corrupted metadata")
+
+        with (
+            patch("importlib.metadata.entry_points", _boom),
+            caplog.at_level(logging.WARNING, logger="mureo.context.platform_guards"),
+        ):
+            doc = set_platform_metrics(
+                path, "logly_ads_context", "act_1", totals={"spend": 1.0}
+            )
+        assert set(doc.platforms) == {"logly_ads_context"}
+        assert any(r.levelno == logging.WARNING for r in caplog.records)
+
+    def test_upsert_campaign_shares_the_guard(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _pin_installed_platforms(monkeypatch, "logly_ads_context")
+        path = tmp_path / "STATE.json"
+        with pytest.raises(ValueError, match="logly_ads"):
+            upsert_campaign(
+                path,
+                CampaignSnapshot(campaign_id="c1", campaign_name="C1", status="ACTIVE"),
+                platform="logly_ads",
+                account_id="act_1",
+            )
+        assert not path.exists()
+
+    def test_set_conversion_action_types_shares_the_guard(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from mureo.context.state import set_conversion_action_types
+
+        _pin_installed_platforms(monkeypatch, "logly_ads_context")
+        path = tmp_path / "STATE.json"
+        with pytest.raises(ValueError, match="logly_ads"):
+            set_conversion_action_types(path, "logly_ads", "act_1", ["lead"])
+        assert not path.exists()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What this fixes

An agent operating through mureo wrote LOGLY Ads Context snapshots under the key `logly_ads`. The bridge's provider is `logly_ads_context`. Both keys landed in the same `platforms` map carrying the same ad account, the reporting view summed them, and the operator was told to repair it by hand.

`reject_unusable_platform_key` only checked the key's *shape* — empty, whitespace-padded, or a malformed `plugin:` claim. An arbitrary plausible string was not one of those, so `logly_ads` passed. That guard's docstring argues against silently *rewriting* an unknown key, which is right; it does not argue against *refusing* one, and refusing is what stops this.

This is the upstream cause of #606 (fixed downstream in #607, which corrected the contradictory wording the two conflict notes produced, not the bad key being written).

## What changed

`guard_platform_entry_write` branch (1) — create — now also calls `reject_unknown_platform_key`. Three vocabularies are accepted and nothing else:

1. a **built-in** key (`google_ads` / `meta_ads` / `search_console` / `ga4` / `tiktok_ads`);
2. a platform an **installed plugin registered** — the entry-point *names* under `mureo.providers` **and** `mureo.analytics`;
3. a **canonical `plugin:<distribution>:<provider>`** key (or the legacy `plugin:<distribution>`), accepted *without* requiring the distribution to be installed here.

The refusal names the key and lists what would have been accepted, so an agent's next attempt is informed rather than a second guess.

### Where the valid-key vocabulary lives, and why

`_BUILTIN_DISPLAY_NAMES` moved from `mureo/web/reports.py` to `mureo/core/platform_keys.py` as `BUILTIN_PLATFORM_DISPLAY_NAMES` (read-only `MappingProxyType`); `web/reports.py` keeps its local name as an alias so the read-side resolver and its existing drift guard read unchanged.

`mureo/core/platform_keys.py` is where it belongs: it is already the single source of "what a platform key is" (the plugin half), it is pure data with no imports, and both consumers can reach it without a layering inversion. `context/` importing `web/` would put the configure UI's import graph on the state-write path and would make a UI surface the owner of a vocabulary it merely consumes. A new module was not warranted for one dict that sits next to the other half of the same convention.

### Enumerating installed plugin platforms

`_provider_entry_points()` follows the shape of `mureo/mcp/server.py::_policy_gate_entry_points` — isolated so tests can pin the environment instead of monkeypatching `importlib.metadata`, and defensive about `entry_points` raising. Two deliberate differences:

- **Names only, never `ep.load()`.** Loading would import third-party code on a state write, under the state lock. The name is all the check needs.
- **Failure fails open, not closed.** The policy-gate loader treats an `importlib.metadata` blow-up as "zero gates". This one cannot treat it as "zero providers" — that would turn a corrupted-metadata environment into a refusal of every plugin platform key. A broken environment is not evidence that a key is wrong, so it logs a warning and lets the write through.

`mureo.analytics` is included alongside `mureo.providers` (the issue named only the latter): a distribution may ship an analytics module without a provider, its registry name is the same `<provider>` component per `core/platform_keys`, and refusing it would be a false rejection. Widening the accepted set is the safe direction here. `mureo.change_feeds` was considered and left out — a change feed imports into `action_log` and never names a `platforms` key of its own.

## The writer-by-writer split

Every writer was enumerated before anything was tightened. The split is "did a caller name this platform, or did this document arrive from elsewhere?".

**Tighten — a caller named one platform, so there is something to refuse and someone to tell:**

| Writer | Reached from |
|---|---|
| `mureo.context.state.upsert_campaign` | `mureo_state_upsert_campaign` |
| `mureo.context.state.set_platform_metrics` | `mureo_state_platform_metrics_set` — the ingress of the reported incident |
| `mureo.context.state.set_conversion_action_types` | `mureo_state_set_conversion_events` |

These three are the only callers of `guard_platform_entry_write`. Out-of-tree callers (bridges, mureo-agency) call the same three functions directly and get the same rule, which is the point — the writer that produced the observed duplicate never passed through MCP validation.

**Stay permissive — the document arrived from elsewhere:**

| Path | Why it must not refuse |
|---|---|
| `write_state_file` (and `_locked_state_mutation`) | The funnel every whole-document writer uses. A whole document has no notion of which entry is new, and a document that already carries a bad key has to stay writable or the operator can never repair it. `warn_on_duplicate_accounts` keeps reporting only. |
| `FilesystemStateStore.write_state` | Delegates to `write_state_file`; mureo-agency's digest sync writes this way. |
| `mureo.context.state_codec.parse_state` / `render_state` | The tolerant read/serialize path — restores, backups, another machine's state. |
| `mureo.demo.installer` | Renders a scenario's STATE.json straight to disk. |
| `mureo.byod.*` | Writes CSVs and a manifest under `~/.mureo/byod/`; never touches `platforms`. |
| `mureo.change_import.importer` | Reads `doc.platforms` to decide coverage; appends to `action_log` only. |
| `mureo.web.*` | `reports.py` reads; the `platform` in `/api/providers/native-toggle` is a provider preference, not a STATE.json key. |

**Left alone deliberately:** branches (2), (3) and (4) of `guard_platform_entry_write` re-validate nothing about the key, exactly as before. An entry that already exists keeps taking writes, so uninstalling a bridge does not freeze its data and an operator holding a bad key can still sync and repair.

The three cases the issue flagged as at risk are all covered without weakening the rule: a snapshot for a bridge that is not installed here uses the canonical `plugin:<dist>:<provider>` form, which needs no registry; imports and restores go through the whole-document path, which is untouched; and `tiktok_ads` — a hosted connector with no provider entry point at all — is a built-in key, so it is accepted with zero plugins installed.

## Tests

`tests/test_state.py::TestUnknownPlatformKeyGuard` (11 cases) and one case on the MCP surface in `tests/test_mcp_tools_mureo_context.py`:

- an invented key is refused on create, the message names the key, a built-in, the installed provider and the `plugin:` form, and nothing lands on disk;
- an installed provider's name is accepted;
- **the LOGLY case pinned end to end** — `logly_ads` refused, `logly_ads_context` accepted, one account keeps one key;
- every built-in is accepted with **no** plugin installed (including `tiktok_ads`);
- the installed set is read from the environment, not from a list in the source (with nothing installed, `logly_ads_context` is refused);
- a canonical plugin key is accepted when nothing is installed;
- uninstalling a provider does not strand its existing entries;
- an existing unknown key stays writable (the repair path);
- a whole-document write carrying an unknown key still lands;
- an unreadable plugin environment fails open, with a warning;
- `upsert_campaign` and `set_conversion_action_types` share the guard;
- the tool surface an agent actually calls refuses the invented key.

Every test **pins the installed set** with a fake entry point. This machine has real bridges installed (`logly_ads_context`, `yahoo_ads`, …), so a test reading the ambient environment would pass for a reason it did not assert, and would flip on a machine with none.

One pre-existing test changed: `test_non_canonical_and_canonical_plugin_key_collide` seeded a bare distribution name (`mureo-logly-bridge`) through `set_platform_metrics`, which is now refused on create. It seeds through the whole-document path instead — state that already carries that key still has to collide, and still has to stay repairable.

## Docs

`docs/strategy-context.md` → *Platform keys* documents the accepted set and the create-only scope; `skills/_mureo-shared/SKILL.md` (and its `mureo/_data/` copy, kept byte-identical) tells agents not to invent or abbreviate a key, with `logly_ads_context` vs `logly_ads` as the example. The `platform` descriptions on the three writing tools now name all three accepted forms and say a new key outside them is rejected — the built-in enumeration the drift guard anchors on is unchanged.

## Checks

`black --check`, `ruff check` and `mypy` clean on every file touched. Full `pytest`: 8984 passed, 12 failed — all in the known plugin-leakage set (`test_mcp_server_plugin_wiring.py`, `test_mcp_tool_provider.py`, `test_mcp_server.py`, `tests/analytics/builtin/test_live_clients.py`), which assume no plugins are installed and fail on this machine before any change here.

Closes #609
