### PR TITLE
fix: one answer for "is this platform key real?" (#631)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,7 +149,8 @@ mureo/
 │   ├── models.py        # StrategyEntry, StateDocument, CampaignSnapshot, ActionLogEntry (rollback_of, batch_id), BatchRecord
 │   ├── batch.py         # Batch id minting + the action_log stamping rule (#549)
 │   ├── platform_guards.py # Write-time platform-key guards (#534/#609) — the one "is this key
-│   │                      #   real?" answer every other surface asks
+│   │                      #   real?" answer every other surface asks, including the read-side
+│   │                      #   label path (`installed_platform_names`, shared since #631)
 │   ├── platform_repair.py # The repair half (#610): plan + drop an entry under an unresolvable
 │   │                      #   key. Unresolvable is the FILTER, not the criterion — the document
 │   │                      #   must show the entry wrong (#616), and conversion_action_types is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 ## [Unreleased]
 
+### Fixed
+
+- **A platform key mureo accepts on write was reported as unresolvable on
+  read** (#631). A `platforms` entry filed under an installed plugin's bare
+  provider name — `logly_ads_context`, the LOGLY bridge's real platform name —
+  was accepted by the write guard, reported `Clean` by
+  `mureo repair platform-key --all`, and *simultaneously* flagged in the
+  Reports view as a key mureo cannot resolve. Nothing was wrong with the
+  entry, and this fired on every such entry on any install carrying a bridge.
+
+  Two functions were answering one question: #609 made a bare provider name a
+  valid write vocabulary and the label path was never taught about it.
+  `platform_display_name` now resolves it from the **same** installed-plugin
+  enumeration the guard reads (`installed_platform_names`, one home in
+  `mureo/context/platform_guards.py`), labels it like the canonical key for
+  the same platform (`Logly Ads Context (plugin)` — the entry comes from a
+  plugin under either spelling), and inherits the guard's fail-open: an
+  environment that cannot be enumerated labels the key rather than starting to
+  flag every plugin entry. The enumeration is memoized, keyed by the
+  enumerator itself, since the Reports view asks per platform per client.
+
+  The regression guard is an agreement test rather than a test for this one
+  key shape: for built-ins, canonical `plugin:<dist>:<provider>` keys, legacy
+  `plugin:<dist>` keys, installed bare provider names and an invented key, the
+  label path and `is_unresolvable_platform_key` must give the same answer.
+  That is what would have caught #609 widening the write vocabulary without
+  touching the read side.
+
 ## [0.10.46] - 2026-08-15
 
 ### Fixed

--- a/docs/strategy-context.md
+++ b/docs/strategy-context.md
@@ -346,6 +346,17 @@ operator's next move differs:
 | `duplicate_account` | Two or more keys resolve to **one** ad account, so any total over these rows is double-counted *right now* | `duplicate_account_entries` (the shared join above) |
 | `unrecognized_key` | A key **no mureo surface can resolve**, so mureo cannot say which platform that entry describes — and, when the entry names no ad account either (`account_known: false`), it *may* duplicate a canonical one | `platform_display_name(key) == key` — the key resolves to no label |
 
+The label lookup resolves exactly the vocabulary the write guard accepts: a
+built-in key, a `plugin:<dist>:<provider>` key (or the legacy `plugin:<dist>`),
+**and a bare provider name an installed plugin registered** —
+`logly_ads_context` renders `Logly Ads Context (plugin)`. Both sides read one
+enumeration of the installed plugins and both fail open when the environment
+cannot be enumerated, so a key mureo itself accepts on write is never reported
+here, and `mureo repair platform-key` and the Reports view cannot give an
+operator opposite answers about one entry. (Until they could: the bare form
+was accepted on write, reported `Clean` by the repair command, and flagged
+here, all at once.)
+
 The `unrecognized_key` condition tests the **key** alone, so it also fires on
 an entry whose `account_id` resolves perfectly well — including one the
 `duplicate_account` row has just named with certainty. `account_known` is what
@@ -374,6 +385,13 @@ both forms coexist only after a hand edit or a write that predates the guard.
 mureo merges and rewrites nothing — check which entry holds the right figures,
 keep the key that platform is already stored under, and delete the other
 yourself.
+
+The bare provider name is the third spelling of that same platform, and it
+renders *identically* to the canonical key (`Logly Ads Context (plugin)`) —
+it is the same platform from the same plugin, so a second label would be a
+fiction. Two rows sharing one label therefore mean two entries for one
+platform, which is what the `duplicate_account` conflict names whenever they
+also carry the same `account_id`.
 
 What the dashboard does about it:
 

--- a/mureo/_data/web/dashboard.js
+++ b/mureo/_data/web/dashboard.js
@@ -1990,12 +1990,14 @@
         card.appendChild(note);
       });
       // Where the way out lives (#610). The repair is NOT offered as a
-      // button here: `unrecognized_key` tests whether a key resolves to a
-      // display label, and by that test the CORRECT key in the reported
-      // incident (`logly_ads_context`) is just as unrecognised as the
-      // invented one — so a button hung off this signal would offer to
-      // delete the right entry. The CLI asks #609's resolvability question
-      // directly, in-process. This is a pointer, not an action.
+      // button here. Since #631 this signal does agree with mureo's
+      // write-time answer — the CORRECT key in the reported incident
+      // (`logly_ads_context`) no longer fires it — but agreeing about the
+      // key is not deciding the repair: removal needs the DOCUMENT to show
+      // the entry wrong (a resolvable sibling on the same ad account, or an
+      // entry storing nothing) and is refused for one carrying
+      // `conversion_action_types` (#616/#617). None of that evidence is on
+      // the wire. This is a pointer, not an action.
       const hint = document.createElement("p");
       hint.className = "report-card-conflict-hint";
       hint.textContent = MUREO.t("dashboard.reports_conflict_repair_hint");

--- a/mureo/cli/repair_cmd.py
+++ b/mureo/cli/repair_cmd.py
@@ -50,15 +50,24 @@ Why the CLI and not a dashboard button
 --------------------------------------
 The finding surfaces on the dashboard's platform card, and the card now points
 here (``dashboard.reports_conflict_repair_hint``), but the repair itself is
-not offered there. The card cannot tell the two keys apart: the dashboard's
-``unrecognized_key`` signal tests whether a key resolves to a display *label*,
-and by that test ``logly_ads_context`` — the CORRECT key in the reported
-incident — is just as unrecognised as the invented ``logly_ads``. A button
-placed on that signal would offer to delete the right entry. Teaching the
-dashboard the difference means putting #609's resolvability answer on the wire
-and enumerating installed entry points on every dashboard poll, in a module
-whose contract is that it never mutates state. The terminal already has the
-answer, in-process and current.
+not offered there.
+
+The card's ``unrecognized_key`` signal does now agree with #609's answer:
+since #631 the label path resolves a bare provider name from the same
+installed-plugin enumeration the guard reads, so ``logly_ads_context`` — the
+CORRECT key in the reported incident — no longer fires it while the invented
+``logly_ads`` still does.
+
+Agreeing about the key is not deciding the repair, though, and the second
+half is what keeps the button off that card. "Unresolvable" is the FILTER,
+not the criterion (#616): removal needs the DOCUMENT to show the entry wrong
+— a resolvable sibling holding the same ad account, or an entry storing
+nothing at all — and is refused outright for an entry carrying
+``conversion_action_types`` (#617). None of that evidence is on the wire, by
+design: a conflict row carries keys and a presence bit, never an ad account
+id. So an action hung off the signal alone would still offer a deletion this
+command refuses — in a module whose contract is that it never mutates state.
+The terminal has the whole answer, in-process and current.
 """
 
 from __future__ import annotations

--- a/mureo/context/platform_guards.py
+++ b/mureo/context/platform_guards.py
@@ -84,6 +84,20 @@ this machine does not have installed — is not stranded either: the canonical
 ``plugin:<distribution>:<provider>`` form names its own distribution and so
 is accepted without any registry to consult.
 
+One enumeration, two surfaces (#631)
+------------------------------------
+:func:`installed_platform_names` is public because the **read** side has to
+give the same answer: :func:`~mureo.web.reports.platform_display_name` labels
+a bare provider name from it, so a key this module accepts can no longer be
+reported "unrecognised" by the dashboard on the same machine at the same
+moment. ``web`` importing ``context`` is the direction that already holds
+(Reports reads ``state`` and ``platform_accounts``); the reverse would put the
+configure UI's import graph on the state-write path and invert the layering.
+
+The read side inherits the fail-open with it. A label path that failed closed
+on an environment it could not enumerate would be the same drift pointing the
+other way — flagging every plugin entry the guard had just accepted.
+
 One corner this does **not** defend: writing an explicit ``account_id=""``
 onto an entry that holds a known id silently reverts that entry to "unknown",
 because ``""`` is by contract free rather than taken. The MCP surface blocks
@@ -107,6 +121,7 @@ from mureo.context.platform_accounts import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
 
     from mureo.context.models import PlatformState, StateDocument
@@ -239,21 +254,69 @@ def _provider_entry_points() -> tuple[Any, ...] | None:
     return tuple(found)
 
 
-def _installed_platform_names() -> frozenset[str] | None:
+_INSTALLED_PLATFORM_NAMES_CACHE: (
+    tuple[Callable[[], tuple[Any, ...] | None], frozenset[str]] | None
+) = None
+"""Memoized :func:`installed_platform_names`, keyed by the enumeration itself.
+
+Keyed rather than a plain value because the pair
+``(_provider_entry_points, result)`` makes a stale answer structurally
+impossible where it would actually bite: a test that installs a plugin
+mid-process does it by swapping that function, and the swapped function is a
+different object, so the memo misses. Nothing has to remember to clear a
+cache, and no test's pin can leak into the next one through this module — the
+hazard the ``_DUPLICATE_ACCOUNT_WARNED`` latch needs a conftest fixture for.
+
+A **failed** enumeration is deliberately not stored (see
+:func:`installed_platform_names`), so the cache only ever holds an answer the
+environment actually gave. Writing the pair is a single assignment, so a
+concurrent reader (the configure server serves requests on threads) sees
+either the previous answer or the new one, never half of one.
+
+What it does not see: a plugin pip-installed while this process runs. That
+costs a restart, and it costs it to the label path and the guard *identically*
+— which is the property #631 is about, since two surfaces reading one
+enumeration at two different moments is the drift all over again. The
+canonical ``plugin:<distribution>:<provider>`` key needs no enumeration at
+all, so nothing is unwritable in the meantime.
+"""
+
+
+def installed_platform_names() -> frozenset[str] | None:
     """The platform names installed plugins registered, or ``None``.
 
-    ``None`` propagates :func:`_provider_entry_points`' "could not enumerate".
-    A nameless or blank entry point is dropped: it can never equal a key that
+    The **one** enumeration of the plugin half of the platform vocabulary.
+    :func:`reject_unknown_platform_key` accepts these names on write (#609)
+    and :func:`~mureo.web.reports.platform_display_name` labels them on read
+    (#631); a second copy anywhere is how the two surfaces come to disagree
+    about which keys are real.
+
+    ``None`` propagates :func:`_provider_entry_points`' "could not enumerate",
+    and every caller has to fail open on it. A nameless or blank entry point
+    is dropped: it can never equal a key that
     :func:`reject_unusable_platform_key` already let through.
+
+    Memoized (:data:`_INSTALLED_PLATFORM_NAMES_CACHE`) because the read side
+    asks per platform per client while rendering Reports, and the scan costs
+    ~43 ms. The failure is not memoized: "could not enumerate" is a moment,
+    not a fact about the machine, so caching it would let one unlucky call
+    fail this process open for its whole lifetime.
     """
-    eps = _provider_entry_points()
+    global _INSTALLED_PLATFORM_NAMES_CACHE
+    enumerate_entry_points = _provider_entry_points
+    cached = _INSTALLED_PLATFORM_NAMES_CACHE
+    if cached is not None and cached[0] is enumerate_entry_points:
+        return cached[1]
+    eps = enumerate_entry_points()
     if eps is None:
         return None
-    return frozenset(
+    names = frozenset(
         name
         for ep in eps
         if isinstance(name := getattr(ep, "name", None), str) and name.strip()
     )
+    _INSTALLED_PLATFORM_NAMES_CACHE = (enumerate_entry_points, names)
+    return names
 
 
 def reject_unknown_platform_key(platform: str) -> None:
@@ -264,7 +327,7 @@ def reject_unknown_platform_key(platform: str) -> None:
     - a built-in key (:data:`~mureo.core.platform_keys.
       BUILTIN_PLATFORM_DISPLAY_NAMES`), which includes the hosted connectors
       that have no provider entry point at all;
-    - a platform an installed plugin registered (:func:`_installed_platform_names`);
+    - a platform an installed plugin registered (:func:`installed_platform_names`);
     - a canonical ``plugin:<distribution>:<provider>`` key (or the legacy
       ``plugin:<distribution>``), accepted **without** checking that the
       distribution is installed — it names its own distribution, so a snapshot
@@ -291,7 +354,7 @@ def reject_unknown_platform_key(platform: str) -> None:
 
     if platform in BUILTIN_PLATFORM_DISPLAY_NAMES or is_plugin_platform_key(platform):
         return
-    installed = _installed_platform_names()
+    installed = installed_platform_names()
     if installed is None or platform in installed:
         return
     builtins = ", ".join(sorted(BUILTIN_PLATFORM_DISPLAY_NAMES))
@@ -426,6 +489,7 @@ def warn_on_duplicate_accounts(path: Path, doc: StateDocument) -> None:
 
 __all__ = [
     "guard_platform_entry_write",
+    "installed_platform_names",
     "reject_unknown_platform_key",
     "reject_unusable_platform_key",
     "warn_on_duplicate_accounts",

--- a/mureo/web/reports.py
+++ b/mureo/web/reports.py
@@ -52,9 +52,15 @@ from mureo.context.platform_accounts import (
     duplicate_account_entries,
     normalize_account_id,
 )
+
+# The plugin half of the platform vocabulary, enumerated ONCE for the whole
+# tree (#631). ``web`` -> ``context`` is the direction that already holds
+# above; see that module's "One enumeration, two surfaces".
+from mureo.context.platform_guards import installed_platform_names
 from mureo.context.state import read_state_file
 from mureo.core.platform_keys import (
     BUILTIN_PLATFORM_DISPLAY_NAMES,
+    PLUGIN_PLATFORM_PREFIX,
     is_plugin_platform_key,
     plugin_platform_parts,
 )
@@ -132,6 +138,15 @@ mureo answers "is this key recognisable", and asking the dashboard's own
 resolver means this can never drift from what the dashboard renders. The
 alternative, an alias table mapping arbitrary keys onto platforms, would be a
 guess.
+
+That resolver now reads the **same** installed-plugin enumeration the write
+guard does (:func:`~mureo.context.platform_guards.installed_platform_names`,
+#631), so this signal can no longer fire on a key mureo itself accepted on
+write. Until it did, a bare provider name — ``logly_ads_context``, the LOGLY
+bridge's real platform name — was accepted by the guard, reported ``Clean``
+by ``mureo repair platform-key``, and flagged here, all on one machine at one
+moment. An operator who learns this fires on healthy state stops reading it,
+which costs more than the finding is worth.
 """
 
 # How many of the most-recent ``action_log`` entries the summary surfaces.
@@ -241,6 +256,10 @@ def platform_display_name(key: str) -> str:
       ``plugin:mureo-logly-bridge`` → ``"Logly (plugin)"``,
       ``plugin:acme-ads`` → ``"Acme Ads (plugin)"``). Unchanged, so state
       written before #537 keeps the label it already had.
+    - A bare provider name an INSTALLED plugin registered (#609/#631) → the
+      humanized name with the same ``" (plugin)"`` suffix
+      (``logly_ads_context`` → ``"Logly Ads Context (plugin)"``). See
+      :func:`_installed_plugin_platform_label`.
     - Anything else (an unknown built-in-shaped key) → the key itself, so
       the dashboard never renders a blank label.
 
@@ -263,7 +282,48 @@ def platform_display_name(key: str) -> str:
         if not label:
             label = _humanize_dist(dist)
         return f"{label} (plugin)" if label else key
-    return key
+    return _installed_plugin_platform_label(key) or key
+
+
+def _installed_plugin_platform_label(key: str) -> str:
+    """Label a bare provider name an installed plugin registered (#631).
+
+    ``key`` is a platform name straight out of the ``mureo.providers`` /
+    ``mureo.analytics`` entry points — ``logly_ads_context``, not
+    ``plugin:mureo-logly-bridge:logly_ads_context``. That has been a valid
+    key to WRITE since #609, and this function is why the read side no longer
+    calls it unresolvable: a key the guard accepted was being flagged
+    ``unrecognized_key`` on the dashboard at the same moment
+    ``mureo repair platform-key`` reported the same entry ``Clean``.
+
+    Same ``" (plugin)"`` suffix as the canonical key for the same platform:
+    the entry comes from a plugin under either spelling, and two labels for
+    one platform on one dashboard would replace this inconsistency with
+    another. :data:`_OFFICIAL_BRIDGE_DISPLAY_NAMES` cannot apply here — it is
+    keyed by distribution and a bare name carries none — so an in-tree bridge
+    held under its bare provider name keeps the suffix. Resolving that would
+    mean reading ``ep.dist``, i.e. reading more of an entry point than the
+    guard does, and mureo writes the canonical key for those anyway.
+
+    Fails OPEN exactly as :func:`~mureo.context.platform_guards.
+    reject_unknown_platform_key` does: an environment that cannot be
+    enumerated labels the key rather than reporting it unrecognised, because
+    a broken ``importlib.metadata`` is not evidence that a key is wrong.
+
+    Two shapes are excluded whatever the registry says: a key claiming the
+    plugin namespace without naming a platform (``plugin:``,
+    ``plugin:<dist>:``), which the write path refuses on shape alone
+    (``reject_unusable_platform_key``) and which no enumeration failure can
+    make legitimate; and a name that humanizes to nothing. Both yield ``""``
+    and the caller falls back to the raw key.
+    """
+    if key.startswith(PLUGIN_PLATFORM_PREFIX):
+        return ""
+    installed = installed_platform_names()
+    if installed is not None and key not in installed:
+        return ""
+    label = _humanize_words(key)
+    return f"{label} (plugin)" if label else ""
 
 
 def _humanize_words(name: str) -> str:

--- a/tests/test_platform_key_agreement.py
+++ b/tests/test_platform_key_agreement.py
@@ -1,0 +1,237 @@
+"""One answer to "is this platform key real?" (Issue #631).
+
+Two functions answer that question for the same key on the same machine:
+
+- the **write** side — :func:`~mureo.context.platform_guards.
+  reject_unknown_platform_key` (#609), which also decides what
+  ``mureo repair platform-key`` calls resolvable (via
+  :func:`~mureo.context.platform_repair.is_unresolvable_platform_key`);
+- the **read** side — :func:`~mureo.web.reports.platform_display_name`,
+  whose "returns the key unchanged" is the Reports view's
+  ``unrecognized_key`` signal.
+
+They drifted: #609 made a bare provider name an installed plugin registered
+(``logly_ads_context``) a valid write vocabulary and nothing taught the label
+path about it, so ``mureo repair platform-key --all`` reported every client
+``Clean`` while the Reports view told the same operator, about the same entry,
+that mureo could not resolve its key.
+
+The symptom was one key shape; the defect is that two functions can drift.
+So the test that matters is the **agreement** across every shape, not a test
+for the bare-name symptom — that is what would have caught #609 widening the
+write vocabulary without touching the read side.
+
+Every test here pins the entry-point set with a fake. The machine that
+reported this really has the LOGLY and LINE/Yahoo bridges installed, so a test
+leaning on the environment passes there and fails in CI.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from mureo.context import platform_guards
+from mureo.context.platform_guards import (
+    installed_platform_names,
+    reject_unknown_platform_key,
+)
+from mureo.context.platform_repair import is_unresolvable_platform_key
+from mureo.web.reports import platform_display_name
+
+pytestmark = pytest.mark.unit
+
+
+def _pin_installed_platforms(monkeypatch: pytest.MonkeyPatch, *names: str) -> None:
+    """Pin which plugin platforms the environment reports as installed.
+
+    The same pin the #609 guard tests and the #610 repair tests use, and for
+    the same reason.
+    """
+    entries = tuple(SimpleNamespace(name=name) for name in names)
+    monkeypatch.setattr(platform_guards, "_provider_entry_points", lambda: entries)
+
+
+# Every platform-key shape mureo has, and whether a machine with the LOGLY and
+# LINE/Yahoo bridges installed can resolve it. One table, asked of both sides.
+_KEY_SHAPES: tuple[tuple[str, bool], ...] = (
+    # built-ins, including the hosted connector with no entry point at all
+    ("google_ads", True),
+    ("tiktok_ads", True),
+    # canonical plugin key (#537) — accepted without the distribution being
+    # installed, so it resolves for a bridge this machine does not have
+    ("plugin:mureo-lineyahoo-bridge:yahoo_ads", True),
+    ("plugin:not-installed-anywhere:some_ads", True),
+    # the legacy short form (#481), still valid on read
+    ("plugin:mureo-logly-bridge", True),
+    # a bare provider name an installed plugin registered (#609) — the shape
+    # this issue is about
+    ("logly_ads_context", True),
+    ("yahoo_ads", True),
+    # the invented key from the field: the bridge's provider is
+    # ``logly_ads_context``, so this one names nothing
+    ("logly_ads", False),
+    ("totally_made_up", False),
+    # claims the plugin namespace without naming a platform
+    ("plugin:", False),
+    ("plugin:acme-ads:", False),
+)
+
+
+@pytest.mark.parametrize(("key", "resolvable"), _KEY_SHAPES)
+def test_the_label_path_and_the_guard_agree_on_every_key_shape(
+    monkeypatch: pytest.MonkeyPatch, key: str, resolvable: bool
+) -> None:
+    """The invariant, both directions, for every vocabulary mureo has.
+
+    ``platform_display_name(key) == key`` is the Reports view's
+    ``unrecognized_key`` condition and ``is_unresolvable_platform_key`` is
+    what ``mureo repair platform-key`` prints ``Clean`` from. Whenever those
+    two disagree, one surface warns an operator about a key another surface
+    has just told them is fine.
+    """
+    _pin_installed_platforms(monkeypatch, "logly_ads_context", "yahoo_ads")
+
+    labelled = platform_display_name(key) != key
+    accepted = not is_unresolvable_platform_key(key)
+
+    assert labelled == accepted, (
+        f"{key!r}: the label path says resolvable={labelled} and the write "
+        f"guard says resolvable={accepted} — one of them will warn about a "
+        f"key the other accepts"
+    )
+    assert accepted is resolvable
+
+
+def test_the_reported_entry_is_labelled_and_not_flagged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The symptom itself: the key the guard accepted was reported unresolvable."""
+    _pin_installed_platforms(monkeypatch, "logly_ads_context")
+
+    reject_unknown_platform_key("logly_ads_context")  # accepted since #609
+    assert platform_display_name("logly_ads_context") == "Logly Ads Context (plugin)"
+
+
+def test_the_bare_form_reads_as_the_canonical_key_does(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One platform, one label.
+
+    The entry comes from a plugin under either spelling, so the bare provider
+    name carries the same ``" (plugin)"`` suffix as the canonical key for the
+    same platform. Two labels for one platform on one dashboard would be a
+    fresh inconsistency in place of the one being fixed.
+    """
+    _pin_installed_platforms(monkeypatch, "logly_ads_context", "yahoo_ads")
+
+    assert platform_display_name(
+        "plugin:mureo-logly-bridge:logly_ads_context"
+    ) == platform_display_name("logly_ads_context")
+    assert platform_display_name("yahoo_ads") == "Yahoo Ads (plugin)"
+
+
+def test_the_label_path_fails_open_exactly_as_the_guard_does(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An environment that cannot be enumerated must not start flagging keys.
+
+    The guard fails OPEN on it (#609): a broken ``importlib.metadata`` is not
+    evidence that a key is wrong. A label path that failed closed would drift
+    in the other direction — every plugin entry on that machine would be
+    reported unrecognised.
+    """
+    monkeypatch.setattr(platform_guards, "_provider_entry_points", lambda: None)
+
+    for key in ("logly_ads_context", "some_bridge_platform"):
+        assert not is_unresolvable_platform_key(key)
+        assert platform_display_name(key) != key
+
+
+def test_a_key_claiming_the_plugin_namespace_is_never_labelled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """…not even on an environment that cannot be enumerated.
+
+    ``plugin:`` and ``plugin:<dist>:`` name no platform whatever the registry
+    says, and the write path refuses them on shape alone
+    (``reject_unusable_platform_key``), which no enumeration failure can
+    change. Labelling them from the fail-open branch would dress up a
+    malformed entry.
+    """
+    monkeypatch.setattr(platform_guards, "_provider_entry_points", lambda: None)
+
+    for key in ("plugin:", "plugin:acme-ads:"):
+        assert platform_display_name(key) == key
+
+
+# ---------------------------------------------------------------------------
+# The enumeration is shared, and cached
+# ---------------------------------------------------------------------------
+
+
+def test_both_surfaces_read_one_enumeration(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Not two copies: patching the single seam moves both answers."""
+    _pin_installed_platforms(monkeypatch, "acme_ads")
+
+    assert platform_display_name("acme_ads") == "Acme Ads (plugin)"
+    assert not is_unresolvable_platform_key("acme_ads")
+
+
+def test_the_entry_points_are_enumerated_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reports renders per platform per client; the scan costs ~43 ms."""
+    calls = 0
+
+    def _enumerate() -> tuple[SimpleNamespace, ...]:
+        nonlocal calls
+        calls += 1
+        return (SimpleNamespace(name="logly_ads_context"),)
+
+    monkeypatch.setattr(platform_guards, "_provider_entry_points", _enumerate)
+
+    for _ in range(5):
+        assert (
+            platform_display_name("logly_ads_context") == "Logly Ads Context (plugin)"
+        )
+        reject_unknown_platform_key("logly_ads_context")
+
+    assert calls == 1
+
+
+def test_the_cache_cannot_serve_a_stale_answer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A plugin appearing mid-process is seen, not answered from the cache.
+
+    The cache is keyed by the enumeration itself, so swapping it — which is
+    how every test installs a plugin — can never be served the previous
+    answer, whatever order the suite runs in.
+    """
+    _pin_installed_platforms(monkeypatch, "logly_ads_context")
+    assert platform_display_name("yahoo_ads") == "yahoo_ads"
+
+    _pin_installed_platforms(monkeypatch, "logly_ads_context", "yahoo_ads")
+
+    assert platform_display_name("yahoo_ads") == "Yahoo Ads (plugin)"
+    assert not is_unresolvable_platform_key("yahoo_ads")
+
+
+def test_a_failed_enumeration_is_never_cached(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ "Could not enumerate" is a moment, not a fact about the machine.
+
+    Caching it would make one unlucky call fail the whole process open for
+    its lifetime.
+    """
+    outcomes: list[tuple[SimpleNamespace, ...] | None] = [
+        None,
+        (SimpleNamespace(name="logly_ads_context"),),
+    ]
+    monkeypatch.setattr(
+        platform_guards, "_provider_entry_points", lambda: outcomes.pop(0)
+    )
+
+    assert installed_platform_names() is None
+    assert installed_platform_names() == frozenset({"logly_ads_context"})

--- a/tests/test_web_assets_reports_conflicts.py
+++ b/tests/test_web_assets_reports_conflicts.py
@@ -413,11 +413,13 @@ def test_a_conflicted_platform_card_points_at_the_repair_command() -> None:
     told mureo will not fix it, and the only remaining move is editing
     STATE.json by hand.
 
-    A pointer, not a button: ``unrecognized_key`` tests whether a key
-    resolves to a display LABEL, and by that test the correct key in the
-    reported incident (``logly_ads_context``) is just as unrecognised as the
-    invented one — so an action hung off this signal would offer to delete
-    the right entry. The card therefore names the command and nothing more.
+    A pointer, not a button. Since #631 the signal agrees with mureo's
+    write-time answer (the correct key in the reported incident,
+    ``logly_ads_context``, no longer fires it), but agreeing about the key is
+    not deciding the repair: removal needs the DOCUMENT to show the entry
+    wrong and is refused for one carrying ``conversion_action_types``
+    (#616/#617), and none of that evidence crosses the wire. The card
+    therefore names the command and nothing more.
     """
     js = _read("dashboard.js")
     css = _read("app.css")

--- a/tests/test_web_reports_conflicts.py
+++ b/tests/test_web_reports_conflicts.py
@@ -28,10 +28,12 @@ from __future__ import annotations
 import json
 import re
 from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 
 import pytest
 
+from mureo.context import platform_guards
 from mureo.context.models import PlatformState, StateDocument
 from mureo.core.runtime_context import (
     default_runtime_context,
@@ -65,6 +67,18 @@ def _write_state(workspace: Path, doc: StateDocument) -> None:
     from mureo.context.state import write_state_file
 
     write_state_file(workspace / "STATE.json", doc)
+
+
+def _pin_installed_platforms(monkeypatch: pytest.MonkeyPatch, *names: str) -> None:
+    """Pin which plugin platforms the environment reports as installed (#631).
+
+    The read side resolves a bare provider name through the same enumeration
+    the write guard uses, so a fixture using one is machine-dependent
+    otherwise: the machine that reported #631 really has the LOGLY and
+    LINE/Yahoo bridges installed. Same pin the #609 / #610 tests use.
+    """
+    entries = tuple(SimpleNamespace(name=name) for name in names)
+    monkeypatch.setattr(platform_guards, "_provider_entry_points", lambda: entries)
 
 
 def _ago(days: float) -> str:
@@ -193,12 +207,51 @@ def test_the_reported_field_shape_is_caught_by_the_unrecognised_key_signal(
 ) -> None:
     """The shape actually reported from the field.
 
-    One canonical key with a real id, one key an out-of-tree writer chose
+    One canonical key with a real id, one key an out-of-tree writer INVENTED
+    (``logly_ads``, for a bridge whose platform is ``logly_ads_context``)
     whose ``account_id`` never resolved (``""``). ``account_ids_match("", "")``
     is ``False`` BY DESIGN, so the duplicate-account join reports nothing here
     — account joining alone does NOT detect the reported bug. The second
     signal (a key no mureo surface can label) is what catches it.
+
+    The entry-point set is pinned (#631): the bridge's real platform name is
+    installed on the reporting machine and is a key mureo resolves, so an
+    unpinned fixture would assert something different there than in CI.
     """
+    _pin_installed_platforms(monkeypatch, "logly_ads_context")
+    _use_workspace(monkeypatch, tmp_path)
+    _write_state(
+        tmp_path,
+        StateDocument(
+            version="2",
+            platforms={
+                "google_ads": PlatformState(
+                    account_id="123-456", totals={"spend": 900.0}
+                ),
+                "logly_ads": PlatformState(account_id="", totals={"spend": 400.0}),
+            },
+        ),
+    )
+
+    summary = build_report_summary()
+    assert _conflicts(summary, CONFLICT_DUPLICATE_ACCOUNT) == []
+    (found,) = _conflicts(summary, CONFLICT_UNRECOGNIZED_KEY)
+    assert found["platform_keys"] == ["logly_ads"]
+
+
+@pytest.mark.unit
+def test_a_bare_installed_platform_name_is_not_reported_as_unrecognised(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """#631, end to end: the same document the repair command calls Clean.
+
+    A bare provider name an installed plugin registered is a key mureo
+    ACCEPTS on write (#609). Reporting it here told the operator, about an
+    entry nothing is wrong with, that mureo cannot tell which platform it
+    names — while ``mureo repair platform-key --all`` reported every client
+    clean. The row still renders, now with a label.
+    """
+    _pin_installed_platforms(monkeypatch, "logly_ads_context")
     _use_workspace(monkeypatch, tmp_path)
     _write_state(
         tmp_path,
@@ -216,9 +269,9 @@ def test_the_reported_field_shape_is_caught_by_the_unrecognised_key_signal(
     )
 
     summary = build_report_summary()
-    assert _conflicts(summary, CONFLICT_DUPLICATE_ACCOUNT) == []
-    (found,) = _conflicts(summary, CONFLICT_UNRECOGNIZED_KEY)
-    assert found["platform_keys"] == ["logly_ads_context"]
+    assert summary["platform_conflicts"] == []
+    labels = {p["key"]: p["display_name"] for p in summary["platforms"]}
+    assert labels["logly_ads_context"] == "Logly Ads Context (plugin)"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Before / After

**Before:** a `platforms` entry filed under an installed plugin's bare provider name — `logly_ads_context` — is accepted on write, reported `Clean` by `mureo repair platform-key --all`, and *simultaneously* flagged in the Reports view as a key mureo cannot resolve. Nothing is wrong with the entry.

**After:** one answer. The key gets a label (`Logly Ads Context (plugin)`) and no warning, on every surface.

```
reject_unknown_platform_key("logly_ads_context")   # accepted (unchanged)
platform_display_name("logly_ads_context")          # 'Logly Ads Context (plugin)'  (was: 'logly_ads_context')
platform_display_name("logly_ads")                  # 'logly_ads' — still flagged, still repairable
```

## The four decisions the issue asked to settle

**Where the enumeration lives — it does not move.** `mureo/web/reports.py` already imports `mureo.context.state` and `mureo.context.platform_accounts`, so `web` → `context` is the direction that holds; the reverse is explicitly ruled out in `mureo/core/platform_keys.py` (it would put the configure UI's import graph on the state-write path and invert the layering). So `platform_guards._installed_platform_names` simply becomes public as `installed_platform_names`, exported, and documented as the single enumeration both sides read. No copy anywhere, and `AGENTS.md`'s line for that module now says so.

**The label path is never stricter than the guard.** It reads `ep.name` only (through the same function), and it **fails open** on an environment that cannot be enumerated: an unresolvable key is labelled rather than reported, because a broken `importlib.metadata` is not evidence a key is wrong. Failing closed there would have been the same drift pointing the other way — every plugin entry on that machine flagged. One shape is excluded whatever the registry says: a key claiming the plugin namespace without naming a platform (`plugin:`, `plugin:<dist>:`), which the write path refuses on shape alone via `reject_unusable_platform_key`, so no enumeration failure can dress up a malformed entry.

**The label carries the `" (plugin)"` suffix.** The bare name and the canonical key denote the same platform from the same plugin, so they now render identically — a second label for one platform would replace this inconsistency with a new one. Consequence worth knowing, and documented in `docs/strategy-context.md`: two rows sharing one label mean two entries for one platform, which is exactly what `duplicate_account` names when they also share an `account_id`. One corner: `_OFFICIAL_BRIDGE_DISPLAY_NAMES` (which drops the suffix for in-tree bridges) is keyed by *distribution*, and a bare name carries none, so an official bridge held under its bare provider name keeps the suffix. Resolving that would mean reading `ep.dist` — more of an entry point than the guard reads — and mureo writes the canonical key for those anyway.

**Cost.** The enumeration is memoized, keyed **by the enumerator itself** (`(_provider_entry_points, result)`). A test that installs a plugin mid-process does it by swapping that function, and a swapped function is a different object, so the memo misses — structurally, with no fixture to remember and no pin able to leak into the next test. A **failed** enumeration is never cached ("could not enumerate" is a moment, not a fact about the machine). What the cache does not see is a plugin pip-installed while the process runs; that costs a restart, and it costs it to the guard and the label path *identically*, which is the property this issue is about — while the canonical `plugin:<dist>:<provider>` key needs no enumeration at all, so nothing is unwritable in the meantime. 200 label lookups: 0.4 ms, against ~43 ms for one scan.

## The regression guard

`tests/test_platform_key_agreement.py` asserts the two functions **agree**, rather than testing this one symptom. For every shape — built-in (incl. the entry-point-less `tiktok_ads`), canonical `plugin:<dist>:<provider>` (installed and not), legacy `plugin:<dist>`, an installed bare provider name, an invented key, and a malformed `plugin:` — `platform_display_name(key) == key` must match `is_unresolvable_platform_key(key)`, which is what `mureo repair platform-key` prints `Clean` from. That is what would have caught #609 widening the write vocabulary without touching the read side. It also pins the shared fail-open, that both surfaces move together when the single seam is patched, that the scan happens once, that a swapped seam is never answered from the cache, and that a failure is not cached.

Every fixture that touches this now **pins the entry-point set with a fake**: this machine really has the LOGLY and LINE/Yahoo bridges installed. That also fixed a latent trap — `test_the_reported_field_shape_is_caught_by_the_unrecognised_key_signal` used `logly_ads_context` as its "unrecognisable" key, i.e. it encoded this bug; it now uses the invented `logly_ads` (which is the key from the field) with the set pinned.

## Other callers of the same proxy

Checked: `platform_display_name(key) == key` is used in exactly one place, `_build_platform_conflicts`. The two `=== key` comparisons in the browser assets (`dashboard.js`, `reports_format.js`) are i18n "did the translation resolve?" guards, unrelated. Nothing else inherits the bug.

Two places *explained* themselves in terms of the old behaviour and would now be false — `mureo/cli/repair_cmd.py`'s "why the CLI and not a dashboard button" and the matching comment on the conflicted platform card ("`logly_ads_context` is just as unrecognised as the invented `logly_ads`"). Both now say what is still true: the signal agrees with the write-time answer, but agreeing about the key is not deciding the repair — unresolvable is the *filter*, not the criterion (#616), and an entry carrying `conversion_action_types` is refused outright (#617); none of that evidence crosses the wire. No behaviour change there.

## What the issue got wrong

Nothing material. One clarification: the issue's table says `platform_display_name` "knows nothing about installed entry points" — true, and the reason it looked like a pure display bug is that the *write* guard also has the fail-open path, which meant the two functions could disagree in **both** directions, not just this one. Hence the agreement test rather than a bare-name test.

## Verification

- `black --check mureo tests` — clean (712 files)
- `ruff check mureo tests` — clean
- `mypy mureo` — 14 errors, all pre-existing missing-library-stub errors in unrelated modules; identical count on the base commit
- `node --test tests/js/*.test.js` — 143 pass, 0 fail
- `pytest tests/` — 9298 passed, 14 failed; all 14 fail identically on the base commit (locally-installed plugins: `test_mcp_server*`, `test_mcp_tool_provider`, `analytics/builtin/test_live_clients`, and two `test_web_handlers` client-registry tests)

Closes #631
