### PR TITLE
fix: make the platform-key repair's preview true before it removes anything

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,9 +127,13 @@ mureo/
 │   ├── upgrade_cmd.py   # `mureo upgrade` — pipx venv-aware bulk upgrade of mureo + plugins
 │   ├── auth_cmd.py      # `mureo auth setup` / `status` / `check-*` / `upgrade-google`
 │   ├── rollback_cmd.py  # `mureo rollback list` / `show` (inspection only; apply routes through MCP)
-│   ├── repair_cmd.py    # `mureo repair platform-key` — drop a platforms entry filed under a
-│   │                    #   key mureo cannot resolve; dry run by default, backs up first (#610).
+│   ├── repair_cmd.py    # `mureo repair platform-key` — drop a platforms entry the DOCUMENT
+│   │                    #   shows to be wrong (duplicate of a resolvable key, or empty stub);
+│   │                    #   dry run by default, backs up first (#610/#616).
 │   │                    #   `--all` sweeps every client, summary first, one prompt (#614)
+│   ├── _repair_preview.py # What that command prints — the half that has to be TRUE: why an
+│   │                    #   entry can go, what is NOT changed (scoped to the plan), every
+│   │                    #   same-account sibling, and conversion_action_types (#616/#617/#618)
 │   ├── _repair_clients.py # Which STATE.json files `--all` sweeps — reuses the Reports tab's
 │   │                    #   optional list_clients / state_store_for_client seam, never a second one
 │   ├── _state_file.py   # The shared `--state-file` option + workspace default (rollback + repair)
@@ -143,7 +147,9 @@ mureo/
 │   ├── platform_guards.py # Write-time platform-key guards (#534/#609) — the one "is this key
 │   │                      #   real?" answer every other surface asks
 │   ├── platform_repair.py # The repair half (#610): plan + drop an entry under an unresolvable
-│   │                      #   key. Drops, never merges; backs up; not an action_log entry
+│   │                      #   key. Unresolvable is the FILTER, not the criterion — the document
+│   │                      #   must show the entry wrong (#616), and conversion_action_types is
+│   │                      #   never dropped (#617). Drops, never merges; backs up; no action_log
 │   └── errors.py        # Context-specific errors
 ├── analysis/            # Analysis utilities
 │   ├── lp_analyzer.py   # Landing page analyzer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,26 @@
   when every entry for an ad account is in the plan, every block says the
   account will be left with no record at all — before the confirmation.
 
+- **A schema-invalid STATE.json ended `mureo repair platform-key` in a raw
+  traceback** (#618). `read_state_file` wraps `json.JSONDecodeError` only, and
+  strict parsing also raises a bare `ValueError` for a document that is valid
+  JSON but invalid against the schema — a campaign missing `campaign_name`,
+  say. The single-workspace path caught only `ContextFileError`, so that
+  document produced a Python traceback, while `--all` caught broadly and
+  reported the very same file under `Could not be read`. One document, two
+  answers, and the person this command exists for cannot read the second one.
+
+  Both CLI entry points now catch it and print the same `Error: ...` block the
+  command uses everywhere else, naming the file and the reason — reusing
+  `--all`'s own wording so the two paths cannot drift apart again.
+  `read_state_file`'s contract is deliberately unchanged (fifteen-odd callers
+  depend on it); the docstring on `apply_state_file_repairs`, which promised
+  `ContextFileError` for every unparseable document, is corrected to state that
+  `ValueError` passes through and that a caller reporting to a person must
+  catch both. While there: `--all` no longer closes a sweep in which nothing
+  could be read with "every client's platform entries are filed under keys
+  mureo can resolve", which it could not know.
+
 - **Four test modules edited `GoogleAdsException` for the rest of the
   session.** Each built a fake exception with `__new__` and then attached a
   fake `failure` through `type(exc).failure = property(...)`. `type(exc)` is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,54 @@
 
 ### Fixed
 
+- **`mureo repair platform-key` offered to delete a legitimate solitary entry
+  when its plugin was not installed on the machine running the repair**
+  (#616). The delete criterion was resolvability, alone — and "mureo cannot
+  resolve this key" is a fact about *this machine's* installed bridges, not
+  about the entry. The same STATE.json was therefore judged differently on two
+  machines, and on the one lacking a bridge a real platform's real figures,
+  duplicating nothing, became a deletion candidate. Worst under `--all`, which
+  sweeps every client from one host whose plugin set need not match the machine
+  that wrote each document.
+
+  Removal is now proposed only when the **document itself** shows the entry is
+  wrong: it duplicates a key mureo *can* resolve holding the same ad account,
+  or it is an empty stub (no campaigns, no `totals`, no stored periods, no
+  declared settings). An empty `account_id` deliberately does not make a stub —
+  the shape reported from the field carries one, and an entry that never said
+  which account it describes can still hold every figure a platform has.
+  Everything else unresolvable is reported and handed back with its reason,
+  the way an undecidable duplicate already was.
+
+- **A dropped platform entry silently took the operator-declared conversion
+  allow-list with it** (#617). `conversion_action_types` is set by a person so
+  a custom-event advertiser is counted correctly (#342); nothing on the
+  platform side knows it, so no sync restores it. The preview described the
+  change entirely in terms of re-fetchable figures and never named the field,
+  so the operator confirmed a loss they were never shown.
+
+  The field is now carried on `PlatformEntryFacts` and printed whenever an
+  entry holds one — count, the action types themselves, and that no sync
+  restores them — and an entry carrying one is **refused** rather than offered.
+  Refusing rather than asking a second time is the point: the existing
+  confirmation is skippable with `--yes`, which is exactly how the
+  whole-machine sweep is run, so a second prompt would protect nobody on the
+  path that matters.
+
+- **With two or more entries dropped in one pass, each preview block claimed
+  the others were left untouched** (#618). `every other platform entry is left
+  exactly as it is` was printed unconditionally, once per block, so each block
+  contradicted the ones around it. And sibling entries for the same ad account
+  were filtered to the resolvable ones — precisely hiding the siblings that
+  were *also* being dropped, so a pass that removed an account's last record
+  never said so.
+
+  The reassurance is now scoped to entries outside the plan and names the plan
+  when it holds more than one key; siblings are listed whether or not mureo can
+  resolve them, each labelled as staying or as being removed by this run; and
+  when every entry for an ad account is in the plan, every block says the
+  account will be left with no record at all — before the confirmation.
+
 - **Four test modules edited `GoogleAdsException` for the rest of the
   session.** Each built a fake exception with `__new__` and then attached a
   fake `failure` through `type(exc).failure = property(...)`. `type(exc)` is

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -398,6 +398,17 @@ If this turns out wrong, put it back with:
 
 That backup is the undo. The repair is not recorded in `action_log`: that log records changes made to an *ad platform* and feeds the rollback planner, and a local-file edit has neither a platform operation to name nor one to reverse. With no TTY — an AI agent's shell, a CI runner — `--apply` declines rather than proceeding, so nothing destructive happens where the question could not be asked.
 
+A STATE.json mureo cannot read — bad JSON, or valid JSON that does not satisfy the schema — is reported as an error and repaired not at all, on both paths. The single-workspace run names the file and the reason:
+
+```
+Error: mureo cannot read STATE.json: /path/to/STATE.json
+       Campaign is missing required field 'campaign_name': {'campaign_id': 'c-1'}
+       Nothing was changed. This command will not repair a document it cannot
+       read in full: writing it back would drop whatever the read skipped.
+```
+
+`--all` reports the same reason under `Could not be read` and carries on with the other clients. The repair deliberately refuses a document it can only parse *tolerantly*: writing back a tolerant parse would silently drop whatever that parse skipped, which is a bigger loss than the one you came to fix.
+
 The same finding is flagged on the configure UI's Reports cards, which now name this command.
 
 ### Every client at once: `--all`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -278,7 +278,18 @@ A bulk pass wrapped in a batch (`mureo_batch_begin` / `mureo_batch_end`) is plan
 
 `mureo repair` fixes the STATE.json problems mureo can fix **without guessing**. Today that is one: a `platforms` entry filed under a key that names no advertising platform at all — an agent writing LOGLY snapshots under `logly_ads` when the bridge's provider is `logly_ads_context`, for instance. Both keys then carry the same ad account, and the dashboard reports the spend, conversions and CPA as double-counted.
 
-A duplicate whose two keys **both** name real platforms is reported and handed back to you: which of two sets of partial figures is true is a question about money that only you can answer, and mureo will not answer it for you.
+### What is actually removed, and what is only reported
+
+"mureo cannot resolve this key" is a fact about **the machine running the repair** — which plugin bridges are installed on it right now — not about the entry. The same STATE.json is judged differently on two machines, so unresolvability on its own selects nothing. An entry is offered for removal only when the **document itself** shows it is wrong:
+
+- **it duplicates a key mureo can resolve** holding the same ad account — the record survives under the key the account is really stored under; or
+- **it is an empty stub** — no campaigns, no `totals`, no stored periods and no settings of your own. Note that an empty `account_id` does *not* make a stub: an entry that never said which account it describes can still hold every figure a platform has.
+
+Everything else it finds is **reported and handed back to you**, with the reason under each block:
+
+- **a duplicate whose two keys both name real platforms** — which of two sets of partial figures is true is a question about money that only you can answer;
+- **an unresolvable entry that duplicates nothing and carries figures** — it may be the only record of that spend, and the key may belong to a plugin that is simply not installed on this machine. mureo will not delete it on a guess;
+- **any entry carrying `conversion_action_types`** — the conversion allow-list you declared by hand with `mureo_state_set_conversion_events`. Every figure in an entry can be re-fetched from the platform; that setting cannot, because nothing on the platform side knows it. mureo refuses to remove such an entry rather than asking you to confirm a loss — a second prompt would be skipped by `--yes`, which is exactly how the whole-machine sweep is run. To remove it anyway: declare those action types on the entry you are keeping, clear them here, then run the command again.
 
 ```bash
 # Show what mureo would do. Changes nothing — this is the default.
@@ -299,13 +310,16 @@ mureo repair platform-key --all
 mureo repair platform-key --all --apply
 ```
 
-The dry run names the key, the ad account, how many campaigns the entry carries, whether it holds a `totals` rollup and which windows it covers with each window's fetch time — for the unresolvable entry **and** for the entry the same ad account is stored under — then states exactly what would change:
+The dry run names the key, the ad account, how many campaigns the entry carries, whether it holds a `totals` rollup and which windows it covers with each window's fetch time — for the entry being removed **and** for every other entry holding the same ad account, whether or not mureo can resolve those — then states why it can go and exactly what would change:
 
 ```
   logly_ads — mureo cannot resolve this key.
     It is not one of mureo's own platform names, no plugin installed here
-    registers it, and it is not a plugin:<distribution>:<provider> key. So no
-    platform's data can belong to it.
+    registers it, and it is not a plugin:<distribution>:<provider> key.
+
+    Why it can go: the same ad account is stored under logly_ads_context, which
+    mureo CAN resolve — so this entry duplicates a record that survives, and
+    holds nothing a sync cannot refill.
 
     This entry holds:
       ad account:  1234567890
@@ -313,9 +327,8 @@ The dry run names the key, the ad account, how many campaigns the entry carries,
       totals:      stored, covering LAST_30_DAYS, fetched 2026-08-01T03:00:00+00:00
       periods:     LAST_30_DAYS (fetched 2026-08-01T03:00:00+00:00)
 
-    The same ad account is also stored under a key mureo CAN resolve, which
-    holds:
-      logly_ads_context
+    The same ad account is also stored under:
+      logly_ads_context — mureo CAN resolve this key; it stays.
         campaigns:   1
         totals:      stored, covering LAST_30_DAYS, fetched 2026-08-12T03:00:00+00:00
         periods:     none stored
@@ -327,6 +340,53 @@ The dry run names the key, the ad account, how many campaigns the entry carries,
 ```
 
 Nothing is ever merged or summed: two partial entries added together over-count exactly as much as dropping one under-counts. The unresolvable entry is **removed**, and the next sync refills the key the account is really stored under.
+
+**When one run removes two or more entries**, the "would NOT change" line is scoped to the entries outside the plan and the plan is listed, so no block claims the others are untouched:
+
+```
+    Would NOT change: no figures are added together, moved or edited. Every
+    platform entry other than the 2 this run removes is left exactly as it is.
+    This run removes: logly_ads, logly_adz.
+```
+
+**When every entry for one ad account is in the plan**, both blocks say so before the confirmation, rather than each describing its own removal in isolation:
+
+```
+    The same ad account is also stored under:
+      logly_adz — this run removes this entry too.
+        ...
+
+    Afterwards: this run removes every entry for ad account 1234567890
+    (logly_ads, logly_adz), so STATE.json will hold NO record of that account at all.
+    The figures stay in the backup; re-sync the platform under its real
+    key once you know what that is.
+```
+
+**An entry mureo will not remove** is shown in the same shape, with `Would change: nothing.` and what to do about it:
+
+```
+  logly_ads — mureo cannot resolve this key, and will NOT remove it.
+    It is not one of mureo's own platform names, no plugin installed here
+    registers it, and it is not a plugin:<distribution>:<provider> key.
+
+    Why it stays: it carries conversion_action_types — a conversion allow-list
+    you declared by hand. Every figure here can be re-fetched from the platform;
+    that setting cannot, because nothing on the platform side knows it. Removing
+    the entry would take it with it, so mureo refuses rather than asking you to
+    confirm a loss it can avoid.
+
+    This entry holds:
+      ad account:  1234567890
+      campaigns:   0
+      totals:      stored, covering LAST_30_DAYS, fetched 2026-08-13T23:10:00Z
+      periods:     none stored
+      conversions: 1 conversion_action_type you declared — no sync restores this
+                   offsite_conversion.custom.90210
+
+    Would change: nothing.
+    Yours to decide: declare those action types on the entry you are keeping,
+    clear them here, then run this command again.
+```
 
 `--apply` backs STATE.json up first, timestamped, and prints the command that restores it:
 
@@ -347,27 +407,28 @@ A bad key is rarely one directory's problem. It is written by an agent, and an a
 ```
 === mureo repair platform-key --all ===
 
-Surveyed 6 clients.
+Surveyed 7 clients.
 
-  Need repair (2 of 6):
+  Need repair (2 of 7):
     acme (Acme Co) — logly_ads
     beta (Beta Ltd) — logly_ads
 
-  Need your decision (1 of 6):
+  Need your decision (2 of 7):
     epsilon (Epsilon GmbH) [archived] — one ad account under two real platform keys (see below)
+    theta (Theta AB) — mureo cannot resolve logly_ads_v2, and will not remove it (see below)
 
-  Clean (2 of 6):
+  Clean (2 of 7):
     gamma (Gamma KK)
     zeta (Zeta SA) — no STATE.json yet
 
-  Could not be read (1 of 6):
+  Could not be read (1 of 7):
     delta (Delta Inc) — Failed to parse JSON in STATE.json: /clients/delta/STATE.json
 ```
 
 The per-client detail follows, in the same shape as the single-workspace run, for every client that has a finding. Then:
 
 - **Dry run is still the default.** `--all` on its own changes nothing.
-- **`Need your decision` is its own group, not a footnote under `Clean`.** An ad account stored under two keys that *both* name real platforms is still double-counted; mureo simply will not choose which entry to drop, because the two usually hold different partial figures. It is not a repair this command can make, and it is not clean either — so it is counted separately rather than qualified after an em dash in a line you would skim.
+- **`Need your decision` is its own group, not a footnote under `Clean`.** An ad account stored under two keys that *both* name real platforms is still double-counted; mureo simply will not choose which entry to drop, because the two usually hold different partial figures. The same group holds the entries mureo *can* see are unresolvable but will not remove — one that duplicates nothing and carries figures, or one holding a `conversion_action_types` override. None of those is a repair this command makes, and none of them is clean either, so they are counted separately rather than qualified after an em dash in a line you would skim. A client whose only finding is one of these is **never** counted under `Need repair`: the sweep would not touch it, and `Need repair (N of M)` has to be the number of clients `--apply` will actually change.
 - **`--all --apply` asks once**, with the whole list in view — not once per client. A prompt per client teaches you to hold down `y`, which is the opposite of what a confirmation is for. Every repaired client is still backed up individually, and the `cp` that restores it is printed per client.
 - **One client failing does not stop the sweep.** An unparseable STATE.json, a lock it cannot take, a permission error — that client is named in the summary and under `Could not be read`, the rest are repaired, and the command exits non-zero so a script notices. A *finding* is not a failure: a dry run that reports work to do exits `0`.
 - **`--all` and `--state-file` are refused together.** One says "every client", the other says "this one file".

--- a/mureo/cli/_repair_clients.py
+++ b/mureo/cli/_repair_clients.py
@@ -46,7 +46,7 @@ from typing import TYPE_CHECKING, Any
 
 from mureo.cli._state_file import resolve_default_state_file, state_file_for_store
 from mureo.cli._tty import terminal_safe as _safe
-from mureo.context.platform_repair import plan_platform_key_repairs
+from mureo.context.platform_repair import plan_platform_keys
 from mureo.context.state import read_state_file
 
 if TYPE_CHECKING:
@@ -54,7 +54,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from mureo.context.models import StateDocument
-    from mureo.context.platform_repair import PlatformKeyRepair
+    from mureo.context.platform_repair import PlatformKeyFinding, PlatformKeyRepair
 
 _UNRESOLVED_STORE = "its state store did not say where its STATE.json lives"
 
@@ -92,16 +92,21 @@ class ClientRegistry:
 class ClientSurvey:
     """What one client's STATE.json turned out to hold.
 
-    Exactly one of three states, and the caller reads them in this order:
-    ``error`` set (could not be read), ``repairs`` non-empty (needs work), or
-    neither (clean). ``doc`` is kept so the caller can report the findings
-    this command deliberately does NOT repair — a duplicate whose two keys
-    both name real platforms — without re-reading the file.
+    Read in this order: ``error`` set (could not be read), ``repairs``
+    non-empty (needs work), ``kept`` non-empty (needs the operator's
+    decision), or none of them (clean). ``kept`` carries the unresolvable
+    entries the repair deliberately will NOT remove (#616/#617) — a client
+    with only those is not clean and is not repairable either, so a summary
+    that reads ``repairs`` alone would file it wrongly whichever way it went.
+    ``doc`` is kept so the caller can also report the other finding this
+    command does not repair — a duplicate whose two keys both name real
+    platforms — without re-reading the file.
     """
 
     target: ClientTarget
     doc: StateDocument | None
     repairs: tuple[PlatformKeyRepair, ...]
+    kept: tuple[PlatformKeyFinding, ...]
     error: str | None
 
     @property
@@ -145,20 +150,21 @@ def survey_client(
     """Read one client and plan its repairs, converting failure to a report.
 
     ``keys`` narrows the plan exactly as
-    :func:`~mureo.context.platform_repair.plan_platform_key_repairs` does. The
-    read is strict, like the single-workspace command's: a document that only
-    parses tolerantly must not be rewritten, because the entries the tolerant
-    parse skipped would be dropped by the write-back.
+    :func:`~mureo.context.platform_repair.plan_platform_keys` does. The read is
+    strict, like the single-workspace command's: a document that only parses
+    tolerantly must not be rewritten, because the entries the tolerant parse
+    skipped would be dropped by the write-back.
     """
     if target.state_file is None:
-        return ClientSurvey(target, None, (), target.error or _UNRESOLVED_STORE)
+        return ClientSurvey(target, None, (), (), target.error or _UNRESOLVED_STORE)
     if not target.state_file.exists():
-        return ClientSurvey(target, None, (), None)
+        return ClientSurvey(target, None, (), (), None)
     try:
         doc = read_state_file(target.state_file)
     except Exception as exc:  # noqa: BLE001 — one bad client is not a bad sweep
-        return ClientSurvey(target, None, (), _reason(exc))
-    return ClientSurvey(target, doc, plan_platform_key_repairs(doc, keys=keys), None)
+        return ClientSurvey(target, None, (), (), _reason(exc))
+    plan = plan_platform_keys(doc, keys=keys)
+    return ClientSurvey(target, doc, plan.repairs, plan.kept, None)
 
 
 def survey_clients(

--- a/mureo/cli/_repair_clients.py
+++ b/mureo/cli/_repair_clients.py
@@ -162,7 +162,7 @@ def survey_client(
     try:
         doc = read_state_file(target.state_file)
     except Exception as exc:  # noqa: BLE001 — one bad client is not a bad sweep
-        return ClientSurvey(target, None, (), (), _reason(exc))
+        return ClientSurvey(target, None, (), (), unreadable_reason(exc))
     plan = plan_platform_keys(doc, keys=keys)
     return ClientSurvey(target, doc, plan.repairs, plan.kept, None)
 
@@ -216,13 +216,18 @@ def _active_workspace_target() -> ClientTarget:
     )
 
 
-def _reason(exc: Exception) -> str:
-    """One scrubbed line saying why a client could not be read.
+def unreadable_reason(exc: Exception) -> str:
+    """One scrubbed line saying why a STATE.json could not be read.
 
     STATE.json is agent-writable, so an exception carrying a fragment of it
     carries attacker-influenceable text straight to a terminal — the same
     reason every other string this command prints goes through
     ``terminal_safe``.
+
+    Shared with the single-workspace path (:mod:`mureo.cli.repair_cmd`) rather
+    than reimplemented there: the two used to give different answers about one
+    document — this one named it under "Could not be read", the other ended in
+    a traceback — and one wording is how they are kept in step (#618).
     """
     text = _safe(str(exc)).strip()
     return text or type(exc).__name__
@@ -235,4 +240,5 @@ __all__ = [
     "list_repair_targets",
     "survey_client",
     "survey_clients",
+    "unreadable_reason",
 ]

--- a/mureo/cli/_repair_preview.py
+++ b/mureo/cli/_repair_preview.py
@@ -1,0 +1,376 @@
+"""What ``mureo repair platform-key`` prints before it is allowed to act.
+
+Split out of :mod:`mureo.cli.repair_cmd` when the preview grew the three
+things #616/#617/#618 found missing, and worth keeping apart: this module is
+where every claim made to the operator is worded, and it is the half that has
+to be true. The command module decides what to do; this one says what that
+would mean.
+
+The claims it is responsible for
+--------------------------------
+- **Why an entry can go.** Not "mureo cannot resolve this key" — that is a
+  fact about the machine running the repair, and an operator cannot tell it
+  apart from a bridge that is simply not installed here (#616). Each block
+  names the evidence in the document instead: the resolvable key holding the
+  same account, or the entry being an empty stub.
+- **What is NOT changed.** Scoped to the entries outside the plan. Printed
+  unconditionally, one block per repair, it contradicted the block below it
+  the moment a run removed two entries (#618).
+- **What else holds this ad account.** Every sibling, resolvable or not.
+  Filtering to the resolvable ones hid precisely the siblings that were also
+  being removed, so a run that left an account with no entry at all said
+  nothing about it (#618).
+- **What no sync brings back.** ``conversion_action_types`` is printed
+  whenever an entry carries one (#617). A preview can only show what
+  ``PlatformEntryFacts`` carries, and the field's absence there is what made
+  the loss silent.
+
+Every string that came out of STATE.json goes through ``terminal_safe``:
+the file is agent-writable, so its keys, account ids and timestamps are
+attacker-influenceable text on its way to a terminal.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import typer
+
+from mureo.cli._tty import terminal_safe as _safe
+from mureo.context.platform_accounts import duplicate_account_entries
+from mureo.context.platform_repair import (
+    DROP_DUPLICATE,
+    KEEP_CARRIES_FIGURES,
+    KEEP_CONVERSION_OVERRIDE,
+    is_unresolvable_platform_key,
+)
+
+if TYPE_CHECKING:
+    from mureo.context.models import StateDocument
+    from mureo.context.platform_accounts import DuplicateAccountEntry
+    from mureo.context.platform_repair import (
+        PlatformEntryFacts,
+        PlatformKeyFinding,
+        PlatformKeyRepair,
+    )
+
+
+def _echo_entry_facts(
+    facts: PlatformEntryFacts, indent: str, *, show_account: bool = True
+) -> None:
+    """Print one entry's contents — never its figures, only what it holds.
+
+    The key is the caller's to print: it is already the subject of the
+    sentence introducing each block. ``show_account`` drops the ad account on
+    a block the surrounding sentence has already said shares one, so the
+    operator reads facts rather than repetition.
+    """
+    if show_account:
+        typer.echo(
+            f"{indent}ad account:  {_safe(facts.account_id) or '(none recorded)'}"
+        )
+    typer.echo(f"{indent}campaigns:   {facts.campaign_count}")
+    typer.echo(f"{indent}totals:      {_totals_line(facts)}")
+    typer.echo(f"{indent}periods:     {_periods_line(facts)}")
+    _echo_conversion_override(facts, indent)
+
+
+def _echo_conversion_override(facts: PlatformEntryFacts, indent: str) -> None:
+    """Name ``conversion_action_types`` whenever an entry carries one (#617).
+
+    Printed only when set, so an entry without one reads exactly as before.
+    The action types themselves are listed, not just counted: they are the
+    one thing in the entry no sync brings back, so an operator who has to
+    re-declare them needs to be able to read them off the screen.
+    """
+    types = facts.conversion_action_types
+    if not types:
+        return
+    noun = "conversion_action_type" if len(types) == 1 else "conversion_action_types"
+    typer.echo(
+        f"{indent}conversions: {len(types)} {noun} you declared — "
+        f"no sync restores this"
+    )
+    typer.echo(f"{indent}             {', '.join(_safe(t) for t in types)}")
+
+
+def _totals_line(facts: PlatformEntryFacts) -> str:
+    if not facts.has_totals:
+        return "none stored"
+    window = (
+        _safe(facts.metrics_period) if facts.metrics_period else "an unnamed window"
+    )
+    when = (
+        f"fetched {_safe(facts.totals_fetched_at)}"
+        if facts.totals_fetched_at
+        else "no fetch time recorded"
+    )
+    return f"stored, covering {window}, {when}"
+
+
+def _periods_line(facts: PlatformEntryFacts) -> str:
+    if not facts.rollups:
+        return "none stored"
+    return "; ".join(
+        f"{_safe(rollup.period)} "
+        + (
+            f"(fetched {_safe(rollup.fetched_at)})"
+            if rollup.fetched_at
+            else "(no fetch time recorded)"
+        )
+        for rollup in facts.rollups
+    )
+
+
+_UNRESOLVABLE_EXPLANATION = (
+    "    It is not one of mureo's own platform names, no plugin installed "
+    "here\n    registers it, and it is not a plugin:<distribution>:<provider> "
+    "key."
+)
+
+
+def echo_repair(repair: PlatformKeyRepair, *, removing: frozenset[str]) -> None:
+    """Show one finding and exactly what removing it would and would not do.
+
+    ``removing`` is every key THIS run drops, not just this one. Without it
+    each block reassured the operator that every other entry was left alone
+    while the block below removed one, and a sibling holding the same ad
+    account disappeared without either block saying so (#618).
+    """
+    typer.echo("")
+    typer.echo(f"  {_safe(repair.entry.key)} — mureo cannot resolve this key.")
+    typer.echo(_UNRESOLVABLE_EXPLANATION)
+    typer.echo("")
+    typer.echo(f"    Why it can go: {_drop_reason_line(repair)}")
+    typer.echo("")
+    typer.echo("    This entry holds:")
+    _echo_entry_facts(repair.entry, "      ")
+    _echo_same_account(repair.same_account, removing=removing)
+    typer.echo("")
+    typer.echo(
+        f"    Would change: the whole {_safe(repair.entry.key)} entry is removed "
+        f"from STATE.json."
+    )
+    _echo_unchanged_claim(removing)
+    _echo_afterwards(repair, removing=removing)
+
+
+def _drop_reason_line(repair: PlatformKeyRepair) -> str:
+    """Why the DOCUMENT — not this machine's plugin list — condemns the entry.
+
+    An operator told only "mureo cannot resolve this key" cannot tell a real
+    mistake from a bridge that is not installed here, which is the confusion
+    #616 was filed for. So the block names the evidence.
+    """
+    if repair.reason == DROP_DUPLICATE:
+        duplicated = ", ".join(
+            _safe(facts.key) for facts in repair.same_account if facts.resolvable
+        )
+        return (
+            f"the same ad account is stored under {duplicated}, which\n    mureo CAN "
+            f"resolve — so this entry duplicates a record that survives, and\n    "
+            f"holds nothing a sync cannot refill."
+        )
+    return (
+        "the entry is an empty stub — no campaigns, no totals, no\n    stored periods "
+        "and no settings of your own. Removing it loses nothing."
+    )
+
+
+def _sibling_note(facts: PlatformEntryFacts, *, removing: frozenset[str]) -> str:
+    """How one same-account sibling is labelled in a repair block."""
+    if facts.key in removing:
+        return "this run removes this entry too"
+    if facts.resolvable:
+        return "mureo CAN resolve this key; it stays"
+    return "mureo cannot resolve this key either; it stays"
+
+
+def _echo_same_account(
+    siblings: tuple[PlatformEntryFacts, ...], *, removing: frozenset[str]
+) -> None:
+    """Every other entry for this ad account — resolvable or not.
+
+    Filtering to the resolvable ones hid exactly the siblings that were also
+    being dropped, so the operator was never shown that an account was about
+    to lose its last record (#618).
+    """
+    if not siblings:
+        return
+    typer.echo("")
+    typer.echo("    The same ad account is also stored under:")
+    for facts in siblings:
+        typer.echo(
+            f"      {_safe(facts.key)} — {_sibling_note(facts, removing=removing)}."
+        )
+        _echo_entry_facts(facts, "        ", show_account=False)
+
+
+def _echo_unchanged_claim(removing: frozenset[str]) -> None:
+    """Scope the reassurance to the entries outside this run's plan (#618)."""
+    if len(removing) < 2:
+        typer.echo(
+            "    Would NOT change: no figures are added together, moved or edited, "
+            "and every\n    other platform entry is left exactly as it is."
+        )
+        return
+    typer.echo(
+        f"    Would NOT change: no figures are added together, moved or edited. "
+        f"Every\n    platform entry other than the {len(removing)} this run removes "
+        f"is left exactly as it is."
+    )
+    typer.echo(
+        f"    This run removes: {', '.join(_safe(k) for k in sorted(removing))}."
+    )
+
+
+def _echo_afterwards(repair: PlatformKeyRepair, *, removing: frozenset[str]) -> None:
+    """What is left holding this ad account once the run finishes."""
+    staying = [facts for facts in repair.same_account if facts.key not in removing]
+    refilled = [facts for facts in staying if facts.resolvable]
+    if refilled:
+        typer.echo(
+            f"    Afterwards: the next sync refills {_safe(refilled[0].key)} from "
+            f"the platform itself."
+        )
+    elif staying:
+        keys = ", ".join(_safe(facts.key) for facts in staying)
+        typer.echo(
+            f"    Afterwards: this ad account is still stored under {keys}, which "
+            f"mureo\n    cannot resolve either — so nothing refills it on its own. "
+            f"The figures stay\n    in the backup."
+        )
+    elif repair.same_account:
+        gone = ", ".join(
+            _safe(key)
+            for key in [repair.entry.key, *(f.key for f in repair.same_account)]
+        )
+        typer.echo(
+            f"    Afterwards: this run removes every entry for ad account "
+            f"{_safe(repair.entry.account_id)}"
+        )
+        typer.echo(
+            f"    ({gone}), so STATE.json will hold NO record of that account at all."
+        )
+        typer.echo(
+            "    The figures stay in the backup; re-sync the platform under its real"
+            "\n    key once you know what that is."
+        )
+    else:
+        typer.echo(
+            "    Afterwards: no key mureo can resolve holds this ad account, so "
+            "nothing refills\n    it on its own. The figures stay in the backup; "
+            "re-sync the platform under its\n    real key once you know what that is."
+        )
+
+
+def echo_kept_findings(kept: tuple[PlatformKeyFinding, ...]) -> None:
+    """Report the unresolvable entries mureo refuses to remove, and why."""
+    if not kept:
+        return
+    typer.echo("")
+    typer.echo(
+        f"Found {len(kept)} platform {'entry' if len(kept) == 1 else 'entries'} "
+        f"mureo cannot resolve but will NOT remove."
+    )
+    for finding in kept:
+        _echo_kept_finding(finding)
+
+
+def _echo_kept_finding(finding: PlatformKeyFinding) -> None:
+    """One entry handed back, in the same shape as a repair block."""
+    typer.echo("")
+    typer.echo(
+        f"  {_safe(finding.entry.key)} — mureo cannot resolve this key, and will "
+        f"NOT remove it."
+    )
+    typer.echo(_UNRESOLVABLE_EXPLANATION)
+    typer.echo("")
+    typer.echo(_KEPT_REASONS[finding.reason])
+    typer.echo("")
+    typer.echo("    This entry holds:")
+    _echo_entry_facts(finding.entry, "      ")
+    typer.echo("")
+    typer.echo("    Would change: nothing.")
+    typer.echo(_KEPT_NEXT_STEPS[finding.reason])
+
+
+_KEPT_REASONS = {
+    KEEP_CARRIES_FIGURES: (
+        "    Why it stays: that is a fact about THIS machine, not about the "
+        "entry — the\n    plugin that owns the key may simply not be installed "
+        "here. Nothing in\n    STATE.json says the entry is wrong: no key mureo "
+        "can resolve holds its ad\n    account, and it is not empty. So this "
+        "entry may be the only record of the\n    figures below, and mureo will "
+        "not delete it on a guess."
+    ),
+    KEEP_CONVERSION_OVERRIDE: (
+        "    Why it stays: it carries conversion_action_types — a conversion "
+        "allow-list\n    you declared by hand. Every figure here can be "
+        "re-fetched from the platform;\n    that setting cannot, because nothing "
+        "on the platform side knows it. Removing\n    the entry would take it "
+        "with it, so mureo refuses rather than asking you to\n    confirm a loss "
+        "it can avoid."
+    ),
+}
+
+_KEPT_NEXT_STEPS = {
+    KEEP_CARRIES_FIGURES: (
+        "    Yours to decide: install the plugin that owns this key, or check the "
+        "figures\n    and remove the entry yourself."
+    ),
+    KEEP_CONVERSION_OVERRIDE: (
+        "    Yours to decide: declare those action types on the entry you are "
+        "keeping,\n    clear them here, then run this command again."
+    ),
+}
+
+
+def undecidable_groups(doc: StateDocument | None) -> tuple[DuplicateAccountEntry, ...]:
+    """Duplicates whose keys ALL name real platforms — mureo's to report only.
+
+    Split out of the echo so the ``--all`` summary can flag a client whose
+    only finding is one of these without printing the whole block twice.
+    """
+    if doc is None:
+        return ()
+    return tuple(
+        group
+        for group in duplicate_account_entries(doc.platforms or {})
+        if not any(is_unresolvable_platform_key(key) for key in group.platform_keys)
+    )
+
+
+def echo_undecidable_duplicates(doc: StateDocument | None) -> None:
+    """Report a duplicate this command will not touch, and say why.
+
+    Both keys name real platforms, so the question is which set of partial
+    figures is true — the one ``mureo/web/reports.py`` refuses to answer, and
+    is right to refuse. Saying nothing here would read as "mureo found no
+    problem" to an operator who came from a dashboard warning.
+    """
+    groups = undecidable_groups(doc)
+    if not groups:
+        return
+    typer.echo("")
+    for group in groups:
+        keys = ", ".join(_safe(key) for key in group.platform_keys)
+        typer.echo(
+            f"One ad account ({_safe(group.account_id)}) is stored under platform "
+            f"keys that\nBOTH name real platforms ({keys}), so its spend, "
+            f"conversions and CPA are\ncounted twice."
+        )
+    typer.echo(
+        "mureo does not choose between them: the two entries usually hold "
+        "different\npartial figures, so dropping either under-counts as much as "
+        "adding them\ntogether over-counts. Check which entry holds the right "
+        "figures and remove\nthe other yourself."
+    )
+
+
+__all__ = [
+    "echo_kept_findings",
+    "echo_repair",
+    "echo_undecidable_duplicates",
+    "undecidable_groups",
+]

--- a/mureo/cli/repair_cmd.py
+++ b/mureo/cli/repair_cmd.py
@@ -24,6 +24,9 @@ What is printed lives in :mod:`mureo.cli._repair_preview` — this module
 decides what to do, that one words what it would mean. Every claim it makes
 has to survive the run it precedes; the three that did not are #618.
 
+A document mureo cannot read is an ``Error:`` line, never a traceback, on
+both paths — see :func:`_echo_unreadable`.
+
 ``--all``: the same repair, once per client
 -------------------------------------------
 The incident is not one directory's. It was made by an agent running against
@@ -65,7 +68,11 @@ from typing import TYPE_CHECKING
 
 import typer
 
-from mureo.cli._repair_clients import list_repair_targets, survey_clients
+from mureo.cli._repair_clients import (
+    list_repair_targets,
+    survey_clients,
+    unreadable_reason,
+)
 from mureo.cli._repair_preview import (
     echo_kept_findings,
     echo_repair,
@@ -106,9 +113,39 @@ def _read_document(state_file: Path) -> StateDocument:
         raise typer.Exit(1)
     try:
         return read_state_file(state_file)
-    except ContextFileError as exc:
-        typer.echo(f"Error: {exc}", err=True)
+    except (ContextFileError, ValueError) as exc:
+        _echo_unreadable(state_file, exc)
         raise typer.Exit(1) from exc
+
+
+def _echo_unreadable(state_file: Path, exc: Exception) -> None:
+    """Report a STATE.json this command cannot read, and stop.
+
+    ``read_state_file`` wraps ``json.JSONDecodeError`` as ``ContextFileError``
+    and nothing else, but strict parsing also raises a bare ``ValueError`` for
+    a document that is valid JSON and invalid against the schema — a campaign
+    missing ``campaign_name``, say. Catching only ``ContextFileError`` left
+    that document ending in a Python traceback here while ``--all`` reported
+    the same file under "Could not be read": one document, two answers, and
+    the person this command exists for cannot read the second one (#618).
+
+    Caught at the CLI rather than by widening ``read_state_file``'s contract:
+    that function has fifteen-odd other callers, some of which may well be
+    relying on a ``ValueError`` passing through, and this is not the place to
+    find out.
+
+    The reason text is ``--all``'s own, so the two paths cannot drift into
+    describing one file differently again. It is scrubbed — the failing
+    fragment comes out of an agent-writable STATE.json.
+    """
+    typer.echo(f"Error: mureo cannot read STATE.json: {state_file}", err=True)
+    typer.echo(f"       {unreadable_reason(exc)}", err=True)
+    typer.echo(
+        "       Nothing was changed. This command will not repair a document it "
+        "cannot\n       read in full: writing it back would drop whatever the "
+        "read skipped.",
+        err=True,
+    )
 
 
 def _reject_unusable_key_argument(doc: StateDocument, key: str) -> None:
@@ -277,7 +314,15 @@ def _apply(state_file: Path, keys: tuple[str, ...] | None) -> None:
     """Run the repair and report the backup before what it removed."""
     try:
         outcome = apply_state_file_repairs(state_file, keys=keys)
-    except (ContextFileError, OSError) as exc:
+    except (ContextFileError, ValueError) as exc:
+        # Between the preview and the lock, the document became one mureo
+        # cannot parse strictly — a concurrent writer, or a file swapped under
+        # it. Reported exactly as the read path reports it, and for the same
+        # reason: a bare ``ValueError`` out of strict parsing is not a
+        # traceback this command's operator should ever see (#618).
+        _echo_unreadable(state_file, exc)
+        raise typer.Exit(1) from exc
+    except OSError as exc:
         typer.echo(f"Error: STATE.json was not changed: {exc}", err=True)
         raise typer.Exit(1) from exc
     if not outcome.changed:
@@ -327,6 +372,14 @@ def _repair_every_client(
         typer.echo(
             "Nothing to repair automatically: mureo will not remove the entries "
             "above, for the reason given under each one."
+        )
+    elif not needing and failures:
+        # "Every client's entries resolve" is false when a client's entries
+        # could not be read at all — the same false reassurance #616/#618 are
+        # about, one line further down.
+        typer.echo(
+            "Nothing to repair in the clients that could be read. The ones "
+            "listed under\n'Could not be read' were not surveyed at all."
         )
     elif not needing:
         typer.echo(

--- a/mureo/cli/repair_cmd.py
+++ b/mureo/cli/repair_cmd.py
@@ -8,12 +8,21 @@ decide safely and shows its work for everything else:
   the keys, the ad account and what each entry holds (``fetched_at``, which
   windows, whether a ``totals`` rollup is there), then states exactly what
   would change. ``--apply`` is the second, deliberate step, and it still asks.
-- **It only ever removes an entry filed under a key mureo cannot resolve.** A
-  duplicate whose two keys BOTH name real platforms is reported and handed
-  back — that is a question about which figures are true, which only the
-  operator can answer.
+- **It removes an entry only when the DOCUMENT shows it is wrong** — a
+  duplicate of a key mureo can resolve holding the same ad account, or an
+  empty stub (#616). "No plugin here registers this key" is a fact about the
+  machine running the repair, not about the entry, so it selects nothing on
+  its own. Everything else it finds is reported and handed back: a duplicate
+  whose two keys BOTH name real platforms (which figures are true is the
+  operator's question), an unresolvable entry that duplicates nothing and
+  carries figures, and any entry holding ``conversion_action_types``, which no
+  sync restores (#617).
 - **It backs the document up first**, timestamped, and prints the command that
   puts it back.
+
+What is printed lives in :mod:`mureo.cli._repair_preview` — this module
+decides what to do, that one words what it would mean. Every claim it makes
+has to survive the run it precedes; the three that did not are #618.
 
 ``--all``: the same repair, once per client
 -------------------------------------------
@@ -57,15 +66,20 @@ from typing import TYPE_CHECKING
 import typer
 
 from mureo.cli._repair_clients import list_repair_targets, survey_clients
+from mureo.cli._repair_preview import (
+    echo_kept_findings,
+    echo_repair,
+    echo_undecidable_duplicates,
+    undecidable_groups,
+)
 from mureo.cli._state_file import STATE_FILE_OPTION, resolve_default_state_file
 from mureo.cli._tty import confirm_or_default
 from mureo.cli._tty import terminal_safe as _safe
 from mureo.context.errors import ContextFileError
-from mureo.context.platform_accounts import duplicate_account_entries
 from mureo.context.platform_repair import (
     apply_state_file_repairs,
     is_unresolvable_platform_key,
-    plan_platform_key_repairs,
+    plan_platform_keys,
 )
 from mureo.context.state import read_state_file
 
@@ -74,8 +88,7 @@ if TYPE_CHECKING:
 
     from mureo.cli._repair_clients import ClientSurvey, ClientTarget
     from mureo.context.models import StateDocument
-    from mureo.context.platform_accounts import DuplicateAccountEntry
-    from mureo.context.platform_repair import PlatformEntryFacts, PlatformKeyRepair
+    from mureo.context.platform_repair import PlatformKeyRepair
 
 repair_app = typer.Typer(
     name="repair",
@@ -129,139 +142,6 @@ def _reject_resolvable_key(key: str) -> None:
             err=True,
         )
         raise typer.Exit(1)
-
-
-def _echo_entry_facts(
-    facts: PlatformEntryFacts, indent: str, *, show_account: bool = True
-) -> None:
-    """Print one entry's contents — never its figures, only what it holds.
-
-    The key is the caller's to print: it is already the subject of the
-    sentence introducing each block. ``show_account`` drops the ad account on
-    a block the surrounding sentence has already said shares one, so the
-    operator reads facts rather than repetition.
-    """
-    if show_account:
-        typer.echo(
-            f"{indent}ad account:  {_safe(facts.account_id) or '(none recorded)'}"
-        )
-    typer.echo(f"{indent}campaigns:   {facts.campaign_count}")
-    typer.echo(f"{indent}totals:      {_totals_line(facts)}")
-    typer.echo(f"{indent}periods:     {_periods_line(facts)}")
-
-
-def _totals_line(facts: PlatformEntryFacts) -> str:
-    if not facts.has_totals:
-        return "none stored"
-    window = (
-        _safe(facts.metrics_period) if facts.metrics_period else "an unnamed window"
-    )
-    when = (
-        f"fetched {_safe(facts.totals_fetched_at)}"
-        if facts.totals_fetched_at
-        else "no fetch time recorded"
-    )
-    return f"stored, covering {window}, {when}"
-
-
-def _periods_line(facts: PlatformEntryFacts) -> str:
-    if not facts.rollups:
-        return "none stored"
-    return "; ".join(
-        f"{_safe(rollup.period)} "
-        + (
-            f"(fetched {_safe(rollup.fetched_at)})"
-            if rollup.fetched_at
-            else "(no fetch time recorded)"
-        )
-        for rollup in facts.rollups
-    )
-
-
-def _echo_repair(repair: PlatformKeyRepair) -> None:
-    """Show one finding and exactly what removing it would and would not do."""
-    typer.echo("")
-    typer.echo(f"  {_safe(repair.entry.key)} — mureo cannot resolve this key.")
-    typer.echo(
-        "    It is not one of mureo's own platform names, no plugin installed "
-        "here\n    registers it, and it is not a plugin:<distribution>:<provider> "
-        "key. So no\n    platform's data can belong to it."
-    )
-    typer.echo("")
-    typer.echo("    This entry holds:")
-    _echo_entry_facts(repair.entry, "      ")
-    survivors = [facts for facts in repair.same_account if facts.resolvable]
-    if survivors:
-        typer.echo("")
-        typer.echo(
-            "    The same ad account is also stored under a key mureo CAN "
-            "resolve, which\n    holds:"
-        )
-        for facts in survivors:
-            typer.echo(f"      {_safe(facts.key)}")
-            _echo_entry_facts(facts, "        ", show_account=False)
-    typer.echo("")
-    typer.echo(
-        f"    Would change: the whole {_safe(repair.entry.key)} entry is removed "
-        f"from STATE.json."
-    )
-    typer.echo(
-        "    Would NOT change: no figures are added together, moved or edited, "
-        "and every\n    other platform entry is left exactly as it is."
-    )
-    if survivors:
-        typer.echo(
-            f"    Afterwards: the next sync refills {_safe(survivors[0].key)} from "
-            f"the platform itself."
-        )
-    else:
-        typer.echo(
-            "    Afterwards: no key mureo can resolve holds this ad account, so "
-            "nothing refills\n    it on its own. The figures stay in the backup; "
-            "re-sync the platform under its\n    real key once you know what that is."
-        )
-
-
-def _undecidable_groups(doc: StateDocument | None) -> tuple[DuplicateAccountEntry, ...]:
-    """Duplicates whose keys ALL name real platforms — mureo's to report only.
-
-    Split out of the echo so the ``--all`` summary can flag a client whose
-    only finding is one of these without printing the whole block twice.
-    """
-    if doc is None:
-        return ()
-    return tuple(
-        group
-        for group in duplicate_account_entries(doc.platforms or {})
-        if not any(is_unresolvable_platform_key(key) for key in group.platform_keys)
-    )
-
-
-def _echo_undecidable_duplicates(doc: StateDocument | None) -> None:
-    """Report a duplicate this command will not touch, and say why.
-
-    Both keys name real platforms, so the question is which set of partial
-    figures is true — the one ``mureo/web/reports.py`` refuses to answer, and
-    is right to refuse. Saying nothing here would read as "mureo found no
-    problem" to an operator who came from a dashboard warning.
-    """
-    groups = _undecidable_groups(doc)
-    if not groups:
-        return
-    typer.echo("")
-    for group in groups:
-        keys = ", ".join(_safe(key) for key in group.platform_keys)
-        typer.echo(
-            f"One ad account ({_safe(group.account_id)}) is stored under platform "
-            f"keys that\nBOTH name real platforms ({keys}), so its spend, "
-            f"conversions and CPA are\ncounted twice."
-        )
-    typer.echo(
-        "mureo does not choose between them: the two entries usually hold "
-        "different\npartial figures, so dropping either under-counts as much as "
-        "adding them\ntogether over-counts. Check which entry holds the right "
-        "figures and remove\nthe other yourself."
-    )
 
 
 def _echo_apply_result(repairs: tuple[PlatformKeyRepair, ...]) -> None:
@@ -323,31 +203,41 @@ def _repair_one_workspace(
     if key is not None:
         _reject_unusable_key_argument(doc, key)
     keys = (key,) if key is not None else None
-    repairs = plan_platform_key_repairs(doc, keys=keys)
+    plan = plan_platform_keys(doc, keys=keys)
+    repairs = plan.repairs
 
     typer.echo(f"=== {_COMMAND} ===")
     typer.echo("")
     typer.echo(f"STATE.json: {state_file}")
-    if not repairs:
+    if not repairs and not plan.kept:
         typer.echo("")
         typer.echo(
             "Nothing to repair: every platform entry is filed under a key mureo "
             "can resolve."
         )
-        _echo_undecidable_duplicates(doc)
+        echo_undecidable_duplicates(doc)
         return
 
-    typer.echo("")
-    typer.echo(
-        f"Found {len(repairs)} platform "
-        f"{'entry' if len(repairs) == 1 else 'entries'} filed under a key mureo "
-        f"cannot resolve."
-    )
-    for repair in repairs:
-        _echo_repair(repair)
-    _echo_undecidable_duplicates(doc)
+    if repairs:
+        typer.echo("")
+        typer.echo(
+            f"Found {len(repairs)} platform "
+            f"{'entry' if len(repairs) == 1 else 'entries'} filed under a key mureo "
+            f"cannot resolve."
+        )
+        removing = frozenset(repair.entry.key for repair in repairs)
+        for repair in repairs:
+            echo_repair(repair, removing=removing)
+    echo_kept_findings(plan.kept)
+    echo_undecidable_duplicates(doc)
     typer.echo("")
 
+    if not repairs:
+        # Everything found is the operator's call, so there is nothing
+        # ``--apply`` could do and no confirmation worth asking for.
+        typer.echo("Nothing to repair automatically: mureo will not remove the")
+        typer.echo("entries above, for the reason given under each one.")
+        return
     if not _confirmed(apply=apply, yes=yes):
         return
     _apply(state_file, keys)
@@ -431,7 +321,14 @@ def _repair_every_client(
     typer.echo("")
 
     needing = [survey for survey in surveys if survey.repairs]
-    if not needing:
+    if not needing and any(survey.kept for survey in surveys):
+        # Unresolvable entries were found; mureo just will not remove them.
+        # Saying "every key resolves" here would be plainly false (#616).
+        typer.echo(
+            "Nothing to repair automatically: mureo will not remove the entries "
+            "above, for the reason given under each one."
+        )
+    elif not needing:
         typer.echo(
             "Nothing to repair: every client's platform entries are filed under "
             "keys mureo can resolve."
@@ -512,22 +409,23 @@ def _echo_survey_summary(
     # so it gets its own group rather than a note hung off "Clean". The
     # operator this command is for reads "Clean (3 of 6)" as "three are
     # fine"; a qualifier after an em dash is exactly what they skim past.
+    # Since #616 the same applies to an unresolvable entry mureo declines to
+    # remove: it is neither a repair the sweep makes nor a clean client.
     _echo_survey_group(
         "Need your decision",
-        [
-            s
-            for s in surveys
-            if not s.repairs and not s.error and _undecidable_groups(s.doc)
-        ],
+        [s for s in surveys if _needs_a_decision(s)],
         total,
-        lambda _s: "one ad account under two real platform keys (see below)",
+        _decision_note,
     )
     _echo_survey_group(
         "Clean",
         [
             s
             for s in surveys
-            if not s.repairs and not s.error and not _undecidable_groups(s.doc)
+            if not s.repairs
+            and not s.error
+            and not s.kept
+            and not undecidable_groups(s.doc)
         ],
         total,
         _clean_note,
@@ -557,6 +455,29 @@ def _echo_survey_group(
     typer.echo("")
 
 
+def _needs_a_decision(survey: ClientSurvey) -> bool:
+    """Has this client a finding mureo reports but will not act on?
+
+    Only asked of clients with no repair of their own: a client that needs
+    both is counted under "Need repair", where the sweep will visit it anyway,
+    and its other findings still print in the detail below.
+    """
+    if survey.repairs or survey.error:
+        return False
+    return bool(survey.kept) or bool(undecidable_groups(survey.doc))
+
+
+def _decision_note(survey: ClientSurvey) -> str:
+    """Which of the two undecidable findings this client has — or both."""
+    notes = []
+    if undecidable_groups(survey.doc):
+        notes.append("one ad account under two real platform keys")
+    if survey.kept:
+        keys = ", ".join(_safe(finding.entry.key) for finding in survey.kept)
+        notes.append(f"mureo cannot resolve {keys}, and will not remove it")
+    return f"{'; '.join(notes)} (see below)"
+
+
 def _clean_note(survey: ClientSurvey) -> str:
     """Why a "clean" client may still not be the one holding the figures.
 
@@ -573,16 +494,20 @@ def _clean_note(survey: ClientSurvey) -> str:
 def _echo_survey_details(surveys: tuple[ClientSurvey, ...]) -> None:
     """The single-workspace detail block, per client that has a finding."""
     for survey in surveys:
-        if not survey.repairs and not _undecidable_groups(survey.doc):
+        if not (survey.repairs or survey.kept or undecidable_groups(survey.doc)):
             continue
         typer.echo("")
         typer.echo(f"--- {_client_label(survey.target)} ---")
         # Scrubbed: unlike the single run's ``--state-file``, this path came
         # from a backend's client registry rather than from the operator.
         typer.echo(f"STATE.json: {_safe(str(survey.target.state_file))}")
+        # Scoped per client: a sweep removes each client's entries from that
+        # client's document, so one client's plan says nothing about another's.
+        removing = frozenset(repair.entry.key for repair in survey.repairs)
         for repair in survey.repairs:
-            _echo_repair(repair)
-        _echo_undecidable_duplicates(survey.doc)
+            echo_repair(repair, removing=removing)
+        echo_kept_findings(survey.kept)
+        echo_undecidable_duplicates(survey.doc)
 
 
 def _apply_every_client(

--- a/mureo/context/platform_repair.py
+++ b/mureo/context/platform_repair.py
@@ -449,10 +449,20 @@ def apply_state_file_repairs(
         pre-repair document was backed up to.
 
     Raises:
-        ContextFileError: ``path`` exists but cannot be read or parsed. The
-            repair refuses to proceed on a document it cannot parse strictly,
-            because writing back a tolerantly-parsed one would silently drop
-            the entries the tolerant parse skipped.
+        ContextFileError: ``path`` exists but could not be opened, or its
+            bytes are not valid JSON.
+        ValueError: ``path`` holds valid JSON that does not satisfy the strict
+            schema — a campaign missing ``campaign_name``, say. This is what
+            :func:`~mureo.context.state.parse_state` raises and
+            :func:`~mureo.context.state.read_state_file` passes through
+            unwrapped; it is stated here because an earlier version of this
+            docstring promised ``ContextFileError`` for every unparseable
+            document, and a caller that believed it ended in a traceback
+            (#618). Callers reporting to a person must catch both.
+
+            Either way the repair refuses to proceed on a document it cannot
+            parse strictly, because writing back a tolerantly-parsed one would
+            silently drop the entries the tolerant parse skipped.
         OSError: The backup could not be written. Nothing is overwritten in
             that case — :func:`mureo.fsutil.backup_file` fails closed.
     """

--- a/mureo/context/platform_repair.py
+++ b/mureo/context/platform_repair.py
@@ -18,6 +18,46 @@ fail-open behaviour too: when the environment cannot be enumerated at all,
 every key is treated as resolvable and this module proposes nothing. A broken
 install is not evidence that an entry should be deleted.
 
+Unresolvable is not enough to propose removal (#616)
+----------------------------------------------------
+"mureo cannot resolve this key" is a fact about the **machine running the
+repair** — which plugins are importable at this moment — not about the entry.
+The same document is judged differently on two machines, and on the machine
+lacking a bridge a *legitimate* solitary entry, holding a real account's real
+figures and duplicating nothing, looked exactly like the invented key the
+command exists to remove.
+
+So the plan asks the **document** whether the entry is wrong, and offers
+removal only on one of two answers:
+
+- :data:`DROP_DUPLICATE` — another key in the same ``platforms`` map holds the
+  same ad account and mureo CAN resolve it. The record survives under the key
+  the account is really stored under, so this one is a second copy.
+- :data:`DROP_EMPTY_STUB` — the entry stores nothing at all: no campaigns, no
+  ``totals``, no ``periods`` and no operator-declared setting. There is
+  nothing in it to lose, whoever the key turns out to belong to.
+
+Everything else unresolvable is reported as a :class:`PlatformKeyFinding` and
+handed back, the way an undecidable duplicate already is. Note what does NOT
+make a stub: an empty ``account_id``. The shape reported from the field
+carries one, and treating "did not say which account" as "holds nothing"
+would delete precisely the solitary entry #616 is about.
+
+The one field a sync does not bring back (#617)
+------------------------------------------------
+``conversion_action_types`` (:class:`~mureo.context.models.PlatformState`) is
+an allow-list a **person** declared so a custom-event advertiser is counted
+correctly (#342). Nothing on the platform side knows it, so no sync restores
+it — unlike every figure in the entry. An entry carrying one is therefore
+never dropped, even when it is otherwise removable; it is reported as
+:data:`KEEP_CONVERSION_OVERRIDE` instead.
+
+Refusing rather than asking a second time is deliberate. The confirmation this
+command already asks is skippable with ``--yes``, which is exactly how the
+sweep this feature leads with (``--all --apply --yes``) is run, so a second
+prompt would protect nobody on the path that matters. A setting only an
+operator can supply is also, by definition, not mureo's to decide.
+
 Drop, never merge
 -----------------
 Two repairs were plausible: **move** the unresolvable entry's figures under
@@ -32,7 +72,9 @@ refuse. It is also undefined in the shape actually reported from the field: an
 unresolvable entry whose ``account_id`` is ``""`` joins with nothing, so there
 is no canonical entry to move it to. Dropping needs no such judgement. The
 figures are not lost — they are re-fetchable from the platform, and the
-pre-repair document is backed up first.
+pre-repair document is backed up first. That argument covers figures and
+nothing else, which is why the one operator-declared field is excluded from
+dropping altogether (see above).
 
 Nothing else in the document is touched. In particular ``last_synced_at`` is
 **not** re-stamped: a repair is not a sync, and re-stamping it would make
@@ -89,6 +131,18 @@ if TYPE_CHECKING:
 
     from mureo.context.models import PlatformState, StateDocument
 
+DROP_DUPLICATE = "duplicate"
+"""Offered: a key mureo CAN resolve holds the same ad account."""
+
+DROP_EMPTY_STUB = "empty_stub"
+"""Offered: the entry stores nothing — no figures, no declared settings."""
+
+KEEP_CARRIES_FIGURES = "carries_figures"
+"""Kept: nothing in the document says this entry is wrong (#616)."""
+
+KEEP_CONVERSION_OVERRIDE = "conversion_override"
+"""Kept: it carries ``conversion_action_types``, which no sync restores."""
+
 
 @dataclass(frozen=True)
 class RollupFacts:
@@ -113,6 +167,11 @@ class PlatformEntryFacts:
     it covers. No figures — the decision this supports is about identity, not
     about whose spend is larger, and putting the numbers side by side would
     invite exactly the comparison this module refuses to make.
+
+    ``conversion_action_types`` is the exception that proves the contract:
+    it is not a figure but a setting an operator declared, and it is the one
+    thing in the entry no sync restores (#617). A preview can only print what
+    this dataclass carries, so leaving it out was what made the loss silent.
     """
 
     key: str
@@ -123,6 +182,24 @@ class PlatformEntryFacts:
     metrics_period: str | None
     totals_fetched_at: str | None
     rollups: tuple[RollupFacts, ...]
+    conversion_action_types: tuple[str, ...] = ()
+
+    @property
+    def is_empty_stub(self) -> bool:
+        """Does this entry store nothing a removal could lose?
+
+        No campaigns, no ``totals``, no per-period rollups and no declared
+        conversion allow-list. An empty ``account_id`` deliberately does NOT
+        count towards this: the shape reported from the field carries one, and
+        an entry that declined to name its account can still hold every figure
+        a platform has (#616).
+        """
+        return not (
+            self.campaign_count
+            or self.has_totals
+            or self.rollups
+            or self.conversion_action_types
+        )
 
 
 @dataclass(frozen=True)
@@ -130,15 +207,52 @@ class PlatformKeyRepair:
     """One unresolvable entry mureo offers to drop, plus its context.
 
     ``same_account`` is every OTHER key that describes the same ad account, in
-    document order — the entries that survive the repair. It is empty when the
-    entry names no account mureo can join on, which is the shape reported from
-    the field (``account_id: ""``); an empty tuple therefore means "mureo
-    found nothing this could be a duplicate of", never "there is nothing
-    else".
+    document order. It is empty when the entry names no account mureo can join
+    on, which is the shape reported from the field (``account_id: ""``); an
+    empty tuple therefore means "mureo found nothing this could be a duplicate
+    of", never "there is nothing else". Its members are not all survivors —
+    another one may be in the same plan — so a caller previewing this has to
+    compare against the plan's own keys before promising anything about them
+    (#618).
+
+    ``reason`` is :data:`DROP_DUPLICATE` or :data:`DROP_EMPTY_STUB`: what in
+    the DOCUMENT says this entry is wrong. Unresolvability alone is not one of
+    them.
     """
 
     entry: PlatformEntryFacts
     same_account: tuple[PlatformEntryFacts, ...]
+    reason: str
+
+
+@dataclass(frozen=True)
+class PlatformKeyFinding:
+    """One unresolvable entry mureo will NOT remove, and why.
+
+    Reported rather than repaired, the way an undecidable duplicate already
+    is. ``reason`` is :data:`KEEP_CARRIES_FIGURES` (nothing in the document
+    says the entry is wrong — the key may belong to a plugin that is simply
+    not installed on this machine) or :data:`KEEP_CONVERSION_OVERRIDE` (the
+    entry could otherwise go, but carries a setting no sync restores).
+    """
+
+    entry: PlatformEntryFacts
+    same_account: tuple[PlatformEntryFacts, ...]
+    reason: str
+
+
+@dataclass(frozen=True)
+class PlatformKeyPlan:
+    """Every unresolvable entry, split by whether mureo will act on it.
+
+    ``repairs`` is what an ``--apply`` would remove; ``kept`` is what it would
+    leave and report. A caller reporting "nothing to repair" has to consult
+    both: a document whose only finding is in ``kept`` is not clean, it is
+    waiting on the operator.
+    """
+
+    repairs: tuple[PlatformKeyRepair, ...]
+    kept: tuple[PlatformKeyFinding, ...]
 
 
 @dataclass(frozen=True)
@@ -204,41 +318,89 @@ def _describe(key: str, entry: PlatformState) -> PlatformEntryFacts:
             RollupFacts(period=str(period), fetched_at=_rollup_fetched_at(rollup))
             for period, rollup in periods.items()
         ),
+        conversion_action_types=tuple(entry.conversion_action_types or ()),
     )
 
 
-def plan_platform_key_repairs(
+def _drop_reason(
+    entry: PlatformEntryFacts, same_account: tuple[PlatformEntryFacts, ...]
+) -> str | None:
+    """What in the DOCUMENT says this entry is wrong, or ``None`` (#616).
+
+    Two answers only, and neither of them is "the key does not resolve on this
+    machine". A sibling that is itself unresolvable does not count as a
+    duplicate: two entries mureo cannot vouch for are not evidence against
+    each other, and dropping either still loses figures nothing refills.
+    """
+    if any(other.resolvable for other in same_account):
+        return DROP_DUPLICATE
+    if entry.is_empty_stub:
+        return DROP_EMPTY_STUB
+    return None
+
+
+def plan_platform_keys(
     doc: StateDocument, *, keys: Iterable[str] | None = None
-) -> tuple[PlatformKeyRepair, ...]:
-    """Every entry filed under a key mureo cannot resolve, in document order.
+) -> PlatformKeyPlan:
+    """Every unresolvable entry, split into what mureo will and will not touch.
 
     Pure — it reads ``doc`` and returns a description. This is what a dry run
-    shows, and what :func:`apply_state_file_repairs` re-derives under the lock
+    shows, and :func:`apply_state_file_repairs` re-derives it under the lock
     before writing anything.
 
     ``keys`` narrows the plan to the named keys. A named key that resolves
-    fine, or that the document does not carry, simply produces no repair;
+    fine, or that the document does not carry, simply produces nothing;
     telling the operator which of the two happened needs the document itself
     and is the caller's job.
     """
     platforms = doc.platforms or {}
     wanted = frozenset(keys) if keys is not None else None
-    return tuple(
-        PlatformKeyRepair(
-            entry=_describe(key, entry),
-            same_account=tuple(
-                _describe(other, platforms[other])
-                for other in platform_keys_for_account(platforms, entry.account_id)
-                if other != key
-            ),
+    repairs: list[PlatformKeyRepair] = []
+    kept: list[PlatformKeyFinding] = []
+    for key, entry in platforms.items():
+        if wanted is not None and key not in wanted:
+            continue
+        if not is_unresolvable_platform_key(key):
+            continue
+        facts = _describe(key, entry)
+        same_account = tuple(
+            _describe(other, platforms[other])
+            for other in platform_keys_for_account(platforms, entry.account_id)
+            if other != key
         )
-        for key, entry in platforms.items()
-        if (wanted is None or key in wanted) and is_unresolvable_platform_key(key)
-    )
+        reason = _drop_reason(facts, same_account)
+        if reason is None:
+            kept.append(PlatformKeyFinding(facts, same_account, KEEP_CARRIES_FIGURES))
+        elif facts.conversion_action_types:
+            # Removable by the document, but it carries the one field a sync
+            # does not bring back (#617). Reported, never dropped.
+            kept.append(
+                PlatformKeyFinding(facts, same_account, KEEP_CONVERSION_OVERRIDE)
+            )
+        else:
+            repairs.append(PlatformKeyRepair(facts, same_account, reason))
+    return PlatformKeyPlan(repairs=tuple(repairs), kept=tuple(kept))
+
+
+def plan_platform_key_repairs(
+    doc: StateDocument, *, keys: Iterable[str] | None = None
+) -> tuple[PlatformKeyRepair, ...]:
+    """Only the entries :func:`plan_platform_keys` offers to remove.
+
+    The narrow view, for callers with nothing to say about the entries mureo
+    hands back. Anything that reports to an operator wants
+    :func:`plan_platform_keys`: an empty result here does NOT mean the
+    document is clean.
+    """
+    return plan_platform_keys(doc, keys=keys).repairs
 
 
 def drop_platform_entries(doc: StateDocument, keys: Iterable[str]) -> StateDocument:
     """Return ``doc`` without the ``platforms`` entries named by ``keys``.
+
+    Removes the WHOLE entry, ``conversion_action_types`` included — which is
+    why :func:`plan_platform_keys` never names a key carrying one (#617).
+    This function takes the caller's word for it and does not re-check.
 
     Pure, and deliberately narrow: only the ``platforms`` map changes.
     ``last_synced_at`` is not re-stamped (a repair is not a sync), the legacy
@@ -258,7 +420,13 @@ def drop_platform_entries(doc: StateDocument, keys: Iterable[str]) -> StateDocum
 def apply_state_file_repairs(
     path: Path, *, keys: Iterable[str] | None = None
 ) -> RepairOutcome:
-    """Drop every unresolvable ``platforms`` entry in ``path``, safely.
+    """Drop every ``platforms`` entry the document shows to be wrong, safely.
+
+    "Unresolvable" is the filter, not the criterion: an entry is removed only
+    when it duplicates a resolvable key holding the same ad account or is an
+    empty stub, and never when it carries an operator-declared conversion
+    allow-list. See :func:`plan_platform_keys`.
+
 
     The whole cycle — read, plan, back up, write — runs inside the STATE.json
     sidecar lock every other mutator contends on, so a concurrent sync cannot
@@ -304,7 +472,13 @@ def apply_state_file_repairs(
 
 
 __all__ = [
+    "DROP_DUPLICATE",
+    "DROP_EMPTY_STUB",
+    "KEEP_CARRIES_FIGURES",
+    "KEEP_CONVERSION_OVERRIDE",
     "PlatformEntryFacts",
+    "PlatformKeyFinding",
+    "PlatformKeyPlan",
     "PlatformKeyRepair",
     "RepairOutcome",
     "RollupFacts",
@@ -312,4 +486,5 @@ __all__ = [
     "drop_platform_entries",
     "is_unresolvable_platform_key",
     "plan_platform_key_repairs",
+    "plan_platform_keys",
 ]

--- a/tests/test_cli_repair.py
+++ b/tests/test_cli_repair.py
@@ -284,6 +284,158 @@ class TestScope:
 
 
 # ---------------------------------------------------------------------------
+# The preview has to be TRUE (#616 / #617 / #618)
+# ---------------------------------------------------------------------------
+
+
+class TestThePreviewIsTrue:
+    """Every sentence printed before the confirmation has to hold afterwards.
+
+    The person reading it cannot open STATE.json to check, so a reassurance
+    that is false for the run they are about to approve is worse than no
+    reassurance at all.
+    """
+
+    def test_a_solitary_entry_with_figures_is_reported_not_offered(
+        self, tmp_path: Path
+    ) -> None:
+        """#616. ``logly_ads_v2`` is not registered by the one pinned plugin,
+        but nothing in the document says it is wrong — so it is handed back."""
+        state = tmp_path / "STATE.json"
+        _write(
+            state,
+            {
+                "version": "2",
+                "platforms": {
+                    "logly_ads_v2": {
+                        "account_id": "1234567890",
+                        "totals": {
+                            "spend": 128000.0,
+                            "fetched_at": "2026-08-13T23:10:00Z",
+                        },
+                        "metrics_period": "LAST_30_DAYS",
+                    }
+                },
+            },
+        )
+        before = state.read_bytes()
+
+        result = _run("--state-file", str(state), "--apply", "--yes")
+
+        assert result.exit_code == 0, result.output
+        assert state.read_bytes() == before
+        assert "will NOT remove" in result.output
+        assert "not be installed" in result.output
+
+    def test_a_conversion_override_is_named_and_the_entry_is_kept(
+        self, tmp_path: Path
+    ) -> None:
+        """#617. The allow-list is operator-declared and no sync restores it,
+        so it is named in the preview AND the entry is refused, not offered
+        behind a confirmation the ``--yes`` flag would walk straight through."""
+        state = tmp_path / "STATE.json"
+        _write(
+            state,
+            {
+                "version": "2",
+                "platforms": {
+                    "logly_ads": {
+                        "account_id": "1234567890",
+                        "conversion_action_types": ["offsite_conversion.custom.90210"],
+                    },
+                    "logly_ads_context": {"account_id": "1234567890"},
+                },
+            },
+        )
+        before = state.read_bytes()
+
+        result = _run("--state-file", str(state), "--apply", "--yes")
+
+        assert result.exit_code == 0, result.output
+        out = result.output
+        assert "conversion_action_types" in out
+        assert "offsite_conversion.custom.90210" in out
+        assert "no sync restores this" in out
+        assert "will NOT remove" in out
+        # And nothing was removed.
+        assert state.read_bytes() == before
+
+    def test_two_entries_in_one_plan_never_claim_the_others_are_untouched(
+        self, tmp_path: Path
+    ) -> None:
+        """#618, first half. ``every other platform entry is left exactly as
+        it is`` printed once per block contradicts itself the moment a plan
+        holds two entries."""
+        state = tmp_path / "STATE.json"
+        _write(
+            state,
+            {
+                "version": "2",
+                "platforms": {
+                    "logly_ads": {"account_id": "1111111111"},
+                    "logly_adz": {"account_id": "2222222222"},
+                    "logly_ads_context": {"account_id": "3333333333"},
+                },
+            },
+        )
+
+        result = _run("--state-file", str(state))
+
+        assert result.exit_code == 0, result.output
+        out = result.output
+        assert "Found 2 platform entries" in out
+        assert "other platform entry is left exactly as it is" not in out
+        assert "other than the 2 this run removes" in out
+        assert "This run removes: logly_ads, logly_adz." in out
+
+    def test_one_entry_in_a_plan_keeps_the_plain_reassurance(
+        self, tmp_path: Path
+    ) -> None:
+        state = tmp_path / "STATE.json"
+        _reported_state(state)
+
+        result = _run("--state-file", str(state))
+
+        assert result.exit_code == 0, result.output
+        assert "other platform entry is left exactly as it is" in result.output
+
+    def test_two_dropped_entries_sharing_an_account_say_it_is_left_empty(
+        self, tmp_path: Path
+    ) -> None:
+        """#618, second half. Neither block used to mention the other, so the
+        operator was never told the ad account would have no entry left."""
+        state = tmp_path / "STATE.json"
+        _write(
+            state,
+            {
+                "version": "2",
+                "platforms": {
+                    "logly_ads": {"account_id": "1234567890"},
+                    "logly_adz": {"account_id": "1234567890"},
+                },
+            },
+        )
+
+        result = _run("--state-file", str(state))
+
+        assert result.exit_code == 0, result.output
+        out = result.output
+        # Both blocks say it, not just the first.
+        assert out.count("NO record of that account") == 2
+        assert out.count("this run removes this entry too") == 2
+
+    def test_the_reason_the_entry_can_go_is_stated(self, tmp_path: Path) -> None:
+        state = tmp_path / "STATE.json"
+        _reported_state(state)
+
+        result = _run("--state-file", str(state))
+
+        assert result.exit_code == 0, result.output
+        assert "Why it can go:" in result.output
+        assert "duplicates" in result.output
+
+
+# ---------------------------------------------------------------------------
 # STATE.json is agent-writable, so its strings are attacker-influenceable
 # ---------------------------------------------------------------------------
 

--- a/tests/test_cli_repair.py
+++ b/tests/test_cli_repair.py
@@ -161,6 +161,124 @@ class TestDryRunIsTheDefault:
 
 
 # ---------------------------------------------------------------------------
+# A document mureo cannot read is an error, never a traceback (#618)
+# ---------------------------------------------------------------------------
+
+
+class TestAnUnreadableDocument:
+    """The person this command is for cannot read a traceback.
+
+    ``read_state_file`` wraps ``json.JSONDecodeError`` only. Strict parsing
+    also raises a bare ``ValueError`` for a document that is valid JSON but
+    invalid against the schema, and nothing on this path caught it — so a
+    campaign missing ``campaign_name`` ended in a full Python traceback while
+    ``--all`` reported the same file as "Could not be read".
+    """
+
+    def test_a_schema_invalid_document_is_an_error_not_a_traceback(
+        self, tmp_path: Path
+    ) -> None:
+        state = tmp_path / "STATE.json"
+        _write(
+            state,
+            {
+                "version": "2",
+                "platforms": {
+                    "logly_ads": {
+                        "account_id": "1234567890",
+                        "campaigns": [{"campaign_id": "c-1"}],
+                    }
+                },
+            },
+        )
+
+        result = _run("--state-file", str(state))
+
+        assert result.exit_code == 1
+        assert result.exception is None or isinstance(result.exception, SystemExit)
+        assert "Traceback" not in result.output
+        assert "Error:" in result.output
+        assert str(state) in result.output
+        assert "Campaign is missing required field" in result.output
+
+    def test_apply_on_a_schema_invalid_document_is_an_error_too(
+        self, tmp_path: Path
+    ) -> None:
+        """Same file, the destructive flags. It must not crash there either,
+        and nothing may be written or backed up."""
+        state = tmp_path / "STATE.json"
+        _write(
+            state,
+            {
+                "version": "2",
+                "platforms": {
+                    "logly_ads": {
+                        "account_id": "1234567890",
+                        "campaigns": [{"campaign_id": "c-1"}],
+                    }
+                },
+            },
+        )
+        before = state.read_bytes()
+
+        result = _run("--state-file", str(state), "--apply", "--yes")
+
+        assert result.exit_code == 1
+        assert "Traceback" not in result.output
+        assert "Error:" in result.output
+        assert state.read_bytes() == before
+        assert list(tmp_path.glob("STATE.json.bak.*")) == []
+
+    def test_a_document_that_breaks_between_preview_and_lock_is_an_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The apply path re-reads under the lock, so a concurrent writer can
+        hand it a document the preview never saw. That is the same
+        ``ValueError``, and it must not surface as a traceback either."""
+        from mureo.cli import repair_cmd
+
+        state = tmp_path / "STATE.json"
+        _reported_state(state)
+
+        def _explode(*_args: Any, **_kwargs: Any) -> None:
+            raise ValueError("Campaign is missing required field 'campaign_name': {}")
+
+        monkeypatch.setattr(repair_cmd, "apply_state_file_repairs", _explode)
+
+        result = _run("--state-file", str(state), "--apply", "--yes")
+
+        assert result.exit_code == 1
+        assert "Traceback" not in result.output
+        assert "Error: mureo cannot read STATE.json" in result.output
+        assert "Campaign is missing required field" in result.output
+
+    def test_control_characters_in_the_parse_error_are_scrubbed(
+        self, tmp_path: Path
+    ) -> None:
+        """The failing text comes out of STATE.json, so the exception carries
+        agent-writable content straight to a terminal."""
+        state = tmp_path / "STATE.json"
+        _write(
+            state,
+            {
+                "version": "2",
+                "platforms": {
+                    "logly_ads": {
+                        "account_id": "1234567890",
+                        "campaigns": [{"campaign_id": "c-1\x1b[2J\x07"}],
+                    }
+                },
+            },
+        )
+
+        result = _run("--state-file", str(state))
+
+        assert result.exit_code == 1
+        assert "\x1b" not in result.output
+        assert "\x07" not in result.output
+
+
+# ---------------------------------------------------------------------------
 # Applying
 # ---------------------------------------------------------------------------
 

--- a/tests/test_cli_repair_all.py
+++ b/tests/test_cli_repair_all.py
@@ -472,6 +472,58 @@ class TestPartialFailure:
         assert _platform_keys(paths["acme"]) == {"logly_ads_context"}
         assert _platform_keys(paths["beta"]) == {"logly_ads_context"}
 
+    def test_both_paths_report_the_same_unreadable_document_the_same_way(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """#618's point is that the two paths DISAGREED about one file.
+
+        A STATE.json that is valid JSON but invalid against the schema was
+        reported by ``--all`` under "Could not be read" and crashed the
+        single-workspace run with a raw traceback. Same document, same
+        command, two answers — and the operator this is written for cannot
+        read the second one. So the reason text is asserted to be the same on
+        both paths, not merely "neither traceback".
+        """
+        state = tmp_path / "theta" / "STATE.json"
+        _write(
+            state,
+            {
+                "version": "2",
+                "platforms": {
+                    "logly_ads": {
+                        "account_id": "1234567890",
+                        "campaigns": [{"campaign_id": "c-1"}],
+                    }
+                },
+            },
+        )
+        reason = "Campaign is missing required field 'campaign_name'"
+
+        single = _run("--state-file", str(state))
+
+        assert single.exit_code == 1
+        assert "Traceback" not in single.output
+        assert "Error:" in single.output
+        assert reason in single.output
+        assert str(state) in single.output
+
+        rows = [{"slug": "theta", "name": "Theta AB", "active": True}]
+        _install_store(
+            monkeypatch,
+            _AgencyStore(state, rows, {"theta": _ClientStore(state)}),
+        )
+
+        sweep = _run("--all")
+
+        assert sweep.exit_code == 1
+        assert "Traceback" not in sweep.output
+        assert "Could not be read (1 of 1)" in sweep.output
+        assert reason in sweep.output
+        # And the sweep does not close by calling a document it never read
+        # clean: "every client's entries resolve" is not knowable here.
+        assert "every client's platform entries are filed under" not in sweep.output
+        assert "Nothing to repair in the clients that could be read." in sweep.output
+
     def test_an_unreadable_client_makes_even_a_dry_run_exit_non_zero(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_cli_repair_all.py
+++ b/tests/test_cli_repair_all.py
@@ -239,6 +239,94 @@ class TestSurvey:
         # The one genuinely finished client is the only one called clean.
         assert "Clean (1 of 3)" in out
 
+    def test_an_entry_mureo_will_not_remove_is_not_counted_as_needing_repair(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """#616 narrowed the plan, and the summary has to follow it.
+
+        ``theta``'s only finding is a solitary entry under a key no plugin
+        installed HERE registers, holding figures and duplicating nothing.
+        mureo will not remove it, so counting theta under "Need repair" would
+        promise a repair the sweep never makes — and counting it under "Clean"
+        would tell the operator there is nothing to look at.
+        """
+        paths = {
+            slug: tmp_path / slug / "STATE.json" for slug in ("acme", "theta", "gamma")
+        }
+        _bad_state(paths["acme"], "1111111111")
+        _write(
+            paths["theta"],
+            {
+                "version": "2",
+                "platforms": {
+                    "logly_ads_v2": {
+                        "account_id": "5555555555",
+                        "totals": {
+                            "spend": 128000.0,
+                            "fetched_at": "2026-08-13T23:10:00+00:00",
+                        },
+                        "metrics_period": "LAST_30_DAYS",
+                    }
+                },
+            },
+        )
+        _clean_state(paths["gamma"], "3333333333")
+        stores = {slug: _ClientStore(path) for slug, path in paths.items()}
+        rows = [
+            {"slug": "acme", "name": "Acme Co", "active": True},
+            {"slug": "theta", "name": "Theta AB", "active": False},
+            {"slug": "gamma", "name": "Gamma KK", "active": False},
+        ]
+        _install_store(monkeypatch, _AgencyStore(paths["acme"], rows, dict(stores)))
+        before = paths["theta"].read_bytes()
+
+        result = _run("--all", "--apply", "--yes")
+
+        assert result.exit_code == 0, result.output
+        out = result.output
+        assert "Need repair (1 of 3)" in out
+        assert "Need your decision (1 of 3)" in out
+        assert "Clean (1 of 3)" in out
+        # And the sweep left it alone.
+        assert paths["theta"].read_bytes() == before
+        assert list(tmp_path.glob("theta/STATE.json.bak.*")) == []
+
+    def test_a_sweep_whose_only_findings_are_undecidable_says_so(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With nothing to repair the sweep must not claim every key resolves
+        — one of them plainly does not."""
+        path = tmp_path / "theta" / "STATE.json"
+        _write(
+            path,
+            {
+                "version": "2",
+                "platforms": {
+                    "logly_ads_v2": {
+                        "account_id": "5555555555",
+                        "totals": {
+                            "spend": 128000.0,
+                            "fetched_at": "2026-08-13T23:10:00+00:00",
+                        },
+                    }
+                },
+            },
+        )
+        rows = [{"slug": "theta", "name": "Theta AB", "active": True}]
+        _install_store(
+            monkeypatch, _AgencyStore(path, rows, {"theta": _ClientStore(path)})
+        )
+
+        result = _run("--all")
+
+        assert result.exit_code == 0, result.output
+        out = result.output
+        assert "Need your decision (1 of 1)" in out
+        assert (
+            "every client's platform entries are filed under keys mureo can" not in out
+        )
+        assert "Nothing to repair automatically" in out
+
     def test_the_summary_comes_before_the_per_client_detail(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_platform_repair.py
+++ b/tests/test_platform_repair.py
@@ -16,10 +16,14 @@ What these tests pin:
   - a duplicate whose two keys BOTH name real platforms is left alone — that
     is the case ``mureo/web/reports.py`` deliberately refuses to decide, and
     this repair does not widen into a general duplicate merger;
-  - a lone unresolvable key that is NOT part of a duplicate is IN scope. It
-    has to be: the shape actually reported from the field carries
-    ``account_id: ""`` on one of the two entries, and an unknown id is never
-    a join key, so the account join cannot see that pair at all;
+  - **unresolvable alone is not enough to offer removal** (#616). "mureo
+    cannot resolve this key" is a fact about the machine running the repair,
+    not about the entry — the plugin that registers the key may simply not be
+    installed here. Removal is offered only when the DOCUMENT shows the entry
+    is wrong: it duplicates a key mureo CAN resolve holding the same ad
+    account, or it is an empty stub;
+  - an entry carrying ``conversion_action_types`` is never dropped (#617).
+    That allow-list is operator-declared, so no sync restores it;
   - the write goes through a path ``guard_platform_entry_write`` does not
     refuse — verified against a document the create guard would reject;
   - nothing is summed, moved or re-stamped: the surviving entry is byte-for
@@ -41,10 +45,15 @@ import pytest
 
 from mureo.context import platform_guards
 from mureo.context.platform_repair import (
+    DROP_DUPLICATE,
+    DROP_EMPTY_STUB,
+    KEEP_CARRIES_FIGURES,
+    KEEP_CONVERSION_OVERRIDE,
     apply_state_file_repairs,
     drop_platform_entries,
     is_unresolvable_platform_key,
     plan_platform_key_repairs,
+    plan_platform_keys,
 )
 from mureo.context.state import read_state_file
 from mureo.core.runtime_context import default_runtime_context, reset_runtime_context
@@ -433,14 +442,20 @@ class TestScope:
         assert outcome.changed is False
         assert path.read_bytes() == before
 
-    def test_a_lone_unresolvable_key_is_in_scope(
+    def test_a_lone_unresolvable_key_with_figures_is_out_of_scope(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """IN scope, and it has to be: the shape actually reported from the
-        field has ``account_id: ""`` on the bad entry, and an unknown id is
-        never a join key — so ``duplicate_account_entries`` cannot see that
-        pair, and a duplicate-only repair would miss the very incident this
-        issue was filed for."""
+        """Reversed by #616, deliberately.
+
+        It used to be IN scope, on the reasoning that the reported shape
+        carries ``account_id: ""`` on the bad entry so the account join cannot
+        see the pair. But an entry that joins with nothing and carries figures
+        is indistinguishable from a legitimate solitary entry whose bridge is
+        not installed on THIS machine — and deleting that one loses the only
+        record of real spend. An entry with an unknown account id and nothing
+        stored is still offered (it is an empty stub); one carrying figures is
+        reported for the operator instead.
+        """
         _pin_installed_platforms(monkeypatch, "logly_ads_context")
         path = tmp_path / "STATE.json"
         _write(
@@ -456,15 +471,19 @@ class TestScope:
                 },
             },
         )
+        before = path.read_bytes()
 
-        (repair,) = plan_platform_key_repairs(read_state_file(path))
-        assert repair.entry.key == "logly_ads"
-        assert repair.entry.account_id == ""
-        # The join cannot connect the two, so the plan claims no context.
-        assert repair.same_account == ()
+        plan = plan_platform_keys(read_state_file(path))
+        assert plan.repairs == ()
+        (finding,) = plan.kept
+        assert finding.entry.key == "logly_ads"
+        assert finding.entry.account_id == ""
+        assert finding.reason == KEEP_CARRIES_FIGURES
+        # The join cannot connect the two, so the finding claims no context.
+        assert finding.same_account == ()
 
-        apply_state_file_repairs(path)
-        assert set(read_state_file(path).platforms) == {"logly_ads_context"}
+        assert apply_state_file_repairs(path).changed is False
+        assert path.read_bytes() == before
 
     def test_only_the_named_key_is_repaired(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -519,6 +538,288 @@ class TestScope:
 
         assert outcome.changed is False
         assert not path.exists()
+
+
+# ---------------------------------------------------------------------------
+# What the document has to SAY before an entry is offered (#616)
+# ---------------------------------------------------------------------------
+
+
+class TestWhatIsOfferedForRemoval:
+    """Unresolvable alone selects nothing. The document has to show it is wrong.
+
+    ``is_unresolvable_platform_key`` answers a question about the machine
+    running the repair — which plugins are importable right now — not about
+    the entry. On a machine where a bridge is not installed, that machine's
+    legitimate solitary entry looks exactly like an invented key. So the plan
+    asks the DOCUMENT instead: is this a duplicate of a key mureo can resolve
+    holding the same ad account, or is it an empty stub?
+    """
+
+    def test_a_solitary_entry_with_figures_is_not_offered(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The #616 case: a real platform, real figures, duplicating nothing —
+        on a machine that simply does not have the bridge installed."""
+        _pin_installed_platforms(monkeypatch)  # no plugin installed HERE
+        path = tmp_path / "STATE.json"
+        _write(
+            path,
+            {
+                "version": "2",
+                "platforms": {
+                    "logly_ads_context": {
+                        "account_id": "1234567890",
+                        "campaigns": [
+                            {
+                                "campaign_id": "c-1",
+                                "campaign_name": "Always-on prospecting",
+                                "status": "ENABLED",
+                            }
+                        ],
+                        "totals": _logly_totals(128000.0, "2026-08-13T23:10:00Z"),
+                        "metrics_period": "LAST_30_DAYS",
+                    }
+                },
+            },
+        )
+        before = path.read_bytes()
+
+        plan = plan_platform_keys(read_state_file(path))
+
+        assert plan.repairs == ()
+        (finding,) = plan.kept
+        assert finding.entry.key == "logly_ads_context"
+        assert finding.reason == KEEP_CARRIES_FIGURES
+        assert apply_state_file_repairs(path).changed is False
+        assert path.read_bytes() == before
+
+    def test_a_duplicate_of_a_resolvable_key_is_offered(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The incident's own shape: same ad account, one key that resolves."""
+        _pin_installed_platforms(monkeypatch, "logly_ads_context")
+        path = tmp_path / "STATE.json"
+        _write(path, _reported_document())
+
+        plan = plan_platform_keys(read_state_file(path))
+
+        (repair,) = plan.repairs
+        assert repair.entry.key == "logly_ads"
+        assert repair.reason == DROP_DUPLICATE
+        assert plan.kept == ()
+
+    def test_a_duplicate_of_another_UNRESOLVABLE_key_is_not_offered(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Two entries neither of which mureo can vouch for are not evidence
+        against each other: dropping one still loses figures nothing refills."""
+        _pin_installed_platforms(monkeypatch)
+        path = tmp_path / "STATE.json"
+        _write(
+            path,
+            {
+                "version": "2",
+                "platforms": {
+                    "logly_ads": {
+                        "account_id": "1234567890",
+                        "totals": _logly_totals(9000.0, "2026-08-01T03:00:00+00:00"),
+                    },
+                    "logly_ads_context": {
+                        "account_id": "1234567890",
+                        "totals": _logly_totals(4500.0, "2026-08-12T03:00:00+00:00"),
+                    },
+                },
+            },
+        )
+
+        plan = plan_platform_keys(read_state_file(path))
+
+        assert plan.repairs == ()
+        assert [f.reason for f in plan.kept] == [
+            KEEP_CARRIES_FIGURES,
+            KEEP_CARRIES_FIGURES,
+        ]
+
+    def test_an_empty_stub_is_offered(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No campaigns, no totals, no periods, no declared settings — there
+        is nothing in it to lose, whoever the key belongs to."""
+        _pin_installed_platforms(monkeypatch)
+        path = tmp_path / "STATE.json"
+        _write(
+            path,
+            {"version": "2", "platforms": {"logly_ads": {"account_id": "1234567890"}}},
+        )
+
+        plan = plan_platform_keys(read_state_file(path))
+
+        (repair,) = plan.repairs
+        assert repair.entry.key == "logly_ads"
+        assert repair.reason == DROP_EMPTY_STUB
+        apply_state_file_repairs(path)
+        assert read_state_file(path).platforms == {}
+
+    def test_an_id_less_empty_stub_is_offered(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An empty ``account_id`` is not what makes a stub — an entry with an
+        unknown id and real figures is NOT one — but it does not save an entry
+        that stores nothing either."""
+        _pin_installed_platforms(monkeypatch, "logly_ads_context")
+        path = tmp_path / "STATE.json"
+        _write(
+            path,
+            {
+                "version": "2",
+                "platforms": {
+                    "logly_ads_context": {"account_id": "1234567890"},
+                    "logly_ads": {"account_id": ""},
+                },
+            },
+        )
+
+        plan = plan_platform_keys(read_state_file(path))
+
+        (repair,) = plan.repairs
+        assert repair.entry.key == "logly_ads"
+        assert repair.reason == DROP_EMPTY_STUB
+
+    def test_an_entry_that_only_carries_periods_is_not_a_stub(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _pin_installed_platforms(monkeypatch)
+        path = tmp_path / "STATE.json"
+        _write(
+            path,
+            {
+                "version": "2",
+                "platforms": {
+                    "logly_ads": {
+                        "account_id": "",
+                        "periods": {
+                            "YESTERDAY": {
+                                "spend": 100.0,
+                                "fetched_at": "2026-08-13T00:00:00Z",
+                            }
+                        },
+                    }
+                },
+            },
+        )
+
+        plan = plan_platform_keys(read_state_file(path))
+
+        assert plan.repairs == ()
+        assert [f.reason for f in plan.kept] == [KEEP_CARRIES_FIGURES]
+
+
+# ---------------------------------------------------------------------------
+# The one field no sync brings back (#617)
+# ---------------------------------------------------------------------------
+
+
+class TestOperatorDeclaredSettings:
+    """``conversion_action_types`` is declared by a person, not fetched (#342).
+
+    Every other thing a ``platforms`` entry holds — the ad account, campaigns,
+    ``totals``, ``periods``, ``metrics_period`` — is re-fetchable, which is
+    what makes "drop it, the next sync refills the real key" a safe repair.
+    This one is not: nothing on the platform side knows it, so dropping the
+    entry loses it for good. mureo refuses rather than asking the operator to
+    confirm a loss it can avoid.
+    """
+
+    def test_an_entry_carrying_an_override_is_never_dropped(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _pin_installed_platforms(monkeypatch, "logly_ads_context")
+        path = tmp_path / "STATE.json"
+        _write(
+            path,
+            {
+                "version": "2",
+                "platforms": {
+                    "logly_ads": {
+                        "account_id": "1234567890",
+                        "conversion_action_types": ["offsite_conversion.custom.90210"],
+                    },
+                    "logly_ads_context": {"account_id": "1234567890"},
+                },
+            },
+        )
+        before = path.read_bytes()
+
+        plan = plan_platform_keys(read_state_file(path))
+
+        # It IS a duplicate of a resolvable key — the only thing holding it
+        # back is the setting no sync restores.
+        assert plan.repairs == ()
+        (finding,) = plan.kept
+        assert finding.entry.key == "logly_ads"
+        assert finding.reason == KEEP_CONVERSION_OVERRIDE
+        assert apply_state_file_repairs(path).changed is False
+        assert path.read_bytes() == before
+
+    def test_the_override_is_carried_into_the_facts_an_operator_reads(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``PlatformEntryFacts`` is what the preview can print, so a field
+        that is invisible there cannot be named before a confirmation."""
+        _pin_installed_platforms(monkeypatch, "logly_ads_context")
+        path = tmp_path / "STATE.json"
+        _write(
+            path,
+            {
+                "version": "2",
+                "platforms": {
+                    "logly_ads": {
+                        "account_id": "1234567890",
+                        "conversion_action_types": [
+                            "offsite_conversion.custom.90210",
+                            "offsite_conversion.custom.90211",
+                        ],
+                    },
+                },
+            },
+        )
+
+        (finding,) = plan_platform_keys(read_state_file(path)).kept
+
+        assert finding.entry.conversion_action_types == (
+            "offsite_conversion.custom.90210",
+            "offsite_conversion.custom.90211",
+        )
+
+    def test_an_override_survives_a_repair_of_a_sibling_entry(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The refusal is per entry, not per document: a stub beside it is
+        still removed, and the declared allow-list is still there afterwards."""
+        _pin_installed_platforms(monkeypatch, "logly_ads_context")
+        path = tmp_path / "STATE.json"
+        _write(
+            path,
+            {
+                "version": "2",
+                "platforms": {
+                    "logly_ads": {"account_id": "1234567890"},
+                    "logly_ads_context": {
+                        "account_id": "1234567890",
+                        "conversion_action_types": ["offsite_conversion.custom.90210"],
+                    },
+                },
+            },
+        )
+
+        outcome = apply_state_file_repairs(path)
+
+        assert [r.entry.key for r in outcome.repairs] == ["logly_ads"]
+        doc = read_state_file(path)
+        assert doc.platforms["logly_ads_context"].conversion_action_types == (
+            "offsite_conversion.custom.90210",
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`mureo repair platform-key` was shipped this morning (#610/#614) for a live
incident, and is about to be run on real data by a non-engineer. Three
defects held it back. They overlap in the same two functions, so they are
fixed together.

The bar this PR is written to: **the preview must be true, and nothing
irreplaceable may be removed without the operator being told.**

## #616 — the delete criterion was wrong

`plan_platform_key_repairs` selected every entry for which
`is_unresolvable_platform_key(key)` was true. But "mureo cannot resolve this
key" is a fact about the **machine running the repair** — which plugin
bridges are importable right now — not about the entry. The same STATE.json
was therefore judged differently on two machines, and on the machine lacking
a bridge a *legitimate* solitary entry (real platform, real figures,
duplicating nothing) became a deletion candidate. Worst under `--all`, which
sweeps every client from one host whose plugin set need not match the machine
that wrote each document.

**New criterion.** Unresolvability is now the *filter*; the criterion is what
the **document** says. An entry is offered for removal only when:

- `DROP_DUPLICATE` — another key in the same `platforms` map holds the same ad
  account **and mureo can resolve it**. The record survives under the key the
  account is really stored under. A sibling that is itself unresolvable does
  not count: two entries mureo cannot vouch for are not evidence against each
  other.
- `DROP_EMPTY_STUB` — the entry stores nothing: no campaigns, no `totals`, no
  `periods`, no `conversion_action_types`.

An empty `account_id` deliberately does **not** make a stub. The shape
reported from the field carries one, and an entry that never said which
account it describes can still hold every figure a platform has — defining
the stub by the missing id would delete exactly the entry this issue is
about.

Everything else unresolvable is reported and handed back, with the reason
under each block, the way an undecidable duplicate already was:

- `KEEP_CARRIES_FIGURES` — nothing in the document says it is wrong.
- `KEEP_CONVERSION_OVERRIDE` — see below.

This reverses a decision recorded in `tests/test_platform_repair.py` (the
lone `account_id: ""` entry was deliberately kept in scope). That test is
rewritten with the reasoning for the reversal: an entry that joins with
nothing and carries figures is indistinguishable from a legitimate solitary
entry whose bridge is not installed here, and deleting it loses the only
record of real spend. The incident's own document is still repaired — both
its entries carry the same ad account, so the duplicate rule catches it.

## #617 — silent loss of a non-recoverable setting

`conversion_action_types` is an allow-list a **person** declares so a
custom-event advertiser is counted correctly (#342). Nothing on the platform
side knows it, so no sync restores it — and it did not exist on
`PlatformEntryFacts`, so no line of the preview could mention it. The
operator confirmed a change described entirely in terms of re-fetchable
figures.

**Audit of the whole entry shape.** `account_id`, `campaigns`, `totals`,
`metrics_period` and `periods` are all written by a sync and re-fetchable
from the platform. `conversion_action_types` is the **only** operator-declared
field on `PlatformState`. No other field needs this treatment.

**Chosen: refuse, not a second confirmation.** The existing confirmation is
skippable with `--yes`, which is exactly how the whole-machine sweep this
release leads with (`--all --apply --yes`) is run — so a second prompt would
protect nobody on the path that matters, while a refusal is honoured on every
path. It also matches the command's stated design: it removes only what it
can decide safely, and a setting only an operator can supply is by definition
not mureo's to decide. The field is carried on `PlatformEntryFacts` and
printed either way, so the operator is told it exists before anything else in
that document is touched.

The refusal is per entry, not per document: a stub beside such an entry is
still removed, and the allow-list is still there afterwards.

## #618 — the preview lied

1. `every other platform entry is left exactly as it is` was printed
   unconditionally, once per block, so with two or more entries in one plan
   each block contradicted the others.
2. Same-account siblings were filtered on `facts.resolvable`, hiding
   precisely the siblings that were **also being dropped** — so when two
   dropped entries held the same ad account, neither block mentioned the
   other and the operator was never told the account would have no entry
   left.

Both fixed. `echo_repair` now takes the run's whole key set:

- one entry in the plan keeps the plain sentence;
- two or more get `Every platform entry other than the N this run removes is
  left exactly as it is.` followed by `This run removes: k1, k2.`;
- every sibling is listed, resolvable or not, labelled `mureo CAN resolve
  this key; it stays` / `mureo cannot resolve this key either; it stays` /
  `this run removes this entry too`;
- when every entry for an account is in the plan, each block says
  `this run removes every entry for ad account <id> (k1, k2), so STATE.json
  will hold NO record of that account at all.`

Each block also now opens with `Why it can go:` — naming the evidence in the
document rather than leaving "mureo cannot resolve this key" to do work it
cannot do.

## #618, secondary — a schema-invalid STATE.json produced a raw traceback

`read_state_file` wraps `json.JSONDecodeError` and nothing else. Strict
parsing also raises a bare `ValueError` for a document that is valid JSON and
invalid against the schema — a campaign missing `campaign_name`, say. The
single-workspace path caught only `ContextFileError`, so that document ended
in a full Python traceback; `--all` caught broadly and reported the **very
same file** under `Could not be read`. One document, two answers, and the
person this command exists for cannot read the second one.

**Fixed narrowly, at the CLI.** `_read_document` and `_apply` now catch
`ValueError` alongside what they already caught. `read_state_file`'s contract
is deliberately **not** widened: it has fifteen-odd other callers, some of
which may be relying on a `ValueError` passing through, and this is not the
place to find out. The cost of the narrow fix is a docstring that overstated
what `apply_state_file_repairs` raises, so that docstring is corrected to
describe what actually happens — `ValueError` passes through, and a caller
reporting to a person must catch both.

The reason text is `--all`'s own (`_reason` renamed to the shared
`unreadable_reason`), so the two paths cannot drift into describing one file
differently again. It stays scrubbed through `terminal_safe`: the failing
fragment comes straight out of an agent-writable STATE.json.

```
Error: mureo cannot read STATE.json: /path/to/STATE.json
       Campaign is missing required field 'campaign_name': {'campaign_id': 'c-1'}
       Nothing was changed. This command will not repair a document it cannot
       read in full: writing it back would drop whatever the read skipped.
```

A test drives **both paths over the same malformed document** and asserts they
agree on the reason text — not merely that neither produces a traceback, since
that was the point of the report.

## `--all` stays coherent

`ClientSurvey` carries `kept` alongside `repairs`. `Need repair` is still
exactly the clients `--apply` will change; a client whose only finding is now
"not offered for deletion" is counted under `Need your decision` (never
`Need repair`, never `Clean`), with the key named in the summary line and the
full block in the detail below. When a sweep finds only such entries it says
`Nothing to repair automatically` instead of the old — and now false —
"every client's platform entries are filed under keys mureo can resolve".

## Tests

`tests/test_platform_repair.py`, `tests/test_cli_repair.py`,
`tests/test_cli_repair_all.py`, all with the installed-plugin set pinned (this
machine really has the LOGLY and LINE/Yahoo bridges, so an unpinned test would
pass here and fail in CI):

- solitary unresolvable entry **with figures**, no duplicate → not offered;
- unresolvable entry duplicating a **resolvable** key with the same ad
  account → still offered (the incident's shape);
- unresolvable entry duplicating another **unresolvable** key → not offered;
- empty stub → offered, including one with an empty `account_id`;
- an entry holding only `periods` → not a stub;
- `conversion_action_types` named in the preview, the entry refused, and a
  sibling stub still repaired around it;
- two entries in one plan → no block claims the others are untouched;
- two dropped entries sharing an ad account → both blocks say the account is
  left with nothing;
- `--all` summary counts under all of the above;
- a schema-invalid document on the single-workspace path, on `--apply --yes`,
  on the apply path's re-read under the lock, with control characters in the
  failing fragment, and **both paths agreeing** on one file.

Full suite: 9127 passed, 8 skipped (excluding the four modules with
pre-existing failures from locally-installed plugins). `black --check`,
`ruff check` clean; `mypy` unchanged from baseline (14 missing-stub errors).

## Also in this PR

The preview moved to `mureo/cli/_repair_preview.py`. The additions took
`repair_cmd.py` to 853 lines, past the repo's 800-line limit; the wording of
every claim made to the operator is a coherent module on its own, and it is
the half that has to be true. `repair_cmd.py` is now 594 lines.

`--all` no longer closes a sweep in which nothing could be read with `Nothing
to repair: every client's platform entries are filed under keys mureo can
resolve` — it has no way to know that. Same false-reassurance class as the
rest of this branch, one line further down, and it surfaced in the output of
the cross-path test above.

`CHANGELOG.md`, `docs/cli.md` (the criterion, the three new preview shapes,
the unreadable-document error, the `--all` grouping rule) and the `AGENTS.md`
architecture tree are updated.

Closes #616
Closes #617
Closes #618
