### PR TITLE
refactor: split web/reports.py into assembly, document and label layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 ### Changed
 
+- **`mureo/web/reports.py` split into an assembly layer and the two layers it
+  asks** (#678). At 1,070 lines it held twenty-six functions covering platform
+  naming, the tolerant STATE.json read, conflict detection, freshness,
+  period vocabulary, `not_collected` notes, wire sanitisation and the summary
+  assembly itself — one file, eight concerns.
+
+  - `mureo/web/report_labels.py` — the platform key to display-name resolver.
+    Three cases, and the third carries weight: an unrecognisable key is
+    returned **unchanged**, which is precisely how `CONFLICT_UNRECOGNIZED_KEY`
+    is defined, so a prettier fallback here would silently switch off a
+    conflict finding a module away.
+  - `mureo/web/report_document.py` — everything asked OF one stored document:
+    the tolerant read, the two conflict findings (#533), freshness (#535), the
+    windows the document carries, its `not_collected` notes (#638), and the
+    canonical-key filter that decides what may reach the wire.
+  - `mureo/web/reports.py` — the assembly: resolve the store, walk the document
+    once, shape the payload.
+
+  No behaviour change and no API change. Every name is re-exported from
+  `mureo.web.reports`, including the four private tables the suite reads off
+  it, so `from mureo.web.reports import platform_display_name` and
+  `mureo.web.reports._BUILTIN_DISPLAY_NAMES` resolve exactly as before. All
+  twenty-six functions are AST-identical to the originals. The import
+  direction is one-way — `reports` to `report_document` to `report_labels` —
+  so there is no cycle.
+
 - **`mureo/mcp/server.py` gave up two self-contained blocks** (#678). At 1,587
   lines it had grown past the point where one reader could hold it, and the
   cost showed up on every recent change to it: implementers merge-conflicted

--- a/mureo/context/models.py
+++ b/mureo/context/models.py
@@ -24,7 +24,7 @@ EXTERNAL_ORIGIN = "external"
 #: (:func:`mureo.context.state.set_platform_not_collected` /
 #: :func:`mureo.context.state.set_workspace_not_collected`) and the dashboard's
 #: read (:func:`mureo.web.reports._platform_row` /
-#: :func:`mureo.web.reports._workspace_not_collected`) — because a document can
+#: :func:`mureo.web.report_document._workspace_not_collected`) — because a document can
 #: also be written wholesale by a digest that goes near neither.
 NOT_COLLECTED_REASON_MAX_CHARS = 500
 
@@ -378,7 +378,7 @@ class PlatformState:
     #
     # That contract is a duty, not a guarantee, so nothing an operator SEES
     # is allowed to depend on it: the read side drops a note that any later
-    # collection has already answered (:func:`mureo.web.reports.
+    # collection has already answered (:func:`mureo.web.report_document.
     # _platform_not_collected`). A document holding a fresh ``fetched_at``
     # and an older failure states two contradictory answers to one question;
     # the contract stops that being written, and the read rule stops it being
@@ -449,7 +449,7 @@ class StateDocument:
     # separate writers, and retired on separate evidence.
     #
     # Retirement follows #638's rule one level up: the read side
-    # (:func:`mureo.web.reports._workspace_not_collected`) drops the note once
+    # (:func:`mureo.web.report_document._workspace_not_collected`) drops the note once
     # ANY rollup anywhere in the document carries a ``fetched_at`` later than
     # ``attempted_at`` — a collection that succeeded after the failure has
     # already answered it. Clearing it is still the collector's duty

--- a/mureo/context/observations.py
+++ b/mureo/context/observations.py
@@ -89,7 +89,7 @@ def due_observation_dates(entries: Sequence[Any], today: date) -> list[date]:
 
     An ``observation_due`` that is not an ISO date is skipped. It cannot be
     judged against ``today``, and unknown is not a verdict — the same
-    position :func:`mureo.web.reports._platform_freshness` takes on a
+    position :func:`mureo.web.report_document._platform_freshness` takes on a
     ``fetched_at`` it cannot parse. It is also writer-supplied text, so
     parsing is what keeps it from reaching a caller that relays the date.
 

--- a/mureo/context/platform_repair.py
+++ b/mureo/context/platform_repair.py
@@ -239,7 +239,7 @@ class PlatformEntryFacts:
     time, and no later run re-derives it — a successful one retires it, a
     second failure writes a new note about a new attempt. Relayed verbatim,
     and taken from the entry as STORED: whether a surface should still SHOW a
-    note is the read side's rule (:func:`mureo.web.reports.
+    note is the read side's rule (:func:`mureo.web.report_document.
     _platform_not_collected`), while what a removal would take is what the
     entry holds.
     """

--- a/mureo/context/state.py
+++ b/mureo/context/state.py
@@ -271,7 +271,7 @@ def _stamp_fetched_at(rollup: Any, written_at: str) -> Any:
       timestamp at all: a caller writing a historical window is stating
       something the server cannot re-derive, and the read side keeps an
       uninterpretable string on purpose (see
-      :func:`mureo.web.reports._platform_freshness`) because it is the only
+      :func:`mureo.web.report_document._platform_freshness`) because it is the only
       clue to the writer that produced it.
     - **An empty rollup is left empty.** An advisory bridge keeps an entry
       with no figures; a lone ``fetched_at`` would turn "no synced metrics"
@@ -611,7 +611,7 @@ def set_platform_metrics(
     is the one moment the caller still holds the figures and can re-file
     them. This is the WRITE half of a deliberate asymmetry: the read side
     stays tolerant of labels already on disk (see
-    :func:`~mureo.web.reports._available_periods`), which are real figures
+    :func:`~mureo.web.report_document._available_periods`), which are real figures
     under an unexpected name.
 
     Re-stamps ``last_synced_at`` and writes back atomically under the state
@@ -736,7 +736,7 @@ def set_platform_not_collected(
 
     The dashboard does not TRUST that contract, and should not have to: it
     drops a note any later collection has already answered (see
-    :func:`mureo.web.reports._platform_not_collected`). Clearing it here is
+    :func:`mureo.web.report_document._platform_not_collected`). Clearing it here is
     still what keeps the document itself honest — the read rule only decides
     what is shown.
 
@@ -833,7 +833,7 @@ def set_workspace_not_collected(
     The read side does not TRUST that contract and should not have to: it
     drops a note that any later collection anywhere in the document has
     already answered (see
-    :func:`mureo.web.reports._workspace_not_collected`), the same
+    :func:`mureo.web.report_document._workspace_not_collected`), the same
     evidence-based retirement #638 gave the per-platform note.
 
     ``last_synced_at`` is deliberately NOT re-stamped, for the same reason

--- a/mureo/core/metrics_windows.py
+++ b/mureo/core/metrics_windows.py
@@ -30,7 +30,7 @@ The asymmetry is deliberate, and it is not an inconsistency:
 - **Read** — tolerate. Labels already on disk are real figures, correctly
   collected, filed under a name no view expects. Refusing to read them would
   delete data mureo did collect in order to tidy a vocabulary. So
-  :func:`~mureo.web.reports._available_periods` still surfaces them, and the
+  :func:`~mureo.web.report_document._available_periods` still surfaces them, and the
   report summary NAMES them (``non_canonical_periods``) so an operator can
   see what accumulated and decide.
 

--- a/mureo/web/report_document.py
+++ b/mureo/web/report_document.py
@@ -1,0 +1,624 @@
+"""What mureo can say about one stored document (#678).
+
+Lifted verbatim out of :mod:`mureo.web.reports`, which had grown past the
+point where one reader could hold it. Nothing here changed in the move — same
+functions, same bodies, same order.
+
+:mod:`mureo.web.reports` assembles the summary payload. This module answers
+the questions that payload is made of, each about the STATE.json document
+alone:
+
+  - **Read it at all.** ``store.read_state()`` validates strictly; a document
+    with one hand-authored campaign entry would otherwise blank out a view
+    whose platforms and periods are perfectly renderable. So a failed strict
+    read retries tolerantly against the raw file before the view degrades to
+    empty. A read-only dashboard degrades; it never 500s.
+  - **May these rows be added together?** Two conflict findings (#533),
+    deliberately never merged into one warning: they are different facts and
+    the operator's next move differs. See :data:`CONFLICT_DUPLICATE_ACCOUNT`
+    and :data:`CONFLICT_UNRECOGNIZED_KEY`.
+  - **Is this figure still worth showing?** Freshness (#535) against the
+    window the figure claims to cover, plus the grace that keeps one missed
+    sync from painting a healthy account red.
+  - **Which windows does this document actually carry**, and which of them are
+    outside the canonical vocabulary.
+  - **Why did the figures not move?** The stored ``not_collected`` note (#638),
+    per platform and for the workspace, truncated to the same bound the write
+    side enforces.
+  - **What is safe to put on the wire?** ``totals`` is copied key by key
+    against a canonical allow-list, so a stray or secret-shaped key written
+    into a document can never reach the dashboard.
+
+Not one figure is computed here that the document does not already state, and
+nothing in this module mutates anything — it is read-only, exactly as
+``reports.py`` is.
+
+The only sibling this module reads is :mod:`mureo.web.report_labels`, and only
+because :data:`CONFLICT_UNRECOGNIZED_KEY` is *defined* as "the key the display
+resolver could make nothing of". Deciding recognisability a second time here
+is how this layer and the grid it describes would start disagreeing.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING, Any
+
+# The stored shape's own length bound (#638), so the read side and the write
+# helper truncate a collection failure's reason to the same length.
+from mureo.context.models import NOT_COLLECTED_REASON_MAX_CHARS
+from mureo.context.platform_accounts import (
+    duplicate_account_entries,
+    normalize_account_id,
+)
+from mureo.context.state import read_state_file
+from mureo.core.metrics_windows import (
+    CANONICAL_METRICS_WINDOWS,
+    is_canonical_metrics_window,
+)
+from mureo.web.report_labels import platform_display_name
+
+if TYPE_CHECKING:
+    from mureo.context.models import PlatformState, StateDocument
+    from mureo.core.state_store import StateStore
+
+logger = logging.getLogger(__name__)
+
+
+# ``platform_conflicts[].kind`` — the wire vocabulary for "do not add these
+# rows together" (#533). TWO findings, deliberately never merged into one
+# warning: they are different facts and an operator's next move differs.
+CONFLICT_DUPLICATE_ACCOUNT = "duplicate_account"
+"""Two or more keys resolve to ONE ad account.
+
+Established by the shared join in :mod:`mureo.context.platform_accounts`.
+The consequence is present-tense and certain: any total over these rows
+counts that account's spend / conversions / CPA more than once, right now.
+"""
+
+CONFLICT_UNRECOGNIZED_KEY = "unrecognized_key"
+"""A key no mureo surface can resolve to a platform.
+
+The account join CANNOT find this case. The shape actually reported from the
+field had ``account_id = ""`` on one of the two entries, and
+``account_ids_match("", "")`` is ``False`` by design (an unknown id is not a
+value), so :func:`~mureo.context.platform_accounts.duplicate_account_entries`
+deliberately does not report that pair. This second, independent signal is
+what catches it: an entry whose identity cannot be established at all, and
+which may therefore be a duplicate of a canonical one.
+
+The condition itself is narrower than that motivating case: it tests the
+KEY only, so it also fires on a key mureo cannot label whose ``account_id``
+resolves perfectly well. Both belong here — the operator has to look at the
+key either way — but they are not the same finding, so the row carries
+``account_known`` and the dashboard says the milder thing (mureo cannot
+tell which *platform* this is) when the account is in fact known. Claiming
+the ad account is unidentifiable there would contradict the
+``duplicate_account`` row sitting on the same key (#606).
+
+Recognition is delegated to :func:`platform_display_name`, which returns the
+key unchanged exactly when it can make nothing of it — that is already how
+mureo answers "is this key recognisable", and asking the dashboard's own
+resolver means this can never drift from what the dashboard renders. The
+alternative, an alias table mapping arbitrary keys onto platforms, would be a
+guess.
+
+That resolver now reads the **same** installed-plugin enumeration the write
+guard does (:func:`~mureo.context.platform_guards.installed_platform_names`,
+#631), so this signal can no longer fire on a key mureo itself accepted on
+write. Until it did, a bare provider name — ``logly_ads_context``, the LOGLY
+bridge's real platform name — was accepted by the guard, reported ``Clean``
+by ``mureo repair platform-key``, and flagged here, all on one machine at one
+moment. An operator who learns this fires on healthy state stops reading it,
+which costs more than the finding is worth.
+"""
+
+# The canonical metric keys a platform's ``totals`` may carry (the shared
+# vocabulary documented in ``_mureo-strategy`` → *Performance Metrics*). The
+# summary copies only these keys so a future stray/secret-shaped key written
+# into ``totals`` can never reach the dashboard. ``result_indicator`` is
+# Meta-only but harmless to allow for every platform.
+_CANONICAL_TOTAL_KEYS: tuple[str, ...] = (
+    "spend",
+    "impressions",
+    "clicks",
+    "conversions",
+    "cpa",
+    "ctr",
+    "result_indicator",
+    "period",
+    "fetched_at",
+)
+
+# Canonical period tokens in dashboard-toggle order. The default view is the
+# most recent day (``YESTERDAY``) — daily-check runs every day, so the prior
+# day's state is what an operator checks first; ``LAST_30_DAYS`` is the
+# trend window written by sync-state. Windows not listed here sort after
+# these, alphabetically (see :func:`_available_periods`).
+#
+# The table itself lives in ``mureo.core.metrics_windows`` (#659), for the
+# same reason the display names do: the WRITE guard has to refuse exactly the
+# windows this view cannot render, and ``mureo.context`` cannot import
+# ``mureo.web``. Two copies would be free to drift, and the drift is the bug
+# — a writer accepting a window nothing here reads.
+_PERIOD_ORDER: tuple[str, ...] = tuple(CANONICAL_METRICS_WINDOWS)
+
+# Canonical window → the length of that window in days. The stale threshold
+# is derived from this rather than written down as a per-window magic number,
+# so the rationale below is the only thing to check when a window is added.
+_PERIOD_LENGTH_DAYS: dict[str, int] = dict(CANONICAL_METRICS_WINDOWS)
+
+_STALE_GRACE_DAYS = 1
+"""Slack added to a window's own length before its figure is called stale.
+
+Absorbs one missed daily sync run and the platforms' own reporting lag
+(conversions backfill for a day or two is normal), so a single hiccup does
+not paint a healthy account red.
+"""
+
+_STALE_AFTER_DAYS_DEFAULT = max(_PERIOD_LENGTH_DAYS.values()) + _STALE_GRACE_DAYS
+"""Threshold for a window whose length mureo does not know.
+
+The most forgiving known threshold, not the strictest: a window we cannot
+reason about must not be flagged on a guess. Crying wolf on figures mureo
+cannot judge would teach operators to ignore the marker, which costs more
+than the occasional missed stale entry.
+"""
+
+
+def _read_state_safe(store: StateStore) -> StateDocument | None:
+    """Read the document, returning ``None`` on any failure.
+
+    ``read_state_file`` already returns a default document for a missing
+    file, but a malformed STATE.json raises ``ContextFileError`` and an
+    alternate backend could raise anything — the dashboard must degrade to
+    an empty summary, never 500.
+
+    When the strict read fails, retry tolerantly against the raw file before
+    giving up: ``store.read_state()`` validates the campaign list strictly, so
+    one variant / hand-authored campaign entry (e.g. ``name`` instead of
+    ``campaign_name``) would otherwise blank out a document whose
+    platforms/periods/reports the read-only dashboard can still render.
+    """
+    try:
+        return store.read_state()
+    except Exception:  # noqa: BLE001 — read-only view degrades, never raises
+        # Expected + handled for a STATE.json with nonconforming entries (e.g. a
+        # hand-authored legacy campaign list, or a platform missing account_id):
+        # the tolerant retry below renders the view fine. The read-only
+        # dashboard re-reads on every poll, so log this at DEBUG — a per-render
+        # WARNING + traceback would flood the daemon log on every refresh and
+        # read as a failure when it is not.
+        logger.debug(
+            "strict STATE.json read failed; retrying tolerantly for the "
+            "read-only Reports view",
+            exc_info=True,
+        )
+        return _read_state_tolerant(store)
+
+
+def _read_state_tolerant(store: StateStore) -> StateDocument | None:
+    """Re-read ``store``'s STATE.json skipping nonconforming campaign entries.
+
+    Needs the backing file path (``state_path``), which the filesystem store —
+    including the Agency per-client stores resolved by
+    :func:`state_store_for_client` — exposes. A store without one cannot be
+    re-read tolerantly, so the view degrades to an empty summary.
+    """
+    path = getattr(store, "state_path", None)
+    if path is None:
+        logger.warning("STATE.json unreadable and no path to retry; empty summary")
+        return None
+    try:
+        return read_state_file(path, strict=False)
+    except Exception:  # noqa: BLE001 — last-resort guard; never raise from a read
+        logger.exception("tolerant STATE.json read also failed; empty summary")
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Conflicts — why these rows must not be added together (#533)
+# ---------------------------------------------------------------------------
+
+
+def _build_platform_conflicts(doc: StateDocument | None) -> list[dict[str, Any]]:
+    """Reasons the caller must NOT sum this document's platform rows.
+
+    Each row is ``{"kind": <CONFLICT_*>, "platform_keys": [...],
+    "account_known": <bool>}`` — the grouping the browser cannot do, since
+    the rows carry no ``account_id``. Nothing here identifies an ad account:
+    the keys alone are what an operator needs to find the entries in
+    STATE.json, and putting the id on the wire would undo
+    :func:`_platform_row`'s omission. ``account_known`` is a presence bit,
+    not an id — it says only whether the entries behind the row named an ad
+    account mureo could resolve, which is a fact about the *document*, not
+    about the account.
+
+    Two independent signals, reported separately (see
+    :data:`CONFLICT_DUPLICATE_ACCOUNT` and
+    :data:`CONFLICT_UNRECOGNIZED_KEY` for why neither can stand in for the
+    other). A single key can legitimately appear in both — and when it does,
+    ``account_known`` is what keeps the two notes from asserting opposite
+    facts about it (#606). The unrecognised-key condition never inspects the
+    id, so without this bit the renderer would have to claim the ad account
+    is unidentifiable for an entry the duplicate finding just identified.
+    On a duplicate-account row it is always ``True``: that group is built BY
+    a resolvable id. It is stated anyway so every row answers the same
+    question and no consumer has to special-case a kind.
+
+    **Detection, not repair.** Duplicated entries typically hold different
+    *partial* figures, so summing over-counts exactly as much as dropping
+    one under-counts. This module never merges, drops or reorders a row; it
+    reports, and the operator decides.
+    """
+    if doc is None or not doc.platforms:
+        return []
+    rows: list[dict[str, Any]] = [
+        {
+            "kind": CONFLICT_DUPLICATE_ACCOUNT,
+            "platform_keys": list(group.platform_keys),
+            "account_known": True,
+        }
+        for group in duplicate_account_entries(doc.platforms)
+    ]
+    rows.extend(
+        {
+            "kind": CONFLICT_UNRECOGNIZED_KEY,
+            "platform_keys": [key],
+            # Folded the way the account join folds it, so "known here" and
+            # "joinable there" can never mean two different things.
+            "account_known": bool(normalize_account_id(entry.account_id)),
+        }
+        for key, entry in doc.platforms.items()
+        if platform_display_name(key) == key
+    )
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Per-platform freshness (#535)
+# ---------------------------------------------------------------------------
+
+
+def _platform_freshness(
+    totals: dict[str, Any] | None, metrics_period: str | None
+) -> dict[str, Any]:
+    """How old THIS platform's figures are — ``{fetched_at, stale,
+    stale_after_days}``.
+
+    ``fetched_at`` is the optional, writer-stamped time the numbers were
+    pulled (canonical vocabulary; see ``_mureo-strategy`` → *Performance
+    Metrics*). It is read off the rollup actually being rendered, so a
+    period-toggled view reports the freshness of the window on screen, and it
+    is relayed **verbatim** — including a value that is not a timestamp at
+    all. ``stale`` is the authoritative "could this be interpreted?" answer;
+    blanking an uninterpretable string would throw away the only clue an
+    operator has for finding the writer that produced it, and this module
+    reports what the document says rather than silently normalising it.
+    Consumers must therefore treat ``fetched_at`` as an opaque string unless
+    ``stale`` is not ``None``.
+
+    ``stale`` is deliberately three-valued. ``None`` means **unknown** —
+    ``fetched_at`` was absent or unparseable — and that is a real state, not
+    an error: the field is optional and writer-dependent, so claiming either
+    "fresh" or "stale" would assert something mureo cannot back. Callers
+    render it as its own thing.
+
+    Why this exists at all: the only freshness the dashboard used to show was
+    the document-level ``last_synced_at``, which the state layer re-stamps on
+    ANY platform write — so refreshing one platform made every other
+    platform's months-old numbers read as just-synced (#535). That timestamp
+    is still correct about what it means; it just cannot answer this
+    question.
+    """
+    stale_after = _stale_after_days(metrics_period)
+    fetched_raw = totals.get("fetched_at") if totals else None
+    fetched_at = fetched_raw if isinstance(fetched_raw, str) and fetched_raw else None
+    parsed = _parse_timestamp(fetched_at)
+    stale = (
+        None
+        if parsed is None
+        else parsed < datetime.now(timezone.utc) - timedelta(days=stale_after)
+    )
+    return {
+        "fetched_at": fetched_at,
+        "stale": stale,
+        "stale_after_days": stale_after,
+    }
+
+
+def _stale_after_days(metrics_period: str | None) -> int:
+    """Age at which a figure covering ``metrics_period`` is called stale.
+
+    **The window's own length, plus one grace day.** A figure fetched longer
+    ago than the window it summarises no longer overlaps that window at all:
+    a ``LAST_30_DAYS`` rollup pulled 31 days ago describes days -31 to -61,
+    while today's ``LAST_30_DAYS`` is days 0 to -30 — not one shared day. So
+    the figure is not "a bit old", it is about a different period than the
+    label claims. :data:`_STALE_GRACE_DAYS` then absorbs one missed daily
+    sync and platform reporting lag.
+
+    That is why a ``YESTERDAY`` figure (stale after 2 days) and a
+    ``LAST_30_DAYS`` figure (stale after 31) are judged so differently: they
+    are not the same claim aging at the same rate.
+
+    An unrecognised window falls back to :data:`_STALE_AFTER_DAYS_DEFAULT`.
+    """
+    if metrics_period is None:
+        return _STALE_AFTER_DAYS_DEFAULT
+    length = _PERIOD_LENGTH_DAYS.get(metrics_period)
+    if length is None:
+        return _STALE_AFTER_DAYS_DEFAULT
+    return length + _STALE_GRACE_DAYS
+
+
+def _parse_timestamp(value: str | None) -> datetime | None:
+    """Parse an ISO-8601 ``fetched_at``, or ``None`` if it is not one.
+
+    Tolerates a trailing ``Z`` (Python < 3.11 ``fromisoformat`` does not) and
+    treats a naive timestamp as UTC — writers are inconsistent about the
+    offset and refusing one would report a real timestamp as unknown.
+    A value that is not a timestamp at all yields ``None`` (unknown) rather
+    than a guess, and never an exception out of this read-only view.
+    """
+    if not value:
+        return None
+    text = value.strip()
+    if text.endswith(("Z", "z")):
+        text = f"{text[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=timezone.utc)
+
+
+def _period_totals(state: PlatformState, period: str) -> dict[str, Any] | None:
+    """Resolve a platform's totals for ``period`` (whitelisted) or ``None``.
+
+    Precedence:
+    1. ``periods[period]`` when the key is PRESENT — authoritative, even if
+       it whitelists down to nothing (``None``).
+    2. else the legacy single rollup (``totals``) ONLY when its stored
+       ``metrics_period`` equals ``period`` — never mislabel another window.
+    3. else ``None`` (no data for this window).
+    """
+    if state.periods is not None and period in state.periods:
+        bucket = state.periods[period]
+        return _safe_totals(bucket if isinstance(bucket, dict) else None)
+    if state.metrics_period == period:
+        return _safe_totals(state.totals)
+    return None
+
+
+def _available_periods(doc: StateDocument | None) -> list[str]:
+    """Windows with data anywhere in the document, in canonical order.
+
+    Union over every platform's ``periods`` keys plus its legacy
+    ``metrics_period`` (so a legacy single-rollup window still advertises
+    itself). Sorted with :data:`_PERIOD_ORDER` first, unknown windows
+    appended alphabetically — gives the dashboard a stable toggle order.
+
+    **This stays tolerant of a non-canonical window, on purpose (#659).**
+    The write path now refuses one (see
+    :func:`~mureo.context.state.set_platform_metrics`), but a window already
+    on disk was written before that guard existed: real figures, correctly
+    collected, filed under a name no view expects. Refusing to READ them
+    would delete data mureo did collect in order to tidy a vocabulary. They
+    are surfaced separately instead — see :func:`_non_canonical_periods` —
+    so an operator can see what accumulated and decide, rather than have the
+    dashboard decide silently in either direction.
+    """
+    if doc is None or not doc.platforms:
+        return []
+    found = _periods_present(doc)
+    known = [p for p in _PERIOD_ORDER if p in found]
+    extra = sorted(p for p in found if p not in _PERIOD_ORDER)
+    return known + extra
+
+
+def _periods_present(doc: StateDocument | None) -> set[str]:
+    """Every window token this document carries, canonical or not."""
+    if doc is None or not doc.platforms:
+        return set()
+    found: set[str] = set()
+    for state in doc.platforms.values():
+        if state.periods:
+            found.update(k for k in state.periods if isinstance(k, str) and k)
+        if state.metrics_period:
+            found.add(state.metrics_period)
+    return found
+
+
+def _non_canonical_periods(doc: StateDocument | None) -> list[str]:
+    """Windows on disk that are not windows mureo defines (#659).
+
+    Neither silent option is right. Dropping them from the toggle hides
+    figures mureo really did collect; keeping them unmarked leaves an
+    operator choosing between seven tabs, four of which are one agent's
+    ad-hoc phrasings from one session, with no way to tell which window
+    their reports are keyed to. So the summary NAMES them, and the operator
+    decides.
+
+    Empty (never absent) on a healthy document, like ``platform_conflicts``:
+    "nothing accumulated" and "this mureo cannot tell you" must not be the
+    same payload.
+    """
+    return sorted(
+        p for p in _periods_present(doc) if not is_canonical_metrics_window(p)
+    )
+
+
+def _platform_not_collected(state: PlatformState) -> dict[str, Any] | None:
+    """Why this platform's figures did not move — unless a later collection
+    already answered that (#638).
+
+    The stored note is dropped here when ANY of this platform's rollups was
+    collected AFTER the failure it describes. Retiring the note is the
+    collector's job (see
+    :func:`mureo.context.state.set_platform_not_collected`), but the
+    correctness of what an operator sees must not depend on a writer
+    remembering to do it: nothing in the ``mureo_state_platform_metrics_set``
+    path forces a second call, so a document would otherwise carry a fresh
+    ``fetched_at`` and a days-old collection failure at once, permanently,
+    and the card would render both. Two independent answers to one question,
+    with nothing checking them against each other, is the defect this whole
+    issue is about — a dashboard stating something untrue and no one able to
+    tell.
+
+    Decided ONCE, here, exactly as the staleness verdict is: the browser is
+    handed a resolved answer rather than a second copy of the rule.
+
+    Three deliberate asymmetries:
+
+    - **Any window counts.** The note is platform-level, so a daily-check
+      writing ``YESTERDAY`` proves the platform was reachable just as well as
+      a sync writing ``LAST_30_DAYS``. The comparison uses the NEWEST
+      ``fetched_at`` in the entry, not the window the toggle happens to show
+      — otherwise switching window could resurrect a retired note.
+    - **No collection time, no retirement.** A platform with no ``fetched_at``
+      anywhere has never been collected as far as the document knows, and
+      that is the case where the note is the only thing the card can say.
+    - **Retirement must be PROVED.** An unparseable ``fetched_at`` or a note
+      with no ``attempted_at`` (mureo's own writer always stamps one) leaves
+      the question open, and open is not retired — the same position
+      :func:`_platform_freshness` takes on a value it cannot interpret.
+    """
+    note = _safe_not_collected(state.not_collected)
+    if note is None:
+        return None
+    attempted = _parse_timestamp(note.get("attempted_at"))
+    if attempted is None:
+        return note
+    collected = _newest_collection(state)
+    if collected is not None and collected > attempted:
+        return None
+    return note
+
+
+def _workspace_not_collected(doc: StateDocument | None) -> dict[str, Any] | None:
+    """Why this WORKSPACE could not be collected — unless a later collection
+    already answered that (#661).
+
+    #638's retirement rule, one level up. The stored note is dropped here
+    when ANY rollup ANYWHERE in the document was collected after the failure
+    it describes: the note is about the workspace, so any platform being
+    reached is evidence the collection ran. Retiring it is the collector's
+    job (see :func:`mureo.context.state.set_workspace_not_collected`), but
+    what an operator SEES must not depend on a writer remembering — a
+    document carrying a fresh ``fetched_at`` and a days-old
+    "could not be collected" states two contradictory answers to one
+    question, and that is the defect this field exists to remove, not to
+    reintroduce.
+
+    Put on the wire under its OWN key, never merged into a platform row: the
+    acceptance condition is that "this workspace could not be collected" and
+    "this workspace's Meta failed" do not render as one sentence. Their
+    evidence differs too — a rollup on ANY platform retires this one, while a
+    platform's note is retired only by its own rollups — so one is never
+    computed from the other.
+
+    The same three limits as the per-platform rule: any window counts, no
+    collection time means no retirement, and retirement must be PROVED (an
+    unparseable ``fetched_at``, or a note with no ``attempted_at``, leaves
+    the question open, and open is not retired).
+    """
+    if doc is None:
+        return None
+    note = _safe_not_collected(doc.workspace_not_collected)
+    if note is None:
+        return None
+    attempted = _parse_timestamp(note.get("attempted_at"))
+    if attempted is None:
+        return note
+    collected = _newest_document_collection(doc)
+    if collected is not None and collected > attempted:
+        return None
+    return note
+
+
+def _newest_document_collection(doc: StateDocument) -> datetime | None:
+    """The most recent ``fetched_at`` across EVERY platform's rollups.
+
+    ``None`` when not one platform in the document carries a usable
+    timestamp — which is not "never collected" as a fact about the world,
+    only about what the document can show.
+    """
+    newest: datetime | None = None
+    for state in (doc.platforms or {}).values():
+        collected = _newest_collection(state)
+        if collected is not None and (newest is None or collected > newest):
+            newest = collected
+    return newest
+
+
+def _newest_collection(state: PlatformState) -> datetime | None:
+    """The most recent ``fetched_at`` across ALL of a platform's rollups.
+
+    ``totals`` and every ``periods`` bucket, because any of them landing is
+    evidence the platform was reached. ``None`` when not one of them carries
+    a usable timestamp — which is not "never collected" as a fact about the
+    world, only about what the document can show.
+    """
+    rollups: list[Any] = [state.totals]
+    if isinstance(state.periods, dict):
+        rollups.extend(state.periods.values())
+    newest: datetime | None = None
+    for rollup in rollups:
+        if not isinstance(rollup, dict):
+            continue
+        raw = rollup.get("fetched_at")
+        parsed = _parse_timestamp(raw if isinstance(raw, str) else None)
+        if parsed is not None and (newest is None or parsed > newest):
+            newest = parsed
+    return newest
+
+
+def _safe_not_collected(note: dict[str, Any] | None) -> dict[str, Any] | None:
+    """The stored "why the figures did not move" note, fit to render (#638).
+
+    Returns ``{"attempted_at", "reason"}`` — the two known keys and nothing
+    else, the same whitelist discipline :func:`_safe_totals` applies, so a
+    stray or secret-shaped key a buggy or hostile writer slipped in can never
+    reach the page. ``None`` when there is no usable note, and ``None`` is put
+    on the wire explicitly so every row has one shape.
+
+    ``reason`` is truncated to
+    :data:`~mureo.context.models.NOT_COLLECTED_REASON_MAX_CHARS`. The write
+    helper caps what it stores, but a digest can write the whole document
+    without going near it, and a page of raw API JSON in a card is not a
+    reason an operator can read.
+
+    A note with no usable ``reason`` is no note: it would say something
+    happened and refuse to say what, which is the state this field exists to
+    end. ``attempted_at`` is relayed verbatim, like ``fetched_at`` — the only
+    clue to the writer that produced an uninterpretable one.
+    """
+    if not isinstance(note, dict):
+        return None
+    reason = note.get("reason")
+    if not isinstance(reason, str) or not reason.strip():
+        return None
+    attempted_at = note.get("attempted_at")
+    return {
+        "attempted_at": (
+            attempted_at.strip()
+            if isinstance(attempted_at, str) and attempted_at.strip()
+            else None
+        ),
+        "reason": reason.strip()[:NOT_COLLECTED_REASON_MAX_CHARS],
+    }
+
+
+def _safe_totals(totals: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Copy only canonical metric keys out of ``totals`` (or ``None``).
+
+    Whitelisting the keys means a stray/secret-shaped key a buggy or hostile
+    writer slipped into ``totals`` can never reach the dashboard. ``None``
+    (no rollup) is preserved so the frontend can distinguish "no metrics"
+    from "zeroed metrics".
+    """
+    if not totals:
+        return None
+    return {k: totals[k] for k in _CANONICAL_TOTAL_KEYS if k in totals} or None

--- a/mureo/web/report_labels.py
+++ b/mureo/web/report_labels.py
@@ -1,0 +1,185 @@
+"""Platform key → the name an operator reads (#678).
+
+Lifted verbatim out of :mod:`mureo.web.reports`, which had grown past the
+point where one reader could hold it. Nothing here changed in the move — same
+functions, same bodies, same order.
+
+One question is answered here and nowhere else: given a ``platforms`` key as
+stored in STATE.json, what does the dashboard call it? Three cases, and the
+third is the one that carries weight:
+
+  1. A built-in key (``google_ads``, ``meta_ads``, …) has a name in the shared
+     table :data:`~mureo.core.platform_keys.BUILTIN_PLATFORM_DISPLAY_NAMES`.
+  2. A ``plugin:<dist>`` key belonging to an in-tree bridge is labelled as the
+     first-party integration it is, without a ``(plugin)`` suffix.
+  3. Anything else is returned **unchanged**. That is not a fallback but a
+     signal: returning the key verbatim is precisely how mureo answers "this
+     key is unrecognisable", and :data:`~mureo.web.report_document
+     .CONFLICT_UNRECOGNIZED_KEY` is defined in terms of it. So a change here
+     that invented a prettier name for an unknown key would silently switch
+     off a conflict finding two modules away.
+
+The plugin half of the vocabulary is read from
+:func:`~mureo.context.platform_guards.installed_platform_names` — the same
+enumeration the write-time guard uses (#631) — so this resolver can never
+disagree with what mureo accepted on write.
+
+No document, no store, no I/O: every function takes a string and returns a
+string.
+"""
+
+from __future__ import annotations
+
+from mureo.context.platform_guards import installed_platform_names
+from mureo.core.platform_keys import (
+    BUILTIN_PLATFORM_DISPLAY_NAMES,
+    PLUGIN_PLATFORM_PREFIX,
+    is_plugin_platform_key,
+    plugin_platform_parts,
+)
+
+# Built-in platform key → human display name. Plugin keys (``plugin:<dist>``)
+# and any unknown key are resolved by :func:`platform_display_name` instead.
+#
+# The map itself lives in ``mureo.core.platform_keys`` (#609): the write-time
+# guard has to accept exactly these keys, and ``mureo.context`` cannot import
+# ``mureo.web``. This module keeps the local name because it is the read-side
+# resolver's own vocabulary and every reference below reads as one.
+_BUILTIN_DISPLAY_NAMES = BUILTIN_PLATFORM_DISPLAY_NAMES
+
+# Distribution → display name for OFFICIAL, in-tree bridges (audit #30).
+# These ride the ``plugin:<dist>`` dispatch path to reuse the plugin safety
+# layer, but that is an implementation detail: they ship inside mureo, so
+# labelling them "(plugin)" would tell the operator a first-party integration
+# is third-party. Only in-tree bridges belong here; a genuine third-party
+# distribution keeps the suffix.
+#
+# The key is spelled out rather than imported from
+# ``mureo.amazon_ads.provider.AMAZON_SOURCE_DISTRIBUTION`` on purpose: that
+# module pulls the bridge (and the mcp SDK types it imports) onto the
+# configure-UI import path, which the wizard deliberately avoids. A test pins
+# the two strings together.
+_OFFICIAL_BRIDGE_DISPLAY_NAMES: dict[str, str] = {
+    "mureo-amazon-ads-bridge": "Amazon Ads",
+}
+
+
+def platform_display_name(key: str) -> str:
+    """Resolve a human label for a ``platforms`` key.
+
+    Rules:
+    - A built-in key (``google_ads`` / ``meta_ads`` / ``search_console`` /
+      ``ga4``) → its registered name.
+    - A plugin key naming an OFFICIAL in-tree bridge → its registered
+      name, with no ``" (plugin)"`` suffix (e.g.
+      ``plugin:mureo-amazon-ads-bridge`` → ``"Amazon Ads"``). See
+      :data:`_OFFICIAL_BRIDGE_DISPLAY_NAMES`.
+    - A canonical ``plugin:<dist>:<provider>`` key (#537) → a humanized
+      label from ``<provider>``, suffixed ``" (plugin)"``: the provider
+      names the *platform*, which is what a label is for, while the
+      distribution is packaging (e.g.
+      ``plugin:mureo-lineyahoo-bridge:yahoo_ads`` → ``"Yahoo Ads
+      (plugin)"``, not a mangled ``"Mureo-Lineyahoo-Bridge:Yahoo Ads"``).
+      A provider that humanizes to nothing falls back to the distribution.
+    - A legacy ``plugin:<dist>`` key → a humanized label from ``<dist>``:
+      drop a leading ``mureo-`` and a trailing ``-bridge``, title-case the
+      hyphen-separated words, and suffix ``" (plugin)"`` (e.g.
+      ``plugin:mureo-logly-bridge`` → ``"Logly (plugin)"``,
+      ``plugin:acme-ads`` → ``"Acme Ads (plugin)"``). Unchanged, so state
+      written before #537 keeps the label it already had.
+    - A bare provider name an INSTALLED plugin registered (#609/#631) → the
+      humanized name with the same ``" (plugin)"`` suffix
+      (``logly_ads_context`` → ``"Logly Ads Context (plugin)"``). See
+      :func:`_installed_plugin_platform_label`.
+    - Anything else (an unknown built-in-shaped key) → the key itself, so
+      the dashboard never renders a blank label.
+
+    :data:`_OFFICIAL_BRIDGE_DISPLAY_NAMES` is keyed by distribution, so an
+    official bridge shipping several platforms would label them all alike;
+    none does today, and the fix when one appears is a per-provider entry,
+    not a change to this resolution order.
+    """
+    builtin = _BUILTIN_DISPLAY_NAMES.get(key)
+    if builtin is not None:
+        return builtin
+    # Issues #481 / #537: the canonical plugin key — see
+    # mureo.core.platform_keys.
+    if is_plugin_platform_key(key):
+        dist, provider = plugin_platform_parts(key)
+        official = _OFFICIAL_BRIDGE_DISPLAY_NAMES.get(dist)
+        if official is not None:
+            return official
+        label = _humanize_words(provider) if provider else ""
+        if not label:
+            label = _humanize_dist(dist)
+        return f"{label} (plugin)" if label else key
+    return _installed_plugin_platform_label(key) or key
+
+
+def _installed_plugin_platform_label(key: str) -> str:
+    """Label a bare provider name an installed plugin registered (#631).
+
+    ``key`` is a platform name straight out of the ``mureo.providers`` /
+    ``mureo.analytics`` entry points — ``logly_ads_context``, not
+    ``plugin:mureo-logly-bridge:logly_ads_context``. That has been a valid
+    key to WRITE since #609, and this function is why the read side no longer
+    calls it unresolvable: a key the guard accepted was being flagged
+    ``unrecognized_key`` on the dashboard at the same moment
+    ``mureo repair platform-key`` reported the same entry ``Clean``.
+
+    Same ``" (plugin)"`` suffix as the canonical key for the same platform:
+    the entry comes from a plugin under either spelling, and two labels for
+    one platform on one dashboard would replace this inconsistency with
+    another. :data:`_OFFICIAL_BRIDGE_DISPLAY_NAMES` cannot apply here — it is
+    keyed by distribution and a bare name carries none — so an in-tree bridge
+    held under its bare provider name keeps the suffix. Resolving that would
+    mean reading ``ep.dist``, i.e. reading more of an entry point than the
+    guard does, and mureo writes the canonical key for those anyway.
+
+    Fails OPEN exactly as :func:`~mureo.context.platform_guards.
+    reject_unknown_platform_key` does: an environment that cannot be
+    enumerated labels the key rather than reporting it unrecognised, because
+    a broken ``importlib.metadata`` is not evidence that a key is wrong.
+
+    Two shapes are excluded whatever the registry says: a key claiming the
+    plugin namespace without naming a platform (``plugin:``,
+    ``plugin:<dist>:``), which the write path refuses on shape alone
+    (``reject_unusable_platform_key``) and which no enumeration failure can
+    make legitimate; and a name that humanizes to nothing. Both yield ``""``
+    and the caller falls back to the raw key.
+    """
+    if key.startswith(PLUGIN_PLATFORM_PREFIX):
+        return ""
+    installed = installed_platform_names()
+    if installed is not None and key not in installed:
+        return ""
+    label = _humanize_words(key)
+    return f"{label} (plugin)" if label else ""
+
+
+def _humanize_words(name: str) -> str:
+    """Title-case a ``-``/``_``-separated identifier.
+
+    ``yahoo_ads`` → ``Yahoo Ads``; ``acme-ads`` → ``Acme Ads``. An
+    identifier that carries no word characters yields ``""`` so the
+    caller can fall back.
+    """
+    words = [w for w in name.strip().replace("_", "-").split("-") if w]
+    return " ".join(word.capitalize() for word in words)
+
+
+def _humanize_dist(dist: str) -> str:
+    """Turn a distribution name into a Title-Cased label.
+
+    ``mureo-logly-bridge`` → ``Logly``; ``acme-ads`` → ``Acme Ads``. A
+    leading ``mureo-`` and a trailing ``-bridge`` are mureo packaging
+    conventions, not part of the brand, so they are stripped. An empty
+    result (e.g. ``plugin:mureo-``, which is nothing but conventions)
+    yields ``""`` and the caller falls back to the raw key.
+    """
+    name = dist.strip()
+    if name.startswith("mureo-"):
+        name = name[len("mureo-") :]
+    if name.endswith("-bridge"):
+        name = name[: -len("-bridge")]
+    return _humanize_words(name)

--- a/mureo/web/reports.py
+++ b/mureo/web/reports.py
@@ -58,43 +58,36 @@ card per render). A single workspace has no second client to triage against,
 so the layer is omitted rather than degraded to one row — and omitted means
 the payload keeps the exact keys, in the exact order, it had before this
 existed.
+
+Where the pieces live (#678)
+----------------------------
+
+This module is the assembly: it resolves the store, walks the document once
+and shapes the payload. The questions that payload is made of were moved out
+verbatim when this file passed a thousand lines, and are re-exported from
+here so every existing importer keeps resolving:
+
+  :mod:`mureo.web.report_document` — everything asked OF the document: the
+    tolerant read, the two conflict findings, freshness, the windows it
+    carries, its ``not_collected`` notes, and the canonical-key filter that
+    decides what may go on the wire.
+  :mod:`mureo.web.report_labels` — the platform key to display-name resolver,
+    which :data:`~mureo.web.report_document.CONFLICT_UNRECOGNIZED_KEY` is
+    defined in terms of.
+
+The import direction is one-way — ``reports`` to ``report_document`` to
+``report_labels`` — so there is no cycle to reason about.
 """
 
 from __future__ import annotations
 
-import logging
-from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any
-
-# The stored shape's own length bound (#638), so the read side and the write
-# helper truncate a collection failure's reason to the same length.
-from mureo.context.models import NOT_COLLECTED_REASON_MAX_CHARS
 
 # "Which observations are still owed a review" — the rule that already
 # defines ``mureo_state_get(action_log="pending")``, read here rather than
 # restated (#651).
 from mureo.context.observations import due_observation_dates
-from mureo.context.platform_accounts import (
-    duplicate_account_entries,
-    normalize_account_id,
-)
-
-# The plugin half of the platform vocabulary, enumerated ONCE for the whole
-# tree (#631). ``web`` -> ``context`` is the direction that already holds
-# above; see that module's "One enumeration, two surfaces".
-from mureo.context.platform_guards import installed_platform_names
-from mureo.context.state import read_state_file
 from mureo.core import clock
-from mureo.core.metrics_windows import (
-    CANONICAL_METRICS_WINDOWS,
-    is_canonical_metrics_window,
-)
-from mureo.core.platform_keys import (
-    BUILTIN_PLATFORM_DISPLAY_NAMES,
-    PLUGIN_PLATFORM_PREFIX,
-    is_plugin_platform_key,
-    plugin_platform_parts,
-)
 
 # The client seam. Imported (not re-implemented) and re-exported through
 # ``__all__`` so ``from mureo.web.reports import state_store_for_client``
@@ -110,15 +103,41 @@ from mureo.web.report_clients import (
     state_store_for_client,
 )
 
+# The document layer (#678). Most of these are called below; ``_PERIOD_ORDER``
+# and ``_PERIOD_LENGTH_DAYS`` are re-export only — the window vocabulary moved
+# with the functions that read it, and the suite reads both tables off THIS
+# module. Hence the blanket noqa rather than a per-name one.
+from mureo.web.report_document import (  # noqa: F401
+    _PERIOD_LENGTH_DAYS,
+    _PERIOD_ORDER,
+    CONFLICT_DUPLICATE_ACCOUNT,
+    CONFLICT_UNRECOGNIZED_KEY,
+    _available_periods,
+    _build_platform_conflicts,
+    _non_canonical_periods,
+    _period_totals,
+    _platform_freshness,
+    _platform_not_collected,
+    _read_state_safe,
+    _safe_totals,
+    _workspace_not_collected,
+)
+
+# The display-name resolver (#678). ``platform_display_name`` is called below
+# and is in ``__all__``; the two tables behind it are re-export only, read off
+# this module by the suite.
+from mureo.web.report_labels import (  # noqa: F401
+    _BUILTIN_DISPLAY_NAMES,
+    _OFFICIAL_BRIDGE_DISPLAY_NAMES,
+    platform_display_name,
+)
+
 if TYPE_CHECKING:
     from mureo.context.models import (
         ActionLogEntry,
         PlatformState,
         StateDocument,
     )
-    from mureo.core.state_store import StateStore
-
-logger = logging.getLogger(__name__)
 
 __all__ = [
     "CONFLICT_DUPLICATE_ACCOUNT",
@@ -133,255 +152,9 @@ __all__ = [
 ]
 
 
-# ``platform_conflicts[].kind`` — the wire vocabulary for "do not add these
-# rows together" (#533). TWO findings, deliberately never merged into one
-# warning: they are different facts and an operator's next move differs.
-CONFLICT_DUPLICATE_ACCOUNT = "duplicate_account"
-"""Two or more keys resolve to ONE ad account.
-
-Established by the shared join in :mod:`mureo.context.platform_accounts`.
-The consequence is present-tense and certain: any total over these rows
-counts that account's spend / conversions / CPA more than once, right now.
-"""
-
-CONFLICT_UNRECOGNIZED_KEY = "unrecognized_key"
-"""A key no mureo surface can resolve to a platform.
-
-The account join CANNOT find this case. The shape actually reported from the
-field had ``account_id = ""`` on one of the two entries, and
-``account_ids_match("", "")`` is ``False`` by design (an unknown id is not a
-value), so :func:`~mureo.context.platform_accounts.duplicate_account_entries`
-deliberately does not report that pair. This second, independent signal is
-what catches it: an entry whose identity cannot be established at all, and
-which may therefore be a duplicate of a canonical one.
-
-The condition itself is narrower than that motivating case: it tests the
-KEY only, so it also fires on a key mureo cannot label whose ``account_id``
-resolves perfectly well. Both belong here — the operator has to look at the
-key either way — but they are not the same finding, so the row carries
-``account_known`` and the dashboard says the milder thing (mureo cannot
-tell which *platform* this is) when the account is in fact known. Claiming
-the ad account is unidentifiable there would contradict the
-``duplicate_account`` row sitting on the same key (#606).
-
-Recognition is delegated to :func:`platform_display_name`, which returns the
-key unchanged exactly when it can make nothing of it — that is already how
-mureo answers "is this key recognisable", and asking the dashboard's own
-resolver means this can never drift from what the dashboard renders. The
-alternative, an alias table mapping arbitrary keys onto platforms, would be a
-guess.
-
-That resolver now reads the **same** installed-plugin enumeration the write
-guard does (:func:`~mureo.context.platform_guards.installed_platform_names`,
-#631), so this signal can no longer fire on a key mureo itself accepted on
-write. Until it did, a bare provider name — ``logly_ads_context``, the LOGLY
-bridge's real platform name — was accepted by the guard, reported ``Clean``
-by ``mureo repair platform-key``, and flagged here, all on one machine at one
-moment. An operator who learns this fires on healthy state stops reading it,
-which costs more than the finding is worth.
-"""
-
 # How many of the most-recent ``action_log`` entries the summary surfaces.
 # The dashboard shows a short activity feed, not the full history.
 _RECENT_ACTIONS_LIMIT = 20
-
-# The canonical metric keys a platform's ``totals`` may carry (the shared
-# vocabulary documented in ``_mureo-strategy`` → *Performance Metrics*). The
-# summary copies only these keys so a future stray/secret-shaped key written
-# into ``totals`` can never reach the dashboard. ``result_indicator`` is
-# Meta-only but harmless to allow for every platform.
-_CANONICAL_TOTAL_KEYS: tuple[str, ...] = (
-    "spend",
-    "impressions",
-    "clicks",
-    "conversions",
-    "cpa",
-    "ctr",
-    "result_indicator",
-    "period",
-    "fetched_at",
-)
-
-# Built-in platform key → human display name. Plugin keys (``plugin:<dist>``)
-# and any unknown key are resolved by :func:`platform_display_name` instead.
-#
-# The map itself lives in ``mureo.core.platform_keys`` (#609): the write-time
-# guard has to accept exactly these keys, and ``mureo.context`` cannot import
-# ``mureo.web``. This module keeps the local name because it is the read-side
-# resolver's own vocabulary and every reference below reads as one.
-_BUILTIN_DISPLAY_NAMES = BUILTIN_PLATFORM_DISPLAY_NAMES
-
-# Distribution → display name for OFFICIAL, in-tree bridges (audit #30).
-# These ride the ``plugin:<dist>`` dispatch path to reuse the plugin safety
-# layer, but that is an implementation detail: they ship inside mureo, so
-# labelling them "(plugin)" would tell the operator a first-party integration
-# is third-party. Only in-tree bridges belong here; a genuine third-party
-# distribution keeps the suffix.
-#
-# The key is spelled out rather than imported from
-# ``mureo.amazon_ads.provider.AMAZON_SOURCE_DISTRIBUTION`` on purpose: that
-# module pulls the bridge (and the mcp SDK types it imports) onto the
-# configure-UI import path, which the wizard deliberately avoids. A test pins
-# the two strings together.
-_OFFICIAL_BRIDGE_DISPLAY_NAMES: dict[str, str] = {
-    "mureo-amazon-ads-bridge": "Amazon Ads",
-}
-
-# Canonical period tokens in dashboard-toggle order. The default view is the
-# most recent day (``YESTERDAY``) — daily-check runs every day, so the prior
-# day's state is what an operator checks first; ``LAST_30_DAYS`` is the
-# trend window written by sync-state. Windows not listed here sort after
-# these, alphabetically (see :func:`_available_periods`).
-#
-# The table itself lives in ``mureo.core.metrics_windows`` (#659), for the
-# same reason the display names do: the WRITE guard has to refuse exactly the
-# windows this view cannot render, and ``mureo.context`` cannot import
-# ``mureo.web``. Two copies would be free to drift, and the drift is the bug
-# — a writer accepting a window nothing here reads.
-_PERIOD_ORDER: tuple[str, ...] = tuple(CANONICAL_METRICS_WINDOWS)
-
-# Canonical window → the length of that window in days. The stale threshold
-# is derived from this rather than written down as a per-window magic number,
-# so the rationale below is the only thing to check when a window is added.
-_PERIOD_LENGTH_DAYS: dict[str, int] = dict(CANONICAL_METRICS_WINDOWS)
-
-_STALE_GRACE_DAYS = 1
-"""Slack added to a window's own length before its figure is called stale.
-
-Absorbs one missed daily sync run and the platforms' own reporting lag
-(conversions backfill for a day or two is normal), so a single hiccup does
-not paint a healthy account red.
-"""
-
-_STALE_AFTER_DAYS_DEFAULT = max(_PERIOD_LENGTH_DAYS.values()) + _STALE_GRACE_DAYS
-"""Threshold for a window whose length mureo does not know.
-
-The most forgiving known threshold, not the strictest: a window we cannot
-reason about must not be flagged on a guess. Crying wolf on figures mureo
-cannot judge would teach operators to ignore the marker, which costs more
-than the occasional missed stale entry.
-"""
-
-
-def platform_display_name(key: str) -> str:
-    """Resolve a human label for a ``platforms`` key.
-
-    Rules:
-    - A built-in key (``google_ads`` / ``meta_ads`` / ``search_console`` /
-      ``ga4``) → its registered name.
-    - A plugin key naming an OFFICIAL in-tree bridge → its registered
-      name, with no ``" (plugin)"`` suffix (e.g.
-      ``plugin:mureo-amazon-ads-bridge`` → ``"Amazon Ads"``). See
-      :data:`_OFFICIAL_BRIDGE_DISPLAY_NAMES`.
-    - A canonical ``plugin:<dist>:<provider>`` key (#537) → a humanized
-      label from ``<provider>``, suffixed ``" (plugin)"``: the provider
-      names the *platform*, which is what a label is for, while the
-      distribution is packaging (e.g.
-      ``plugin:mureo-lineyahoo-bridge:yahoo_ads`` → ``"Yahoo Ads
-      (plugin)"``, not a mangled ``"Mureo-Lineyahoo-Bridge:Yahoo Ads"``).
-      A provider that humanizes to nothing falls back to the distribution.
-    - A legacy ``plugin:<dist>`` key → a humanized label from ``<dist>``:
-      drop a leading ``mureo-`` and a trailing ``-bridge``, title-case the
-      hyphen-separated words, and suffix ``" (plugin)"`` (e.g.
-      ``plugin:mureo-logly-bridge`` → ``"Logly (plugin)"``,
-      ``plugin:acme-ads`` → ``"Acme Ads (plugin)"``). Unchanged, so state
-      written before #537 keeps the label it already had.
-    - A bare provider name an INSTALLED plugin registered (#609/#631) → the
-      humanized name with the same ``" (plugin)"`` suffix
-      (``logly_ads_context`` → ``"Logly Ads Context (plugin)"``). See
-      :func:`_installed_plugin_platform_label`.
-    - Anything else (an unknown built-in-shaped key) → the key itself, so
-      the dashboard never renders a blank label.
-
-    :data:`_OFFICIAL_BRIDGE_DISPLAY_NAMES` is keyed by distribution, so an
-    official bridge shipping several platforms would label them all alike;
-    none does today, and the fix when one appears is a per-provider entry,
-    not a change to this resolution order.
-    """
-    builtin = _BUILTIN_DISPLAY_NAMES.get(key)
-    if builtin is not None:
-        return builtin
-    # Issues #481 / #537: the canonical plugin key — see
-    # mureo.core.platform_keys.
-    if is_plugin_platform_key(key):
-        dist, provider = plugin_platform_parts(key)
-        official = _OFFICIAL_BRIDGE_DISPLAY_NAMES.get(dist)
-        if official is not None:
-            return official
-        label = _humanize_words(provider) if provider else ""
-        if not label:
-            label = _humanize_dist(dist)
-        return f"{label} (plugin)" if label else key
-    return _installed_plugin_platform_label(key) or key
-
-
-def _installed_plugin_platform_label(key: str) -> str:
-    """Label a bare provider name an installed plugin registered (#631).
-
-    ``key`` is a platform name straight out of the ``mureo.providers`` /
-    ``mureo.analytics`` entry points — ``logly_ads_context``, not
-    ``plugin:mureo-logly-bridge:logly_ads_context``. That has been a valid
-    key to WRITE since #609, and this function is why the read side no longer
-    calls it unresolvable: a key the guard accepted was being flagged
-    ``unrecognized_key`` on the dashboard at the same moment
-    ``mureo repair platform-key`` reported the same entry ``Clean``.
-
-    Same ``" (plugin)"`` suffix as the canonical key for the same platform:
-    the entry comes from a plugin under either spelling, and two labels for
-    one platform on one dashboard would replace this inconsistency with
-    another. :data:`_OFFICIAL_BRIDGE_DISPLAY_NAMES` cannot apply here — it is
-    keyed by distribution and a bare name carries none — so an in-tree bridge
-    held under its bare provider name keeps the suffix. Resolving that would
-    mean reading ``ep.dist``, i.e. reading more of an entry point than the
-    guard does, and mureo writes the canonical key for those anyway.
-
-    Fails OPEN exactly as :func:`~mureo.context.platform_guards.
-    reject_unknown_platform_key` does: an environment that cannot be
-    enumerated labels the key rather than reporting it unrecognised, because
-    a broken ``importlib.metadata`` is not evidence that a key is wrong.
-
-    Two shapes are excluded whatever the registry says: a key claiming the
-    plugin namespace without naming a platform (``plugin:``,
-    ``plugin:<dist>:``), which the write path refuses on shape alone
-    (``reject_unusable_platform_key``) and which no enumeration failure can
-    make legitimate; and a name that humanizes to nothing. Both yield ``""``
-    and the caller falls back to the raw key.
-    """
-    if key.startswith(PLUGIN_PLATFORM_PREFIX):
-        return ""
-    installed = installed_platform_names()
-    if installed is not None and key not in installed:
-        return ""
-    label = _humanize_words(key)
-    return f"{label} (plugin)" if label else ""
-
-
-def _humanize_words(name: str) -> str:
-    """Title-case a ``-``/``_``-separated identifier.
-
-    ``yahoo_ads`` → ``Yahoo Ads``; ``acme-ads`` → ``Acme Ads``. An
-    identifier that carries no word characters yields ``""`` so the
-    caller can fall back.
-    """
-    words = [w for w in name.strip().replace("_", "-").split("-") if w]
-    return " ".join(word.capitalize() for word in words)
-
-
-def _humanize_dist(dist: str) -> str:
-    """Turn a distribution name into a Title-Cased label.
-
-    ``mureo-logly-bridge`` → ``Logly``; ``acme-ads`` → ``Acme Ads``. A
-    leading ``mureo-`` and a trailing ``-bridge`` are mureo packaging
-    conventions, not part of the brand, so they are stripped. An empty
-    result (e.g. ``plugin:mureo-``, which is nothing but conventions)
-    yields ``""`` and the caller falls back to the raw key.
-    """
-    name = dist.strip()
-    if name.startswith("mureo-"):
-        name = name[len("mureo-") :]
-    if name.endswith("-bridge"):
-        name = name[: -len("-bridge")]
-    return _humanize_words(name)
 
 
 # ---------------------------------------------------------------------------
@@ -540,56 +313,6 @@ def _build_observations_due(doc: StateDocument | None) -> dict[str, Any]:
     }
 
 
-def _read_state_safe(store: StateStore) -> StateDocument | None:
-    """Read the document, returning ``None`` on any failure.
-
-    ``read_state_file`` already returns a default document for a missing
-    file, but a malformed STATE.json raises ``ContextFileError`` and an
-    alternate backend could raise anything — the dashboard must degrade to
-    an empty summary, never 500.
-
-    When the strict read fails, retry tolerantly against the raw file before
-    giving up: ``store.read_state()`` validates the campaign list strictly, so
-    one variant / hand-authored campaign entry (e.g. ``name`` instead of
-    ``campaign_name``) would otherwise blank out a document whose
-    platforms/periods/reports the read-only dashboard can still render.
-    """
-    try:
-        return store.read_state()
-    except Exception:  # noqa: BLE001 — read-only view degrades, never raises
-        # Expected + handled for a STATE.json with nonconforming entries (e.g. a
-        # hand-authored legacy campaign list, or a platform missing account_id):
-        # the tolerant retry below renders the view fine. The read-only
-        # dashboard re-reads on every poll, so log this at DEBUG — a per-render
-        # WARNING + traceback would flood the daemon log on every refresh and
-        # read as a failure when it is not.
-        logger.debug(
-            "strict STATE.json read failed; retrying tolerantly for the "
-            "read-only Reports view",
-            exc_info=True,
-        )
-        return _read_state_tolerant(store)
-
-
-def _read_state_tolerant(store: StateStore) -> StateDocument | None:
-    """Re-read ``store``'s STATE.json skipping nonconforming campaign entries.
-
-    Needs the backing file path (``state_path``), which the filesystem store —
-    including the Agency per-client stores resolved by
-    :func:`state_store_for_client` — exposes. A store without one cannot be
-    re-read tolerantly, so the view degrades to an empty summary.
-    """
-    path = getattr(store, "state_path", None)
-    if path is None:
-        logger.warning("STATE.json unreadable and no path to retry; empty summary")
-        return None
-    try:
-        return read_state_file(path, strict=False)
-    except Exception:  # noqa: BLE001 — last-resort guard; never raise from a read
-        logger.exception("tolerant STATE.json read also failed; empty summary")
-        return None
-
-
 def _build_platforms(
     doc: StateDocument | None, period: str | None
 ) -> list[dict[str, Any]]:
@@ -635,413 +358,6 @@ def _platform_row(key: str, state: PlatformState, period: str | None) -> dict[st
         "freshness": _platform_freshness(totals, metrics_period),
         "not_collected": _platform_not_collected(state),
     }
-
-
-# ---------------------------------------------------------------------------
-# Conflicts — why these rows must not be added together (#533)
-# ---------------------------------------------------------------------------
-
-
-def _build_platform_conflicts(doc: StateDocument | None) -> list[dict[str, Any]]:
-    """Reasons the caller must NOT sum this document's platform rows.
-
-    Each row is ``{"kind": <CONFLICT_*>, "platform_keys": [...],
-    "account_known": <bool>}`` — the grouping the browser cannot do, since
-    the rows carry no ``account_id``. Nothing here identifies an ad account:
-    the keys alone are what an operator needs to find the entries in
-    STATE.json, and putting the id on the wire would undo
-    :func:`_platform_row`'s omission. ``account_known`` is a presence bit,
-    not an id — it says only whether the entries behind the row named an ad
-    account mureo could resolve, which is a fact about the *document*, not
-    about the account.
-
-    Two independent signals, reported separately (see
-    :data:`CONFLICT_DUPLICATE_ACCOUNT` and
-    :data:`CONFLICT_UNRECOGNIZED_KEY` for why neither can stand in for the
-    other). A single key can legitimately appear in both — and when it does,
-    ``account_known`` is what keeps the two notes from asserting opposite
-    facts about it (#606). The unrecognised-key condition never inspects the
-    id, so without this bit the renderer would have to claim the ad account
-    is unidentifiable for an entry the duplicate finding just identified.
-    On a duplicate-account row it is always ``True``: that group is built BY
-    a resolvable id. It is stated anyway so every row answers the same
-    question and no consumer has to special-case a kind.
-
-    **Detection, not repair.** Duplicated entries typically hold different
-    *partial* figures, so summing over-counts exactly as much as dropping
-    one under-counts. This module never merges, drops or reorders a row; it
-    reports, and the operator decides.
-    """
-    if doc is None or not doc.platforms:
-        return []
-    rows: list[dict[str, Any]] = [
-        {
-            "kind": CONFLICT_DUPLICATE_ACCOUNT,
-            "platform_keys": list(group.platform_keys),
-            "account_known": True,
-        }
-        for group in duplicate_account_entries(doc.platforms)
-    ]
-    rows.extend(
-        {
-            "kind": CONFLICT_UNRECOGNIZED_KEY,
-            "platform_keys": [key],
-            # Folded the way the account join folds it, so "known here" and
-            # "joinable there" can never mean two different things.
-            "account_known": bool(normalize_account_id(entry.account_id)),
-        }
-        for key, entry in doc.platforms.items()
-        if platform_display_name(key) == key
-    )
-    return rows
-
-
-# ---------------------------------------------------------------------------
-# Per-platform freshness (#535)
-# ---------------------------------------------------------------------------
-
-
-def _platform_freshness(
-    totals: dict[str, Any] | None, metrics_period: str | None
-) -> dict[str, Any]:
-    """How old THIS platform's figures are — ``{fetched_at, stale,
-    stale_after_days}``.
-
-    ``fetched_at`` is the optional, writer-stamped time the numbers were
-    pulled (canonical vocabulary; see ``_mureo-strategy`` → *Performance
-    Metrics*). It is read off the rollup actually being rendered, so a
-    period-toggled view reports the freshness of the window on screen, and it
-    is relayed **verbatim** — including a value that is not a timestamp at
-    all. ``stale`` is the authoritative "could this be interpreted?" answer;
-    blanking an uninterpretable string would throw away the only clue an
-    operator has for finding the writer that produced it, and this module
-    reports what the document says rather than silently normalising it.
-    Consumers must therefore treat ``fetched_at`` as an opaque string unless
-    ``stale`` is not ``None``.
-
-    ``stale`` is deliberately three-valued. ``None`` means **unknown** —
-    ``fetched_at`` was absent or unparseable — and that is a real state, not
-    an error: the field is optional and writer-dependent, so claiming either
-    "fresh" or "stale" would assert something mureo cannot back. Callers
-    render it as its own thing.
-
-    Why this exists at all: the only freshness the dashboard used to show was
-    the document-level ``last_synced_at``, which the state layer re-stamps on
-    ANY platform write — so refreshing one platform made every other
-    platform's months-old numbers read as just-synced (#535). That timestamp
-    is still correct about what it means; it just cannot answer this
-    question.
-    """
-    stale_after = _stale_after_days(metrics_period)
-    fetched_raw = totals.get("fetched_at") if totals else None
-    fetched_at = fetched_raw if isinstance(fetched_raw, str) and fetched_raw else None
-    parsed = _parse_timestamp(fetched_at)
-    stale = (
-        None
-        if parsed is None
-        else parsed < datetime.now(timezone.utc) - timedelta(days=stale_after)
-    )
-    return {
-        "fetched_at": fetched_at,
-        "stale": stale,
-        "stale_after_days": stale_after,
-    }
-
-
-def _stale_after_days(metrics_period: str | None) -> int:
-    """Age at which a figure covering ``metrics_period`` is called stale.
-
-    **The window's own length, plus one grace day.** A figure fetched longer
-    ago than the window it summarises no longer overlaps that window at all:
-    a ``LAST_30_DAYS`` rollup pulled 31 days ago describes days -31 to -61,
-    while today's ``LAST_30_DAYS`` is days 0 to -30 — not one shared day. So
-    the figure is not "a bit old", it is about a different period than the
-    label claims. :data:`_STALE_GRACE_DAYS` then absorbs one missed daily
-    sync and platform reporting lag.
-
-    That is why a ``YESTERDAY`` figure (stale after 2 days) and a
-    ``LAST_30_DAYS`` figure (stale after 31) are judged so differently: they
-    are not the same claim aging at the same rate.
-
-    An unrecognised window falls back to :data:`_STALE_AFTER_DAYS_DEFAULT`.
-    """
-    if metrics_period is None:
-        return _STALE_AFTER_DAYS_DEFAULT
-    length = _PERIOD_LENGTH_DAYS.get(metrics_period)
-    if length is None:
-        return _STALE_AFTER_DAYS_DEFAULT
-    return length + _STALE_GRACE_DAYS
-
-
-def _parse_timestamp(value: str | None) -> datetime | None:
-    """Parse an ISO-8601 ``fetched_at``, or ``None`` if it is not one.
-
-    Tolerates a trailing ``Z`` (Python < 3.11 ``fromisoformat`` does not) and
-    treats a naive timestamp as UTC — writers are inconsistent about the
-    offset and refusing one would report a real timestamp as unknown.
-    A value that is not a timestamp at all yields ``None`` (unknown) rather
-    than a guess, and never an exception out of this read-only view.
-    """
-    if not value:
-        return None
-    text = value.strip()
-    if text.endswith(("Z", "z")):
-        text = f"{text[:-1]}+00:00"
-    try:
-        parsed = datetime.fromisoformat(text)
-    except ValueError:
-        return None
-    return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=timezone.utc)
-
-
-def _period_totals(state: PlatformState, period: str) -> dict[str, Any] | None:
-    """Resolve a platform's totals for ``period`` (whitelisted) or ``None``.
-
-    Precedence:
-    1. ``periods[period]`` when the key is PRESENT — authoritative, even if
-       it whitelists down to nothing (``None``).
-    2. else the legacy single rollup (``totals``) ONLY when its stored
-       ``metrics_period`` equals ``period`` — never mislabel another window.
-    3. else ``None`` (no data for this window).
-    """
-    if state.periods is not None and period in state.periods:
-        bucket = state.periods[period]
-        return _safe_totals(bucket if isinstance(bucket, dict) else None)
-    if state.metrics_period == period:
-        return _safe_totals(state.totals)
-    return None
-
-
-def _available_periods(doc: StateDocument | None) -> list[str]:
-    """Windows with data anywhere in the document, in canonical order.
-
-    Union over every platform's ``periods`` keys plus its legacy
-    ``metrics_period`` (so a legacy single-rollup window still advertises
-    itself). Sorted with :data:`_PERIOD_ORDER` first, unknown windows
-    appended alphabetically — gives the dashboard a stable toggle order.
-
-    **This stays tolerant of a non-canonical window, on purpose (#659).**
-    The write path now refuses one (see
-    :func:`~mureo.context.state.set_platform_metrics`), but a window already
-    on disk was written before that guard existed: real figures, correctly
-    collected, filed under a name no view expects. Refusing to READ them
-    would delete data mureo did collect in order to tidy a vocabulary. They
-    are surfaced separately instead — see :func:`_non_canonical_periods` —
-    so an operator can see what accumulated and decide, rather than have the
-    dashboard decide silently in either direction.
-    """
-    if doc is None or not doc.platforms:
-        return []
-    found = _periods_present(doc)
-    known = [p for p in _PERIOD_ORDER if p in found]
-    extra = sorted(p for p in found if p not in _PERIOD_ORDER)
-    return known + extra
-
-
-def _periods_present(doc: StateDocument | None) -> set[str]:
-    """Every window token this document carries, canonical or not."""
-    if doc is None or not doc.platforms:
-        return set()
-    found: set[str] = set()
-    for state in doc.platforms.values():
-        if state.periods:
-            found.update(k for k in state.periods if isinstance(k, str) and k)
-        if state.metrics_period:
-            found.add(state.metrics_period)
-    return found
-
-
-def _non_canonical_periods(doc: StateDocument | None) -> list[str]:
-    """Windows on disk that are not windows mureo defines (#659).
-
-    Neither silent option is right. Dropping them from the toggle hides
-    figures mureo really did collect; keeping them unmarked leaves an
-    operator choosing between seven tabs, four of which are one agent's
-    ad-hoc phrasings from one session, with no way to tell which window
-    their reports are keyed to. So the summary NAMES them, and the operator
-    decides.
-
-    Empty (never absent) on a healthy document, like ``platform_conflicts``:
-    "nothing accumulated" and "this mureo cannot tell you" must not be the
-    same payload.
-    """
-    return sorted(
-        p for p in _periods_present(doc) if not is_canonical_metrics_window(p)
-    )
-
-
-def _platform_not_collected(state: PlatformState) -> dict[str, Any] | None:
-    """Why this platform's figures did not move — unless a later collection
-    already answered that (#638).
-
-    The stored note is dropped here when ANY of this platform's rollups was
-    collected AFTER the failure it describes. Retiring the note is the
-    collector's job (see
-    :func:`mureo.context.state.set_platform_not_collected`), but the
-    correctness of what an operator sees must not depend on a writer
-    remembering to do it: nothing in the ``mureo_state_platform_metrics_set``
-    path forces a second call, so a document would otherwise carry a fresh
-    ``fetched_at`` and a days-old collection failure at once, permanently,
-    and the card would render both. Two independent answers to one question,
-    with nothing checking them against each other, is the defect this whole
-    issue is about — a dashboard stating something untrue and no one able to
-    tell.
-
-    Decided ONCE, here, exactly as the staleness verdict is: the browser is
-    handed a resolved answer rather than a second copy of the rule.
-
-    Three deliberate asymmetries:
-
-    - **Any window counts.** The note is platform-level, so a daily-check
-      writing ``YESTERDAY`` proves the platform was reachable just as well as
-      a sync writing ``LAST_30_DAYS``. The comparison uses the NEWEST
-      ``fetched_at`` in the entry, not the window the toggle happens to show
-      — otherwise switching window could resurrect a retired note.
-    - **No collection time, no retirement.** A platform with no ``fetched_at``
-      anywhere has never been collected as far as the document knows, and
-      that is the case where the note is the only thing the card can say.
-    - **Retirement must be PROVED.** An unparseable ``fetched_at`` or a note
-      with no ``attempted_at`` (mureo's own writer always stamps one) leaves
-      the question open, and open is not retired — the same position
-      :func:`_platform_freshness` takes on a value it cannot interpret.
-    """
-    note = _safe_not_collected(state.not_collected)
-    if note is None:
-        return None
-    attempted = _parse_timestamp(note.get("attempted_at"))
-    if attempted is None:
-        return note
-    collected = _newest_collection(state)
-    if collected is not None and collected > attempted:
-        return None
-    return note
-
-
-def _workspace_not_collected(doc: StateDocument | None) -> dict[str, Any] | None:
-    """Why this WORKSPACE could not be collected — unless a later collection
-    already answered that (#661).
-
-    #638's retirement rule, one level up. The stored note is dropped here
-    when ANY rollup ANYWHERE in the document was collected after the failure
-    it describes: the note is about the workspace, so any platform being
-    reached is evidence the collection ran. Retiring it is the collector's
-    job (see :func:`mureo.context.state.set_workspace_not_collected`), but
-    what an operator SEES must not depend on a writer remembering — a
-    document carrying a fresh ``fetched_at`` and a days-old
-    "could not be collected" states two contradictory answers to one
-    question, and that is the defect this field exists to remove, not to
-    reintroduce.
-
-    Put on the wire under its OWN key, never merged into a platform row: the
-    acceptance condition is that "this workspace could not be collected" and
-    "this workspace's Meta failed" do not render as one sentence. Their
-    evidence differs too — a rollup on ANY platform retires this one, while a
-    platform's note is retired only by its own rollups — so one is never
-    computed from the other.
-
-    The same three limits as the per-platform rule: any window counts, no
-    collection time means no retirement, and retirement must be PROVED (an
-    unparseable ``fetched_at``, or a note with no ``attempted_at``, leaves
-    the question open, and open is not retired).
-    """
-    if doc is None:
-        return None
-    note = _safe_not_collected(doc.workspace_not_collected)
-    if note is None:
-        return None
-    attempted = _parse_timestamp(note.get("attempted_at"))
-    if attempted is None:
-        return note
-    collected = _newest_document_collection(doc)
-    if collected is not None and collected > attempted:
-        return None
-    return note
-
-
-def _newest_document_collection(doc: StateDocument) -> datetime | None:
-    """The most recent ``fetched_at`` across EVERY platform's rollups.
-
-    ``None`` when not one platform in the document carries a usable
-    timestamp — which is not "never collected" as a fact about the world,
-    only about what the document can show.
-    """
-    newest: datetime | None = None
-    for state in (doc.platforms or {}).values():
-        collected = _newest_collection(state)
-        if collected is not None and (newest is None or collected > newest):
-            newest = collected
-    return newest
-
-
-def _newest_collection(state: PlatformState) -> datetime | None:
-    """The most recent ``fetched_at`` across ALL of a platform's rollups.
-
-    ``totals`` and every ``periods`` bucket, because any of them landing is
-    evidence the platform was reached. ``None`` when not one of them carries
-    a usable timestamp — which is not "never collected" as a fact about the
-    world, only about what the document can show.
-    """
-    rollups: list[Any] = [state.totals]
-    if isinstance(state.periods, dict):
-        rollups.extend(state.periods.values())
-    newest: datetime | None = None
-    for rollup in rollups:
-        if not isinstance(rollup, dict):
-            continue
-        raw = rollup.get("fetched_at")
-        parsed = _parse_timestamp(raw if isinstance(raw, str) else None)
-        if parsed is not None and (newest is None or parsed > newest):
-            newest = parsed
-    return newest
-
-
-def _safe_not_collected(note: dict[str, Any] | None) -> dict[str, Any] | None:
-    """The stored "why the figures did not move" note, fit to render (#638).
-
-    Returns ``{"attempted_at", "reason"}`` — the two known keys and nothing
-    else, the same whitelist discipline :func:`_safe_totals` applies, so a
-    stray or secret-shaped key a buggy or hostile writer slipped in can never
-    reach the page. ``None`` when there is no usable note, and ``None`` is put
-    on the wire explicitly so every row has one shape.
-
-    ``reason`` is truncated to
-    :data:`~mureo.context.models.NOT_COLLECTED_REASON_MAX_CHARS`. The write
-    helper caps what it stores, but a digest can write the whole document
-    without going near it, and a page of raw API JSON in a card is not a
-    reason an operator can read.
-
-    A note with no usable ``reason`` is no note: it would say something
-    happened and refuse to say what, which is the state this field exists to
-    end. ``attempted_at`` is relayed verbatim, like ``fetched_at`` — the only
-    clue to the writer that produced an uninterpretable one.
-    """
-    if not isinstance(note, dict):
-        return None
-    reason = note.get("reason")
-    if not isinstance(reason, str) or not reason.strip():
-        return None
-    attempted_at = note.get("attempted_at")
-    return {
-        "attempted_at": (
-            attempted_at.strip()
-            if isinstance(attempted_at, str) and attempted_at.strip()
-            else None
-        ),
-        "reason": reason.strip()[:NOT_COLLECTED_REASON_MAX_CHARS],
-    }
-
-
-def _safe_totals(totals: dict[str, Any] | None) -> dict[str, Any] | None:
-    """Copy only canonical metric keys out of ``totals`` (or ``None``).
-
-    Whitelisting the keys means a stray/secret-shaped key a buggy or hostile
-    writer slipped into ``totals`` can never reach the dashboard. ``None``
-    (no rollup) is preserved so the frontend can distinguish "no metrics"
-    from "zeroed metrics".
-    """
-    if not totals:
-        return None
-    return {k: totals[k] for k in _CANONICAL_TOTAL_KEYS if k in totals} or None
 
 
 def _build_recent_actions(doc: StateDocument | None) -> list[dict[str, Any]]:

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1766,7 +1766,7 @@ class TestSetPlatformMetricsFetchedAt:
     ) -> None:
         """The read side deliberately relays an uninterpretable value rather
         than blanking it — it is the only clue to the writer that produced it
-        (see ``mureo.web.reports._platform_freshness``). Stamping over it here
+        (see ``mureo.web.report_document._platform_freshness``). Stamping over it here
         would throw that clue away before it ever reached the document."""
         fp = tmp_path / "STATE.json"
         write_state_file(fp, StateDocument(version="2"))

--- a/tests/test_web_reports_conflicts.py
+++ b/tests/test_web_reports_conflicts.py
@@ -521,7 +521,7 @@ def _write_path_builtin_keys() -> set[str]:
     assert enumeration is not None, (
         "mureo_state_platform_metrics_set no longer describes its built-in "
         "platform keys as 'a built-in (...)'. This test anchors "
-        "mureo.web.reports._BUILTIN_DISPLAY_NAMES to that enumeration; "
+        "mureo.web.report_labels._BUILTIN_DISPLAY_NAMES to that enumeration; "
         "re-point it at the new wording rather than deleting it, or an "
         "unlisted native key silently earns a permanent 'unrecognized_key' "
         f"banner. Description was: {description!r}"


### PR DESCRIPTION
## What

`mureo/web/reports.py` was 1,070 lines holding twenty-six functions across eight concerns: platform naming, the tolerant STATE.json read, conflict detection, freshness, the period vocabulary, `not_collected` notes, wire sanitisation, and the summary assembly that uses all of them.

| File | Lines |
|---|---|
| `mureo/web/reports.py` | 1,070 → **386** |
| `mureo/web/report_document.py` (new) | **624** |
| `mureo/web/report_labels.py` (new) | **185** |

**`report_labels.py`** — platform key → the name an operator reads. Three cases, and the third carries the weight: an unrecognisable key is returned **unchanged**, which is precisely how `CONFLICT_UNRECOGNIZED_KEY` is defined. A prettier fallback invented here would silently switch off a conflict finding a module away, so the two now sit one import apart and say so.

**`report_document.py`** — everything asked OF one stored document: the tolerant read, the two conflict findings (#533), freshness (#535), which windows the document carries, its `not_collected` notes (#638), and the canonical-key filter that decides what may reach the wire.

**`reports.py`** — the assembly: resolve the store, walk the document once, shape the payload. Plus the facade every existing importer already targets.

Import direction is one-way — `reports` → `report_document` → `report_labels` — so there is no cycle to reason about.

## Why this file could be cut where `mcp/server.py` could not

The two mechanisms that pinned `server.py` in place (#684) are both absent here. Measured, not assumed:

- **Nothing reloads `mureo.web.reports`.** `importlib.reload` appears nowhere against it, so no module-level statement has to stay put in order to be re-run.
- **Nothing monkey-patches a name on it.** All twenty runtime-context patches in the suite target `"mureo.web.report_clients.get_runtime_context"` — a module that was already split out. The one clock patch goes to `mureo.core.clock.server_now`, and this module reaches it as a module attribute (`clock.server_now()`), which survives any move.
- **No static text pins.** No test reads any `mureo/**.py` as source, so none of the grep-pin problem that blocks the `dashboard.js` half of #678 applies here.

## Equivalence

- All **26** top-level definitions are present across the three files with identical `ast.dump(..., include_attributes=False)` output. **0 missing, 0 added, 0 changed bodies.**
- Of the **31** module-level statements, **29 survive verbatim**. The two that do not are (a) the module docstring, extended with a "Where the pieces live" section — the original text is asserted to be a verbatim prefix of the new one — and (b) the `if TYPE_CHECKING:` block, split across the three files with the union of its names preserved.
- Every name is re-exported from `mureo.web.reports`: the nine in `__all__`, plus the four private tables the suite reads off it directly (`_BUILTIN_DISPLAY_NAMES`, `_OFFICIAL_BRIDGE_DISPLAY_NAMES`, `_PERIOD_ORDER`, `_PERIOD_LENGTH_DAYS`). `from mureo.web.reports import platform_display_name` and `mureo.web.reports._BUILTIN_DISPLAY_NAMES` resolve exactly as before.
- Ten docstring cross-references in `mureo/` are re-pointed at the module each function moved to (`context/observations.py`, `context/models.py` ×2, `context/platform_repair.py`, `context/state.py` ×4, `core/metrics_windows.py`). `mureo.web.reports._platform_row` is deliberately left alone — that one stayed. References to `platform_display_name` are left pointing at the facade, which is its public surface and still correct.

### Test changes: two prose strings, no assertion touched

- `tests/test_web_reports_conflicts.py` — one assertion **message** string naming `_BUILTIN_DISPLAY_NAMES`, re-pointed at `report_labels`.
- `tests/test_state.py` — one **docstring** naming `_platform_freshness`, re-pointed at `report_document`.

Neither is the subject of an assertion. No assertion, fixture, import or test name changed anywhere in the suite.

## Verification

- `pytest tests/ -q` → **`14 failed, 9832 passed, 8 skipped in 675.27s`**. The same 14 pre-existing failures as `origin/main`, name for name (`tests/analytics/builtin/test_live_clients.py` ×9, `test_mcp_server.py::TestListTools::test_list_tools_returns_all_tools`, `test_mcp_server_plugin_wiring.py::test_no_plugins_is_additive_no_op`, `test_mcp_tool_provider.py::test_default_discover_is_registry_and_yields_no_op_when_empty`, `test_web_handlers.py` ×2). **Zero new failures.**
- Reports-focused group (13 files, 681 tests) → `2 failed, 679 passed`; both failures are the pre-existing `test_web_handlers.py` pair.
- `node --test tests/js/*.test.js` → 355 pass, 0 fail.
- `black --check mureo/ tests/` → 742 files unchanged. `ruff check mureo/ tests/` → All checks passed.
- `mypy` → 14 errors, all pre-existing `import-untyped` missing-stub reports (`jsonschema`, `openpyxl`, `google.protobuf`); identical count and set on the unmodified tree.

Refs #678
