### PR TITLE
perf: discover the policy gates once, not on every tool dispatch (#633)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 ### Fixed
 
+- **Every MCP tool call spent ~11 ms re-discovering the policy gates before
+  any gate logic ran** (#633). `_evaluate_policy_gates` re-enumerated the
+  `mureo.policy_gates` entry-point group, `load()`-ed every gate class and
+  constructed every gate, on **every dispatch** — justified in the code by
+  "`importlib.metadata.entry_points` is itself cached internally, so the
+  per-call cost is microseconds". Measured on Python 3.10 with four gates
+  installed, `_load_policy_gates()` cost **11.76 ms per call**, of which
+  11.43 ms was the enumeration: it re-stats and re-parses the environment
+  every time, which is exactly the freshness being paid for, so it never
+  converges toward free. It is now **1.0 µs** warm, and the whole gate
+  chain (built-in gate included) went from 10.94 ms to 0.09 ms per dispatch.
+
+  The freshness that cost bought was not reachable in a useful form. A
+  distribution installed into a running server contributes no tools
+  (`_PLUGIN_TOOLS` / `_PLUGIN_DISPATCH` are built at module import,
+  `_PLUGIN_SEMANTICS` and the throttler/declaration registries are
+  comprehensions over them) and no runtime context
+  (`get_runtime_context` caches the first one it resolves). Every
+  gate-registering distribution also registers `mureo.providers`, so the
+  case was never "a gate arrives alone" — it was a bridge whose gate went
+  live while its tools and its tenant resolution stayed unregistered.
+  The gate set is now fixed at the first dispatch and changing it costs a
+  restart, the same trade #631 made on the platform-name enumeration and
+  the same restart the tool set already required.
+
+  What is **not** cached is any failure. An unreadable environment is
+  re-enumerated on the next dispatch, and a gate whose `load()` raised keeps
+  being retried — it is still dropped with a WARNING while the others load,
+  but a transient import error can no longer remove a guardrail for the life
+  of the process. The memo is keyed by the enumerator itself, so a test that
+  installs fake gates by patching it structurally misses the memo and cannot
+  leak into the next test. Loaded *classes* are cached, never instances: the
+  `PolicyGate` ABI promises third-party authors a fresh instance per tool
+  call, and `cls()` costs nothing worth breaking that for.
+
 - **A platform key mureo accepts on write was reported as unresolvable on
   read** (#631). A `platforms` entry filed under an installed plugin's bare
   provider name — `logly_ads_context`, the LOGLY bridge's real platform name —

--- a/docs/ABI-stability.md
+++ b/docs/ABI-stability.md
@@ -463,6 +463,18 @@ contract:
   in `reason`; that is the only field surfaced.
 - The default behaviour with zero gates registered is byte-
   identical to v0.9.22: every call dispatches normally.
+- **Lifecycle** (pinned since v0.10.47, #633): the entry point is
+  enumerated and `load()`-ed **once per process**, on the first
+  dispatch, and the resulting class is memoized. The *instance* is
+  still constructed fresh per tool call, so instance attributes do
+  not persist across calls — put cross-call state on a class
+  attribute or a module-level singleton, as before. Consequence: a
+  gate installed or uninstalled while the server runs takes effect
+  on restart, the same as its distribution's tools (collected at
+  module import) and its runtime-context factory (resolved once).
+  A gate whose `load()` *raised* is not memoized — it is retried on
+  the next dispatch, so a transient import error cannot silently
+  remove a guardrail for the life of the process.
 
 The groups are independent: a package may register against any subset
 (provider only, analytics only, change feed only, any combination) —

--- a/docs/plugin-authoring.md
+++ b/docs/plugin-authoring.md
@@ -940,6 +940,14 @@ Rules for a gate of this kind:
 - **Do not also declare.** A declaration replaces the built-in scan for the
   proposed budgets, which would switch off the very keys your gate injects.
   Pick one mechanism per tool, and pin the choice with a test.
+- **Your module is imported once; your class is constructed per call.**
+  mureo enumerates and `load()`s the entry point on the first dispatch and
+  memoizes the class (#633), so module-level work happens once — but
+  `__init__` runs on every tool call and instance attributes never survive
+  it. Keep `__init__` empty; put any cross-call cache on a class attribute.
+  Installing or uninstalling your package while a server runs does not
+  change the gate set until restart, exactly as it does not change the tool
+  set.
 
 **Structural strategy parity (mutating tools).** A mutating plugin
 call gets the same *structural* strategy handling as a built-in write:

--- a/mureo/context/platform_guards.py
+++ b/mureo/context/platform_guards.py
@@ -225,13 +225,15 @@ def _provider_entry_points() -> tuple[Any, ...] | None:
 
     ``None`` — distinct from an empty tuple — means the environment could not
     be enumerated. ``importlib.metadata`` blowing up is rare but possible
-    (unusual install layout, corrupted metadata), and unlike the policy-gate
-    loader (:func:`mureo.mcp.server._policy_gate_entry_points`, which treats
-    the failure as "zero gates") this one cannot treat it as "zero providers":
-    that would turn a broken environment into a refusal of every plugin
+    (unusual install layout, corrupted metadata), and treating it as "zero
+    providers" would turn a broken environment into a refusal of every plugin
     platform key. A failure is not evidence the key is wrong, so the caller
-    fails open. Isolated as its own function so tests can pin the environment
-    rather than monkeypatching ``importlib.metadata``.
+    fails open. The policy-gate loader
+    (:func:`mureo.mcp.server._policy_gate_entry_points`) draws the same
+    distinction for a different reason: its answer is memoized, so a failure
+    stored as "zero gates" would drop every third-party guardrail for the life
+    of the process (#633). Isolated as its own function so tests can pin the
+    environment rather than monkeypatching ``importlib.metadata``.
     """
     from importlib.metadata import entry_points
 

--- a/mureo/core/policy.py
+++ b/mureo/core/policy.py
@@ -49,8 +49,8 @@ Per-gate evaluation rules enforced by the dispatcher (in
 
 Implementations MUST be pure and fast — ``evaluate`` runs on every
 tool call. Cache any expensive lookup (file reads, network calls)
-behind a TTL inside the implementation itself; the dispatcher does
-no caching.
+behind a TTL inside the implementation itself; the dispatcher caches
+gate *discovery* (#633) but nothing your ``evaluate`` does.
 """
 
 from __future__ import annotations
@@ -102,6 +102,13 @@ class PolicyGate(Protocol):
     cross-call caching (e.g. a TTL'd re-read of
     ``~/.mureo/config.json``), put the cache on a class attribute
     or a module-level singleton — instance state is ephemeral.
+    The *class* is loaded once per process: the entry point is
+    enumerated and ``load()``-ed on the first dispatch and memoized
+    (#633), so import-time work in your module runs once, but
+    ``__init__`` runs per call and must stay trivial. A gate
+    installed or uninstalled while the server runs is therefore not
+    picked up until restart — the same as its distribution's tools,
+    which are collected at module import.
 
     **Async**: the v1 contract is synchronous by design. A future
     Protocol for asynchronous gates may be added under a separate

--- a/mureo/mcp/server.py
+++ b/mureo/mcp/server.py
@@ -45,6 +45,8 @@ from mcp.server import Server
 from mcp.server.stdio import stdio_server
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from mcp.types import Tool
 
     from mureo.core.policy import PolicyDecision, PolicyGate
@@ -757,10 +759,20 @@ async def handle_list_tools() -> list[Any]:
     return list(_ALL_TOOLS)
 
 
-def _policy_gate_entry_points() -> tuple[Any, ...]:
-    """Return the entry points registered under
-    ``mureo.policy_gates``. Isolated so the unit tests can patch this
-    without monkeypatching ``importlib.metadata``."""
+def _policy_gate_entry_points() -> tuple[Any, ...] | None:
+    """Return the entry points registered under ``mureo.policy_gates``.
+
+    ``None`` — distinct from an empty tuple — means the environment could not
+    be enumerated at all. The two must not collapse into one value, because
+    :func:`_load_policy_gates` memoizes its answer (#633) and memoizing a
+    failure as "zero gates registered" would run the rest of the process with
+    every third-party guardrail silently missing. An empty tuple is a machine
+    with no gates installed; ``None`` is a moment.
+
+    Isolated as its own function so the unit tests can patch this without
+    monkeypatching ``importlib.metadata`` — and, since the memo is keyed by
+    this function object, so that patching it is what misses the memo.
+    """
     from importlib.metadata import entry_points
 
     from mureo.core.policy import POLICY_GATES_ENTRY_POINT_GROUP
@@ -774,11 +786,49 @@ def _policy_gate_entry_points() -> tuple[Any, ...]:
         # the situation as "no gates registered".
         logger.warning(
             "policy gates: importlib.metadata.entry_points failed (%s); "
-            "treating as zero gates registered",
+            "treating as zero gates for this call",
             exc,
         )
-        return ()
+        return None
     return tuple(eps)
+
+
+_POLICY_GATE_CLASS_CACHE: (
+    tuple[
+        Callable[[], tuple[Any, ...] | None],
+        tuple[Any, ...],
+        list[type[PolicyGate] | None],
+    ]
+    | None
+) = None
+"""Memoized gate discovery for :func:`_load_policy_gates` (#633).
+
+Three parts: the enumerator that produced it, the entry points it returned,
+and the class each of those entry points loaded to — ``None`` in that last
+list where the load has not succeeded (yet).
+
+**Keyed by the enumerator itself**, the pattern
+:func:`mureo.context.platform_guards.installed_platform_names` uses: the tests
+install fake gates by replacing :func:`_policy_gate_entry_points`, and a
+different function object structurally misses the memo. So no test's gates can
+leak into the next test, whatever order the suite runs in, and nothing has to
+remember to clear anything.
+
+**Absence is never cached.** A failed enumeration is not stored at all, and an
+entry point whose ``load()`` raised keeps its slot at ``None`` and is retried
+on the next dispatch. A dropped gate is a missing guardrail; a memo that
+remembered one would turn a transient import error into an enforcement hole
+for the life of the process, which is the opposite of what this module exists
+to do. Retrying costs an ``ep.load()`` (microseconds once the module is in
+``sys.modules``, and this path is only reached at all when something is
+broken), not a re-enumeration.
+
+What is cached is the *class*, never the instance — see
+:func:`_load_policy_gates`.
+
+Written as one assignment, and the per-entry slot as one item store, so a
+concurrent reader sees either the old answer or the new one, never half.
+"""
 
 
 def _load_policy_gates() -> tuple[PolicyGate, ...]:
@@ -788,12 +838,38 @@ def _load_policy_gates() -> tuple[PolicyGate, ...]:
     Per-entry-point exception isolation: a broken third-party
     package (partial install, import error) MUST NOT take mureo
     offline. The failing entry is dropped with a WARNING and the
-    rest still load.
+    rest still load — and it is retried on the next call, never
+    remembered as absent (:data:`_POLICY_GATE_CLASS_CACHE`).
+
+    Discovery is memoized; **instantiation is not**. ``cls()`` is a few
+    microseconds even with every bridge installed, and
+    :class:`mureo.core.policy.PolicyGate` promises third-party authors that
+    the dispatcher constructs their gate fresh per tool call, so instance
+    attributes do not persist and cross-call state belongs on a class
+    attribute. Reusing one instance would quietly break every gate written to
+    that published contract to save nothing, so what the cache holds is the
+    loaded class.
     """
+    global _POLICY_GATE_CLASS_CACHE
+
+    enumerate_entry_points = _policy_gate_entry_points
+    cached = _POLICY_GATE_CLASS_CACHE
+    if cached is not None and cached[0] is enumerate_entry_points:
+        entries, classes = cached[1], cached[2]
+    else:
+        found = enumerate_entry_points()
+        if found is None:  # could not enumerate; not an answer worth keeping
+            return ()
+        entries, classes = found, [None] * len(found)
+        _POLICY_GATE_CLASS_CACHE = (enumerate_entry_points, entries, classes)
+
     gates: list[PolicyGate] = []
-    for ep in _policy_gate_entry_points():
+    for index, ep in enumerate(entries):
         try:
-            cls = ep.load()
+            cls = classes[index]
+            if cls is None:
+                cls = ep.load()
+                classes[index] = cls
             instance = cls()
         except Exception as exc:  # noqa: BLE001
             logger.warning(
@@ -827,11 +903,44 @@ def _evaluate_policy_gates(
     """Run every gate — built-in then third-party. Returns the first deny
     decision, or ``None`` if every gate allowed (or abstained on exception).
 
-    Calls :func:`_load_policy_gates` on every dispatch rather than
-    caching at module-import time so a (rare) at-runtime
-    install/uninstall of a third-party gate is picked up without a
-    server restart. ``importlib.metadata.entry_points`` is itself
-    cached internally, so the per-call cost is microseconds.
+    The gate set is discovered once per process (#633)
+    ---------------------------------------------------
+
+    This used to call :func:`_load_policy_gates` uncached on every dispatch,
+    to pick up an at-runtime install/uninstall of a third-party gate without a
+    server restart, on the claim that ``importlib.metadata.entry_points`` is
+    "itself cached internally, so the per-call cost is microseconds". That
+    claim was wrong by four orders of magnitude. Measured on Python 3.10 with
+    four gates installed: 11.76 ms per ``_load_policy_gates()`` call, of which
+    **11.43 ms is the enumeration**, which re-stats and re-parses the
+    environment every time — that re-check is precisely the freshness being
+    paid for, so it never converges toward free. Every MCP tool call paid it
+    before any gate logic ran.
+
+    And the freshness bought a state nobody wants. A distribution installed
+    into a running server contributes **no tools**: ``_PLUGIN_TOOLS`` /
+    ``_PLUGIN_DISPATCH`` are built by ``collect_plugin_tools`` at module
+    import, ``_PLUGIN_SEMANTICS`` and the throttler/declaration registries are
+    module-level comprehensions over them, and
+    :func:`mureo.core.runtime_context.get_runtime_context` caches the first
+    context it resolves. Every gate-registering distribution observed in the
+    wild also registers ``mureo.providers``, so "the gate arrives alone" is not
+    the scenario — the scenario is a bridge whose gate goes live while its
+    tools and its analytics module stay unregistered, so its own budget gate
+    guards tool names that cannot be dispatched. A distribution shipping a
+    *global* gate is worse rather than better: mureo-agency's read-only gate
+    would start refusing mutations while the runtime-context factory deciding
+    *whose* account is being refused — which it registers in the same
+    ``pyproject.toml`` — is still the OSS default, because that one is
+    resolved once. Uninstall is the worse direction again: a guardrail
+    disappearing mid-process, silently.
+
+    So the gate set is fixed at the first dispatch and changing it costs a
+    restart — which is what changing the tool set already cost. This is the
+    same trade #631 made for the platform-name enumeration, for the same
+    reason: one consistent answer beats a fresher one that disagrees with the
+    rest of the process. What is **not** cached is any failure; see
+    :data:`_POLICY_GATE_CLASS_CACHE`.
     """
     # Lazy-imported so the type is available for the isinstance guard
     # without re-introducing the runtime import at module top (it lives

--- a/tests/test_policy_gate.py
+++ b/tests/test_policy_gate.py
@@ -15,6 +15,9 @@ group. mureo OSS itself ships zero gates — third-party packages
 4. Refuse messages surface the gate's ``reason`` to the agent.
 5. Default behaviour (no gates registered) is byte-identical to
    v0.9.22 — zero overhead, every call dispatches.
+6. The dispatch path enumerates and loads the gate set once per
+   process (#633), without ever caching a *failure* — and therefore
+   without picking up a mid-process install.
 """
 
 from __future__ import annotations
@@ -319,3 +322,239 @@ class TestPolicyGateEntryPointDiscovery:
             gates = _load_policy_gates()
         assert len(gates) == 1
         assert any("broken" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# What the dispatch path pays for the gate set (#633)
+# ---------------------------------------------------------------------------
+
+
+class _FakeEntryPoint:
+    """A ``mureo.policy_gates`` entry point that counts its ``load()``.
+
+    ``loader`` is called on every ``load()``, so a test can make the first
+    load fail and a later one succeed.
+    """
+
+    def __init__(self, name: str, loader: Any) -> None:
+        self.name = name
+        self._loader = loader
+        self.loads = 0
+
+    def load(self) -> Any:
+        self.loads += 1
+        return self._loader()
+
+
+class _AllowGate:
+    """Minimal conforming gate — abstains on everything."""
+
+    def evaluate(self, tool_name: str, arguments: dict[str, Any]) -> PolicyDecision:
+        return PolicyDecision(allowed=True)
+
+
+@pytest.mark.unit
+class TestPolicyGateLoadCost:
+    """``_load_policy_gates`` runs on every tool dispatch.
+
+    Measured on Python 3.10 with four gates installed, the uncached version
+    cost 11.76 ms per dispatch — of which 11.43 ms was
+    ``importlib.metadata.entry_points(group=...)``, which re-stats and
+    re-parses the environment on every call rather than costing
+    "microseconds". These pin the cost away without weakening the isolation
+    the loader exists to provide.
+    """
+
+    def test_the_entry_points_are_enumerated_once(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from mureo.mcp import server
+
+        calls = 0
+
+        def _enumerate() -> tuple[Any, ...]:
+            nonlocal calls
+            calls += 1
+            return (_FakeEntryPoint("acme", lambda: _AllowGate),)
+
+        monkeypatch.setattr(server, "_policy_gate_entry_points", _enumerate)
+
+        for _ in range(5):
+            assert len(server._load_policy_gates()) == 1
+
+        assert calls == 1
+
+    def test_each_gate_class_is_loaded_once(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``ep.load()`` imports third-party code; once per process is enough."""
+        from mureo.mcp import server
+
+        ep = _FakeEntryPoint("acme", lambda: _AllowGate)
+        monkeypatch.setattr(server, "_policy_gate_entry_points", lambda: (ep,))
+
+        for _ in range(5):
+            assert len(server._load_policy_gates()) == 1
+
+        assert ep.loads == 1
+
+    def test_the_dispatch_path_does_not_re_enumerate(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The property that matters is on ``_evaluate_policy_gates``."""
+        from mureo.mcp import server
+
+        ep = _FakeEntryPoint("acme", lambda: _AllowGate)
+        calls = 0
+
+        def _enumerate() -> tuple[Any, ...]:
+            nonlocal calls
+            calls += 1
+            return (ep,)
+
+        monkeypatch.setattr(server, "_policy_gate_entry_points", _enumerate)
+
+        for _ in range(5):
+            assert server._evaluate_policy_gates("mureo_state_get", {}) is None
+
+        assert (calls, ep.loads) == (1, 1)
+
+    def test_a_fresh_instance_is_constructed_per_call(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The class is cached; the instance is not.
+
+        ``mureo.core.policy.PolicyGate`` promises third-party authors that
+        "instance attributes do NOT persist across calls" and that a gate
+        needing cross-call state must put it on a class attribute. Reusing
+        one instance would silently break every gate written to that
+        contract, so what is memoized is the loaded class.
+        """
+        from mureo.mcp import server
+
+        monkeypatch.setattr(
+            server,
+            "_policy_gate_entry_points",
+            lambda: (_FakeEntryPoint("acme", lambda: _AllowGate),),
+        )
+
+        first = server._load_policy_gates()
+        second = server._load_policy_gates()
+
+        assert type(first[0]) is type(second[0])
+        assert first[0] is not second[0]
+
+    def test_a_failed_load_is_retried_not_remembered(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A dropped gate is a missing guardrail; never cache one.
+
+        A transient import error must not remove a gate for the life of the
+        process, so the failure is re-attempted on the next dispatch while
+        the gates that did load keep loading.
+        """
+        from mureo.mcp import server
+
+        outcomes: list[Any] = [ImportError("partial install"), _AllowGate]
+
+        def _load_flaky() -> Any:
+            outcome = outcomes.pop(0)
+            if isinstance(outcome, Exception):
+                raise outcome
+            return outcome
+
+        flaky = _FakeEntryPoint("flaky", _load_flaky)
+        healthy = _FakeEntryPoint("healthy", lambda: _AllowGate)
+        monkeypatch.setattr(
+            server, "_policy_gate_entry_points", lambda: (flaky, healthy)
+        )
+
+        with caplog.at_level(logging.WARNING, logger="mureo.mcp.server"):
+            first = server._load_policy_gates()
+        assert len(first) == 1  # the healthy gate still loaded
+        assert any("flaky" in record.message for record in caplog.records)
+
+        assert len(server._load_policy_gates()) == 2
+        assert (flaky.loads, healthy.loads) == (2, 1)
+
+    def test_a_failed_enumeration_is_never_cached(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """ "Could not enumerate" is a moment, not a fact about the machine.
+
+        Same rule as :func:`mureo.context.platform_guards.installed_platform_names`
+        — caching it would mean one unlucky call runs the rest of the process
+        with zero third-party gates.
+        """
+        from mureo.mcp import server
+
+        outcomes: list[tuple[Any, ...] | None] = [
+            None,
+            (_FakeEntryPoint("acme", lambda: _AllowGate),),
+        ]
+        monkeypatch.setattr(
+            server, "_policy_gate_entry_points", lambda: outcomes.pop(0)
+        )
+
+        assert server._load_policy_gates() == ()
+        assert len(server._load_policy_gates()) == 1
+
+    def test_the_environment_is_re_read_when_the_enumerator_is_swapped(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The memo is keyed by the enumerator, so a test's pin cannot leak.
+
+        Every test installs a fake gate by replacing
+        ``_policy_gate_entry_points``; a different function object structurally
+        misses the memo, so no test can be served the previous test's gates and
+        nothing has to remember to clear a cache (the #631 pattern).
+        """
+        from mureo.mcp import server
+
+        class _DenyGate:
+            def evaluate(
+                self, tool_name: str, arguments: dict[str, Any]
+            ) -> PolicyDecision:
+                return PolicyDecision(allowed=False, reason="nope")
+
+        monkeypatch.setattr(
+            server,
+            "_policy_gate_entry_points",
+            lambda: (_FakeEntryPoint("allow", lambda: _AllowGate),),
+        )
+        assert isinstance(server._load_policy_gates()[0], _AllowGate)
+
+        monkeypatch.setattr(
+            server,
+            "_policy_gate_entry_points",
+            lambda: (_FakeEntryPoint("deny", lambda: _DenyGate),),
+        )
+        assert isinstance(server._load_policy_gates()[0], _DenyGate)
+
+    def test_a_gate_installed_mid_process_is_not_picked_up(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The deliberate trade, pinned so it cannot be changed by accident.
+
+        A distribution pip-installed into a running server registers no tools
+        (``_PLUGIN_TOOLS`` / ``_PLUGIN_DISPATCH`` / ``_PLUGIN_SEMANTICS`` are
+        module-import-time) and no runtime context
+        (``get_runtime_context`` caches the first one it resolves), so picking
+        its *gate* up alone produced a half-configured process. The gate set is
+        now fixed at the first dispatch; changing it costs a restart, which is
+        what changing the tool set already cost.
+        """
+        from mureo.mcp import server
+
+        installed = [_FakeEntryPoint("acme", lambda: _AllowGate)]
+        monkeypatch.setattr(
+            server, "_policy_gate_entry_points", lambda: tuple(installed)
+        )
+
+        assert len(server._load_policy_gates()) == 1
+
+        installed.append(_FakeEntryPoint("late", lambda: _AllowGate))
+
+        assert len(server._load_policy_gates()) == 1


### PR DESCRIPTION
Closes #633

## What was measured

The comment on `_evaluate_policy_gates` said `importlib.metadata.entry_points`
"is itself cached internally, so the per-call cost is microseconds". Re-measured
on this machine (Python 3.10.0, four gates installed — mureo-agency,
mureo-smartnews-bridge, mureo-logly-bridge, mureo-lineyahoo-bridge):

| | before | after |
|---|---|---|
| `entry_points(group="mureo.policy_gates")` | 11.43 ms/call | not called after the first dispatch |
| `_load_policy_gates()` | **11.76 ms/call** | **1.04 µs/call** |
| `_evaluate_policy_gates()` (built-in gate included) | **10.94 ms/call** | **0.09 ms/call** |

So the claim was wrong by four orders of magnitude, and every MCP tool call
paid ~11 ms before any gate logic ran.

Two corrections to the issue's own numbers, since they are load-bearing for the
fix:

- The issue's comment says the `ep.load()` + `cls()` work is "on top and is the
  part that grows". It is not the part that grows: once the gate modules are in
  `sys.modules`, `load()` + `cls()` for all four gates costs **0.04 ms** — 0.3%
  of the total. The enumeration is 97% of it, and it is the enumeration that
  scales with the size of the *environment*, not with the number of gates.
- 11 ms is not accidental overhead that a cleverer `entry_points` would remove.
  In 3.10 the per-call work is re-stat'ing each `sys.path` root and re-deriving
  the group selection when the mtime moved — i.e. it *is* the mid-process-install
  freshness, charged per call. That is why it does not converge toward free with
  repetition, and it is why "make the enumeration cheaper" is not an option
  separate from "stop asking for freshness".

## Is runtime gate pickup a real scenario?

It is reachable, and it produces a state worse than not picking the gate up at
all. Evidence, in this tree and in the installed environment:

- **Tools cannot arrive mid-process.** `_PLUGIN_TOOLS` / `_PLUGIN_DISPATCH` come
  from `collect_plugin_tools(...)` at module import (`mureo/mcp/server.py:250`);
  `_PLUGIN_SEMANTICS`, `_PLUGIN_TOOL_THROTTLERS` and the budget/bid declaration
  registries are module-level comprehensions over them.
- **Neither can the runtime context.** `get_runtime_context()`
  (`mureo/core/runtime_context.py`) resolves `mureo.runtime_context_factory`
  once and caches the result for the process.
- **A gate never arrives alone.** All four gate-registering distributions
  installed here also register `mureo.providers`; three also register
  `mureo.analytics` and `mureo.skills`; mureo-agency also registers
  `mureo.runtime_context_factory` and `mureo.web_extensions`.

So the *bridge budget gate* case is the theoretical one — picked up mid-process,
it would guard tool names that are not dispatchable, and enforce nothing. The
*global gate* case (mureo-agency's `ReadOnlyGate`, which refuses mutations of
built-in tools, so its value genuinely does not depend on its own tools being
registered) is the one that is real — and it is the one that argues hardest for
caching: picked up mid-process it starts refusing mutations while the
runtime-context factory declared in the same `pyproject.toml`, which decides
*whose* account is being refused, is still the OSS default. That is a
half-configured process, not a feature. Uninstall is the same trade pointing the
worse way: a guardrail vanishing mid-process, silently.

## What this does

Memoizes gate **discovery** — the enumerated entry points and the class each one
loaded to — keyed by `_policy_gate_entry_points` itself, the pattern #631 used
for `installed_platform_names`. The gate set is fixed at the first dispatch;
changing it costs a restart, which is what changing the tool set already cost.
That matches #631's reasoning rather than contradicting it.

**Failure isolation survives, and is now pinned in both directions:**

- `_policy_gate_entry_points` now returns `None` (not `()`) when
  `importlib.metadata` blows up, so "could not enumerate" is distinguishable
  from "no gates installed" and is never stored. `()` from a failure would have
  meant one unlucky call running the rest of the process with zero third-party
  guardrails. This mirrors `_provider_entry_points` in `platform_guards.py`,
  whose docstring cross-referenced the old behaviour and is updated.
- An entry point whose `load()` raised keeps its cache slot empty: still dropped
  with a WARNING while the others load, and **retried on the next dispatch**.
  A transient import error cannot become a permanently missing gate. Retrying
  costs an `ep.load()`, not a re-enumeration.
- In-tree precedent for exactly this: `get_runtime_context` caches only
  successfully-constructed contexts, "because the alternative (caching the
  exception) hides a fix-in-place".

**Classes are cached, instances are not.** `mureo.core.policy.PolicyGate`
publishes to third-party authors that "the dispatcher instantiates the gate class
fresh on every dispatch … instance attributes therefore do NOT persist across
calls", and tells them to put cross-call state on a class attribute. Reusing one
instance would silently break every gate written to that contract. `StrategyPolicyGate`
is stateless (no `__init__`, one `staticmethod` plus `evaluate`) and
mureo-agency's `ReadOnlyGate` has an empty `__dict__`, but out-of-tree gates are
*contractually permitted* per-call instance state, and `cls()` measures at ~0 µs
for all four gates — there is nothing to gain by breaking it.

## Tests

New `TestPolicyGateLoadCost` in `tests/test_policy_gate.py` — all assert on call
counts against a patched enumerator, never on wall-clock:

- the entry points are enumerated once across five `_load_policy_gates()` calls;
- each gate class is `load()`-ed once;
- `_evaluate_policy_gates` (the dispatch path itself) re-enumerates and re-loads
  zero times across five calls;
- a fresh instance is constructed per call, and it is a different object;
- a gate that raises on `load()` is dropped with a warning, the other still
  loads, **and the next call retries it** (`(flaky.loads, healthy.loads) == (2, 1)`);
- a failed enumeration is never cached;
- swapping the enumerator misses the memo, so a test's pin cannot leak into the
  next test;
- **a gate appearing mid-process is not picked up** — the trade is pinned, so
  changing it has to be deliberate.

Docs updated with the code: `docs/ABI-stability.md` (`mureo.policy_gates`
lifecycle is now a stated part of the contract), `docs/plugin-authoring.md`
(keep `__init__` empty; install/uninstall takes a restart, same as tools),
`mureo/core/policy.py` docstrings, and the `platform_guards.py` cross-reference.

## Verification

- `pytest tests/test_policy_gate.py` — 29 passed (6 of the new ones failed
  before the implementation).
- `pytest` (full) — 9306 passed, 14 failed. All 14 are pre-existing: the same 14
  fail on this branch with the change stashed (locally-installed plugins;
  `tests/analytics/builtin/test_live_clients.py` ×9, `tests/test_mcp_server.py`,
  `tests/test_mcp_server_plugin_wiring.py`, `tests/test_mcp_tool_provider.py`,
  `tests/test_web_handlers.py` ×2).
- `black --check mureo/ tests/` clean, `ruff check` clean, `mypy mureo/` — 14
  errors, byte-identical to the same run with the change stashed (all
  `import-untyped` missing stubs).
