### PR TITLE
test: pin both skill trees to each other in full, in one place (#672)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -245,6 +245,14 @@ skills/                       # Native slash skills — one `<name>/SKILL.md` pe
 docs/integrations.md          # Platform discovery + external MCP integration guide
 ```
 
+**The skill tree ships twice.** `skills/` is canonical; `mureo/_data/skills/`
+is the copy the wheel installs. Edit both, always — every skill present in
+either tree is byte-compared, whole directory against whole directory, by
+`tests/test_plugin_manifests.py::test_skill_copies_are_byte_identical`. The
+one exemption is `_mureo-pro-diagnosis` (canonical only, because `/learn`
+scaffolds the operator's own copy under `~/.claude/skills/`); it is declared
+in `_CANONICAL_ONLY_SKILLS` with its reason, not hidden behind a name filter.
+
 ## MCP Tools
 
 ### Google Ads

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,40 @@
   stored paragraph still reads back verbatim, and writing today's weekly
   report is not refused because last month's daily report is a wall.
 
+### Fixed
+
+- **The two skill trees are now pinned to each other in full** (#672).
+  `skills/` and `mureo/_data/skills/` are copies of one another — the second
+  is what a `pip install` puts in front of an agent — and the pin that says
+  so was assembled from pieces. One test parametrized over a
+  `not name.startswith("_")` filter, which excluded every `_mureo-*`
+  foundation skill; the aggregate test that did cover them walked the
+  packaged tree and looked up each file in the canonical one, so it could
+  only see a file that exists on the side it walked *from*. A `references/`
+  file added to `skills/<skill>/` and forgotten in the packaged copy was
+  invisible to the whole suite — verified, not assumed: the pre-change suite
+  passed with exactly that drift injected.
+
+  `test_skill_copies_are_byte_identical` replaces both. It parametrizes over
+  the **union** of the two trees, so a skill added to one side only fails as
+  that skill rather than as a missing parametrization, and compares the union
+  of relative paths under each pair of directories, so drift is caught in
+  either direction and for every file a skill carries, not just `SKILL.md`. A
+  one-character edit to any of `_mureo-google-ads`, `_mureo-meta-ads`,
+  `_mureo-amazon-ads`, `_mureo-learning`, `_mureo-shared` or
+  `_mureo-strategy` now fails CI naming that skill.
+
+  **The one asymmetry is declared, not filtered.** `_mureo-pro-diagnosis`
+  lives only in `skills/`: it is the operator's learnable knowledge base and
+  `/learn` scaffolds their own copy under `~/.claude/skills/`, so the wheel
+  ships nothing for that write to fork from. It has never existed under
+  `mureo/_data/skills/`. It is now named once, in `_CANONICAL_ONLY_SKILLS`,
+  with the reason attached — and a separate test fails if the exemption stops
+  being true, so it cannot decay into a filter that hides real drift.
+
+  No skill file changed: the two trees were already identical everywhere they
+  overlap.
+
 ## [0.12.1] - 2026-08-21
 
 ### Fixed

--- a/tests/test_plugin_manifests.py
+++ b/tests/test_plugin_manifests.py
@@ -149,35 +149,117 @@ def test_mcp_json_command_gates_missing_wrapper() -> None:
 _CANONICAL_SKILLS = REPO_ROOT / "skills"
 _PACKAGED_SKILLS = REPO_ROOT / "mureo" / "_data" / "skills"
 
+# The one deliberate asymmetry between the two trees, stated once and used
+# by every test below (#672). ``_mureo-pro-diagnosis`` is the operator's
+# *learnable* knowledge base: ``FilesystemKnowledgeStore`` scaffolds it into
+# ``~/.claude/skills/_mureo-pro-diagnosis/SKILL.md`` on the first ``/learn``
+# write, so the repo keeps the canonical catalogue while the wheel ships no
+# copy for that write to fork from. It has never existed under
+# ``mureo/_data/skills/`` (no commit in the history touches that path), and
+# ``tests/test_platform_conditional_bidding.py`` reads it from the repo root
+# for the same reason. Anything else appearing on one side only is drift.
+_CANONICAL_ONLY_SKILLS = frozenset({"_mureo-pro-diagnosis"})
+
 
 def _packaged_names() -> set[str]:
     return {p.name for p in _PACKAGED_SKILLS.iterdir() if p.is_dir()}
 
 
-def test_packaged_skills_match_canonical_byte_for_byte() -> None:
-    """``mureo/_data/skills/`` is what PyPI users get; ``skills/`` is
-    the canonical source. They must stay byte-identical for every skill
-    that the package ships, otherwise the docs on GitHub diverge from
-    what installed users see in their editors."""
+def _canonical_names() -> set[str]:
+    return {p.name for p in _CANONICAL_SKILLS.iterdir() if p.is_dir()}
+
+
+def _dual_tree_skill_names() -> list[str]:
+    """Every skill that must exist — byte-identical — in *both* trees.
+
+    Built from the union of the two trees rather than from either one, so a
+    skill added to one side only is a failure of the pair test rather than a
+    silently missing parametrization.
+    """
+    return sorted((_canonical_names() | _packaged_names()) - _CANONICAL_ONLY_SKILLS)
+
+
+def _relative_files(root: Path) -> set[Path]:
+    return {p.relative_to(root) for p in root.rglob("*") if p.is_file()}
+
+
+def test_dual_tree_population_covers_foundation_and_operational_skills() -> None:
+    """Structural anchor for the parametrized pair test below.
+
+    A parametrized suite over an empty (or foundation-free) list passes
+    vacuously, which is exactly the failure #672 reports: the previous
+    per-skill pin parametrized over a ``not name.startswith("_")`` filter, so
+    every ``_mureo-*`` skill was excluded and nothing said so.
+    """
+    names = set(_dual_tree_skill_names())
+    assert len(names) >= 20, f"implausibly few dual-tree skills: {sorted(names)}"
+    foundation = {n for n in names if n.startswith("_mureo-")}
+    assert foundation >= {
+        "_mureo-amazon-ads",
+        "_mureo-google-ads",
+        "_mureo-learning",
+        "_mureo-meta-ads",
+        "_mureo-shared",
+        "_mureo-strategy",
+    }, f"foundation skills dropped out of the pair test: {sorted(foundation)}"
+
+
+@pytest.mark.parametrize("skill", _dual_tree_skill_names())
+def test_skill_copies_are_byte_identical(skill: str) -> None:
+    """``mureo/_data/skills/`` is what PyPI users get; ``skills/`` is the
+    canonical source. Every skill present in either tree must exist in both
+    and match byte-for-byte across its **whole directory** — not just
+    ``SKILL.md`` — otherwise the docs on GitHub diverge from what installed
+    users see in their editors.
+
+    The whole directory, because a skill is free to carry ``references/`` and
+    other companion files alongside ``SKILL.md``; the two trees are copies of
+    each other, so the unit of the invariant is the directory.
+
+    Both directions, because a one-directional walk cannot see a file that
+    exists only on the side it walks *to*.
+    """
+    canonical_dir = _CANONICAL_SKILLS / skill
+    packaged_dir = _PACKAGED_SKILLS / skill
+    assert canonical_dir.is_dir(), (
+        f"{skill}: packaged but missing from canonical skills/ — add it there, "
+        "the packaged tree is a copy, not a source."
+    )
+    assert packaged_dir.is_dir(), (
+        f"{skill}: canonical but missing from mureo/_data/skills/ — add it "
+        "there, or add it to _CANONICAL_ONLY_SKILLS with a stated reason."
+    )
+
     drift: list[str] = []
-    for packaged_dir in sorted(p for p in _PACKAGED_SKILLS.iterdir() if p.is_dir()):
-        skill = packaged_dir.name
-        canonical_dir = _CANONICAL_SKILLS / skill
-        if not canonical_dir.exists():
-            drift.append(f"{skill}: missing in canonical skills/")
-            continue
-        for packaged_file in packaged_dir.rglob("*"):
-            if packaged_file.is_dir():
-                continue
-            rel = packaged_file.relative_to(packaged_dir)
-            canonical_file = canonical_dir / rel
-            if not canonical_file.exists():
-                drift.append(f"{skill}/{rel}: missing in canonical")
-                continue
-            if packaged_file.read_bytes() != canonical_file.read_bytes():
-                drift.append(f"{skill}/{rel}: contents differ")
-    assert not drift, "Drift between skills/ and mureo/_data/skills/:\n" + "\n".join(
-        f"  - {d}" for d in drift
+    for rel in sorted(_relative_files(canonical_dir) | _relative_files(packaged_dir)):
+        canonical_file = canonical_dir / rel
+        packaged_file = packaged_dir / rel
+        if not canonical_file.is_file():
+            drift.append(f"{rel}: missing in skills/")
+        elif not packaged_file.is_file():
+            drift.append(f"{rel}: missing in mureo/_data/skills/")
+        elif canonical_file.read_bytes() != packaged_file.read_bytes():
+            drift.append(f"{rel}: contents differ")
+    detail = "\n".join(f"  - {d}" for d in drift)
+    assert not drift, f"{skill}: skills/ and mureo/_data/skills/ drifted:\n{detail}"
+
+
+def test_canonical_only_exemptions_are_still_true() -> None:
+    """An exemption that no longer describes reality is a filter that hides
+    drift. Each name in ``_CANONICAL_ONLY_SKILLS`` must still be present in
+    ``skills/`` and still absent from ``mureo/_data/skills/`` — if one gets
+    packaged, the entry must go so the pair test starts guarding it."""
+    canonical = _canonical_names()
+    packaged = _packaged_names()
+    stale = sorted(n for n in _CANONICAL_ONLY_SKILLS if n not in canonical)
+    assert not stale, (
+        f"exempted skills no longer exist in skills/: {stale}. "
+        "Drop them from _CANONICAL_ONLY_SKILLS."
+    )
+    now_packaged = sorted(n for n in _CANONICAL_ONLY_SKILLS if n in packaged)
+    assert not now_packaged, (
+        f"exempted skills are now packaged: {now_packaged}. "
+        "Drop them from _CANONICAL_ONLY_SKILLS so they are byte-compared."
     )
 
 
@@ -245,19 +327,20 @@ def test_diagnostic_skills_invoke_consult_advisor() -> None:
 
 def test_canonical_skills_not_unexpectedly_richer() -> None:
     """Every skill in ``skills/`` must also be packaged unless it's an
-    explicit opt-out (currently: ``_mureo-pro-diagnosis``). Forgetting to
-    sync a new skill into ``mureo/_data/skills/`` would silently break
-    the PyPI install."""
-    intentional_canonical_only = {"_mureo-pro-diagnosis"}
-    canonical = {
-        p.name for p in _CANONICAL_SKILLS.iterdir() if p.is_dir()
-    } - intentional_canonical_only
+    explicit opt-out (``_CANONICAL_ONLY_SKILLS``). Forgetting to sync a new
+    skill into ``mureo/_data/skills/`` would silently break the PyPI install.
+
+    The whole-set view of what ``test_skill_copies_are_byte_identical``
+    reports one skill at a time: this one names every unpackaged skill in a
+    single message, which is the shape of the mistake when a new skill lands.
+    """
+    canonical = _canonical_names() - _CANONICAL_ONLY_SKILLS
     packaged = _packaged_names()
     missing = canonical - packaged
     assert not missing, (
         f"Skills in skills/ but not in mureo/_data/skills/: {sorted(missing)}. "
         "Either add them to the packaged copy or extend "
-        "intentional_canonical_only in this test."
+        "_CANONICAL_ONLY_SKILLS with a stated reason."
     )
 
 

--- a/tests/test_skill_ja_triggers.py
+++ b/tests/test_skill_ja_triggers.py
@@ -12,6 +12,12 @@ skill does.
 Foundation skills (``_mureo-*`` prefix) are exempt: they are loaded as
 PREREQUISITEs by other skills, never fired from a user utterance.
 
+That exemption is about *triggers only*. This module used to also pin the
+``skills/`` ↔ ``mureo/_data/skills/`` byte-identity over the same filtered
+list, which quietly left every foundation skill unpinned there (#672). The
+byte-identity pin now lives in one place that covers both trees in full —
+``tests/test_plugin_manifests.py::test_skill_copies_are_byte_identical``.
+
 Marks: unit — pure on-disk file inspection, no network.
 """
 
@@ -26,7 +32,6 @@ from mureo.core.skills.parser import parse_skill_md
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 _PACKAGED = REPO_ROOT / "mureo" / "_data" / "skills"
-_MIRROR = REPO_ROOT / "skills"
 
 # Hiragana, katakana, and CJK unified ideographs — any hit means the
 # description carries at least one Japanese trigger phrase.
@@ -64,14 +69,3 @@ class TestOperationalSkillJapaneseTriggers:
             "skill never firing (#396). Follow the enumeration style of "
             "ad-fatigue-check / audience-review."
         )
-
-    @pytest.mark.parametrize("skill_dir", _operational_skill_dirs(), ids=_skill_ids())
-    def test_packaged_and_mirror_copies_stay_identical(self, skill_dir: Path) -> None:
-        """The repo-root ``skills/`` mirror must match the packaged copy
-        byte-for-byte, so a trigger edit cannot land on one side only."""
-        mirror = _MIRROR / skill_dir.name / "SKILL.md"
-        assert mirror.exists(), f"missing mirror for {skill_dir.name}"
-        packaged_text = (skill_dir / "SKILL.md").read_text(encoding="utf-8")
-        assert (
-            mirror.read_text(encoding="utf-8") == packaged_text
-        ), f"{skill_dir.name}: skills/ mirror differs from mureo/_data/skills/"


### PR DESCRIPTION
## What this is

`skills/` and `mureo/_data/skills/` are copies of one another — the second is what a `pip install` puts in front of an agent — and the pin that says so was assembled from pieces. This lands one test that covers both trees in full.

Closes #672.

## What #672 got right, and what it got wrong

**Wrong:** the foundation skills were not unpinned. `tests/test_plugin_manifests.py::test_packaged_skills_match_canonical_byte_for_byte` already walked every packaged skill directory recursively and byte-compared every file, `_mureo-*` included. A one-character drift in `_mureo-google-ads` already failed CI before this PR — checked, not assumed:

```
E       AssertionError: Drift between skills/ and mureo/_data/skills/:
E           - _mureo-google-ads/SKILL.md: contents differ
```

**Right, and worse than reported:** the pin was one-directional. It walked the packaged tree and looked up each file in the canonical one, so it could only see a file that exists on the side it walks *from*. A `references/` file added to `skills/<skill>/` and forgotten in the packaged copy was invisible to the entire suite:

```
$ mkdir -p skills/_mureo-google-ads/references
$ echo "canonical-only reference" > skills/_mureo-google-ads/references/checklist.md
$ pytest tests/ -k "skill or manifest" -q
716 passed, 7 skipped, 9035 deselected
```

That is the gap the issue is really about, and it is exactly the shape #672 describes: an edit lands on one side and nothing says so. The `not name.startswith("_")` filter in `test_skill_ja_triggers.py` was real too — it just duplicated a pin that already existed elsewhere rather than being the only one.

**Also right:** the two trees are byte-identical today, foundation skills included. `diff -rq` reports one difference and it is the deliberate one (below). Nothing was repaired; there was nothing to repair.

## The test

`test_skill_copies_are_byte_identical` replaces both the filtered per-skill test and the one-directional aggregate:

- **Parametrized over the union of the two trees**, not over either one. A skill added to one side only fails as *that skill*, rather than as a parametrization that silently never ran.
- **Compares the union of relative paths under each pair of directories.** Both directions, and the whole directory rather than `SKILL.md` alone — a skill is free to carry `references/` and other companion files, so the unit of the invariant is the directory, not the file. (No skill carries companion files today; the point is that adding one does not silently open a hole.)
- **Anchored.** `test_dual_tree_population_covers_foundation_and_operational_skills` asserts the parametrization is non-empty and still names all six dual-tree foundation skills. A parametrized suite filtered down to nothing is green, which is how the original gap survived.

## The one asymmetry, declared rather than filtered

`_mureo-pro-diagnosis` lives only in `skills/`. It is the operator's *learnable* knowledge base: `FilesystemKnowledgeStore` scaffolds their own copy at `~/.claude/skills/_mureo-pro-diagnosis/SKILL.md` on the first `/learn` write, so the wheel ships nothing for that write to fork from. It has never existed under `mureo/_data/skills/` in any commit, and `tests/test_platform_conditional_bidding.py` already reads it from the repo root for the same reason.

It is now named once, in `_CANONICAL_ONLY_SKILLS` with the reason attached, and shared with `test_canonical_skills_not_unexpectedly_richer` instead of being spelled twice. `test_canonical_only_exemptions_are_still_true` fails if the exemption stops describing reality — if the skill gets packaged, the entry has to go so the pair test starts guarding it. An exemption that outlives its reason is just a filter again.

## Mutation evidence

Every one of these fails after the change, and the first two passed before it:

| injected | caught by |
|---|---|
| canonical-only `references/checklist.md` in `_mureo-google-ads` | `test_skill_copies_are_byte_identical[_mureo-google-ads]` |
| one char appended to `skills/_mureo-google-ads/SKILL.md` | same, named per skill |
| …same for `_mureo-meta-ads`, `_mureo-amazon-ads`, `_mureo-learning` | same |
| new skill in `skills/` only | pair test + `test_canonical_skills_not_unexpectedly_richer` |
| new skill in `mureo/_data/skills/` only | pair test |
| `_mureo-pro-diagnosis` copied into the packaged tree | `test_canonical_only_exemptions_are_still_true` |

## Verification

- `pytest tests/test_plugin_manifests.py tests/test_skill_ja_triggers.py -q` → 60 passed
- `pytest tests/ -q` → 9743 passed, 8 skipped, 14 failed — the 14 are the known local-environment failures (`analytics/builtin/test_live_clients.py`, MCP tool-count, `test_web_handlers.py`), unchanged by this branch and unrelated to skills
- `black --check tests/` → clean (379 files)
- `ruff check tests/` → clean
- mypy is scoped to `mureo/` in CI; no production code changed

`AGENTS.md` gains the invariant in prose (edit both trees; here is the pin; here is the single exemption), and `CHANGELOG.md` an Unreleased entry.

No skill file, and no production file, is touched by this PR.

> Rebased onto #669, which edited `_mureo-strategy/SKILL.md`. It updated both trees, so the branch is still green and the two trees are still identical everywhere they overlap — the new test says so per skill rather than by inspection, which is the point.
