### PR TITLE
feat: let code read the monthly budget target, not just the skill (#652)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,6 +156,12 @@ mureo/
 │   │                    #   past due (#651). ONE rule for `mureo_state_get(
 │   │                    #   action_log="pending")` and the Reports triage count;
 │   │                    #   two entry shapes (rendered dict / ActionLogEntry)
+│   ├── monthly_budget.py # The `## Custom: Monthly Budget` reader (#652) — the operator's
+│   │                     #   INTENDED monthly spend, twin of `guardrails_from_strategy_text`.
+│   │                     #   Separate type from `Guardrails` on purpose: a target is not a
+│   │                     #   ceiling. "Not set" is a first-class answer (never 0), a total
+│   │                     #   derived from `max_total_daily_budget` says so, and the figure
+│   │                     #   stays in STRATEGY.md — never copied into STATE.json
 │   ├── platform_guards.py # Write-time platform-key guards (#534/#609) — the one "is this key
 │   │                      #   real?" answer every other surface asks, including the read-side
 │   │                      #   label path (`installed_platform_names`, shared since #631)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,46 @@
   parse as a date is not counted (unknown is not a verdict), and `oldest_due`
   is re-rendered from the date mureo itself parsed rather than echoed.
 
+- **The monthly budget target is now readable from code** (#652).
+  `## Custom: Monthly Budget` has been the home of an operator's monthly
+  spend target for a while — `/budget-pacing` reads it, and offers to
+  persist one in that shape when it is missing. Nothing else could. The
+  section was reachable only by an agent that had loaded the skill, so
+  "is this client over or under its intended spend" could not appear on
+  any surface that skill was not already running on, the Reports view
+  included.
+
+  `mureo.context.monthly_budget` is the twin of
+  `mureo.policy.strategy_gate.guardrails_from_strategy_text` for the
+  neighbouring section: `parse_monthly_budget`,
+  `monthly_budget_from_strategy_text`, and `resolve_monthly_budget`,
+  which applies the skill's precedence — the explicit section wins,
+  `## Guardrails` → `max_total_daily_budget` × days in month is the
+  fallback, and neither means the operator has to be asked. A test pins
+  that agreement against the skill file so the two cannot drift into two
+  different answers to one question.
+
+  It is deliberately **not** part of `Guardrails`. Guardrails carry
+  ceilings — figures whose job is to refuse an operation that exceeds
+  them. A monthly target is the intended spend: underspending it is a
+  problem too, and no operation should be blocked for approaching it.
+  Filing it there would make an intended figure look enforceable.
+
+  Three answers, kept distinguishable because collapsing them is how a
+  budget reader misleads. **Not set** is first class — `total is None`,
+  never `0`, never `100 %`, never "on pace" — so a client with no target
+  cannot be rendered as one that is on plan. A total **derived** from the
+  daily ceiling comes back with `is_derived` set, because a ceiling
+  stretched over a month is a cap and not a plan, and handing it over
+  unlabelled is the same failure in a different coat. A malformed section
+  degrades to "not set" rather than raising out of a read path, and an
+  unreadable sub-target bullet drops only itself.
+
+  The figure stays in STRATEGY.md, its single home: it is not copied into
+  STATE.json for a reader's convenience. A number in two places is a
+  number that will disagree with itself — which is the defect class
+  #631 / #636 / #638 / #647 each came from.
+
 - **A platform plugin can now state how its own platform works, on the one
   route that is always read** (#648). The only text a plugin could put in
   front of the agent unconditionally was its MCP tool names and tool

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -142,6 +142,7 @@ mureo/
 │   ├── models.py            # Immutable dataclasses (ActionLogEntry.rollback_of / .batch_id, BatchRecord)
 │   ├── strategy.py          # STRATEGY.md parser / renderer
 │   ├── batch.py             # Batch id minting, the stamping rule, membership queries (#549)
+│   ├── monthly_budget.py    # `## Custom: Monthly Budget` reader (#652) — target, not a ceiling
 │   ├── state.py             # STATE.json read / mutate / atomic write + state lock (re-exports the two below)
 │   ├── state_codec.py       # STATE.json <-> StateDocument codec (parse_state / render_state)
 │   ├── conversion_overrides.py # Per-account conversion action_type override lookup (#342)

--- a/docs/strategy-context.md
+++ b/docs/strategy-context.md
@@ -88,6 +88,41 @@ A section the STRATEGY.md parser preserves verbatim (it has no `context_type` of
 
 mureo parses this section itself — the agent passes the text through unchanged. Declaring nothing is fine: the zero-configuration checks still run. See [tracking-consistency.md](tracking-consistency.md).
 
+### `## Custom: Monthly Budget` (opt-in)
+
+The operator's **intended monthly spend** — what `/budget-pacing` reads, offers to persist, and paces against:
+
+```markdown
+## Custom: Monthly Budget
+- total: 300000
+- google_ads: 180000
+- meta_ads: 120000
+```
+
+`total:` is the whole-month figure and is required; every other numeric bullet is a per-platform sub-target, keyed by platform key (a plugin's own key works too). Code can read it too (#652), so monthly pacing can reach a surface the skill is not running on:
+
+```python
+from mureo.context import resolve_monthly_budget
+
+# days_in_month belongs to the caller: pacing's "today" comes from
+# server_now, never from this machine's clock.
+budget = resolve_monthly_budget(strategy_text, days_in_month=31)
+if not budget.is_set:
+    ...  # no target — ask the operator; do NOT render 0, 100%, or "on pace"
+elif budget.is_derived:
+    ...  # a ceiling stretched over a month; label it as an implied cap
+```
+
+The precedence is the skill's, matched rather than replaced:
+
+1. **`## Custom: Monthly Budget`** wins — `source == "strategy_section"`. A `total: 0` is a real target ("spend nothing"), not an absence.
+2. Otherwise **`## Guardrails` → `max_total_daily_budget` × days in month**, returned with `is_derived` set and `source == "implied_daily_ceiling"`. It is a **cap, not a plan**: show it as derived wherever it appears.
+3. Otherwise **not set** — `total is None`, `is_set` false. Ask the operator.
+
+A missing, empty or malformed section degrades to "not set" rather than raising; an unreadable sub-target bullet drops only itself.
+
+**This is not a guardrail.** `Guardrails` carries ceilings that refuse an operation; a monthly target is the intended spend, where underspending is a problem too and nothing should be blocked for approaching it. Hence a separate type (`MonthlyBudget`) and separate functions (`parse_monthly_budget`, `monthly_budget_from_strategy_text`, `resolve_monthly_budget`). The figure lives in STRATEGY.md only — it is deliberately not copied into STATE.json.
+
 ### Python API
 
 ```python

--- a/mureo/context/__init__.py
+++ b/mureo/context/__init__.py
@@ -17,6 +17,16 @@ from mureo.context.models import (
     StateDocument,
     StrategyEntry,
 )
+from mureo.context.monthly_budget import (
+    MONTHLY_BUDGET_HEADING,
+    SOURCE_IMPLIED_DAILY_CEILING,
+    SOURCE_NOT_SET,
+    SOURCE_STRATEGY_SECTION,
+    MonthlyBudget,
+    monthly_budget_from_strategy_text,
+    parse_monthly_budget,
+    resolve_monthly_budget,
+)
 from mureo.context.state import (
     append_action_log,
     begin_batch,
@@ -54,6 +64,15 @@ __all__ = [
     "PlatformState",
     "StateDocument",
     "StrategyEntry",
+    # monthly budget target (#652)
+    "MONTHLY_BUDGET_HEADING",
+    "SOURCE_IMPLIED_DAILY_CEILING",
+    "SOURCE_NOT_SET",
+    "SOURCE_STRATEGY_SECTION",
+    "MonthlyBudget",
+    "monthly_budget_from_strategy_text",
+    "parse_monthly_budget",
+    "resolve_monthly_budget",
     # strategy
     "add_strategy_entry",
     "parse_strategy",

--- a/mureo/context/monthly_budget.py
+++ b/mureo/context/monthly_budget.py
@@ -1,0 +1,249 @@
+"""Read the operator's monthly budget target from STRATEGY.md (#652).
+
+``## Custom: Monthly Budget`` is where an operator's monthly spend target
+already lives — ``skills/budget-pacing/SKILL.md`` reads it, and offers to
+persist one in that shape when it is missing. Until this module there was no
+code path to it, so monthly pacing could only appear where that skill was
+running. This is the twin of
+:func:`mureo.policy.strategy_gate.guardrails_from_strategy_text` for the
+neighbouring section, and it deliberately stops at reading: the figure stays
+in STRATEGY.md, its single home, and is not copied into STATE.json for a
+reader's convenience — a number in two places is a number that will disagree
+with itself.
+
+**This is not a guardrail, and the distinction is the point.**
+:class:`~mureo.policy.strategy_gate.Guardrails` carries ceilings — values
+whose job is to REFUSE an operation that exceeds them. A monthly budget target
+is the intended spend: underspending it is a problem too, and no operation
+should be blocked for approaching it. Hence a separate type and a separate
+function; putting the target into ``Guardrails`` would make an intended figure
+look enforceable.
+
+Three answers, and each has to stay distinguishable from the other two
+(:data:`SOURCE_NOT_SET` / :data:`SOURCE_STRATEGY_SECTION` /
+:data:`SOURCE_IMPLIED_DAILY_CEILING`):
+
+- **The operator wrote a target.** It wins, whatever the guardrails say —
+  including a target of ``0``, which is a real instruction to spend nothing.
+- **No target, but a ``max_total_daily_budget`` ceiling.** ``ceiling × days in
+  month`` is an *implied cap*, never a plan. It is returned only with
+  :attr:`MonthlyBudget.is_derived` set, so a caller cannot render it as
+  something the operator asked for.
+- **Neither.** "Not set", carrying ``total=None`` — never ``0``, never a
+  percentage, never "on pace". The skill's answer here is to ask the operator,
+  and a caller cannot ask a question it was not told to ask.
+
+The precedence above is ``skills/budget-pacing/SKILL.md`` step 3, which is the
+specification this module matches rather than replaces;
+``tests/test_monthly_budget.py`` pins the agreement so the two cannot drift.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Final
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+from mureo.context.strategy import parse_strategy
+
+#: The (case-insensitive) STRATEGY.md section title carrying the target. The
+#: skill writes it as ``## Custom: Monthly Budget``, which ``strategy.py``
+#: parses into a ``custom`` entry titled "Monthly Budget"; a bare
+#: ``## Monthly Budget`` round-trips as a raw-heading entry with the same
+#: title, and is read too. Matching on the title alone mirrors
+#: :func:`mureo.policy.strategy_gate.guardrails_from_strategy_text`.
+MONTHLY_BUDGET_HEADING: Final = "monthly budget"
+
+#: No target anywhere. ``total`` is ``None`` — the caller must not render a
+#: figure, a percentage, or a pacing verdict from this.
+SOURCE_NOT_SET: Final = "not_set"
+#: The operator's own figure, read from the STRATEGY.md section.
+SOURCE_STRATEGY_SECTION: Final = "strategy_section"
+#: Derived: ``## Guardrails`` → ``max_total_daily_budget`` × days in month. A
+#: ceiling stretched over a month, not a plan. Label it as such wherever it
+#: is shown.
+SOURCE_IMPLIED_DAILY_CEILING: Final = "implied_daily_ceiling"
+
+#: The bullet naming the whole-month figure; every other numeric bullet is a
+#: per-platform sub-target. Not restricted to mureo's built-in platform keys:
+#: the skill paces hosted-connector and plugin platforms too.
+_TOTAL_KEY: Final = "total"
+
+#: Longest a calendar month can be — the bound on ``days_in_month``.
+_MAX_DAYS_IN_MONTH: Final = 31
+
+# Same bullet shape the ``## Guardrails`` readers accept.
+_BULLET_RE: Final[re.Pattern[str]] = re.compile(
+    r"^\s*[-*]\s*([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(.+?)\s*$"
+)
+
+#: Shared read-only default so no instance allocates (or leaks) a mutable one.
+_EMPTY_PER_PLATFORM: Final[Mapping[str, float]] = MappingProxyType({})
+
+
+@dataclass(frozen=True)
+class MonthlyBudget:
+    """The operator's intended monthly spend, or the absence of one.
+
+    Attributes:
+        total: Whole-month figure, or ``None`` when no target is set.
+            ``None`` and ``0.0`` are different answers: ``0.0`` is an
+            operator who said "spend nothing", ``None`` is an operator who
+            said nothing.
+        per_platform: Read-only per-platform sub-targets, keyed by platform
+            key (``google_ads``, ``meta_ads``, a plugin's own key). Empty
+            when the section names none, and always empty for a derived
+            total — a total ceiling says nothing about the split.
+        source: Which of the three answers this is — one of
+            :data:`SOURCE_NOT_SET`, :data:`SOURCE_STRATEGY_SECTION`,
+            :data:`SOURCE_IMPLIED_DAILY_CEILING`.
+    """
+
+    total: float | None = None
+    per_platform: Mapping[str, float] = field(
+        default_factory=lambda: _EMPTY_PER_PLATFORM
+    )
+    source: str = SOURCE_NOT_SET
+
+    @property
+    def is_set(self) -> bool:
+        """False when there is no target — the caller's cue to ask, not guess."""
+        return self.source != SOURCE_NOT_SET
+
+    @property
+    def is_derived(self) -> bool:
+        """True when ``total`` came from a ceiling, not from an operator."""
+        return self.source == SOURCE_IMPLIED_DAILY_CEILING
+
+
+def _amount(raw: str | None) -> float | None:
+    """A non-negative finite bullet amount, or ``None`` when it is not one.
+
+    Rejects rather than coerces: a bullet mureo cannot read must drop out, so
+    a typo degrades to "not set" instead of becoming a figure nobody wrote.
+    """
+    if raw is None:
+        return None
+    try:
+        number = float(raw.replace(",", "").replace("_", "").strip())
+    except (AttributeError, ValueError):
+        return None
+    if not math.isfinite(number) or number < 0:
+        return None
+    return number
+
+
+def _bullets(content: str) -> dict[str, str]:
+    """``- key: value`` bullets of a section body, last occurrence winning."""
+    found: dict[str, str] = {}
+    for line in content.splitlines():
+        match = _BULLET_RE.match(line)
+        if match is not None:
+            found[match.group(1).lower()] = match.group(2).strip()
+    return found
+
+
+def parse_monthly_budget(content: str) -> MonthlyBudget:
+    """Parse a ``## Custom: Monthly Budget`` body into :class:`MonthlyBudget`.
+
+    ``- total:`` is required — a section without a readable one is malformed
+    and degrades to "not set" rather than to a sum of whatever sub-targets
+    happen to be there, which would be a figure the operator never wrote. An
+    unreadable sub-target drops only itself, mirroring
+    :func:`~mureo.policy.strategy_gate.parse_guardrails`. Never raises: this
+    is a read path.
+    """
+    bullets = _bullets(content)
+    total = _amount(bullets.get(_TOTAL_KEY))
+    if total is None:
+        return MonthlyBudget()
+
+    per_platform: dict[str, float] = {}
+    for key, raw in bullets.items():
+        if key == _TOTAL_KEY:
+            continue
+        amount = _amount(raw)
+        if amount is not None:
+            per_platform[key] = amount
+
+    return MonthlyBudget(
+        total=total,
+        per_platform=MappingProxyType(per_platform),
+        source=SOURCE_STRATEGY_SECTION,
+    )
+
+
+def monthly_budget_from_strategy_text(text: str) -> MonthlyBudget:
+    """The operator's explicit target from full STRATEGY.md text.
+
+    "Not set" when the section is absent, empty or malformed. This reads only
+    what the operator wrote — see :func:`resolve_monthly_budget` for the
+    skill's full precedence, which may fall back to the guardrail ceiling.
+    """
+    for entry in parse_strategy(text):
+        if entry.title.strip().lower() == MONTHLY_BUDGET_HEADING:
+            return parse_monthly_budget(entry.content)
+    return MonthlyBudget()
+
+
+def resolve_monthly_budget(text: str, *, days_in_month: int) -> MonthlyBudget:
+    """The monthly target for a month of ``days_in_month`` days.
+
+    Applies ``skills/budget-pacing/SKILL.md`` step 3 in order: an explicit
+    ``## Custom: Monthly Budget`` wins; failing that, ``## Guardrails`` →
+    ``max_total_daily_budget`` × ``days_in_month`` is returned as an implied
+    cap with :attr:`MonthlyBudget.is_derived` set; failing both, "not set".
+
+    ``days_in_month`` belongs to the caller because pacing's "today" comes
+    from ``server_now``, never from this machine's clock. It is validated
+    here rather than defaulted — a wrong month length silently mis-states
+    the cap.
+
+    Args:
+        text: Full STRATEGY.md text.
+        days_in_month: Length of the pacing month, 1..31.
+
+    Raises:
+        ValueError: ``days_in_month`` is not a possible calendar-month
+            length. Malformed STRATEGY.md content never raises.
+    """
+    if not 1 <= days_in_month <= _MAX_DAYS_IN_MONTH:
+        raise ValueError(
+            f"days_in_month must be between 1 and {_MAX_DAYS_IN_MONTH}, "
+            f"got {days_in_month}"
+        )
+
+    explicit = monthly_budget_from_strategy_text(text)
+    if explicit.is_set:
+        return explicit
+
+    # Local import: the ceiling is a guardrail, and this module stays out of
+    # the policy package's import path for the (far more common) explicit
+    # case. ``strategy_gate`` owns that section's parsing so the two readers
+    # cannot drift onto different spellings of the same rule.
+    from mureo.policy.strategy_gate import guardrails_from_strategy_text
+
+    ceiling = guardrails_from_strategy_text(text).max_total_daily_budget
+    if ceiling is None or not math.isfinite(ceiling) or ceiling < 0:
+        return MonthlyBudget()
+    return MonthlyBudget(
+        total=ceiling * days_in_month,
+        source=SOURCE_IMPLIED_DAILY_CEILING,
+    )
+
+
+__all__ = [
+    "MONTHLY_BUDGET_HEADING",
+    "SOURCE_IMPLIED_DAILY_CEILING",
+    "SOURCE_NOT_SET",
+    "SOURCE_STRATEGY_SECTION",
+    "MonthlyBudget",
+    "monthly_budget_from_strategy_text",
+    "parse_monthly_budget",
+    "resolve_monthly_budget",
+]

--- a/tests/test_monthly_budget.py
+++ b/tests/test_monthly_budget.py
@@ -1,0 +1,265 @@
+"""Tests for the ``## Custom: Monthly Budget`` reader (mureo.context.monthly_budget).
+
+The monthly budget target is the operator's INTENDED monthly spend. It is not
+a ceiling, so these tests pin the three properties that keep it from being
+read as one:
+
+- "not set" is a first-class answer, distinguishable from a target of ``0``;
+- a figure derived from the ``## Guardrails`` daily ceiling is labelled as
+  derived, never handed back as if the operator had written it;
+- a malformed section degrades to "not set" instead of raising out of a read
+  path.
+
+``TestSkillPrecedenceAgreement`` pins the reader against
+``skills/budget-pacing/SKILL.md``, which is the specification, so the skill
+and the code cannot answer the same question two different ways.
+
+Marks: unit — pure text parsing, no network and no filesystem writes.
+"""
+
+from __future__ import annotations
+
+import re
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from mureo.context.monthly_budget import (
+    MONTHLY_BUDGET_HEADING,
+    SOURCE_IMPLIED_DAILY_CEILING,
+    SOURCE_NOT_SET,
+    SOURCE_STRATEGY_SECTION,
+    MonthlyBudget,
+    monthly_budget_from_strategy_text,
+    parse_monthly_budget,
+    resolve_monthly_budget,
+)
+
+pytestmark = pytest.mark.unit
+
+_ROOT = Path(__file__).resolve().parent.parent
+_PACKAGED_SKILL = _ROOT / "mureo" / "_data" / "skills" / "budget-pacing" / "SKILL.md"
+_MIRROR_SKILL = _ROOT / "skills" / "budget-pacing" / "SKILL.md"
+
+_STRATEGY_WITH_TARGET = """# Strategy
+
+## Persona
+A shoe shop.
+
+## Custom: Monthly Budget
+- total: 300000
+- google_ads: 180000
+- meta_ads: 120000
+
+## Guardrails
+- max_total_daily_budget: 20000
+"""
+
+_STRATEGY_CEILING_ONLY = """# Strategy
+
+## Guardrails
+- max_total_daily_budget: 20000
+"""
+
+
+class TestParseMonthlyBudget:
+    def test_reads_total_and_per_platform_sub_targets(self) -> None:
+        budget = parse_monthly_budget(
+            "- total: 300,000\n- google_ads: 180000\n- meta_ads: 120000\n"
+        )
+        assert budget.total == 300000
+        assert dict(budget.per_platform) == {
+            "google_ads": 180000,
+            "meta_ads": 120000,
+        }
+        assert budget.source == SOURCE_STRATEGY_SECTION
+        assert budget.is_set
+        assert not budget.is_derived
+
+    def test_total_alone_is_enough(self) -> None:
+        budget = parse_monthly_budget("- total: 300000\n")
+        assert budget.total == 300000
+        assert dict(budget.per_platform) == {}
+        assert budget.is_set
+
+    def test_zero_is_a_real_target_not_absence(self) -> None:
+        budget = parse_monthly_budget("- total: 0\n")
+        assert budget.total == 0.0
+        assert budget.is_set
+        assert budget.source == SOURCE_STRATEGY_SECTION
+
+    def test_per_platform_mapping_is_read_only(self) -> None:
+        budget = parse_monthly_budget("- total: 300000\n- google_ads: 180000\n")
+        with pytest.raises(TypeError):
+            budget.per_platform["google_ads"] = 1.0  # type: ignore[index]
+
+
+class TestMalformedDegradesToNotSet:
+    @pytest.mark.parametrize(
+        "content",
+        [
+            "",
+            "   \n\n",
+            "The operator will tell us later.",
+            "- total: not a number",
+            "- total:\n",
+            "- total: -100",
+            "- google_ads: 180000",  # sub-targets without a total
+        ],
+    )
+    def test_returns_not_set_without_raising(self, content: str) -> None:
+        budget = parse_monthly_budget(content)
+        assert not budget.is_set
+        assert budget.total is None
+        assert budget.source == SOURCE_NOT_SET
+
+    def test_malformed_sub_target_drops_only_that_bullet(self) -> None:
+        budget = parse_monthly_budget(
+            "- total: 300000\n- google_ads: oops\n- meta_ads: -1\n- tiktok_ads: 5000\n"
+        )
+        assert budget.total == 300000
+        assert dict(budget.per_platform) == {"tiktok_ads": 5000}
+
+
+class TestMonthlyBudgetFromStrategyText:
+    def test_reads_the_section_from_a_full_document(self) -> None:
+        budget = monthly_budget_from_strategy_text(_STRATEGY_WITH_TARGET)
+        assert budget.total == 300000
+        assert dict(budget.per_platform) == {
+            "google_ads": 180000,
+            "meta_ads": 120000,
+        }
+        assert budget.source == SOURCE_STRATEGY_SECTION
+
+    def test_absent_section_is_not_set_and_is_not_zero(self) -> None:
+        budget = monthly_budget_from_strategy_text("# Strategy\n\n## Persona\nHi\n")
+        assert not budget.is_set
+        assert budget.total is None
+        assert budget.total != 0
+        assert budget.source == SOURCE_NOT_SET
+
+    def test_heading_match_is_case_insensitive(self) -> None:
+        budget = monthly_budget_from_strategy_text(
+            "# Strategy\n\n## Custom: MONTHLY BUDGET\n- total: 1000\n"
+        )
+        assert budget.total == 1000
+
+    def test_malformed_section_does_not_raise(self) -> None:
+        budget = monthly_budget_from_strategy_text(
+            "# Strategy\n\n## Custom: Monthly Budget\nask the operator\n"
+        )
+        assert not budget.is_set
+
+    def test_empty_document_is_not_set(self) -> None:
+        assert not monthly_budget_from_strategy_text("").is_set
+
+
+class TestResolveMonthlyBudgetPrecedence:
+    def test_explicit_section_wins_over_the_daily_ceiling(self) -> None:
+        budget = resolve_monthly_budget(_STRATEGY_WITH_TARGET, days_in_month=31)
+        assert budget.total == 300000
+        assert budget.source == SOURCE_STRATEGY_SECTION
+        assert not budget.is_derived
+
+    def test_explicit_zero_still_wins_over_the_daily_ceiling(self) -> None:
+        text = (
+            "# Strategy\n\n## Custom: Monthly Budget\n- total: 0\n\n"
+            "## Guardrails\n- max_total_daily_budget: 20000\n"
+        )
+        budget = resolve_monthly_budget(text, days_in_month=30)
+        assert budget.total == 0.0
+        assert budget.source == SOURCE_STRATEGY_SECTION
+
+    def test_ceiling_only_is_derived_and_says_so(self) -> None:
+        budget = resolve_monthly_budget(_STRATEGY_CEILING_ONLY, days_in_month=30)
+        assert budget.total == 600000
+        assert budget.is_set
+        assert budget.is_derived
+        assert budget.source == SOURCE_IMPLIED_DAILY_CEILING
+        assert dict(budget.per_platform) == {}
+
+    def test_derived_total_follows_the_length_of_the_month(self) -> None:
+        february = resolve_monthly_budget(_STRATEGY_CEILING_ONLY, days_in_month=28)
+        assert february.total == 560000
+
+    def test_neither_present_is_not_set(self) -> None:
+        budget = resolve_monthly_budget(
+            "# Strategy\n\n## Persona\nHi\n", days_in_month=31
+        )
+        assert not budget.is_set
+        assert not budget.is_derived
+        assert budget.total is None
+
+    def test_malformed_guardrail_ceiling_is_not_set(self) -> None:
+        budget = resolve_monthly_budget(
+            "# Strategy\n\n## Guardrails\n- max_total_daily_budget: oops\n",
+            days_in_month=31,
+        )
+        assert not budget.is_set
+
+    @pytest.mark.parametrize("days", [0, -1, 32, 365])
+    def test_rejects_an_impossible_month_length(self, days: int) -> None:
+        with pytest.raises(ValueError):
+            resolve_monthly_budget(_STRATEGY_CEILING_ONLY, days_in_month=days)
+
+
+class TestSkillPrecedenceAgreement:
+    """The reader must answer what ``/budget-pacing`` answers (issue #652)."""
+
+    def _skill_text(self) -> str:
+        packaged = _PACKAGED_SKILL.read_bytes()
+        assert packaged == _MIRROR_SKILL.read_bytes(), (
+            "budget-pacing: packaged skill and repo-root mirror have drifted; "
+            "they must stay byte-identical."
+        )
+        return packaged.decode("utf-8")
+
+    def test_skill_still_names_the_section_this_reader_reads(self) -> None:
+        assert "## Custom: Monthly Budget" in self._skill_text()
+        assert MONTHLY_BUDGET_HEADING == "monthly budget"
+
+    def test_skill_still_states_the_precedence_the_reader_implements(self) -> None:
+        text = self._skill_text()
+        # 1. explicit section wins, and is a target rather than a ceiling.
+        assert (
+            "This wins; it is the intended monthly spend, not a safety ceiling" in text
+        )
+        # 2. the daily ceiling is an implied cap, used only in its absence.
+        assert "max_total_daily_budget" in text
+        assert "Multiply by the number of days in the current calendar month" in text
+        assert "prefer it only when no explicit Monthly Budget exists" in text
+        # 3. otherwise ask the operator — the reader's "not set".
+        assert "ask the operator" in text
+
+    def test_reader_parses_the_section_the_skill_persists(self) -> None:
+        """The skill's own persist example must round-trip through the reader."""
+        block = re.search(
+            r"```markdown\n(\s*## Custom: Monthly Budget\n.*?)\s*```",
+            self._skill_text(),
+            re.DOTALL,
+        )
+        assert block is not None, "budget-pacing no longer shows the persist example"
+        example = textwrap.dedent(block.group(1))
+        budget = monthly_budget_from_strategy_text(f"# Strategy\n\n{example}")
+        assert budget.total == 300000
+        assert dict(budget.per_platform) == {
+            "google_ads": 180000,
+            "meta_ads": 120000,
+        }
+        assert budget.source == SOURCE_STRATEGY_SECTION
+
+    def test_explicit_target_and_ceiling_together_resolve_the_skills_way(self) -> None:
+        """Both present: the reader takes the target, not the ceiling×days."""
+        budget = resolve_monthly_budget(_STRATEGY_WITH_TARGET, days_in_month=31)
+        assert budget.total == 300000
+        assert budget.total != 20000 * 31
+
+
+class TestMonthlyBudgetDefaults:
+    def test_default_instance_is_not_set(self) -> None:
+        budget = MonthlyBudget()
+        assert not budget.is_set
+        assert not budget.is_derived
+        assert budget.total is None
+        assert dict(budget.per_platform) == {}

--- a/tests/test_monthly_budget.py
+++ b/tests/test_monthly_budget.py
@@ -154,6 +154,17 @@ class TestMonthlyBudgetFromStrategyText:
     def test_empty_document_is_not_set(self) -> None:
         assert not monthly_budget_from_strategy_text("").is_set
 
+    def test_reads_a_crlf_document(self) -> None:
+        """A STRATEGY.md written on Windows must read the same."""
+        budget = monthly_budget_from_strategy_text(
+            _STRATEGY_WITH_TARGET.replace("\n", "\r\n")
+        )
+        assert budget.total == 300000
+        assert dict(budget.per_platform) == {
+            "google_ads": 180000,
+            "meta_ads": 120000,
+        }
+
 
 class TestResolveMonthlyBudgetPrecedence:
     def test_explicit_section_wins_over_the_daily_ceiling(self) -> None:
@@ -208,12 +219,18 @@ class TestSkillPrecedenceAgreement:
     """The reader must answer what ``/budget-pacing`` answers (issue #652)."""
 
     def _skill_text(self) -> str:
+        """The skill file, newline-normalised.
+
+        Read as bytes so the packaged/mirror comparison stays exact, then
+        normalised to ``\\n`` because a Windows checkout hands back CRLF and
+        the multi-line pins below would silently stop matching.
+        """
         packaged = _PACKAGED_SKILL.read_bytes()
         assert packaged == _MIRROR_SKILL.read_bytes(), (
             "budget-pacing: packaged skill and repo-root mirror have drifted; "
             "they must stay byte-identical."
         )
-        return packaged.decode("utf-8")
+        return packaged.decode("utf-8").replace("\r\n", "\n")
 
     def test_skill_still_names_the_section_this_reader_reads(self) -> None:
         assert "## Custom: Monthly Budget" in self._skill_text()


### PR DESCRIPTION
## What this is

`## Custom: Monthly Budget` has been the home of an operator's monthly spend target for a while — `/budget-pacing` reads it (`skills/budget-pacing/SKILL.md:30`) and offers to persist one in that shape when it is missing. **Nothing else could.** The section was reachable only by an agent that had loaded the skill, so "is this client over or under its intended spend" could not appear on any surface that skill was not already running on — the Reports view included.

This adds the reader, and nothing more.

## The shape

`mureo.context.monthly_budget` is the twin of `mureo.policy.strategy_gate.guardrails_from_strategy_text` for the neighbouring section:

| function | answers |
|---|---|
| `parse_monthly_budget(content)` | the section body |
| `monthly_budget_from_strategy_text(text)` | the operator's explicit target, from a whole STRATEGY.md |
| `resolve_monthly_budget(text, days_in_month=…)` | the skill's full precedence |

`resolve_monthly_budget` applies `SKILL.md` step 3 in order: the explicit section wins; failing that, `## Guardrails` → `max_total_daily_budget` × days in month; failing both, "not set" — which is the skill's *ask the operator*. `TestSkillPrecedenceAgreement` pins that agreement against the skill file (packaged copy and repo-root mirror, asserted byte-identical), including a round-trip of the skill's own persist example, so the code and the skill cannot drift into two different answers to one question.

## Why it is not a `Guardrails` field

`Guardrails` carries ceilings — `max_daily_budget_per_campaign`, `max_total_daily_budget` — figures whose job is to **refuse an operation that exceeds them**.

A monthly target is not that. **Underspending it is a problem too**, and no operation should be blocked for approaching it. Filing it in `Guardrails` would make an intended figure look enforceable, which is the opposite of what it is. Hence a separate type (`MonthlyBudget`) and separate functions.

## Three answers, kept distinguishable

Collapsing them is how a budget reader misleads:

- **Not set is first class.** `total is None`, `is_set` false, `source == "not_set"`. Never `0`, never `100 %`, never "on pace" — a client with no target cannot be rendered as one that is on plan.
- **A derived total says it is derived.** The ceiling fallback returns `is_derived` set and `source == "implied_daily_ceiling"`. A daily ceiling stretched over a month is a cap, not a plan; handing it over unlabelled is the same failure in a different coat.
- **A target of `0` is a real target.** `- total: 0` reads as `0.0` with `is_set` true — an operator who said "spend nothing", not one who said nothing.

Per-platform sub-targets are read too (`google_ads`, `meta_ads`, or a plugin's own key), as a read-only mapping.

A malformed section degrades to "not set" rather than raising out of a read path; an unreadable sub-target bullet drops only itself, mirroring `parse_guardrails`. `days_in_month` is the caller's to supply and is validated rather than defaulted — pacing's "today" comes from `server_now`, never from this machine's clock, and a wrong month length silently mis-states the cap.

## One home

The figure stays in STRATEGY.md. It is **not** copied into STATE.json for a reader's convenience — a number in two places is a number that will disagree with itself, the defect class #631 / #636 / #638 / #647 each came from.

## Not in this PR

- Pacing on the Reports view — that is the consumer, #651.
- Any change to `/budget-pacing`. The skill is the specification here, matched rather than replaced; `SKILL.md` is untouched.

## Verification

- TDD: the suite was written first and failed on `ModuleNotFoundError: No module named 'mureo.context.monthly_budget'`.
- `pytest tests/test_monthly_budget.py` — 32 passed, 100 % statement coverage of the new module.
- `pytest tests/` — 9528 passed, 14 pre-existing failures unrelated to this change (locally installed downstream packages), unchanged from `origin/main`.
- `ruff check .`, `black --check .`, `mypy mureo/ --ignore-missing-imports` — clean.

Docs updated alongside: `docs/strategy-context.md` (the section, its precedence and the API), `docs/architecture.md`, `AGENTS.md`, `CHANGELOG.md`.

Closes #652
