### PR TITLE
test: stop the oversize-POST test depending on socket timing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,17 @@
 
 ### Fixed
 
+- **A Windows CI failure that had nothing to do with the change under
+  test.** `test_oversize_post_body_rejected` asserted the client sees a
+  `413`. The handler answers it *without reading the body* — deliberately,
+  since reading it is what the cap exists to avoid — so the client is still
+  writing 20 KB when the server replies and closes. Whether it reads the
+  status or has its socket torn out first is socket buffering: Linux and
+  macOS deliver the response, Windows raises `ConnectionAbortedError` first.
+  Both prove the body was refused rather than buffered, so the test now
+  accepts either and additionally asserts the server still serves the next
+  request — the part neither outcome shows on its own.
+
 - **Four test modules edited `GoogleAdsException` for the rest of the
   session.** Each built a fake exception with `__new__` and then attached a
   fake `failure` through `type(exc).failure = property(...)`. `type(exc)` is

--- a/tests/test_web_auth.py
+++ b/tests/test_web_auth.py
@@ -785,7 +785,25 @@ class TestSecurityHardening:
         assert wizard.session.csrf_token != original_token
 
     def test_oversize_post_body_rejected(self, wizard: Any) -> None:
-        """Cap on POST Content-Length prevents local DoS / OOM."""
+        """Cap on POST Content-Length prevents local DoS / OOM.
+
+        The handler answers 413 **without reading the body** — deliberately,
+        since reading it is the thing the cap exists to avoid. That makes what
+        the client observes a matter of transport timing: it is still writing
+        20 KB when the server replies and closes, so whether it gets to read
+        the 413 or has its socket torn out from under it first depends on
+        socket buffering. On Linux and macOS the body fits in the buffers and
+        the response arrives; on Windows the write is aborted first and
+        ``urllib`` raises ``ConnectionAbortedError`` (WinError 10053) before
+        any status line is seen. Asserting only on ``HTTPError`` made this
+        test fail on Windows CI at random.
+
+        Both outcomes prove the same thing, which is what this test is for:
+        the body was refused rather than buffered. So accept either, require
+        413 whenever a status is actually observed, and then assert the part
+        neither outcome shows on its own — that the server refused this one
+        request and is still serving.
+        """
         huge = b"a" * (20 * 1024)  # 20 KB > 16 KB cap
         req = urllib.request.Request(
             _url(wizard, "/google-ads/submit"),
@@ -793,9 +811,22 @@ class TestSecurityHardening:
             method="POST",
             headers={"Content-Type": "application/x-www-form-urlencoded"},
         )
-        with pytest.raises(urllib.error.HTTPError) as exc_info:
+
+        # Narrow on purpose: the 413 the server sends, or the connection being
+        # torn down mid-write. Not bare OSError, and not ConnectionError
+        # either — both would swallow ConnectionRefusedError from a server
+        # that never came up, and this test would pass while proving nothing.
+        with pytest.raises(
+            (urllib.error.HTTPError, ConnectionAbortedError, ConnectionResetError)
+        ) as exc_info:
             urllib.request.urlopen(req, timeout=2.0)
-        assert exc_info.value.code == 413
+        if isinstance(exc_info.value, urllib.error.HTTPError):
+            assert exc_info.value.code == 413
+
+        # Refused, not crashed: a normal request still works afterwards. This
+        # is what distinguishes the cap doing its job from the server dying on
+        # the oversize body — the failure mode the cap exists to prevent.
+        assert _fetch(wizard, "/google-ads").status == 200
 
 
 class TestDoneRoute:


### PR DESCRIPTION
Found when `test-windows` failed on PR #627, a branch that touches neither `tests/test_web_auth.py` nor `mureo/cli/web_auth.py`.

## Why it fails, and why only on Windows

`_handle_google_submit` answers an oversize POST with `413` **without reading the body** (`mureo/cli/web_auth.py:646-648`). That is the right behaviour — reading it is exactly what the cap exists to avoid — but it makes what the client observes a matter of transport timing:

- the client is still writing 20 KB when the server replies and closes
- on Linux and macOS the body fits in the socket buffers, the write completes, and `urllib` reads the `413`
- on Windows the write is aborted first: `ConnectionAbortedError: [WinError 10053]`, raised from `socket.py` during send, before any status line exists to read

The test asserted `pytest.raises(urllib.error.HTTPError)` and then `code == 413`, so the Windows path failed. Nothing about the change under test was involved; it fails on whatever PR happens to be running when the timing lands that way, which trains everyone to re-run a red `test-windows` instead of reading it.

## The fix

Both outcomes prove the same property — the body was refused rather than buffered — so the test accepts either, and requires `413` whenever a status is actually observed.

Accepting a second exception on its own would weaken the test, so it also asserts the part neither outcome shows alone: **the server refused this one request and is still serving.** A subsequent `GET /google-ads` must return 200. That is what separates "the cap did its job" from "the server died on the oversize body", which is the failure the cap exists to prevent.

The catch is deliberately narrow — `(HTTPError, ConnectionAbortedError, ConnectionResetError)`, not `OSError` and not `ConnectionError`. Both of the broader forms would also swallow `ConnectionRefusedError` from a server that never came up, and the test would pass while proving nothing.

## Verification

- `tests/test_web_auth.py`: 57 passed.
- The target test run 6× consecutively: stable.
- Cannot reproduce the Windows path locally; the fix is reasoned from the traceback in [that run](https://github.com/logly/mureo/actions/runs/31860531439/job/94953152688) plus the handler's read-nothing behaviour. `test-windows` on this PR is the real check.
- `black --check`, `ruff check`: clean.

Test-only change; no production code touched.
