### PR TITLE
fix: state auction and bid-strategy semantics as platform-conditional (#647)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,54 @@
 
 ### Fixed
 
+- **Auction and smart-bidding semantics were stated as unconditional facts**
+  (#647). mureo's platform-agnostic instruction text and its shared entity
+  vocabulary described bidding, auctions and smart-bidding learning phases as
+  properties of advertising rather than properties of the platforms that work
+  that way. On a platform whose delivery is not selected by a bid, those
+  sentences are simply false — and the agent carried them over anyway, writing
+  routine report lines and stored learning entries about a campaign in another
+  platform's terms. A learning entry written under the wrong model outlives the
+  session that produced it: nothing downstream re-derives whether the premise
+  held.
+
+  The wording to copy already existed in the tree — `budget-pacing` qualifies
+  the >20 % budget-step warning with the platforms whose learning phase it can
+  reset, and `daily-check`'s learning-state guard names the platform states it
+  is about. The unqualified twins are now qualified the same way, in
+  `budget-rebalance`, `_mureo-learning` (observation windows, confounding
+  factors, metrics-to-record), `daily-check` (`COMPETITOR_DEFENSE`),
+  `incident-postmortem` (the cause taxonomy), `sync-state` (the diff list) and
+  `_mureo-pro-diagnosis` (the diagnostic order). `impression_share` is now
+  attributed to Google Ads and explicitly marked as outside the canonical
+  metric vocabulary, rather than listed as if every platform reported it.
+
+  The **status vocabulary contract** in `_mureo-shared` already carried exactly
+  this discipline for delivery-status strings: store them verbatim, never
+  translate them into another platform's spelling, and let a platform that has
+  no such thing omit the field rather than have one invented for it. That last
+  limb now covers every platform-conditional field in the snapshot —
+  `bidding_strategy_type` and `bidding_details` included — so no skill requires
+  a bid strategy of a platform that has none, or narrates an auction, a win
+  rate or a learning phase for it. Metrics fall under the same limb: a platform
+  whose own primary figure has no canonical key omits it rather than borrowing
+  a key that means something else, because an eCPM-priced network's selection
+  price written into `cpa` makes every consumer of that number wrong.
+
+  `BidStrategy` gained a `NOT_APPLICABLE` member (an additive, non-breaking
+  enum change per `docs/ABI-stability.md` §5). Before it, a platform with no
+  bid strategy had to name itself one of three auction strategies or leave the
+  field empty — and empty already means *unknown / not fetched*, so the two
+  statements were indistinguishable. They are now distinct and documented;
+  `NOT_APPLICABLE` is read-side only and the Google Ads adapter refuses it on a
+  create/update request.
+
+  `mureo_state_upsert_campaign` is the single cross-platform state-write tool,
+  so its schema sits in the model's context in every session the mureo server
+  is loaded in. Its `bidding_strategy_type` had no description at all, and the
+  sibling `bidding_details` opened with a Google-shaped example. Both now state
+  the platform-conditional contract first, in two lines.
+
 - **A platform entry holding only a "why this was not collected" note was
   deleted as empty** (#643). `mureo repair platform-key` removes an entry the
   document itself shows to be wrong, and one of those two proofs is that the

--- a/docs/ABI-stability.md
+++ b/docs/ABI-stability.md
@@ -43,7 +43,7 @@ The mureo plugin ABI consists of exactly the following:
 | `ChangeFeedProvider` Protocol shape (`platform` + `async fetch_change_events()`) — the opt-in change-import secondary Protocol (#545) | `mureo.change_import.protocol` | Stable (structural / `runtime_checkable`) |
 | `ExternalChange` / `ChangeFeedResult` / `ChangeImportOutcome` dataclass shapes and the `ChangeImportStatus` / `ImportVerdict` **enum values** | `mureo.change_import.models` | Stable (additive evolution allowed) |
 | Model dataclass shapes (`Campaign`, `Ad`, `Keyword`, ...) | `mureo.core.providers.models` | Stable (Phase 1; additive evolution allowed) |
-| Status / Kind / MatchType / BidStrategy **enum values** | `mureo.core.providers.models` | Stable |
+| Status / Kind / MatchType / BidStrategy **enum values** | `mureo.core.providers.models` | Stable (additive evolution allowed) |
 | Entry-point group names (`mureo.providers`, `mureo.skills`, `mureo.native_skills`) | `mureo.core.providers.registry` | Stable |
 | `ProviderEntry` field set and order | `mureo.core.providers.registry` | Stable |
 | `SkillEntry` field set | `mureo.core.skills.models` | Stable |
@@ -389,6 +389,35 @@ Every entity / DTO in `mureo.core.providers.models` is
   `CampaignStatus.PAUSED`).
 - **Changing the frozen=True invariant** (allowing mutation).
   Plugins may rely on dataclass instances being hashable.
+
+### Enum members
+
+Adding a member to a `mureo.core.providers.models` enum is
+**non-breaking** (minor), for the same reason as `Capability`
+(section 3): plugins use existing members as constants, and a new
+member does not invalidate an existing reference. A plugin that
+maps the enum exhaustively should map unknown members to its own
+fallback rather than raising. Removing or renaming a member is
+breaking (above).
+
+### `BidStrategy.NOT_APPLICABLE` vs `None`
+
+`BidStrategy` carries a `NOT_APPLICABLE` member for a platform that
+does not select delivery by a bid. The two ways a
+`bidding_strategy: BidStrategy | None` field can be non-committal
+mean **different** things, and the distinction is part of the ABI:
+
+| Value | Meaning |
+|---|---|
+| `BidStrategy.NOT_APPLICABLE` | This platform has no bid strategy. A fetched, final answer. |
+| `None` | Unknown / not fetched. Says nothing about the platform. |
+
+A provider that has no bid strategy reports `NOT_APPLICABLE` rather
+than picking the closest-looking auction member; it never leaves the
+field `None` to mean the same thing. `NOT_APPLICABLE` is a read-side
+descriptor: adapters reject it on `CreateCampaignRequest` /
+`UpdateCampaignRequest`, since it names the absence of a strategy
+rather than one to set.
 
 ### Currency convention
 

--- a/docs/plugin-authoring.md
+++ b/docs/plugin-authoring.md
@@ -1105,7 +1105,7 @@ These are what providers **accept**:
 | `ExtensionStatus` | `ENABLED`, `PAUSED`, `REMOVED` | Same convention. |
 | `ExtensionKind` | `SITELINK`, `CALLOUT`, `CONVERSION` | Type-safe dispatch in `list_extensions` / `add_extension`. |
 | `KeywordMatchType` | `EXACT`, `PHRASE`, `BROAD` | |
-| `BidStrategy` | `MANUAL_CPC`, `TARGET_CPA`, `MAXIMIZE_CONVERSIONS` | |
+| `BidStrategy` | `MANUAL_CPC`, `TARGET_CPA`, `MAXIMIZE_CONVERSIONS`, `NOT_APPLICABLE` | `NOT_APPLICABLE` is for a platform that does not select delivery by a bid — report it instead of the closest-looking auction member. `None` still means *unknown / not fetched*, which is a different statement; read-side only (adapters reject it on a create/update request). |
 
 ### Currency and date conventions
 

--- a/mureo/_data/skills/_mureo-learning/SKILL.md
+++ b/mureo/_data/skills/_mureo-learning/SKILL.md
@@ -65,15 +65,17 @@ Different actions need different wait times before evaluation:
 
 | Action Type | Observation Window | Why |
 |------------|-------------------|-----|
-| Budget change (>10%) | 7 days | Smart bidding needs ~7 days to re-learn |
+| Budget change (>10%) | 7 days | Where a budget step makes the platform re-learn (Google Ads Smart Bidding, Meta CBO), that takes ~7 days |
 | Keyword addition/removal | 14 days | Need enough impressions/clicks to evaluate |
 | Negative keyword addition | 14 days | Impact on CPA unfolds gradually |
 | Creative/ad copy change | 14 days | Ad rotation needs time to gather data |
-| Bid strategy change | 21 days | Full learning period for smart bidding |
+| Bid strategy change | 21 days | Full learning period on the platforms that have one — Google Ads Smart Bidding, Meta |
 | Audience/targeting change | 14 days | Need sufficient reach data |
 | Operation Mode change | 21 days | Compound effects across multiple campaigns |
 
 **Do NOT evaluate an action before its observation window has passed.**
+
+The *why* column is platform-conditional; the *window* is not. A platform that does not select delivery by a bid has no learning phase to wait out, but its numbers still need the same time to accumulate — keep the window and drop the learning-reset explanation, rather than narrating a re-learn it cannot have.
 
 ## Minimum Sample Sizes
 
@@ -124,7 +126,7 @@ Ask these questions:
 3. **Were there confounding factors?**
    - Did another change happen to the same campaign during the window?
    - Did seasonality, a holiday, or external event affect the data?
-   - Did a competitor enter or exit the auction?
+   - Did competitive pressure change? On an auction platform (Google Ads, Meta) that is a competitor entering or leaving the auction; on a platform that selects delivery some other way, ask what its own model exposes instead.
 
 4. **Does the direction match the hypothesis?**
    - If you added negative keywords expecting CPA to drop, did CPA actually drop?
@@ -225,7 +227,7 @@ When executing any write operation, record the context needed for future evaluat
 | Keyword change | impressions, clicks, conversions, cpa, ctr |
 | Creative change | impressions, clicks, ctr, conversions, cpa |
 | Targeting change | impressions, clicks, conversions, cpa, reach |
-| Bid strategy change | conversions, cpa, cost, impression_share |
+| Bid strategy change | conversions, cpa, cost — plus `impression_share` on Google Ads, which reports it. `impression_share` is NOT in the canonical metric vocabulary (`../_mureo-strategy/SKILL.md` → *Performance Metrics*): record it in the action_log entry only, never as a STATE.json metric |
 
 ## Consulting Past Evidence
 

--- a/mureo/_data/skills/_mureo-shared/SKILL.md
+++ b/mureo/_data/skills/_mureo-shared/SKILL.md
@@ -610,8 +610,20 @@ campaign snapshot's `status` and in each `ads[]` entry's `status` /
   `mureo/core/providers/models.py`, whose values are the public ABI) — so
   those lowercase values are what its STATE.json carries. Do not translate
   them into another platform's spelling.
-- **A platform that exposes no delivery status omits the field** rather than
+- **A platform that does not have the concept omits the field** rather than
   having one invented for it: only `ad_id` is required on an `ads[]` entry.
+  This limb is not about statuses alone — it governs every platform-conditional
+  field in the snapshot, `bidding_strategy_type` and `bidding_details`
+  included. Pricing and delivery selection differ per platform: a platform that
+  does not select delivery by a bid stores no bid strategy, and no skill may
+  require one of it or narrate an auction, a win rate, a bid floor or a
+  smart-bidding learning phase for it. Those are facts about the platforms that
+  work that way, not facts about advertising. Metrics follow the same limb
+  (`../_mureo-strategy/SKILL.md` → *Performance Metrics*): **a platform whose
+  own primary figure has no canonical key omits it rather than borrowing a key
+  that means something else** — writing an eCPM-priced network's selection
+  price into `cpa` or `ctr` makes every consumer of that number wrong. Name
+  such a figure in prose instead, in the platform's own words.
 
 The `/daily-check` and `/sync-state` diffs compare the **stored previous**
 value against the **stored current** value **case-insensitively**, so any

--- a/mureo/_data/skills/_mureo-strategy/SKILL.md
+++ b/mureo/_data/skills/_mureo-strategy/SKILL.md
@@ -447,8 +447,8 @@ verbatim and should surface it to the operator rather than retrying.
 | `campaign_id` | string | Yes | Campaign identifier |
 | `campaign_name` | string | Yes | Human-readable name |
 | `status` | string | Yes | `ENABLED`, `PAUSED`, or `REMOVED` |
-| `bidding_strategy_type` | string | No | e.g., `MAXIMIZE_CONVERSIONS`, `TARGET_CPA` |
-| `bidding_details` | object | No | Strategy-specific details (target_cpa, target_roas, etc.) |
+| `bidding_strategy_type` | string | No | The platform's OWN name for the strategy, verbatim (Google Ads e.g. `MAXIMIZE_CONVERSIONS`, `TARGET_CPA`). Omit for a platform that does not select delivery by a bid — see `../_mureo-shared/SKILL.md` → *Status vocabulary contract* |
+| `bidding_details` | object | No | Strategy-specific details (target_cpa, target_roas, etc.); omitted alongside `bidding_strategy_type` |
 | `daily_budget` | number | No | Daily budget in currency units |
 | `device_targeting` | array | No | Device bid modifiers |
 | `campaign_goal` | string | No | Business objective for this campaign |

--- a/mureo/_data/skills/budget-rebalance/SKILL.md
+++ b/mureo/_data/skills/budget-rebalance/SKILL.md
@@ -62,7 +62,7 @@ Analyze budget allocation and suggest rebalancing across all campaigns.
 
     **Every `Reason` must be marginal, not average.** A rank by average CPA identifies *candidates*; it does not justify the move. State what the next (or removed) unit of spend is expected to do — a top-average campaign that is not budget-limited is usually saturated, and a bad-average campaign may simply be spend-suppressed. Where the marginal effect is genuinely unknown, say so and offer `/experiment` instead of asserting it. See `../_mureo-pro-diagnosis/SKILL.md` → *Allocation & Learning-State Discipline*.
 
-12. **Risk assessment**: Flag any budget changes >20% (smart bidding learning risk).
+12. **Risk assessment**: Flag any single budget change **>20%** — on Google Ads Smart Bidding / Meta CBO a large step can reset the learning phase, so prefer staged changes (e.g. two ≤20% steps). A platform that does not select delivery by a bid has no learning phase to reset: do not warn about one for it.
 
 13. **Ask for approval** before any changes.
 

--- a/mureo/_data/skills/daily-check/SKILL.md
+++ b/mureo/_data/skills/daily-check/SKILL.md
@@ -78,7 +78,7 @@ Step 2b **imports** what mureo can fetch, so much of that work is now in `action
    - **EFFICIENCY_STABILIZE**: Analyze CPA trends across all platforms. Flag if CPA increased >10% on any platform.
    - **TURNAROUND_RESCUE**: Identify zero-conversion campaigns and cost spikes across all platforms.
    - **SCALE_EXPANSION**: Check budget utilization across all platforms. Flag underspending campaigns.
-   - **COMPETITOR_DEFENSE**: Run auction/competitive insights on key campaigns. Flag impression share drops >5%.
+   - **COMPETITOR_DEFENSE**: Run each platform's competitive insights where it publishes them — on Google Ads, auction insights and impression share — and flag impression share drops >5%. A platform that publishes no competitive data contributes nothing to this mode: report that gap rather than inferring competitor activity from its own delivery numbers.
    - **CREATIVE_TESTING**: Audit ad asset performance across all platforms. Flag underperforming creatives.
    - **LTV_QUALITY_FOCUS**: Review search term quality and audience alignment across all platforms.
 

--- a/mureo/_data/skills/incident-postmortem/SKILL.md
+++ b/mureo/_data/skills/incident-postmortem/SKILL.md
@@ -30,10 +30,10 @@ After the fire is out, learn from it. A rescue that is never reflected on repeat
    - **Outcomes** — for each action whose `observation_due` window has now closed (its date is on or before `server_now`'s date), call `mureo_outcome_evaluate` (`before` = that entry's `metrics_at_action`, `after` = current numbers) for a deterministic improved / regressed / inconclusive verdict per action. For actions still inside their window, mark them **still observing** — do not score them (respect `../_mureo-learning/SKILL.md`).
 
 3. **Root-cause analysis**: Classify the cause into one (or a ranked combination) of four buckets, with the **evidence** for each:
-   - **Platform-side** — a bid-strategy misfire, a budget/CBO change, an auction/CPM shift, a disapproval. Evidence: change history, CPM/CPC trend, delivery diagnostics.
+   - **Platform-side** — a budget/CBO change, a disapproval, and on the platforms that price delivery by auction (Google Ads, Meta) a bid-strategy misfire or an auction shift. Evidence: change history, the platform's own unit-cost trend (CPC / CPM where it reports one), delivery diagnostics.
    - **Site-side** — a landing-page break, a checkout/lead-form failure, a speed regression. Evidence: CVR collapse with stable CTR, a deploy that lines up with the drop.
    - **Measurement-side** — a pixel/tag break, a conversion-action misconfig, an attribution change. Evidence: conversions flatlining while sessions/clicks hold (cross-check `/tracking-health`).
-   - **External** — seasonality, a holiday, a competitor entering the auction, a demand shift. Evidence: same-period-last-year, category-wide movement, impression-share change.
+   - **External** — seasonality, a holiday, a demand shift, and on Google Ads / Meta a competitor entering the auction. Evidence: same-period-last-year, category-wide movement, and an impression-share change where the platform reports one.
    Run a **5-whys** chain until you reach a **controllable cause** (something the operator can change) or an **honest unknown** (say "root cause not determinable from available data" rather than forcing a story). Do not stop at the first symptom.
 
 4. **What-worked / what-didn't table** — grade the response, not just the incident:

--- a/mureo/_data/skills/sync-state/SKILL.md
+++ b/mureo/_data/skills/sync-state/SKILL.md
@@ -49,7 +49,7 @@ Manual operation in the platform UI and mureo-driven operation coexist — most 
    - Campaigns removed/paused
    - Budget changes
    - Status changes
-   - Bidding strategy changes
+   - Bidding strategy changes, on the platforms that have one (see `../_mureo-shared/SKILL.md` → *Status vocabulary contract*)
    - **Ad-level status changes** — ads added or removed, plus **any change to a stored status field**, diffed against the `ads` the previous run stored: compare each ad's `status`, and its `effective_status` when the platform reports one, against the previous run's stored value for that *same* field, and report every difference. An ad **stopped delivering** when such a value moved away from the platform's active value — matched **case-insensitively**, so `ACTIVE`, `ENABLED` and `enabled` all count as active — which makes the limb fire on a platform that reports only one status field, in its own vocabulary, instead of falling through (see `../_mureo-shared/SKILL.md` → *Status vocabulary contract*). Changes mureo did not make are the point of this line: name them explicitly (see *Mixed operation*) instead of letting the new snapshot quietly replace the old.
 
 9. **Update `last_synced_at`** timestamp — use `server_now` from step 0 (the `mureo_state_*` write tools stamp it for you; on the Code `Write` path write that value yourself).

--- a/mureo/adapters/google_ads/adapter.py
+++ b/mureo/adapters/google_ads/adapter.py
@@ -49,6 +49,7 @@ from mureo.core.providers.credentials import AccountCredentialField
 from mureo.core.providers.models import (
     Ad,
     AdStatus,
+    BidStrategy,
     Campaign,
     CampaignFilters,
     CreateAdRequest,
@@ -277,6 +278,12 @@ class GoogleAdsAdapter:
             )
             if budget_id is not None:
                 params["budget_id"] = str(budget_id)
+        if request.bidding_strategy is BidStrategy.NOT_APPLICABLE:
+            raise UnsupportedOperation(
+                "create_campaign: BidStrategy.NOT_APPLICABLE describes a "
+                "platform that has no bid strategy; it is not a strategy "
+                "Google Ads can be set to."
+            )
         if request.bidding_strategy is not None:
             params["bidding_strategy"] = request.bidding_strategy.value.upper()
 
@@ -306,6 +313,12 @@ class GoogleAdsAdapter:
         params: dict[str, Any] = {"campaign_id": campaign_id}
         if request.name is not None:
             params["name"] = request.name
+        if request.bidding_strategy is BidStrategy.NOT_APPLICABLE:
+            raise UnsupportedOperation(
+                "update_campaign: BidStrategy.NOT_APPLICABLE describes a "
+                "platform that has no bid strategy; it is not a strategy "
+                "Google Ads can be set to."
+            )
         if request.bidding_strategy is not None:
             params["bidding_strategy"] = request.bidding_strategy.value.upper()
 

--- a/mureo/adapters/google_ads/adapter.py
+++ b/mureo/adapters/google_ads/adapter.py
@@ -263,6 +263,13 @@ class GoogleAdsAdapter:
                 "schedule fields will be implemented in a follow-up task."
             )
 
+        if request.bidding_strategy is BidStrategy.NOT_APPLICABLE:
+            raise UnsupportedOperation(
+                "create_campaign: BidStrategy.NOT_APPLICABLE describes a "
+                "platform that has no bid strategy; it is not a strategy "
+                "Google Ads can be set to."
+            )
+
         params: dict[str, Any] = {"name": request.name}
         if request.daily_budget_micros and request.daily_budget_micros > 0:
             budget_response = self._run(
@@ -278,12 +285,6 @@ class GoogleAdsAdapter:
             )
             if budget_id is not None:
                 params["budget_id"] = str(budget_id)
-        if request.bidding_strategy is BidStrategy.NOT_APPLICABLE:
-            raise UnsupportedOperation(
-                "create_campaign: BidStrategy.NOT_APPLICABLE describes a "
-                "platform that has no bid strategy; it is not a strategy "
-                "Google Ads can be set to."
-            )
         if request.bidding_strategy is not None:
             params["bidding_strategy"] = request.bidding_strategy.value.upper()
 

--- a/mureo/adapters/google_ads/errors.py
+++ b/mureo/adapters/google_ads/errors.py
@@ -38,6 +38,9 @@ class UnsupportedOperation(GoogleAdsAdapterError):  # noqa: N818
         * ``set_extension_status(..., ExtensionStatus.ENABLED |
           ExtensionStatus.PAUSED)`` — the existing extension mixins
           expose remove-only mutations.
+        * ``create_campaign`` / ``update_campaign`` carrying
+          ``BidStrategy.NOT_APPLICABLE`` — that member describes a
+          platform with no bid strategy, so there is nothing to set.
     """
 
 

--- a/mureo/core/providers/models.py
+++ b/mureo/core/providers/models.py
@@ -232,11 +232,25 @@ class KeywordMatchType(StrEnum):
 
 
 class BidStrategy(StrEnum):
-    """Stable identifiers for campaign bidding strategies."""
+    """Stable identifiers for campaign bidding strategies.
+
+    The first three members are auction strategies. ``NOT_APPLICABLE`` is
+    for a platform that does not select delivery by a bid at all — it
+    states that fact instead of misreporting itself as one of the three.
+    It is a **read-side descriptor only**: adapters reject it on a
+    create / update request, because it names the absence of a strategy
+    rather than a strategy to set.
+
+    ``bidding_strategy=None`` keeps its own, different meaning: **unknown
+    / not fetched**. The two must stay distinct — a field left empty
+    because nobody asked the platform yet must never read as "this
+    platform has no bid strategy".
+    """
 
     MANUAL_CPC = "manual_cpc"
     TARGET_CPA = "target_cpa"
     MAXIMIZE_CONVERSIONS = "maximize_conversions"
+    NOT_APPLICABLE = "not_applicable"
 
 
 # ---------------------------------------------------------------------------

--- a/mureo/mcp/tools_mureo_context.py
+++ b/mureo/mcp/tools_mureo_context.py
@@ -278,11 +278,20 @@ _CAMPAIGN_PROPERTY = {
                 "detect a second entry for the same account."
             ),
         },
-        "bidding_strategy_type": {"type": "string"},
+        "bidding_strategy_type": {
+            "type": "string",
+            "description": (
+                "Bid strategy as the platform itself names it, verbatim. "
+                "Omit it for a platform that does not select delivery by a "
+                "bid — never borrow another platform's strategy name."
+            ),
+        },
         "bidding_details": {
             "type": "object",
             "description": (
-                "Free-form bidding detail (e.g. {'target_cpa': 5000}). One "
+                "Free-form bidding detail in the platform's own vocabulary "
+                "(e.g. {'target_cpa': 5000}); omit it alongside "
+                "bidding_strategy_type where the platform has neither. One "
                 "key is read by mureo: for Google Ads, "
                 "'bidding_strategy_system_status' — the value "
                 "google_ads_campaigns_get / google_ads_campaigns_diagnose "

--- a/skills/_mureo-learning/SKILL.md
+++ b/skills/_mureo-learning/SKILL.md
@@ -65,15 +65,17 @@ Different actions need different wait times before evaluation:
 
 | Action Type | Observation Window | Why |
 |------------|-------------------|-----|
-| Budget change (>10%) | 7 days | Smart bidding needs ~7 days to re-learn |
+| Budget change (>10%) | 7 days | Where a budget step makes the platform re-learn (Google Ads Smart Bidding, Meta CBO), that takes ~7 days |
 | Keyword addition/removal | 14 days | Need enough impressions/clicks to evaluate |
 | Negative keyword addition | 14 days | Impact on CPA unfolds gradually |
 | Creative/ad copy change | 14 days | Ad rotation needs time to gather data |
-| Bid strategy change | 21 days | Full learning period for smart bidding |
+| Bid strategy change | 21 days | Full learning period on the platforms that have one — Google Ads Smart Bidding, Meta |
 | Audience/targeting change | 14 days | Need sufficient reach data |
 | Operation Mode change | 21 days | Compound effects across multiple campaigns |
 
 **Do NOT evaluate an action before its observation window has passed.**
+
+The *why* column is platform-conditional; the *window* is not. A platform that does not select delivery by a bid has no learning phase to wait out, but its numbers still need the same time to accumulate — keep the window and drop the learning-reset explanation, rather than narrating a re-learn it cannot have.
 
 ## Minimum Sample Sizes
 
@@ -124,7 +126,7 @@ Ask these questions:
 3. **Were there confounding factors?**
    - Did another change happen to the same campaign during the window?
    - Did seasonality, a holiday, or external event affect the data?
-   - Did a competitor enter or exit the auction?
+   - Did competitive pressure change? On an auction platform (Google Ads, Meta) that is a competitor entering or leaving the auction; on a platform that selects delivery some other way, ask what its own model exposes instead.
 
 4. **Does the direction match the hypothesis?**
    - If you added negative keywords expecting CPA to drop, did CPA actually drop?
@@ -225,7 +227,7 @@ When executing any write operation, record the context needed for future evaluat
 | Keyword change | impressions, clicks, conversions, cpa, ctr |
 | Creative change | impressions, clicks, ctr, conversions, cpa |
 | Targeting change | impressions, clicks, conversions, cpa, reach |
-| Bid strategy change | conversions, cpa, cost, impression_share |
+| Bid strategy change | conversions, cpa, cost — plus `impression_share` on Google Ads, which reports it. `impression_share` is NOT in the canonical metric vocabulary (`../_mureo-strategy/SKILL.md` → *Performance Metrics*): record it in the action_log entry only, never as a STATE.json metric |
 
 ## Consulting Past Evidence
 

--- a/skills/_mureo-pro-diagnosis/SKILL.md
+++ b/skills/_mureo-pro-diagnosis/SKILL.md
@@ -38,7 +38,7 @@ When analyzing a campaign, work through issues in this priority:
 
 ```
 1. Structure    → Is the account structure appropriate for the budget?
-2. Data         → Is there enough conversion data for the bidding strategy?
+2. Data         → Is there enough conversion data for the bidding strategy, where the platform has one?
 3. Targeting    → Are keywords/audiences reaching the right people?
 4. Creative     → Are ads relevant, compelling, and aligned with the LP?
 5. Bids/Budget  → Are bid targets and budgets realistic?

--- a/skills/_mureo-shared/SKILL.md
+++ b/skills/_mureo-shared/SKILL.md
@@ -610,8 +610,20 @@ campaign snapshot's `status` and in each `ads[]` entry's `status` /
   `mureo/core/providers/models.py`, whose values are the public ABI) — so
   those lowercase values are what its STATE.json carries. Do not translate
   them into another platform's spelling.
-- **A platform that exposes no delivery status omits the field** rather than
+- **A platform that does not have the concept omits the field** rather than
   having one invented for it: only `ad_id` is required on an `ads[]` entry.
+  This limb is not about statuses alone — it governs every platform-conditional
+  field in the snapshot, `bidding_strategy_type` and `bidding_details`
+  included. Pricing and delivery selection differ per platform: a platform that
+  does not select delivery by a bid stores no bid strategy, and no skill may
+  require one of it or narrate an auction, a win rate, a bid floor or a
+  smart-bidding learning phase for it. Those are facts about the platforms that
+  work that way, not facts about advertising. Metrics follow the same limb
+  (`../_mureo-strategy/SKILL.md` → *Performance Metrics*): **a platform whose
+  own primary figure has no canonical key omits it rather than borrowing a key
+  that means something else** — writing an eCPM-priced network's selection
+  price into `cpa` or `ctr` makes every consumer of that number wrong. Name
+  such a figure in prose instead, in the platform's own words.
 
 The `/daily-check` and `/sync-state` diffs compare the **stored previous**
 value against the **stored current** value **case-insensitively**, so any

--- a/skills/_mureo-strategy/SKILL.md
+++ b/skills/_mureo-strategy/SKILL.md
@@ -447,8 +447,8 @@ verbatim and should surface it to the operator rather than retrying.
 | `campaign_id` | string | Yes | Campaign identifier |
 | `campaign_name` | string | Yes | Human-readable name |
 | `status` | string | Yes | `ENABLED`, `PAUSED`, or `REMOVED` |
-| `bidding_strategy_type` | string | No | e.g., `MAXIMIZE_CONVERSIONS`, `TARGET_CPA` |
-| `bidding_details` | object | No | Strategy-specific details (target_cpa, target_roas, etc.) |
+| `bidding_strategy_type` | string | No | The platform's OWN name for the strategy, verbatim (Google Ads e.g. `MAXIMIZE_CONVERSIONS`, `TARGET_CPA`). Omit for a platform that does not select delivery by a bid — see `../_mureo-shared/SKILL.md` → *Status vocabulary contract* |
+| `bidding_details` | object | No | Strategy-specific details (target_cpa, target_roas, etc.); omitted alongside `bidding_strategy_type` |
 | `daily_budget` | number | No | Daily budget in currency units |
 | `device_targeting` | array | No | Device bid modifiers |
 | `campaign_goal` | string | No | Business objective for this campaign |

--- a/skills/budget-rebalance/SKILL.md
+++ b/skills/budget-rebalance/SKILL.md
@@ -62,7 +62,7 @@ Analyze budget allocation and suggest rebalancing across all campaigns.
 
     **Every `Reason` must be marginal, not average.** A rank by average CPA identifies *candidates*; it does not justify the move. State what the next (or removed) unit of spend is expected to do — a top-average campaign that is not budget-limited is usually saturated, and a bad-average campaign may simply be spend-suppressed. Where the marginal effect is genuinely unknown, say so and offer `/experiment` instead of asserting it. See `../_mureo-pro-diagnosis/SKILL.md` → *Allocation & Learning-State Discipline*.
 
-12. **Risk assessment**: Flag any budget changes >20% (smart bidding learning risk).
+12. **Risk assessment**: Flag any single budget change **>20%** — on Google Ads Smart Bidding / Meta CBO a large step can reset the learning phase, so prefer staged changes (e.g. two ≤20% steps). A platform that does not select delivery by a bid has no learning phase to reset: do not warn about one for it.
 
 13. **Ask for approval** before any changes.
 

--- a/skills/daily-check/SKILL.md
+++ b/skills/daily-check/SKILL.md
@@ -78,7 +78,7 @@ Step 2b **imports** what mureo can fetch, so much of that work is now in `action
    - **EFFICIENCY_STABILIZE**: Analyze CPA trends across all platforms. Flag if CPA increased >10% on any platform.
    - **TURNAROUND_RESCUE**: Identify zero-conversion campaigns and cost spikes across all platforms.
    - **SCALE_EXPANSION**: Check budget utilization across all platforms. Flag underspending campaigns.
-   - **COMPETITOR_DEFENSE**: Run auction/competitive insights on key campaigns. Flag impression share drops >5%.
+   - **COMPETITOR_DEFENSE**: Run each platform's competitive insights where it publishes them — on Google Ads, auction insights and impression share — and flag impression share drops >5%. A platform that publishes no competitive data contributes nothing to this mode: report that gap rather than inferring competitor activity from its own delivery numbers.
    - **CREATIVE_TESTING**: Audit ad asset performance across all platforms. Flag underperforming creatives.
    - **LTV_QUALITY_FOCUS**: Review search term quality and audience alignment across all platforms.
 

--- a/skills/incident-postmortem/SKILL.md
+++ b/skills/incident-postmortem/SKILL.md
@@ -30,10 +30,10 @@ After the fire is out, learn from it. A rescue that is never reflected on repeat
    - **Outcomes** — for each action whose `observation_due` window has now closed (its date is on or before `server_now`'s date), call `mureo_outcome_evaluate` (`before` = that entry's `metrics_at_action`, `after` = current numbers) for a deterministic improved / regressed / inconclusive verdict per action. For actions still inside their window, mark them **still observing** — do not score them (respect `../_mureo-learning/SKILL.md`).
 
 3. **Root-cause analysis**: Classify the cause into one (or a ranked combination) of four buckets, with the **evidence** for each:
-   - **Platform-side** — a bid-strategy misfire, a budget/CBO change, an auction/CPM shift, a disapproval. Evidence: change history, CPM/CPC trend, delivery diagnostics.
+   - **Platform-side** — a budget/CBO change, a disapproval, and on the platforms that price delivery by auction (Google Ads, Meta) a bid-strategy misfire or an auction shift. Evidence: change history, the platform's own unit-cost trend (CPC / CPM where it reports one), delivery diagnostics.
    - **Site-side** — a landing-page break, a checkout/lead-form failure, a speed regression. Evidence: CVR collapse with stable CTR, a deploy that lines up with the drop.
    - **Measurement-side** — a pixel/tag break, a conversion-action misconfig, an attribution change. Evidence: conversions flatlining while sessions/clicks hold (cross-check `/tracking-health`).
-   - **External** — seasonality, a holiday, a competitor entering the auction, a demand shift. Evidence: same-period-last-year, category-wide movement, impression-share change.
+   - **External** — seasonality, a holiday, a demand shift, and on Google Ads / Meta a competitor entering the auction. Evidence: same-period-last-year, category-wide movement, and an impression-share change where the platform reports one.
    Run a **5-whys** chain until you reach a **controllable cause** (something the operator can change) or an **honest unknown** (say "root cause not determinable from available data" rather than forcing a story). Do not stop at the first symptom.
 
 4. **What-worked / what-didn't table** — grade the response, not just the incident:

--- a/skills/sync-state/SKILL.md
+++ b/skills/sync-state/SKILL.md
@@ -49,7 +49,7 @@ Manual operation in the platform UI and mureo-driven operation coexist — most 
    - Campaigns removed/paused
    - Budget changes
    - Status changes
-   - Bidding strategy changes
+   - Bidding strategy changes, on the platforms that have one (see `../_mureo-shared/SKILL.md` → *Status vocabulary contract*)
    - **Ad-level status changes** — ads added or removed, plus **any change to a stored status field**, diffed against the `ads` the previous run stored: compare each ad's `status`, and its `effective_status` when the platform reports one, against the previous run's stored value for that *same* field, and report every difference. An ad **stopped delivering** when such a value moved away from the platform's active value — matched **case-insensitively**, so `ACTIVE`, `ENABLED` and `enabled` all count as active — which makes the limb fire on a platform that reports only one status field, in its own vocabulary, instead of falling through (see `../_mureo-shared/SKILL.md` → *Status vocabulary contract*). Changes mureo did not make are the point of this line: name them explicitly (see *Mixed operation*) instead of letting the new snapshot quietly replace the old.
 
 9. **Update `last_synced_at`** timestamp — use `server_now` from step 0 (the `mureo_state_*` write tools stamp it for you; on the Code `Write` path write that value yourself).

--- a/tests/adapters/google_ads/test_adapter.py
+++ b/tests/adapters/google_ads/test_adapter.py
@@ -1179,6 +1179,36 @@ def test_create_campaign_with_end_date_raises_unsupported(
 
 
 @pytest.mark.unit
+def test_create_campaign_rejects_not_applicable_bid_strategy(
+    adapter: GoogleAdsAdapter, mock_client: Mock
+) -> None:
+    """``BidStrategy.NOT_APPLICABLE`` describes a platform that has no bid
+    strategy (#647). It is a read-side descriptor, so the write path must
+    refuse it rather than send ``NOT_APPLICABLE`` to Google Ads as if it
+    were a strategy."""
+    request = CreateCampaignRequest(
+        name="Test",
+        daily_budget_micros=1_000_000,
+        bidding_strategy=BidStrategy.NOT_APPLICABLE,
+    )
+    with pytest.raises(UnsupportedOperation, match="NOT_APPLICABLE"):
+        adapter.create_campaign(request)
+    assert mock_client.create_campaign.await_count == 0
+
+
+@pytest.mark.unit
+def test_update_campaign_rejects_not_applicable_bid_strategy(
+    adapter: GoogleAdsAdapter, mock_client: Mock
+) -> None:
+    """Same contract on the update path — and no client call is issued."""
+    request = UpdateCampaignRequest(bidding_strategy=BidStrategy.NOT_APPLICABLE)
+    with pytest.raises(UnsupportedOperation, match="NOT_APPLICABLE"):
+        adapter.update_campaign("111", request)
+    assert mock_client.update_campaign.await_count == 0
+    assert mock_client.update_campaign_status.await_count == 0
+
+
+@pytest.mark.unit
 def test_create_campaign_passes_amount_micros_directly(
     adapter: GoogleAdsAdapter, mock_client: Mock
 ) -> None:

--- a/tests/adapters/google_ads/test_adapter.py
+++ b/tests/adapters/google_ads/test_adapter.py
@@ -1193,7 +1193,9 @@ def test_create_campaign_rejects_not_applicable_bid_strategy(
     )
     with pytest.raises(UnsupportedOperation, match="NOT_APPLICABLE"):
         adapter.create_campaign(request)
+    # Refused before any client work — no budget is created either.
     assert mock_client.create_campaign.await_count == 0
+    assert mock_client.create_budget.await_count == 0
 
 
 @pytest.mark.unit

--- a/tests/test_platform_conditional_bidding.py
+++ b/tests/test_platform_conditional_bidding.py
@@ -1,0 +1,244 @@
+"""Auction / bid-strategy semantics are platform-conditional (#647).
+
+mureo's platform-agnostic instruction text and its shared entity vocabulary
+used to state auction, smart-bidding and bid-strategy semantics as
+unconditional facts. On a platform whose delivery is not selected by a bid
+those statements are simply false, and the agent carries them over anyway —
+describing such a campaign in another platform's terms, in a report or in a
+stored learning entry.
+
+Three properties keep that from coming back, and this module pins all three:
+
+1. **The shared enum can say "not applicable".** ``BidStrategy`` has a member
+   for a platform that has no bid strategy, kept distinct from ``None``
+   ("unknown / not fetched"). A write path never accepts it.
+2. **The always-loaded MCP schema says so too.** ``mureo_state_upsert_campaign``
+   is the single cross-platform state-write tool, so its bidding fields carry
+   descriptions that state the platform-conditional contract.
+3. **The prose is qualified, not unconditional.** Each shared-skill line that
+   asserted an auction / smart-bidding fact now names the platforms it holds
+   for, the way ``budget-pacing`` and ``daily-check`` already did.
+
+Skill assertions run against the PACKAGED copy (what PyPI users get) and
+require the repo-root mirror to be byte-identical, matching the convention in
+``test_ad_level_status_visibility.py``. ``_mureo-pro-diagnosis`` ships only
+from the repo root, so it is read there.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _skill_body(name: str) -> str:
+    mirror = _ROOT / "skills" / name / "SKILL.md"
+    packaged = _ROOT / "mureo" / "_data" / "skills" / name / "SKILL.md"
+    if not packaged.exists():
+        # Repo-root-only skill (e.g. the pro diagnosis framework).
+        return mirror.read_text(encoding="utf-8")
+    assert packaged.read_bytes() == mirror.read_bytes(), (
+        f"{name}: packaged skill and repo-root mirror have drifted; "
+        "they must stay byte-identical."
+    )
+    return packaged.read_text(encoding="utf-8")
+
+
+def _line_with(body: str, anchor: str, *, skill: str) -> str:
+    matches = [line for line in body.splitlines() if anchor in line]
+    assert matches, f"{skill}: no line containing {anchor!r}"
+    return "\n".join(matches)
+
+
+# A platform condition is either a named platform or an explicit "the
+# platforms that work this way" limb — the two shapes already in the tree
+# (``budget-pacing`` line 63, ``daily-check``'s learning-state guard).
+_QUALIFIER = re.compile(
+    r"Google Ads|Meta|Amazon|platforms? that|platforms? whose|"
+    r"where the platform|platform-conditional|has no bid strategy",
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. The shared enum can say "not applicable"
+# ---------------------------------------------------------------------------
+
+
+def test_bid_strategy_has_a_not_applicable_member() -> None:
+    """A platform that selects delivery some other way than by a bid needs a
+    value of its own — otherwise it must misreport itself as one of the
+    auction strategies."""
+    from mureo.core.providers.models import BidStrategy
+
+    assert BidStrategy.NOT_APPLICABLE.value == "not_applicable"
+
+
+def test_bid_strategy_values_are_the_documented_set() -> None:
+    """The values are the ABI (``docs/ABI-stability.md`` section 5): additions
+    are non-breaking, removals are not."""
+    from mureo.core.providers.models import BidStrategy
+
+    assert {member.value for member in BidStrategy} == {
+        "manual_cpc",
+        "target_cpa",
+        "maximize_conversions",
+        "not_applicable",
+    }
+    assert all(re.fullmatch(r"[a-z][a-z0-9_]*", m.value) for m in BidStrategy)
+
+
+def test_not_applicable_is_distinguishable_from_unknown() -> None:
+    """``None`` keeps its own meaning — *not fetched*. Collapsing the two
+    would make an unasked platform read as a platform without bidding."""
+    from mureo.core.providers.models import (
+        BidStrategy,
+        CreateCampaignRequest,
+        UpdateCampaignRequest,
+    )
+
+    not_fetched = CreateCampaignRequest(name="c", daily_budget_micros=1_000_000)
+    declared = CreateCampaignRequest(
+        name="c",
+        daily_budget_micros=1_000_000,
+        bidding_strategy=BidStrategy.NOT_APPLICABLE,
+    )
+    assert not_fetched.bidding_strategy is None
+    assert declared.bidding_strategy is BidStrategy.NOT_APPLICABLE
+    assert declared.bidding_strategy != not_fetched.bidding_strategy
+
+    assert UpdateCampaignRequest().bidding_strategy is None
+
+
+def test_not_applicable_is_documented_for_plugin_authors() -> None:
+    """Plugins implement the shared vocabulary from the docs, not the source."""
+    abi = (_ROOT / "docs" / "ABI-stability.md").read_text(encoding="utf-8")
+    authoring = (_ROOT / "docs" / "plugin-authoring.md").read_text(encoding="utf-8")
+    for name, text in (("ABI-stability.md", abi), ("plugin-authoring.md", authoring)):
+        assert "NOT_APPLICABLE" in text, f"{name}: NOT_APPLICABLE undocumented"
+
+
+# ---------------------------------------------------------------------------
+# 2. The always-loaded MCP schema
+# ---------------------------------------------------------------------------
+
+
+def _upsert_campaign_properties() -> dict:
+    from mureo.mcp.tools_mureo_context import TOOLS
+
+    tool = next(t for t in TOOLS if t.name == "mureo_state_upsert_campaign")
+    return tool.inputSchema["properties"]["campaign"]["properties"]
+
+
+def test_bidding_strategy_type_carries_a_description() -> None:
+    """The single cross-platform state-write tool sits in context in every
+    session the mureo server is loaded in — an undescribed bidding field is
+    filled in from whatever vocabulary the model already has."""
+    described = _upsert_campaign_properties()["bidding_strategy_type"]
+    assert described.get("description"), "bidding_strategy_type has no description"
+
+
+def test_bidding_field_descriptions_state_the_platform_condition() -> None:
+    """Both bidding fields say the same thing the skill contract says: the
+    platform's own vocabulary, omitted where the concept does not exist."""
+    props = _upsert_campaign_properties()
+    for field in ("bidding_strategy_type", "bidding_details"):
+        description = props[field]["description"]
+        assert "Omit" in description or "omit" in description, (
+            f"{field}: description does not say to omit the field for a "
+            "platform that has no bid strategy"
+        )
+
+
+def test_bidding_details_does_not_lead_with_one_platform() -> None:
+    """The Google Ads key is a real, useful detail — but it is an example of
+    the contract, not the contract itself, so it must not open the text."""
+    description = _upsert_campaign_properties()["bidding_details"]["description"]
+    assert "Google Ads" in description
+    assert _QUALIFIER.search(description)
+    assert description.index("own vocabulary") < description.index("Google Ads")
+
+
+# ---------------------------------------------------------------------------
+# 3. The prose is qualified, not unconditional
+# ---------------------------------------------------------------------------
+
+
+# (skill, the exact unconditional wording that must not come back)
+_RETIRED_WORDINGS: tuple[tuple[str, str], ...] = (
+    ("budget-rebalance", "(smart bidding learning risk)"),
+    ("_mureo-learning", "Smart bidding needs ~7 days to re-learn"),
+    ("_mureo-learning", "Full learning period for smart bidding"),
+    ("_mureo-learning", "Did a competitor enter or exit the auction?"),
+    ("daily-check", "Run auction/competitive insights on key campaigns."),
+    ("incident-postmortem", "a holiday, a competitor entering the auction,"),
+    ("incident-postmortem", "an auction/CPM shift"),
+    ("_mureo-pro-diagnosis", "conversion data for the bidding strategy?"),
+)
+
+
+@pytest.mark.parametrize(("skill", "wording"), _RETIRED_WORDINGS)
+def test_unconditional_wording_stays_retired(skill: str, wording: str) -> None:
+    assert wording not in _skill_body(skill), (
+        f"{skill}: {wording!r} states an auction fact unconditionally; "
+        "qualify it with the platforms it holds for."
+    )
+
+
+# (skill, anchor that survives the edit)
+_QUALIFIED_LINES: tuple[tuple[str, str], ...] = (
+    ("budget-rebalance", "**Risk assessment**"),
+    ("_mureo-learning", "| Budget change (>10%) |"),
+    ("_mureo-learning", "| Bid strategy change | 21 days |"),
+    ("_mureo-learning", "competitor"),
+    ("daily-check", "**COMPETITOR_DEFENSE**"),
+    ("incident-postmortem", "**Platform-side**"),
+    ("incident-postmortem", "**External**"),
+    ("sync-state", "Bidding strategy changes"),
+    ("_mureo-pro-diagnosis", "2. Data "),
+)
+
+
+@pytest.mark.parametrize(("skill", "anchor"), _QUALIFIED_LINES)
+def test_bidding_lines_name_their_platform_condition(skill: str, anchor: str) -> None:
+    line = _line_with(_skill_body(skill), anchor, skill=skill)
+    assert _QUALIFIER.search(line), (
+        f"{skill}: the line at {anchor!r} states an auction / bid-strategy "
+        "fact without naming the platforms it holds for."
+    )
+
+
+def test_impression_share_is_attributed_not_canonical() -> None:
+    """``impression_share`` is not in the canonical metric vocabulary
+    (``_mureo-strategy`` → *Performance Metrics*), so every mention has to say
+    whose metric it is."""
+    body = _skill_body("_mureo-learning")
+    for line in body.splitlines():
+        if "impression_share" in line:
+            assert "Google Ads" in line, (
+                "_mureo-learning: impression_share is listed as if it were a "
+                f"canonical cross-platform metric: {line!r}"
+            )
+
+
+def test_shared_contract_covers_pricing_and_selection_fields() -> None:
+    """The status-vocabulary contract is the one place that already says
+    'store it verbatim, do not translate it, omit it where the platform has no
+    such thing'. Pricing and delivery-selection fields live under the same
+    rule — not under a second one written next to it."""
+    body = _skill_body("_mureo-shared")
+    start = body.index("### Status vocabulary contract")
+    end = body.index("\n## ", start)
+    section = body[start:end]
+
+    assert "bidding_strategy_type" in section
+    assert "bidding_details" in section
+    assert "omits" in section
+    # A platform whose primary figure has no canonical key must not borrow
+    # one that means something else (the CPM / eCPM case).
+    assert "canonical key" in section


### PR DESCRIPTION
## What

mureo's platform-agnostic instruction text and its shared entity vocabulary
stated auction, smart-bidding and bid-strategy semantics as **unconditional
facts**. On a platform whose delivery is not selected by a bid those statements
are simply false, and the agent carried them over anyway — describing such a
campaign in another platform's terms in routine reports and in stored learning
entries, which outlive the session that produced them.

This PR qualifies the prose, generalises the one contract that already had the
right discipline, gives the shared enum a way to say "not applicable", and
describes the two bidding fields on the always-in-context MCP schema.

## 1. Qualified, not deleted

Each unconditional statement now names the platforms it holds for, copying the
wording already in the tree (`budget-pacing` line 63, `daily-check`'s
learning-state guard):

| File | Was | Now |
|---|---|---|
| `budget-rebalance` | "Flag any budget changes >20% (smart bidding learning risk)." | names Google Ads Smart Bidding / Meta CBO, and says a platform that does not select delivery by a bid has no learning phase to reset |
| `_mureo-learning` (windows) | "Smart bidding needs ~7 days to re-learn", "Full learning period for smart bidding" | the *why* column names the platforms; a note states the window stays for statistical reasons where the learning phase does not exist |
| `_mureo-learning` (confounders) | "Did a competitor enter or exit the auction?" | "Did competitive pressure change?" with the auction reading scoped to Google Ads / Meta |
| `_mureo-learning` (metrics) | `impression_share` listed as a plain metric | attributed to Google Ads and marked as NOT in the canonical metric vocabulary — action_log only, never a STATE.json metric |
| `daily-check` | "Run auction/competitive insights on key campaigns." | per-platform, "where it publishes them"; a platform with no competitive data is a reported gap, not an inference |
| `incident-postmortem` | "an auction/CPM shift", "a competitor entering the auction" | both scoped to the platforms that price delivery by auction |
| `sync-state` | "Bidding strategy changes" | "…on the platforms that have one", pointing at the contract |
| `_mureo-pro-diagnosis` | "enough conversion data for the bidding strategy?" | "…, where the platform has one?" |

`_mureo-strategy`'s snapshot-schema rows for `bidding_strategy_type` /
`bidding_details` are qualified the same way, since they documented the value
space as Google's.

## 2. One contract, widened — not a second rule

`_mureo-shared` → *Status vocabulary contract* already established exactly this
discipline for delivery-status strings: store verbatim, never translate into
another platform's spelling, and **a platform that exposes no delivery status
omits the field** rather than having one invented for it.

That last limb is now stated as what it always was — a rule about
platform-conditional fields, not about statuses in particular. It now covers
`bidding_strategy_type` / `bidding_details` explicitly (no skill may require a
bid strategy of a platform that has none, or narrate an auction, a win rate, a
bid floor or a learning phase for it), and the metric vocabulary: **a platform
whose own primary figure has no canonical key omits it rather than borrowing a
key that means something else.** That is the CPM/eCPM case — writing an
eCPM-priced network's selection price into `cpa` makes every consumer of that
number wrong. No canonical metric was added; that is a separate decision.

## 3. `BidStrategy.NOT_APPLICABLE` — the design choice and why

`BidStrategy` had three auction members, so a platform with no bid strategy had
to name itself one of them or leave the field empty — and empty already means
*unknown / not fetched*, so the two statements were indistinguishable.

**Chosen: a new enum member,** `NOT_APPLICABLE = "not_applicable"`, with `None`
keeping its existing meaning.

| Value | Meaning |
|---|---|
| `BidStrategy.NOT_APPLICABLE` | This platform has no bid strategy. A fetched, final answer. |
| `None` | Unknown / not fetched. Says nothing about the platform. |

**Why this is allowed by the ABI promise.** `docs/ABI-stability.md` section 1
lists "Status / Kind / MatchType / BidStrategy **enum values**" as stable, and
section 5 (*Model dataclass shapes*) enumerates the breaking changes — it lists
"**Removing an enum member** (e.g. dropping `CampaignStatus.PAUSED`)" and does
not list adding one. Section 3 gives the reasoning for the sibling case
verbatim:

> Adding new members is safe because plugins use existing members as constants —
> a new member does not invalidate existing references.

The one documented carve-out is the *Delete-via-status invariant*, where adding
a member would be breaking "even though additions are nominally non-breaking,
because it would invalidate the documented status-update convention".
`NOT_APPLICABLE` invalidates no documented convention: it names a state that had
no spelling at all. So this is a **minor-level, additive** change, consistent
with the promise rather than an exception to it.

`docs/ABI-stability.md` is updated in this PR: the enum-addition rule is now
stated for `mureo.core.providers.models` (it was only implied), the surface
table row reads "Stable (additive evolution allowed)" like its siblings, and a
short subsection pins `NOT_APPLICABLE` vs `None`. `docs/plugin-authoring.md`'s
enum table carries the member and the same distinction.

**Alternatives not taken:**

- *Document `None` as "not applicable".* Collapses "the platform has none" into
  "nobody asked yet". Cheapest to ship and the only option that makes the
  distinction unrecoverable — which is the whole point of the issue.
- *A new field* (e.g. `pricing_model: str | None`) on `Campaign` /
  `CreateCampaignRequest` / `UpdateCampaignRequest`. Also non-breaking, but it
  adds three fields to do one field's job, and it would need a value vocabulary
  mureo has no first-party evidence to enumerate — the same reason
  `learning_rules` ships rules only for platforms with a published trigger list.
- *A new Protocol.* There is no method to add; the gap is a value, not a
  behaviour.

`NOT_APPLICABLE` is a **read-side descriptor**: the Google Ads adapter raises
`UnsupportedOperation` if it appears on a create/update request, rather than
sending `NOT_APPLICABLE` to the API as if it were a strategy. (Meta already
refuses every `bidding_strategy` in Phase 1.)

## 4. The always-in-context MCP schema

`mureo_state_upsert_campaign` is the single cross-platform state-write tool, so
its schema sits in the model's context in every session the mureo server is
loaded in — including sessions that never touch an auction platform.
`bidding_strategy_type` carried no `description` at all, and the sibling
`bidding_details` opened with a Google-shaped example. Both now lead with the
platform-conditional contract, in two lines each; the Google Ads
`bidding_strategy_system_status` detail (which the learning pre-flight reads) is
kept, as an example of the contract rather than as the contract.

## Tests

`tests/test_platform_conditional_bidding.py` (26 tests, written first and
confirmed red):

- `NOT_APPLICABLE` exists, is snake_case, and is distinguishable from `None` on
  both request DTOs; the member set is pinned so a removal is caught.
- both docs mention it.
- the MCP schema's bidding fields carry descriptions that state the contract,
  and `bidding_details` does not lead with one platform.
- the retired unconditional wordings cannot come back (exact strings), and each
  edited line must carry a platform condition — the text-asset test shape
  `tests/test_web_i18n_keys.py` / `tests/test_ad_level_status_visibility.py`
  already use, including the packaged-vs-repo-root byte-identity check.
- `impression_share` may only appear on a line that names Google Ads.
- the `_mureo-shared` contract section covers the bidding fields and the
  canonical-key rule.

`tests/adapters/google_ads/test_adapter.py` gains two tests pinning that
`NOT_APPLICABLE` is refused on create and update with no client call issued.

## Verification

- `pytest tests/` — 9460 passed, 14 failed. The 14 are pre-existing on this
  machine (an installed agency/bridge distribution changes the MCP tool count
  and the client registry: `assert 517 == 223`), identical to the run on `main`
  before this change, and none is in a suite this PR touches.
- `black --check .`, `ruff check .`, `mypy mureo/` — clean.

## Not in this PR

- No CPM/eCPM addition to the canonical metric vocabulary (schema change with
  wider blast radius; the issue does not list it as a fix either).
- The plugin-declares-its-own-semantics path is a separate issue.

Closes #647
