### PR TITLE
feat: read and swap Performance Max asset-group images (#626)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,8 +33,12 @@ mureo/
 │   ├── _placement_mappers.py # Negative-placement + group_placement_view row mappers (#544/#547)
 │   ├── _ads.py          # AdsMixin (RSA create/update/status/list)
 │   ├── _ads_display.py  # DisplayAdsMixin (RDA create + RDAUploadError)
-│   ├── _asset_groups.py # AssetGroupsMixin (Performance Max asset-group text: read +
-│   │                    #   swap via one atomic GoogleAdsService.mutate, #590)
+│   ├── _asset_groups.py # AssetGroupsMixin (Performance Max asset groups: one read for
+│   │                    #   text + images, and the text swap via one atomic
+│   │                    #   GoogleAdsService.mutate, #590/#626). Owns both field-type
+│   │                    #   tables — text width limits and image dimension rules
+│   ├── _asset_groups_images.py # AssetGroupImagesMixin (the P-MAX image swap, #626:
+│   │                    #   existing asset id or local upload, one atomic mutate)
 │   ├── _keywords.py     # KeywordsMixin (add/remove/suggest/diagnose)
 │   ├── _placements.py   # PlacementsMixin (negative placements: sites/apps/app categories, #544)
 │   ├── _analysis.py     # AnalysisMixin aggregator, composing the split modules below
@@ -231,7 +235,7 @@ docs/integrations.md          # Platform discovery + external MCP integration gu
 | Device | `device.analyze` |
 | CPC | `cpc.detect_trend` |
 | Assets | `assets.upload_image`, `image_assets.list` |
-| Performance Max (#590) | `asset_group_assets.list`, `asset_group_assets.replace` — P-MAX ad copy lives on `asset_group_asset`, not `ad_group_ad` |
+| Performance Max (#590, #626) | `asset_group_assets.list` (text + images in one read), `asset_group_assets.replace` (text), `asset_group_images.replace` (images, from an asset id or a local file) — P-MAX creative lives on `asset_group_asset`, not `ad_group_ad` |
 
 ### Meta Ads
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,55 @@
 ## [Unreleased]
 
+### Added
+
+- **A Performance Max asset group's images can now be read and swapped**
+  (#626). #590 made a P-MAX asset group's *text* readable and writable; its
+  pictures stayed invisible. No tool reported which images an asset group
+  served — `google_ads_image_assets_list` is account-wide and never says
+  which asset group or ad uses an asset — so "show me this asset group's
+  creative" could only be half-answered, and nothing could change one.
+
+  `google_ads_asset_group_assets_list` now returns **both** halves from one
+  query. Every entry still carries the link and asset-group columns;
+  `field_type` says what the rest holds. A text link adds `text`, exactly as
+  #590 shipped it — no key added, none removed. An image link
+  (`MARKETING_IMAGE`, `SQUARE_MARKETING_IMAGE`,
+  `PORTRAIT_MARKETING_IMAGE`, `LOGO`, `LANDSCAPE_LOGO`) adds `asset_name`,
+  `url` (the full-size serving URL), `width_pixels` and `height_pixels`. One
+  read rather than two, because a text-only answer to "show me this asset
+  group's creative" is how #591's field report came to conclude a P-MAX
+  account had no creative at all.
+
+  The new `google_ads_asset_group_images_replace` swaps one of them. Both
+  situations go through it: pass `new_asset_id` for an image the account
+  already holds, or `new_image_path` for a local file it uploads first —
+  exactly one of the two, so an operator never has to work out which
+  situation they are in to pick a tool name. Like the text swap it is one
+  atomic `GoogleAdsService.mutate` with the create first, here two
+  operations rather than three (an image asset already exists before the
+  asset group can point at it), so the per-field-type count never dips below
+  the Performance Max minimum — `AssetGroupError.NOT_ENOUGH_*` is reported
+  as an actionable message rather than a raw API error, and
+  `partial_failure` is deliberately unset.
+
+  Google enforces a shape per slot (1.91:1, 1:1, 4:5, 1:1 and 4:1
+  respectively, each with its own pixel floor). mureo checks it **before**
+  uploading or linking anything, so a wrongly proportioned file costs no API
+  call and leaves no unlinked asset in the account. For a format it cannot
+  measure locally — a GIF, or an unrecognised header — it does not guess:
+  the file goes to Google and the `ImageError` refusal comes back translated
+  into the rule for that slot. It never crops or resizes.
+
+  Video stays out of scope: a video asset references a YouTube video id
+  rather than uploaded bytes, so it is a different entry shape and a
+  different operator workflow.
+
+  `/creative-refresh` is updated in the same change. It previously stated
+  that a P-MAX asset group's images were not retrievable and that every
+  image was draft-only, which the read half now makes false; its *Apply or
+  draft* rule keys on whether a write tool exists for the surface, so the
+  new tool flows through it rather than needing the rule rewritten.
+
 ### Fixed
 
 - **Four test modules edited `GoogleAdsException` for the rest of the

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -282,37 +282,67 @@ Excluded websites, mobile apps and mobile app categories — the placement side 
 | `google_ads_assets_upload_image` | Upload a local image file as a Google Ads asset | `customer_id`, `file_path` |
 | `google_ads_image_assets_list` | List existing image assets with their names and dimensions (width/height, file size, serving URL) | `customer_id` |
 
-#### Performance Max asset-group text
+#### Performance Max asset groups
 
 `google_ads_ads_list` returns no rows for a Performance Max campaign: P-MAX
-has no `ad_group_ad`, and its headlines, long headlines and descriptions are
-assets linked to an **asset group** through `asset_group_asset`. These two
-tools are the P-MAX ad-copy surface.
+has no `ad_group_ad`. Its headlines, long headlines and descriptions — and
+its images and logos — are assets linked to an **asset group** through
+`asset_group_asset`. These three tools are the P-MAX creative surface.
 
 | Tool | Description | Required Parameters |
 |------|-------------|-------------------|
-| `google_ads_asset_group_assets_list` | List the HEADLINE / LONG_HEADLINE / DESCRIPTION assets linked to Performance Max asset groups, with the `asset_id` and the `asset_group_asset` handle for each. Optionally filtered by `asset_group_id` or `campaign_id` | `customer_id` |
+| `google_ads_asset_group_assets_list` | List the text AND image assets linked to Performance Max asset groups, with the `asset_id` and the `asset_group_asset` handle for each. Optionally filtered by `asset_group_id` or `campaign_id` | `customer_id` |
 | `google_ads_asset_group_assets_replace` | Swap one headline, long headline or description of an asset group for new text | `customer_id`, `asset_group_id`, `field_type`, `old_asset_id`, `new_text` |
+| `google_ads_asset_group_images_replace` | Swap one image or logo of an asset group, from an existing asset id or a local file | `customer_id`, `asset_group_id`, `field_type`, `old_asset_id`, and one of `new_asset_id` / `new_image_path` |
 
-A Google Ads text `Asset` is immutable, so the swap is not an update: it
-creates a new `Asset`, links it under the same `field_type`, and removes the
-old link. All three go in **one** atomic `GoogleAdsService.mutate`, so the
-asset group's asset count for that field type never dips below the
-Performance Max minimum — a removal issued on its own can be refused with
-`AssetGroupError.NOT_ENOUGH_HEADLINE_ASSET` (or the long-headline /
-description twin), which the tool reports as an actionable message rather
-than a raw API error. The old `Asset` itself is not deleted; only its link to
-that asset group is. The swap is not automatically reversible: to undo it,
-call the tool again with the old text.
+**One read, two row shapes.** `google_ads_asset_group_assets_list` issues one
+query covering both halves, because the question is "show me this asset
+group's creative", not "show me its text". Every entry carries
+`resource_name`, `field_type`, `status`, `asset_id`, `asset_group_id`,
+`asset_group_name`, `campaign_id` and `campaign_resource_name`; `field_type`
+says what the rest holds. A text link (`HEADLINE`, `LONG_HEADLINE`,
+`DESCRIPTION`) adds `text`. An image link (`MARKETING_IMAGE`,
+`SQUARE_MARKETING_IMAGE`, `PORTRAIT_MARKETING_IMAGE`, `LOGO`,
+`LANDSCAPE_LOGO`) adds `asset_name`, `url` (the full-size serving URL),
+`width_pixels` and `height_pixels`. This is also the only Google read that
+says *which* asset group serves a given image: `google_ads_image_assets_list`
+is account-wide and does not.
 
-**Text only.** These two tools cover the three text field types and nothing
-else: an asset group's image, video, logo, business-name and other non-text
-assets are not returned by
-`google_ads_asset_group_assets_list` and cannot be replaced.
-`google_ads_image_assets_list` lists the account's image assets with a
-serving URL, but it is account-wide — it does not report which asset group or
-ad uses one, so the images of a given Performance Max asset group cannot be
-enumerated. `/creative-refresh` treats every surface with no write tool as
+**The text swap.** A Google Ads text `Asset` is immutable, so the swap is not
+an update: it creates a new `Asset`, links it under the same `field_type`,
+and removes the old link. All three go in **one** atomic
+`GoogleAdsService.mutate`, so the asset group's asset count for that field
+type never dips below the Performance Max minimum — a removal issued on its
+own can be refused with `AssetGroupError.NOT_ENOUGH_HEADLINE_ASSET` (or the
+long-headline / description twin), which the tool reports as an actionable
+message rather than a raw API error. The old `Asset` itself is not deleted;
+only its link to that asset group is.
+
+**The image swap.** Nothing has to be created inside the mutate — an image
+asset exists before an asset group can point at it — so the request is two
+operations, link then unlink, again as one atomic mutate against the same
+`NOT_ENOUGH_MARKETING_IMAGE_ASSET` / `NOT_ENOUGH_SQUARE_MARKETING_IMAGE_ASSET`
+/ `NOT_ENOUGH_LOGO_ASSET` floors. Pass `new_asset_id` for an image the
+account already holds, or `new_image_path` for a local file — exactly one of
+the two; the tool uploads the file itself, so an operator never has to work
+out which situation they are in. Google enforces a shape per slot
+(`MARKETING_IMAGE` 1.91:1 min 600x314, `SQUARE_MARKETING_IMAGE` 1:1 min
+300x300, `PORTRAIT_MARKETING_IMAGE` 4:5 min 480x600, `LOGO` 1:1 min 128x128,
+`LANDSCAPE_LOGO` 4:1 min 512x128) and mureo checks it **before** uploading or
+linking anything, so a wrongly proportioned file costs no API call and leaves
+no unlinked asset behind. For a format it cannot measure locally (GIF, or an
+unrecognised header) it does not guess: the file goes to Google and an
+`ImageError` refusal comes back translated into the rule for that slot.
+mureo never crops or resizes.
+
+Neither swap is automatically reversible: to undo one, call the tool again
+with the old text or the old `asset_id`.
+
+**Text and images only.** Video, business name, and every other field type of
+an asset group are neither returned by `google_ads_asset_group_assets_list`
+nor replaceable. A video asset references a YouTube video id rather than
+uploaded bytes, so it is a different entry shape and a different operator
+workflow. `/creative-refresh` treats every surface with no write tool as
 draft-only and says so before drafting rather than after the operator agrees;
 see its *Apply or draft* section.
 

--- a/mureo/_data/skills/creative-refresh/SKILL.md
+++ b/mureo/_data/skills/creative-refresh/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: creative-refresh
-description: "Refresh ad copy and creative assets based on performance signals and brand voice. Use when the user asks to refresh creative, propose new ad copy, A/B test creatives, update RSA assets, swap Performance Max asset-group headlines or descriptions, rotate underperformers, or visually evaluate / compare banner (image) creatives. Also use when the user asks in Japanese (クリエイティブを刷新して / 広告文の改善案がほしい / RSAアセットの入れ替え / P-MAXの見出しを差し替えて / バナーを比較評価して)."
+description: "Refresh ad copy and creative assets based on performance signals and brand voice. Use when the user asks to refresh creative, propose new ad copy, A/B test creatives, update RSA assets, swap Performance Max asset-group headlines, descriptions, images or logos, rotate underperformers, or visually evaluate / compare banner (image) creatives. Also use when the user asks in Japanese (クリエイティブを刷新して / 広告文の改善案がほしい / RSAアセットの入れ替え / P-MAXの見出しを差し替えて / P-MAXの画像を差し替えて / バナーを比較評価して)."
 metadata:
   version: 0.10.45
 ---
@@ -26,11 +26,11 @@ Refresh ad creatives based on strategy context and performance data across all p
 2. **Discover platforms**: Identify all configured ad platforms from STATE.json `platforms`. Also include any **hosted official-MCP connector** present in the session (e.g. TikTok, key `tiktok_ads`) — drive it via its own tools and skip mureo-only value-adds; see `../_mureo-shared/SKILL.md` → *Hosted-connector platforms*.
 
 3. **Audit current creatives**: For each ad platform:
-   - **Google Ads**: prefer mureo native — call `google_ads_ad_performance_report` per campaign, plus `google_ads_rsa_assets_audit` (per-asset CTR/CVR ratings) and `google_ads_rsa_assets_analyze` (LOW/POOR detection). A **Performance Max** campaign has no `ad_group_ad`, so `google_ads_ads_list` and the RSA asset tools return nothing for it — an audit that stops there reports a P-MAX account as having no ad copy at all. Read its copy with `google_ads_asset_group_assets_list` (pass `campaign_id` when you have no `asset_group_id`); it returns the HEADLINE / LONG_HEADLINE / DESCRIPTION assets, **text only**, one entry per link with the `asset_id` you will need to change one. In BYOD mode, the Apps Script bundle does not include per-asset ratings — these tools return `[]`; fall back to `google_ads_ads_list` for headline/description text and use `ad_performance.report` for ad-level CTR/conv only. If mureo's Google Ads tools are unavailable (e.g. `MUREO_DISABLE_GOOGLE_ADS=1` after `mureo providers add google-ads-official`), fall back to the official `google-ads-official` MCP for ad-level performance and ad listing, then **skip the mureo-only RSA asset audit tools** (`google_ads_rsa_assets_audit`, `google_ads_rsa_assets_analyze`) and note: "per-asset LOW/POOR detection and the RSA asset audit are mureo-specific value-add features — install or re-enable via `mureo setup claude-code` for the full creative audit."
+   - **Google Ads**: prefer mureo native — call `google_ads_ad_performance_report` per campaign, plus `google_ads_rsa_assets_audit` (per-asset CTR/CVR ratings) and `google_ads_rsa_assets_analyze` (LOW/POOR detection). A **Performance Max** campaign has no `ad_group_ad`, so `google_ads_ads_list` and the RSA asset tools return nothing for it — an audit that stops there reports a P-MAX account as having no creative at all. Read its creative with `google_ads_asset_group_assets_list` (pass `campaign_id` when you have no `asset_group_id`); one call returns **both** the HEADLINE / LONG_HEADLINE / DESCRIPTION text (each entry with `text`) and the MARKETING_IMAGE / SQUARE_MARKETING_IMAGE / PORTRAIT_MARKETING_IMAGE / LOGO / LANDSCAPE_LOGO images (each entry with `asset_name`, a full-size serving `url`, `width_pixels`, `height_pixels`). `field_type` says which. Every entry carries the `asset_id` you will need to change it. Video and business-name assets are not returned. In BYOD mode, the Apps Script bundle does not include per-asset ratings — these tools return `[]`; fall back to `google_ads_ads_list` for headline/description text and use `ad_performance.report` for ad-level CTR/conv only. If mureo's Google Ads tools are unavailable (e.g. `MUREO_DISABLE_GOOGLE_ADS=1` after `mureo providers add google-ads-official`), fall back to the official `google-ads-official` MCP for ad-level performance and ad listing, then **skip the mureo-only RSA asset audit tools** (`google_ads_rsa_assets_audit`, `google_ads_rsa_assets_analyze`) and note: "per-asset LOW/POOR detection and the RSA asset audit are mureo-specific value-add features — install or re-enable via `mureo setup claude-code` for the full creative audit."
    - **Meta Ads**: prefer mureo native — call `meta_ads_creatives_list`, `meta_ads_analysis_compare_ads`, and `meta_ads_analysis_suggest_creative`. In BYOD mode, creative URLs / headlines / body / CTA may be present in `~/.mureo/byod/meta_ads/creatives.csv` (best-effort, populated only when those columns were in the export). If mureo's Meta Ads tools are unavailable, fall back to the official `meta-ads-official` hosted MCP for the creative list and ad-level insights only, then **skip the mureo-only analysis tools** (`meta_ads_analysis_compare_ads`, `meta_ads_analysis_suggest_creative`); perform the ad-comparison and creative-suggestion logic yourself using the rules in step 6 and note to the user that mureo's automated creative-suggestion engine requires the native MCP.
    - mureo BYOD data is centralized in the workspace `byod/` directory (or `~/.mureo/byod/` for legacy CLI users) and is only accessible through mureo MCP tools — do **not** look for raw CSVs in the project directory.
    - Identify underperforming assets (LOW/POOR ratings for search ads, low CTR/engagement for social ads).
-   - **Image / banner creatives**: the text-and-metrics audit above does not look at the picture itself. When a creative carries an image you can actually reach — `image_url` / `thumbnail_url` from `meta_ads_creatives_list`, or a Google image asset from `google_ads_image_assets_list` (account-level: name, dimensions and a full-size serving `url`) — also run the **Visual creative evaluation** section below to score the banner's design, not just its copy and CTR.
+   - **Image / banner creatives**: the text-and-metrics audit above does not look at the picture itself. When a creative carries an image you can actually reach — `image_url` / `thumbnail_url` from `meta_ads_creatives_list`, a P-MAX asset group's images from `google_ads_asset_group_assets_list` (which says *which* asset group serves each one), or a Google image asset from `google_ads_image_assets_list` (account-level: name, dimensions and a full-size serving `url`) — also run the **Visual creative evaluation** section below to score the banner's design, not just its copy and CTR.
 
 4. **Analyze landing pages**: For each campaign's final URL, analyze the landing page to extract key selling points, CTAs, and features. If GA4 is available, pull engagement metrics (time on page, scroll depth, bounce rate) to inform creative direction.
 
@@ -56,7 +56,7 @@ Refresh ad creatives based on strategy context and performance data across all p
 
 10. **Check pending observations**: Before executing, check `action_log` for campaigns being modified. If a previous creative change is still within its observation window, warn about stacking changes.
 
-11. **Execute approved changes**: Use each platform's ad creation/update tools to apply changes. For Google Performance Max copy that is `google_ads_asset_group_assets_replace` — one call per asset, taking `asset_group_id` + `field_type` + `old_asset_id` (from `google_ads_asset_group_assets_list`) + `new_text` — not `google_ads_ads_update`, which cannot see a P-MAX campaign. A draft-only item produces **no tool call at all**.
+11. **Execute approved changes**: Use each platform's ad creation/update tools to apply changes. For Google Performance Max copy that is `google_ads_asset_group_assets_replace` — one call per asset, taking `asset_group_id` + `field_type` + `old_asset_id` (from `google_ads_asset_group_assets_list`) + `new_text` — not `google_ads_ads_update`, which cannot see a P-MAX campaign. For a P-MAX **image or logo** it is `google_ads_asset_group_images_replace`, same targeting arguments plus either `new_asset_id` (an image the account already holds) or `new_image_path` (a local file to upload) — exactly one, and you do not need to know which situation you are in to pick the tool. A draft-only item produces **no tool call at all**.
 
 12. **Record outcome context**: For each campaign modified, log to `action_log` with `metrics_at_action` (current CTR, CPA, conversions, impressions, clicks) and `observation_due` (14 days from `server_now`'s date). Log only what mureo actually wrote: a draft the operator was asked to paste in by hand is not a mureo change and gets no `action_log` entry (log it, and `/ad-fatigue-check` and the outcome evaluator will later measure a change that may never have been made).
 
@@ -85,9 +85,12 @@ What Google Ads copy mureo can write **today**:
 | Surface | Read | Write |
 |---|---|---|
 | Search RSA headlines / descriptions | `google_ads_ads_list`, `google_ads_rsa_assets_audit` | `google_ads_ads_create`, `google_ads_ads_update` |
-| Performance Max asset-group text — HEADLINE / LONG_HEADLINE / DESCRIPTION | `google_ads_asset_group_assets_list` (text only) | `google_ads_asset_group_assets_replace` — one asset per call, by `asset_group_id` + `field_type` + `old_asset_id` |
+| Performance Max asset-group text — HEADLINE / LONG_HEADLINE / DESCRIPTION | `google_ads_asset_group_assets_list` (the `text` of each entry) | `google_ads_asset_group_assets_replace` — one asset per call, by `asset_group_id` + `field_type` + `old_asset_id` |
+| Performance Max asset-group images — MARKETING_IMAGE / SQUARE_MARKETING_IMAGE / PORTRAIT_MARKETING_IMAGE / LOGO / LANDSCAPE_LOGO | `google_ads_asset_group_assets_list` (the `url` + dimensions of each entry) | `google_ads_asset_group_images_replace` — one image per call, by `asset_group_id` + `field_type` + `old_asset_id` + either `new_asset_id` or `new_image_path` |
 | Responsive Display Ad text | `google_ads_ads_list` | create only (`google_ads_ads_create_display`); no text update — **draft-only** for an edit |
-| Any image, video, logo or business name — including every non-text field type of a P-MAX asset group | `google_ads_image_assets_list` lists account-level images with a serving URL, but nothing reports which asset group or ad uses one | none — **draft-only** |
+| A Responsive Display Ad's images | `google_ads_ads_list` returns asset resource names; join by id to `google_ads_image_assets_list` for a URL | none — **draft-only** |
+| Video, business name, and every other non-text non-image field type of a P-MAX asset group | not returned by `google_ads_asset_group_assets_list` | none — **draft-only** |
+| Any image outside the surfaces above | `google_ads_image_assets_list` lists account-level images with a serving URL, but does not report which ad uses one | none — **draft-only** |
 
 That table is a **snapshot of the tool layer, not** the boundary. The boundary
 is the tool list you can actually see in this session, and it moves in both
@@ -123,18 +126,20 @@ score, an empty rubric, or an "image not found" finding for a text ad.
 
 1. Collect each creative's image reference: `image_url` (or `thumbnail_url` for
    video — you evaluate the still frame only, not motion) from
-   `meta_ads_creatives_list`; for Google, the full-size serving `url` of an
-   image asset from `google_ads_image_assets_list`. In BYOD mode use the URL
-   column from `creatives.csv` when present.
+   `meta_ads_creatives_list`; for a **Performance Max** asset group, the
+   `url` of each image entry from `google_ads_asset_group_assets_list` — that
+   is the one Google read that says *which* asset group serves an image, so
+   "the images of this asset group" is directly enumerable (pass
+   `campaign_id` when you have no `asset_group_id`); for any other Google
+   image, the full-size serving `url` from `google_ads_image_assets_list`. In
+   BYOD mode use the URL column from `creatives.csv` when present.
    **What Google will not give you**: `google_ads_image_assets_list` is
-   account-wide — it does not say which ad or asset group serves an asset, so
-   you cannot enumerate "the images of this Performance Max asset group" from
-   it. `google_ads_asset_group_assets_list` returns the asset group's
-   headlines, long headlines and descriptions — text only, no image, video or
-   logo assets. A Responsive Display Ad is the one case with a link:
+   account-wide — outside a P-MAX asset group it does not say which ad serves
+   an asset. A Responsive Display Ad is the one other case with a link:
    `google_ads_ads_list` returns its `marketing_images` /
    `square_marketing_images` / `logo_images` as asset **resource names**,
    which you match by id against `google_ads_image_assets_list` to get a URL.
+   And no Google read returns video assets at all.
    For any image you cannot reach, score the copy and metrics, say plainly
    that the picture could not be retrieved, and ask the operator to paste it
    into chat if they want it graded — never a guessed visual score, and never
@@ -145,8 +150,9 @@ score, an empty rubric, or an "image not found" finding for a text ad.
    `Read` that file — the Read tool renders the pixels so you can actually see
    the banner. Only fetch URLs on the ad platform's own CDN
    (`*.fbcdn.net` / `*.cdninstagram.com` / `googleusercontent.com` /
-   `gstatic.com` etc.); refuse arbitrary hosts (SSRF hygiene). Delete the temp
-   files when done.
+   `gstatic.com` / `googlesyndication.com` — the last is where a P-MAX asset
+   group's image `url` points); refuse arbitrary hosts (SSRF hygiene). Delete
+   the temp files when done.
 3. **On Desktop / Cowork (MCP-only, no Read/Bash):** you generally cannot fetch
    and view an arbitrary URL yourself. Present the `image_url` to the operator
    and ask them to paste/drop the image into chat so you can see it; if they

--- a/mureo/_image_validation.py
+++ b/mureo/_image_validation.py
@@ -232,6 +232,23 @@ def _enforce_image_header(path: Path, *, max_pixels: int) -> None:
         )
 
 
+def read_image_dimensions(path: Path) -> tuple[int | None, int | None]:
+    """Return ``(width, height)`` for a PNG/JPEG/WebP file, else ``(None, None)``.
+
+    The honest answer for anything else: this project has no image-library
+    dependency, so a GIF, or a header these std-lib probes cannot parse,
+    yields ``(None, None)`` rather than a guess. Callers that enforce a
+    per-slot dimension rule must treat that as "not known", never as "not
+    allowed" — see
+    ``mureo.google_ads._asset_groups._validate_image_dimensions``.
+    """
+    probed = _probe_image(path)
+    if probed is None:
+        return (None, None)
+    _, width, height = probed
+    return (width, height)
+
+
 def validate_image_file(
     file_path: str,
     *,

--- a/mureo/google_ads/_asset_groups.py
+++ b/mureo/google_ads/_asset_groups.py
@@ -1,13 +1,30 @@
-"""Performance Max asset-group text assets (#590).
+"""Performance Max asset-group assets — text read/swap, image read (#590, #626).
 
 A Performance Max campaign has no ``ad_group_ad``, so every ad-text query
 in this package returns nothing for it: its headlines, long headlines and
 descriptions are assets linked to an **asset group** through
-``asset_group_asset``. This mixin is the read and the write for those
-three field types.
+``asset_group_asset``. The same is true of everything an asset group
+shows — its landscape, square and portrait images and its two logos are
+links on the same resource.
 
-Why the write is a swap and not an update
------------------------------------------
+This module is the read for both kinds and the write for text. The image
+write lives next door in :mod:`mureo.google_ads._asset_groups_images`,
+which imports the field-type table and the dimension rules from here.
+
+One read, two row shapes
+------------------------
+:meth:`_AssetGroupsMixin.list_asset_group_assets` issues **one** query
+covering both tables, because the question an operator asks is "show me
+this asset group's creative", not "show me its text" — and a text-only
+read is exactly how #591's field report came to conclude a P-MAX account
+had no ad copy at all. A text row and an image row share the link and
+asset-group columns and differ in their payload: ``text`` for text,
+``asset_name`` / ``url`` / ``width_pixels`` / ``height_pixels`` for
+images. ``field_type`` is the discriminator. Text rows are returned by
+:func:`_map_text_asset_row` exactly as #590 shipped them.
+
+Why the text write is a swap and not an update
+----------------------------------------------
 A text ``Asset`` is immutable — the string cannot be edited in place, and
 ``AssetGroupAssetService`` only re-points a link. Replacing one headline
 is therefore three operations: create the new ``Asset``, create the
@@ -32,6 +49,7 @@ https://developers.google.com/google-ads/api/performance-max/asset-requirements
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from google.ads.googleads.errors import GoogleAdsException
@@ -60,6 +78,62 @@ PMAX_TEXT_FIELD_TYPES: dict[str, int] = {
     "DESCRIPTION": 90,
 }
 
+
+@dataclass(frozen=True)
+class PmaxImageSpec:
+    """What Google requires of an image linked under one field type.
+
+    ``aspect_ratio`` is width / height. ``ratio_label`` is the same rule
+    as Google writes it, so an error message can quote the requirement
+    rather than a float.
+    """
+
+    aspect_ratio: float
+    ratio_label: str
+    min_width: int
+    min_height: int
+    recommended: str
+
+
+#: The Performance Max image field types this package reads, mapped to the
+#: dimension rule Google enforces on each. Parallel to
+#: :data:`PMAX_TEXT_FIELD_TYPES`, not shared with it: a text field type
+#: carries a display-width limit and an image field type carries a shape.
+#:
+#: Five of the eight image field types in ``AssetFieldTypeEnum`` are here.
+#: The three that are not:
+#:
+#: * ``TALL_PORTRAIT_MARKETING_IMAGE`` (9:16) — Demand Gen's vertical
+#:   slot. The only place the vendored SDK names it is
+#:   ``GenerateImagesRequest``, which spans four channel types.
+#: * ``BUSINESS_LOGO`` — a *campaign* asset
+#:   (``ResourceLimitType.BUSINESS_LOGO_CAMPAIGN_ASSETS_PER_CAMPAIGN``),
+#:   not an asset-group link.
+#: * ``AD_IMAGE`` — "linked for use to select an ad image", an ad-level
+#:   selection, not an asset-group slot.
+#:
+#: The corroboration inside the SDK is ``AssetGroupErrorEnum``: it defines
+#: an asset-count floor for ``MARKETING_IMAGE``, ``SQUARE_MARKETING_IMAGE``
+#: and ``LOGO`` and for no other image field type. Those three are the
+#: required ones; ``PORTRAIT_MARKETING_IMAGE`` and ``LANDSCAPE_LOGO`` are
+#: optional, which is why they have no floor rather than why they are absent.
+PMAX_IMAGE_FIELD_TYPES: dict[str, PmaxImageSpec] = {
+    "MARKETING_IMAGE": PmaxImageSpec(1.91, "1.91:1", 600, 314, "1200x628"),
+    "SQUARE_MARKETING_IMAGE": PmaxImageSpec(1.0, "1:1", 300, 300, "1200x1200"),
+    "PORTRAIT_MARKETING_IMAGE": PmaxImageSpec(0.8, "4:5", 480, 600, "960x1200"),
+    "LOGO": PmaxImageSpec(1.0, "1:1", 128, 128, "1200x1200"),
+    "LANDSCAPE_LOGO": PmaxImageSpec(4.0, "4:1", 512, 128, "1200x300"),
+}
+
+#: How far a supplied image may sit from its field type's nominal ratio.
+#: Deliberately loose. A false reject here has no override — mureo would
+#: refuse an image Google would have taken, and never resizes to make one
+#: fit — while a false accept costs one translated API refusal. 5% passes
+#: every size Google itself recommends (1200x628 is 1.911, not 1.910) and
+#: still catches the mistake this check exists for: a square image handed
+#: to a landscape slot.
+_ASPECT_RATIO_TOLERANCE = 0.05
+
 #: ``AssetGroupError`` codes that mean "this would leave the asset group
 #: below its minimum". Surfaced as an actionable message rather than a raw
 #: API error, since the operator's next step differs from any other failure.
@@ -76,28 +150,40 @@ _TEMP_ASSET_ID = "-1"
 
 # The field-type filter is spelled out so the query stays a pure literal and
 # can carry the validate_static_query marker. test_google_ads_asset_groups.py
-# pins it against PMAX_TEXT_FIELD_TYPES so the two cannot drift.
-_TEXT_ASSET_QUERY = """
+# pins it against PMAX_TEXT_FIELD_TYPES + PMAX_IMAGE_FIELD_TYPES so the three
+# cannot drift.
+_ASSET_QUERY = """
             SELECT
                 asset_group_asset.resource_name,
                 asset_group_asset.field_type,
                 asset_group_asset.status,
                 asset.id,
+                asset.name,
                 asset.text_asset.text,
+                asset.image_asset.full_size.url,
+                asset.image_asset.full_size.width_pixels,
+                asset.image_asset.full_size.height_pixels,
                 asset_group.id,
                 asset_group.name,
                 asset_group.campaign
             FROM asset_group_asset
-            WHERE asset_group_asset.field_type IN ('HEADLINE', 'LONG_HEADLINE', 'DESCRIPTION')
+            WHERE asset_group_asset.field_type IN (
+                'HEADLINE', 'LONG_HEADLINE', 'DESCRIPTION',
+                'MARKETING_IMAGE', 'SQUARE_MARKETING_IMAGE',
+                'PORTRAIT_MARKETING_IMAGE', 'LOGO', 'LANDSCAPE_LOGO'
+            )
 """
 
 
 def _map_text_asset_row(row: Any) -> dict[str, Any]:
-    """Map one ``asset_group_asset`` row, verbatim.
+    """Map one text ``asset_group_asset`` row, verbatim.
 
     ``campaign_id`` is the trailing segment of the asset group's own
     ``campaign`` resource name; the full resource name is returned beside
     it so the derivation is visible rather than implied.
+
+    The key set is the one #590 shipped and its tests pin: the image half
+    of #626 added no field here and removed none.
     """
     link = row.asset_group_asset
     group = row.asset_group
@@ -115,6 +201,49 @@ def _map_text_asset_row(row: Any) -> dict[str, Any]:
     }
 
 
+def _map_image_asset_row(row: Any) -> dict[str, Any]:
+    """Map one image ``asset_group_asset`` row.
+
+    Shares every link and asset-group column with
+    :func:`_map_text_asset_row` and replaces ``text`` with the picture:
+    ``url`` / ``width_pixels`` / ``height_pixels`` are named as
+    ``list_image_assets`` names them, so an agent holding both results can
+    join them without a translation table. ``asset_name`` is spelled out
+    rather than ``name`` because the row already carries
+    ``asset_group_name`` and a bare ``name`` beside it is ambiguous.
+    """
+    link = row.asset_group_asset
+    group = row.asset_group
+    campaign_resource = str(group.campaign)
+    full_size = row.asset.image_asset.full_size
+    return {
+        "resource_name": str(link.resource_name),
+        "field_type": map_enum_name(link.field_type, ASSET_FIELD_TYPE_MAP),
+        "status": map_enum_name(link.status, ASSET_LINK_STATUS_MAP),
+        "asset_id": str(row.asset.id),
+        "asset_name": str(row.asset.name),
+        "url": str(full_size.url),
+        "width_pixels": int(full_size.width_pixels),
+        "height_pixels": int(full_size.height_pixels),
+        "asset_group_id": str(group.id),
+        "asset_group_name": str(group.name),
+        "campaign_id": campaign_resource.rsplit("/", 1)[-1],
+        "campaign_resource_name": campaign_resource,
+    }
+
+
+def _map_asset_row(row: Any) -> dict[str, Any]:
+    """Route a row to the mapper for its field type.
+
+    The query's ``IN`` clause is the authority on what can arrive, so
+    anything that is not one of the image field types is text.
+    """
+    field_type = map_enum_name(row.asset_group_asset.field_type, ASSET_FIELD_TYPE_MAP)
+    if field_type in PMAX_IMAGE_FIELD_TYPES:
+        return _map_image_asset_row(row)
+    return _map_text_asset_row(row)
+
+
 def _validate_field_type(value: Any) -> str:
     """Return ``value`` if it is one of the three P-MAX text field types."""
     if not isinstance(value, str) or value not in PMAX_TEXT_FIELD_TYPES:
@@ -123,6 +252,50 @@ def _validate_field_type(value: Any) -> str:
             f"{', '.join(PMAX_TEXT_FIELD_TYPES)}."
         )
     return value
+
+
+def _validate_image_field_type(value: Any) -> str:
+    """Return ``value`` if it is one of the five P-MAX image field types."""
+    if not isinstance(value, str) or value not in PMAX_IMAGE_FIELD_TYPES:
+        raise ValueError(
+            f"Invalid field_type: {value!r}. Supported: "
+            f"{', '.join(PMAX_IMAGE_FIELD_TYPES)}."
+        )
+    return value
+
+
+def _validate_image_dimensions(
+    field_type: str, width: int | None, height: int | None
+) -> None:
+    """Refuse an image whose shape the field type cannot take.
+
+    Checked before anything is uploaded or linked, mirroring how
+    :func:`_validate_text` refuses over-long copy: a refusal that costs no
+    API call can name the exact rule, and it leaves no unlinked asset
+    behind in the account.
+
+    Unknown dimensions are **not** an error. ``width``/``height`` are
+    ``None`` for a GIF or any header mureo cannot parse, and guessing is
+    the one thing this must not do — those go to Google and come back as a
+    translated ``ImageError``. mureo never resizes.
+    """
+    if not width or not height:
+        return
+    spec = PMAX_IMAGE_FIELD_TYPES[field_type]
+    if width < spec.min_width or height < spec.min_height:
+        raise ValueError(
+            f"{field_type} requires at least {spec.min_width}x{spec.min_height} "
+            f"pixels; this image is {width}x{height}. Google recommends "
+            f"{spec.recommended}. Supply a larger image — mureo does not resize."
+        )
+    ratio = width / height
+    if abs(ratio - spec.aspect_ratio) > spec.aspect_ratio * _ASPECT_RATIO_TOLERANCE:
+        raise ValueError(
+            f"{field_type} requires a {spec.ratio_label} image; this one is "
+            f"{width}x{height} ({ratio:.2f}:1). Google recommends "
+            f"{spec.recommended}. Supply a correctly proportioned image — "
+            f"mureo does not crop or resize."
+        )
 
 
 def _validate_text(value: Any, field_type: str) -> str:
@@ -190,7 +363,7 @@ def _swap_result(
 
 
 class _AssetGroupsMixin:
-    """Performance Max asset-group text reads and swaps."""
+    """Performance Max asset-group reads, and the text swap."""
 
     _customer_id: str
     _client: GoogleAdsClient
@@ -204,24 +377,27 @@ class _AssetGroupsMixin:
         exc: GoogleAdsException, attr_name: str, error_name: str
     ) -> bool: ...
 
-    async def list_asset_group_text_assets(
+    async def list_asset_group_assets(
         self,
         asset_group_id: str | None = None,
         campaign_id: str | None = None,
     ) -> list[dict[str, Any]]:
-        """List the text assets linked to Performance Max asset groups.
+        """List the text and image assets linked to P-MAX asset groups.
 
         Returns one entry per ``asset_group_asset`` link whose ``field_type``
-        is HEADLINE, LONG_HEADLINE or DESCRIPTION — in the order the API
-        returned them, with nothing summed, deduplicated or reordered. Two
-        links carrying the same text are two entries, because that is what
-        the asset group has.
+        is one of the three text types or the five image types — in the order
+        the API returned them, with nothing summed, deduplicated or reordered.
+        Two links carrying the same asset are two entries, because that is
+        what the asset group has.
+
+        Text rows carry ``text``; image rows carry ``asset_name``, ``url``,
+        ``width_pixels`` and ``height_pixels``. ``field_type`` says which.
 
         Args:
             asset_group_id: Restrict to one asset group.
             campaign_id: Restrict to the asset groups of one campaign.
         """
-        query = validate_static_query(_TEXT_ASSET_QUERY)
+        query = validate_static_query(_ASSET_QUERY)
         if asset_group_id:
             self._validate_id(asset_group_id, "asset_group_id")
             query += f"                AND asset_group.id = {asset_group_id}\n"
@@ -232,7 +408,7 @@ class _AssetGroupsMixin:
                 f"'customers/{self._customer_id}/campaigns/{campaign_id}'\n"
             )
         rows = await self._search(query)
-        return [_map_text_asset_row(row) for row in rows]
+        return [_map_asset_row(row) for row in rows]
 
     @_wrap_mutate_error("Performance Max asset-group text replacement")
     async def replace_asset_group_text_asset(
@@ -248,7 +424,7 @@ class _AssetGroupsMixin:
         Supported ``params`` keys (all required): ``asset_group_id``,
         ``field_type`` (HEADLINE / LONG_HEADLINE / DESCRIPTION),
         ``old_asset_id`` (the ``asset_id`` reported by
-        :meth:`list_asset_group_text_assets`), ``new_text``.
+        :meth:`list_asset_group_assets`), ``new_text``.
         """
         asset_group_id = self._validate_id(
             str(params.get("asset_group_id", "")), "asset_group_id"
@@ -293,9 +469,7 @@ class _AssetGroupsMixin:
         """
         linked = [
             row
-            for row in await self.list_asset_group_text_assets(
-                asset_group_id=asset_group_id
-            )
+            for row in await self.list_asset_group_assets(asset_group_id=asset_group_id)
             if row["field_type"] == field_type
         ]
         if any(row["text"] == new_text for row in linked):

--- a/mureo/google_ads/_asset_groups_images.py
+++ b/mureo/google_ads/_asset_groups_images.py
@@ -1,0 +1,485 @@
+"""Performance Max asset-group image swap (#626).
+
+The write half of the image surface whose read lives in
+:mod:`mureo.google_ads._asset_groups`. Swapping one image of an asset
+group is the same 1:1 exchange #590 shipped for text — one image out, one
+image in, the per-field-type asset count unchanged.
+
+Two situations, one tool
+------------------------
+The replacement is either an image the account already holds (an asset
+id) or one that is still a file on the operator's disk. Which of the two
+they are in is mureo's problem, not theirs: both arrive at
+:meth:`_AssetGroupImagesMixin.replace_asset_group_image_asset`, which
+resolves ``new_image_path`` into an asset id by uploading it and then
+runs the identical swap. There is exactly one write path below the
+resolution step.
+
+Why the swap is only two operations
+-----------------------------------
+Unlike a text swap, nothing has to be *created* inside the mutate: an
+image asset exists before the asset group can point at it, either because
+it already did or because the upload just made it. So the atomic request
+is create-link then remove-link — creates first, for the same reason #590
+gives. An asset group has a per-field-type minimum
+(``AssetGroupError.NOT_ENOUGH_MARKETING_IMAGE_ASSET`` and its square and
+logo twins), so a removal issued on its own can be refused, and if it were
+not refused the split would leave the asset group short between the two
+round trips. ``partial_failure`` is deliberately left off.
+
+The upload is a separate request by necessity — it reuses the validated
+``upload_image_asset`` path rather than restating its guards — so
+everything that can be checked is checked *before* it runs: the link
+being replaced, the duplicate-link rule, and the field type's dimension
+rule. What remains after a successful upload is the mutate itself; if
+that is refused, the account is left holding an unlinked (and therefore
+non-serving) image asset, and the error says so.
+
+References:
+https://developers.google.com/google-ads/api/performance-max/asset-requirements
+https://developers.google.com/google-ads/api/docs/assets/working-with-assets
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from google.ads.googleads.errors import GoogleAdsException
+
+from mureo._image_validation import read_image_dimensions, validate_image_file
+from mureo.google_ads._asset_groups import (
+    PMAX_IMAGE_FIELD_TYPES,
+    _result_resource_name,
+    _validate_image_dimensions,
+    _validate_image_field_type,
+)
+from mureo.google_ads._enum_names import map_enum_name
+from mureo.google_ads._gaql_validator import validate_static_query
+from mureo.google_ads._media import (
+    _GOOGLE_ALLOWED_IMAGE_EXTENSIONS,
+    _GOOGLE_MAX_IMAGE_SIZE_BYTES,
+)
+from mureo.google_ads.client import _wrap_mutate_error
+from mureo.google_ads.mappers import ASSET_TYPE_MAP
+
+if TYPE_CHECKING:
+    from google.ads.googleads.client import GoogleAdsClient
+
+logger = logging.getLogger(__name__)
+
+#: ``AssetGroupError`` codes that mean "this would leave the asset group
+#: below its image minimum". Only three of the five field types have one:
+#: ``AssetGroupErrorEnum`` defines no floor for PORTRAIT_MARKETING_IMAGE or
+#: LANDSCAPE_LOGO, because Performance Max does not require either.
+_NOT_ENOUGH_IMAGE_ASSET_ERRORS: tuple[str, ...] = (
+    "NOT_ENOUGH_MARKETING_IMAGE_ASSET",
+    "NOT_ENOUGH_SQUARE_MARKETING_IMAGE_ASSET",
+    "NOT_ENOUGH_LOGO_ASSET",
+)
+
+#: ``ImageError`` codes that mean "this picture is the wrong shape or size
+#: for the slot". mureo checks that itself whenever it can read the
+#: dimensions, so these only arrive for a format it cannot probe (a GIF).
+#: Translated rather than passed through, because the operator's next step
+#: is a different image and the raw code does not say which one.
+_IMAGE_CONSTRAINT_ERRORS: tuple[str, ...] = (
+    "ASPECT_RATIO_NOT_ALLOWED",
+    "IMAGE_TOO_SMALL",
+    "IMAGE_CONSTRAINTS_VIOLATED",
+    "UNEXPECTED_SIZE",
+)
+
+_ASSET_LOOKUP_QUERY = """
+            SELECT
+                asset.id,
+                asset.name,
+                asset.type,
+                asset.image_asset.full_size.url,
+                asset.image_asset.full_size.width_pixels,
+                asset.image_asset.full_size.height_pixels
+            FROM asset
+"""
+
+
+def _validate_image_source(params: dict[str, Any]) -> tuple[str, str]:
+    """Return ``("asset_id" | "path", value)`` for the replacement image.
+
+    Exactly one of the two must be given. Refusing both together is not
+    pedantry: with both accepted, one of them would be silently ignored
+    and the asset group would end up carrying an image the operator did
+    not choose.
+    """
+    asset_id = params.get("new_asset_id")
+    path = params.get("new_image_path")
+    given = [
+        (kind, str(value))
+        for kind, value in (("asset_id", asset_id), ("path", path))
+        if isinstance(value, str) and value.strip()
+    ]
+    if len(given) != 1:
+        raise ValueError(
+            "Supply exactly one of new_asset_id (an image the account "
+            "already holds — see google_ads_image_assets_list) or "
+            "new_image_path (a local file to upload). "
+            f"Got {len(given)}."
+        )
+    return given[0]
+
+
+def _image_swap_result(
+    responses: Any,
+    *,
+    asset_group_id: str,
+    field_type: str,
+    new: dict[str, Any],
+    old: dict[str, Any],
+    removed_link: str,
+) -> dict[str, Any]:
+    """Report both sides of the swap, as the mutate confirmed them."""
+    return {
+        "asset_group_id": asset_group_id,
+        "field_type": field_type,
+        "added": {
+            "asset_id": new["asset_id"],
+            "asset_name": new["asset_name"],
+            "width_pixels": new["width_pixels"],
+            "height_pixels": new["height_pixels"],
+            "source": new["source"],
+            "asset_group_asset": _result_resource_name(
+                responses, 0, "asset_group_asset_result"
+            ),
+        },
+        "removed": {
+            "asset_id": old["asset_id"],
+            "asset_name": old["asset_name"],
+            "url": old["url"],
+            "asset_group_asset": removed_link,
+        },
+        "note": (
+            "Sent as one atomic GoogleAdsService.mutate (link the new image, "
+            "unlink the old one), so the asset group never drops below the "
+            "Performance Max minimum for this field type. Neither Asset was "
+            "deleted; only the old link to this asset group was removed."
+        ),
+    }
+
+
+class _AssetGroupImagesMixin:
+    """Performance Max asset-group image swaps."""
+
+    _customer_id: str
+    _client: GoogleAdsClient
+
+    # Stubs satisfied by the GoogleAdsApiClient base class.
+    @staticmethod
+    def _validate_id(value: str, field_name: str) -> str: ...  # type: ignore[empty-body]
+    def _get_service(self, service_name: str) -> Any: ...
+    async def _search(self, query: str) -> Any: ...
+    @staticmethod
+    def _has_error_code(  # type: ignore[empty-body]
+        exc: GoogleAdsException, attr_name: str, error_name: str
+    ) -> bool: ...
+
+    if TYPE_CHECKING:
+        # Provided at runtime by sibling mixins on GoogleAdsApiClient —
+        # list_asset_group_assets by _AssetGroupsMixin, upload_image_asset
+        # by _MediaMixin. Declared inside TYPE_CHECKING so mypy sees them
+        # without a real body shadowing theirs in the MRO: _MediaMixin is
+        # composed AFTER this mixin, so a plain stub here would win the
+        # lookup and every image upload would silently return None.
+        async def list_asset_group_assets(
+            self,
+            asset_group_id: str | None = None,
+            campaign_id: str | None = None,
+        ) -> list[dict[str, Any]]: ...
+
+        async def upload_image_asset(
+            self, file_path: str, name: str | None = None
+        ) -> dict[str, Any]: ...
+
+    @_wrap_mutate_error("Performance Max asset-group image replacement")
+    async def replace_asset_group_image_asset(
+        self, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Swap one image or logo of a Performance Max asset group.
+
+        Links the replacement image under the same ``field_type`` and
+        unlinks the old one, as a single atomic mutate, so the asset
+        group's asset count for that field type never dips below the
+        Performance Max minimum. Neither ``Asset`` is deleted.
+
+        Required ``params`` keys: ``asset_group_id``, ``field_type`` (one
+        of the five P-MAX image field types), ``old_asset_id`` (the
+        ``asset_id`` reported by :meth:`list_asset_group_assets`), and
+        **exactly one** of ``new_asset_id`` (an image the account already
+        holds) or ``new_image_path`` (a local file, uploaded first).
+        Optional: ``new_image_name``, the asset name for that upload.
+        """
+        asset_group_id = self._validate_id(
+            str(params.get("asset_group_id", "")), "asset_group_id"
+        )
+        old_asset_id = self._validate_id(
+            str(params.get("old_asset_id", "")), "old_asset_id"
+        )
+        field_type = _validate_image_field_type(params.get("field_type"))
+        kind, value = _validate_image_source(params)
+        if kind == "asset_id":
+            # Validated here rather than at the lookup, so the duplicate-link
+            # check below compares the same normalised id the lookup will use.
+            value = self._validate_id(value, "new_asset_id")
+
+        old = await self._find_linked_image_asset(
+            asset_group_id,
+            field_type,
+            old_asset_id,
+            value if kind == "asset_id" else "",
+        )
+        new = await self._resolve_new_image(kind, value, field_type, params)
+        operations, removed_link = self._build_image_swap_operations(
+            asset_group_id=asset_group_id,
+            old_asset_id=old_asset_id,
+            new_asset_id=new["asset_id"],
+            field_type=field_type,
+        )
+        responses = self._send_image_swap(operations, field_type, new["source"])
+        return _image_swap_result(
+            responses,
+            asset_group_id=asset_group_id,
+            field_type=field_type,
+            new=new,
+            old=old,
+            removed_link=removed_link,
+        )
+
+    async def _find_linked_image_asset(
+        self,
+        asset_group_id: str,
+        field_type: str,
+        old_asset_id: str,
+        new_asset_id: str,
+    ) -> dict[str, Any]:
+        """Return the link being replaced, or raise with what IS linked.
+
+        Also refuses an asset that is already linked under the same field
+        type: Google rejects a duplicate link, and saying so here costs
+        one read instead of a failed mutate the agent has to decode. A
+        freshly uploaded asset cannot be linked yet, so ``new_asset_id``
+        is empty on that path.
+        """
+        linked = [
+            row
+            for row in await self.list_asset_group_assets(asset_group_id=asset_group_id)
+            if row["field_type"] == field_type
+        ]
+        if new_asset_id and any(row["asset_id"] == new_asset_id for row in linked):
+            raise ValueError(
+                f"Asset {new_asset_id} is already linked to asset group "
+                f"{asset_group_id} as a {field_type}. Google Ads rejects a "
+                f"duplicate link; supply a different image."
+            )
+        for row in linked:
+            if row["asset_id"] == old_asset_id:
+                return row
+        available = ", ".join(
+            f"{row['asset_id']} ({row['asset_name']!r})" for row in linked
+        )
+        raise ValueError(
+            f"Asset {old_asset_id} is not linked to asset group "
+            f"{asset_group_id} as a {field_type}. Linked {field_type} assets: "
+            f"{available or 'none'}."
+        )
+
+    async def _resolve_new_image(
+        self,
+        kind: str,
+        value: str,
+        field_type: str,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Turn either entry point into one asset id, dimensions checked."""
+        if kind == "asset_id":
+            return await self._existing_image_asset(value, field_type)
+        return await self._uploaded_image_asset(value, field_type, params)
+
+    async def _existing_image_asset(
+        self, new_asset_id: str, field_type: str
+    ) -> dict[str, Any]:
+        """Read an asset the account already holds, and vet it for the slot."""
+        asset_id = self._validate_id(str(new_asset_id), "new_asset_id")
+        query = validate_static_query(_ASSET_LOOKUP_QUERY)
+        query += f"            WHERE asset.id = {asset_id}\n"
+        rows = list(await self._search(query))
+        if not rows:
+            raise ValueError(
+                f"Asset {asset_id} was not found in this account. Use "
+                f"google_ads_image_assets_list to find an image asset id."
+            )
+        asset = rows[0].asset
+        asset_type = map_enum_name(asset.type_, ASSET_TYPE_MAP)
+        if asset_type != "IMAGE":
+            raise ValueError(
+                f"Asset {asset_id} is a {asset_type} asset, not an image. "
+                f"{field_type} takes an image asset."
+            )
+        full_size = asset.image_asset.full_size
+        width = int(full_size.width_pixels)
+        height = int(full_size.height_pixels)
+        _validate_image_dimensions(field_type, width, height)
+        return {
+            "asset_id": asset_id,
+            "asset_name": str(asset.name),
+            "width_pixels": width,
+            "height_pixels": height,
+            "source": "existing_asset",
+        }
+
+    async def _uploaded_image_asset(
+        self, file_path: str, field_type: str, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Validate a local file, then upload it as a new image asset.
+
+        The dimension check runs against the bytes on disk, before the
+        upload, so a wrongly proportioned file costs no API call and
+        leaves no unlinked asset in the account.
+        """
+        path = validate_image_file(
+            file_path,
+            max_size_bytes=_GOOGLE_MAX_IMAGE_SIZE_BYTES,
+            max_size_label="5MB",
+            allowed_extensions=_GOOGLE_ALLOWED_IMAGE_EXTENSIONS,
+        )
+        width, height = read_image_dimensions(path)
+        _validate_image_dimensions(field_type, width, height)
+        name = params.get("new_image_name")
+        uploaded = await self.upload_image_asset(
+            str(path), str(name) if isinstance(name, str) and name.strip() else None
+        )
+        return {
+            "asset_id": str(uploaded["id"]),
+            "asset_name": str(uploaded["name"]),
+            "width_pixels": width or 0,
+            "height_pixels": height or 0,
+            "source": "uploaded",
+        }
+
+    def _build_image_swap_operations(
+        self,
+        *,
+        asset_group_id: str,
+        old_asset_id: str,
+        new_asset_id: str,
+        field_type: str,
+    ) -> tuple[list[Any], str]:
+        """Build the two operations, the link before the unlink.
+
+        Returns them with the resource name of the link being removed,
+        which the response cannot be relied on to echo back.
+        """
+        link_new = self._client.get_type("MutateOperation")
+        link = link_new.asset_group_asset_operation.create
+        link.asset_group = self._client.get_service(
+            "AssetGroupService"
+        ).asset_group_path(self._customer_id, asset_group_id)
+        link.asset = self._client.get_service("AssetService").asset_path(
+            self._customer_id, new_asset_id
+        )
+        link.field_type = getattr(self._client.enums.AssetFieldTypeEnum, field_type)
+
+        removed_link = self._client.get_service(
+            "AssetGroupAssetService"
+        ).asset_group_asset_path(
+            self._customer_id, asset_group_id, old_asset_id, field_type
+        )
+        unlink_old = self._client.get_type("MutateOperation")
+        unlink_old.asset_group_asset_operation.remove = removed_link
+        return [link_new, unlink_old], removed_link
+
+    def _send_image_swap(
+        self, operations: list[Any], field_type: str, source: str
+    ) -> Any:
+        """Issue the bulk mutate; translate the two refusals worth naming."""
+        service = self._get_service("GoogleAdsService")
+        try:
+            response = service.mutate(
+                customer_id=self._customer_id,
+                mutate_operations=operations,
+            )
+        except GoogleAdsException as exc:
+            # Each helper re-raises the refusal it recognises and returns
+            # quietly otherwise, so an unrecognised failure falls through to
+            # the bare `raise` and _wrap_mutate_error's curated detail.
+            self._raise_asset_count_refusal(exc, field_type)
+            self._raise_image_constraint_refusal(exc, field_type, source)
+            raise
+        return list(response.mutate_operation_responses)
+
+    def _raise_asset_count_refusal(
+        self, exc: GoogleAdsException, field_type: str
+    ) -> None:
+        """Re-raise a ``NOT_ENOUGH_*_ASSET`` refusal as advice."""
+        shortfall = next(
+            (
+                code
+                for code in _NOT_ENOUGH_IMAGE_ASSET_ERRORS
+                if self._has_error_code(exc, "asset_group_error", code)
+            ),
+            None,
+        )
+        if shortfall is None:
+            return
+        # Class name / curated detail only, never the exception: its repr
+        # carries the request metadata (developer token, authorization
+        # header) — see mureo/google_ads/accounts.py (#603).
+        logger.warning(
+            "Performance Max %s image swap refused for asset-count reasons (%s)",
+            field_type,
+            shortfall,
+        )
+        raise RuntimeError(
+            f"Google Ads refused the swap: the asset group would be left with "
+            f"too few {field_type} assets ({shortfall}). The link and the "
+            f"removal were sent as one atomic request, so the count does not "
+            f"dip mid-flight — the asset group is already at or below the "
+            f"Performance Max minimum for {field_type}. Add another "
+            f"{field_type} to the asset group first, then retry."
+        ) from exc
+
+    def _raise_image_constraint_refusal(
+        self, exc: GoogleAdsException, field_type: str, source: str
+    ) -> None:
+        """Re-raise an ``ImageError`` shape refusal as the slot's rule.
+
+        Only reachable for a file mureo could not measure itself; anything
+        it can probe was refused before the upload.
+        """
+        constraint = next(
+            (
+                code
+                for code in _IMAGE_CONSTRAINT_ERRORS
+                if self._has_error_code(exc, "image_error", code)
+            ),
+            None,
+        )
+        if constraint is None:
+            return
+        spec = PMAX_IMAGE_FIELD_TYPES[field_type]
+        logger.warning(
+            "Performance Max %s image swap refused on image constraints (%s)",
+            field_type,
+            constraint,
+        )
+        orphan = (
+            " The uploaded asset is still in the account, unlinked and not serving."
+            if source == "uploaded"
+            else ""
+        )
+        raise RuntimeError(
+            f"Google Ads refused the image for {field_type} ({constraint}). "
+            f"That slot takes a {spec.ratio_label} image of at least "
+            f"{spec.min_width}x{spec.min_height} pixels; Google recommends "
+            f"{spec.recommended}. mureo could not read this file's dimensions "
+            f"itself (GIF and unrecognised headers are not probed), so the "
+            f"check happened server-side. Supply a correctly proportioned "
+            f"image — mureo does not crop or resize." + orphan
+        ) from exc

--- a/mureo/google_ads/client.py
+++ b/mureo/google_ads/client.py
@@ -234,6 +234,9 @@ def _wrap_mutate_error(label: str) -> Callable[[_F], _F]:
 from mureo.google_ads._ads import _AdsMixin  # noqa: E402
 from mureo.google_ads._ads_display import _DisplayAdsMixin  # noqa: E402
 from mureo.google_ads._asset_groups import _AssetGroupsMixin  # noqa: E402
+from mureo.google_ads._asset_groups_images import (  # noqa: E402
+    _AssetGroupImagesMixin,
+)
 from mureo.google_ads._extensions import _ExtensionsMixin  # noqa: E402
 from mureo.google_ads._keywords import _KeywordsMixin  # noqa: E402
 from mureo.google_ads._placements import _PlacementsMixin  # noqa: E402
@@ -246,6 +249,7 @@ class GoogleAdsApiClient(  # type: ignore[misc]
     _AdsMixin,
     _DisplayAdsMixin,
     _AssetGroupsMixin,
+    _AssetGroupImagesMixin,
     _KeywordsMixin,
     _PlacementsMixin,
     _MonitoringMixin,

--- a/mureo/mcp/_handlers_google_ads.py
+++ b/mureo/mcp/_handlers_google_ads.py
@@ -676,7 +676,7 @@ async def handle_image_assets_list(args: dict[str, Any]) -> list[TextContent]:
 
 
 # ---------------------------------------------------------------------------
-# Performance Max asset-group text assets (#590)
+# Performance Max asset-group assets (#590 text, #626 images)
 # ---------------------------------------------------------------------------
 
 
@@ -685,7 +685,7 @@ async def handle_asset_group_assets_list(args: dict[str, Any]) -> list[TextConte
     client = _get_client(args)
     if client is None:
         return _no_google_creds()
-    result = await client.list_asset_group_text_assets(
+    result = await client.list_asset_group_assets(
         asset_group_id=_opt(args, "asset_group_id"),
         campaign_id=_opt(args, "campaign_id"),
     )
@@ -704,6 +704,27 @@ async def handle_asset_group_assets_replace(args: dict[str, Any]) -> list[TextCo
         "new_text": _require(args, "new_text"),
     }
     result = await client.replace_asset_group_text_asset(params)
+    return _json_result(result)
+
+
+@api_error_handler
+async def handle_asset_group_images_replace(args: dict[str, Any]) -> list[TextContent]:
+    client = _get_client(args)
+    if client is None:
+        return _no_google_creds()
+    params: dict[str, Any] = {
+        "asset_group_id": _require(args, "asset_group_id"),
+        "field_type": _require(args, "field_type"),
+        "old_asset_id": _require(args, "old_asset_id"),
+    }
+    # new_asset_id / new_image_path are exactly-one-of, which `_require`
+    # cannot express. The client refuses zero or two, so the rule holds for
+    # any caller, not just this handler.
+    for key in ("new_asset_id", "new_image_path", "new_image_name"):
+        value = _opt(args, key)
+        if value is not None:
+            params[key] = value
+    result = await client.replace_asset_group_image_asset(params)
     return _json_result(result)
 
 
@@ -747,6 +768,7 @@ _HANDLERS_BASE: dict[str, Any] = {
     "google_ads_image_assets_list": handle_image_assets_list,
     "google_ads_asset_group_assets_list": handle_asset_group_assets_list,
     "google_ads_asset_group_assets_replace": handle_asset_group_assets_replace,
+    "google_ads_asset_group_images_replace": handle_asset_group_images_replace,
 }
 
 # Merge extension and analysis handlers

--- a/mureo/mcp/_tools_google_ads_asset_groups.py
+++ b/mureo/mcp/_tools_google_ads_asset_groups.py
@@ -1,4 +1,4 @@
-"""Google Ads tool definitions -- Performance Max asset-group text assets (#590)"""
+"""Google Ads tool definitions -- Performance Max asset-group assets (#590, #626)"""
 
 from __future__ import annotations
 
@@ -16,24 +16,42 @@ _CUSTOMER_ID_PARAM = {
 
 _FIELD_TYPES = ["HEADLINE", "LONG_HEADLINE", "DESCRIPTION"]
 
+_IMAGE_FIELD_TYPES = [
+    "MARKETING_IMAGE",
+    "SQUARE_MARKETING_IMAGE",
+    "PORTRAIT_MARKETING_IMAGE",
+    "LOGO",
+    "LANDSCAPE_LOGO",
+]
+
 TOOLS: list[Tool] = [
     Tool(
         name="google_ads_asset_group_assets_list",
         description=(
-            "Lists the headlines, long headlines and descriptions attached "
-            "to Performance Max asset groups. Read-only. This is the tool "
-            "for P-MAX ad copy: google_ads_ads_list returns no rows for a "
-            "Performance Max campaign because P-MAX has no ad_group_ad — "
-            "its text lives on asset_group_asset. Returns one entry per "
-            "link shaped {resource_name (the asset_group_asset handle), "
-            "field_type ('HEADLINE' | 'LONG_HEADLINE' | 'DESCRIPTION'), "
-            "status (the LINK status: 'ENABLED' | 'PAUSED' | 'REMOVED'), "
-            "asset_id, text, asset_group_id, asset_group_name, campaign_id, "
-            "campaign_resource_name}. Entries are returned in the order the "
-            "API returned them and are not deduplicated — two links "
-            "carrying identical text are two entries, because that is what "
-            "the asset group has. Pass the asset_id of the entry you want "
-            "to change to google_ads_asset_group_assets_replace."
+            "Lists the text AND the images attached to Performance Max "
+            "asset groups. Read-only. This is the tool for P-MAX creative: "
+            "google_ads_ads_list returns no rows for a Performance Max "
+            "campaign because P-MAX has no ad_group_ad — its headlines and "
+            "its pictures alike live on asset_group_asset. It is also the "
+            "only way to say WHICH asset group serves a given image; "
+            "google_ads_image_assets_list is account-wide and does not. "
+            "Returns one entry per link. Every entry carries {resource_name "
+            "(the asset_group_asset handle), field_type, status (the LINK "
+            "status: 'ENABLED' | 'PAUSED' | 'REMOVED'), asset_id, "
+            "asset_group_id, asset_group_name, campaign_id, "
+            "campaign_resource_name}. field_type says what the rest of the "
+            "entry holds: a text link ('HEADLINE' | 'LONG_HEADLINE' | "
+            "'DESCRIPTION') adds {text}; an image link ('MARKETING_IMAGE' | "
+            "'SQUARE_MARKETING_IMAGE' | 'PORTRAIT_MARKETING_IMAGE' | 'LOGO' "
+            "| 'LANDSCAPE_LOGO') adds {asset_name, url (the full-size "
+            "serving URL — fetch it to actually look at the creative), "
+            "width_pixels, height_pixels}. Entries are returned in the "
+            "order the API returned them and are not deduplicated — two "
+            "links carrying the same asset are two entries, because that is "
+            "what the asset group has. Video, business name and other field "
+            "types are not returned. Pass the asset_id of the entry you "
+            "want to change to google_ads_asset_group_assets_replace (text) "
+            "or google_ads_asset_group_images_replace (images)."
         ),
         inputSchema={
             "type": "object",
@@ -128,6 +146,107 @@ TOOLS: list[Tool] = [
                 "field_type",
                 "old_asset_id",
                 "new_text",
+            ],
+            "additionalProperties": False,
+        },
+    ),
+    Tool(
+        name="google_ads_asset_group_images_replace",
+        description=(
+            "Swaps one image or logo of a Performance Max asset group for "
+            "another. Mutating. Use this whichever situation you are in: "
+            "pass new_asset_id when the account already holds the image "
+            "(google_ads_image_assets_list finds one), or new_image_path to "
+            "upload a local file first — exactly one of the two, and mureo "
+            "handles the difference. The replacement is linked under the "
+            "same field_type and the old link is removed in ONE atomic "
+            "GoogleAdsService.mutate, so the asset group's asset count for "
+            "that field type never dips below the Performance Max minimum "
+            "(a removal issued on its own is refused with "
+            "AssetGroupError.NOT_ENOUGH_MARKETING_IMAGE_ASSET or its square "
+            "/ logo twin). Neither Asset is deleted; only the old link to "
+            "this asset group is. Google enforces a shape per slot — "
+            "MARKETING_IMAGE 1.91:1 (min 600x314), SQUARE_MARKETING_IMAGE "
+            "1:1 (min 300x300), PORTRAIT_MARKETING_IMAGE 4:5 (min 480x600), "
+            "LOGO 1:1 (min 128x128), LANDSCAPE_LOGO 4:1 (min 512x128) — and "
+            "mureo checks it before uploading or linking anything, then "
+            "refuses with the rule spelled out. It never crops or resizes. "
+            "Returns {asset_group_id, field_type, added: {asset_id, "
+            "asset_name, width_pixels, height_pixels, source "
+            "('existing_asset' | 'uploaded'), asset_group_asset}, removed: "
+            "{asset_id, asset_name, url, asset_group_asset}, note}. Not "
+            "automatically reversible — to swap back, call this tool again "
+            "with the old asset_id; record before-state with "
+            "mureo_state_action_log_append if you may need to roll back. "
+            "Call google_ads_asset_group_assets_list first to get "
+            "old_asset_id. For headlines and descriptions use "
+            "google_ads_asset_group_assets_replace instead."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "customer_id": _CUSTOMER_ID_PARAM,
+                "asset_group_id": {
+                    "type": "string",
+                    "description": (
+                        "Asset group whose image is being changed, as "
+                        "reported by google_ads_asset_group_assets_list."
+                    ),
+                },
+                "field_type": {
+                    "type": "string",
+                    "enum": _IMAGE_FIELD_TYPES,
+                    "description": (
+                        "Which image slot to swap. Must match the field_type "
+                        "the old asset is linked under — the same image can "
+                        "be linked as more than one field type, and each has "
+                        "its own required aspect ratio."
+                    ),
+                },
+                "old_asset_id": {
+                    "type": "string",
+                    "description": (
+                        "asset_id of the entry being replaced, from "
+                        "google_ads_asset_group_assets_list. Rejected before "
+                        "any write if it is not linked to this asset group "
+                        "under this field_type."
+                    ),
+                },
+                "new_asset_id": {
+                    "type": "string",
+                    "description": (
+                        "An image asset the account already holds, from "
+                        "google_ads_image_assets_list or from another asset "
+                        "group's entry. Rejected if it is not an image "
+                        "asset, if its dimensions do not fit this "
+                        "field_type, or if it is already linked to this "
+                        "asset group under this field_type (Google Ads "
+                        "refuses a duplicate link). Supply this OR "
+                        "new_image_path, never both."
+                    ),
+                },
+                "new_image_path": {
+                    "type": "string",
+                    "description": (
+                        "Local path to an image to upload and link "
+                        "(jpg/jpeg/png/gif, max 5MB). Its dimensions are "
+                        "checked against this field_type BEFORE the upload, "
+                        "so a wrongly proportioned file costs no API call. "
+                        "Supply this OR new_asset_id, never both."
+                    ),
+                },
+                "new_image_name": {
+                    "type": "string",
+                    "description": (
+                        "Asset name for the uploaded image. Only used with "
+                        "new_image_path; defaults to the file name."
+                    ),
+                },
+            },
+            "required": [
+                "asset_group_id",
+                "field_type",
+                "old_asset_id",
             ],
             "additionalProperties": False,
         },

--- a/skills/creative-refresh/SKILL.md
+++ b/skills/creative-refresh/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: creative-refresh
-description: "Refresh ad copy and creative assets based on performance signals and brand voice. Use when the user asks to refresh creative, propose new ad copy, A/B test creatives, update RSA assets, swap Performance Max asset-group headlines or descriptions, rotate underperformers, or visually evaluate / compare banner (image) creatives. Also use when the user asks in Japanese (クリエイティブを刷新して / 広告文の改善案がほしい / RSAアセットの入れ替え / P-MAXの見出しを差し替えて / バナーを比較評価して)."
+description: "Refresh ad copy and creative assets based on performance signals and brand voice. Use when the user asks to refresh creative, propose new ad copy, A/B test creatives, update RSA assets, swap Performance Max asset-group headlines, descriptions, images or logos, rotate underperformers, or visually evaluate / compare banner (image) creatives. Also use when the user asks in Japanese (クリエイティブを刷新して / 広告文の改善案がほしい / RSAアセットの入れ替え / P-MAXの見出しを差し替えて / P-MAXの画像を差し替えて / バナーを比較評価して)."
 metadata:
   version: 0.10.45
 ---
@@ -26,11 +26,11 @@ Refresh ad creatives based on strategy context and performance data across all p
 2. **Discover platforms**: Identify all configured ad platforms from STATE.json `platforms`. Also include any **hosted official-MCP connector** present in the session (e.g. TikTok, key `tiktok_ads`) — drive it via its own tools and skip mureo-only value-adds; see `../_mureo-shared/SKILL.md` → *Hosted-connector platforms*.
 
 3. **Audit current creatives**: For each ad platform:
-   - **Google Ads**: prefer mureo native — call `google_ads_ad_performance_report` per campaign, plus `google_ads_rsa_assets_audit` (per-asset CTR/CVR ratings) and `google_ads_rsa_assets_analyze` (LOW/POOR detection). A **Performance Max** campaign has no `ad_group_ad`, so `google_ads_ads_list` and the RSA asset tools return nothing for it — an audit that stops there reports a P-MAX account as having no ad copy at all. Read its copy with `google_ads_asset_group_assets_list` (pass `campaign_id` when you have no `asset_group_id`); it returns the HEADLINE / LONG_HEADLINE / DESCRIPTION assets, **text only**, one entry per link with the `asset_id` you will need to change one. In BYOD mode, the Apps Script bundle does not include per-asset ratings — these tools return `[]`; fall back to `google_ads_ads_list` for headline/description text and use `ad_performance.report` for ad-level CTR/conv only. If mureo's Google Ads tools are unavailable (e.g. `MUREO_DISABLE_GOOGLE_ADS=1` after `mureo providers add google-ads-official`), fall back to the official `google-ads-official` MCP for ad-level performance and ad listing, then **skip the mureo-only RSA asset audit tools** (`google_ads_rsa_assets_audit`, `google_ads_rsa_assets_analyze`) and note: "per-asset LOW/POOR detection and the RSA asset audit are mureo-specific value-add features — install or re-enable via `mureo setup claude-code` for the full creative audit."
+   - **Google Ads**: prefer mureo native — call `google_ads_ad_performance_report` per campaign, plus `google_ads_rsa_assets_audit` (per-asset CTR/CVR ratings) and `google_ads_rsa_assets_analyze` (LOW/POOR detection). A **Performance Max** campaign has no `ad_group_ad`, so `google_ads_ads_list` and the RSA asset tools return nothing for it — an audit that stops there reports a P-MAX account as having no creative at all. Read its creative with `google_ads_asset_group_assets_list` (pass `campaign_id` when you have no `asset_group_id`); one call returns **both** the HEADLINE / LONG_HEADLINE / DESCRIPTION text (each entry with `text`) and the MARKETING_IMAGE / SQUARE_MARKETING_IMAGE / PORTRAIT_MARKETING_IMAGE / LOGO / LANDSCAPE_LOGO images (each entry with `asset_name`, a full-size serving `url`, `width_pixels`, `height_pixels`). `field_type` says which. Every entry carries the `asset_id` you will need to change it. Video and business-name assets are not returned. In BYOD mode, the Apps Script bundle does not include per-asset ratings — these tools return `[]`; fall back to `google_ads_ads_list` for headline/description text and use `ad_performance.report` for ad-level CTR/conv only. If mureo's Google Ads tools are unavailable (e.g. `MUREO_DISABLE_GOOGLE_ADS=1` after `mureo providers add google-ads-official`), fall back to the official `google-ads-official` MCP for ad-level performance and ad listing, then **skip the mureo-only RSA asset audit tools** (`google_ads_rsa_assets_audit`, `google_ads_rsa_assets_analyze`) and note: "per-asset LOW/POOR detection and the RSA asset audit are mureo-specific value-add features — install or re-enable via `mureo setup claude-code` for the full creative audit."
    - **Meta Ads**: prefer mureo native — call `meta_ads_creatives_list`, `meta_ads_analysis_compare_ads`, and `meta_ads_analysis_suggest_creative`. In BYOD mode, creative URLs / headlines / body / CTA may be present in `~/.mureo/byod/meta_ads/creatives.csv` (best-effort, populated only when those columns were in the export). If mureo's Meta Ads tools are unavailable, fall back to the official `meta-ads-official` hosted MCP for the creative list and ad-level insights only, then **skip the mureo-only analysis tools** (`meta_ads_analysis_compare_ads`, `meta_ads_analysis_suggest_creative`); perform the ad-comparison and creative-suggestion logic yourself using the rules in step 6 and note to the user that mureo's automated creative-suggestion engine requires the native MCP.
    - mureo BYOD data is centralized in the workspace `byod/` directory (or `~/.mureo/byod/` for legacy CLI users) and is only accessible through mureo MCP tools — do **not** look for raw CSVs in the project directory.
    - Identify underperforming assets (LOW/POOR ratings for search ads, low CTR/engagement for social ads).
-   - **Image / banner creatives**: the text-and-metrics audit above does not look at the picture itself. When a creative carries an image you can actually reach — `image_url` / `thumbnail_url` from `meta_ads_creatives_list`, or a Google image asset from `google_ads_image_assets_list` (account-level: name, dimensions and a full-size serving `url`) — also run the **Visual creative evaluation** section below to score the banner's design, not just its copy and CTR.
+   - **Image / banner creatives**: the text-and-metrics audit above does not look at the picture itself. When a creative carries an image you can actually reach — `image_url` / `thumbnail_url` from `meta_ads_creatives_list`, a P-MAX asset group's images from `google_ads_asset_group_assets_list` (which says *which* asset group serves each one), or a Google image asset from `google_ads_image_assets_list` (account-level: name, dimensions and a full-size serving `url`) — also run the **Visual creative evaluation** section below to score the banner's design, not just its copy and CTR.
 
 4. **Analyze landing pages**: For each campaign's final URL, analyze the landing page to extract key selling points, CTAs, and features. If GA4 is available, pull engagement metrics (time on page, scroll depth, bounce rate) to inform creative direction.
 
@@ -56,7 +56,7 @@ Refresh ad creatives based on strategy context and performance data across all p
 
 10. **Check pending observations**: Before executing, check `action_log` for campaigns being modified. If a previous creative change is still within its observation window, warn about stacking changes.
 
-11. **Execute approved changes**: Use each platform's ad creation/update tools to apply changes. For Google Performance Max copy that is `google_ads_asset_group_assets_replace` — one call per asset, taking `asset_group_id` + `field_type` + `old_asset_id` (from `google_ads_asset_group_assets_list`) + `new_text` — not `google_ads_ads_update`, which cannot see a P-MAX campaign. A draft-only item produces **no tool call at all**.
+11. **Execute approved changes**: Use each platform's ad creation/update tools to apply changes. For Google Performance Max copy that is `google_ads_asset_group_assets_replace` — one call per asset, taking `asset_group_id` + `field_type` + `old_asset_id` (from `google_ads_asset_group_assets_list`) + `new_text` — not `google_ads_ads_update`, which cannot see a P-MAX campaign. For a P-MAX **image or logo** it is `google_ads_asset_group_images_replace`, same targeting arguments plus either `new_asset_id` (an image the account already holds) or `new_image_path` (a local file to upload) — exactly one, and you do not need to know which situation you are in to pick the tool. A draft-only item produces **no tool call at all**.
 
 12. **Record outcome context**: For each campaign modified, log to `action_log` with `metrics_at_action` (current CTR, CPA, conversions, impressions, clicks) and `observation_due` (14 days from `server_now`'s date). Log only what mureo actually wrote: a draft the operator was asked to paste in by hand is not a mureo change and gets no `action_log` entry (log it, and `/ad-fatigue-check` and the outcome evaluator will later measure a change that may never have been made).
 
@@ -85,9 +85,12 @@ What Google Ads copy mureo can write **today**:
 | Surface | Read | Write |
 |---|---|---|
 | Search RSA headlines / descriptions | `google_ads_ads_list`, `google_ads_rsa_assets_audit` | `google_ads_ads_create`, `google_ads_ads_update` |
-| Performance Max asset-group text — HEADLINE / LONG_HEADLINE / DESCRIPTION | `google_ads_asset_group_assets_list` (text only) | `google_ads_asset_group_assets_replace` — one asset per call, by `asset_group_id` + `field_type` + `old_asset_id` |
+| Performance Max asset-group text — HEADLINE / LONG_HEADLINE / DESCRIPTION | `google_ads_asset_group_assets_list` (the `text` of each entry) | `google_ads_asset_group_assets_replace` — one asset per call, by `asset_group_id` + `field_type` + `old_asset_id` |
+| Performance Max asset-group images — MARKETING_IMAGE / SQUARE_MARKETING_IMAGE / PORTRAIT_MARKETING_IMAGE / LOGO / LANDSCAPE_LOGO | `google_ads_asset_group_assets_list` (the `url` + dimensions of each entry) | `google_ads_asset_group_images_replace` — one image per call, by `asset_group_id` + `field_type` + `old_asset_id` + either `new_asset_id` or `new_image_path` |
 | Responsive Display Ad text | `google_ads_ads_list` | create only (`google_ads_ads_create_display`); no text update — **draft-only** for an edit |
-| Any image, video, logo or business name — including every non-text field type of a P-MAX asset group | `google_ads_image_assets_list` lists account-level images with a serving URL, but nothing reports which asset group or ad uses one | none — **draft-only** |
+| A Responsive Display Ad's images | `google_ads_ads_list` returns asset resource names; join by id to `google_ads_image_assets_list` for a URL | none — **draft-only** |
+| Video, business name, and every other non-text non-image field type of a P-MAX asset group | not returned by `google_ads_asset_group_assets_list` | none — **draft-only** |
+| Any image outside the surfaces above | `google_ads_image_assets_list` lists account-level images with a serving URL, but does not report which ad uses one | none — **draft-only** |
 
 That table is a **snapshot of the tool layer, not** the boundary. The boundary
 is the tool list you can actually see in this session, and it moves in both
@@ -123,18 +126,20 @@ score, an empty rubric, or an "image not found" finding for a text ad.
 
 1. Collect each creative's image reference: `image_url` (or `thumbnail_url` for
    video — you evaluate the still frame only, not motion) from
-   `meta_ads_creatives_list`; for Google, the full-size serving `url` of an
-   image asset from `google_ads_image_assets_list`. In BYOD mode use the URL
-   column from `creatives.csv` when present.
+   `meta_ads_creatives_list`; for a **Performance Max** asset group, the
+   `url` of each image entry from `google_ads_asset_group_assets_list` — that
+   is the one Google read that says *which* asset group serves an image, so
+   "the images of this asset group" is directly enumerable (pass
+   `campaign_id` when you have no `asset_group_id`); for any other Google
+   image, the full-size serving `url` from `google_ads_image_assets_list`. In
+   BYOD mode use the URL column from `creatives.csv` when present.
    **What Google will not give you**: `google_ads_image_assets_list` is
-   account-wide — it does not say which ad or asset group serves an asset, so
-   you cannot enumerate "the images of this Performance Max asset group" from
-   it. `google_ads_asset_group_assets_list` returns the asset group's
-   headlines, long headlines and descriptions — text only, no image, video or
-   logo assets. A Responsive Display Ad is the one case with a link:
+   account-wide — outside a P-MAX asset group it does not say which ad serves
+   an asset. A Responsive Display Ad is the one other case with a link:
    `google_ads_ads_list` returns its `marketing_images` /
    `square_marketing_images` / `logo_images` as asset **resource names**,
    which you match by id against `google_ads_image_assets_list` to get a URL.
+   And no Google read returns video assets at all.
    For any image you cannot reach, score the copy and metrics, say plainly
    that the picture could not be retrieved, and ask the operator to paste it
    into chat if they want it graded — never a guessed visual score, and never
@@ -145,8 +150,9 @@ score, an empty rubric, or an "image not found" finding for a text ad.
    `Read` that file — the Read tool renders the pixels so you can actually see
    the banner. Only fetch URLs on the ad platform's own CDN
    (`*.fbcdn.net` / `*.cdninstagram.com` / `googleusercontent.com` /
-   `gstatic.com` etc.); refuse arbitrary hosts (SSRF hygiene). Delete the temp
-   files when done.
+   `gstatic.com` / `googlesyndication.com` — the last is where a P-MAX asset
+   group's image `url` points); refuse arbitrary hosts (SSRF hygiene). Delete
+   the temp files when done.
 3. **On Desktop / Cowork (MCP-only, no Read/Bash):** you generally cannot fetch
    and view an arbitrary URL yourself. Present the `image_url` to the operator
    and ask them to paste/drop the image into chat so you can see it; if they

--- a/tests/test_creative_apply_scope.py
+++ b/tests/test_creative_apply_scope.py
@@ -6,14 +6,21 @@ discovered that every write tool it knew (``google_ads_ads_create`` /
 ``google_ads_ads_update``) is RSA-only. The answer became "do it yourself in
 the Google Ads UI" after the operator had already spent a round trip.
 
-#590 has since landed ``google_ads_asset_group_assets_list`` /
-``google_ads_asset_group_assets_replace``, so P-MAX **text** is now
-applicable. That fixes one instance; it does not fix the shape of the bug.
-The durable requirement is that the offer be scoped by *whether a write tool
-exists for this exact surface*, decided **before** drafting — so the same
-guidance keeps working for the surfaces still uncovered (every image, video,
-logo and business-name asset, including every non-text field type of a P-MAX
+#590 landed ``google_ads_asset_group_assets_list`` /
+``google_ads_asset_group_assets_replace`` and #626 widened the read to a
+P-MAX asset group's images and added
+``google_ads_asset_group_images_replace``, so P-MAX text and images are both
+applicable now. That fixes two instances; it does not fix the shape of the
+bug. The durable requirement is that the offer be scoped by *whether a write
+tool exists for this exact surface*, decided **before** drafting — so the
+same guidance keeps working for the surfaces still uncovered (video,
+business name, and every other non-text non-image field type of a P-MAX
 asset group) and for whatever the tool layer gains next.
+
+The tests below therefore pin the rule's *shape* and its accuracy at this
+moment, and are expected to be edited whenever the tool layer moves. Prose
+that claims a surface is draft-only after it gained a write tool is the same
+defect pointing the other way.
 
 Pinned in BOTH the packaged copy and the repo-root mirror, kept
 byte-identical.
@@ -44,6 +51,9 @@ _RULE_HEADING = "## Apply or draft"
 #: The P-MAX ad-copy surface #590 added.
 _PMAX_LIST = "google_ads_asset_group_assets_list"
 _PMAX_REPLACE = "google_ads_asset_group_assets_replace"
+
+#: The P-MAX image surface #626 added, on the same read.
+_PMAX_IMAGE_REPLACE = "google_ads_asset_group_images_replace"
 
 
 def _body(name: str) -> str:
@@ -151,14 +161,36 @@ def test_rule_names_the_rsa_route_and_its_limit() -> None:
     assert "google_ads_ads_create" in rule
 
 
-def test_rule_marks_non_text_assets_draft_only() -> None:
-    """#590 swaps text by ``field_type``. Images, video, logos and business
-    names — including every non-text field type of a P-MAX asset group —
-    have no write tool."""
+def test_rule_names_the_pmax_image_route() -> None:
+    """#626 landed: a P-MAX asset group's images are applicable now, from
+    the same read. Calling them draft-only would be #591's defect pointing
+    the other way."""
+    rule = _section(_body("creative-refresh"), _RULE_HEADING)
+    assert _PMAX_IMAGE_REPLACE in rule
+    for field_type in ("MARKETING_IMAGE", "LOGO"):
+        assert field_type in rule
+
+
+def test_rule_names_both_image_entry_points_on_one_tool() -> None:
+    """The operator must not have to know whether the account already holds
+    the image in order to pick a tool name."""
+    rule = _section(_body("creative-refresh"), _RULE_HEADING)
+    image_lines = "\n".join(_lines(rule, _PMAX_IMAGE_REPLACE))
+    assert "new_asset_id" in image_lines
+    assert "new_image_path" in image_lines
+
+
+def test_rule_still_marks_the_uncovered_asset_kinds_draft_only() -> None:
+    """What the tool layer does NOT cover: video, business name, and every
+    other non-text non-image field type of a P-MAX asset group."""
     rule = _section(_body("creative-refresh"), _RULE_HEADING).lower()
     assert "draft-only" in rule
-    for kind in ("image", "video", "logo", "business name"):
+    for kind in ("video", "business name"):
         assert kind in rule, f"the uncovered surfaces must name {kind}"
+    uncovered = "\n".join(
+        ln for ln in _lines(rule, "draft-only") if "video" in ln.lower()
+    )
+    assert "none" in uncovered, "an uncovered surface must show no write tool"
 
 
 def test_audit_step_reads_pmax_copy_instead_of_missing_it() -> None:
@@ -183,28 +215,64 @@ def test_execute_step_routes_pmax_to_the_replace_tool() -> None:
         assert arg in joined, f"the P-MAX swap must name {arg}"
 
 
+def test_execute_step_routes_pmax_images_to_their_own_tool() -> None:
+    """An image swap is not a text swap: it takes an asset id or a file
+    path, not ``new_text``."""
+    body = _body("creative-refresh")
+    exec_lines = "\n".join(_lines(body, _PMAX_IMAGE_REPLACE))
+    assert exec_lines
+    for arg in ("asset_group_id", "field_type", "old_asset_id"):
+        assert arg in exec_lines, f"the P-MAX image swap must name {arg}"
+
+
+def test_audit_step_reads_pmax_images_not_only_its_text() -> None:
+    """The read returns both kinds in one call; an audit that reports only
+    the text is the same "P-MAX has no creative" blind spot one level in."""
+    body = _body("creative-refresh")
+    reads = "\n".join(_lines(body, _PMAX_LIST))
+    assert "MARKETING_IMAGE" in reads
+    assert "url" in reads
+
+
 # ---------------------------------------------------------------------------
 # The visual-evaluation instruction the issue calls out as unsatisfiable
 # ---------------------------------------------------------------------------
 
 
 def test_visual_evaluation_no_longer_claims_a_pmax_asset_is_retrievable() -> None:
-    """``a Google image/Display/PMax asset`` promised something no tool
-    delivers. #590 covers text, not pixels — the claim is still false."""
+    """``a Google image/Display/PMax asset`` was one undifferentiated
+    promise. The surfaces differ and the skill has to say how."""
     body = _body("creative-refresh")
     assert "image/Display/PMax asset" not in body
 
 
-def test_visual_evaluation_states_what_can_and_cannot_be_retrieved() -> None:
-    """Precisely: account-level image assets have a serving URL; which asset
-    group uses them is not retrievable, and the P-MAX text tool returns text."""
+def test_visual_evaluation_routes_pmax_images_to_the_asset_group_read() -> None:
+    """#626 closed the gap #591 recorded: the images of a given P-MAX asset
+    group are enumerable now, so the visual-evaluation instruction is
+    satisfiable for P-MAX and must name the read that satisfies it."""
+    body = _body("creative-refresh")
+    section = _section(body, "### Getting the image in front of you")
+    assert _PMAX_LIST in section
+    assert "url" in section
+
+
+def test_visual_evaluation_still_states_what_cannot_be_retrieved() -> None:
+    """The account-wide caveat on ``google_ads_image_assets_list`` survives:
+    outside a P-MAX asset group it still does not say which ad serves an
+    asset, and no Google read returns video assets."""
     body = _body("creative-refresh")
     assert "google_ads_image_assets_list" in body
-    text_only = [ln for ln in _lines(body, _PMAX_LIST) if "text only" in ln.lower()]
-    assert text_only, (
-        f"{_PMAX_LIST} must be qualified as text only, so no reader takes it "
-        "for an image route"
-    )
+    section = _section(body, "### Getting the image in front of you").lower()
+    assert "account-wide" in section
+    assert "video" in section
+
+
+def test_no_line_still_calls_the_pmax_read_text_only() -> None:
+    """The #591 wording. Leaving it in place would send a reader looking for
+    an image route that is now right there in the same result."""
+    body = _body("creative-refresh")
+    stale = [ln for ln in _lines(body, _PMAX_LIST) if "text only" in ln.lower()]
+    assert not stale, f"stale text-only claim about {_PMAX_LIST}: {stale}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_google_ads_asset_group_images.py
+++ b/tests/test_google_ads_asset_group_images.py
@@ -1,0 +1,832 @@
+"""Performance Max asset-group image swap (#626).
+
+Covers ``_AssetGroupImagesMixin``: replacing one image or logo of a
+Performance Max asset group, from either entry point — an image asset the
+account already holds, or a local file that has to be uploaded first.
+
+**Real SDK messages, faked transport.** As in
+``tests/test_google_ads_asset_groups.py``: a ``GoogleAdsClient`` built with
+mock credentials opens no channel until a call is issued, so the production
+code below runs against the real v23 protos — the operations it builds, the
+enums it sets and the resource-name paths it derives are the ones the API
+would receive. Only ``_search``, ``upload_image_asset`` and the outbound
+``GoogleAdsService.mutate`` are replaced. A ``MagicMock`` client would have
+accepted any misspelt field name.
+
+What is NOT covered here and is only reasoned about from the API reference:
+
+- whether Google's asset-count validation runs on the request's final state
+  (the premise behind sending link + unlink as one atomic mutate);
+- the exact dimension and aspect-ratio figures per field type — they come
+  from Google's Performance Max asset-requirements page, not from anything
+  the SDK declares. What IS pinned here is that mureo applies them
+  consistently, never resizes, and translates the server's refusal when it
+  could not check for itself.
+
+No live P-MAX account is available to this suite.
+"""
+
+from __future__ import annotations
+
+import struct
+import zlib
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from google.ads.googleads import util
+from google.ads.googleads.errors import GoogleAdsException
+from google.ads.googleads.v23.services.types.asset_group_asset_service import (
+    MutateAssetGroupAssetResult,
+)
+from google.ads.googleads.v23.services.types.google_ads_service import (
+    GoogleAdsRow,
+    MutateGoogleAdsResponse,
+    MutateOperationResponse,
+)
+
+from mureo.google_ads._asset_groups import PMAX_IMAGE_FIELD_TYPES
+from mureo.google_ads.client import GoogleAdsApiClient
+
+CUSTOMER_ID = "1234567890"
+
+# AssetFieldTypeEnum / AssetTypeEnum values, spelled out so the fixtures do
+# not depend on the same lookup the production mappers use.
+MARKETING_IMAGE = 5
+SQUARE_MARKETING_IMAGE = 19
+LOGO = 21
+LANDSCAPE_LOGO = 22
+HEADLINE = 2
+ASSET_TYPE_IMAGE = 4
+ASSET_TYPE_TEXT = 5
+
+_FIELD_TYPE_NAMES = {
+    MARKETING_IMAGE: "MARKETING_IMAGE",
+    SQUARE_MARKETING_IMAGE: "SQUARE_MARKETING_IMAGE",
+    LOGO: "LOGO",
+    LANDSCAPE_LOGO: "LANDSCAPE_LOGO",
+    HEADLINE: "HEADLINE",
+}
+
+
+def _make_client() -> GoogleAdsApiClient:
+    """A client whose SDK layer is real and whose transport is not."""
+    return GoogleAdsApiClient(
+        credentials=MagicMock(),
+        customer_id=CUSTOMER_ID,
+        developer_token="test-token",
+    )
+
+
+def _link_row(
+    *,
+    asset_id: int = 555,
+    asset_name: str = "Spring hero",
+    field_type: int = MARKETING_IMAGE,
+    url: str = "https://tpc.googlesyndication.com/simgad/555",
+    width: int = 1200,
+    height: int = 628,
+    asset_group_id: int = 4242,
+) -> Any:
+    """One ``asset_group_asset`` row for the group's current images."""
+    row = GoogleAdsRow()
+    link = row.asset_group_asset
+    link.resource_name = (
+        f"customers/{CUSTOMER_ID}/assetGroupAssets/"
+        f"{asset_group_id}~{asset_id}~{_FIELD_TYPE_NAMES[field_type]}"
+    )
+    link.field_type = field_type
+    link.status = 2  # ENABLED
+    row.asset.id = asset_id
+    row.asset.name = asset_name
+    row.asset.image_asset.full_size.url = url
+    row.asset.image_asset.full_size.width_pixels = width
+    row.asset.image_asset.full_size.height_pixels = height
+    row.asset_group.id = asset_group_id
+    row.asset_group.name = "PMax JP"
+    row.asset_group.campaign = f"customers/{CUSTOMER_ID}/campaigns/900"
+    return util.convert_proto_plus_to_protobuf(row)
+
+
+def _asset_row(
+    *,
+    asset_id: int = 777,
+    name: str = "New hero",
+    asset_type: int = ASSET_TYPE_IMAGE,
+    width: int = 1200,
+    height: int = 628,
+) -> Any:
+    """One ``asset`` row, as the new-asset lookup receives it."""
+    row = GoogleAdsRow()
+    row.asset.id = asset_id
+    row.asset.name = name
+    row.asset.type_ = asset_type
+    row.asset.image_asset.full_size.url = (
+        f"https://tpc.googlesyndication.com/simgad/{asset_id}"
+    )
+    row.asset.image_asset.full_size.width_pixels = width
+    row.asset.image_asset.full_size.height_pixels = height
+    return util.convert_proto_plus_to_protobuf(row)
+
+
+def _current_links() -> list[Any]:
+    return [
+        _link_row(asset_id=555, asset_name="Spring hero", field_type=MARKETING_IMAGE),
+        _link_row(asset_id=556, asset_name="Kept hero", field_type=MARKETING_IMAGE),
+        _link_row(
+            asset_id=557,
+            asset_name="Square one",
+            field_type=SQUARE_MARKETING_IMAGE,
+            width=1200,
+            height=1200,
+        ),
+    ]
+
+
+def _install_search(
+    client: GoogleAdsApiClient,
+    *,
+    links: list[Any] | None = None,
+    assets: list[Any] | None = None,
+) -> list[str]:
+    """Route the two reads the swap makes; return the captured queries."""
+    queries: list[str] = []
+
+    async def _search(query: str) -> list[Any]:
+        queries.append(query)
+        if "FROM asset_group_asset" in query:
+            return _current_links() if links is None else links
+        return [_asset_row()] if assets is None else assets
+
+    client._search = _search  # type: ignore[method-assign]
+    return queries
+
+
+def _mutate_response() -> Any:
+    """The two-result response the atomic image swap produces."""
+    response = MutateGoogleAdsResponse(
+        mutate_operation_responses=[
+            MutateOperationResponse(
+                asset_group_asset_result=MutateAssetGroupAssetResult(
+                    resource_name=(
+                        f"customers/{CUSTOMER_ID}/assetGroupAssets/"
+                        "4242~777~MARKETING_IMAGE"
+                    )
+                )
+            ),
+            MutateOperationResponse(
+                asset_group_asset_result=MutateAssetGroupAssetResult(
+                    resource_name=(
+                        f"customers/{CUSTOMER_ID}/assetGroupAssets/"
+                        "4242~555~MARKETING_IMAGE"
+                    )
+                )
+            ),
+        ]
+    )
+    return util.convert_proto_plus_to_protobuf(response)
+
+
+def _google_ads_exception(attr_name: str, *error_names: str) -> GoogleAdsException:
+    """A ``GoogleAdsException`` carrying error codes under ``attr_name``.
+
+    ``_has_error_code`` reads ``error.error_code.<attr>.name``, so the
+    stand-in only needs that shape. Built through ``__new__``, with
+    ``failure`` assigned on the INSTANCE — assigning through ``type(exc)``
+    would edit ``GoogleAdsException`` for the rest of the session and break
+    every module collected afterwards (#624).
+
+    ``error_code`` is a ``MagicMock``, which answers every attribute, so the
+    codes are also set to a non-matching name on the sibling attribute this
+    module's production code queries. Without that, a lookup against the
+    wrong attribute would match anyway and the test would prove nothing.
+    """
+    other = "asset_group_error" if attr_name == "image_error" else "image_error"
+    errors = []
+    for name in error_names:
+        error = MagicMock()
+        error.message = f"server said: {name}"
+        getattr(error.error_code, attr_name).name = name
+        getattr(error.error_code, other).name = "UNSPECIFIED"
+        errors.append(error)
+    failure = MagicMock()
+    failure.errors = errors
+    exc = GoogleAdsException.__new__(GoogleAdsException)
+    exc.failure = failure
+    exc._call = MagicMock()
+    exc._request_id = "req-1"
+    return exc
+
+
+def _install_fake_mutate(client: GoogleAdsApiClient, response: Any) -> list[Any]:
+    """Capture the operations the client sends; return the capture list."""
+    captured: list[Any] = []
+    service = MagicMock()
+
+    def _mutate(
+        *, customer_id: str, mutate_operations: list[Any], **kwargs: Any
+    ) -> Any:
+        captured.append((customer_id, list(mutate_operations), kwargs))
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+    service.mutate.side_effect = _mutate
+    real_get_service = client._get_service
+
+    def _get_service(name: str) -> Any:
+        if name == "GoogleAdsService":
+            return service
+        return real_get_service(name)
+
+    client._get_service = _get_service  # type: ignore[method-assign]
+    return captured
+
+
+def _install_fake_upload(client: GoogleAdsApiClient) -> list[Any]:
+    """Replace the upload; return the capture list."""
+    captured: list[Any] = []
+
+    async def _upload(file_path: str, name: str | None = None) -> dict[str, Any]:
+        captured.append((file_path, name))
+        return {
+            "resource_name": f"customers/{CUSTOMER_ID}/assets/888",
+            "id": "888",
+            "name": name or Path(file_path).name,
+        }
+
+    client.upload_image_asset = _upload  # type: ignore[method-assign]
+    return captured
+
+
+def _write_png(path: Path, width: int, height: int) -> Path:
+    """A real PNG header the std-lib prober can measure."""
+    ihdr = struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)
+    chunk = struct.pack(">I", len(ihdr)) + b"IHDR" + ihdr
+    chunk += struct.pack(">I", zlib.crc32(b"IHDR" + ihdr))
+    path.write_bytes(b"\x89PNG\r\n\x1a\n" + chunk)
+    return path
+
+
+def _swap_params(**overrides: Any) -> dict[str, Any]:
+    params: dict[str, Any] = {
+        "asset_group_id": "4242",
+        "field_type": "MARKETING_IMAGE",
+        "old_asset_id": "555",
+        "new_asset_id": "777",
+    }
+    params.update(overrides)
+    return params
+
+
+# ---------------------------------------------------------------------------
+# The swap itself
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestReplaceAssetGroupImageAsset:
+    async def test_sends_one_atomic_mutate_with_the_link_before_the_unlink(
+        self,
+    ) -> None:
+        """Two operations, not three: an image Asset exists before the asset
+        group can point at it. Both go in ONE request so the asset group
+        never dips below the P-MAX minimum for the field type."""
+        client = _make_client()
+        _install_search(client)
+        captured = _install_fake_mutate(client, _mutate_response())
+
+        await client.replace_asset_group_image_asset(_swap_params())
+
+        assert len(captured) == 1, "the swap must be a single request"
+        customer_id, operations, kwargs = captured[0]
+        assert customer_id == CUSTOMER_ID
+        assert len(operations) == 2
+        assert operations[0].asset_group_asset_operation.WhichOneof("operation") == (
+            "create"
+        )
+        assert operations[1].asset_group_asset_operation.WhichOneof("operation") == (
+            "remove"
+        )
+        # Atomicity is the guard against the count floor: partial_failure
+        # would let the remove land on its own.
+        assert kwargs.get("partial_failure") in (None, False)
+
+    async def test_links_the_named_asset_under_the_named_field_type(self) -> None:
+        client = _make_client()
+        _install_search(client)
+        captured = _install_fake_mutate(client, _mutate_response())
+
+        await client.replace_asset_group_image_asset(_swap_params())
+
+        _, operations, _ = captured[0]
+        link = operations[0].asset_group_asset_operation.create
+        assert link.asset == f"customers/{CUSTOMER_ID}/assets/777"
+        assert link.asset_group == f"customers/{CUSTOMER_ID}/assetGroups/4242"
+        assert link.field_type == MARKETING_IMAGE
+        assert operations[1].asset_group_asset_operation.remove == (
+            f"customers/{CUSTOMER_ID}/assetGroupAssets/4242~555~MARKETING_IMAGE"
+        )
+
+    async def test_no_asset_is_created_inside_the_mutate(self) -> None:
+        """The text swap creates its Asset in-request because a text Asset is
+        immutable. An image asset already exists — creating a second copy of
+        the same bytes would be pure account clutter."""
+        client = _make_client()
+        _install_search(client)
+        captured = _install_fake_mutate(client, _mutate_response())
+
+        await client.replace_asset_group_image_asset(_swap_params())
+
+        _, operations, _ = captured[0]
+        assert all(
+            op.WhichOneof("operation") == "asset_group_asset_operation"
+            for op in operations
+        )
+
+    async def test_result_reports_both_sides_of_the_swap(self) -> None:
+        client = _make_client()
+        _install_search(client)
+        _install_fake_mutate(client, _mutate_response())
+
+        result = await client.replace_asset_group_image_asset(_swap_params())
+
+        assert result["asset_group_id"] == "4242"
+        assert result["field_type"] == "MARKETING_IMAGE"
+        assert result["added"]["asset_id"] == "777"
+        assert result["added"]["asset_name"] == "New hero"
+        assert result["added"]["width_pixels"] == 1200
+        assert result["added"]["height_pixels"] == 628
+        assert result["added"]["source"] == "existing_asset"
+        assert result["added"]["asset_group_asset"].endswith("4242~777~MARKETING_IMAGE")
+        assert result["removed"]["asset_id"] == "555"
+        assert result["removed"]["asset_name"] == "Spring hero"
+        assert result["removed"]["url"].endswith("/555")
+        assert result["removed"]["asset_group_asset"].endswith(
+            "4242~555~MARKETING_IMAGE"
+        )
+
+    async def test_a_logo_uses_its_own_field_type_and_shape(self) -> None:
+        client = _make_client()
+        _install_search(
+            client,
+            links=[
+                _link_row(
+                    asset_id=600,
+                    asset_name="Old logo",
+                    field_type=LOGO,
+                    width=1200,
+                    height=1200,
+                )
+            ],
+            assets=[_asset_row(asset_id=601, width=512, height=512)],
+        )
+        captured = _install_fake_mutate(client, _mutate_response())
+
+        await client.replace_asset_group_image_asset(
+            _swap_params(field_type="LOGO", old_asset_id="600", new_asset_id="601")
+        )
+
+        _, operations, _ = captured[0]
+        assert operations[0].asset_group_asset_operation.create.field_type == LOGO
+        assert operations[1].asset_group_asset_operation.remove.endswith("~600~LOGO")
+
+
+# ---------------------------------------------------------------------------
+# The two entry points
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestNewImageSource:
+    async def test_a_local_path_is_uploaded_then_linked(self, tmp_path: Any) -> None:
+        """The second situation, reached by the same tool: bytes on disk
+        become an asset id and then the identical swap."""
+        client = _make_client()
+        _install_search(client)
+        uploads = _install_fake_upload(client)
+        captured = _install_fake_mutate(client, _mutate_response())
+        image = _write_png(tmp_path / "hero.png", 1200, 628)
+
+        result = await client.replace_asset_group_image_asset(
+            _swap_params(new_asset_id=None, new_image_path=str(image))
+        )
+
+        assert len(uploads) == 1
+        assert uploads[0][0].endswith("hero.png")
+        _, operations, _ = captured[0]
+        assert operations[0].asset_group_asset_operation.create.asset == (
+            f"customers/{CUSTOMER_ID}/assets/888"
+        )
+        assert result["added"]["asset_id"] == "888"
+        assert result["added"]["source"] == "uploaded"
+
+    async def test_the_upload_takes_the_supplied_asset_name(
+        self, tmp_path: Any
+    ) -> None:
+        client = _make_client()
+        _install_search(client)
+        uploads = _install_fake_upload(client)
+        _install_fake_mutate(client, _mutate_response())
+        image = _write_png(tmp_path / "hero.png", 1200, 628)
+
+        await client.replace_asset_group_image_asset(
+            _swap_params(
+                new_asset_id=None,
+                new_image_path=str(image),
+                new_image_name="Autumn hero",
+            )
+        )
+
+        assert uploads[0][1] == "Autumn hero"
+
+    @pytest.mark.parametrize(
+        "params",
+        [
+            {"new_asset_id": None},
+            {"new_asset_id": "777", "new_image_path": "/tmp/hero.png"},
+            {"new_asset_id": "", "new_image_path": "   "},
+        ],
+    )
+    async def test_refuses_anything_but_exactly_one_source(
+        self, params: dict[str, Any]
+    ) -> None:
+        """Accepting both would silently ignore one, and the asset group
+        would end up carrying an image the operator did not choose."""
+        client = _make_client()
+        _install_search(client)
+        captured = _install_fake_mutate(client, _mutate_response())
+
+        with pytest.raises(ValueError, match="exactly one"):
+            await client.replace_asset_group_image_asset(_swap_params(**params))
+        assert not captured
+
+    async def test_refuses_an_asset_id_that_is_not_an_image(self) -> None:
+        client = _make_client()
+        _install_search(client, assets=[_asset_row(asset_type=ASSET_TYPE_TEXT)])
+        captured = _install_fake_mutate(client, _mutate_response())
+
+        with pytest.raises(ValueError, match="not an image"):
+            await client.replace_asset_group_image_asset(_swap_params())
+        assert not captured
+
+    async def test_refuses_an_asset_id_the_account_does_not_hold(self) -> None:
+        client = _make_client()
+        _install_search(client, assets=[])
+        captured = _install_fake_mutate(client, _mutate_response())
+
+        with pytest.raises(ValueError, match="not found"):
+            await client.replace_asset_group_image_asset(_swap_params())
+        assert not captured
+
+    async def test_refuses_an_image_already_linked_under_the_field_type(self) -> None:
+        """Google rejects a duplicate link; say so before spending the call."""
+        client = _make_client()
+        _install_search(client, assets=[_asset_row(asset_id=556)])
+        captured = _install_fake_mutate(client, _mutate_response())
+
+        with pytest.raises(ValueError, match="already linked"):
+            await client.replace_asset_group_image_asset(
+                _swap_params(new_asset_id="556")
+            )
+        assert not captured
+
+    async def test_refuses_swapping_an_image_for_itself(self) -> None:
+        """The old asset is linked by definition, so it is a duplicate link
+        — and a swap that changes nothing should not spend a mutate."""
+        client = _make_client()
+        _install_search(client, assets=[_asset_row(asset_id=555)])
+        captured = _install_fake_mutate(client, _mutate_response())
+
+        with pytest.raises(ValueError, match="already linked"):
+            await client.replace_asset_group_image_asset(
+                _swap_params(new_asset_id="555")
+            )
+        assert not captured
+
+
+# ---------------------------------------------------------------------------
+# Dimension rules
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDimensionRules:
+    @pytest.mark.parametrize(
+        "field_type,width,height,expected",
+        [
+            ("MARKETING_IMAGE", 1200, 1200, "1.91:1"),
+            ("SQUARE_MARKETING_IMAGE", 1200, 628, "1:1"),
+            ("PORTRAIT_MARKETING_IMAGE", 1200, 1200, "4:5"),
+            ("LANDSCAPE_LOGO", 1200, 1200, "4:1"),
+        ],
+    )
+    async def test_refuses_an_existing_asset_of_the_wrong_shape(
+        self, field_type: str, width: int, height: int, expected: str
+    ) -> None:
+        """Every slot has its own shape: a square image is not a landscape
+        one, and the refusal has to say which rule it broke."""
+        client = _make_client()
+        _install_search(client, assets=[_asset_row(width=width, height=height)])
+
+        with pytest.raises(ValueError) as excinfo:
+            await client._existing_image_asset("777", field_type)
+
+        message = str(excinfo.value)
+        assert expected in message
+        assert f"{width}x{height}" in message
+        assert "resize" in message
+
+    async def test_a_wrong_shape_asset_blocks_the_whole_swap(self) -> None:
+        """End to end: the shape check sits before the mutate, not beside
+        it."""
+        client = _make_client()
+        _install_search(client, assets=[_asset_row(width=1200, height=1200)])
+        captured = _install_fake_mutate(client, _mutate_response())
+
+        with pytest.raises(ValueError, match="1.91:1"):
+            await client.replace_asset_group_image_asset(_swap_params())
+
+        assert not captured
+
+    @pytest.mark.parametrize(
+        "field_type,width,height",
+        [
+            ("MARKETING_IMAGE", 382, 200),
+            ("SQUARE_MARKETING_IMAGE", 200, 200),
+            ("LOGO", 64, 64),
+            ("LANDSCAPE_LOGO", 400, 100),
+        ],
+    )
+    async def test_refuses_an_image_below_the_field_type_minimum(
+        self, field_type: str, width: int, height: int
+    ) -> None:
+        """Right shape, too few pixels."""
+        client = _make_client()
+        _install_search(client, assets=[_asset_row(width=width, height=height)])
+
+        with pytest.raises(ValueError, match="at least"):
+            await client._existing_image_asset("777", field_type)
+
+    async def test_a_local_file_is_measured_before_it_is_uploaded(
+        self, tmp_path: Any
+    ) -> None:
+        """A wrongly proportioned file must cost no API call and leave no
+        unlinked asset behind in the account."""
+        client = _make_client()
+        _install_search(client)
+        uploads = _install_fake_upload(client)
+        captured = _install_fake_mutate(client, _mutate_response())
+        image = _write_png(tmp_path / "square.png", 1200, 1200)
+
+        with pytest.raises(ValueError, match="1.91:1"):
+            await client.replace_asset_group_image_asset(
+                _swap_params(new_asset_id=None, new_image_path=str(image))
+            )
+
+        assert not uploads, "nothing may be uploaded before the shape is checked"
+        assert not captured
+
+    async def test_an_unmeasurable_file_is_not_refused_on_a_guess(
+        self, tmp_path: Any
+    ) -> None:
+        """A GIF has no std-lib prober here. mureo does not know its shape,
+        so it does not pretend to: the file goes to Google and the refusal,
+        if any, comes back translated."""
+        client = _make_client()
+        _install_search(client)
+        uploads = _install_fake_upload(client)
+        _install_fake_mutate(client, _mutate_response())
+        image = tmp_path / "animated.gif"
+        image.write_bytes(b"GIF89a" + b"\x00" * 32)
+
+        result = await client.replace_asset_group_image_asset(
+            _swap_params(new_asset_id=None, new_image_path=str(image))
+        )
+
+        assert len(uploads) == 1
+        assert result["added"]["source"] == "uploaded"
+
+    @pytest.mark.parametrize(
+        "width,height",
+        [(1200, 628), (600, 314), (1200, 630)],
+    )
+    async def test_accepts_the_sizes_google_itself_publishes(
+        self, width: int, height: int
+    ) -> None:
+        """1200x628 is 1.911:1, not 1.910:1 — a tolerance-free ratio check
+        would refuse Google's own recommended size."""
+        client = _make_client()
+        _install_search(client, assets=[_asset_row(width=width, height=height)])
+
+        resolved = await client._existing_image_asset("777", "MARKETING_IMAGE")
+
+        assert resolved["asset_id"] == "777"
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestInputValidation:
+    async def test_refuses_an_asset_id_not_linked_under_that_field_type(self) -> None:
+        """557 is linked, but as a SQUARE_MARKETING_IMAGE."""
+        client = _make_client()
+        _install_search(client)
+        captured = _install_fake_mutate(client, _mutate_response())
+
+        with pytest.raises(ValueError, match="557"):
+            await client.replace_asset_group_image_asset(
+                _swap_params(old_asset_id="557")
+            )
+        assert not captured
+
+    @pytest.mark.parametrize(
+        "field_type", ["HEADLINE", "YOUTUBE_VIDEO", "AD_IMAGE", "marketing_image"]
+    )
+    async def test_refuses_a_field_type_outside_the_five_image_types(
+        self, field_type: str
+    ) -> None:
+        client = _make_client()
+        client._search = MagicMock()  # type: ignore[method-assign]
+        with pytest.raises(ValueError, match="field_type"):
+            await client.replace_asset_group_image_asset(
+                _swap_params(field_type=field_type)
+            )
+
+    @pytest.mark.parametrize("key", ["asset_group_id", "old_asset_id"])
+    async def test_refuses_non_numeric_ids(self, key: str) -> None:
+        client = _make_client()
+        client._search = MagicMock()  # type: ignore[method-assign]
+        with pytest.raises(ValueError, match=key):
+            await client.replace_asset_group_image_asset(_swap_params(**{key: "4242'"}))
+
+    async def test_refuses_a_non_numeric_new_asset_id(self) -> None:
+        client = _make_client()
+        _install_search(client)
+        captured = _install_fake_mutate(client, _mutate_response())
+
+        with pytest.raises(ValueError, match="new_asset_id"):
+            await client.replace_asset_group_image_asset(
+                _swap_params(new_asset_id="７７７")
+            )
+        assert not captured
+
+    async def test_refuses_a_traversing_image_path(self, tmp_path: Any) -> None:
+        client = _make_client()
+        _install_search(client)
+        uploads = _install_fake_upload(client)
+
+        with pytest.raises(ValueError):
+            await client.replace_asset_group_image_asset(
+                _swap_params(new_asset_id=None, new_image_path="../../etc/passwd.png")
+            )
+        assert not uploads
+
+
+# ---------------------------------------------------------------------------
+# API refusals worth translating
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestTranslatedRefusals:
+    @pytest.mark.parametrize(
+        "code",
+        [
+            "NOT_ENOUGH_MARKETING_IMAGE_ASSET",
+            "NOT_ENOUGH_SQUARE_MARKETING_IMAGE_ASSET",
+            "NOT_ENOUGH_LOGO_ASSET",
+        ],
+    )
+    async def test_asset_count_floor_becomes_an_actionable_message(
+        self, code: str
+    ) -> None:
+        """The image twins of #590's ``NOT_ENOUGH_HEADLINE_ASSET``. They must
+        not reach the agent as a raw API error."""
+        client = _make_client()
+        _install_search(client)
+        _install_fake_mutate(client, _google_ads_exception("asset_group_error", code))
+
+        with pytest.raises(RuntimeError) as excinfo:
+            await client.replace_asset_group_image_asset(_swap_params())
+
+        message = str(excinfo.value)
+        assert code in message
+        assert "minimum" in message.lower()
+
+    @pytest.mark.parametrize(
+        "code",
+        [
+            "ASPECT_RATIO_NOT_ALLOWED",
+            "IMAGE_TOO_SMALL",
+            "IMAGE_CONSTRAINTS_VIOLATED",
+            "UNEXPECTED_SIZE",
+        ],
+    )
+    async def test_image_constraint_refusal_names_the_rule_for_the_slot(
+        self, code: str
+    ) -> None:
+        """The backstop for what mureo could not measure itself: the message
+        has to say what shape the slot takes, not just echo an enum name."""
+        client = _make_client()
+        _install_search(client)
+        _install_fake_mutate(client, _google_ads_exception("image_error", code))
+
+        with pytest.raises(RuntimeError) as excinfo:
+            await client.replace_asset_group_image_asset(_swap_params())
+
+        message = str(excinfo.value)
+        assert code in message
+        assert "1.91:1" in message
+        assert "600x314" in message
+        assert "resize" in message
+
+    async def test_a_failed_swap_after_an_upload_says_the_asset_is_orphaned(
+        self, tmp_path: Any
+    ) -> None:
+        """The upload is a separate request, so a refusal afterwards leaves
+        an unlinked asset in the account. Say so rather than let the
+        operator find it."""
+        client = _make_client()
+        _install_search(client)
+        _install_fake_upload(client)
+        _install_fake_mutate(
+            client, _google_ads_exception("image_error", "ASPECT_RATIO_NOT_ALLOWED")
+        )
+        image = tmp_path / "animated.gif"
+        image.write_bytes(b"GIF89a" + b"\x00" * 32)
+
+        with pytest.raises(RuntimeError) as excinfo:
+            await client.replace_asset_group_image_asset(
+                _swap_params(new_asset_id=None, new_image_path=str(image))
+            )
+
+        assert "unlinked" in str(excinfo.value)
+
+    async def test_other_api_errors_keep_the_curated_server_detail(self) -> None:
+        client = _make_client()
+        _install_search(client)
+        _install_fake_mutate(
+            client, _google_ads_exception("asset_group_error", "DUPLICATE_NAME")
+        )
+
+        with pytest.raises(RuntimeError) as excinfo:
+            await client.replace_asset_group_image_asset(_swap_params())
+
+        assert "server said: DUPLICATE_NAME" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestImageErrorConstants:
+    def test_every_translated_code_is_a_real_enum_member(self) -> None:
+        """A misspelt code silently never matches, and the refusal it exists
+        to explain reaches the agent raw."""
+        from google.ads.googleads.v23.errors.types.asset_group_error import (
+            AssetGroupErrorEnum,
+        )
+        from google.ads.googleads.v23.errors.types.image_error import ImageErrorEnum
+
+        from mureo.google_ads._asset_groups_images import (
+            _IMAGE_CONSTRAINT_ERRORS,
+            _NOT_ENOUGH_IMAGE_ASSET_ERRORS,
+        )
+
+        group_codes = {m.name for m in AssetGroupErrorEnum.AssetGroupError}
+        image_codes = {m.name for m in ImageErrorEnum.ImageError}
+        assert set(_NOT_ENOUGH_IMAGE_ASSET_ERRORS) <= group_codes
+        assert set(_IMAGE_CONSTRAINT_ERRORS) <= image_codes
+
+    def test_the_mixin_shadows_no_sibling_implementation(self) -> None:
+        """The image mixin needs ``upload_image_asset`` and
+        ``list_asset_group_assets``, both owned by other mixins. A plain
+        ``...`` stub for either would win the MRO — ``_MediaMixin`` is
+        composed after this one — and every upload would silently return
+        ``None``, which is exactly what happened before this was pinned.
+        """
+        from mureo.google_ads._asset_groups import _AssetGroupsMixin
+        from mureo.google_ads._asset_groups_images import _AssetGroupImagesMixin
+        from mureo.google_ads._media import _MediaMixin
+
+        for name, owner in (
+            ("upload_image_asset", _MediaMixin),
+            ("list_asset_group_assets", _AssetGroupsMixin),
+        ):
+            assert not hasattr(
+                _AssetGroupImagesMixin, name
+            ), f"{name} must be declared under TYPE_CHECKING only"
+            assert getattr(GoogleAdsApiClient, name) is getattr(owner, name)
+
+    def test_every_field_type_has_a_dimension_rule(self) -> None:
+        for field_type, spec in PMAX_IMAGE_FIELD_TYPES.items():
+            assert spec.aspect_ratio > 0, field_type
+            assert spec.min_width > 0 and spec.min_height > 0, field_type
+            assert spec.ratio_label and spec.recommended, field_type

--- a/tests/test_google_ads_asset_groups.py
+++ b/tests/test_google_ads_asset_groups.py
@@ -1,8 +1,10 @@
-"""Performance Max asset-group text assets (#590).
+"""Performance Max asset-group assets — read + text swap (#590, #626).
 
-Covers ``_AssetGroupsMixin``: the read of the HEADLINE / LONG_HEADLINE /
-DESCRIPTION assets linked to a Performance Max asset group, and the swap
-that replaces one of them.
+Covers ``_AssetGroupsMixin``: the read of the assets linked to a
+Performance Max asset group — the HEADLINE / LONG_HEADLINE / DESCRIPTION
+text of #590 and the five image field types of #626, in one query — and
+the swap that replaces one text asset. The image swap has its own module,
+``tests/test_google_ads_asset_group_images.py``.
 
 **Real SDK messages, faked transport.** A ``GoogleAdsClient`` built with
 mock credentials opens no channel until a call is actually issued, so the
@@ -37,7 +39,10 @@ from google.ads.googleads.v23.services.types.google_ads_service import (
     MutateOperationResponse,
 )
 
-from mureo.google_ads._asset_groups import PMAX_TEXT_FIELD_TYPES
+from mureo.google_ads._asset_groups import (
+    PMAX_IMAGE_FIELD_TYPES,
+    PMAX_TEXT_FIELD_TYPES,
+)
 from mureo.google_ads.client import GoogleAdsApiClient
 
 CUSTOMER_ID = "1234567890"
@@ -47,10 +52,16 @@ CUSTOMER_ID = "1234567890"
 HEADLINE = 2
 DESCRIPTION = 3
 LONG_HEADLINE = 17
+MARKETING_IMAGE = 5
+SQUARE_MARKETING_IMAGE = 19
+LOGO = 21
 _FIELD_TYPE_NAMES = {
     HEADLINE: "HEADLINE",
     DESCRIPTION: "DESCRIPTION",
     LONG_HEADLINE: "LONG_HEADLINE",
+    MARKETING_IMAGE: "MARKETING_IMAGE",
+    SQUARE_MARKETING_IMAGE: "SQUARE_MARKETING_IMAGE",
+    LOGO: "LOGO",
 }
 
 
@@ -85,6 +96,39 @@ def _row(
     link.status = status
     row.asset.id = asset_id
     row.asset.text_asset.text = text
+    row.asset_group.id = asset_group_id
+    row.asset_group.name = asset_group_name
+    row.asset_group.campaign = f"customers/{CUSTOMER_ID}/campaigns/{campaign_id}"
+    return util.convert_proto_plus_to_protobuf(row)
+
+
+def _image_row(
+    *,
+    asset_id: int = 555,
+    asset_name: str = "Spring hero",
+    field_type: int = MARKETING_IMAGE,
+    url: str = "https://tpc.googlesyndication.com/simgad/555",
+    width: int = 1200,
+    height: int = 628,
+    status: int = 2,  # AssetLinkStatusEnum.ENABLED
+    asset_group_id: int = 4242,
+    asset_group_name: str = "PMax JP",
+    campaign_id: int = 900,
+) -> Any:
+    """One image ``asset_group_asset`` row, raw-protobuf shaped."""
+    row = GoogleAdsRow()
+    link = row.asset_group_asset
+    link.resource_name = (
+        f"customers/{CUSTOMER_ID}/assetGroupAssets/"
+        f"{asset_group_id}~{asset_id}~{_FIELD_TYPE_NAMES[field_type]}"
+    )
+    link.field_type = field_type
+    link.status = status
+    row.asset.id = asset_id
+    row.asset.name = asset_name
+    row.asset.image_asset.full_size.url = url
+    row.asset.image_asset.full_size.width_pixels = width
+    row.asset.image_asset.full_size.height_pixels = height
     row.asset_group.id = asset_group_id
     row.asset_group.name = asset_group_name
     row.asset_group.campaign = f"customers/{CUSTOMER_ID}/campaigns/{campaign_id}"
@@ -178,7 +222,7 @@ def _install_fake_mutate(client: GoogleAdsApiClient, response: Any) -> list[Any]
 
 
 # ---------------------------------------------------------------------------
-# list_asset_group_text_assets
+# list_asset_group_assets
 # ---------------------------------------------------------------------------
 
 
@@ -197,13 +241,131 @@ class TestListAssetGroupTextAssets:
             return []
 
         client._search = _search  # type: ignore[method-assign]
-        await client.list_asset_group_text_assets()
+        await client.list_asset_group_assets()
 
         assert len(queries) == 1
         assert "FROM asset_group_asset" in queries[0]
         assert "asset.text_asset.text" in queries[0]
         for field_type in PMAX_TEXT_FIELD_TYPES:
             assert f"'{field_type}'" in queries[0]
+
+    async def test_one_query_covers_the_images_too(self) -> None:
+        """#626: "show me this asset group's creative" must not need two
+        calls, and a text-only read is how #591's field report concluded a
+        P-MAX account had no creative at all."""
+        client = _make_client()
+        queries: list[str] = []
+
+        async def _search(query: str) -> list[Any]:
+            queries.append(query)
+            return []
+
+        client._search = _search  # type: ignore[method-assign]
+        await client.list_asset_group_assets()
+
+        assert len(queries) == 1, "text and images come back in one round trip"
+        for field_type in PMAX_IMAGE_FIELD_TYPES:
+            assert f"'{field_type}'" in queries[0]
+        for column in (
+            "asset.name",
+            "asset.image_asset.full_size.url",
+            "asset.image_asset.full_size.width_pixels",
+            "asset.image_asset.full_size.height_pixels",
+        ):
+            assert column in queries[0]
+
+    async def test_video_field_types_are_not_selected(self) -> None:
+        """Out of scope by design: a video asset references a YouTube id
+        rather than uploaded bytes, so it is a different entry shape."""
+        client = _make_client()
+        queries: list[str] = []
+
+        async def _search(query: str) -> list[Any]:
+            queries.append(query)
+            return []
+
+        client._search = _search  # type: ignore[method-assign]
+        await client.list_asset_group_assets()
+
+        for field_type in ("YOUTUBE_VIDEO", "VIDEO", "RELATED_YOUTUBE_VIDEOS"):
+            assert f"'{field_type}'" not in queries[0]
+
+    async def test_image_rows_carry_the_picture_and_its_dimensions(self) -> None:
+        client = _make_client()
+
+        async def _search(query: str) -> list[Any]:
+            return [_image_row()]
+
+        client._search = _search  # type: ignore[method-assign]
+        (entry,) = await client.list_asset_group_assets()
+
+        assert entry["field_type"] == "MARKETING_IMAGE"
+        assert entry["asset_id"] == "555"
+        assert entry["asset_name"] == "Spring hero"
+        assert entry["url"] == "https://tpc.googlesyndication.com/simgad/555"
+        assert entry["width_pixels"] == 1200
+        assert entry["height_pixels"] == 628
+        assert entry["status"] == "ENABLED"
+        assert entry["asset_group_id"] == "4242"
+        assert entry["campaign_id"] == "900"
+        assert "text" not in entry, "an image link has no text to report"
+
+    async def test_text_rows_are_unchanged_by_the_image_half(self) -> None:
+        """#590's row shape is a contract: the image half added no key to a
+        text row and removed none."""
+        client = _make_client()
+
+        async def _search(query: str) -> list[Any]:
+            return [_row(asset_id=111, text="Old headline"), _image_row()]
+
+        client._search = _search  # type: ignore[method-assign]
+        text_entry, image_entry = await client.list_asset_group_assets()
+
+        assert set(text_entry) == {
+            "resource_name",
+            "field_type",
+            "status",
+            "asset_id",
+            "text",
+            "asset_group_id",
+            "asset_group_name",
+            "campaign_id",
+            "campaign_resource_name",
+        }
+        assert set(image_entry) - set(text_entry) == {
+            "asset_name",
+            "url",
+            "width_pixels",
+            "height_pixels",
+        }
+        assert set(text_entry) - set(image_entry) == {"text"}
+
+    async def test_both_kinds_come_back_from_one_call_in_api_order(self) -> None:
+        client = _make_client()
+        rows = [
+            _image_row(asset_id=555, field_type=MARKETING_IMAGE),
+            _row(asset_id=111, text="A headline"),
+            _image_row(
+                asset_id=556,
+                field_type=LOGO,
+                width=1200,
+                height=1200,
+                asset_name="Logo",
+            ),
+        ]
+
+        async def _search(query: str) -> list[Any]:
+            return rows
+
+        client._search = _search  # type: ignore[method-assign]
+        result = await client.list_asset_group_assets()
+
+        assert [r["asset_id"] for r in result] == ["555", "111", "556"]
+        assert [r["field_type"] for r in result] == [
+            "MARKETING_IMAGE",
+            "HEADLINE",
+            "LOGO",
+        ]
 
     async def test_returns_every_row_the_api_returned_in_order(self) -> None:
         """No summing, no dedupe, no reordering — three identical texts under
@@ -219,7 +381,7 @@ class TestListAssetGroupTextAssets:
             return rows
 
         client._search = _search  # type: ignore[method-assign]
-        result = await client.list_asset_group_text_assets()
+        result = await client.list_asset_group_assets()
 
         assert [r["asset_id"] for r in result] == ["1", "2", "3"]
         assert [r["text"] for r in result] == ["Same", "Same", "Long one"]
@@ -236,7 +398,7 @@ class TestListAssetGroupTextAssets:
             return [_row(asset_id=111, text="Old headline")]
 
         client._search = _search  # type: ignore[method-assign]
-        (entry,) = await client.list_asset_group_text_assets()
+        (entry,) = await client.list_asset_group_assets()
 
         assert entry["resource_name"].startswith(
             f"customers/{CUSTOMER_ID}/assetGroupAssets/"
@@ -259,9 +421,7 @@ class TestListAssetGroupTextAssets:
             return []
 
         client._search = _search  # type: ignore[method-assign]
-        await client.list_asset_group_text_assets(
-            asset_group_id="4242", campaign_id="900"
-        )
+        await client.list_asset_group_assets(asset_group_id="4242", campaign_id="900")
 
         assert "asset_group.id = 4242" in queries[0]
         assert (
@@ -275,7 +435,7 @@ class TestListAssetGroupTextAssets:
         client = _make_client()
         client._search = MagicMock()  # type: ignore[method-assign]
         with pytest.raises(ValueError):
-            await client.list_asset_group_text_assets(asset_group_id=bad)
+            await client.list_asset_group_assets(asset_group_id=bad)
 
     async def test_an_empty_filter_is_no_filter_not_an_error(self) -> None:
         """Matches ``list_ads``: a falsy filter means "whole account"."""
@@ -287,9 +447,10 @@ class TestListAssetGroupTextAssets:
             return []
 
         client._search = _search  # type: ignore[method-assign]
-        await client.list_asset_group_text_assets(asset_group_id="", campaign_id="")
+        await client.list_asset_group_assets(asset_group_id="", campaign_id="")
 
-        assert "AND" not in queries[0]
+        # Not a bare "AND": LANDSCAPE_LOGO in the IN clause contains one.
+        assert "AND asset_group." not in queries[0]
 
 
 # ---------------------------------------------------------------------------
@@ -560,16 +721,22 @@ class TestReplaceAssetGroupTextAsset:
 
 @pytest.mark.unit
 class TestFieldTypeConstants:
-    def test_the_query_and_the_limit_table_name_the_same_field_types(self) -> None:
+    def test_the_query_and_the_two_tables_name_the_same_field_types(self) -> None:
         """The GAQL ``IN`` clause is a static literal (so it can carry the
         ``validate_static_query`` marker); this stops it drifting from the
-        table the write half validates against."""
-        from mureo.google_ads._asset_groups import _TEXT_ASSET_QUERY
+        two tables the write halves validate against."""
+        from mureo.google_ads._asset_groups import _ASSET_QUERY
 
-        for field_type in PMAX_TEXT_FIELD_TYPES:
-            assert f"'{field_type}'" in _TEXT_ASSET_QUERY
-        quoted = _TEXT_ASSET_QUERY.split("IN (")[1].split(")")[0]
-        assert quoted.count("'") == 2 * len(PMAX_TEXT_FIELD_TYPES)
+        expected = set(PMAX_TEXT_FIELD_TYPES) | set(PMAX_IMAGE_FIELD_TYPES)
+        for field_type in expected:
+            assert f"'{field_type}'" in _ASSET_QUERY
+        quoted = _ASSET_QUERY.split("IN (")[1].split(")")[0]
+        assert quoted.count("'") == 2 * len(expected)
+
+    def test_the_two_tables_do_not_overlap(self) -> None:
+        """Parallel, not shared: a text field type carries a width limit and
+        an image field type carries a shape."""
+        assert not set(PMAX_TEXT_FIELD_TYPES) & set(PMAX_IMAGE_FIELD_TYPES)
 
     def test_every_field_type_is_a_real_asset_field_type_enum_member(self) -> None:
         from google.ads.googleads.v23.enums.types.asset_field_type import (
@@ -578,6 +745,47 @@ class TestFieldTypeConstants:
 
         names = {member.name for member in AssetFieldTypeEnum.AssetFieldType}
         assert set(PMAX_TEXT_FIELD_TYPES) <= names
+        assert set(PMAX_IMAGE_FIELD_TYPES) <= names
+
+    def test_the_image_table_excludes_the_non_asset_group_image_types(self) -> None:
+        """``AssetFieldTypeEnum`` has eight image field types; three of them
+        are not Performance Max asset-group slots. Pinned so a later "the
+        enum has more, add them" edit has to argue with this."""
+        excluded = {"TALL_PORTRAIT_MARKETING_IMAGE", "BUSINESS_LOGO", "AD_IMAGE"}
+        assert not excluded & set(PMAX_IMAGE_FIELD_TYPES)
+
+    def test_every_required_image_type_has_an_asset_count_floor(self) -> None:
+        """The SDK's own corroboration that these are asset-group slots:
+        ``AssetGroupErrorEnum`` defines ``NOT_ENOUGH_*`` for exactly the
+        three required image field types and for no other."""
+        from google.ads.googleads.v23.errors.types.asset_group_error import (
+            AssetGroupErrorEnum,
+        )
+
+        from mureo.google_ads._asset_groups_images import (
+            _NOT_ENOUGH_IMAGE_ASSET_ERRORS,
+        )
+
+        codes = {m.name for m in AssetGroupErrorEnum.AssetGroupError}
+        assert set(_NOT_ENOUGH_IMAGE_ASSET_ERRORS) <= codes
+        floors = {c for c in codes if c.startswith("NOT_ENOUGH_")}
+        image_floors = {
+            c
+            for c in floors
+            if any(f"NOT_ENOUGH_{ft}_ASSET" == c for ft in PMAX_IMAGE_FIELD_TYPES)
+        }
+        assert image_floors == set(_NOT_ENOUGH_IMAGE_ASSET_ERRORS)
+
+    def test_the_dimension_rules_are_self_consistent(self) -> None:
+        """Each spec's own minimum has to satisfy the ratio it declares —
+        otherwise the smallest allowed image would be refused by the very
+        check the same table drives."""
+        from mureo.google_ads._asset_groups import _validate_image_dimensions
+
+        for field_type, spec in PMAX_IMAGE_FIELD_TYPES.items():
+            _validate_image_dimensions(field_type, spec.min_width, spec.min_height)
+            width, height = (int(part) for part in spec.recommended.split("x"))
+            _validate_image_dimensions(field_type, width, height)
 
 
 @pytest.mark.unit
@@ -588,5 +796,6 @@ def test_mixin_is_composed_into_the_client() -> None:
             customer_id=CUSTOMER_ID,
             developer_token="t",
         )
-    assert hasattr(client, "list_asset_group_text_assets")
+    assert hasattr(client, "list_asset_group_assets")
     assert hasattr(client, "replace_asset_group_text_asset")
+    assert hasattr(client, "replace_asset_group_image_asset")

--- a/tests/test_google_ads_enum_reads.py
+++ b/tests/test_google_ads_enum_reads.py
@@ -90,6 +90,8 @@ _STR_READ_SUBJECTS: dict[tuple[str, str], tuple[str, str]] = {
     ("_asset_groups.py", "row"): ("services", "GoogleAdsRow"),
     ("_asset_groups.py", "link"): ("resources", "AssetGroupAsset"),
     ("_asset_groups.py", "group"): ("resources", "AssetGroup"),
+    ("_asset_groups.py", "full_size"): ("common", "ImageDimension"),
+    ("_asset_groups_images.py", "asset"): ("resources", "Asset"),
     ("_creative.py", "ad"): ("resources", "Ad"),
     ("_diagnostics.py", "row"): ("services", "GoogleAdsRow"),
     ("_diagnostics.py", "ad"): ("resources", "AdGroupAd"),

--- a/tests/test_image_validation_dimensions.py
+++ b/tests/test_image_validation_dimensions.py
@@ -161,3 +161,53 @@ def test_truncated_png_signature_passes_through(tmp_path: Path) -> None:
     img = tmp_path / "raw.png"
     img.write_bytes(b"\x89PNG raw visual")  # not the full 8-byte signature
     assert _validate(img) == img
+
+
+# ---------------------------------------------------------------------------
+# read_image_dimensions (#626)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "name,payload,expected",
+    [
+        ("hero.png", _png(1200, 628), (1200, 628)),
+        ("hero.jpg", _jpeg(600, 314), (600, 314)),
+        ("hero.webp", _webp_vp8x(960, 1200), (960, 1200)),
+    ],
+)
+def test_read_image_dimensions_measures_what_it_can(
+    tmp_path: Path, name: str, payload: bytes, expected: tuple[int, int]
+) -> None:
+    """The P-MAX image swap refuses a wrongly shaped file before uploading
+    it, which it can only do for the formats these probes cover."""
+    from mureo._image_validation import read_image_dimensions
+
+    img = tmp_path / name
+    img.write_bytes(payload)
+    assert read_image_dimensions(img) == expected
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "name,payload",
+    [
+        ("animated.gif", b"GIF89a" + b"\x00" * 32),
+        ("placeholder.png", b"\x00" * 100),
+        ("missing.png", None),
+    ],
+)
+def test_read_image_dimensions_says_unknown_rather_than_guessing(
+    tmp_path: Path, name: str, payload: bytes | None
+) -> None:
+    """``(None, None)`` is the honest answer for a format with no std-lib
+    probe here. A caller enforcing a per-slot shape must read that as "not
+    known", never as "not allowed" — mureo does not guess and does not
+    resize."""
+    from mureo._image_validation import read_image_dimensions
+
+    img = tmp_path / name
+    if payload is not None:
+        img.write_bytes(payload)
+    assert read_image_dimensions(img) == (None, None)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -63,10 +63,10 @@ class TestListTools:
     """Verify list_tools returns the correct tool definitions."""
 
     async def test_list_tools_returns_all_tools(self) -> None:
-        """list_tools returns all tools (Google Ads 91 + Meta Ads 90 + Search Console 10
+        """list_tools returns all tools (Google Ads 92 + Meta Ads 90 + Search Console 10
         + Rollback 2 + Batch 3 + Change Import 1 + Analysis 5 + Mureo Context 9
         + Analytics Registry 2 + Learning 2 + Learning pre-flight 1
-        + Creative Studio 5 = 221).
+        + Creative Studio 5 = 222).
 
         Analytics Registry is 2: mureo_analytics_modules_list +
         mureo_analytics_run (#440). Batch is 3: mureo_batch_begin / _end /
@@ -78,7 +78,7 @@ class TestListTools:
         mureo_learning_reset_preflight (#548)."""
         mod = _import_server_module()
         tools = await mod.handle_list_tools()
-        assert len(tools) == 221
+        assert len(tools) == 222
 
     async def test_list_tools_contains_google_and_meta(self) -> None:
         """Google Ads and Meta Ads tools are included."""

--- a/tests/test_mcp_tools_google_ads.py
+++ b/tests/test_mcp_tools_google_ads.py
@@ -53,9 +53,10 @@ class TestGoogleAdsToolDefinitions:
     """Verify the Google Ads tool list is defined correctly."""
 
     def test_tool_count(self) -> None:
-        """All 91 tools are defined (89 + P-MAX asset-group list/replace, #590)."""
+        """All 92 tools are defined (89 + P-MAX asset-group list/replace
+        (#590) + the P-MAX asset-group image swap (#626))."""
         mod = _import_google_ads_tools()
-        assert len(mod.TOOLS) == 91
+        assert len(mod.TOOLS) == 92
 
     def test_all_tool_names(self) -> None:
         """Every tool name starts with google_ads_ (underscore-separated, per MCP spec)."""

--- a/tests/test_mcp_tools_google_ads_asset_groups.py
+++ b/tests/test_mcp_tools_google_ads_asset_groups.py
@@ -1,4 +1,4 @@
-"""MCP surface for Performance Max asset-group text assets (#590).
+"""MCP surface for Performance Max asset-group assets (#590, #626).
 
 Tool schemas, handler wiring, and the two classification seams a new tool
 has to land on the right side of: the strategy-reminder mutation
@@ -17,6 +17,7 @@ import pytest
 
 _LIST_TOOL = "google_ads_asset_group_assets_list"
 _REPLACE_TOOL = "google_ads_asset_group_assets_replace"
+_REPLACE_IMAGE_TOOL = "google_ads_asset_group_images_replace"
 
 
 def _import_google_ads_tools():
@@ -53,9 +54,9 @@ def _standalone_google_ads():
 
 @pytest.mark.unit
 class TestAssetGroupToolDefinitions:
-    def test_both_tools_are_registered(self) -> None:
+    def test_all_three_tools_are_registered(self) -> None:
         names = {t.name for t in _import_google_ads_tools().TOOLS}
-        assert {_LIST_TOOL, _REPLACE_TOOL} <= names
+        assert {_LIST_TOOL, _REPLACE_TOOL, _REPLACE_IMAGE_TOOL} <= names
 
     def test_list_takes_no_required_parameter(self) -> None:
         schema = _tool(_LIST_TOOL).inputSchema
@@ -96,6 +97,59 @@ class TestAssetGroupToolDefinitions:
         assert _LIST_TOOL in _tool(_REPLACE_TOOL).description
 
 
+@pytest.mark.unit
+class TestImageToolDefinition:
+    """#626: the image half of the same surface."""
+
+    def test_image_field_type_is_enum_locked_to_the_five_image_types(self) -> None:
+        from mureo.google_ads._asset_groups import PMAX_IMAGE_FIELD_TYPES
+
+        schema = _tool(_REPLACE_IMAGE_TOOL).inputSchema
+        assert set(schema["properties"]["field_type"]["enum"]) == set(
+            PMAX_IMAGE_FIELD_TYPES
+        )
+
+    def test_neither_image_source_is_required_but_both_are_offered(self) -> None:
+        """ "Exactly one of" is not expressible in ``required``; the client
+        enforces it so every caller gets the rule, not just this schema."""
+        schema = _tool(_REPLACE_IMAGE_TOOL).inputSchema
+        assert set(schema["required"]) == {
+            "asset_group_id",
+            "field_type",
+            "old_asset_id",
+        }
+        assert {"new_asset_id", "new_image_path"} <= set(schema["properties"])
+
+    def test_one_tool_covers_both_situations(self) -> None:
+        """The operator must not have to work out whether the account
+        already holds the image in order to pick a tool name."""
+        description = _tool(_REPLACE_IMAGE_TOOL).description
+        assert "new_asset_id" in description
+        assert "new_image_path" in description
+        assert "exactly one" in description.lower()
+
+    def test_the_description_names_the_shape_of_every_slot(self) -> None:
+        """An agent that cannot see the rule will offer an image that gets
+        refused."""
+        description = _tool(_REPLACE_IMAGE_TOOL).description
+        for rule in ("1.91:1", "1:1", "4:5", "4:1"):
+            assert rule in description
+        assert "resize" in description
+
+    def test_the_read_and_the_two_writes_point_at_each_other(self) -> None:
+        assert _REPLACE_IMAGE_TOOL in _tool(_LIST_TOOL).description
+        assert _LIST_TOOL in _tool(_REPLACE_IMAGE_TOOL).description
+        assert _REPLACE_TOOL in _tool(_REPLACE_IMAGE_TOOL).description
+
+    def test_the_read_advertises_the_image_columns(self) -> None:
+        """#591's defect in reverse: describing the read as text-only now
+        hides half of what it returns."""
+        description = _tool(_LIST_TOOL).description
+        for column in ("asset_name", "url", "width_pixels", "height_pixels"):
+            assert column in description
+        assert "MARKETING_IMAGE" in description
+
+
 # ---------------------------------------------------------------------------
 # Name-shape classification
 # ---------------------------------------------------------------------------
@@ -125,6 +179,18 @@ class TestToolNameClassification:
 
         assert reads_as_a_report_only_action(_REPLACE_TOOL) is False
 
+    def test_the_image_replace_is_classified_as_a_mutation(self) -> None:
+        """#590 found `_replace` missing from the classifier's suffixes the
+        hard way. The image tool's name has to land on the same entry."""
+        from mureo.core.strategy_reminder import is_mutating_builtin_tool
+
+        assert is_mutating_builtin_tool(_REPLACE_IMAGE_TOOL) is True
+
+    def test_the_image_replace_does_not_read_as_report_only(self) -> None:
+        from mureo.core.tool_names import reads_as_a_report_only_action
+
+        assert reads_as_a_report_only_action(_REPLACE_IMAGE_TOOL) is False
+
 
 # ---------------------------------------------------------------------------
 # Handlers
@@ -140,8 +206,9 @@ class TestAssetGroupHandlers:
     async def test_list_forwards_both_filters(self) -> None:
         mod = _import_google_ads_tools()
         creds, client = _mock_google_ads_context()
-        client.list_asset_group_text_assets.return_value = [
-            {"asset_id": "111", "text": "Old", "field_type": "HEADLINE"}
+        client.list_asset_group_assets.return_value = [
+            {"asset_id": "111", "text": "Old", "field_type": "HEADLINE"},
+            {"asset_id": "555", "url": "https://x/555", "field_type": "LOGO"},
         ]
 
         h = _import_handlers()
@@ -158,15 +225,17 @@ class TestAssetGroupHandlers:
                 },
             )
 
-        client.list_asset_group_text_assets.assert_awaited_once_with(
+        client.list_asset_group_assets.assert_awaited_once_with(
             asset_group_id="4242", campaign_id="900"
         )
-        assert json.loads(result[0].text)[0]["asset_id"] == "111"
+        parsed = json.loads(result[0].text)
+        assert parsed[0]["asset_id"] == "111"
+        assert parsed[1]["url"] == "https://x/555"
 
     async def test_list_without_filters_passes_none(self) -> None:
         mod = _import_google_ads_tools()
         creds, client = _mock_google_ads_context()
-        client.list_asset_group_text_assets.return_value = []
+        client.list_asset_group_assets.return_value = []
 
         h = _import_handlers()
         with (
@@ -175,7 +244,7 @@ class TestAssetGroupHandlers:
         ):
             await mod.handle_tool(_LIST_TOOL, {"customer_id": "1234567890"})
 
-        client.list_asset_group_text_assets.assert_awaited_once_with(
+        client.list_asset_group_assets.assert_awaited_once_with(
             asset_group_id=None, campaign_id=None
         )
 
@@ -243,13 +312,142 @@ class TestAssetGroupHandlers:
         client.replace_asset_group_text_asset.assert_not_awaited()
 
 
+@pytest.mark.unit
+class TestAssetGroupImageHandlers:
+    async def test_forwards_an_existing_asset_swap(self) -> None:
+        mod = _import_google_ads_tools()
+        creds, client = _mock_google_ads_context()
+        client.replace_asset_group_image_asset.return_value = {
+            "asset_group_id": "4242",
+            "field_type": "MARKETING_IMAGE",
+            "added": {"asset_id": "777", "source": "existing_asset"},
+            "removed": {"asset_id": "555"},
+        }
+
+        h = _import_handlers()
+        with (
+            patch.object(h, "load_google_ads_credentials", return_value=creds),
+            patch.object(h, "create_google_ads_client", return_value=client),
+        ):
+            result = await mod.handle_tool(
+                _REPLACE_IMAGE_TOOL,
+                {
+                    "customer_id": "1234567890",
+                    "asset_group_id": "4242",
+                    "field_type": "MARKETING_IMAGE",
+                    "old_asset_id": "555",
+                    "new_asset_id": "777",
+                },
+            )
+
+        client.replace_asset_group_image_asset.assert_awaited_once_with(
+            {
+                "asset_group_id": "4242",
+                "field_type": "MARKETING_IMAGE",
+                "old_asset_id": "555",
+                "new_asset_id": "777",
+            }
+        )
+        assert json.loads(result[0].text)["added"]["asset_id"] == "777"
+
+    async def test_forwards_an_upload_swap_with_its_name(self) -> None:
+        mod = _import_google_ads_tools()
+        creds, client = _mock_google_ads_context()
+        client.replace_asset_group_image_asset.return_value = {"added": {}}
+
+        h = _import_handlers()
+        with (
+            patch.object(h, "load_google_ads_credentials", return_value=creds),
+            patch.object(h, "create_google_ads_client", return_value=client),
+        ):
+            await mod.handle_tool(
+                _REPLACE_IMAGE_TOOL,
+                {
+                    "customer_id": "1234567890",
+                    "asset_group_id": "4242",
+                    "field_type": "LOGO",
+                    "old_asset_id": "555",
+                    "new_image_path": "/tmp/logo.png",
+                    "new_image_name": "Autumn logo",
+                },
+            )
+
+        client.replace_asset_group_image_asset.assert_awaited_once_with(
+            {
+                "asset_group_id": "4242",
+                "field_type": "LOGO",
+                "old_asset_id": "555",
+                "new_image_path": "/tmp/logo.png",
+                "new_image_name": "Autumn logo",
+            }
+        )
+
+    async def test_an_absent_source_is_not_forwarded_as_none(self) -> None:
+        """The client decides "exactly one of"; a ``None`` sitting in the
+        params would make an absent argument look supplied."""
+        mod = _import_google_ads_tools()
+        creds, client = _mock_google_ads_context()
+        client.replace_asset_group_image_asset.return_value = {"added": {}}
+
+        h = _import_handlers()
+        with (
+            patch.object(h, "load_google_ads_credentials", return_value=creds),
+            patch.object(h, "create_google_ads_client", return_value=client),
+        ):
+            await mod.handle_tool(
+                _REPLACE_IMAGE_TOOL,
+                {
+                    "customer_id": "1234567890",
+                    "asset_group_id": "4242",
+                    "field_type": "LOGO",
+                    "old_asset_id": "555",
+                    "new_asset_id": "777",
+                },
+            )
+
+        params = client.replace_asset_group_image_asset.await_args.args[0]
+        assert "new_image_path" not in params
+        assert "new_image_name" not in params
+
+    @pytest.mark.parametrize(
+        "missing", ["asset_group_id", "field_type", "old_asset_id"]
+    )
+    async def test_requires_every_targeting_parameter(self, missing: str) -> None:
+        mod = _import_google_ads_tools()
+        creds, client = _mock_google_ads_context()
+        args = {
+            "customer_id": "1234567890",
+            "asset_group_id": "4242",
+            "field_type": "MARKETING_IMAGE",
+            "old_asset_id": "555",
+            "new_asset_id": "777",
+        }
+        args.pop(missing)
+
+        h = _import_handlers()
+        with (
+            patch.object(h, "load_google_ads_credentials", return_value=creds),
+            patch.object(h, "create_google_ads_client", return_value=client),
+            pytest.raises(ValueError, match=missing),
+        ):
+            await mod.handle_tool(_REPLACE_IMAGE_TOOL, args)
+
+        client.replace_asset_group_image_asset.assert_not_awaited()
+
+
 # ---------------------------------------------------------------------------
 # BYOD
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
-def test_the_swap_is_refused_in_byod_read_only_mode(tmp_path: Any) -> None:
+@pytest.mark.parametrize(
+    "method",
+    ["replace_asset_group_text_asset", "replace_asset_group_image_asset"],
+)
+def test_the_swaps_are_refused_in_byod_read_only_mode(
+    tmp_path: Any, method: str
+) -> None:
     """A BYOD client answers unknown READS with an empty list; a write must
     not take that path and read as a swap that quietly did nothing."""
     import asyncio
@@ -257,6 +455,6 @@ def test_the_swap_is_refused_in_byod_read_only_mode(tmp_path: Any) -> None:
     from mureo.byod.clients import ByodGoogleAdsClient
 
     client = ByodGoogleAdsClient(data_dir=tmp_path / "google_ads")
-    result = asyncio.run(client.replace_asset_group_text_asset({"a": 1}))
+    result = asyncio.run(getattr(client, method)({"a": 1}))
     assert result["status"] == "skipped_in_byod_readonly"
-    assert result["operation"] == "replace_asset_group_text_asset"
+    assert result["operation"] == method

--- a/tests/test_strategy_reminder.py
+++ b/tests/test_strategy_reminder.py
@@ -125,6 +125,7 @@ _MUTATING_CATALOGUE: frozenset[str] = frozenset(
         # Google Ads — mutating
         "google_ads_ad_groups_create",
         "google_ads_asset_group_assets_replace",
+        "google_ads_asset_group_images_replace",
         "google_ads_ad_groups_update",
         "google_ads_ads_create",
         "google_ads_ads_create_display",


### PR DESCRIPTION
## Before / After

**Before:** #590 made a Performance Max asset group's **text** readable and swappable. Its images stayed invisible. `google_ads_image_assets_list` lists the account's image assets but never says which asset group or ad uses one, so "show me this asset group's creative" could only be half-answered, and nothing could change an image.

**After:** `google_ads_asset_group_assets_list` returns an asset group's text **and** its images, and `google_ads_asset_group_images_replace` swaps one.

## The three design calls

### 1. One read, wider results — not a second tool

The read tool's name never said "text", and a text-only answer to "show me this asset group's creative" is exactly how #591's field report came to conclude a P-MAX account had no creative at all. A second tool would rebuild that blind spot for anyone who found only the first one. So `google_ads_asset_group_assets_list` covers both halves in **one** GAQL query.

Every entry carries the link and asset-group columns (`resource_name`, `field_type`, `status`, `asset_id`, `asset_group_id`, `asset_group_name`, `campaign_id`, `campaign_resource_name`). `field_type` says what the rest holds:

| kind | adds |
|---|---|
| `HEADLINE` / `LONG_HEADLINE` / `DESCRIPTION` | `text` |
| `MARKETING_IMAGE` / `SQUARE_MARKETING_IMAGE` / `PORTRAIT_MARKETING_IMAGE` / `LOGO` / `LANDSCAPE_LOGO` | `asset_name`, `url`, `width_pixels`, `height_pixels` |

Text rows are byte-for-byte what #590 shipped — a test asserts the exact key set, and that the image keys are strictly additive on the other kind. The client method is renamed `list_asset_group_text_assets` to `list_asset_group_assets`, since it is no longer text.

### 2. One write tool, both entry points

`google_ads_asset_group_images_replace` takes either `new_asset_id` (an image the account already holds) or `new_image_path` (a local file it uploads via the existing `upload_image_asset`) — **exactly one**, refused otherwise. Whether the account already holds the bytes is mureo's problem, not the operator's, so it must not be encoded in a tool name. Both paths resolve to one asset id *before* anything is written, and the swap below that point is a single code path.

The text swap stays its own tool: text versus a picture is a distinction the operator can already see, and merging them would have made `new_text` XOR `new_asset_id` XOR `new_image_path` on one schema.

### 3. Validate up front, and translate the refusal where it cannot

Both — the same shape #590 already has, where `_validate_text` enforces a hardcoded width table *and* `NOT_ENOUGH_*` is translated.

mureo checks the field type's shape before uploading or linking anything, because a refusal that costs no API call can name the exact rule and leaves no unlinked asset in the account. Dimensions come from the API's own `width_pixels`/`height_pixels` for an existing asset, and from the std-lib header probes in `mureo/_image_validation.py` for a local file (new public `read_image_dimensions`).

The aspect-ratio tolerance is deliberately loose (5%), because the errors are not symmetric: a false reject has **no override** — mureo would refuse an image Google would have taken and it never resizes to make one fit — while a false accept costs one translated refusal. 5% passes every size Google itself recommends (1200x628 is 1.911:1, not 1.910:1) and still catches the mistake the check exists for, a square image handed to a landscape slot.

For a format the probes cannot measure — a GIF, or an unrecognised header — it does **not** guess. `read_image_dimensions` returns `(None, None)`, the file goes to Google, and `ImageError.ASPECT_RATIO_NOT_ALLOWED` / `IMAGE_TOO_SMALL` / `IMAGE_CONSTRAINTS_VIOLATED` / `UNEXPECTED_SIZE` come back translated into the slot's rule — including the fact that the uploaded asset is sitting in the account unlinked. **Never a silent resize.**

## Field types: five of the eight, and why

`AssetFieldTypeEnum` in v23 has eight image field types. The issue listed five; verified against the enum, those five are right:

**Included** — `MARKETING_IMAGE` (1.91:1, min 600x314), `SQUARE_MARKETING_IMAGE` (1:1, min 300x300), `PORTRAIT_MARKETING_IMAGE` (4:5, min 480x600), `LOGO` (1:1, min 128x128), `LANDSCAPE_LOGO` (4:1, min 512x128).

**Excluded**, with the reason from the vendored SDK:

- `TALL_PORTRAIT_MARKETING_IMAGE` — Demand Gen's 9:16 slot. The only place the SDK names it is `GenerateImagesRequest`, whose channel list spans four campaign types.
- `BUSINESS_LOGO` — a *campaign* asset: `ResourceLimitType.BUSINESS_LOGO_CAMPAIGN_ASSETS_PER_CAMPAIGN`, not an asset-group link.
- `AD_IMAGE` — "linked for use to select an ad image", an ad-level selection.

The corroboration is `AssetGroupErrorEnum`: it defines an asset-count floor for `MARKETING_IMAGE`, `SQUARE_MARKETING_IMAGE` and `LOGO` and for no other image field type. A test pins that the translated codes are exactly the image floors the enum declares, and another pins the three exclusions so a later "the enum has more, add them" edit has to argue with it. `PORTRAIT_MARKETING_IMAGE` and `LANDSCAPE_LOGO` have no floor because P-MAX does not require them, not because they are absent.

**Video stays out of scope.** A video asset references a YouTube video id rather than uploaded bytes — a different entry shape and a different operator workflow.

## The write sequence

1. validate `asset_group_id`, `old_asset_id`, `new_asset_id`, `field_type`;
2. refuse anything but exactly one of `new_asset_id` / `new_image_path`;
3. read the asset group's links — refuse if `old_asset_id` is not linked under that `field_type` (listing what is), refuse a duplicate link (which also catches swapping an image for itself);
4. resolve the replacement — read the existing asset and refuse a non-image or a wrong shape; or validate the local file, measure it, refuse a wrong shape, **then** upload;
5. one `GoogleAdsService.mutate`, two operations, **create first**: `asset_group_asset.create` (new link) then `asset_group_asset.remove` (old link). `partial_failure` deliberately unset;
6. translate `NOT_ENOUGH_MARKETING_IMAGE_ASSET` / `_SQUARE_MARKETING_IMAGE_ASSET` / `_LOGO_ASSET`, then the `ImageError` shapes; anything else keeps the curated server detail through `_wrap_mutate_error`.

Two operations rather than the text swap's three: an image `Asset` exists before the asset group can point at it, either because it already did or because step 4 just made it. The upload is necessarily a separate request (it reuses the validated `upload_image_asset` path), which is why every check that can run does run before it.

## Tested vs reasoned about

**Tested**, against real v23 protos with only the transport faked — a `MagicMock` client would accept any misspelt field: the query's field list and `IN` clause; both row shapes and the text row's exact key set; the two operations, their order, the resource-name paths, the enum values and `partial_failure`; both entry points; every refusal (not linked, duplicate link, self-swap, non-image asset, unknown asset, wrong shape, below minimum, non-numeric ids, traversing path, wrong field type); that a local file is measured *before* the upload; that an unmeasurable file is not refused on a guess; that every translated error code is a real enum member; that the classifier reads the new name as a mutation and not as report-only; that BYOD refuses both swaps.

**Reasoned about from the API reference only** — no live P-MAX account is available to this suite:

- whether Google's asset-count validation runs on the request's final state (the premise behind one atomic mutate — inherited from #590);
- the dimension and aspect-ratio figures themselves, which come from Google's Performance Max asset-requirements page, not from anything the SDK declares. What *is* pinned is that mureo applies them consistently, that each spec's own minimum and recommended size satisfy the ratio it declares, and that it never resizes;
- that selecting `asset.text_asset.text` and `asset.image_asset.*` in one query is accepted. Every path resolves against the vendored protos (`tests/test_gaql_field_names.py`), but simultaneous selection across the `Asset` oneof is not something the suite can prove.

## What the issue got wrong

Nothing material. It flagged its own image list as unverified, and the verification confirmed it: five field types, not the enum's eight. It also asked whether the image asset-count codes differ from the text ones — they do, three of them, and only for the three required field types.

## Also in this PR

`skills/creative-refresh/SKILL.md` (and its byte-identical packaged copy): #591 landed wording that P-MAX images are not retrievable and that every image is draft-only. Both are now false, so the audit step, the execute step, the *Apply or draft* table and the visual-evaluation section are updated, and `googlesyndication.com` joins the SSRF host allow-list (a P-MAX image `url` points there). The apply-or-draft rule itself is untouched: it keys on whether a write tool exists for the surface, so the new tool flowed through it. `tests/test_creative_apply_scope.py` is updated to pin the new truth — video and business name are still draft-only, P-MAX images are not — rather than the old.

`CHANGELOG.md` under `## [Unreleased]`, `docs/mcp-server.md` where #590's tools are documented, and the `AGENTS.md` architecture map and tool table.

## Verification

- `black --check .` clean; `ruff check .` clean; `mypy mureo` 14 errors, all pre-existing missing-stub imports, none in the changed files.
- `pytest tests/` — 9257 passed, 12 failed. The 12 are the known local-plugin environment noise (`test_live_clients.py`, `test_mcp_server.py`, `test_mcp_server_plugin_wiring.py`, `test_mcp_tool_provider.py`); confirmed identical on a clean tree at this branch point.
- 100% line coverage on `mureo/google_ads/_asset_groups.py` and `mureo/google_ads/_asset_groups_images.py`.

Closes #626
