### PR TITLE
fix: name both distributions when two plugins claim one tool name (#589)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 ## [Unreleased]
 
+### Fixed
+
+- **Two plugins shipping the same tool name lost one plugin's guardrails
+  without saying whose** (#589). mureo's three plugin declaration registries —
+  the budget keys, the bid keys and the `readOnlyHint` that decide whether a
+  tool is treated as read-only and how its money changes are gated — are keyed
+  by bare tool name, with no distribution behind it. Two honest bridges both
+  shipping `update_campaign` is enough to make that matter.
+
+  The registries themselves turn out to be safe: mureo already drops a
+  duplicate plugin tool name at discovery, first-installed wins, so exactly one
+  tool per name is ever exposed and the declaration held under a name always
+  belongs to the tool that name dispatches to. A declaration from one
+  distribution can never be paired with another distribution's tool. What was
+  wrong was the *reporting*: the drop was announced as a warning naming only
+  the losing provider's entry-point name, with neither distribution named and
+  no mention that the dropped tool's budget/bid caps and `readOnlyHint` went
+  with it. An operator with two bridges installed had no way to tell which one
+  was silently no longer being enforced.
+
+  That message now names both distributions and both providers, says the
+  dropped tool is not callable and that its guardrail declarations are gone
+  with it, and is written to the log as well as to `warnings` — stderr from a
+  stdio MCP server is routinely swallowed by the client. Separately, a
+  conflicting re-registration through the public `register_budget_declaration`
+  / `register_bid_declaration` / `register_read_only_hint` API (the path a
+  sibling bridge can still take) is logged with the tool name and both values.
+
+  Deliberately **not** fatal. A colliding pair costs the operator one
+  unavailable tool, not an unguarded money path, and these registries are
+  populated at import — refusing to start would let one bad plugin pair stop
+  mureo from starting at all, including the surfaces the operator would use to
+  uninstall it. Re-registration also still takes the last write, so a bridge's
+  deliberate override keeps working; it is now announced rather than silent.
+
 ## [0.10.45] - 2026-08-14
 
 ### Fixed

--- a/docs/plugin-authoring.md
+++ b/docs/plugin-authoring.md
@@ -546,6 +546,15 @@ Rules the server enforces (a non-conforming provider is skipped with a
   name (e.g. `acme_ads_list_campaigns`). Built-in tool names are
   reserved — a colliding plugin tool is dropped (built-ins win), and a
   name already taken by an earlier plugin is dropped (first wins).
+  Your **guardrail declarations go with the dropped tool**: mureo keys
+  the budget/bid registries and the `readOnlyHint` registry by tool name
+  alone, so a dropped tool contributes no declaration and every mureo
+  guardrail on that name follows the plugin that won it. The drop is
+  reported as a `PluginToolWarning` and on the log, naming both
+  distributions and both providers, and it never stops the server —
+  but an operator running two bridges that share a generic name like
+  `update_campaign` has one of them silently unavailable until they
+  look. A prefix is the only reliable fix.
 - **Keep `inputSchema` honest — mureo enforces it server-side.** Since
   #324 the dispatcher validates every call against your declared
   `inputSchema` *before* it reaches your handler and rejects a violation

--- a/mureo/mcp/server.py
+++ b/mureo/mcp/server.py
@@ -340,6 +340,16 @@ _PLUGIN_THROTTLER = Throttler(PLUGIN_THROTTLE)
 # metadata (annotations.readOnlyHint + optional meta["mureo"]). No new
 # ABI surface. A declared throttle hint gets its own bucket; everything
 # else shares _PLUGIN_THROTTLER. Undeclared ⇒ mutating (conservative).
+#
+# Keyed by BARE tool name, and that is safe rather than lucky (#589):
+# ``collect_plugin_tools`` already dedupes tool names first-wins, dropping the
+# duplicate from BOTH ``_PLUGIN_TOOLS`` and ``_PLUGIN_DISPATCH`` and naming the
+# two distributions involved. So this map — and the three declaration
+# registries fed from it below — holds the semantics of the ONE tool that is
+# actually dispatchable under that name. A second distribution's declaration
+# can never be paired with a first distribution's tool, which is what re-keying
+# by ``(distribution, name)`` would have bought; what identity is needed for is
+# the *message*, and that is emitted where identity lives, at collection.
 _PLUGIN_SEMANTICS: dict[str, ToolSemantics] = {
     t.name: derive_semantics(t) for t in _PLUGIN_TOOLS
 }

--- a/mureo/mcp/tool_provider.py
+++ b/mureo/mcp/tool_provider.py
@@ -36,15 +36,21 @@ Design constraints
   in the registry, not a guarantee this layer can make.
 - **Built-ins win on name collision**; first plugin wins on
   plugin↔plugin collision — mirroring the registry's dedupe policy so
-  a later-installed plugin cannot shadow a core tool.
+  a later-installed plugin cannot shadow a core tool. A plugin↔plugin
+  drop is reported naming BOTH distributions (#589): it silently takes
+  the dropped tool's guardrail declarations with it, so an operator has
+  to be able to see which of two installed packages lost.
 """
 
 from __future__ import annotations
 
 import contextlib
 import inspect
+import logging
 import warnings
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
@@ -254,13 +260,68 @@ def _collect_one(
             )
             continue
         if tool_name in dispatch:
-            _warn(
-                f"provider {label!r}: tool {tool_name!r} already provided by "
-                f"an earlier plugin; duplicate dropped (first wins)"
+            message = _duplicate_tool_name_message(
+                tool_name, dispatch[tool_name], entry
             )
+            _warn(message)
+            # Also on the logger, not only as a ``warnings`` line: this drops
+            # one distribution's guardrail declarations along with its tool,
+            # and stderr from a stdio MCP server is routinely swallowed by
+            # the client. An operator has to be able to find this afterwards.
+            logger.warning("%s", message)
             continue
         tools.append(tool)
         dispatch[tool_name] = instance
+
+
+#: Rendered in place of a distribution mureo could not attribute. Never
+#: ``None``: a message reading "distribution None" tells an operator nothing
+#: about which package to look for.
+UNKNOWN_DISTRIBUTION = "<unknown distribution>"
+
+
+def _identity_label(distribution: str | None, provider_name: str | None) -> str:
+    """Name one side of a collision the way the audit trail names a call.
+
+    ``plugin:<distribution>:<provider>`` is the canonical platform key (#537),
+    and both halves are needed: one distribution can ship several providers
+    (``mureo-lineyahoo-bridge`` ships three), so the distribution alone would
+    not tell an operator which of them to look at.
+    """
+    dist = distribution or UNKNOWN_DISTRIBUTION
+    provider = provider_name or "<unknown provider>"
+    return f"distribution {dist!r} (provider {provider!r})"
+
+
+def _duplicate_tool_name_message(
+    tool_name: str, incumbent: object, challenger: ProviderEntry
+) -> str:
+    """Describe a plugin↔plugin tool-name collision, naming BOTH sides (#589).
+
+    The drop itself is not new — first-wins dedupe has always happened here,
+    and it is what keeps mureo's three bare-name declaration registries
+    honest: exactly one tool per name survives into ``_PLUGIN_TOOLS``, so the
+    declaration a registry ends up holding always belongs to the tool that is
+    actually dispatchable. The two can never disagree, which is why those
+    registries do not need a ``(distribution, name)`` key.
+
+    What was missing is that the operator could not see *whose* guardrails
+    went away: the message named the losing provider's entry-point name only,
+    with no distribution on either side and no mention of the incumbent. Both
+    are known right here — the incumbent through the breadcrumb stamped on its
+    instance, the challenger through its registry entry — so both are named.
+    """
+    return (
+        f"tool {tool_name!r} is shipped by two plugins: "
+        f"{_identity_label(plugin_source(incumbent), plugin_provider_name(incumbent))} "
+        f"already provides it, and "
+        f"{_identity_label(challenger.source_distribution, challenger.name)} "
+        f"ships the same name; the duplicate is dropped (first wins). Only one "
+        f"plugin can own a tool name, so the dropped tool is not callable and "
+        f"its budget/bid declarations and readOnlyHint are dropped with it — "
+        f"every mureo guardrail on {tool_name!r} follows the plugin that won. "
+        f"Uninstall one of the two if that is not the one you meant."
+    )
 
 
 def plugin_source(provider: object) -> str:

--- a/mureo/policy/declarations.py
+++ b/mureo/policy/declarations.py
@@ -18,7 +18,18 @@ builds on:
   paths itself; a channel field accepts either a flat key (unchanged) or this.
 - Their process-wide registries and register / lookup / reset helpers,
   populated by ``mureo.mcp.server`` from plugin tool metadata at import so the
-  pure decision layer stays I/O-free and needs no plugin imports.
+  pure decision layer stays I/O-free and needs no plugin imports. They are
+  keyed by BARE tool name, deliberately: every lookup here is reached with a
+  tool name and nothing else — ``StrategyPolicyGate.evaluate`` sits behind the
+  public two-argument :class:`~mureo.core.policy.PolicyGate` Protocol that
+  third parties implement, and :mod:`mureo.policy.learning_reset` is a pure
+  layer with no provider handle — so an identity-keyed registry would have
+  nothing to resolve an identity from. It does not need one: mureo exposes at
+  most one plugin tool per name (see :func:`~mureo.mcp.tool_provider.
+  collect_plugin_tools`), so the declaration held under a name always belongs
+  to the tool that name dispatches to. A *conflicting* re-registration is
+  still announced rather than applied in silence — see
+  :func:`_log_conflicting_registration` (#589).
 - The same for one tool's ``annotations.readOnlyHint``
   (:func:`register_read_only_hint` / :func:`declared_read_only_hint` /
   :func:`reset_read_only_hints`) — so a pure decision that has to ask "is this
@@ -35,10 +46,13 @@ re-export block in that module.
 
 from __future__ import annotations
 
+import logging
 import math
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 #: A path segment suffix meaning "descend every item of this array".
 ARRAY_SUFFIX = "[]"
@@ -239,6 +253,50 @@ class BudgetDeclaration:
     micros: bool = False
 
 
+def _log_conflicting_registration(
+    channel: str, tool_name: str, existing: object, incoming: object
+) -> None:
+    """Announce a second, DIFFERENT registration under the same tool name (#589).
+
+    All three registries below are keyed by BARE tool name — no plugin, no
+    distribution — and every one is last-write-wins, so a second registration
+    replaces a guardrail rather than adding one. That is the right default and
+    stays: reversing it to first-wins would silently break the deliberate
+    override an out-of-tree caller makes (these registrars are public API,
+    re-exported from :mod:`mureo.policy.strategy_gate` for the sibling
+    bridges). What must not stay is the *silence* — a replaced budget key
+    points the gate at an argument the called tool does not have, and a
+    replaced ``readOnlyHint`` can turn a real mutation into a "read" that
+    loses both its pattern-fallback money scan and its
+    ``block_learning_resets`` refusal.
+
+    Re-registering the SAME value is not a collision and says nothing: server
+    startup and a test's ``reset_*`` + re-discovery both replay identical
+    registrations, and a warning there would be noise that trains an operator
+    to ignore the real one.
+
+    This layer is pure and holds no plugin identity, so the message names the
+    tool and both values but cannot name the distributions. The one collision
+    where identity IS known — two installed plugins shipping the same tool
+    name — is reported at collection time by
+    :func:`mureo.mcp.tool_provider.collect_plugin_tools`, which names both.
+    """
+    if existing == incoming:
+        return
+    logger.warning(
+        "conflicting %s declaration for tool '%s': %r was already registered "
+        "and is being replaced by %r (last registration wins). These "
+        "registries are keyed by tool name alone, so the usual cause is two "
+        "installed distributions claiming the same name; check which one "
+        "supplies '%s' before trusting the guardrail on it.",
+        channel,
+        tool_name,
+        existing,
+        incoming,
+        tool_name,
+    )
+
+
 # Tool name → declaration. Populated by the MCP server from plugin tool
 # metadata at import (see ``mureo.mcp.server``), so the pure decision layer
 # stays I/O-free and the gate needs no plugin imports.
@@ -246,7 +304,14 @@ _BUDGET_DECLARATIONS: dict[str, BudgetDeclaration] = {}
 
 
 def register_budget_declaration(tool_name: str, declaration: BudgetDeclaration) -> None:
-    """Bind ``tool_name``'s budget argument keys (last registration wins)."""
+    """Bind ``tool_name``'s budget argument keys (last registration wins).
+
+    A conflicting re-registration is logged rather than refused — see
+    :func:`_log_conflicting_registration`.
+    """
+    existing = _BUDGET_DECLARATIONS.get(tool_name)
+    if existing is not None:
+        _log_conflicting_registration("budget", tool_name, existing, declaration)
     _BUDGET_DECLARATIONS[tool_name] = declaration
 
 
@@ -320,7 +385,14 @@ _BID_DECLARATIONS: dict[str, BidDeclaration] = {}
 
 
 def register_bid_declaration(tool_name: str, declaration: BidDeclaration) -> None:
-    """Bind ``tool_name``'s bid argument keys (last registration wins)."""
+    """Bind ``tool_name``'s bid argument keys (last registration wins).
+
+    A conflicting re-registration is logged rather than refused — see
+    :func:`_log_conflicting_registration`.
+    """
+    existing = _BID_DECLARATIONS.get(tool_name)
+    if existing is not None:
+        _log_conflicting_registration("bid", tool_name, existing, declaration)
     _BID_DECLARATIONS[tool_name] = declaration
 
 
@@ -348,7 +420,16 @@ def register_read_only_hint(tool_name: str, read_only: bool) -> None:
     layer otherwise has nothing but the tool's NAME to go on, and a name shape
     is a guess where a declaration is evidence — registering the declaration
     lets the guess be demoted to a fallback.
+
+    A conflicting re-registration is logged rather than refused — see
+    :func:`_log_conflicting_registration`. The membership test is deliberate:
+    a stored ``False`` is a DECLARED value, and ``.get()`` would read it as
+    "nothing was registered" and skip the check on the one flip that matters.
     """
+    if tool_name in _READ_ONLY_HINTS:
+        _log_conflicting_registration(
+            "readOnlyHint", tool_name, _READ_ONLY_HINTS[tool_name], read_only
+        )
     _READ_ONLY_HINTS[tool_name] = read_only
 
 

--- a/tests/test_declaration_registry_collisions.py
+++ b/tests/test_declaration_registry_collisions.py
@@ -1,0 +1,327 @@
+"""#589: a declaration-registry collision must never be silent.
+
+The three registries in :mod:`mureo.policy.declarations` are keyed by BARE
+tool name, with no plugin or distribution identity, and every one of them is
+last-write-wins. Two things are pinned here:
+
+1. **The collection layer already drops the duplicate.**
+   :func:`~mureo.mcp.tool_provider.collect_plugin_tools` dedupes plugin tool
+   names first-wins *before* ``_PLUGIN_SEMANTICS`` is built, so a second
+   distribution shipping the same tool name never reaches the registries at
+   all — the surviving tool keeps its OWN declaration and the dropped one
+   contributes nothing. What was missing is that the drop did not name the
+   two distributions involved, so an operator could not see whose guardrail
+   went away. The message must now name both, and it must not be fatal.
+
+2. **A direct re-registration under the same name is announced.**
+   ``register_budget_declaration`` / ``register_bid_declaration`` /
+   ``register_read_only_hint`` are public API (re-exported from
+   ``mureo.policy.strategy_gate`` for the sibling bridges), so an out-of-tree
+   caller can still replace a declaration the collection layer got right.
+   Last write still wins — reversing that would silently break a deliberate
+   override — but a CONFLICTING write is logged.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from mcp.types import TextContent, Tool
+
+from mureo.core.providers.capabilities import Capability
+from mureo.core.providers.registry import ProviderEntry
+from mureo.mcp.tool_provider import PluginToolWarning, collect_plugin_tools
+from mureo.policy.declarations import (
+    _BID_DECLARATIONS,
+    _BUDGET_DECLARATIONS,
+    _READ_ONLY_HINTS,
+    BidDeclaration,
+    BudgetDeclaration,
+    bid_declaration_for,
+    budget_declaration_for,
+    declared_read_only_hint,
+    register_bid_declaration,
+    register_budget_declaration,
+    register_read_only_hint,
+    reset_bid_declarations,
+    reset_budget_declarations,
+    reset_read_only_hints,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+DECLARATIONS_LOGGER = "mureo.policy.declarations"
+TOOL_PROVIDER_LOGGER = "mureo.mcp.tool_provider"
+
+
+@pytest.fixture(autouse=True)
+def _clean_registries() -> Iterator[None]:
+    """Isolate the three process-global registries WITHOUT destroying them.
+
+    ``mureo.mcp.server`` populates them once at import from real plugin
+    discovery, and a developer machine with bridges installed has non-empty
+    ones; a destructive clear would drop those for the rest of the session.
+    """
+    saved_budget = dict(_BUDGET_DECLARATIONS)
+    saved_bid = dict(_BID_DECLARATIONS)
+    saved_hints = dict(_READ_ONLY_HINTS)
+    reset_budget_declarations()
+    reset_bid_declarations()
+    reset_read_only_hints()
+    yield
+    reset_budget_declarations()
+    reset_bid_declarations()
+    reset_read_only_hints()
+    _BUDGET_DECLARATIONS.update(saved_budget)
+    _BID_DECLARATIONS.update(saved_bid)
+    _READ_ONLY_HINTS.update(saved_hints)
+
+
+# ---------------------------------------------------------------------------
+# (1) A conflicting re-registration is logged; an identical one is not.
+# ---------------------------------------------------------------------------
+
+
+def test_conflicting_budget_registration_is_logged(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    register_budget_declaration("update_campaign", BudgetDeclaration(daily_key="a"))
+    with caplog.at_level(logging.WARNING, logger=DECLARATIONS_LOGGER):
+        register_budget_declaration("update_campaign", BudgetDeclaration(daily_key="b"))
+    message = "\n".join(r.getMessage() for r in caplog.records)
+    assert "update_campaign" in message
+    # Both sides quoted: an operator cannot act on "something changed".
+    assert "'a'" in message
+    assert "'b'" in message
+
+
+def test_conflicting_budget_registration_still_takes_the_last_write(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Announced, not refused — reversing this breaks a deliberate override."""
+    register_budget_declaration("update_campaign", BudgetDeclaration(daily_key="a"))
+    with caplog.at_level(logging.WARNING, logger=DECLARATIONS_LOGGER):
+        register_budget_declaration("update_campaign", BudgetDeclaration(daily_key="b"))
+    declaration = budget_declaration_for("update_campaign")
+    assert declaration is not None
+    assert declaration.daily_key == "b"
+
+
+def test_identical_budget_re_registration_is_silent(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A re-discovery re-registers the same value; that is not a collision."""
+    register_budget_declaration("update_campaign", BudgetDeclaration(daily_key="a"))
+    with caplog.at_level(logging.WARNING, logger=DECLARATIONS_LOGGER):
+        register_budget_declaration("update_campaign", BudgetDeclaration(daily_key="a"))
+    assert caplog.records == []
+
+
+def test_first_budget_registration_is_silent(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.WARNING, logger=DECLARATIONS_LOGGER):
+        register_budget_declaration("update_campaign", BudgetDeclaration(daily_key="a"))
+    assert caplog.records == []
+
+
+def test_conflicting_bid_registration_is_logged(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    register_bid_declaration("update_bid", BidDeclaration(cpc_bid_key="a"))
+    with caplog.at_level(logging.WARNING, logger=DECLARATIONS_LOGGER):
+        register_bid_declaration("update_bid", BidDeclaration(cpc_bid_key="b"))
+    message = "\n".join(r.getMessage() for r in caplog.records)
+    assert "update_bid" in message
+    assert "'a'" in message
+    assert "'b'" in message
+    declaration = bid_declaration_for("update_bid")
+    assert declaration is not None
+    assert declaration.cpc_bid_key == "b"
+
+
+def test_identical_bid_re_registration_is_silent(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    register_bid_declaration("update_bid", BidDeclaration(cpc_bid_key="a"))
+    with caplog.at_level(logging.WARNING, logger=DECLARATIONS_LOGGER):
+        register_bid_declaration("update_bid", BidDeclaration(cpc_bid_key="a"))
+    assert caplog.records == []
+
+
+def test_conflicting_read_only_hint_is_logged(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The one that flips a mutation into a "read" and drops both its gates."""
+    register_read_only_hint("update_campaign", False)
+    with caplog.at_level(logging.WARNING, logger=DECLARATIONS_LOGGER):
+        register_read_only_hint("update_campaign", True)
+    message = "\n".join(r.getMessage() for r in caplog.records)
+    assert "update_campaign" in message
+    assert "False" in message
+    assert "True" in message
+    assert declared_read_only_hint("update_campaign") is True
+
+
+def test_identical_read_only_hint_re_registration_is_silent(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    register_read_only_hint("update_campaign", False)
+    with caplog.at_level(logging.WARNING, logger=DECLARATIONS_LOGGER):
+        register_read_only_hint("update_campaign", False)
+    assert caplog.records == []
+
+
+def test_registering_a_hint_over_an_absent_one_is_silent(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``False`` is a declared value, not "absent" — absence must not warn."""
+    with caplog.at_level(logging.WARNING, logger=DECLARATIONS_LOGGER):
+        register_read_only_hint("update_campaign", False)
+    assert caplog.records == []
+    assert declared_read_only_hint("update_campaign") is False
+
+
+# ---------------------------------------------------------------------------
+# (2) The collection-time duplicate names both distributions, and is survivable.
+# ---------------------------------------------------------------------------
+
+_SHARED_TOOL = "update_campaign"
+
+
+def _colliding_tool() -> Tool:
+    return Tool(
+        name=_SHARED_TOOL,
+        description="moves money",
+        inputSchema={"type": "object", "properties": {}},
+        annotations={"readOnlyHint": False},  # type: ignore[arg-type]
+        _meta={"mureo": {"budget": {"daily": "daily_budget"}}},
+    )
+
+
+class _FirstProvider:
+    name = "acme_ads"
+    display_name = "Acme Ads"
+    capabilities = frozenset({Capability.READ_CAMPAIGNS})
+
+    def mcp_tools(self) -> tuple[Tool, ...]:
+        return (_colliding_tool(),)
+
+    async def handle_mcp_tool(self, name: str, arguments: dict[str, Any]) -> list[Any]:
+        return [TextContent(type="text", text="acme")]
+
+
+class _SecondProvider:
+    name = "zenith_ads"
+    display_name = "Zenith Ads"
+    capabilities = frozenset({Capability.READ_CAMPAIGNS})
+
+    def mcp_tools(self) -> tuple[Tool, ...]:
+        return (_colliding_tool(),)
+
+    async def handle_mcp_tool(self, name: str, arguments: dict[str, Any]) -> list[Any]:
+        return [TextContent(type="text", text="zenith")]
+
+
+def _entry(cls: type, distribution: str | None) -> ProviderEntry:
+    return ProviderEntry(
+        name=cls.name,
+        display_name=cls.display_name,
+        capabilities=cls.capabilities,
+        provider_class=cls,
+        source_distribution=distribution,
+    )
+
+
+def _discover_colliding_pair() -> Any:
+    def _fn(**_kw: Any) -> tuple[ProviderEntry, ...]:
+        return (
+            _entry(_FirstProvider, "mureo-acme-bridge"),
+            _entry(_SecondProvider, "mureo-zenith-bridge"),
+        )
+
+    return _fn
+
+
+def test_duplicate_tool_name_warning_names_both_distributions() -> None:
+    with pytest.warns(PluginToolWarning) as caught:
+        collect_plugin_tools(reserved_names=set(), discover=_discover_colliding_pair())
+    message = "\n".join(str(w.message) for w in caught)
+    assert "mureo-acme-bridge" in message
+    assert "mureo-zenith-bridge" in message
+    assert _SHARED_TOOL in message
+
+
+def test_duplicate_tool_name_is_logged_not_only_warned(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A stderr ``warnings`` line an MCP client swallows is not a signal."""
+    with (
+        caplog.at_level(logging.WARNING, logger=TOOL_PROVIDER_LOGGER),
+        pytest.warns(PluginToolWarning),
+    ):
+        collect_plugin_tools(reserved_names=set(), discover=_discover_colliding_pair())
+    message = "\n".join(r.getMessage() for r in caplog.records)
+    assert "mureo-acme-bridge" in message
+    assert "mureo-zenith-bridge" in message
+    assert _SHARED_TOOL in message
+
+
+def test_duplicate_tool_name_does_not_take_the_server_down() -> None:
+    """Deliberate: one bad plugin pair must not stop mureo from starting."""
+    with pytest.warns(PluginToolWarning):
+        tools, dispatch = collect_plugin_tools(
+            reserved_names=set(), discover=_discover_colliding_pair()
+        )
+    assert [t.name for t in tools] == [_SHARED_TOOL]
+    assert type(dispatch[_SHARED_TOOL]).__name__ == "_FirstProvider"
+
+
+def test_an_unknown_distribution_is_labelled_not_rendered_as_none() -> None:
+    def _fn(**_kw: Any) -> tuple[ProviderEntry, ...]:
+        return (
+            _entry(_FirstProvider, None),
+            _entry(_SecondProvider, "mureo-zenith-bridge"),
+        )
+
+    with pytest.warns(PluginToolWarning) as caught:
+        collect_plugin_tools(reserved_names=set(), discover=_fn)
+    message = "\n".join(str(w.message) for w in caught)
+    assert "None" not in message
+    assert "unknown" in message
+
+
+def test_the_dropped_duplicate_contributes_no_declaration() -> None:
+    """The premise #589 assumed was broken, pinned as the reason it is not.
+
+    ``_PLUGIN_SEMANTICS`` is built from the tool list ``collect_plugin_tools``
+    returns, and that list already holds ONE tool per name. So the registry
+    ends up with the declaration of the tool that is actually dispatchable —
+    the two can never disagree — and re-keying by identity would buy nothing
+    a bare name does not already give.
+    """
+    from mureo.mcp.plugin_semantics import derive_semantics
+    from mureo.mcp.server import (
+        _register_plugin_budget_declarations,
+        _register_plugin_read_only_hints,
+    )
+
+    with pytest.warns(PluginToolWarning):
+        tools, dispatch = collect_plugin_tools(
+            reserved_names=set(), discover=_discover_colliding_pair()
+        )
+    semantics = {t.name: derive_semantics(t) for t in tools}
+    assert len(semantics) == 1
+
+    _register_plugin_budget_declarations(semantics)
+    _register_plugin_read_only_hints(semantics)
+
+    declaration = budget_declaration_for(_SHARED_TOOL)
+    assert declaration is not None
+    assert declaration.daily_key == "daily_budget"
+    assert declared_read_only_hint(_SHARED_TOOL) is False
+    # The winner of the registry is the winner of dispatch, by construction.
+    assert type(dispatch[_SHARED_TOOL]).__name__ == "_FirstProvider"


### PR DESCRIPTION
Closes #589

## Which direction, and why

The issue proposed keying the three registries by `(distribution, tool_name)`. Checking every reader first, that direction is not available — and it turns out not to be needed.

**Reader by reader:**

| Reader | What it is handed | Can it resolve identity? |
| --- | --- | --- |
| `StrategyPolicyGate.evaluate` → `budget_declaration_for` / `bid_declaration_for` (`strategy_gate.py:726,729`) | `(tool_name, arguments)` | **No.** It sits behind `mureo.core.policy.PolicyGate`, a public two-argument Protocol that third parties implement via the `mureo.policy_gates` entry-point group. Adding a third argument is an ABI break for every out-of-tree gate. |
| `learning_reset._is_mutation` → `declared_read_only_hint` (`learning_reset.py:194`) | `tool_name` | **No.** Reached from `load_preflight(tool_name, arguments)` *inside* the gate. The module is the pure decision layer; its stated contract is that it holds no plugin imports and no provider handle. |
| `pattern_scan.has_pattern_fallback` | `tool_name` | **No.** Same call site, same constraint. Holds no per-plugin data anyway (issue's open question 4). |

So identity is unavailable at every lookup, which per the task's instruction settles it: direction 2, **make the collision loud, never silent**.

## What the issue got wrong

The issue's premise — that a second distribution's declaration silently overwrites a first's in `_PLUGIN_SEMANTICS` and downstream — does not hold. `collect_plugin_tools` (`tool_provider.py`) already dedupes plugin tool names first-wins, and the loser is `continue`d **before** `tools.append(tool)`, so it is dropped from *both* `_PLUGIN_TOOLS` and `_PLUGIN_DISPATCH`:

```python
if tool_name in dispatch:
    _warn(...)
    continue
tools.append(tool)
dispatch[tool_name] = instance
```

`_PLUGIN_SEMANTICS` is a comprehension over `_PLUGIN_TOOLS`, which therefore already holds at most one tool per name. The consequence is the one the issue was worried about, inverted: the registry entry under a name always belongs to the tool that name *dispatches to*. Plugin A's `update_campaign` can never be paired with plugin B's `BudgetDeclaration`, because plugin B's tool is not exposed at all. `(distribution, name)` keying would have bought nothing that the bare name does not already give.

This is pinned by `test_the_dropped_duplicate_contributes_no_declaration`, so a future change that removes the dedupe cannot quietly re-open the hole the issue described.

The issue's open question 2 (`_PLUGIN_DISPATCH` "collides the same way") is wrong for the same reason — it is the very dict the dedupe is keyed on.

## What was actually broken

The **reporting**. The drop message named only the losing provider's entry-point name:

> `provider 'zenith_ads': tool 'update_campaign' already provided by an earlier plugin; duplicate dropped (first wins)`

Neither distribution named, no mention of the incumbent, and nothing saying that the dropped tool's budget/bid caps and `readOnlyHint` were dropped with it. An operator running two bridges could not tell which one was silently no longer enforced — and the `warnings.warn` line goes to stderr, which an MCP client routinely swallows.

## The fix

1. **`mureo/mcp/tool_provider.py`** — the duplicate-drop message names both distributions and both providers (`distribution 'mureo-acme-bridge' (provider 'acme_ads')`, the same `plugin:<dist>:<provider>` breadcrumb the audit trail uses, #537), says the dropped tool is not callable and its guardrail declarations are gone with it, and is written to the module logger as well as to `warnings`. An unattributable distribution renders as `<unknown distribution>`, never `None`.
2. **`mureo/policy/declarations.py`** — a *conflicting* re-registration through `register_budget_declaration` / `register_bid_declaration` / `register_read_only_hint` is logged with the tool name and both values. These are public API, re-exported from `mureo.policy.strategy_gate` for the sibling bridges and mureo-pro, so an out-of-tree caller can still replace a declaration the collection layer got right. An **identical** re-registration stays silent: startup and a test's `reset_*` + re-discovery both replay identical registrations, and warning there would be noise that trains an operator to ignore the real one. The `readOnlyHint` check uses a membership test rather than `.get()`, because a stored `False` is a declared value.
3. Docstrings on `_PLUGIN_SEMANTICS` and the `declarations` module record *why* the bare key is safe, so the next reader does not re-file this.

## Import-time failure mode — a deliberate choice

**Two conflicting plugins do not stop mureo from starting.** Stated rather than defaulted into:

- A colliding pair costs the operator one **unavailable** tool, not an unguarded money path. The surviving tool keeps its own correct declaration, and the loser cannot be called at all — there is no guardrail bypass to fail closed against.
- These registries are populated at import of `mureo.mcp.server`, which the CLI, the web server and the test suite all pull in. Raising there would let one bad plugin pair prevent mureo from starting *at all* — including the surfaces an operator would use to uninstall the offender. That is a worse failure than the one being defended against, and it contradicts the fault-isolation contract stated in `tool_provider`'s module docstring and in all four `_register_plugin_*` helpers.
- Re-registration likewise still takes the **last** write. Reversing it to first-wins would silently break a bridge's deliberate override — swapping one silent failure for another.

## Tests

New file `tests/test_declaration_registry_collisions.py` (14 tests, written failing first — 6 red before the fix, 8 pinning existing behaviour). The registries are saved and restored around each test rather than cleared, since this machine has real bridges installed:

- Conflicting budget / bid / `readOnlyHint` re-registration is logged, naming the tool and both values.
- Identical re-registration is silent (all three), and so is the first registration.
- `False` over an absent hint does not warn (the `.get()` trap).
- Last write still wins on all three.
- The duplicate-tool warning names both distributions, and is on the logger, not only in `warnings`.
- A colliding pair does not take the server down; first-installed wins.
- An unattributable distribution renders as `unknown`, not `None`.
- `test_the_dropped_duplicate_contributes_no_declaration` — the premise correction, end to end through `collect_plugin_tools` → `derive_semantics` → `_register_plugin_*`.

## Verification

```
black --check .        700 files unchanged
ruff check .           All checks passed
mypy mureo/ --ignore-missing-imports    Success: no issues found in 344 source files
pytest tests/          9051 passed, 12 failed, 8 skipped
```

The 12 failures are the documented pre-existing environment noise from locally-installed plugins (`test_live_clients.py`, `test_mcp_server.py`, `test_mcp_server_plugin_wiring.py`, `test_mcp_tool_provider.py::test_default_discover_is_registry_and_yields_no_op_when_empty`); each was confirmed failing on a stashed tree.

## Out of scope

`pattern_scan._PATTERN_FALLBACK_TOOLS` (issue's open question 4) is left alone: it holds no per-plugin data, only a name set, and the upstream dedupe means a name is registered once regardless.
