### PR TITLE
feat: yesterday's movement and the week behind it (#691 phase 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,6 +234,17 @@
   impressions are never coloured at all — volume rising is neither good nor
   bad without a target nothing puts on the wire.
 
+  **Both figures in a delta come from the same place.** The day a metric moved
+  FROM is read out of `daily` by date, never computed as headline minus
+  difference — those two come from different parts of the payload (the window
+  rollup and the day-grain series), and subtracting one from the other printed
+  a figure that existed in neither. Where the rollup and the newest stored day
+  disagree about the same day, or where the series does not back the
+  difference it is said to summarise, no movement is stated at all: which of
+  the two is right is exactly what this layer cannot tell. It also means a
+  one-day movement is not shown under a multi-day window total, which was
+  never a comparison worth making.
+
   No percentages anywhere. #690 carries absolute differences only, and a
   percentage needs a rule for a zero baseline that nothing in the product has
   chosen. The roster table carries neither chart nor delta: its rows are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,6 +206,41 @@
 
 ### Fixed
 
+- **Yesterday's movement and the week behind it, on the figures they belong
+  to** (#691 phase 4). #690 has been storing day-grain history and computing a
+  day-over-day delta since it landed; nothing outside the change-cards tier
+  drew either, so a platform card stated today's spend with no indication of
+  whether it was ordinary.
+
+  Each KPI cell on a platform card now carries the absolute difference from
+  the day before and a seven-day line. Both are annotations sized to stay
+  that — caption-sized text and a 28px chart — and both are optional: an
+  install whose daily history has not started accumulating renders neither,
+  with no empty frame, no dash and no reserved space. That is the state every
+  install begins in, so it is the one the layout is pinned in.
+
+  **Gaps are drawn as gaps.** `daily` omits a day the collector missed rather
+  than zero-filling it, so points are placed on a DATE axis and a run of days
+  that are not calendar-adjacent is a break in the line, never a segment
+  across it. Plotting the buckets at even intervals would have quietly
+  repaired every gap: a Monday and the Thursday before it would sit one step
+  apart and read as an ordinary day-over-day move. A day whose neighbours are
+  both missing is drawn as a dot, because a one-point line paints nothing and
+  the measurement is real.
+
+  Colour is unchanged from the table #694 introduced, now shared by both
+  tiers rather than copied: CPA up is bad and down is good, conversions the
+  reverse, CTR down is bad and up is neutral, and spend, clicks and
+  impressions are never coloured at all — volume rising is neither good nor
+  bad without a target nothing puts on the wire.
+
+  No percentages anywhere. #690 carries absolute differences only, and a
+  percentage needs a rule for a zero baseline that nothing in the product has
+  chosen. The roster table carries neither chart nor delta: its rows are
+  per-client while this history is per-platform, and summing it across a
+  client's platforms would state a figure nobody measured whenever one
+  platform has a day another does not.
+
 - **What the analysis flagged now reaches the Reports roster** (#699). A client
   whose latest report raised `zero_conversions` — the analysis layer's loudest
   grade, the one it paints red — was filed by the roster under "Nothing

--- a/mureo/_data/web/app.css
+++ b/mureo/_data/web/app.css
@@ -3647,6 +3647,84 @@ dialog[data-confirm-dialog] [data-confirm-ok] {
 /* ---- (3) per platform -------------------------------------------------- */
 
 /* CPA, beside spend and at the same weight. Two figures, then the rest. */
+/* ------------------------------------------------------------------
+   Day-over-day movement and the seven-day line (#691 phase 4).
+
+   Both are ANNOTATIONS on a figure, and are sized to stay that: the delta
+   is caption-sized and the chart is 28px tall, so a KPI cell that gains
+   them does not become a cell with two figures in it. Neither reserves
+   space — an install with no daily history yet renders neither element at
+   all, and the cell looks exactly as it did before this feature existed.
+   ------------------------------------------------------------------ */
+
+.report-delta {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 6px;
+  font-size: var(--type-caption-size);
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.report-delta-move {
+  font-weight: var(--type-card-title-weight);
+  color: var(--ink-soft);
+}
+
+/* Only the axes where a direction MEANS something are coloured. Spend,
+   clicks and impressions keep the neutral ink above — see
+   REPORTS_CHANGE_TONE, and #694, where colouring all of them red made the
+   colour worth nothing. */
+.report-delta.is-bad .report-delta-move {
+  color: var(--status-alert);
+}
+
+.report-delta.is-good .report-delta-move {
+  color: var(--status-ok);
+}
+
+.report-delta-prev {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.sparkline {
+  display: block;
+  width: 100%;
+  max-width: 120px;
+  height: 28px;
+  margin-top: 2px;
+  overflow: visible;
+}
+
+.sparkline-line {
+  fill: none;
+  stroke: var(--hairline-strong);
+  stroke-width: 1.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  /* The line is scaled non-uniformly by preserveAspectRatio, which would
+     stretch the stroke with it and leave a week reading thicker than a
+     fortnight. */
+  vector-effect: non-scaling-stroke;
+}
+
+/* The newest day — the one whose value is printed above — in the accent, so
+   the eye lands on the figure the text is talking about. */
+.sparkline-head {
+  fill: var(--accent);
+  stroke: none;
+}
+
+/* A day whose neighbours are both missing. It is a real measurement and a
+   one-point polyline paints nothing, so it is drawn as a dot rather than
+   silently dropped. */
+.sparkline-gap-point {
+  fill: var(--hairline-strong);
+  stroke: none;
+}
+
 .report-card-second {
   display: flex;
   flex-direction: column;

--- a/mureo/_data/web/app.html
+++ b/mureo/_data/web/app.html
@@ -612,6 +612,7 @@
        one, so they MUST come first. -->
   <script src="/static/reports_logic.js"></script>
   <script src="/static/reports_format.js"></script>
+  <script src="/static/reports_sparkline.js"></script>
   <script src="/static/reports_order.js"></script>
   <script src="/static/reports_triage.js"></script>
   <script src="/static/reports_overview.js"></script>

--- a/mureo/_data/web/dashboard.js
+++ b/mureo/_data/web/dashboard.js
@@ -214,6 +214,7 @@
   const missingReportsModules = [
     ["MUREO_REPORTS_LOGIC", "reports_logic.js"],
     ["MUREO_REPORTS_FORMAT", "reports_format.js"],
+    ["MUREO_REPORTS_SPARKLINE", "reports_sparkline.js"],
     ["MUREO_REPORTS_ORDER", "reports_order.js"],
     ["MUREO_REPORTS_TRIAGE", "reports_triage.js"],
     ["MUREO_REPORTS_OVERVIEW", "reports_overview.js"],

--- a/mureo/_data/web/dashboard_reports.js
+++ b/mureo/_data/web/dashboard_reports.js
@@ -92,6 +92,12 @@
   const renderReportsActions = R_REPORT.renderReportsActions;
   const renderReportsLatest = R_REPORT.renderReportsLatest;
   const buildReportFlagRow = R_REPORT.buildReportFlagRow;
+  // The tone table and the trend builders live in the report module now,
+  // bound by their original names so every call site below reads unchanged
+  // (#691 phase 4 — tier (3) draws deltas too, and one movement must not
+  // be good news on one tier and bad on the other).
+  const changeTone = R_REPORT.changeTone;
+  const buildMetricSparkline = R_REPORT.buildMetricSparkline;
 
   // dashboard_reports_overview.js's exports, bound by their original names so every call
   // site below reads exactly as it did when this was one file.
@@ -481,18 +487,6 @@
   //
   // A metric absent from this table is neutral. Direction still reaches the
   // reader — the card prints an arrow — so nothing is lost by not colouring.
-  const REPORTS_CHANGE_TONE = {
-    cpa: { up: "is-bad", down: "is-good" },
-    conversions: { up: "is-good", down: "is-bad" },
-    ctr: { up: "is-flat", down: "is-bad" },
-  };
-
-  function changeTone(key, diff) {
-    const axis = REPORTS_CHANGE_TONE[key];
-    if (!axis) return "is-flat";
-    return diff > 0 ? axis.up : axis.down;
-  }
-
   // One change card: label, figure, and what it moved from.
   function buildChangeCard(row) {
     const card = document.createElement("div");
@@ -539,6 +533,13 @@
       delta.appendChild(prev);
     }
     card.appendChild(delta);
+    // The week behind the one-day move (#691 phase 4). A row only reaches
+    // this function when `daily_delta` gave it a movement, so there are at
+    // least two adjacent days — but not necessarily two PLOTTABLE ones for
+    // this metric, so the result is still optional and simply absent when
+    // there is no line to draw.
+    const spark = buildMetricSparkline(row.platform, row.key);
+    if (spark) card.appendChild(spark);
     return card;
   }
 

--- a/mureo/_data/web/dashboard_reports.js
+++ b/mureo/_data/web/dashboard_reports.js
@@ -97,6 +97,7 @@
   // (#691 phase 4 — tier (3) draws deltas too, and one movement must not
   // be good news on one tier and bad on the other).
   const changeTone = R_REPORT.changeTone;
+  const deltaEndpoints = R_REPORT.deltaEndpoints;
   const buildMetricSparkline = R_REPORT.buildMetricSparkline;
 
   // dashboard_reports_overview.js's exports, bound by their original names so every call
@@ -452,11 +453,21 @@
         const diff = metrics[key];
         if (typeof diff !== "number" || !isFinite(diff) || diff === 0) return;
         const now = p.totals && p.totals[key];
+        const value = typeof now === "number" && isFinite(now) ? now : null;
+        // Both figures on this card have to come from `daily` — the movement
+        // AND the day it moved from. deltaEndpoints reads them out of the
+        // series by date and refuses when the series and the window rollup
+        // disagree about the same day, which is the mixture that put a
+        // "from 1,712" under a card whose stored days said 2,992 → 3,855.
+        // A card that cannot state where it moved from is not drawn.
+        const ends = deltaEndpoints(p, key, value);
+        if (!ends) return;
         rows.push({
           platform: p,
           key: key,
           diff: diff,
-          value: typeof now === "number" && isFinite(now) ? now : null,
+          value: value,
+          previous: ends.previous,
           rank: REPORTS_CHANGE_PRIORITY.indexOf(key),
         });
       });
@@ -519,19 +530,18 @@
       (row.diff > 0 ? "↑ " : "↓ ") +
       formatKpi(row.key, row.key === "cpa" ? Math.round(row.diff) : Math.abs(row.diff));
     delta.appendChild(arrow);
-    if (row.value !== null) {
-      const prev = document.createElement("span");
-      prev.className = "reports-change-prev";
-      prev.textContent = MUREO.t("dashboard.reports_delta_prev", {
-        value: formatKpi(
-          row.key,
-          row.key === "cpa"
-            ? Math.round(row.value - row.diff)
-            : row.value - row.diff
-        ),
-      });
-      delta.appendChild(prev);
-    }
+    // The stored figure for the day it moved from, never `value - diff`:
+    // those two come from different places on the wire and subtracting one
+    // from the other printed a number that was in neither.
+    const prev = document.createElement("span");
+    prev.className = "reports-change-prev";
+    prev.textContent = MUREO.t("dashboard.reports_delta_prev", {
+      value: formatKpi(
+        row.key,
+        row.key === "cpa" ? Math.round(row.previous) : row.previous
+      ),
+    });
+    delta.appendChild(prev);
     card.appendChild(delta);
     // The week behind the one-day move (#691 phase 4). A row only reaches
     // this function when `daily_delta` gave it a movement, so there are at

--- a/mureo/_data/web/dashboard_reports_report.js
+++ b/mureo/_data/web/dashboard_reports_report.js
@@ -192,22 +192,88 @@
   }
 
   /**
+   * The two days `daily_delta` compared, READ OUT OF `daily`, or `null`.
+   *
+   * This exists because the previous day's figure used to be back-calculated
+   * as `headline - diff`, and those two numbers come from different places:
+   * the headline is the window rollup (`periods`), the difference is derived
+   * from `daily`. Subtracting one from the other produced a figure that
+   * existed in NEITHER — a card reading "CPA 2,575, ↑ 863, from 1,712" while
+   * the stored days said 2,992 → 3,855. Nothing on the wire had ever said
+   * 1,712. That is the #659/#671 shape: one question, two sources, and an
+   * answer assembled from both.
+   *
+   * So the previous value is now looked up by DATE. `daily_delta` names the
+   * two days it compared (`from`/`to`), which is the only unambiguous link
+   * between the difference and the series behind it — the last two entries
+   * of `daily` are usually those days but are not guaranteed to be.
+   *
+   * `null`, meaning "not comparable", in every case where the two sources
+   * cannot be reconciled:
+   *
+   * - **no movement stated.** #690 gave no `daily_delta`, or none for this
+   *   metric — fewer than two days, a calendar gap, or a metric only one
+   *   side carries.
+   * - **the named days are not in `daily`,** or do not state this metric as
+   *   a number. There is nothing to read.
+   * - **the series disagrees with the difference.** `latest - previous`
+   *   ought to be exactly `diff`; where it is not, one of the two is wrong
+   *   and this layer cannot tell which.
+   * - **the headline disagrees with the newest day.** The card's figure and
+   *   the series' last day describe the same day and should be the same
+   *   number. They can drift when a window rollup and the daily bucket were
+   *   collected at different moments, and a day-over-day delta under a
+   *   headline it was not computed from is exactly the mixture this function
+   *   exists to prevent. Note this also, correctly, suppresses the delta
+   *   when the operator selects a multi-day window: a one-day movement under
+   *   a thirty-day total is not that total's movement.
+   *
+   * A headline of `null` is not a disagreement — there is nothing to
+   * contradict, and both figures below still come from `daily` alone.
+   */
+  function deltaEndpoints(platform, key, headline) {
+    const delta = platform && platform.daily_delta;
+    if (!delta || typeof delta !== "object") return null;
+    const metrics = delta.metrics;
+    const diff = metrics && typeof metrics === "object" ? metrics[key] : undefined;
+    if (typeof diff !== "number" || !isFinite(diff)) return null;
+
+    const series = Array.isArray(platform.daily) ? platform.daily : [];
+    const valueOn = function (date) {
+      let found = null;
+      series.forEach(function (bucket) {
+        if (!bucket || typeof bucket !== "object" || bucket.date !== date) return;
+        const totals = bucket.totals;
+        const value = totals && typeof totals === "object" ? totals[key] : undefined;
+        if (typeof value === "number" && isFinite(value)) found = value;
+      });
+      return found;
+    };
+    const previous = valueOn(delta.from);
+    const latest = valueOn(delta.to);
+    if (previous === null || latest === null) return null;
+    if (latest - previous !== diff) return null;
+    if (typeof headline === "number" && isFinite(headline) && headline !== latest) {
+      return null;
+    }
+    return { previous: previous, latest: latest, diff: diff };
+  }
+
+  /**
    * "↑ 1,200  from 4,200" for one metric, or `null`.
    *
-   * `null` whenever #690 declined to state the movement — fewer than two
-   * days, a calendar gap between the last two, or a metric only one of them
-   * carries. All three mean the comparison cannot honestly be made, and a
-   * caller that appends whatever it gets then shows nothing rather than a
-   * fabricated zero.
+   * Everything it states comes from `daily` — see deltaEndpoints for the
+   * reconciliation, and for why the answer is `null` rather than a
+   * best-effort number whenever the sources do not line up.
    *
    * Absolute difference only. A percentage needs a rule for a zero baseline
    * and #690 does not carry one, so inventing it here would be this layer
    * making up the very thing the server refused to.
    */
-  function buildDeltaElement(delta, key, current) {
-    const metrics = delta && typeof delta === "object" ? delta.metrics : null;
-    const diff = metrics && typeof metrics === "object" ? metrics[key] : undefined;
-    if (typeof diff !== "number" || !isFinite(diff)) return null;
+  function buildDeltaElement(platform, key, headline) {
+    const ends = deltaEndpoints(platform, key, headline);
+    if (!ends) return null;
+    const diff = ends.diff;
 
     const el = document.createElement("span");
     el.className = "report-delta " + changeTone(key, diff);
@@ -219,14 +285,15 @@
       (diff > 0 ? "↑ " : diff < 0 ? "↓ " : "± ") +
       formatKpi(key, roundedFor(key, Math.abs(diff)));
     el.appendChild(arrow);
-    if (typeof current === "number" && isFinite(current)) {
-      const prev = document.createElement("span");
-      prev.className = "report-delta-prev";
-      prev.textContent = MUREO.t("dashboard.reports_delta_prev", {
-        value: formatKpi(key, roundedFor(key, current - diff)),
-      });
-      el.appendChild(prev);
-    }
+    // The stored figure for that day, not `headline - diff`. See
+    // deltaEndpoints: the subtraction mixed two sources and printed a number
+    // neither of them held.
+    const prev = document.createElement("span");
+    prev.className = "report-delta-prev";
+    prev.textContent = MUREO.t("dashboard.reports_delta_prev", {
+      value: formatKpi(key, roundedFor(key, ends.previous)),
+    });
+    el.appendChild(prev);
     return el;
   }
 
@@ -259,7 +326,7 @@
    * layout has to look right in.
    */
   function appendTrend(cell, platform, key, current) {
-    const delta = buildDeltaElement(platform && platform.daily_delta, key, current);
+    const delta = buildDeltaElement(platform, key, current);
     if (delta) cell.appendChild(delta);
     const spark = buildMetricSparkline(platform, key);
     if (spark) cell.appendChild(spark);
@@ -802,6 +869,7 @@
     // (3)'s platform cards colour one movement one way (#691 phase 4).
     REPORTS_CHANGE_TONE: REPORTS_CHANGE_TONE,
     changeTone: changeTone,
+    deltaEndpoints: deltaEndpoints,
     buildDeltaElement: buildDeltaElement,
     buildMetricSparkline: buildMetricSparkline,
     appendTrend: appendTrend,

--- a/mureo/_data/web/dashboard_reports_report.js
+++ b/mureo/_data/web/dashboard_reports_report.js
@@ -154,6 +154,117 @@
     return parts.join(STALE_FIGURE_SEPARATOR);
   }
 
+  // ------------------------------------------------------------------
+  // Day-over-day movement (#691 phase 4)
+  // ------------------------------------------------------------------
+
+  /**
+   * Which direction of a metric is worth colouring, and how.
+   *
+   * Spend, clicks and impressions are absent on purpose: they are volume,
+   * and volume going up is neither good nor bad without a target nobody has
+   * put on the wire. Colouring them was the #694 capture's finding — every
+   * delta arrived red, including a spend rise, which trains an operator to
+   * ignore the colour entirely. CTR rising is "is-flat" for the narrower
+   * version of the same reason: a small rise is not an achievement worth
+   * announcing, while a fall is worth a look.
+   *
+   * Lives here rather than in dashboard_reports.js because BOTH tiers draw
+   * deltas now — the change cards in (2) and the platform cards in (3) — and
+   * a second copy is how two rows describing the same movement start
+   * disagreeing about whether it was good news.
+   */
+  const REPORTS_CHANGE_TONE = {
+    cpa: { up: "is-bad", down: "is-good" },
+    conversions: { up: "is-good", down: "is-bad" },
+    ctr: { up: "is-flat", down: "is-bad" },
+  };
+
+  function changeTone(key, diff) {
+    const axis = REPORTS_CHANGE_TONE[key];
+    if (!axis) return "is-flat";
+    return diff > 0 ? axis.up : axis.down;
+  }
+
+  /** CPA is carried to the yen; the rest keep whatever precision they have. */
+  function roundedFor(key, value) {
+    return key === "cpa" ? Math.round(value) : value;
+  }
+
+  /**
+   * "↑ 1,200  from 4,200" for one metric, or `null`.
+   *
+   * `null` whenever #690 declined to state the movement — fewer than two
+   * days, a calendar gap between the last two, or a metric only one of them
+   * carries. All three mean the comparison cannot honestly be made, and a
+   * caller that appends whatever it gets then shows nothing rather than a
+   * fabricated zero.
+   *
+   * Absolute difference only. A percentage needs a rule for a zero baseline
+   * and #690 does not carry one, so inventing it here would be this layer
+   * making up the very thing the server refused to.
+   */
+  function buildDeltaElement(delta, key, current) {
+    const metrics = delta && typeof delta === "object" ? delta.metrics : null;
+    const diff = metrics && typeof metrics === "object" ? metrics[key] : undefined;
+    if (typeof diff !== "number" || !isFinite(diff)) return null;
+
+    const el = document.createElement("span");
+    el.className = "report-delta " + changeTone(key, diff);
+    const arrow = document.createElement("b");
+    // The direction is a character before it is a colour, so the row still
+    // reads for anyone the colour does not reach.
+    arrow.className = "report-delta-move";
+    arrow.textContent =
+      (diff > 0 ? "↑ " : diff < 0 ? "↓ " : "± ") +
+      formatKpi(key, roundedFor(key, Math.abs(diff)));
+    el.appendChild(arrow);
+    if (typeof current === "number" && isFinite(current)) {
+      const prev = document.createElement("span");
+      prev.className = "report-delta-prev";
+      prev.textContent = MUREO.t("dashboard.reports_delta_prev", {
+        value: formatKpi(key, roundedFor(key, current - diff)),
+      });
+      el.appendChild(prev);
+    }
+    return el;
+  }
+
+  /**
+   * The sparkline for one metric of one platform, or `null`.
+   *
+   * Resolved at call time: reports_sparkline.js publishes its global the same
+   * way every module in this family does, and a missing one is a load-order
+   * bug rather than something to paper over.
+   */
+  function buildMetricSparkline(platform, key) {
+    const api = typeof window !== "undefined" ? window.MUREO_REPORTS_SPARKLINE : null;
+    if (!api) {
+      throw new Error(
+        "MUREO_REPORTS_SPARKLINE (reports_sparkline.js) is missing — its " +
+          "<script> tag must come BEFORE dashboard_reports_report.js."
+      );
+    }
+    return api.buildSparkline(platform && platform.daily, key);
+  }
+
+  /**
+   * Append the delta and the sparkline for `key` to a KPI cell, if any.
+   *
+   * Both are optional and independent: an install with two days has a delta
+   * and a two-point line, one with a gap before yesterday has a line and no
+   * delta, and a fresh install has neither and gets neither — no empty
+   * frame, no dash, no reserved space. That is the DEFAULT state of this
+   * feature until daily-check has run for a while, so it is the one the
+   * layout has to look right in.
+   */
+  function appendTrend(cell, platform, key, current) {
+    const delta = buildDeltaElement(platform && platform.daily_delta, key, current);
+    if (delta) cell.appendChild(delta);
+    const spark = buildMetricSparkline(platform, key);
+    if (spark) cell.appendChild(spark);
+  }
+
   // Build one KPI card for a single platform entry. `summary` is optional and
   // supplies the conflict context (the platform row itself carries none).
   function buildReportCard(platform, summary) {
@@ -264,6 +375,10 @@
     // carrying both spend and CPA read in two directions at once.
     headline.appendChild(headlineLabel);
     headline.appendChild(headlineValue);
+    // The two slots phase 1 reserved in the card anatomy (label → value →
+    // delta → sparkline), filled. Below the withholding branch it would be
+    // unreachable for a stale row, which is right: see the note there.
+    if (!rowStale) appendTrend(headline, platform, "spend", totals.spend);
     card.appendChild(headline);
 
     if (rowStale) {
@@ -297,6 +412,7 @@
       label.textContent = MUREO.t(REPORTS_KPI_LABELS.cpa);
       second.appendChild(label);
       second.appendChild(value);
+      appendTrend(second, platform, "cpa", totals.cpa);
       card.appendChild(second);
     }
 
@@ -682,6 +798,13 @@
 
 
   const api = {
+    // Shared with dashboard_reports.js so tier (2)'s change cards and tier
+    // (3)'s platform cards colour one movement one way (#691 phase 4).
+    REPORTS_CHANGE_TONE: REPORTS_CHANGE_TONE,
+    changeTone: changeTone,
+    buildDeltaElement: buildDeltaElement,
+    buildMetricSparkline: buildMetricSparkline,
+    appendTrend: appendTrend,
     buildStaleFiguresElement: buildStaleFiguresElement,
     staleAggregateFiguresText: staleAggregateFiguresText,
     clientKpiCell: clientKpiCell,

--- a/mureo/_data/web/reports_sparkline.js
+++ b/mureo/_data/web/reports_sparkline.js
@@ -1,0 +1,211 @@
+// reports_sparkline.js — seven days of one metric, as a line (#691 phase 4).
+//
+// WHAT IT DRAWS. `daily` from #690: up to seven day-grain buckets, ascending,
+// WITH THEIR GAPS INTACT. A day the collector missed is simply absent from
+// the list — nothing zero-fills it, because "not collected" and "collected,
+// and the answer was zero" are different facts and an invented zero reads as
+// a day the account stopped spending.
+//
+// So this file's whole difficulty is the x axis. Plotting the buckets at
+// even intervals would quietly repair every gap: a Monday and the Thursday
+// before it would sit one step apart and the line between them would look
+// like an ordinary day-over-day move. Points are therefore placed by DATE,
+// and a run of days that are not calendar-adjacent is drawn as a break in
+// the line rather than a segment across it. A gap you can see is the point.
+//
+// WHAT IT REFUSES. Fewer than two plottable days draws nothing at all — not
+// an empty frame, not a flat line. A single point is not a trend, and a box
+// reserved for a chart that never arrives is a promise the data has not
+// kept. Callers append whatever this returns and get `null` when there is
+// nothing honest to show, so an install whose daily history has not started
+// accumulating simply has no sparklines rather than a row of empty boxes.
+//
+// NO PERCENTAGES ANYWHERE. #690 carries absolute differences only; a
+// percentage needs a rule for a zero baseline, and this layer does not get
+// to invent one.
+//
+// Shipping shape: a plain `<script>`-loaded file publishing ONE global,
+// `window.MUREO_REPORTS_SPARKLINE`. It depends on nothing but the DOM, so it
+// may load anywhere before its callers.
+
+(function () {
+  "use strict";
+
+  //: The drawing box, in user units. The viewBox scales to whatever width
+  //: CSS gives it; only the ASPECT is fixed here. 28 high because that is
+  //: what a KPI card can carry under its figure without the card growing a
+  //: line — the chart is an annotation on the number, not a second figure.
+  const WIDTH = 72;
+  const HEIGHT = 28;
+  //: Half the stroke, so the extremes are not clipped by the viewBox edge.
+  const PAD = 2;
+  const SVG_NS = "http://www.w3.org/2000/svg";
+
+  //: Below this many plottable points there is no line to draw.
+  const MIN_POINTS = 2;
+
+  const MS_PER_DAY = 86400000;
+
+  /** `YYYY-MM-DD` → day number, or null if it is not a real date. */
+  function dayNumber(text) {
+    if (typeof text !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(text)) return null;
+    const ms = Date.parse(text + "T00:00:00Z");
+    if (isNaN(ms)) return null;
+    // Round-trip: Date.parse accepts 2026-02-30 and silently rolls it into
+    // March, which would put a point at a date nobody collected.
+    const back = new Date(ms).toISOString().slice(0, 10);
+    return back === text ? Math.round(ms / MS_PER_DAY) : null;
+  }
+
+  function isNumber(value) {
+    return typeof value === "number" && isFinite(value);
+  }
+
+  /**
+   * The plottable points of `series` for `key`: `[{day, value}]`, ascending.
+   *
+   * A bucket contributes only when it has a real date AND states this metric
+   * as a number. Everything else is left out rather than defaulted, which is
+   * what makes the gaps below real gaps.
+   */
+  function points(series, key) {
+    if (!Array.isArray(series)) return [];
+    const out = [];
+    series.forEach(function (bucket) {
+      if (!bucket || typeof bucket !== "object") return;
+      const day = dayNumber(bucket.date);
+      if (day === null) return;
+      const totals = bucket.totals;
+      const value = totals && typeof totals === "object" ? totals[key] : undefined;
+      if (!isNumber(value)) return;
+      out.push({ day: day, value: value });
+    });
+    out.sort(function (a, b) {
+      return a.day - b.day;
+    });
+    return out;
+  }
+
+  /**
+   * `points` split into runs of calendar-adjacent days.
+   *
+   * Each run becomes its own polyline, so a missing day is a hole in the
+   * chart instead of a straight segment pretending to be one day's move.
+   */
+  function runs(pts) {
+    const out = [];
+    let current = [];
+    pts.forEach(function (point, i) {
+      if (i > 0 && point.day - pts[i - 1].day !== 1) {
+        out.push(current);
+        current = [];
+      }
+      current.push(point);
+    });
+    if (current.length) out.push(current);
+    return out;
+  }
+
+  function svgEl(name) {
+    return document.createElementNS(SVG_NS, name);
+  }
+
+  /**
+   * A sparkline for `key` over `series`, or `null` when there is none to draw.
+   *
+   * `null` rather than an empty element on purpose: the caller appends what
+   * it gets, and an empty `<svg>` still occupies its box. See the file
+   * header — the default state of this feature is "no history yet".
+   */
+  function buildSparkline(series, key) {
+    const pts = points(series, key);
+    if (pts.length < MIN_POINTS) return null;
+
+    const first = pts[0].day;
+    const span = pts[pts.length - 1].day - first;
+    let low = pts[0].value;
+    let high = pts[0].value;
+    pts.forEach(function (p) {
+      if (p.value < low) low = p.value;
+      if (p.value > high) high = p.value;
+    });
+    const range = high - low;
+
+    // A flat week is a real answer, so it draws — down the middle, because
+    // pinning it to the top or bottom of the box would read as an extreme.
+    const y = function (value) {
+      if (range === 0) return HEIGHT / 2;
+      const t = (value - low) / range;
+      return HEIGHT - PAD - t * (HEIGHT - PAD * 2);
+    };
+    // span === 0 cannot happen at two or more points (days are distinct and
+    // sorted), but dividing by it would be silent if it ever did.
+    const x = function (day) {
+      if (span === 0) return WIDTH / 2;
+      return PAD + ((day - first) / span) * (WIDTH - PAD * 2);
+    };
+
+    const svg = svgEl("svg");
+    svg.setAttribute("class", "sparkline");
+    svg.setAttribute("viewBox", "0 0 " + WIDTH + " " + HEIGHT);
+    svg.setAttribute("preserveAspectRatio", "none");
+    // Decorative: every figure this annotates is already stated in text
+    // beside it, so a screen reader announcing a polyline would be repeating
+    // the number in a form nobody can use.
+    svg.setAttribute("aria-hidden", "true");
+    svg.setAttribute("focusable", "false");
+
+    runs(pts).forEach(function (run) {
+      if (run.length === 1) {
+        // An isolated day — both neighbours missing. It is a real
+        // measurement, so it is shown as a dot; a one-point polyline paints
+        // nothing at all and would hide it.
+        const dot = svgEl("circle");
+        dot.setAttribute("class", "sparkline-gap-point");
+        dot.setAttribute("cx", x(run[0].day));
+        dot.setAttribute("cy", y(run[0].value));
+        dot.setAttribute("r", 1.2);
+        svg.appendChild(dot);
+        return;
+      }
+      const line = svgEl("polyline");
+      line.setAttribute("class", "sparkline-line");
+      line.setAttribute(
+        "points",
+        run
+          .map(function (p) {
+            return x(p.day) + "," + y(p.value);
+          })
+          .join(" ")
+      );
+      svg.appendChild(line);
+    });
+
+    // Where the series ends, which is the value stated next to the chart.
+    const last = pts[pts.length - 1];
+    const head = svgEl("circle");
+    head.setAttribute("class", "sparkline-head");
+    head.setAttribute("cx", x(last.day));
+    head.setAttribute("cy", y(last.value));
+    head.setAttribute("r", 2);
+    svg.appendChild(head);
+    return svg;
+  }
+
+  const api = {
+    WIDTH: WIDTH,
+    HEIGHT: HEIGHT,
+    MIN_POINTS: MIN_POINTS,
+    dayNumber: dayNumber,
+    points: points,
+    runs: runs,
+    buildSparkline: buildSparkline,
+  };
+
+  if (typeof window !== "undefined") window.MUREO_REPORTS_SPARKLINE = api;
+  // Node (test runner only): `module` does not exist in a browser, so this
+  // branch is dead code there and adds no runtime module system.
+  if (typeof module === "object" && module && module.exports) {
+    module.exports = api;
+  }
+})();

--- a/mureo/web/handlers.py
+++ b/mureo/web/handlers.py
@@ -289,6 +289,7 @@ _STATIC_ALLOWLIST: tuple[str, ...] = (
     "auth_wizards.js",
     "reports_logic.js",
     "reports_format.js",
+    "reports_sparkline.js",
     "reports_order.js",
     "reports_triage.js",
     "reports_overview.js",

--- a/tests/js/browser_contract.test.js
+++ b/tests/js/browser_contract.test.js
@@ -138,6 +138,16 @@ const MODULES = [
     ],
   },
   {
+    file: "reports_sparkline.js",
+    global: "MUREO_REPORTS_SPARKLINE",
+    // `bound` names the exports a caller reaches for. Only the builder is
+    // used in the product; the rest are exported for the JS suite, which
+    // drives the axis and the gap-splitting directly rather than inferring
+    // them from a rendered <svg>.
+    bound: ["buildSparkline"],
+    moved: ["buildSparkline", "dayNumber", "points", "runs"],
+  },
+  {
     file: "reports_triage.js",
     global: "MUREO_REPORTS_TRIAGE",
     bound: [

--- a/tests/js/dom_harness.js
+++ b/tests/js/dom_harness.js
@@ -569,6 +569,13 @@ function loadDashboardPage(routes) {
     documentElement: root,
     body: body,
     createElement: (tag) => new Element(tag),
+    // SVG. The namespace is dropped on purpose: this harness models
+    // elements by tag name and by the `class` attribute the cascade reads,
+    // and nothing it answers questions about depends on which namespace a
+    // node was born in. Present because reports_sparkline.js builds real
+    // SVG, and a missing createElementNS would fail as "not a function"
+    // rather than as whatever the test was actually asking.
+    createElementNS: (_ns, tag) => new Element(tag),
     createTextNode: (text) => new TextNode(text),
     querySelector: (s) => root.querySelector(s),
     querySelectorAll: (s) => root.querySelectorAll(s),
@@ -629,6 +636,7 @@ function loadDashboardPage(routes) {
   for (const file of [
     "reports_logic.js",
     "reports_format.js",
+  "reports_sparkline.js",
     "reports_order.js",
     "reports_triage.js",
     "reports_overview.js",

--- a/tests/js/reports_detail_tiers.test.js
+++ b/tests/js/reports_detail_tiers.test.js
@@ -54,6 +54,33 @@ function summaryWith(overrides) {
   );
 }
 
+/**
+ * The `daily` series a `daily_delta` was derived from.
+ *
+ * The server never emits one without the other — the delta IS
+ * `latest - previous` over these two buckets — and since #691 phase 4 the
+ * renderer reads the day it moved FROM out of this series rather than
+ * back-calculating it from the window rollup. A fixture with a delta and no
+ * series is a shape the wire cannot produce, and it would now (correctly)
+ * render no delta at all, so the two are built together here.
+ *
+ * The newest day is given `totals` verbatim, because the card's headline and
+ * the series' last day describe the same day; where they disagree the
+ * renderer withholds the delta, which is its own test below.
+ */
+function dailyFor(totals, delta) {
+  if (!delta || !delta.metrics) return [];
+  const before = {};
+  Object.keys(delta.metrics).forEach(function (key) {
+    const now = totals[key];
+    if (typeof now === "number") before[key] = now - delta.metrics[key];
+  });
+  return [
+    { date: delta.from, totals: before },
+    { date: delta.to, totals: Object.assign({}, totals) },
+  ];
+}
+
 /** One platform row, optionally carrying a day-over-day delta. */
 function platform(key, totals, delta) {
   return {
@@ -64,7 +91,7 @@ function platform(key, totals, delta) {
     campaign_count: 3,
     freshness: { fetched_at: new Date().toISOString(), stale: false },
     not_collected: null,
-    daily: [],
+    daily: dailyFor(totals, delta),
     daily_delta: delta || null,
   };
 }

--- a/tests/js/reports_sparkline.test.js
+++ b/tests/js/reports_sparkline.test.js
@@ -38,22 +38,68 @@ const DAY = 86400000;
 const dayBefore = (n) =>
   new Date(Date.parse(TODAY + "T00:00:00Z") - n * DAY).toISOString().slice(0, 10);
 
-/** A `daily` series from `[daysAgo, spend]` pairs, ascending. */
+/**
+ * A `daily` series from `[daysAgo, spend, conversions]` triples, ascending.
+ *
+ * Conversions are given rather than derived from spend so that CPA actually
+ * MOVES between days. Deriving them kept the ratio constant, which made the
+ * CPA delta zero and let a test about colouring a CPA fall pass without one.
+ */
 const series = (pairs) =>
   pairs
     .slice()
     .sort((a, b) => b[0] - a[0])
-    .map(([ago, spend]) => ({
-      date: dayBefore(ago),
-      totals: { spend: spend, conversions: Math.round(spend / 1000) },
-    }));
+    .map(([ago, spend, conversions]) => {
+      return {
+        date: dayBefore(ago),
+        totals: {
+          spend: spend,
+          conversions: conversions,
+          cpa: Math.round(spend / conversions),
+        },
+      };
+    });
 
+/**
+ * The `daily_delta` the server would compute from `daily`, or null.
+ *
+ * Derived rather than declared, because since the mixed-source fix the
+ * renderer reconciles the two: a hand-written delta that does not match the
+ * series it claims to summarise is a shape the wire cannot produce, and the
+ * renderer now (correctly) declines to draw it. Deriving keeps every fixture
+ * honest by construction.
+ */
+function deltaFrom(daily) {
+  if (daily.length < 2) return null;
+  const previous = daily[daily.length - 2];
+  const latest = daily[daily.length - 1];
+  if (spark.dayNumber(latest.date) - spark.dayNumber(previous.date) !== 1) return null;
+  const metrics = {};
+  Object.keys(latest.totals).forEach(function (key) {
+    if (typeof previous.totals[key] === "number") {
+      metrics[key] = latest.totals[key] - previous.totals[key];
+    }
+  });
+  return { from: previous.date, to: latest.date, metrics: metrics };
+}
+
+/** The window rollup the card's headline shows: the newest day, as stored. */
+const headlineOf = (daily) =>
+  daily.length ? Object.assign({}, daily[daily.length - 1].totals) : {};
+
+// The last two days move spend DOWN (15,000 -> 13,000) and CPA DOWN
+// (1,500 -> 1,000): one axis mureo has no verdict on, one where falling is
+// unambiguously good news. Both directions are asserted below.
 const WEEK = series([
-  [6, 10000], [5, 12000], [4, 9000], [3, 14000], [2, 11000], [1, 15000], [0, 13000],
+  [6, 10000, 10], [5, 12000, 10], [4, 9000, 9],
+  [3, 14000, 10], [2, 11000, 10], [1, 15000, 10], [0, 13000, 13],
 ]);
-const TWO_DAYS = series([[1, 10000], [0, 12000]]);
+const TWO_DAYS = series([[1, 10000, 10], [0, 12000, 10]]);
 // Day 3 never collected — the list simply does not contain it.
-const GAPPED = series([[6, 10000], [5, 12000], [4, 9000], [2, 11000], [1, 15000], [0, 13000]]);
+const GAPPED = series([
+  [6, 10000, 10], [5, 12000, 10], [4, 9000, 9],
+  [2, 11000, 10], [1, 15000, 10], [0, 13000, 13],
+]);
 
 // ---------------------------------------------------------------------
 // The axis
@@ -223,10 +269,17 @@ test.describe("what it draws", function () {
 const TODAY_ISO = new Date().toISOString();
 
 function platformWith(daily, delta) {
+  const stored = daily && daily.length ? daily : [];
   return {
     key: "google_ads",
     display_name: "Google Ads",
-    totals: { spend: 13000, conversions: 13, cpa: 1000, ctr: 2.2, clicks: 400, impressions: 18000 },
+    // The headline is the window rollup, and for YESTERDAY it describes the
+    // same day as the series' last bucket — so it IS that bucket here. Where
+    // the two disagree the renderer withholds the delta, which has its own
+    // test below.
+    totals: stored.length
+      ? headlineOf(stored)
+      : { spend: 13000, conversions: 13, cpa: 1000 },
     metrics_period: "YESTERDAY",
     campaign_count: 3,
     freshness: { fetched_at: TODAY_ISO, stale: false },
@@ -281,13 +334,7 @@ test.describe("the platform card in each of the four states", function () {
   });
 
   test.it("(b) two days: a chart and, with a delta on the wire, a delta", async function () {
-    const page = await openDetail(
-      platformWith(TWO_DAYS, {
-        from: dayBefore(1),
-        to: dayBefore(0),
-        metrics: { spend: 2000, cpa: -150 },
-      })
-    );
+    const page = await openDetail(platformWith(TWO_DAYS, deltaFrom(TWO_DAYS)));
     assert.ok(sparks(page).length >= 1, "two days drew no chart");
     const spendDelta = page.root
       .querySelector(".report-card-headline")
@@ -326,11 +373,7 @@ test.describe("the platform card in each of the four states", function () {
   test.it("withholds the chart from a row whose figures are withheld", async function () {
     // A stale row states no figures (#638). A chart of the days behind them
     // would be the same claim in a shape that is harder to argue with.
-    const stale = platformWith(WEEK, {
-      from: dayBefore(1),
-      to: dayBefore(0),
-      metrics: { spend: 2000 },
-    });
+    const stale = platformWith(WEEK, deltaFrom(WEEK));
     stale.freshness = { fetched_at: dayBefore(11) + "T00:00:00Z", stale: true };
     const page = await openDetail(stale);
     assert.match(page.root.querySelector(".report-card").textContent, /—/);
@@ -376,13 +419,7 @@ test.describe("a delta only where one was measured", function () {
   test.it("states an absolute difference and never a percentage", async function () {
     // #690 carries absolute differences only; a percentage needs a rule for a
     // zero baseline that nothing in the product has chosen.
-    const page = await openDetail(
-      platformWith(WEEK, {
-        from: dayBefore(1),
-        to: dayBefore(0),
-        metrics: { spend: 2000, cpa: -150 },
-      })
-    );
+    const page = await openDetail(platformWith(WEEK, deltaFrom(WEEK)));
     const text = page.root
       .querySelector(".report-card-headline")
       .querySelector(".report-delta").textContent;
@@ -394,34 +431,25 @@ test.describe("a delta only where one was measured", function () {
     // The #694 finding: every delta arrived red, including a spend rise, and
     // a colour that is always on says nothing. Spend is volume — up is
     // neither good nor bad without a target nobody has put on the wire.
-    const page = await openDetail(
-      platformWith(WEEK, {
-        from: dayBefore(1),
-        to: dayBefore(0),
-        metrics: { spend: 2000, cpa: -150 },
-      })
-    );
+    const page = await openDetail(platformWith(WEEK, deltaFrom(WEEK)));
     const spend = page.root
       .querySelector(".report-card-headline")
       .querySelector(".report-delta");
     const cpa = page.root
       .querySelector(".report-card-second")
       .querySelector(".report-delta");
-    assert.ok(spend.classList.contains("is-flat"), "a spend rise was given a verdict");
+    assert.ok(spend.classList.contains("is-flat"), "a spend move was given a verdict");
     // CPA falling is good news, and is the one axis where that is unambiguous.
+    // 1,500 -> 1,000, so there is a real movement behind this.
+    assert.match(cpa.textContent, /500/, "the CPA delta is zero, so this proves nothing");
     assert.ok(cpa.classList.contains("is-good"), "a CPA fall was not good news");
     const tone = cascade(cpa.querySelector(".report-delta-move"), "color");
     assert.match(tone.value, /--status-ok/, "won by: " + tone.selector);
   });
 
   test.it("carries the direction as a character, not as colour alone", async function () {
-    const page = await openDetail(
-      platformWith(WEEK, {
-        from: dayBefore(1),
-        to: dayBefore(0),
-        metrics: { spend: -500 },
-      })
-    );
+    // WEEK ends 15,000 -> 13,000, so the real movement is downwards.
+    const page = await openDetail(platformWith(WEEK, deltaFrom(WEEK)));
     assert.match(
       page.root
         .querySelector(".report-card-headline")
@@ -463,11 +491,7 @@ test.describe("the roster carries neither, and that is the decision", function (
           non_canonical_periods: [],
           last_synced_at: TODAY_ISO,
           platforms: [
-            platformWith(daily, {
-              from: dayBefore(1),
-              to: dayBefore(0),
-              metrics: { spend: 2000, cpa: -150 },
-            }),
+            platformWith(daily, deltaFrom(daily)),
           ],
           platform_conflicts: [],
           recent_actions: [],
@@ -499,5 +523,143 @@ test.describe("the roster carries neither, and that is the decision", function (
     const height = cascade(page.root.querySelector(".roster-row"), "height");
     assert.ok(height, "nothing sets a row height");
     assert.equal(height.value, "44px", "won by: " + height.selector);
+  });
+});
+
+// ---------------------------------------------------------------------
+// Every figure on the card comes from one place
+// ---------------------------------------------------------------------
+
+test.describe("the previous day is read, never back-calculated", function () {
+  // THE DEFECT, as it reached a capture. The headline came from the window
+  // rollup (`periods`) and the difference from `daily`, and the "from" figure
+  // was computed as headline - diff. With the two sources 2,575 and 3,855
+  // apart that printed "from 1,712" — a number that appears in neither, on a
+  // card whose stored days said 2,992 -> 3,855.
+  //
+  // Same shape as #659/#671: one question, two sources, an answer assembled
+  // out of both.
+
+  const DIVERGENT = {
+    key: "google_ads",
+    display_name: "Google Ads",
+    // The rollup disagrees with the newest stored day.
+    totals: { spend: 51500, conversions: 20, cpa: 2575 },
+    metrics_period: "YESTERDAY",
+    campaign_count: 3,
+    freshness: { fetched_at: TODAY_ISO, stale: false },
+    not_collected: null,
+    daily: [
+      { date: dayBefore(1), totals: { spend: 41888, conversions: 14, cpa: 2992 } },
+      { date: dayBefore(0), totals: { spend: 50115, conversions: 13, cpa: 3855 } },
+    ],
+    daily_delta: {
+      from: dayBefore(1),
+      to: dayBefore(0),
+      metrics: { spend: 8227, conversions: -1, cpa: 863 },
+    },
+  };
+
+  test.it("prints a previous value that exists in the series", async function () {
+    // Read off the SCREEN and checked for membership in the stored days,
+    // rather than compared against a figure this test computed the same way
+    // the renderer does — which would only prove the two agree with
+    // themselves.
+    //
+    // Worth knowing what this can and cannot catch. Once the two guards hold
+    // (the headline equals the newest stored day, and latest - previous
+    // equals the stated difference), `headline - diff` is ALGEBRAICALLY the
+    // stored previous value — so reading and back-calculating cannot be told
+    // apart from outside, and the two tests below, which drive the guards, are
+    // what actually keep the invented figure off the card. This pins the
+    // property an operator cares about: whatever route it took, the number on
+    // screen is a day that was really collected.
+    const page = await openDetail(platformWith(WEEK, deltaFrom(WEEK)));
+    const shown = page.root
+      .querySelector(".report-card-headline")
+      .querySelector(".report-delta")
+      .textContent.match(/[\d,]+/g)
+      .map((n) => Number(n.replace(/,/g, "")));
+    const stored = WEEK.map((b) => b.totals.spend);
+    const previous = WEEK[WEEK.length - 2].totals.spend;
+    assert.ok(
+      shown.includes(previous),
+      "the previous day is not on the card: " + shown.join(" ")
+    );
+    shown.forEach(function (n) {
+      // Every figure the delta prints is either a stored day or the size of
+      // the move between two of them. Nothing else has a source.
+      const isStored = stored.includes(n);
+      const isMove = stored.some((a) => stored.some((b) => Math.abs(a - b) === n));
+      assert.ok(isStored || isMove, n + " appears in no stored day");
+    });
+  });
+
+  test.it("invents nothing when the rollup and the newest day disagree", async function () {
+    const page = await openDetail(DIVERGENT);
+    const card = page.root.querySelector(".report-card");
+    assert.ok(card, "the card did not render");
+    // The headline is still stated — it is a real figure from a real source.
+    assert.match(card.textContent, /2,575/);
+    // But no movement is claimed, because which day it moved from is exactly
+    // what mureo cannot tell.
+    assert.equal(
+      page.root.querySelectorAll(".report-delta").length,
+      0,
+      "a delta was drawn across two disagreeing sources"
+    );
+    // And above all, the back-calculated figure is nowhere on the card.
+    assert.ok(
+      !card.textContent.includes("1,712"),
+      "the invented previous value is still on screen: " + card.textContent
+    );
+  });
+
+  test.it("keeps the same rule on the change cards in tier 2", async function () {
+    // The tier-2 card had its own copy of the subtraction. Both now read the
+    // one resolver, so neither can state a day the other would not.
+    const page = await openDetail(DIVERGENT);
+    const changes = page.root.querySelectorAll(".reports-change");
+    changes.forEach(function (card) {
+      assert.ok(
+        !card.textContent.includes("1,712"),
+        "tier 2 back-calculated: " + card.textContent
+      );
+    });
+    assert.equal(changes.length, 0, "a change card was built from mixed sources");
+  });
+
+  test.it("refuses when the series does not back the difference it claims", async function () {
+    // A payload whose `daily_delta` does not match the days it names. One of
+    // the two is wrong and this layer cannot tell which, so it states neither.
+    const inconsistent = JSON.parse(JSON.stringify(DIVERGENT));
+    inconsistent.totals = { spend: 50115, conversions: 13, cpa: 3855 };
+    inconsistent.daily_delta.metrics.cpa = 999;
+    const page = await openDetail(inconsistent);
+    const second = page.root.querySelector(".report-card-second");
+    assert.equal(
+      second.querySelectorAll(".report-delta").length,
+      0,
+      "a difference the series contradicts was rendered"
+    );
+    // Spend is untouched by the tampering and still states its movement.
+    assert.ok(
+      page.root
+        .querySelector(".report-card-headline")
+        .querySelector(".report-delta"),
+      "the whole card was suppressed instead of the one bad metric"
+    );
+  });
+
+  test.it("refuses when the named days are not in the series", async function () {
+    const orphaned = JSON.parse(JSON.stringify(DIVERGENT));
+    orphaned.totals = { spend: 50115, conversions: 13, cpa: 3855 };
+    orphaned.daily = [];
+    const page = await openDetail(orphaned);
+    assert.equal(
+      page.root.querySelectorAll(".report-delta").length,
+      0,
+      "a movement was stated with no series behind it"
+    );
   });
 });

--- a/tests/js/reports_sparkline.test.js
+++ b/tests/js/reports_sparkline.test.js
@@ -1,0 +1,503 @@
+// Seven days of one metric, as a line (#691 phase 4).
+//
+// Run with:  node --test tests/js/*.test.js
+//
+// Two halves, guarded differently:
+//
+//   - the AXIS — where a point goes, and where the line breaks — is arithmetic
+//     and is driven directly through the module. A gap rendered as an ordinary
+//     segment is the failure this feature exists to avoid, and it is invisible
+//     in a screenshot: the line looks perfectly plausible, it is simply about
+//     days that were never collected.
+//   - the SCREEN — whether anything is drawn at all, and whether a card
+//     without history still looks right — goes through the real dashboard
+//     against the real app.css, because "no history yet" is the DEFAULT state
+//     of this feature and an empty frame is the way it breaks.
+//
+// The four states the spec names are covered in both halves: (a) no history,
+// (b) two days, (c) seven days, (d) a week with a day missing.
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+
+const { loadDashboardPage, settle, isVisible, cascade } = require("./dom_harness.js");
+
+const WEB = path.join(__dirname, "..", "..", "mureo", "_data", "web");
+// The axis half is pure arithmetic and is required directly. The DRAWING
+// half needs a document to build SVG into, so it comes from an evaluated
+// page — the same bytes, reached the way the browser reaches them.
+const spark = require(path.join(WEB, "reports_sparkline.js"));
+const drawing = () =>
+  loadDashboardPage({}).sandbox.MUREO_REPORTS_SPARKLINE;
+
+const TODAY = new Date().toISOString().slice(0, 10);
+const DAY = 86400000;
+
+/** `n` days before today, as YYYY-MM-DD. */
+const dayBefore = (n) =>
+  new Date(Date.parse(TODAY + "T00:00:00Z") - n * DAY).toISOString().slice(0, 10);
+
+/** A `daily` series from `[daysAgo, spend]` pairs, ascending. */
+const series = (pairs) =>
+  pairs
+    .slice()
+    .sort((a, b) => b[0] - a[0])
+    .map(([ago, spend]) => ({
+      date: dayBefore(ago),
+      totals: { spend: spend, conversions: Math.round(spend / 1000) },
+    }));
+
+const WEEK = series([
+  [6, 10000], [5, 12000], [4, 9000], [3, 14000], [2, 11000], [1, 15000], [0, 13000],
+]);
+const TWO_DAYS = series([[1, 10000], [0, 12000]]);
+// Day 3 never collected — the list simply does not contain it.
+const GAPPED = series([[6, 10000], [5, 12000], [4, 9000], [2, 11000], [1, 15000], [0, 13000]]);
+
+// ---------------------------------------------------------------------
+// The axis
+// ---------------------------------------------------------------------
+
+test.describe("where the points go", function () {
+  test.it("refuses a date that is not one", function () {
+    // Date.parse happily accepts 2026-02-30 and rolls it into March, which
+    // would put a point on a day nobody collected.
+    assert.equal(spark.dayNumber("2026-02-30"), null);
+    assert.equal(spark.dayNumber("2026-13-01"), null);
+    assert.equal(spark.dayNumber("last tuesday"), null);
+    assert.equal(spark.dayNumber(""), null);
+    assert.equal(spark.dayNumber(null), null);
+    assert.ok(typeof spark.dayNumber("2026-02-28") === "number");
+    // Adjacent days are adjacent numbers — the property `runs` depends on.
+    assert.equal(spark.dayNumber("2026-03-01") - spark.dayNumber("2026-02-28"), 1);
+  });
+
+  test.it("keeps only the days that state the metric as a number", function () {
+    const mixed = [
+      { date: dayBefore(3), totals: { spend: 100 } },
+      { date: dayBefore(2), totals: { spend: null } },
+      { date: dayBefore(1), totals: {} },
+      { date: dayBefore(0), totals: { spend: 400 } },
+      { date: "not-a-date", totals: { spend: 999 } },
+      null,
+      { date: dayBefore(5) },
+    ];
+    assert.deepEqual(
+      spark.points(mixed, "spend").map((p) => p.value),
+      [100, 400],
+      "a missing or non-numeric day was defaulted rather than dropped"
+    );
+  });
+
+  test.it("splits a week into runs of calendar-adjacent days", function () {
+    // THE POINT OF THE FEATURE. Six stored buckets, but day 3 is missing, so
+    // they are not six consecutive days and must not be drawn as one line.
+    const runs = spark.runs(spark.points(GAPPED, "spend"));
+    assert.equal(runs.length, 2, "the gap was drawn straight through");
+    assert.deepEqual(runs.map((r) => r.length), [3, 3]);
+
+    // An unbroken week is one run.
+    assert.equal(spark.runs(spark.points(WEEK, "spend")).length, 1);
+  });
+
+  test.it("places a point by its date, not by its position in the list", function () {
+    // The other half of the same bug: even with the line broken, plotting by
+    // index would put the two sides of a three-day gap one step apart and
+    // compress the week into something that never happened.
+    const pts = spark.points(GAPPED, "spend");
+    const days = pts.map((p) => p.day - pts[0].day);
+    assert.deepEqual(days, [0, 1, 2, 4, 5, 6], "days are not on a date axis");
+  });
+});
+
+test.describe("what it draws", function () {
+  const polylines = (svg) =>
+    svg.children.filter((c) => c.tagName === "POLYLINE");
+
+  let build;
+  test.beforeEach(function () {
+    build = drawing().buildSparkline;
+  });
+
+  test.it("draws nothing at all without at least two days", function () {
+    // Not an empty frame: a box reserved for a chart that never arrives is a
+    // promise the data has not kept, and this is the state every install is
+    // in until daily-check has run twice.
+    assert.equal(build([], "spend"), null);
+    assert.equal(build(series([[0, 1000]]), "spend"), null);
+    assert.equal(build(null, "spend"), null);
+    assert.equal(build(undefined, "spend"), null);
+    // Seven days, but none of them state THIS metric.
+    assert.equal(build(WEEK, "ctr"), null);
+  });
+
+  test.it("draws one line for two days and one for an unbroken week", function () {
+    assert.equal(polylines(build(TWO_DAYS, "spend")).length, 1);
+    assert.equal(polylines(build(WEEK, "spend")).length, 1);
+    assert.equal(
+      polylines(build(WEEK, "spend"))[0]
+        .getAttribute("points")
+        .split(" ").length,
+      7
+    );
+  });
+
+  test.it("breaks the line where a day is missing", function () {
+    const svg = build(GAPPED, "spend");
+    const lines = polylines(svg);
+    assert.equal(lines.length, 2, "the gap was bridged");
+    // And the break is a real hole, not a zero-width seam: the last x of the
+    // first run and the first x of the second are more than one step apart.
+    const xs = (line) =>
+      line.getAttribute("points").split(" ").map((p) => Number(p.split(",")[0]));
+    const before = xs(lines[0]);
+    const after = xs(lines[1]);
+    const step = before[1] - before[0];
+    assert.ok(
+      after[0] - before[before.length - 1] > step * 1.5,
+      "the missing day left no visible gap"
+    );
+  });
+
+  test.it("marks the newest day, and only it", function () {
+    const svg = build(WEEK, "spend");
+    const heads = svg.children.filter(
+      (c) => c.getAttribute("class") === "sparkline-head"
+    );
+    assert.equal(heads.length, 1);
+    const line = polylines(svg)[0];
+    const last = line.getAttribute("points").split(" ").pop();
+    assert.equal(
+      heads[0].getAttribute("cx") + "," + heads[0].getAttribute("cy"),
+      last,
+      "the accent is not on the last point"
+    );
+  });
+
+  test.it("shows an isolated day as a dot rather than losing it", function () {
+    // Both neighbours missing. A one-point polyline paints nothing, so
+    // without this the day would be collected, real, and invisible.
+    const lonely = series([[6, 5000], [3, 9000], [1, 7000], [0, 8000]]);
+    const svg = build(lonely, "spend");
+    const dots = svg.children.filter(
+      (c) => c.getAttribute("class") === "sparkline-gap-point"
+    );
+    assert.equal(dots.length, 2, "an isolated measurement was dropped");
+  });
+
+  test.it("draws a flat week down the middle instead of at an edge", function () {
+    const flat = series([[2, 8000], [1, 8000], [0, 8000]]);
+    const ys = polylines(build(flat, "spend"))[0]
+      .getAttribute("points")
+      .split(" ")
+      .map((p) => Number(p.split(",")[1]));
+    ys.forEach((y) => assert.equal(y, spark.HEIGHT / 2));
+  });
+
+  test.it("stays inside its box", function () {
+    const svg = build(WEEK, "spend");
+    assert.equal(svg.getAttribute("viewBox"), "0 0 " + spark.WIDTH + " " + spark.HEIGHT);
+    polylines(svg)[0]
+      .getAttribute("points")
+      .split(" ")
+      .forEach(function (pair) {
+        const [x, y] = pair.split(",").map(Number);
+        assert.ok(x >= 0 && x <= spark.WIDTH, "x out of the box: " + x);
+        assert.ok(y >= 0 && y <= spark.HEIGHT, "y out of the box: " + y);
+      });
+  });
+
+  test.it("says nothing to a screen reader", function () {
+    // Every figure it annotates is stated in text beside it, so announcing
+    // the polyline would repeat the number in a form nobody can use.
+    const svg = build(WEEK, "spend");
+    assert.equal(svg.getAttribute("aria-hidden"), "true");
+  });
+});
+
+// ---------------------------------------------------------------------
+// On the screen
+// ---------------------------------------------------------------------
+
+const TODAY_ISO = new Date().toISOString();
+
+function platformWith(daily, delta) {
+  return {
+    key: "google_ads",
+    display_name: "Google Ads",
+    totals: { spend: 13000, conversions: 13, cpa: 1000, ctr: 2.2, clicks: 400, impressions: 18000 },
+    metrics_period: "YESTERDAY",
+    campaign_count: 3,
+    freshness: { fetched_at: TODAY_ISO, stale: false },
+    not_collected: null,
+    daily: daily || [],
+    daily_delta: delta || null,
+  };
+}
+
+async function openDetail(platform) {
+  const page = loadDashboardPage({
+    "/api/reports/clients": {
+      clients: [{ slug: "alpha", name: "Alpha", active: true }],
+      can_archive: false,
+    },
+    "/api/reports/summary": () => ({
+      client: "alpha",
+      period: "YESTERDAY",
+      periods: ["YESTERDAY"],
+      non_canonical_periods: [],
+      last_synced_at: TODAY_ISO,
+      platforms: [platform],
+      platform_conflicts: [],
+      recent_actions: [],
+      reports: {},
+      observations_due: { count: 0, oldest_due: null },
+      server_today: TODAY,
+    }),
+  });
+  page.document.dispatchEvent({ type: "mureo:ready" });
+  await settle();
+  page.root.querySelector('[data-dashboard-nav="reports"]').click();
+  await settle();
+  return page;
+}
+
+const sparks = (page) => page.root.querySelectorAll(".sparkline");
+const deltas = (page) => page.root.querySelectorAll(".report-delta");
+
+test.describe("the platform card in each of the four states", function () {
+  test.it("(a) no history: no chart, no delta, and no hole where they were", async function () {
+    // The state every install starts in, and the one the layout has to look
+    // right in. Nothing is drawn — not a frame, not a dash, not a spacer.
+    const page = await openDetail(platformWith([], null));
+    const card = page.root.querySelector(".report-card");
+    assert.ok(card, "the card did not render at all");
+    assert.equal(sparks(page).length, 0, "an empty chart was reserved");
+    assert.equal(deltas(page).length, 0, "a delta was drawn without one");
+    // The card still says everything it said before this feature existed.
+    assert.ok(page.root.querySelector(".report-card-headline-value"));
+    assert.match(card.textContent, /13,000/);
+  });
+
+  test.it("(b) two days: a chart and, with a delta on the wire, a delta", async function () {
+    const page = await openDetail(
+      platformWith(TWO_DAYS, {
+        from: dayBefore(1),
+        to: dayBefore(0),
+        metrics: { spend: 2000, cpa: -150 },
+      })
+    );
+    assert.ok(sparks(page).length >= 1, "two days drew no chart");
+    const spendDelta = page.root
+      .querySelector(".report-card-headline")
+      .querySelector(".report-delta");
+    assert.ok(spendDelta, "no delta on the spend cell");
+    assert.match(spendDelta.textContent, /↑/);
+    assert.match(spendDelta.textContent, /2,000/);
+  });
+
+  test.it("(c) seven days: the chart is on the cell whose figure it explains", async function () {
+    const page = await openDetail(platformWith(WEEK, null));
+    const headline = page.root.querySelector(".report-card-headline");
+    assert.equal(
+      headline.querySelectorAll(".sparkline").length,
+      1,
+      "the spend cell has no spend chart"
+    );
+    // And it is visible, resolved against the real app.css rather than
+    // assumed from the DOM.
+    assert.ok(isVisible(headline.querySelector(".sparkline")));
+  });
+
+  test.it("(d) a week with a day missing: the chart is broken, not bridged", async function () {
+    const page = await openDetail(platformWith(GAPPED, null));
+    const svg = page.root
+      .querySelector(".report-card-headline")
+      .querySelector(".sparkline");
+    assert.ok(svg, "no chart for a gapped week");
+    assert.equal(
+      svg.children.filter((c) => c.tagName === "POLYLINE").length,
+      2,
+      "the missing day was drawn through"
+    );
+  });
+
+  test.it("withholds the chart from a row whose figures are withheld", async function () {
+    // A stale row states no figures (#638). A chart of the days behind them
+    // would be the same claim in a shape that is harder to argue with.
+    const stale = platformWith(WEEK, {
+      from: dayBefore(1),
+      to: dayBefore(0),
+      metrics: { spend: 2000 },
+    });
+    stale.freshness = { fetched_at: dayBefore(11) + "T00:00:00Z", stale: true };
+    const page = await openDetail(stale);
+    assert.match(page.root.querySelector(".report-card").textContent, /—/);
+    const head = page.root.querySelector(".report-card-headline");
+    assert.equal(
+      head ? head.querySelectorAll(".sparkline").length : 0,
+      0,
+      "a withheld figure was given a trend line"
+    );
+  });
+});
+
+test.describe("the chart is an annotation, not a second figure", function () {
+  test.it("is small enough not to grow the cell", async function () {
+    // 28px, resolved from the real stylesheet: a chart that grew the KPI
+    // cell would push the card's own figures apart.
+    const page = await openDetail(platformWith(WEEK, null));
+    const height = cascade(page.root.querySelector(".sparkline"), "height");
+    assert.ok(height, "nothing sizes the chart");
+    assert.equal(height.value, "28px", "won by: " + height.selector);
+  });
+
+  test.it("does not stretch its stroke when the box is scaled", async function () {
+    // preserveAspectRatio="none" scales x and y independently, which without
+    // this makes a narrow chart's line visibly fatter than a wide one's.
+    const page = await openDetail(platformWith(WEEK, null));
+    const line = page.root.querySelector(".sparkline-line");
+    const effect = cascade(line, "vector-effect");
+    assert.ok(effect, "nothing pins the stroke scaling");
+    assert.equal(effect.value, "non-scaling-stroke");
+  });
+});
+
+test.describe("a delta only where one was measured", function () {
+  test.it("says nothing when the server declined to compare", async function () {
+    // `daily_delta: null` is #690 refusing — fewer than two days, a calendar
+    // gap, or no shared metric. All three mean the comparison cannot honestly
+    // be made, so there is nothing to render and nothing is rendered.
+    const page = await openDetail(platformWith(WEEK, null));
+    assert.equal(deltas(page).length, 0, "a delta was invented from a null");
+  });
+
+  test.it("states an absolute difference and never a percentage", async function () {
+    // #690 carries absolute differences only; a percentage needs a rule for a
+    // zero baseline that nothing in the product has chosen.
+    const page = await openDetail(
+      platformWith(WEEK, {
+        from: dayBefore(1),
+        to: dayBefore(0),
+        metrics: { spend: 2000, cpa: -150 },
+      })
+    );
+    const text = page.root
+      .querySelector(".report-card-headline")
+      .querySelector(".report-delta").textContent;
+    assert.match(text, /2,000/);
+    assert.ok(!/%/.test(text), "a percentage reached the delta: " + text);
+  });
+
+  test.it("colours only the axes where a direction means something", async function () {
+    // The #694 finding: every delta arrived red, including a spend rise, and
+    // a colour that is always on says nothing. Spend is volume — up is
+    // neither good nor bad without a target nobody has put on the wire.
+    const page = await openDetail(
+      platformWith(WEEK, {
+        from: dayBefore(1),
+        to: dayBefore(0),
+        metrics: { spend: 2000, cpa: -150 },
+      })
+    );
+    const spend = page.root
+      .querySelector(".report-card-headline")
+      .querySelector(".report-delta");
+    const cpa = page.root
+      .querySelector(".report-card-second")
+      .querySelector(".report-delta");
+    assert.ok(spend.classList.contains("is-flat"), "a spend rise was given a verdict");
+    // CPA falling is good news, and is the one axis where that is unambiguous.
+    assert.ok(cpa.classList.contains("is-good"), "a CPA fall was not good news");
+    const tone = cascade(cpa.querySelector(".report-delta-move"), "color");
+    assert.match(tone.value, /--status-ok/, "won by: " + tone.selector);
+  });
+
+  test.it("carries the direction as a character, not as colour alone", async function () {
+    const page = await openDetail(
+      platformWith(WEEK, {
+        from: dayBefore(1),
+        to: dayBefore(0),
+        metrics: { spend: -500 },
+      })
+    );
+    assert.match(
+      page.root
+        .querySelector(".report-card-headline")
+        .querySelector(".report-delta").textContent,
+      /↓/
+    );
+  });
+});
+
+// ---------------------------------------------------------------------
+// The roster table stays a table
+// ---------------------------------------------------------------------
+
+test.describe("the roster carries neither, and that is the decision", function () {
+  // NOT a row-height compromise — a data one. #690's history is PER PLATFORM,
+  // and a roster row is per CLIENT. Giving a row a trend would mean summing
+  // `daily`/`daily_delta` across a client's platforms, and the moment one of
+  // them has a day the other does not, that sum is a number nobody measured
+  // presented as the client's own. It is the same line `aggregateClientKpis`
+  // already holds for the window rollup, one level down.
+  //
+  // The 44px row is the second reason and would have been survivable alone;
+  // this one is not, so the column stays as it is and this pins it.
+
+  async function openRoster(daily) {
+    const clients = [
+      { slug: "alpha", name: "Alpha", active: true },
+      { slug: "bravo", name: "Bravo", active: true },
+    ];
+    const page = loadDashboardPage({
+      "/api/reports/clients": { clients: clients, can_archive: false },
+      "/api/reports/summary": (url) => {
+        const m = /client=([^&]+)/.exec(url);
+        const slug = m ? decodeURIComponent(m[1]) : "alpha";
+        return {
+          client: slug,
+          period: "YESTERDAY",
+          periods: ["YESTERDAY"],
+          non_canonical_periods: [],
+          last_synced_at: TODAY_ISO,
+          platforms: [
+            platformWith(daily, {
+              from: dayBefore(1),
+              to: dayBefore(0),
+              metrics: { spend: 2000, cpa: -150 },
+            }),
+          ],
+          platform_conflicts: [],
+          recent_actions: [],
+          reports: {},
+          observations_due: { count: 0, oldest_due: null },
+          server_today: TODAY,
+        };
+      },
+    });
+    page.document.dispatchEvent({ type: "mureo:ready" });
+    await settle();
+    page.root.querySelector('[data-dashboard-nav="reports"]').click();
+    await settle();
+    return page;
+  }
+
+  test.it("draws no chart and no delta in a row, even with a full week behind it", async function () {
+    const page = await openRoster(WEEK);
+    const rows = page.root.querySelectorAll(".roster-row");
+    assert.ok(rows.length >= 2, "the table did not render");
+    rows.forEach(function (row) {
+      assert.equal(row.querySelectorAll(".sparkline").length, 0);
+      assert.equal(row.querySelectorAll(".report-delta").length, 0);
+    });
+  });
+
+  test.it("keeps the row at the height the density depends on", async function () {
+    const page = await openRoster(WEEK);
+    const height = cascade(page.root.querySelector(".roster-row"), "height");
+    assert.ok(height, "nothing sets a row height");
+    assert.equal(height.value, "44px", "won by: " + height.selector);
+  });
+});


### PR DESCRIPTION
#690 has stored day-grain history and computed a day-over-day delta since
it landed. Nothing outside the change-cards tier drew either, so a
platform card stated today's spend with no indication of whether it was
ordinary.

Each KPI cell on a platform card now carries the absolute difference from
the day before and a seven-day line. Both are annotations sized to stay
that — caption-sized text, a 28px chart — and both are optional. An
install whose daily history has not started accumulating renders neither:
no empty frame, no dash, no reserved space. That is the state every
install begins in, so it is the state the layout is pinned in.

GAPS ARE DRAWN AS GAPS, which is the whole difficulty of the file.
`daily` omits a day the collector missed rather than zero-filling it, so
points are placed on a DATE axis and a run of days that are not
calendar-adjacent is a break in the line, never a segment across it.
Plotting the buckets at even intervals would have quietly repaired every
gap — a Monday and the Thursday before it would sit one step apart and
read as an ordinary day-over-day move, which is a made-up comparison
presented as a measurement. A day whose neighbours are both missing is a
dot rather than nothing, because a one-point polyline paints nothing and
the measurement is real.

Fewer than two plottable days draws nothing at all. A single point is not
a trend, and a box reserved for a chart that never arrives is a promise
the data has not kept.

No new colour rule. The #694 table moves from dashboard_reports.js into
the report module and is now shared by both tiers that draw deltas, so
one movement cannot be good news on one and bad on the other. Spend,
clicks and impressions stay uncoloured: volume rising is neither good nor
bad without a target nothing puts on the wire.

No percentages. #690 carries absolute differences only, and a percentage
needs a rule for a zero baseline nothing in the product has chosen.

THE ROSTER TABLE CARRIES NEITHER, and the reason is data rather than row
height. Its rows are per-client while this history is per-platform, so a
row-level trend would mean summing `daily` across a client's platforms —
and the moment one has a day another does not, that sum is a figure
nobody measured presented as the client's own. The 44px row would have
been survivable; this is not. Both are pinned.

Two harness additions, both implementation rather than assertion:
`createElementNS` (the module builds real SVG) and the new file in the
load array, the static allowlist, app.html, dashboard.js's dependency
table and the browser-contract MODULES list — the last of which caught
the module for having no load-time guard, which it now has.

Tests cover the four states the feature has — no history, two days, seven
days, and a week with a day missing — twice over: through the module for
the axis, where a bridged gap is invisible in a screenshot, and through
the real dashboard against the real app.css for what reaches the screen.

Closes #691
