### PR TITLE
fix: pin the documented MCP tool total to the registry (#677)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 ## [Unreleased]
 
+### Fixed
+
+- **The documented MCP tool total is now checked against the registry** (#677).
+  `docs/architecture.md` still said 221 individual MCP tools while the server
+  exposed 224. Three of the four shipped documents that quote the number were
+  updated when #648/#661 grew the tool list; the fourth was not, because no
+  test read the docs. A stale count there does not read as an out-of-date
+  document — it reads as an install that is missing tools, with nothing
+  anywhere to correct that reading.
+
+  `tests/test_doc_claims.py` pins the prose the way `tests/test_mcp_server.py`
+  pins the code: it extracts the total stated in `README.md`, `README.ja.md`,
+  `docs/mcp-server.md` and `docs/architecture.md` and asserts each equals the
+  count summed from the per-family `TOOLS` constants — the shipped surface,
+  not the served list, which also carries whatever provider plugins a machine
+  has installed and honours the `MUREO_DISABLE_*` gates. A claim reworded past
+  its pattern fails a coverage test rather than passing by matching nothing,
+  and a tool family wired into the server but missing from the sum fails too,
+  so the next tool addition stops the suite until every document is updated.
+
 ## [0.13.0] - 2026-08-21
 
 ### Added

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -480,7 +480,7 @@ The Amazon bridge is the reason mureo sits in the request path rather than letti
 
 ## Command-Based Workflow System
 
-In addition to the 221 individual MCP tools, mureo provides **workflow commands** as Claude Code native slash skills (deployed to `~/.claude/skills/`). These commands are **platform-agnostic orchestration instructions** that guide the AI agent to discover platforms, select tools, and synthesize cross-platform insights — all driven by the strategy context in `STRATEGY.md`.
+In addition to the 224 individual MCP tools, mureo provides **workflow commands** as Claude Code native slash skills (deployed to `~/.claude/skills/`). These commands are **platform-agnostic orchestration instructions** that guide the AI agent to discover platforms, select tools, and synthesize cross-platform insights — all driven by the strategy context in `STRATEGY.md`.
 
 ### How It Works
 

--- a/tests/test_doc_claims.py
+++ b/tests/test_doc_claims.py
@@ -1,0 +1,140 @@
+"""Shipped docs must state the tool total the registry actually exposes.
+
+Four shipped documents quote mureo's MCP tool count. #648/#661 grew the tool
+list and updated three of them; ``docs/architecture.md`` kept saying 221
+through the releases that followed, because **no test reads the docs** (#677).
+A stale number there does not read to an operator as "the doc is out of date"
+— it reads as "my install is missing tools", with nothing anywhere to correct
+that reading.
+
+``tests/test_mcp_server.py`` pins the count on the code side, so the code
+cannot drift silently. This module pins the prose the same way, so the next
+tool addition fails the suite until *every* document is updated instead of
+relying on the author remembering all four.
+
+The total is summed from the per-family ``TOOLS`` constants rather than read
+off ``handle_list_tools()``: the served list also carries whatever provider
+plugins the machine happens to have installed, and it honours the
+``MUREO_DISABLE_*`` gates. The docs describe mureo's own shipped surface,
+which is neither of those.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from mureo.mcp.tools_analysis import TOOLS as ANALYSIS_TOOLS
+from mureo.mcp.tools_analytics_registry import TOOLS as ANALYTICS_REGISTRY_TOOLS
+from mureo.mcp.tools_batch import TOOLS as BATCH_TOOLS
+from mureo.mcp.tools_change_import import TOOLS as CHANGE_IMPORT_TOOLS
+from mureo.mcp.tools_creative_studio import TOOLS as CREATIVE_STUDIO_TOOLS
+from mureo.mcp.tools_google_ads import TOOLS as GOOGLE_ADS_TOOLS
+from mureo.mcp.tools_learning import TOOLS as LEARNING_TOOLS
+from mureo.mcp.tools_learning_preflight import TOOLS as LEARNING_PREFLIGHT_TOOLS
+from mureo.mcp.tools_meta_ads import TOOLS as META_ADS_TOOLS
+from mureo.mcp.tools_mureo_context import TOOLS as MUREO_CONTEXT_TOOLS
+from mureo.mcp.tools_rollback import TOOLS as ROLLBACK_TOOLS
+from mureo.mcp.tools_search_console import TOOLS as SEARCH_CONSOLE_TOOLS
+
+pytestmark = pytest.mark.unit
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+#: Every built-in tool family ``mureo.mcp.server`` composes into its tool
+#: list, ungated. A family added to the server without being added here
+#: fails ``test_family_list_covers_every_built_in_tool`` below.
+_TOOL_FAMILIES = (
+    GOOGLE_ADS_TOOLS,
+    META_ADS_TOOLS,
+    SEARCH_CONSOLE_TOOLS,
+    ROLLBACK_TOOLS,
+    BATCH_TOOLS,
+    CHANGE_IMPORT_TOOLS,
+    ANALYSIS_TOOLS,
+    MUREO_CONTEXT_TOOLS,
+    ANALYTICS_REGISTRY_TOOLS,
+    LEARNING_TOOLS,
+    LEARNING_PREFLIGHT_TOOLS,
+    CREATIVE_STUDIO_TOOLS,
+)
+
+#: Each shipped surface that states the total, paired with the pattern that
+#: locates the claim in *that* document's wording. Deliberately not one
+#: generic ``(\d+) tools``: ``docs/mcp-server.md`` also sizes each family in
+#: the same sentence ("2 rollback tools", "3 batch tools", …), and a pattern
+#: that swept those up would compare a family count against the total. A
+#: rewording that drops the shape stops matching, which fails the coverage
+#: test rather than silently leaving that document unchecked. A document
+#: added later that repeats the number has to be listed here to be guarded.
+_CLAIMS = (
+    ("README.md", re.compile(r"exposes \*\*(\d+) MCP tools\*\*")),
+    ("README.ja.md", re.compile(r"\*\*(\d+) の MCP ツール\*\*")),
+    ("docs/mcp-server.md", re.compile(r"exposes (\d+) tools")),
+    ("docs/architecture.md", re.compile(r"the (\d+) individual MCP tools")),
+)
+
+
+def _tool_names() -> frozenset[str]:
+    return frozenset(tool.name for family in _TOOL_FAMILIES for tool in family)
+
+
+def _shipped_tool_count() -> int:
+    return sum(len(family) for family in _TOOL_FAMILIES)
+
+
+def _doc_text(rel: str) -> str:
+    return (_REPO_ROOT / rel).read_text(encoding="utf-8")
+
+
+def _stated_counts(rel: str, pattern: re.Pattern[str]) -> list[int]:
+    return [int(match.group(1)) for match in pattern.finditer(_doc_text(rel))]
+
+
+def test_the_documented_total_counts_distinct_tools() -> None:
+    """A duplicate name across families would inflate the number the docs
+    quote while the server exposed fewer tools than it added up to."""
+    names = _tool_names()
+    assert len(names) == _shipped_tool_count()
+
+
+def test_family_list_covers_every_built_in_tool() -> None:
+    """The families above must still be all of them.
+
+    A new family wired into the server but not listed here would leave the
+    docs' total too low with this pin still green — the exact way #677
+    happened, one layer down. Plugin-provided tools are excluded (they are
+    per-machine, and the docs say so); a subset assertion, not equality, so
+    a run with a ``MUREO_DISABLE_*`` gate set does not fail on the family
+    it correctly left out.
+    """
+    from mureo.mcp import server as mcp_server
+
+    built_in = {tool.name for tool in mcp_server._ALL_TOOLS} - set(
+        mcp_server._PLUGIN_NAMES
+    )
+    missing = sorted(built_in - _tool_names())
+    assert missing == [], f"served but counted by no family here: {missing}"
+
+
+def test_every_shipped_doc_states_the_tool_count() -> None:
+    """Coverage guard: a claim is found by its wording, so a document that
+    reworded past the pattern would silently stop being checked — and this
+    pin would pass by matching nothing at all."""
+    unmatched = [rel for rel, pattern in _CLAIMS if not _stated_counts(rel, pattern)]
+    assert unmatched == [], f"no tool-count claim found in: {unmatched}"
+
+
+def test_shipped_docs_state_the_tool_count_the_registry_exposes() -> None:
+    """The defect: three documents said 224 while ``docs/architecture.md``
+    said 221 and the registry exposed 224 (#677)."""
+    expected = _shipped_tool_count()
+    stale = [
+        (rel, stated)
+        for rel, pattern in _CLAIMS
+        for stated in _stated_counts(rel, pattern)
+        if stated != expected
+    ]
+    assert stale == [], f"docs state a stale tool count (registry: {expected}): {stale}"


### PR DESCRIPTION
## What

`docs/architecture.md` said **221** individual MCP tools while the server exposes **224**, and adds `tests/test_doc_claims.py`, which asserts the total stated in every shipped document that quotes it against the real registry.

Closes #677.

## Why

The tool count appears in four shipped documents. #648/#661 grew the tool list and updated three of them; the fourth kept saying 221 through every release that followed, because **no test reads the docs**. `tests/test_mcp_server.py` pins the count on the code side, so the code cannot drift silently — nothing pinned the prose. A stale number there does not read to an operator as "the doc is out of date"; it reads as "my install is missing tools", with nothing anywhere to correct that reading.

Same defect class the bridge closed in its own `tests/test_doc_claims.py`, and the same "two answers to one question with nothing checking agreement" shape as #659/#662/#671.

## How

`tests/test_doc_claims.py` extracts the stated total from `README.md`, `README.ja.md`, `docs/mcp-server.md` and `docs/architecture.md` and asserts each equals the count summed from the per-family `TOOLS` constants.

**Why the sum and not `handle_list_tools()`**: the served list also carries whatever provider plugins the machine has installed, and it honours the `MUREO_DISABLE_*` gates. The docs describe mureo's own shipped surface, which is neither — a pin read off the served list would fail on any box with a plugin installed and pass while gated families went uncounted.

**The pin cannot go green by matching nothing.** Three guards, all of which fail rather than skip:

- each claim is located by that document's own wording, so a rewording that escapes the pattern fails a coverage test instead of silently dropping the document from the check;
- the patterns are per-document rather than one generic `(\d+) tools`, because `docs/mcp-server.md` sizes each family in the same sentence ("2 rollback tools", "3 batch tools", …) and a sweeping pattern would compare a family count against the total;
- a tool family wired into the server but missing from the sum fails a third test (built-in served names minus plugin names must all be counted here) — otherwise #677 could happen again one layer down, with the docs' total too low and this pin still green.

## Verification

- New test RED before the doc fix (`docs/architecture.md`, 221 vs registry 224), GREEN after.
- Coverage guard mutation-checked: rewording README.md's claim past the pattern fails with `no tool-count claim found in: ['README.md']` rather than passing.
- `ruff check .`, `black --check .` clean; `mypy` reports nothing in the new file.
- Full suite: 9823 passed, 8 skipped, 14 pre-existing local failures unrelated to this change (they come from provider plugins installed on the dev box, including `test_list_tools_returns_all_tools` — which is exactly why the new pin counts statically).
