### PR TITLE
feat: repair every client's bad platform key in one pass (#613)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,7 +126,10 @@ mureo/
 │   ├── auth_cmd.py      # `mureo auth setup` / `status` / `check-*` / `upgrade-google`
 │   ├── rollback_cmd.py  # `mureo rollback list` / `show` (inspection only; apply routes through MCP)
 │   ├── repair_cmd.py    # `mureo repair platform-key` — drop a platforms entry filed under a
-│   │                    #   key mureo cannot resolve; dry run by default, backs up first (#610)
+│   │                    #   key mureo cannot resolve; dry run by default, backs up first (#610).
+│   │                    #   `--all` sweeps every client, summary first, one prompt (#613)
+│   ├── _repair_clients.py # Which STATE.json files `--all` sweeps — reuses the Reports tab's
+│   │                    #   optional list_clients / state_store_for_client seam, never a second one
 │   ├── _state_file.py   # The shared `--state-file` option + workspace default (rollback + repair)
 │   ├── _tty.py          # TTY-safe helpers for non-interactive setup + terminal_safe() scrubbing
 │   └── web_auth.py      # Browser-based OAuth wizard spawned by `mureo configure` (per-platform creds)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,7 +127,7 @@ mureo/
 │   ├── rollback_cmd.py  # `mureo rollback list` / `show` (inspection only; apply routes through MCP)
 │   ├── repair_cmd.py    # `mureo repair platform-key` — drop a platforms entry filed under a
 │   │                    #   key mureo cannot resolve; dry run by default, backs up first (#610).
-│   │                    #   `--all` sweeps every client, summary first, one prompt (#613)
+│   │                    #   `--all` sweeps every client, summary first, one prompt (#614)
 │   ├── _repair_clients.py # Which STATE.json files `--all` sweeps — reuses the Reports tab's
 │   │                    #   optional list_clients / state_store_for_client seam, never a second one
 │   ├── _state_file.py   # The shared `--state-file` option + workspace default (rollback + repair)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,45 @@
   unrecognised as the invented `logly_ads`, so an action hung off it would
   offer to delete the right entry.
 
+- **`mureo repair platform-key --all` — the same repair across every client on
+  the machine** (#613). A bad key is written by an *agent*, and an agent that
+  ran against every client wrote it into every client's STATE.json. Repairing
+  one document at a time asks a non-engineer to remember which directories
+  exist and gives them no way to notice the one they missed.
+
+  `--all` leads with a **summary**: which clients have unresolvable keys,
+  which are clean, which could not be read, each as "N of M" — the number is
+  the point. The per-client detail follows in the same shape the
+  single-workspace run prints. Dry run stays the default, and `--apply`
+  confirms **once**, with the whole list in view; a prompt per client trains
+  an operator to hold down `y`. Each repaired client is still backed up
+  individually and the `cp` that restores it printed per client.
+
+  One client failing — an unparseable document, a lock it cannot take, a
+  permission error — costs that client and not the run: it is named in the
+  summary, the rest are repaired, and the exit status is non-zero so a script
+  notices. A *finding* is not a failure: a dry run that reports work to do
+  exits `0`. `--all` with `--state-file` is refused (one says "every client",
+  the other says "this one file"); `--all --key` narrows the sweep to one key
+  across every client, which is the shape the incident actually took.
+
+  Which clients exist is **not** a new mechanism. It is the same two optional
+  `StateStore` capabilities the read-only Reports tab already reads —
+  `list_clients()` and `state_store_for_client(slug)` — resolved through
+  `mureo.web.report_clients`, so OSS grows no dependency on the backend that
+  supplies them and there is no second answer to "which clients exist" that
+  can drift from the first. A store declaring neither, which is every OSS
+  install, yields exactly one client — the active workspace — and `--all`
+  reports `Surveyed 1 client.` and repairs it. That count is the honest
+  signal when a registry cannot be read: an operator running twelve clients
+  and told one knows where to look.
+
+  **Archived clients are swept too**, and labelled. Archiving means "stop
+  collecting this client's figures" — a decision about what to fetch next,
+  not a statement that what is already stored is correct. Skipping them would
+  leave the bad key in place to reappear the day the client is restored, on a
+  machine whose operator has no reason to run the sweep again.
+
 ### Fixed
 
 - **A platform key an agent invented was accepted on write, creating a phantom

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@
   offer to delete the right entry.
 
 - **`mureo repair platform-key --all` — the same repair across every client on
-  the machine** (#613). A bad key is written by an *agent*, and an agent that
+  the machine** (#614). A bad key is written by an *agent*, and an agent that
   ran against every client wrote it into every client's STATE.json. Repairing
   one document at a time asks a non-engineer to remember which directories
   exist and gives them no way to notice the one they missed.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -351,9 +351,11 @@ Surveyed 6 clients.
     acme (Acme Co) — logly_ads
     beta (Beta Ltd) — logly_ads
 
-  Clean (3 of 6):
-    gamma (Gamma KK)
+  Need your decision (1 of 6):
     epsilon (Epsilon GmbH) [archived] — one ad account under two real platform keys (see below)
+
+  Clean (2 of 6):
+    gamma (Gamma KK)
     zeta (Zeta SA) — no STATE.json yet
 
   Could not be read (1 of 6):
@@ -363,6 +365,7 @@ Surveyed 6 clients.
 The per-client detail follows, in the same shape as the single-workspace run, for every client that has a finding. Then:
 
 - **Dry run is still the default.** `--all` on its own changes nothing.
+- **`Need your decision` is its own group, not a footnote under `Clean`.** An ad account stored under two keys that *both* name real platforms is still double-counted; mureo simply will not choose which entry to drop, because the two usually hold different partial figures. It is not a repair this command can make, and it is not clean either — so it is counted separately rather than qualified after an em dash in a line you would skim.
 - **`--all --apply` asks once**, with the whole list in view — not once per client. A prompt per client teaches you to hold down `y`, which is the opposite of what a confirmation is for. Every repaired client is still backed up individually, and the `cp` that restores it is printed per client.
 - **One client failing does not stop the sweep.** An unparseable STATE.json, a lock it cannot take, a permission error — that client is named in the summary and under `Could not be read`, the rest are repaired, and the command exits non-zero so a script notices. A *finding* is not a failure: a dry run that reports work to do exits `0`.
 - **`--all` and `--state-file` are refused together.** One says "every client", the other says "this one file".

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -291,6 +291,10 @@ mureo repair platform-key --apply --yes
 # Narrow it to one key, or point at another workspace's STATE.json.
 mureo repair platform-key --key logly_ads
 mureo repair platform-key --state-file /path/to/STATE.json
+
+# Survey every client on this machine instead of one workspace.
+mureo repair platform-key --all
+mureo repair platform-key --all --apply
 ```
 
 The dry run names the key, the ad account, how many campaigns the entry carries, whether it holds a `totals` rollup and which windows it covers with each window's fetch time — for the unresolvable entry **and** for the entry the same ad account is stored under — then states exactly what would change:
@@ -333,6 +337,40 @@ If this turns out wrong, put it back with:
 That backup is the undo. The repair is not recorded in `action_log`: that log records changes made to an *ad platform* and feeds the rollback planner, and a local-file edit has neither a platform operation to name nor one to reverse. With no TTY — an AI agent's shell, a CI runner — `--apply` declines rather than proceeding, so nothing destructive happens where the question could not be asked.
 
 The same finding is flagged on the configure UI's Reports cards, which now name this command.
+
+### Every client at once: `--all`
+
+A bad key is rarely one directory's problem. It is written by an agent, and an agent that ran against every client on the machine wrote it into every client's STATE.json. `--all` sweeps them all and **leads with the summary**, so you can see how many of how many need work without scrolling:
+
+```
+=== mureo repair platform-key --all ===
+
+Surveyed 6 clients.
+
+  Need repair (2 of 6):
+    acme (Acme Co) — logly_ads
+    beta (Beta Ltd) — logly_ads
+
+  Clean (3 of 6):
+    gamma (Gamma KK)
+    epsilon (Epsilon GmbH) [archived] — one ad account under two real platform keys (see below)
+    zeta (Zeta SA) — no STATE.json yet
+
+  Could not be read (1 of 6):
+    delta (Delta Inc) — Failed to parse JSON in STATE.json: /clients/delta/STATE.json
+```
+
+The per-client detail follows, in the same shape as the single-workspace run, for every client that has a finding. Then:
+
+- **Dry run is still the default.** `--all` on its own changes nothing.
+- **`--all --apply` asks once**, with the whole list in view — not once per client. A prompt per client teaches you to hold down `y`, which is the opposite of what a confirmation is for. Every repaired client is still backed up individually, and the `cp` that restores it is printed per client.
+- **One client failing does not stop the sweep.** An unparseable STATE.json, a lock it cannot take, a permission error — that client is named in the summary and under `Could not be read`, the rest are repaired, and the command exits non-zero so a script notices. A *finding* is not a failure: a dry run that reports work to do exits `0`.
+- **`--all` and `--state-file` are refused together.** One says "every client", the other says "this one file".
+- **`--all --key <key>` is allowed** and narrows the sweep to that key across every client — the reported incident used one invented key everywhere. A client that does not carry it is simply clean.
+
+Which clients exist comes from the same optional `StateStore` capabilities the configure UI's Reports tab reads (`list_clients()` / `state_store_for_client(slug)` — see [`docs/plugin-authoring.md`](plugin-authoring.md)). A store that declares neither — every OSS install — yields exactly one client, the active workspace, and `--all` reports `Surveyed 1 client.` and repairs it. That count is worth reading: if you run twelve clients and are told one, the client registry is what is broken, not the sweep.
+
+**Archived clients are swept too**, and labelled `[archived]`. Archiving means "stop collecting this client's figures" — a decision about what to fetch next, not a statement that what is already stored is correct. Skipping them would leave the bad key in place to reappear the day the client is restored, on a machine whose operator has no reason to run the sweep again.
 
 ## BYOD Commands (Bring Your Own Data)
 

--- a/docs/strategy-context.md
+++ b/docs/strategy-context.md
@@ -408,6 +408,9 @@ mureo repair platform-key --apply
 
 # Narrow it to one key, or point at another workspace's file.
 mureo repair platform-key --key logly_ads --state-file ./client-a/STATE.json
+
+# Or sweep every client this machine knows about, summary first.
+mureo repair platform-key --all
 ```
 
 What it does, and deliberately does not:
@@ -446,6 +449,17 @@ What it does, and deliberately does not:
   stale figures read as just-synced), and the legacy flat `campaigns` list is
   left alone because it is platform-blind — nothing in it says which entries
   came from the removed key.
+
+- **`--all` repairs every client, not every directory you remembered.** The
+  bad key was written by an agent, and an agent that ran against every client
+  wrote it everywhere. `--all` surveys each client the active `StateStore`
+  advertises (the same `list_clients()` / `state_store_for_client(slug)` seam
+  the Reports tab reads — no OSS dependency on a multi-account backend), leads
+  with "N of M need repair", confirms **once** with the whole list in view,
+  and carries on past a client it cannot read with a non-zero exit. On an
+  install whose store declares neither capability it surveys exactly one
+  client, the active workspace. Archived clients are swept and labelled. See
+  [`docs/cli.md`](cli.md#every-client-at-once---all).
 
 The write goes through `write_state_file`, the whole-document funnel the
 create guard deliberately does not police, so a document that is *already*

--- a/mureo/cli/_repair_clients.py
+++ b/mureo/cli/_repair_clients.py
@@ -1,0 +1,232 @@
+"""Which STATE.json files ``mureo repair platform-key --all`` sweeps.
+
+The incident #610 exists for — LOGLY snapshots written under the invented key
+``logly_ads`` instead of the bridge's ``logly_ads_context`` — was never
+confined to one directory. It was made by an agent that ran against every
+client on the machine, so the repair has to be able to run against every
+client on the machine.
+
+No client registry is invented here
+-----------------------------------
+mureo OSS has no notion of "the other client". The one that exists is the
+optional pair of ``StateStore`` capabilities the read-only Reports tab
+already reads — ``list_clients()`` and ``state_store_for_client(slug)`` —
+resolved in :mod:`mureo.web.report_clients` and supplied by a multi-account
+backend. This module calls **that** seam rather than a second one: two
+answers to "which clients exist" that can drift is the same defect class
+#609/#610 are about, and OSS must not grow a dependency on the backend that
+supplies them.
+
+Everything the seam does defensively is therefore inherited: a store
+declaring neither capability yields exactly one target (the active
+workspace), which is what every OSS install gets, and a registry that cannot
+be read at all degrades to that same single target. The degradation is
+**visible** rather than silent because the summary always leads with how many
+clients were surveyed — an operator who runs twelve clients and is told
+"Surveyed 1 client." has the signal they need.
+
+A store that advertises ``list_clients`` but no ``state_store_for_client``
+resolves every slug to the active store, so several targets can name one
+file. They are not de-duplicated: the summary prints each target's path, and
+inventing a merge here would hide a misconfigured backend rather than show
+it.
+
+Reading is where a client fails, not the sweep
+----------------------------------------------
+:func:`survey_client` converts any failure to read one client — an
+unparseable document, no permission, a store that will not name a file — into
+a :class:`ClientSurvey` carrying ``error``. Nothing raises out of the survey,
+so one bad client costs the operator that client and not the run.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from mureo.cli._state_file import resolve_default_state_file, state_file_for_store
+from mureo.cli._tty import terminal_safe as _safe
+from mureo.context.platform_repair import plan_platform_key_repairs
+from mureo.context.state import read_state_file
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from pathlib import Path
+
+    from mureo.context.models import StateDocument
+    from mureo.context.platform_repair import PlatformKeyRepair
+
+_UNRESOLVED_STORE = "its state store did not say where its STATE.json lives"
+
+
+@dataclass(frozen=True)
+class ClientTarget:
+    """One client the sweep will look at, and the file it will look at.
+
+    ``state_file`` is ``None`` exactly when ``error`` explains why the client
+    could not be located at all; the two are never both set.
+    """
+
+    slug: str
+    name: str
+    archived: bool
+    state_file: Path | None
+    error: str | None
+
+
+@dataclass(frozen=True)
+class ClientRegistry:
+    """The sweep's targets, plus why the enumeration itself is untrustworthy.
+
+    ``warning`` is set only when the client seam raised on the way out —
+    something its own guards are documented to prevent. It is not set for the
+    ordinary "no seam declared" case, which is not a fault: that is every OSS
+    install, and it means one target rather than none.
+    """
+
+    targets: tuple[ClientTarget, ...]
+    warning: str | None
+
+
+@dataclass(frozen=True)
+class ClientSurvey:
+    """What one client's STATE.json turned out to hold.
+
+    Exactly one of three states, and the caller reads them in this order:
+    ``error`` set (could not be read), ``repairs`` non-empty (needs work), or
+    neither (clean). ``doc`` is kept so the caller can report the findings
+    this command deliberately does NOT repair — a duplicate whose two keys
+    both name real platforms — without re-reading the file.
+    """
+
+    target: ClientTarget
+    doc: StateDocument | None
+    repairs: tuple[PlatformKeyRepair, ...]
+    error: str | None
+
+    @property
+    def missing(self) -> bool:
+        """Is this client simply without a STATE.json yet?
+
+        Not a failure: a client that has never synced has nothing to repair.
+        Worth saying out loud though, because an operator expecting figures
+        for it is looking at the wrong workspace.
+        """
+        return self.doc is None and self.error is None
+
+
+def list_repair_targets() -> ClientRegistry:
+    """Every client the active ``StateStore`` advertises, in registry order.
+
+    Falls back to a single target for the active workspace when the store
+    declares no client seam (the OSS default) or when the seam raises.
+    """
+    try:
+        from mureo.web.report_clients import list_report_clients
+
+        rows = list_report_clients()
+    except Exception as exc:  # noqa: BLE001 — a backend fault degrades the sweep
+        return ClientRegistry(
+            targets=(_active_workspace_target(),),
+            warning=(
+                f"the client list could not be read ({type(exc).__name__}), so "
+                f"only the active workspace was surveyed"
+            ),
+        )
+    targets = tuple(_target_for_row(row) for row in rows if isinstance(row, dict))
+    if not targets:
+        return ClientRegistry(targets=(_active_workspace_target(),), warning=None)
+    return ClientRegistry(targets=targets, warning=None)
+
+
+def survey_client(
+    target: ClientTarget, *, keys: Iterable[str] | None = None
+) -> ClientSurvey:
+    """Read one client and plan its repairs, converting failure to a report.
+
+    ``keys`` narrows the plan exactly as
+    :func:`~mureo.context.platform_repair.plan_platform_key_repairs` does. The
+    read is strict, like the single-workspace command's: a document that only
+    parses tolerantly must not be rewritten, because the entries the tolerant
+    parse skipped would be dropped by the write-back.
+    """
+    if target.state_file is None:
+        return ClientSurvey(target, None, (), target.error or _UNRESOLVED_STORE)
+    if not target.state_file.exists():
+        return ClientSurvey(target, None, (), None)
+    try:
+        doc = read_state_file(target.state_file)
+    except Exception as exc:  # noqa: BLE001 — one bad client is not a bad sweep
+        return ClientSurvey(target, None, (), _reason(exc))
+    return ClientSurvey(target, doc, plan_platform_key_repairs(doc, keys=keys), None)
+
+
+def survey_clients(
+    targets: Iterable[ClientTarget], *, keys: Iterable[str] | None = None
+) -> tuple[ClientSurvey, ...]:
+    """Survey every target, in order."""
+    return tuple(survey_client(target, keys=keys) for target in targets)
+
+
+def _target_for_row(row: dict[str, Any]) -> ClientTarget:
+    """Normalize one ``list_clients()`` row into a target.
+
+    Field handling matches :func:`mureo.web.report_clients.list_report_clients`
+    (which already normalized these): ``name`` falls back to the slug and
+    ``archived`` is a coerced bool.
+    """
+    slug = str(row.get("slug", "")).strip()
+    name = str(row.get("name", slug)).strip() or slug
+    archived = bool(row.get("archived", False))
+    if not slug:
+        return ClientTarget("(unnamed)", "(unnamed)", archived, None, "it has no slug")
+    try:
+        from mureo.web.report_clients import state_store_for_client
+
+        store = state_store_for_client(slug)
+    except Exception as exc:  # noqa: BLE001 — a backend fault is one bad client
+        return ClientTarget(
+            slug, name, archived, None, f"its state store raised {type(exc).__name__}"
+        )
+    path = state_file_for_store(store)
+    if path is None:
+        return ClientTarget(slug, name, archived, None, _UNRESOLVED_STORE)
+    return ClientTarget(slug, name, archived, path, None)
+
+
+def _active_workspace_target() -> ClientTarget:
+    """The single target every OSS install sweeps: this workspace."""
+    try:
+        state_file: Path | None = resolve_default_state_file()
+        error = None
+    except Exception as exc:  # noqa: BLE001 — a broken factory is still reportable
+        state_file, error = None, f"its state store raised {type(exc).__name__}"
+    return ClientTarget(
+        slug="this workspace",
+        name="this workspace",
+        archived=False,
+        state_file=state_file,
+        error=error,
+    )
+
+
+def _reason(exc: Exception) -> str:
+    """One scrubbed line saying why a client could not be read.
+
+    STATE.json is agent-writable, so an exception carrying a fragment of it
+    carries attacker-influenceable text straight to a terminal — the same
+    reason every other string this command prints goes through
+    ``terminal_safe``.
+    """
+    text = _safe(str(exc)).strip()
+    return text or type(exc).__name__
+
+
+__all__ = [
+    "ClientRegistry",
+    "ClientSurvey",
+    "ClientTarget",
+    "list_repair_targets",
+    "survey_client",
+    "survey_clients",
+]

--- a/mureo/cli/_state_file.py
+++ b/mureo/cli/_state_file.py
@@ -32,6 +32,24 @@ from it for each command that uses it.
 """
 
 
+def state_file_for_store(store: object) -> Path | None:
+    """Where ``store`` keeps its STATE.json, or ``None`` if it will not say.
+
+    Duck-typed on the two attributes the filesystem store (and the per-client
+    stores an Agency backend hands back) expose: ``state_path`` wins, else
+    ``<workspace>/STATE.json``. A store advertising neither has no file for a
+    file-level command to work on — ``None`` says so rather than guessing at
+    the process's CWD, which would point a repair at the wrong document.
+    """
+    attr = getattr(store, "state_path", None)
+    if attr is not None:
+        return Path(attr).resolve()
+    workspace = getattr(store, "workspace", None)
+    if workspace is None:
+        return None
+    return Path(workspace) / "STATE.json"
+
+
 def resolve_default_state_file() -> Path:
     """Return the workspace-derived default for ``--state-file``.
 
@@ -46,11 +64,11 @@ def resolve_default_state_file() -> Path:
     from mureo.core.runtime_context import get_runtime_context
 
     store = get_runtime_context().state_store
-    attr = getattr(store, "state_path", None)
-    if attr is not None:
-        return Path(attr).resolve()
-    workspace = getattr(store, "workspace", Path.cwd())
-    return Path(workspace) / "STATE.json"
+    return state_file_for_store(store) or Path.cwd() / "STATE.json"
 
 
-__all__ = ["STATE_FILE_OPTION", "resolve_default_state_file"]
+__all__ = [
+    "STATE_FILE_OPTION",
+    "resolve_default_state_file",
+    "state_file_for_store",
+]

--- a/mureo/cli/repair_cmd.py
+++ b/mureo/cli/repair_cmd.py
@@ -15,6 +15,25 @@ decide safely and shows its work for everything else:
 - **It backs the document up first**, timestamped, and prints the command that
   puts it back.
 
+``--all``: the same repair, once per client
+-------------------------------------------
+The incident is not one directory's. It was made by an agent running against
+every client on the machine, so repairing one document at a time asks a
+non-engineer to remember which directories exist — and gives them no way to
+notice the one they missed. ``--all`` surveys every client the active
+``StateStore`` advertises (:mod:`mureo.cli._repair_clients`), leads with a
+summary of how many of how many need work, and confirms **once** with that
+list in view. One client failing costs that client, not the run: the failure
+is named in the summary and the exit status is non-zero.
+
+**Archived clients are swept too**, and labelled. Archiving means "stop
+collecting this client's figures" — a decision about what to fetch next, not
+a statement that what is already stored is correct. Skipping them would leave
+the bad key in place to reappear the day the client is un-archived, on a
+machine whose operator has no reason to run the sweep a second time. The
+dashboard takes the same position where a decision is at stake: its Reports
+routing counts the whole registry, archived rows included.
+
 Why the CLI and not a dashboard button
 --------------------------------------
 The finding surfaces on the dashboard's platform card, and the card now points
@@ -37,6 +56,7 @@ from typing import TYPE_CHECKING
 
 import typer
 
+from mureo.cli._repair_clients import list_repair_targets, survey_clients
 from mureo.cli._state_file import STATE_FILE_OPTION, resolve_default_state_file
 from mureo.cli._tty import confirm_or_default
 from mureo.cli._tty import terminal_safe as _safe
@@ -50,7 +70,11 @@ from mureo.context.platform_repair import (
 from mureo.context.state import read_state_file
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from mureo.cli._repair_clients import ClientSurvey, ClientTarget
     from mureo.context.models import StateDocument
+    from mureo.context.platform_accounts import DuplicateAccountEntry
     from mureo.context.platform_repair import PlatformEntryFacts, PlatformKeyRepair
 
 repair_app = typer.Typer(
@@ -85,6 +109,16 @@ def _reject_unusable_key_argument(doc: StateDocument, key: str) -> None:
             err=True,
         )
         raise typer.Exit(1)
+    _reject_resolvable_key(key)
+
+
+def _reject_resolvable_key(key: str) -> None:
+    """Refuse a ``--key`` naming a platform mureo CAN resolve.
+
+    Shared with ``--all``, which has no single document to check the key's
+    presence against but must give the identical answer to the identical
+    mistake.
+    """
     if not is_unresolvable_platform_key(key):
         typer.echo(
             f"Error: mureo can resolve {_safe(key)!r}, so this is not the case "
@@ -188,7 +222,22 @@ def _echo_repair(repair: PlatformKeyRepair) -> None:
         )
 
 
-def _echo_undecidable_duplicates(doc: StateDocument) -> None:
+def _undecidable_groups(doc: StateDocument | None) -> tuple[DuplicateAccountEntry, ...]:
+    """Duplicates whose keys ALL name real platforms — mureo's to report only.
+
+    Split out of the echo so the ``--all`` summary can flag a client whose
+    only finding is one of these without printing the whole block twice.
+    """
+    if doc is None:
+        return ()
+    return tuple(
+        group
+        for group in duplicate_account_entries(doc.platforms or {})
+        if not any(is_unresolvable_platform_key(key) for key in group.platform_keys)
+    )
+
+
+def _echo_undecidable_duplicates(doc: StateDocument | None) -> None:
     """Report a duplicate this command will not touch, and say why.
 
     Both keys name real platforms, so the question is which set of partial
@@ -196,12 +245,7 @@ def _echo_undecidable_duplicates(doc: StateDocument) -> None:
     is right to refuse. Saying nothing here would read as "mureo found no
     problem" to an operator who came from a dashboard warning.
     """
-    platforms = doc.platforms or {}
-    groups = [
-        group
-        for group in duplicate_account_entries(platforms)
-        if not any(is_unresolvable_platform_key(key) for key in group.platform_keys)
-    ]
+    groups = _undecidable_groups(doc)
     if not groups:
         return
     typer.echo("")
@@ -246,6 +290,15 @@ def repair_platform_key(
             "would do and leaves STATE.json untouched."
         ),
     ),
+    all_clients: bool = typer.Option(
+        False,
+        "--all",
+        help=(
+            "Survey every client this machine knows about instead of one "
+            "workspace, and report which of them need repairing. Cannot be "
+            "combined with --state-file."
+        ),
+    ),
     yes: bool = typer.Option(
         False, "--yes", "-y", help="Skip the confirmation prompt for --apply."
     ),
@@ -254,6 +307,16 @@ def repair_platform_key(
 
     Shows what it would do and changes nothing unless you pass ``--apply``.
     """
+    if all_clients:
+        _repair_every_client(state_file=state_file, key=key, apply=apply, yes=yes)
+        return
+    _repair_one_workspace(state_file=state_file, key=key, apply=apply, yes=yes)
+
+
+def _repair_one_workspace(
+    *, state_file: Path | None, key: str | None, apply: bool, yes: bool
+) -> None:
+    """The single-document run: one STATE.json, shown in full before acting."""
     if state_file is None:
         state_file = resolve_default_state_file()
     doc = _read_document(state_file)
@@ -290,22 +353,31 @@ def repair_platform_key(
     _apply(state_file, keys)
 
 
-def _confirmed(*, apply: bool, yes: bool) -> bool:
+def _confirmed(
+    *,
+    apply: bool,
+    yes: bool,
+    command: str = _COMMAND,
+    prompt: str = "Apply this repair?",
+) -> bool:
     """Has the operator asked for the change AND agreed to it?
 
     Two separate gates. Without ``--apply`` this is a dry run and says so.
     With it, the prompt defaults to **no** and — with no TTY, which is what an
     AI agent's shell looks like — declines rather than proceeding, so a
     destructive step is never taken by a caller that could not be asked.
+
+    ``--all`` passes its own ``command`` and ``prompt`` and calls this **once**
+    for the whole sweep, with every client's finding already on screen. Asking
+    per client would train the operator to hold down ``y`` — the opposite of
+    what a confirmation is for.
     """
     if not apply:
         typer.echo("Nothing has been changed — this was a dry run.")
         typer.echo("To make the change, run the same command with --apply:")
-        typer.echo(f"  {_COMMAND} --apply")
+        typer.echo(f"  {command} --apply")
         return False
-    if confirm_or_default(
-        "Apply this repair?", default=False, override=True if yes else None
-    ):
+    if confirm_or_default(prompt, default=False, override=True if yes else None):
         return True
     typer.echo("Nothing was changed.")
     return False
@@ -329,3 +401,210 @@ def _apply(state_file: Path, keys: tuple[str, ...] | None) -> None:
         typer.echo(f'  cp "{outcome.backup}" "{state_file}"')
         typer.echo("")
     _echo_apply_result(outcome.repairs)
+
+
+# ---------------------------------------------------------------------------
+# --all: every client on the machine, summary first
+# ---------------------------------------------------------------------------
+
+_ALL_COMMAND = f"{_COMMAND} --all"
+
+
+def _repair_every_client(
+    *, state_file: Path | None, key: str | None, apply: bool, yes: bool
+) -> None:
+    """Survey every client, report, and — once confirmed — repair each.
+
+    Exits non-zero when any client could not be surveyed or repaired. A
+    *finding* is not a failure: a dry run that reports work to do exits 0.
+    """
+    _reject_all_conflicts(state_file=state_file, key=key)
+    keys = (key,) if key is not None else None
+    registry = list_repair_targets()
+    surveys = survey_clients(registry.targets, keys=keys)
+    failures = sum(1 for survey in surveys if survey.error)
+
+    typer.echo(f"=== {_ALL_COMMAND} ===")
+    typer.echo("")
+    _echo_survey_summary(surveys, registry.warning)
+    _echo_survey_details(surveys)
+    typer.echo("")
+
+    needing = [survey for survey in surveys if survey.repairs]
+    if not needing:
+        typer.echo(
+            "Nothing to repair: every client's platform entries are filed under "
+            "keys mureo can resolve."
+        )
+    elif _confirmed(
+        apply=apply,
+        yes=yes,
+        command=_ALL_COMMAND,
+        prompt=f"Apply these repairs to {_clients(len(needing))}?",
+    ):
+        failures += _apply_every_client(needing, keys)
+    if failures:
+        # Said last as well as in the summary: on a long sweep the summary has
+        # scrolled off, and the closing line is the one an operator reads.
+        typer.echo("")
+        typer.echo(
+            f"Finished with errors: {failures} of {len(surveys)} clients could "
+            f"not be read or repaired."
+        )
+    if registry.warning is not None or failures:
+        raise typer.Exit(1)
+
+
+def _reject_all_conflicts(*, state_file: Path | None, key: str | None) -> None:
+    """Refuse the flag combinations ``--all`` cannot mean anything with."""
+    if state_file is not None:
+        typer.echo(
+            "Error: --all repairs every client's STATE.json, so it cannot also "
+            "be pointed at a single one with --state-file. Use --all to sweep "
+            "the machine, or --state-file to repair one workspace.",
+            err=True,
+        )
+        raise typer.Exit(1)
+    # ``--key`` still narrows the sweep — the reported incident used the same
+    # invented key everywhere — but it cannot be checked for presence here:
+    # there are many documents, and a client that simply does not carry the
+    # key is a clean client, not an error.
+    if key is not None:
+        _reject_resolvable_key(key)
+
+
+def _clients(count: int) -> str:
+    return f"{count} client" if count == 1 else f"{count} clients"
+
+
+def _client_label(target: ClientTarget) -> str:
+    """How one client is named everywhere in the ``--all`` output.
+
+    Slug first (it is what every other surface identifies the client by), the
+    display name only when it says something the slug does not, and the
+    archived flag always — an operator seeing a repair applied to a client
+    they had shelved should be told that is what happened.
+    """
+    label = _safe(target.slug)
+    if target.name and target.name != target.slug:
+        label = f"{label} ({_safe(target.name)})"
+    return f"{label} [archived]" if target.archived else label
+
+
+def _echo_survey_summary(
+    surveys: tuple[ClientSurvey, ...], warning: str | None
+) -> None:
+    """The whole point of ``--all``: N of M clients need work, at a glance."""
+    total = len(surveys)
+    typer.echo(f"Surveyed {_clients(total)}.")
+    if warning is not None:
+        typer.echo(f"Warning: {_safe(warning)}")
+    typer.echo("")
+    _echo_survey_group(
+        "Need repair",
+        [s for s in surveys if s.repairs],
+        total,
+        lambda s: ", ".join(_safe(r.entry.key) for r in s.repairs),
+    )
+    _echo_survey_group(
+        "Clean",
+        [s for s in surveys if not s.repairs and not s.error],
+        total,
+        _clean_note,
+    )
+    _echo_survey_group(
+        "Could not be read",
+        [s for s in surveys if s.error],
+        total,
+        lambda s: s.error or "",
+    )
+
+
+def _echo_survey_group(
+    title: str,
+    surveys: list[ClientSurvey],
+    total: int,
+    note: Callable[[ClientSurvey], str],
+) -> None:
+    """One block of the summary. Silent when it has no members."""
+    if not surveys:
+        return
+    typer.echo(f"  {title} ({len(surveys)} of {total}):")
+    for survey in surveys:
+        detail = note(survey)
+        suffix = f" — {detail}" if detail else ""
+        typer.echo(f"    {_client_label(survey.target)}{suffix}")
+    typer.echo("")
+
+
+def _clean_note(survey: ClientSurvey) -> str:
+    """Why a client with no repairable entry may still not be finished.
+
+    "Clean" here means only "nothing mureo will remove". A client whose
+    account is stored under two keys that BOTH name real platforms is still
+    double-counting, and a client with no STATE.json at all is not the one
+    holding the figures the operator is looking for — both are said out loud
+    rather than folded into a reassuring word.
+    """
+    if survey.missing:
+        return "no STATE.json yet"
+    if _undecidable_groups(survey.doc):
+        return "one ad account under two real platform keys (see below)"
+    return ""
+
+
+def _echo_survey_details(surveys: tuple[ClientSurvey, ...]) -> None:
+    """The single-workspace detail block, per client that has a finding."""
+    for survey in surveys:
+        if not survey.repairs and not _undecidable_groups(survey.doc):
+            continue
+        typer.echo("")
+        typer.echo(f"--- {_client_label(survey.target)} ---")
+        # Scrubbed: unlike the single run's ``--state-file``, this path came
+        # from a backend's client registry rather than from the operator.
+        typer.echo(f"STATE.json: {_safe(str(survey.target.state_file))}")
+        for repair in survey.repairs:
+            _echo_repair(repair)
+        _echo_undecidable_duplicates(survey.doc)
+
+
+def _apply_every_client(
+    surveys: list[ClientSurvey], keys: tuple[str, ...] | None
+) -> int:
+    """Repair each client in turn, and return how many failed.
+
+    A client that fails is named and the sweep continues: a lock it cannot
+    take or a permission error on one directory is no reason to leave the
+    other eleven broken.
+    """
+    failures = 0
+    for survey in surveys:
+        typer.echo("")
+        typer.echo(f"{_client_label(survey.target)}:")
+        failures += _apply_one_client(survey, keys)
+    typer.echo("")
+    typer.echo(f"Done. Re-run `{_ALL_COMMAND}` to confirm nothing is left.")
+    return failures
+
+
+def _apply_one_client(survey: ClientSurvey, keys: tuple[str, ...] | None) -> int:
+    """Repair one client, returning ``1`` if it failed and ``0`` otherwise."""
+    state_file = survey.target.state_file
+    if state_file is None:  # pragma: no cover — a surveyed client always has one
+        typer.echo(f"  Error: {survey.error or 'no STATE.json to repair'}", err=True)
+        return 1
+    try:
+        outcome = apply_state_file_repairs(state_file, keys=keys)
+    except Exception as exc:  # noqa: BLE001 — one client's failure is not the sweep's
+        typer.echo(f"  Error: STATE.json was not changed: {_safe(str(exc))}", err=True)
+        return 1
+    if not outcome.changed:
+        # The document changed between the survey and the lock being taken.
+        typer.echo("  Nothing was changed — STATE.json no longer needs this repair.")
+        return 0
+    if outcome.backup is not None:
+        typer.echo(f"  Backed up STATE.json to {outcome.backup}")
+        typer.echo(f'  Put it back with: cp "{outcome.backup}" "{state_file}"')
+    for repair in outcome.repairs:
+        typer.echo(f"  Removed the {_safe(repair.entry.key)} entry from STATE.json.")
+    return 0

--- a/mureo/cli/repair_cmd.py
+++ b/mureo/cli/repair_cmd.py
@@ -506,9 +506,29 @@ def _echo_survey_summary(
         total,
         lambda s: ", ".join(_safe(r.entry.key) for r in s.repairs),
     )
+    # A client mureo will not touch is not therefore finished. An account
+    # stored under two keys that BOTH name real platforms is still
+    # double-counting, and mureo deliberately will not choose between them —
+    # so it gets its own group rather than a note hung off "Clean". The
+    # operator this command is for reads "Clean (3 of 6)" as "three are
+    # fine"; a qualifier after an em dash is exactly what they skim past.
+    _echo_survey_group(
+        "Need your decision",
+        [
+            s
+            for s in surveys
+            if not s.repairs and not s.error and _undecidable_groups(s.doc)
+        ],
+        total,
+        lambda _s: "one ad account under two real platform keys (see below)",
+    )
     _echo_survey_group(
         "Clean",
-        [s for s in surveys if not s.repairs and not s.error],
+        [
+            s
+            for s in surveys
+            if not s.repairs and not s.error and not _undecidable_groups(s.doc)
+        ],
         total,
         _clean_note,
     )
@@ -538,19 +558,16 @@ def _echo_survey_group(
 
 
 def _clean_note(survey: ClientSurvey) -> str:
-    """Why a client with no repairable entry may still not be finished.
+    """Why a "clean" client may still not be the one holding the figures.
 
-    "Clean" here means only "nothing mureo will remove". A client whose
-    account is stored under two keys that BOTH name real platforms is still
-    double-counting, and a client with no STATE.json at all is not the one
-    holding the figures the operator is looking for — both are said out loud
-    rather than folded into a reassuring word.
+    A client that has never synced has nothing to repair and nothing to
+    double-count, but it also has none of the numbers the operator came
+    looking for — so it is said out loud rather than folded into a
+    reassuring word. The other not-really-clean case, an account stored
+    under two keys that both name real platforms, is not here: it has its
+    own summary group.
     """
-    if survey.missing:
-        return "no STATE.json yet"
-    if _undecidable_groups(survey.doc):
-        return "one ad account under two real platform keys (see below)"
-    return ""
+    return "no STATE.json yet" if survey.missing else ""
 
 
 def _echo_survey_details(surveys: tuple[ClientSurvey, ...]) -> None:

--- a/tests/test_cli_repair_all.py
+++ b/tests/test_cli_repair_all.py
@@ -195,6 +195,50 @@ class TestSurvey:
         assert "beta" in out
         assert "gamma" in out
 
+    def test_an_undecidable_duplicate_is_not_counted_as_clean(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Its own group, not a note hung off "Clean".
+
+        A client whose account sits under two keys that BOTH name real
+        platforms is still double-counting; mureo just will not choose which
+        entry to drop. Counting it in "Clean (N of M)" tells the operator
+        this command is written for — a non-engineer sweeping every client —
+        that it is fine, and the qualifier after the em dash is exactly what
+        a person skimming a summary does not read.
+        """
+        paths = {
+            slug: tmp_path / slug / "STATE.json" for slug in ("acme", "delta", "gamma")
+        }
+        _bad_state(paths["acme"], "1111111111")
+        _write(
+            paths["delta"],
+            {
+                "version": "2",
+                "platforms": {
+                    "google_ads": {"account_id": "4444444444"},
+                    "logly_ads_context": {"account_id": "4444444444"},
+                },
+            },
+        )
+        _clean_state(paths["gamma"], "3333333333")
+        stores = {slug: _ClientStore(path) for slug, path in paths.items()}
+        rows = [
+            {"slug": "acme", "name": "Acme Co", "active": True},
+            {"slug": "delta", "name": "Delta Inc", "active": False},
+            {"slug": "gamma", "name": "Gamma KK", "active": False},
+        ]
+        _install_store(monkeypatch, _AgencyStore(paths["acme"], rows, dict(stores)))
+
+        result = _run("--all")
+
+        assert result.exit_code == 0, result.output
+        out = result.output
+        assert "Need repair (1 of 3)" in out
+        assert "Need your decision (1 of 3)" in out
+        # The one genuinely finished client is the only one called clean.
+        assert "Clean (1 of 3)" in out
+
     def test_the_summary_comes_before_the_per_client_detail(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_cli_repair_all.py
+++ b/tests/test_cli_repair_all.py
@@ -1,0 +1,414 @@
+"""``mureo repair platform-key --all`` — the whole-machine sweep (#613).
+
+The incident the command exists for spans EVERY client directory on the
+affected machine, and the operator is a non-engineer. Running the
+single-workspace command once per directory gives them no way to notice the
+directory they missed and no single view of how much is wrong, so ``--all``
+has to:
+
+  - survey every client the active ``StateStore`` advertises and print a
+    **summary first** — how many need work out of how many exist;
+  - stay a dry run by default, and confirm exactly **once** for ``--apply``
+    (a per-client prompt trains people to hold down ``y``);
+  - carry on when one client fails, report it, and exit non-zero;
+  - degrade to the single active workspace on a store with no client seam,
+    which is every OSS install.
+
+The store capabilities are faked here on purpose. mureo-agency supplies them
+in production and IS installed on the machine this was written on, so a test
+that leaned on it would pass here and assert nothing in CI.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from typer.testing import CliRunner
+
+from mureo.cli.main import app
+from mureo.context import platform_guards
+from mureo.context.state import read_state_file
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+    from mureo.context.models import StateDocument
+
+pytestmark = pytest.mark.unit
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _clear_runtime_context_cache() -> Iterator[None]:
+    from mureo.core.runtime_context import reset_runtime_context
+
+    reset_runtime_context()
+    yield
+    reset_runtime_context()
+
+
+@pytest.fixture(autouse=True)
+def _pin_logly_bridge_installed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """One installed provider, ``logly_ads_context`` — the reported machine."""
+    entries = (SimpleNamespace(name="logly_ads_context"),)
+    monkeypatch.setattr(platform_guards, "_provider_entry_points", lambda: entries)
+
+
+# ---------------------------------------------------------------------------
+# Fakes for the two optional StateStore capabilities
+# ---------------------------------------------------------------------------
+
+
+class _ClientStore:
+    """A per-client store: the one attribute the repair needs is the path."""
+
+    def __init__(self, state_path: Path) -> None:
+        self.state_path = state_path
+
+    def read_state(self) -> StateDocument:
+        return read_state_file(self.state_path)
+
+
+class _AgencyStore(_ClientStore):
+    """A store advertising ``list_clients`` / ``state_store_for_client``."""
+
+    def __init__(
+        self,
+        state_path: Path,
+        rows: list[dict[str, Any]],
+        stores: dict[str, Any],
+    ) -> None:
+        super().__init__(state_path)
+        self._rows = rows
+        self._stores = stores
+
+    def list_clients(self) -> list[dict[str, Any]]:
+        return self._rows
+
+    def state_store_for_client(self, slug: str) -> Any:
+        return self._stores[slug]
+
+
+def _install_store(monkeypatch: pytest.MonkeyPatch, store: Any) -> None:
+    """Make ``store`` the active one for the Agency seam the CLI reuses."""
+    from mureo.web import report_clients
+
+    monkeypatch.setattr(
+        report_clients,
+        "get_runtime_context",
+        lambda: SimpleNamespace(state_store=store, workspace_id="default"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures on disk
+# ---------------------------------------------------------------------------
+
+
+def _write(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _bad_state(path: Path, account_id: str) -> None:
+    """The reported shape: LOGLY snapshots under the invented key."""
+    _write(
+        path,
+        {
+            "version": "2",
+            "platforms": {
+                "logly_ads": {
+                    "account_id": account_id,
+                    "totals": {
+                        "spend": 9000.0,
+                        "fetched_at": "2026-08-01T03:00:00+00:00",
+                    },
+                    "metrics_period": "LAST_30_DAYS",
+                },
+                "logly_ads_context": {
+                    "account_id": account_id,
+                    "totals": {"fetched_at": "2026-08-12T03:00:00+00:00"},
+                },
+            },
+        },
+    )
+
+
+def _clean_state(path: Path, account_id: str) -> None:
+    _write(
+        path,
+        {
+            "version": "2",
+            "platforms": {"logly_ads_context": {"account_id": account_id}},
+        },
+    )
+
+
+def _three_clients(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, Path]:
+    """acme + beta hold the bad key; gamma is clean."""
+    paths = {slug: tmp_path / slug / "STATE.json" for slug in ("acme", "beta", "gamma")}
+    _bad_state(paths["acme"], "1111111111")
+    _bad_state(paths["beta"], "2222222222")
+    _clean_state(paths["gamma"], "3333333333")
+    stores = {slug: _ClientStore(path) for slug, path in paths.items()}
+    rows = [
+        {"slug": "acme", "name": "Acme Co", "active": True},
+        {"slug": "beta", "name": "Beta Ltd", "active": False},
+        {"slug": "gamma", "name": "Gamma KK", "active": False},
+    ]
+    _install_store(monkeypatch, _AgencyStore(paths["acme"], rows, dict(stores)))
+    return paths
+
+
+def _run(*args: str, **kwargs: Any) -> Any:
+    return runner.invoke(app, ["repair", "platform-key", *args], **kwargs)
+
+
+def _platform_keys(path: Path) -> set[str]:
+    return set(json.loads(path.read_text(encoding="utf-8"))["platforms"])
+
+
+# ---------------------------------------------------------------------------
+# The summary is the point
+# ---------------------------------------------------------------------------
+
+
+class TestSurvey:
+    def test_the_summary_says_how_many_of_how_many_need_work(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _three_clients(tmp_path, monkeypatch)
+
+        result = _run("--all")
+
+        assert result.exit_code == 0, result.output
+        out = result.output
+        assert "Surveyed 3 clients." in out
+        assert "Need repair (2 of 3)" in out
+        assert "Clean (1 of 3)" in out
+        assert "acme" in out
+        assert "beta" in out
+        assert "gamma" in out
+
+    def test_the_summary_comes_before_the_per_client_detail(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _three_clients(tmp_path, monkeypatch)
+
+        result = _run("--all")
+
+        out = result.output
+        assert out.index("Need repair") < out.index("mureo cannot resolve this key")
+
+    def test_a_dry_run_is_the_default_and_changes_nothing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        paths = _three_clients(tmp_path, monkeypatch)
+        before = {slug: path.read_bytes() for slug, path in paths.items()}
+
+        result = _run("--all")
+
+        assert result.exit_code == 0, result.output
+        assert "this was a dry run" in result.output
+        for slug, path in paths.items():
+            assert path.read_bytes() == before[slug]
+        assert list(tmp_path.glob("*/STATE.json.bak.*")) == []
+
+
+# ---------------------------------------------------------------------------
+# Applying
+# ---------------------------------------------------------------------------
+
+
+class TestApplyAll:
+    def test_apply_fixes_exactly_the_clients_that_needed_it(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        paths = _three_clients(tmp_path, monkeypatch)
+        gamma_before = paths["gamma"].read_bytes()
+
+        result = _run("--all", "--apply", "--yes")
+
+        assert result.exit_code == 0, result.output
+        assert _platform_keys(paths["acme"]) == {"logly_ads_context"}
+        assert _platform_keys(paths["beta"]) == {"logly_ads_context"}
+        assert paths["gamma"].read_bytes() == gamma_before
+        # Backed up, per repaired client, and never for the clean one.
+        assert len(list(tmp_path.glob("acme/STATE.json.bak.*"))) == 1
+        assert len(list(tmp_path.glob("beta/STATE.json.bak.*"))) == 1
+        assert list(tmp_path.glob("gamma/STATE.json.bak.*")) == []
+
+    def test_the_confirmation_is_asked_once_not_per_client(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        paths = _three_clients(tmp_path, monkeypatch)
+        asked: list[str] = []
+
+        def _fake_confirm(prompt: str, **kwargs: Any) -> bool:
+            asked.append(prompt)
+            return True
+
+        from mureo.cli import repair_cmd
+
+        monkeypatch.setattr(repair_cmd, "confirm_or_default", _fake_confirm)
+
+        result = _run("--all", "--apply")
+
+        assert result.exit_code == 0, result.output
+        assert len(asked) == 1, asked
+        assert _platform_keys(paths["acme"]) == {"logly_ads_context"}
+        assert _platform_keys(paths["beta"]) == {"logly_ads_context"}
+
+    def test_declining_the_single_confirmation_changes_nothing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        paths = _three_clients(tmp_path, monkeypatch)
+        before = {slug: path.read_bytes() for slug, path in paths.items()}
+
+        result = _run("--all", "--apply", input="n\n")
+
+        assert result.exit_code == 0, result.output
+        for slug, path in paths.items():
+            assert path.read_bytes() == before[slug]
+
+
+# ---------------------------------------------------------------------------
+# Degradation — every OSS install has no client seam at all
+# ---------------------------------------------------------------------------
+
+
+class TestWithoutTheClientSeam:
+    def test_a_store_with_no_list_clients_sweeps_the_active_workspace(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        state = tmp_path / "STATE.json"
+        _bad_state(state, "1234567890")
+        _install_store(monkeypatch, _ClientStore(state))
+
+        result = _run("--all")
+
+        assert result.exit_code == 0, result.output
+        assert "Surveyed 1 client." in result.output
+        assert "logly_ads" in result.output
+        assert state.read_bytes()  # unchanged: still a dry run
+
+    def test_a_store_with_no_list_clients_repairs_the_active_workspace(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        state = tmp_path / "STATE.json"
+        _bad_state(state, "1234567890")
+        _install_store(monkeypatch, _ClientStore(state))
+
+        result = _run("--all", "--apply", "--yes")
+
+        assert result.exit_code == 0, result.output
+        assert _platform_keys(state) == {"logly_ads_context"}
+
+
+# ---------------------------------------------------------------------------
+# One client failing must not abort the sweep
+# ---------------------------------------------------------------------------
+
+
+class TestPartialFailure:
+    def test_an_unreadable_client_is_reported_and_the_others_are_repaired(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        paths = _three_clients(tmp_path, monkeypatch)
+        broken = tmp_path / "delta" / "STATE.json"
+        broken.parent.mkdir(parents=True, exist_ok=True)
+        broken.write_text("{not json", encoding="utf-8")
+        stores = {slug: _ClientStore(path) for slug, path in paths.items()}
+        stores["delta"] = _ClientStore(broken)
+        rows = [
+            {"slug": slug, "name": slug, "active": slug == "acme"}
+            for slug in ("acme", "beta", "gamma", "delta")
+        ]
+        _install_store(monkeypatch, _AgencyStore(paths["acme"], rows, stores))
+
+        result = _run("--all", "--apply", "--yes")
+
+        assert result.exit_code == 1, result.output
+        assert "Could not be read (1 of 4)" in result.output
+        assert "delta" in result.output
+        # The sweep carried on.
+        assert _platform_keys(paths["acme"]) == {"logly_ads_context"}
+        assert _platform_keys(paths["beta"]) == {"logly_ads_context"}
+
+    def test_an_unreadable_client_makes_even_a_dry_run_exit_non_zero(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        broken = tmp_path / "delta" / "STATE.json"
+        broken.parent.mkdir(parents=True, exist_ok=True)
+        broken.write_text("{not json", encoding="utf-8")
+        rows = [{"slug": "delta", "name": "delta", "active": True}]
+        _install_store(
+            monkeypatch,
+            _AgencyStore(broken, rows, {"delta": _ClientStore(broken)}),
+        )
+
+        result = _run("--all")
+
+        assert result.exit_code == 1, result.output
+        assert "Could not be read" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Contradictory flags
+# ---------------------------------------------------------------------------
+
+
+class TestRefusals:
+    def test_all_with_state_file_is_refused(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        paths = _three_clients(tmp_path, monkeypatch)
+        before = paths["acme"].read_bytes()
+
+        result = _run("--all", "--state-file", str(paths["acme"]))
+
+        assert result.exit_code == 1
+        assert "--state-file" in result.output
+        assert paths["acme"].read_bytes() == before
+
+    def test_all_with_a_resolvable_key_is_refused(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _three_clients(tmp_path, monkeypatch)
+
+        result = _run("--all", "--key", "logly_ads_context")
+
+        assert result.exit_code == 1
+        assert "logly_ads_context" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Archived clients are swept too — see the module docstring in repair_cmd
+# ---------------------------------------------------------------------------
+
+
+class TestArchivedClients:
+    def test_an_archived_client_is_surveyed_and_labelled(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        paths = {slug: tmp_path / slug / "STATE.json" for slug in ("acme", "old")}
+        _bad_state(paths["acme"], "1111111111")
+        _bad_state(paths["old"], "9999999999")
+        stores = {slug: _ClientStore(path) for slug, path in paths.items()}
+        rows = [
+            {"slug": "acme", "name": "Acme Co", "active": True},
+            {"slug": "old", "name": "Old Co", "active": False, "archived": True},
+        ]
+        _install_store(monkeypatch, _AgencyStore(paths["acme"], rows, stores))
+
+        result = _run("--all", "--apply", "--yes")
+
+        assert result.exit_code == 0, result.output
+        assert "Surveyed 2 clients." in result.output
+        assert "archived" in result.output
+        assert _platform_keys(paths["old"]) == {"logly_ads_context"}

--- a/tests/test_cli_repair_all.py
+++ b/tests/test_cli_repair_all.py
@@ -1,4 +1,4 @@
-"""``mureo repair platform-key --all`` — the whole-machine sweep (#613).
+"""``mureo repair platform-key --all`` — the whole-machine sweep (#614).
 
 The incident the command exists for spans EVERY client directory on the
 affected machine, and the operator is a non-engineer. Running the


### PR DESCRIPTION
## Why

`mureo repair platform-key` shipped in #612 and works on **one** STATE.json.

The incident it exists for does not. The bad key — LOGLY snapshots filed under
the invented `logly_ads` instead of the bridge's `logly_ads_context` — was
written by an *agent*, and an agent that ran against every client on the
machine wrote it into every client's document. Running the command once per
directory asks a non-engineer to remember which directories exist, gives them
no way to notice the one they missed, and gives them no single view of how
much is wrong.

## What `--all` does

```
=== mureo repair platform-key --all ===

Surveyed 6 clients.

  Need repair (2 of 6):
    acme (Acme Co) — logly_ads
    beta (Beta Ltd) — logly_ads

  Clean (3 of 6):
    gamma (Gamma KK)
    epsilon (Epsilon GmbH) [archived] — one ad account under two real platform keys (see below)
    zeta (Zeta SA) — no STATE.json yet

  Could not be read (1 of 6):
    delta (Delta Inc) — Failed to parse JSON in STATE.json: /clients/delta/STATE.json
```

The summary comes **first** — "N of M" is the whole point of the flag. The
per-client detail follows, in the exact shape the single-workspace run
prints, for every client that has a finding.

- **Dry run is still the default.** `--all` alone changes nothing.
- **`--all --apply` asks once**, with the full list in view. A prompt per
  client trains an operator to hold down `y`, which is the opposite of what a
  confirmation is for. Each repaired client is still backed up individually
  and its restoring `cp` printed.
- **One client failing does not stop the sweep**: it is named in the summary,
  the rest are repaired, and the command exits non-zero. A *finding* is not a
  failure — a dry run that reports work to do exits `0`.
- **`--all` + `--state-file` is refused.** One says "every client", the other
  says "this one file".
- **`--all --key <key>` is allowed** and narrows the sweep to that key across
  every client — the shape the incident actually took. Presence is not checked
  (there are many documents); a client that does not carry it is clean.

## How clients are enumerated

No new mechanism, and no OSS dependency on mureo-agency. `--all` calls the
**same** optional `StateStore` capabilities the read-only Reports tab already
reads, through `mureo.web.report_clients`:

- `list_clients()` → `[{slug, name, active, archived}]`
- `state_store_for_client(slug)` → the per-client `StateStore`

and takes each store's `state_path` (the same duck-typed lookup
`resolve_default_state_file` and `reports._read_state_tolerant` already do,
now shared as `state_file_for_store`). Reusing the seam rather than writing a
second one is the same argument `platform_repair` makes for reusing
`reject_unknown_platform_key`: two answers to one question drift, and that
drift is the defect class #609/#610 are about.

**Degradation.** A store declaring neither capability — every OSS install —
makes `list_report_clients()` return one row for the active workspace and
`state_store_for_client` return that store, so `--all` sweeps exactly the file
the single-workspace run would have and reports `Surveyed 1 client.` A
registry that cannot be read degrades the same way inside the seam, and the
count is what surfaces it: an operator running twelve clients and told
"Surveyed 1 client." knows the registry is what is broken, not the sweep.
That is why the summary always leads with the count. A store that declares
`list_clients` but not `state_store_for_client` resolves every slug to the
active store; those targets are **not** de-duplicated, because printing one
path under several client names shows a misconfigured backend rather than
hiding it.

Anything else that goes wrong per client — no `state_path`, an unparseable
document, no permission — becomes a `Could not be read` row carrying a
`terminal_safe`-scrubbed reason, never an exception out of the sweep.

## Archived clients: swept, and labelled

**Included.** Archiving means "stop collecting this client's figures" — a
decision about what to fetch next, not a statement that what is already
stored is correct. Skipping archived clients would leave the bad key in place
to reappear the day the client is restored, on a machine whose operator has
no reason to run the sweep a second time, and the double-count would be back
with nobody looking for it. The dashboard takes the same position wherever a
decision is at stake rather than a render: its Reports routing counts the
whole registry, archived rows included. They are labelled `[archived]` in
every line the sweep prints, so an operator is never surprised by a repair
applied to a client they had shelved.

## Exit codes

| Situation | Exit |
|---|---|
| Dry run, findings reported | `0` |
| Dry run, a client could not be read | `1` |
| `--apply`, everything repaired | `0` |
| `--apply`, any client unreadable or unrepairable | `1` |
| `--all --state-file`, `--all --key <resolvable>` | `1` |

A closing `Finished with errors: N of M clients could not be read or
repaired.` is printed last as well as in the summary — on a long sweep the
summary has scrolled off and the closing line is the one that gets read.

## Tests

`tests/test_cli_repair_all.py` (13 tests). The store capabilities are
**faked**, never taken from mureo-agency — it is installed on the machine
this was written on, so a test leaning on it would pass locally and assert
nothing in CI.

- 3-client fixture, 2 bad + 1 clean → summary counts correct, summary precedes
  detail, dry run changes nothing (no backups written), `--apply` fixes
  exactly the two and backs up exactly those two.
- a store with **no** `list_clients` → `Surveyed 1 client.`, and `--apply`
  repairs the active workspace.
- one client with an unparseable STATE.json → the other two are still
  repaired, the failure is in `Could not be read (1 of 4)`, exit `1`; a dry
  run over the same client also exits `1`.
- `--all --state-file` refused, document untouched.
- `--all --key logly_ads_context` (resolvable) refused.
- the confirmation is asked **once**, not per client (the prompt seam is
  counted, not inferred).
- an archived client is surveyed, labelled and repaired.

## Verification

- `pytest tests/` — 8969 passed, 8 skipped, with the four
  locally-noisy plugin files excluded (`test_mcp_server_plugin_wiring.py`,
  `test_mcp_tool_provider.py`, `test_mcp_server.py`,
  `analytics/builtin/test_live_clients.py`).
- `black --check` clean, `ruff check` clean, `mypy` reports nothing in
  `mureo/cli/`.

## Not changed

Single-workspace behaviour. The existing body moved verbatim into
`_repair_one_workspace` behind an untouched code path; `tests/test_cli_repair.py`
passes unmodified.
