### PR TITLE
chore: release v0.15.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mureo",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Your local-first AI ad ops crew for Google Ads, Meta Ads, Search Console & GA4. mureo sits on top of the official ad-platform MCPs, gates every change against your strategy, correlates outcomes locally, and keeps an auditable decision log — credentials never leave your machine.",
   "author": {
     "name": "Logly Inc.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+## [0.15.0] - 2026-08-26
+
 ### Changed
 
 - **The `pages_manage_posts` scope is gone; an Instant Form cover is now

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "mureo",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini.",
   "contextFileName": "CONTEXT.md"
 }

--- a/mureo/__init__.py
+++ b/mureo/__init__.py
@@ -1,3 +1,3 @@
 """mureo — your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."""
 
-__version__ = "0.14.0"
+__version__ = "0.15.0"

--- a/mureo/_data/skills/_mureo-amazon-ads/SKILL.md
+++ b/mureo/_data/skills/_mureo-amazon-ads/SKILL.md
@@ -2,7 +2,7 @@
 name: _mureo-amazon-ads
 description: "Amazon Ads (official MCP, bridged by mureo): query campaigns, ad groups, ads and targets, run reports, and manage account access under Amazon's own tool names."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
   openclaw:
     category: "advertising"
     requires:

--- a/mureo/_data/skills/_mureo-google-ads/SKILL.md
+++ b/mureo/_data/skills/_mureo-google-ads/SKILL.md
@@ -2,7 +2,7 @@
 name: _mureo-google-ads
 description: "Google Ads: Manage campaigns, ad groups, ads, keywords, budgets, and performance analysis."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
   openclaw:
     category: "advertising"
     requires:

--- a/mureo/_data/skills/_mureo-learning/SKILL.md
+++ b/mureo/_data/skills/_mureo-learning/SKILL.md
@@ -2,7 +2,7 @@
 name: _mureo-learning
 description: "Evidence-based marketing decision framework: statistical thinking for AI agents operating ad accounts."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
   openclaw:
     category: "marketing"
     requires:

--- a/mureo/_data/skills/_mureo-meta-ads/SKILL.md
+++ b/mureo/_data/skills/_mureo-meta-ads/SKILL.md
@@ -2,7 +2,7 @@
 name: _mureo-meta-ads
 description: "Meta Ads: Manage campaigns, ad sets, ads, insights, and audiences on Facebook/Instagram."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
   openclaw:
     category: "advertising"
     requires:

--- a/mureo/_data/skills/_mureo-shared/SKILL.md
+++ b/mureo/_data/skills/_mureo-shared/SKILL.md
@@ -2,7 +2,7 @@
 name: _mureo-shared
 description: "mureo: Shared patterns for authentication, security rules, and output formatting."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
   openclaw:
     category: "advertising"
     requires:

--- a/mureo/_data/skills/_mureo-strategy/SKILL.md
+++ b/mureo/_data/skills/_mureo-strategy/SKILL.md
@@ -2,7 +2,7 @@
 name: _mureo-strategy
 description: "Strategy Context: Manage business strategy files (STRATEGY.md, STATE.json) for strategy-driven ad operations."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
   openclaw:
     category: "advertising"
     requires:

--- a/mureo/_data/skills/ad-fatigue-check/SKILL.md
+++ b/mureo/_data/skills/ad-fatigue-check/SKILL.md
@@ -2,7 +2,7 @@
 name: ad-fatigue-check
 description: "Detect creative fatigue across active ads — rising frequency, declining CTR week-over-week, and CPM drift — score each ad FATIGUED / WATCH / FRESH, and hand the evidence to a creative refresh. Use when the user asks whether creatives are worn out, why CTR is falling, if frequency is too high, when to rotate or refresh ads, or requests クリエイティブ疲弊チェック / 広告の疲弊を確認 / フリークエンシーが高い / CTRが落ちてきた / そろそろ差し替え時か. Reads active ads per platform, applies documented fatigue thresholds with noise guards, and routes fatigued ads to /creative-generate or /creative-refresh."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
 ---
 
 # Ad Fatigue Check

--- a/mureo/_data/skills/audience-review/SKILL.md
+++ b/mureo/_data/skills/audience-review/SKILL.md
@@ -2,7 +2,7 @@
 name: audience-review
 description: "Audit who your ads actually target and where they run, compare it against the STRATEGY.md Persona, and surface exclusions, bid adjustments, lookalikes, and placement pruning tied to that Persona. Use when the user asks to review targeting, audiences, demographics, placements, or device performance, to check whether spend matches the Persona, to find wasted placements (e.g. Audience Network with no conversions), or requests オーディエンスレビュー / 配置レビュー / ターゲティング見直し / ペルソナと配信のズレを確認 / 除外設定を提案して. Reads Persona + Target Audience from STRATEGY.md and drives the read-only targeting tools."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
 ---
 
 # Audience Review

--- a/mureo/_data/skills/budget-pacing/SKILL.md
+++ b/mureo/_data/skills/budget-pacing/SKILL.md
@@ -2,7 +2,7 @@
 name: budget-pacing
 description: "Month-to-date spend vs the monthly budget target, projected month-end landing, and pace alerts across all configured platforms. Use when the user asks about pacing, burn rate, whether they will overspend or underspend this month, monthly-budget tracking, landing/forecast, 'are we on budget', or requests 予算ペーシング / 着地予測 / 予算消化ペース. DISTINCT from /budget-rebalance (which reallocates budget between campaigns) — this manages total-spend trajectory toward a monthly target. Reads STRATEGY.md Guardrails / a Monthly Budget section and STATE.json."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
 ---
 
 # Budget Pacing

--- a/mureo/_data/skills/budget-rebalance/SKILL.md
+++ b/mureo/_data/skills/budget-rebalance/SKILL.md
@@ -2,7 +2,7 @@
 name: budget-rebalance
 description: "Rebalance campaign budgets across all configured platforms based on strategy and performance signals. Use when the user asks to optimize budgets, redistribute spend, scale efficient campaigns, or cap overspending ones. Reads STRATEGY.md goals, analyzes campaign efficiency, and proposes budget changes with rationale. Also use when the user asks in Japanese (予算を最適化して / 予算の再配分 / 好調なキャンペーンに予算を寄せて / 予算リバランス)."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
 ---
 
 # Budget Rebalance

--- a/mureo/_data/skills/competitive-scan/SKILL.md
+++ b/mureo/_data/skills/competitive-scan/SKILL.md
@@ -2,7 +2,7 @@
 name: competitive-scan
 description: "Scan competitor activity using auction insights and market signals. Use when the user asks about competitors, market dynamics, impression share changes, competitor moves, or competitive positioning. Also use when the user asks in Japanese (競合の動きを調べて / 競合分析 / インプレッションシェアの変化を確認 / 競合にシェアを取られていないか)."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
 ---
 
 # Competitive Scan

--- a/mureo/_data/skills/creative-generate/SKILL.md
+++ b/mureo/_data/skills/creative-generate/SKILL.md
@@ -2,7 +2,7 @@
 name: creative-generate
 description: "Generate creator-quality ad creatives — text-free key visuals plus composed banners — from a strategy-grounded brief. Use when the user asks to create ad creatives, generate ad images or banners, make banner variations, design display / social ad creatives, or asks in Japanese (クリエイティブ作成 / バナー作成 / 広告画像を生成 / バナーのバリエーションを作って). Runs a 6-step workflow (brief → copy → visuals → art-direction scoring loop → HTML/CSS composition → delivery) via the creative_studio_* MCP tools, then hands approved banners to the existing upload tools."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
 ---
 
 # Creative Generate

--- a/mureo/_data/skills/creative-refresh/SKILL.md
+++ b/mureo/_data/skills/creative-refresh/SKILL.md
@@ -2,7 +2,7 @@
 name: creative-refresh
 description: "Refresh ad copy and creative assets based on performance signals and brand voice. Use when the user asks to refresh creative, propose new ad copy, A/B test creatives, update RSA assets, swap Performance Max asset-group headlines, descriptions, images or logos, rotate underperformers, or visually evaluate / compare banner (image) creatives. Also use when the user asks in Japanese (クリエイティブを刷新して / 広告文の改善案がほしい / RSAアセットの入れ替え / P-MAXの見出しを差し替えて / P-MAXの画像を差し替えて / バナーを比較評価して)."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
 ---
 
 # Creative Refresh

--- a/mureo/_data/skills/daily-check/SKILL.md
+++ b/mureo/_data/skills/daily-check/SKILL.md
@@ -2,7 +2,7 @@
 name: daily-check
 description: "Run a daily health check on all configured ad accounts (Google Ads, Meta Ads, Amazon Ads, TikTok Ads, Search Console, GA4, and any configured plugin platform). Use when the user asks for a daily review, health check, status update, anomaly detection, or 'how are my campaigns doing today'. Reads STRATEGY.md and STATE.json, runs platform-specific health diagnostics, checks goal progress, evaluates pending action_log observations, and reports findings as Healthy / Watch / Action-needed. Also use when the user asks in Japanese (デイリーチェック / 今日のアカウント状況は / 異常がないか確認して / 日次ヘルスチェック)."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
 ---
 
 # Daily Check

--- a/mureo/_data/skills/experiment/SKILL.md
+++ b/mureo/_data/skills/experiment/SKILL.md
@@ -2,7 +2,7 @@
 name: experiment
 description: "Design, run, and evaluate a controlled A/B test (split test) on your ad accounts with evidence discipline — one variable, a falsifiable hypothesis, a fixed window, and a per-variant outcome verdict. Use when the user asks to run an A/B test, split test, or experiment, to 'test whether X beats Y', to validate a creative-refresh or learning hunch properly, to validate a breakdown exclusion or reallocation hypothesis before acting on it, or requests A/Bテスト / スプリットテスト設計 / 実験を回したい / どちらが勝ったか評価して / 仮説を検証したい. Forces a designed experiment instead of an ad-hoc change, records the baseline in action_log, and forbids peeking-based decisions before the window closes."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
 ---
 
 # Experiment

--- a/mureo/_data/skills/goal-review/SKILL.md
+++ b/mureo/_data/skills/goal-review/SKILL.md
@@ -2,7 +2,7 @@
 name: goal-review
 description: "Review Goal progress against STRATEGY.md targets. Use when the user asks to evaluate goal achievement, review KPI progress, assess strategy performance, or check if targets are being met. Also use when the user asks in Japanese (目標の進捗を確認 / KPIレビュー / ゴール達成状況は / 目標に届きそうか)."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
 ---
 
 # Goal Review

--- a/mureo/_data/skills/incident-postmortem/SKILL.md
+++ b/mureo/_data/skills/incident-postmortem/SKILL.md
@@ -2,7 +2,7 @@
 name: incident-postmortem
 description: "Close the learning loop after a rescue or incident — reconstruct the timeline from action_log, run root-cause analysis (platform / site / measurement / external), produce a structured postmortem document, distill reusable insights via /learn, and propose preventive guardrails. Use after a /rescue, a CPA spike, a conversion drop, or a runaway-spend event has been handled, or when the user asks for a postmortem, retrospective, root-cause writeup, or requests インシデント振り返り / ポストモーテム / 事後分析 / なぜ起きたのか / 再発防止策. Read-and-document only — makes no ad-platform writes."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
 ---
 
 # Incident Postmortem

--- a/mureo/_data/skills/lead-form-create/SKILL.md
+++ b/mureo/_data/skills/lead-form-create/SKILL.md
@@ -2,7 +2,7 @@
 name: lead-form-create
 description: "Create a Meta Instant Form (Lead Ad form) through a one-question-at-a-time interview. Use when the user asks to create a lead form, Instant Form, CV form, or similar. The agent collects required parameters via a guided dialogue, confirms, then calls meta_ads_lead_forms_create. Also use when the user asks in Japanese (リードフォームを作成 / インスタントフォームを作って / CVフォーム作成)."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
 ---
 
 # Lead Form Create

--- a/mureo/_data/skills/learn/SKILL.md
+++ b/mureo/_data/skills/learn/SKILL.md
@@ -2,7 +2,7 @@
 name: learn
 description: "Save a marketing diagnosis insight to the pro-diagnosis knowledge base so it is applied in future operations across all platforms. Use when the user runs /learn, explicitly teaches the agent a marketing insight, corrects the agent's analysis, or asks to remember/record an operational learning for next time. Also use when the user asks in Japanese (この学びを記録して / 次回から反映して / 運用の気づきを覚えておいて)."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
 ---
 
 # Learn

--- a/mureo/_data/skills/monthly-report/SKILL.md
+++ b/mureo/_data/skills/monthly-report/SKILL.md
@@ -2,7 +2,7 @@
 name: monthly-report
 description: "Stakeholder / client-facing monthly digest across all configured platforms: the previous full calendar month with month-over-month comparison, per-Goal attainment, an action-log recap grouped by command with outcome verdicts, budget utilization, and next-month recommendations. Use when the user asks for a monthly report, month-end summary, client report, monthly recap / digest, or requests 月次レポート / 月次まとめ / クライアント向けレポート. Written in plain language for a client audience."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
 ---
 
 # Monthly Report

--- a/mureo/_data/skills/onboard/SKILL.md
+++ b/mureo/_data/skills/onboard/SKILL.md
@@ -2,7 +2,7 @@
 name: onboard
 description: "Initial account setup — create STRATEGY.md and STATE.json from scratch, import platform data, and establish baseline metrics. Use when the user is starting fresh with mureo, has no STRATEGY.md yet, or asks to set up a new account. Also use when the user asks in Japanese (初期セットアップ / STRATEGY.mdを作成して / mureoを使い始めたい / アカウントの立ち上げ)."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
 ---
 
 # Onboard

--- a/mureo/_data/skills/rescue/SKILL.md
+++ b/mureo/_data/skills/rescue/SKILL.md
@@ -2,7 +2,7 @@
 name: rescue
 description: "Emergency performance fix when an ad account is in trouble. Use when the user reports a sudden CPA spike, conversion drop, runaway spend, or asks for an urgent performance rescue. Sets Operation Mode to TURNAROUND_RESCUE and applies stabilization actions. Also use when the user asks in Japanese (CPAが急に悪化した / CVが激減した / 広告費が暴走している / 緊急で立て直して)."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
 ---
 
 # Rescue

--- a/mureo/_data/skills/search-term-cleanup/SKILL.md
+++ b/mureo/_data/skills/search-term-cleanup/SKILL.md
@@ -2,7 +2,7 @@
 name: search-term-cleanup
 description: "Audit and clean up search terms (negative keywords, intent classification, query hygiene). Use when the user asks to clean up search queries, add negative keywords, review search term reports, or improve match quality. Cross-references Search Console, GA4, and ad platform data. Also use when the user asks in Japanese (検索語句のクリーンアップ / 除外キーワードを追加して / 無駄な検索クエリを止めたい)."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
 ---
 
 # Search Term Cleanup

--- a/mureo/_data/skills/sync-state/SKILL.md
+++ b/mureo/_data/skills/sync-state/SKILL.md
@@ -2,7 +2,7 @@
 name: sync-state
 description: "Sync STATE.json with current campaign data from all platforms. Use when the user asks to refresh state, sync campaigns, update STATE.json from live data, or pull latest campaign snapshots. Also use when the user asks in Japanese (STATE.jsonを更新 / 最新データに同期して / キャンペーン情報を取り込み直して)."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
 ---
 
 # Sync State

--- a/mureo/_data/skills/tracking-health/SKILL.md
+++ b/mureo/_data/skills/tracking-health/SKILL.md
@@ -2,7 +2,7 @@
 name: tracking-health
 description: "Preventive audit of conversion tracking across all configured ad platforms — Meta pixels + CAPI, Google Ads conversion actions, and final-URL tracking-parameter consistency on every platform — with a GA4 cross-check. Use when the user asks to check tracking, audit conversion measurement, verify pixels / tags, check that ads carry the right utm / tracking parameters for the campaign they are in, diagnose why conversions stopped or look wrong, sanity-check CV counting, or requests a 計測ヘルスチェック / タグ・計測監査 / パラメータ整合性チェック / 計測が壊れていないか確認. Reads STRATEGY.md and STATE.json, produces a per-platform tracking scorecard (OK / Watch / Broken per check) and a fix list ranked by revenue risk."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
 ---
 
 # Tracking Health

--- a/mureo/_data/skills/weekly-report/SKILL.md
+++ b/mureo/_data/skills/weekly-report/SKILL.md
@@ -2,7 +2,7 @@
 name: weekly-report
 description: "Generate a weekly summary report across all platforms. Use when the user asks for a weekly report, summary, recap, end-of-week review, or weekly digest. Also use when the user asks in Japanese (週次レポート / 今週のまとめ / 週報を作成して)."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
 ---
 
 # Weekly Report

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mureo"
-version = "0.14.0"
+version = "0.15.0"
 description = "Your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/skills/_mureo-amazon-ads/SKILL.md
+++ b/skills/_mureo-amazon-ads/SKILL.md
@@ -2,7 +2,7 @@
 name: _mureo-amazon-ads
 description: "Amazon Ads (official MCP, bridged by mureo): query campaigns, ad groups, ads and targets, run reports, and manage account access under Amazon's own tool names."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
   openclaw:
     category: "advertising"
     requires:

--- a/skills/_mureo-google-ads/SKILL.md
+++ b/skills/_mureo-google-ads/SKILL.md
@@ -2,7 +2,7 @@
 name: _mureo-google-ads
 description: "Google Ads: Manage campaigns, ad groups, ads, keywords, budgets, and performance analysis."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
   openclaw:
     category: "advertising"
     requires:

--- a/skills/_mureo-learning/SKILL.md
+++ b/skills/_mureo-learning/SKILL.md
@@ -2,7 +2,7 @@
 name: _mureo-learning
 description: "Evidence-based marketing decision framework: statistical thinking for AI agents operating ad accounts."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
   openclaw:
     category: "marketing"
     requires:

--- a/skills/_mureo-meta-ads/SKILL.md
+++ b/skills/_mureo-meta-ads/SKILL.md
@@ -2,7 +2,7 @@
 name: _mureo-meta-ads
 description: "Meta Ads: Manage campaigns, ad sets, ads, insights, and audiences on Facebook/Instagram."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
   openclaw:
     category: "advertising"
     requires:

--- a/skills/_mureo-pro-diagnosis/SKILL.md
+++ b/skills/_mureo-pro-diagnosis/SKILL.md
@@ -2,7 +2,7 @@
 name: _mureo-pro-diagnosis
 description: "Professional marketing diagnostic frameworks: expert-level campaign analysis that grows with your experience."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
   openclaw:
     category: "marketing"
     requires:

--- a/skills/_mureo-shared/SKILL.md
+++ b/skills/_mureo-shared/SKILL.md
@@ -2,7 +2,7 @@
 name: _mureo-shared
 description: "mureo: Shared patterns for authentication, security rules, and output formatting."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
   openclaw:
     category: "advertising"
     requires:

--- a/skills/_mureo-strategy/SKILL.md
+++ b/skills/_mureo-strategy/SKILL.md
@@ -2,7 +2,7 @@
 name: _mureo-strategy
 description: "Strategy Context: Manage business strategy files (STRATEGY.md, STATE.json) for strategy-driven ad operations."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
   openclaw:
     category: "advertising"
     requires:

--- a/skills/ad-fatigue-check/SKILL.md
+++ b/skills/ad-fatigue-check/SKILL.md
@@ -2,7 +2,7 @@
 name: ad-fatigue-check
 description: "Detect creative fatigue across active ads — rising frequency, declining CTR week-over-week, and CPM drift — score each ad FATIGUED / WATCH / FRESH, and hand the evidence to a creative refresh. Use when the user asks whether creatives are worn out, why CTR is falling, if frequency is too high, when to rotate or refresh ads, or requests クリエイティブ疲弊チェック / 広告の疲弊を確認 / フリークエンシーが高い / CTRが落ちてきた / そろそろ差し替え時か. Reads active ads per platform, applies documented fatigue thresholds with noise guards, and routes fatigued ads to /creative-generate or /creative-refresh."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
 ---
 
 # Ad Fatigue Check

--- a/skills/audience-review/SKILL.md
+++ b/skills/audience-review/SKILL.md
@@ -2,7 +2,7 @@
 name: audience-review
 description: "Audit who your ads actually target and where they run, compare it against the STRATEGY.md Persona, and surface exclusions, bid adjustments, lookalikes, and placement pruning tied to that Persona. Use when the user asks to review targeting, audiences, demographics, placements, or device performance, to check whether spend matches the Persona, to find wasted placements (e.g. Audience Network with no conversions), or requests オーディエンスレビュー / 配置レビュー / ターゲティング見直し / ペルソナと配信のズレを確認 / 除外設定を提案して. Reads Persona + Target Audience from STRATEGY.md and drives the read-only targeting tools."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
 ---
 
 # Audience Review

--- a/skills/budget-pacing/SKILL.md
+++ b/skills/budget-pacing/SKILL.md
@@ -2,7 +2,7 @@
 name: budget-pacing
 description: "Month-to-date spend vs the monthly budget target, projected month-end landing, and pace alerts across all configured platforms. Use when the user asks about pacing, burn rate, whether they will overspend or underspend this month, monthly-budget tracking, landing/forecast, 'are we on budget', or requests 予算ペーシング / 着地予測 / 予算消化ペース. DISTINCT from /budget-rebalance (which reallocates budget between campaigns) — this manages total-spend trajectory toward a monthly target. Reads STRATEGY.md Guardrails / a Monthly Budget section and STATE.json."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
 ---
 
 # Budget Pacing

--- a/skills/budget-rebalance/SKILL.md
+++ b/skills/budget-rebalance/SKILL.md
@@ -2,7 +2,7 @@
 name: budget-rebalance
 description: "Rebalance campaign budgets across all configured platforms based on strategy and performance signals. Use when the user asks to optimize budgets, redistribute spend, scale efficient campaigns, or cap overspending ones. Reads STRATEGY.md goals, analyzes campaign efficiency, and proposes budget changes with rationale. Also use when the user asks in Japanese (予算を最適化して / 予算の再配分 / 好調なキャンペーンに予算を寄せて / 予算リバランス)."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
 ---
 
 # Budget Rebalance

--- a/skills/competitive-scan/SKILL.md
+++ b/skills/competitive-scan/SKILL.md
@@ -2,7 +2,7 @@
 name: competitive-scan
 description: "Scan competitor activity using auction insights and market signals. Use when the user asks about competitors, market dynamics, impression share changes, competitor moves, or competitive positioning. Also use when the user asks in Japanese (競合の動きを調べて / 競合分析 / インプレッションシェアの変化を確認 / 競合にシェアを取られていないか)."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
 ---
 
 # Competitive Scan

--- a/skills/creative-generate/SKILL.md
+++ b/skills/creative-generate/SKILL.md
@@ -2,7 +2,7 @@
 name: creative-generate
 description: "Generate creator-quality ad creatives — text-free key visuals plus composed banners — from a strategy-grounded brief. Use when the user asks to create ad creatives, generate ad images or banners, make banner variations, design display / social ad creatives, or asks in Japanese (クリエイティブ作成 / バナー作成 / 広告画像を生成 / バナーのバリエーションを作って). Runs a 6-step workflow (brief → copy → visuals → art-direction scoring loop → HTML/CSS composition → delivery) via the creative_studio_* MCP tools, then hands approved banners to the existing upload tools."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
 ---
 
 # Creative Generate

--- a/skills/creative-refresh/SKILL.md
+++ b/skills/creative-refresh/SKILL.md
@@ -2,7 +2,7 @@
 name: creative-refresh
 description: "Refresh ad copy and creative assets based on performance signals and brand voice. Use when the user asks to refresh creative, propose new ad copy, A/B test creatives, update RSA assets, swap Performance Max asset-group headlines, descriptions, images or logos, rotate underperformers, or visually evaluate / compare banner (image) creatives. Also use when the user asks in Japanese (クリエイティブを刷新して / 広告文の改善案がほしい / RSAアセットの入れ替え / P-MAXの見出しを差し替えて / P-MAXの画像を差し替えて / バナーを比較評価して)."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
 ---
 
 # Creative Refresh

--- a/skills/daily-check/SKILL.md
+++ b/skills/daily-check/SKILL.md
@@ -2,7 +2,7 @@
 name: daily-check
 description: "Run a daily health check on all configured ad accounts (Google Ads, Meta Ads, Amazon Ads, TikTok Ads, Search Console, GA4, and any configured plugin platform). Use when the user asks for a daily review, health check, status update, anomaly detection, or 'how are my campaigns doing today'. Reads STRATEGY.md and STATE.json, runs platform-specific health diagnostics, checks goal progress, evaluates pending action_log observations, and reports findings as Healthy / Watch / Action-needed. Also use when the user asks in Japanese (デイリーチェック / 今日のアカウント状況は / 異常がないか確認して / 日次ヘルスチェック)."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
 ---
 
 # Daily Check

--- a/skills/experiment/SKILL.md
+++ b/skills/experiment/SKILL.md
@@ -2,7 +2,7 @@
 name: experiment
 description: "Design, run, and evaluate a controlled A/B test (split test) on your ad accounts with evidence discipline — one variable, a falsifiable hypothesis, a fixed window, and a per-variant outcome verdict. Use when the user asks to run an A/B test, split test, or experiment, to 'test whether X beats Y', to validate a creative-refresh or learning hunch properly, to validate a breakdown exclusion or reallocation hypothesis before acting on it, or requests A/Bテスト / スプリットテスト設計 / 実験を回したい / どちらが勝ったか評価して / 仮説を検証したい. Forces a designed experiment instead of an ad-hoc change, records the baseline in action_log, and forbids peeking-based decisions before the window closes."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
 ---
 
 # Experiment

--- a/skills/goal-review/SKILL.md
+++ b/skills/goal-review/SKILL.md
@@ -2,7 +2,7 @@
 name: goal-review
 description: "Review Goal progress against STRATEGY.md targets. Use when the user asks to evaluate goal achievement, review KPI progress, assess strategy performance, or check if targets are being met. Also use when the user asks in Japanese (目標の進捗を確認 / KPIレビュー / ゴール達成状況は / 目標に届きそうか)."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
 ---
 
 # Goal Review

--- a/skills/incident-postmortem/SKILL.md
+++ b/skills/incident-postmortem/SKILL.md
@@ -2,7 +2,7 @@
 name: incident-postmortem
 description: "Close the learning loop after a rescue or incident — reconstruct the timeline from action_log, run root-cause analysis (platform / site / measurement / external), produce a structured postmortem document, distill reusable insights via /learn, and propose preventive guardrails. Use after a /rescue, a CPA spike, a conversion drop, or a runaway-spend event has been handled, or when the user asks for a postmortem, retrospective, root-cause writeup, or requests インシデント振り返り / ポストモーテム / 事後分析 / なぜ起きたのか / 再発防止策. Read-and-document only — makes no ad-platform writes."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
 ---
 
 # Incident Postmortem

--- a/skills/lead-form-create/SKILL.md
+++ b/skills/lead-form-create/SKILL.md
@@ -2,7 +2,7 @@
 name: lead-form-create
 description: "Create a Meta Instant Form (Lead Ad form) through a one-question-at-a-time interview. Use when the user asks to create a lead form, Instant Form, CV form, or similar. The agent collects required parameters via a guided dialogue, confirms, then calls meta_ads_lead_forms_create. Also use when the user asks in Japanese (リードフォームを作成 / インスタントフォームを作って / CVフォーム作成)."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
 ---
 
 # Lead Form Create

--- a/skills/learn/SKILL.md
+++ b/skills/learn/SKILL.md
@@ -2,7 +2,7 @@
 name: learn
 description: "Save a marketing diagnosis insight to the pro-diagnosis knowledge base so it is applied in future operations across all platforms. Use when the user runs /learn, explicitly teaches the agent a marketing insight, corrects the agent's analysis, or asks to remember/record an operational learning for next time. Also use when the user asks in Japanese (この学びを記録して / 次回から反映して / 運用の気づきを覚えておいて)."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
 ---
 
 # Learn

--- a/skills/monthly-report/SKILL.md
+++ b/skills/monthly-report/SKILL.md
@@ -2,7 +2,7 @@
 name: monthly-report
 description: "Stakeholder / client-facing monthly digest across all configured platforms: the previous full calendar month with month-over-month comparison, per-Goal attainment, an action-log recap grouped by command with outcome verdicts, budget utilization, and next-month recommendations. Use when the user asks for a monthly report, month-end summary, client report, monthly recap / digest, or requests 月次レポート / 月次まとめ / クライアント向けレポート. Written in plain language for a client audience."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
 ---
 
 # Monthly Report

--- a/skills/onboard/SKILL.md
+++ b/skills/onboard/SKILL.md
@@ -2,7 +2,7 @@
 name: onboard
 description: "Initial account setup — create STRATEGY.md and STATE.json from scratch, import platform data, and establish baseline metrics. Use when the user is starting fresh with mureo, has no STRATEGY.md yet, or asks to set up a new account. Also use when the user asks in Japanese (初期セットアップ / STRATEGY.mdを作成して / mureoを使い始めたい / アカウントの立ち上げ)."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
 ---
 
 # Onboard

--- a/skills/rescue/SKILL.md
+++ b/skills/rescue/SKILL.md
@@ -2,7 +2,7 @@
 name: rescue
 description: "Emergency performance fix when an ad account is in trouble. Use when the user reports a sudden CPA spike, conversion drop, runaway spend, or asks for an urgent performance rescue. Sets Operation Mode to TURNAROUND_RESCUE and applies stabilization actions. Also use when the user asks in Japanese (CPAが急に悪化した / CVが激減した / 広告費が暴走している / 緊急で立て直して)."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
 ---
 
 # Rescue

--- a/skills/search-term-cleanup/SKILL.md
+++ b/skills/search-term-cleanup/SKILL.md
@@ -2,7 +2,7 @@
 name: search-term-cleanup
 description: "Audit and clean up search terms (negative keywords, intent classification, query hygiene). Use when the user asks to clean up search queries, add negative keywords, review search term reports, or improve match quality. Cross-references Search Console, GA4, and ad platform data. Also use when the user asks in Japanese (検索語句のクリーンアップ / 除外キーワードを追加して / 無駄な検索クエリを止めたい)."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
 ---
 
 # Search Term Cleanup

--- a/skills/sync-state/SKILL.md
+++ b/skills/sync-state/SKILL.md
@@ -2,7 +2,7 @@
 name: sync-state
 description: "Sync STATE.json with current campaign data from all platforms. Use when the user asks to refresh state, sync campaigns, update STATE.json from live data, or pull latest campaign snapshots. Also use when the user asks in Japanese (STATE.jsonを更新 / 最新データに同期して / キャンペーン情報を取り込み直して)."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
 ---
 
 # Sync State

--- a/skills/tracking-health/SKILL.md
+++ b/skills/tracking-health/SKILL.md
@@ -2,7 +2,7 @@
 name: tracking-health
 description: "Preventive audit of conversion tracking across all configured ad platforms — Meta pixels + CAPI, Google Ads conversion actions, and final-URL tracking-parameter consistency on every platform — with a GA4 cross-check. Use when the user asks to check tracking, audit conversion measurement, verify pixels / tags, check that ads carry the right utm / tracking parameters for the campaign they are in, diagnose why conversions stopped or look wrong, sanity-check CV counting, or requests a 計測ヘルスチェック / タグ・計測監査 / パラメータ整合性チェック / 計測が壊れていないか確認. Reads STRATEGY.md and STATE.json, produces a per-platform tracking scorecard (OK / Watch / Broken per check) and a fix list ranked by revenue risk."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
 ---
 
 # Tracking Health

--- a/skills/weekly-report/SKILL.md
+++ b/skills/weekly-report/SKILL.md
@@ -2,7 +2,7 @@
 name: weekly-report
 description: "Generate a weekly summary report across all platforms. Use when the user asks for a weekly report, summary, recap, end-of-week review, or weekly digest. Also use when the user asks in Japanese (週次レポート / 今週のまとめ / 週報を作成して)."
 metadata:
-  version: 0.14.0
+  version: 0.15.0
 ---
 
 # Weekly Report


### PR DESCRIPTION
Cuts a `0.15.0` section and bumps every version string. One MCP tool removed,
one added in its place, and one OAuth scope no longer requested.

## What ships

**Changed**

- **The `pages_manage_posts` scope is gone; an Instant Form cover is now chosen,
  not uploaded** (#703). mureo asked for `pages_manage_posts` for exactly one
  call — `POST /{page_id}/photos`, staging an unpublished Page photo whose id
  became `context_card.cover_photo_id`. Meta's App Review rejected the scope
  twice as unnecessary for core functionality, and against Meta's own
  documentation the reviewers were right: the official Lead Ads permission set
  (`ads_management`, `pages_manage_ads`, `pages_read_engagement`,
  `pages_show_list`, `leads_retrieval`) never includes it, and the
  `leadgen_forms` reference requires it only when a file is attached through the
  `cover_photo` parameter. The upload also carried a latent defect: an
  unpublished photo officially lives "about 24 hours" on Meta's servers, and
  whether a form's reference preserves it is undocumented.

  `meta_ads_pages_upload_photo` is replaced by **`meta_ads_pages_photos_list`**
  (`GET /{page_id}/photos?type=uploaded`), which returns one row per photo the
  Page already owns, so the operator picks one and its `id` goes into
  `context_card.cover_photo_id` unchanged. Reading needs only
  `pages_read_engagement` + `pages_show_list` and a Page Access Token, both of
  which mureo already holds. `lead-form-create` now offers the cover as a
  three-step ladder: pick an existing Page photo, skip it (it is optional), or
  set it by hand in Ads Manager.

## Why minor, not patch

**An MCP tool is removed.** `meta_ads_pages_upload_photo` no longer exists.
Anything that called that name directly — an operator's own prompt, a script, a
saved workflow — now gets an unknown tool rather than a photo id. That is a
change an existing user can observe, so it does not belong in a patch release
even though the replacement lands in the same version.

The pinned **total stays 225** (one removed, one added), so no doc or test count
pin moves: `test_doc_claims.py` still reconciles the registry against `README.md`,
`README.ja.md`, `docs/mcp-server.md` and `docs/architecture.md` at the same
number.

**The requested OAuth scope set shrinks.** `pages_manage_posts` is not asked for
any more. Nothing else about the scope list changes.

## No re-authentication needed

Shrinking the requested scope set never invalidates a token. One issued earlier
still carries the granted `pages_manage_posts` permission; nothing in mureo calls
it any more, so it sits there harmlessly and no operator has to do anything. Only
a **new** scope requires re-issuing a token. `docs/authentication.md` and the
CHANGELOG both say so explicitly.

## Contents

- `CHANGELOG.md`: a new `[0.15.0] - 2026-08-26` section, moved down from
  `[Unreleased]` verbatim
- `pyproject.toml`, `mureo/__init__.py`, `.claude-plugin/plugin.json`,
  `gemini-extension.json`: 0.14.0 -> 0.15.0
- 53 SKILL.md frontmatter `version` fields synced

58 files, the same set and the same shape (59 insertions, 57 deletions) as the
v0.14.0 release commit in #702.

## Verification

Base commit `1d22008`, same interpreter (CPython 3.10.0) for base and branch.

- `ruff check .` — all checks passed; `black --check .` — 744 files unchanged;
  `mypy mureo/ --ignore-missing-imports` — no issues found in 359 source files.
  Identical on the base commit.
- `pytest tests/` — **9,908 passed, 14 failed, 8 skipped**, byte-identical
  failure set to the `1d22008` baseline taken on the same interpreter (also
  9,908 / 14 / 8). **Delta: zero.** The 14 are the known local-environment
  failures — `tests/analytics/builtin/test_live_clients.py` (needs platform
  credentials) and the plugin-count-sensitive pins in `test_mcp_server.py`,
  `test_mcp_server_plugin_wiring.py`, `test_mcp_tool_provider.py` and
  `test_web_handlers.py`, which see the provider plugins installed on this
  machine.
- `node --test tests/js/*.test.js` — 498 passed, 0 failed (no browser asset
  touched; regression check only).
- **Tool count pinned at 225.** `tests/test_doc_claims.py` (43 tests with
  `test_plugin_manifests.py`) passes, and the registry read directly with
  plugins excluded returns `len(builtin) == 225`, with
  `meta_ads_pages_upload_photo` absent and `meta_ads_pages_photos_list` present.
- **File set.** `git diff --name-only` against `1d22008`, sorted, is identical
  to `git show --stat` of the v0.14.0 release commit `c4588af` — the same 58
  paths, 59 insertions / 57 deletions.
- **Version consistency.** All four version strings read `0.15.0`, 53 SKILL.md
  frontmatter fields read `0.15.0`, and the two skill trees are byte-identical
  apart from the declared `_mureo-pro-diagnosis` exemption. The only `0.14.0`
  left in the tree is the CHANGELOG's own history heading and the sentence in
  `docs/authentication.md` that says `pages_manage_posts` "was requested through
  v0.14.0" — which is a statement about the last release that requested it, and
  stays true.

