### PR TITLE
Roster usability: the whole row opens its client, and the remembered view gets a reload test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 ## [Unreleased]
 
+### Changed
+
+- **A roster row opens its client from anywhere on the row** (#707). The
+  agency table's rows are 44px tall and carry the client's name, its health
+  dot and every figure — the row reads as one object — but the only part of
+  it that opened anything was the button in the last column. A click anywhere
+  on the row now opens that client, and the row is focusable so Enter does
+  the same.
+
+  It takes only the clicks nobody else wanted. A click that lands on a real
+  control (`a` / `button` / `input` / `select` / `textarea`, or anything
+  `contenteditable`) is that control's, so the "Detail →" button still opens
+  the client exactly once and a link added to a cell later still leads where
+  it leads. A click that ends a text selection is a selection: dragging
+  across two cells to copy a figure ends in a click, and a row that navigated
+  on it would take the screen away at the moment the operator finished
+  reading, losing the copied figure with it.
+
+  No `role` is set on the row. A `<tr>` that claimed to be a button would
+  stop being a row and the figures under it would stop being announced with
+  their columns, so the row is merely focusable and the announced control for
+  a client is still the "Detail →" button — which is why it stays.
+
+### Fixed
+
+- **The remembered table/cards choice now has a reload test behind it**
+  (#707). The roster view is stored per browser under
+  `mureo.reports.roster_view`, and the tests covering it seeded that key into
+  a page rather than letting one page write it and the next read it. A key
+  the two halves disagreed about, or a restore that ran after the default was
+  drawn, would have passed every one of them. The round trip is now asserted
+  in both directions, plus across a client detail and back.
+
 ## [0.15.0] - 2026-08-26
 
 ### Changed

--- a/mureo/_data/web/app.css
+++ b/mureo/_data/web/app.css
@@ -4060,6 +4060,27 @@ dialog[data-confirm-dialog] [data-confirm-ok] {
   background: var(--status-ok);
 }
 
+/* The whole row opens its client (#707), so it has to look like it does.
+   A tint rather than the card's border-color change: these rows share
+   collapsed borders with their neighbours, so a border that lit up would
+   move the row below it. NO `display` here — `.roster tbody tr[hidden]`
+   above is what takes a filtered row off screen, and nothing may outrank
+   it. */
+.roster-row {
+  cursor: pointer;
+}
+
+.roster-row:hover {
+  background: var(--surface-2);
+}
+
+/* Inset, because an outline drawn outside a collapsed-border row is clipped
+   by its neighbours on the two long edges. */
+.roster-row:focus-visible {
+  outline: 2px solid var(--accent-ring);
+  outline-offset: -2px;
+}
+
 /* A row that needs acting on carries the same left rule its card does, so
    the two views mark the same clients the same way. */
 .roster-row.is-attention td:first-child {

--- a/mureo/_data/web/dashboard_reports_table.js
+++ b/mureo/_data/web/dashboard_reports_table.js
@@ -71,6 +71,60 @@
     return api.showReportsClientDetail(slug);
   }
 
+  /**
+   * Open one client, the same two steps a card click takes.
+   *
+   * Both the row and its "Detail →" button go through here, so a client
+   * opened by aiming at the row and one opened by aiming at the button land
+   * in the same place with the same selection recorded.
+   */
+  function openRosterClient(slug) {
+    REPORTS_VIEW_STATE.reportsActiveClient = slug;
+    showReportsClientDetail(slug);
+  }
+
+  // Tags that own their own click. A click landing on one of these is that
+  // control's and never also the row's — otherwise the "Detail →" button
+  // would open the client twice, and a link added to a cell later could
+  // never lead anywhere but the client.
+  const ROW_CONTROL_TAGS = new Set(["A", "BUTTON", "INPUT", "SELECT", "TEXTAREA"]);
+
+  /** True when `node`, or anything between it and `row`, owns the click. */
+  function inRowControl(node, row) {
+    let el = node;
+    while (el && el !== row) {
+      if (ROW_CONTROL_TAGS.has(el.tagName ? String(el.tagName).toUpperCase() : "")) {
+        return true;
+      }
+      // `contenteditable="false"` is the one value that says the opposite,
+      // so it is not a control — a cell explicitly opted OUT of editing.
+      const editable = el.getAttribute ? el.getAttribute("contenteditable") : null;
+      if (editable !== null && editable !== "false") return true;
+      el = el.parentNode;
+    }
+    return false;
+  }
+
+  /**
+   * True when the operator is selecting text rather than aiming at the row.
+   *
+   * Dragging across two cells to copy a figure ends in a click, and a row
+   * that navigated on it would take the screen away at the moment the
+   * operator finished reading it — with the copied figure lost. A table of
+   * numbers that cannot be selected is a table with one use taken off it.
+   */
+  function hasTextSelection() {
+    try {
+      const get = typeof window !== "undefined" ? window.getSelection : null;
+      if (typeof get !== "function") return false;
+      const selection = get.call(window);
+      return !!(selection && !selection.isCollapsed && String(selection).length);
+    } catch (_e) {
+      // No Selection API, or one that refuses to answer. Nothing to protect.
+      return false;
+    }
+  }
+
   // Below this many visible clients the grid is the better view, so the
   // toggle is not offered and the table is not built. Two, because the
   // comparison a table exists for needs two things to compare.
@@ -263,6 +317,42 @@
     return td;
   }
 
+  /**
+   * Make the whole row the target for the client it stands for (#707).
+   *
+   * A 44px row carrying the name, the health dot and every figure reads as
+   * ONE object, so that is what an operator aims at. Before this, the only
+   * part of it that opened anything was the button in the last column.
+   *
+   * Three things it deliberately does not take:
+   *
+   *   • a click that landed on a real control — see inRowControl. The
+   *     "Detail →" button is one, so it still opens the client exactly once.
+   *   • a click that ended a text selection — see hasTextSelection.
+   *   • the row's table semantics. `tabindex` makes the row reachable by
+   *     keyboard, and Enter opens it; NO `role` is set, because a <tr> that
+   *     claimed to be a button would stop being a row, and the cells under
+   *     it would stop being cells. The announced control for the client is
+   *     still the button in the last column, which is why it stays.
+   */
+  function wireRowTarget(tr, slug) {
+    tr.setAttribute("tabindex", "0");
+    tr.addEventListener("click", function (evt) {
+      if (inRowControl(evt && evt.target, tr)) return;
+      if (hasTextSelection()) return;
+      openRosterClient(slug);
+    });
+    tr.addEventListener("keydown", function (evt) {
+      if (!evt || evt.key !== "Enter") return;
+      // Enter inside a control is that control's activation — and a button's
+      // is about to arrive here again as a click, which the guard above
+      // drops. Taking it here too would open the client twice.
+      if (inRowControl(evt.target, tr)) return;
+      if (typeof evt.preventDefault === "function") evt.preventDefault();
+      openRosterClient(slug);
+    });
+  }
+
   function buildRow(row, withRatio) {
     const tr = document.createElement("tr");
     tr.className = "roster-row is-" + row.health;
@@ -271,6 +361,7 @@
     // `hidden`, and nothing may give it a display that outranks it).
     tr.setAttribute("data-health", row.health);
     tr.setAttribute("data-client-name", row.name);
+    wireRowTarget(tr, row.slug);
 
     const nameCell = cell("td", "roster-client");
     nameCell.appendChild(cell("span", "roster-dot is-" + row.health));
@@ -322,10 +413,11 @@
     link.setAttribute("data-reports-open-client", row.slug);
     link.textContent = MUREO.t("dashboard.reports_detail_link");
     // The same two steps a card click takes, so a client opened from the
-    // table and one opened from the grid land in the same place.
+    // table and one opened from the grid land in the same place. It is kept
+    // now that the whole row is a target (#707): this is the affordance a
+    // screen reader announces and the one an operator can point at.
     link.addEventListener("click", function () {
-      REPORTS_VIEW_STATE.reportsActiveClient = row.slug;
-      showReportsClientDetail(row.slug);
+      openRosterClient(row.slug);
     });
     go.appendChild(link);
     tr.appendChild(go);

--- a/tests/js/reports_roster_table.test.js
+++ b/tests/js/reports_roster_table.test.js
@@ -104,6 +104,11 @@ async function openRoster(options) {
   });
   // Seed the remembered view BEFORE the render, which is when it is read.
   if (opts.stored) page.localStore.set(ROSTER_VIEW_KEY, opts.stored);
+  // A RELOAD, rather than a seeded key: the store an earlier page wrote,
+  // carried into this one exactly as a browser carries it across F5. What
+  // `stored` cannot show is that the value the toggle WROTE is the value the
+  // next load READS — the two halves have to meet on their own.
+  if (opts.carry) opts.carry.forEach((value, key) => page.localStore.set(key, value));
   page.document.dispatchEvent({ type: "mureo:ready" });
   await settle();
   page.root.querySelector('[data-dashboard-nav="reports"]').click();
@@ -127,6 +132,32 @@ function sortHeader(page, key) {
   return page.root
     .querySelectorAll("[data-reports-sort]")
     .find((b) => b.getAttribute("data-reports-sort") === key);
+}
+
+const rowFor = (page, name) =>
+  rows(page).find((r) => r.getAttribute("data-client-name") === name);
+
+/**
+ * Every client the table asked to open, in order.
+ *
+ * Counting matters as much as identity here: the row and the "Detail →"
+ * button are two handlers over one click, and "it opened the right client"
+ * is true of a table that opened it twice.
+ */
+function recordOpens(page) {
+  const calls = [];
+  page.sandbox.MUREO_DASHBOARD_REPORTS.showReportsClientDetail = function (slug) {
+    calls.push(slug);
+  };
+  return calls;
+}
+
+/** A selection that is not collapsed, as a browser mid-drag reports one. */
+function selectText(page, text) {
+  page.sandbox.getSelection = () => ({
+    isCollapsed: false,
+    toString: () => text,
+  });
 }
 
 // ---------------------------------------------------------------------
@@ -274,6 +305,63 @@ test.describe("the operator's choice of view survives", function () {
       "a remembered 'cards' did not survive the reload"
     );
     assert.equal(rows(page).length, 0);
+  });
+
+  // The round trip, which neither test above is: one page WRITES the choice,
+  // a second page READS it out of the same storage. A key that only one side
+  // agreed with, or a restore that ran after the default was drawn, passes
+  // both of those and fails this.
+  test.it("still draws the cards after a reload", async function () {
+    const first = await openRoster();
+    viewButton(first, "cards").click();
+    await settle();
+
+    const second = await openRoster({ carry: first.localStore });
+    assert.ok(
+      isVisible(second.root.querySelector("[data-reports-clients]")),
+      "the reload did not open on the cards"
+    );
+    assert.equal(
+      isVisible(second.root.querySelector("[data-reports-roster-table]")),
+      false,
+      "the table came back over a chosen card grid"
+    );
+    assert.equal(rows(second).length, 0, "the table was built anyway");
+  });
+
+  test.it("still draws the table after a reload", async function () {
+    // The other direction, because "table" is also the default: a test that
+    // only ever asserted the table would pass with the storage unread.
+    const first = await openRoster({ stored: "cards" });
+    viewButton(first, "table").click();
+    await settle();
+    assert.equal(first.localStore.get(ROSTER_VIEW_KEY), "table");
+
+    const second = await openRoster({ carry: first.localStore });
+    assert.ok(
+      isVisible(second.root.querySelector("[data-reports-roster-table]")),
+      "the reload did not open on the table"
+    );
+    assert.deepEqual(visibleNames(second).length, 3);
+  });
+
+  test.it("keeps the choice across a client detail and back", async function () {
+    // The other "next time" an operator means: open a client, come back.
+    const page = await openRoster();
+    viewButton(page, "cards").click();
+    await settle();
+    page.root
+      .querySelector("[data-reports-clients]")
+      .querySelector(".reports-client-card")
+      .click();
+    await settle();
+    page.root.querySelector("[data-reports-back]").click();
+    await settle();
+    assert.ok(isVisible(page.root.querySelector("[data-reports-clients]")));
+    assert.equal(
+      isVisible(page.root.querySelector("[data-reports-roster-table]")),
+      false
+    );
   });
 
   test.it("does not resurrect a table for a roster that shrank to one", async function () {
@@ -801,5 +889,153 @@ test.describe("card KPI labels do not break mid-word", function () {
     const ws = cascade(label, "white-space");
     assert.ok(ws, "nothing declares white-space on a card KPI label");
     assert.equal(ws.value, "nowrap", "won by: " + ws.selector);
+  });
+});
+
+// ---------------------------------------------------------------------
+// The whole row is the target (#707)
+// ---------------------------------------------------------------------
+
+test.describe("a click anywhere on a row opens that client", function () {
+  const viewState = (page) =>
+    page.sandbox.MUREO_DASHBOARD_REPORTS_STATE.REPORTS_VIEW_STATE;
+
+  test.it("opens from the client's name", async function () {
+    const page = await openRoster();
+    rowFor(page, "Bravo Logistics").querySelector(".roster-name").click();
+    await settle();
+    assert.equal(viewState(page).reportsActiveClient, "bravo");
+    assert.equal(viewState(page).reportsView, "detail");
+  });
+
+  test.it("opens from a figure cell just as well", async function () {
+    // The point of the change: an operator aims at the client, and the
+    // client is the whole row — not the last column of it.
+    const page = await openRoster();
+    const calls = recordOpens(page);
+    rowFor(page, "Carol Foods").querySelector(".roster-num").click();
+    await settle();
+    assert.deepEqual(calls, ["carol"]);
+  });
+
+  test.it("opens the client ONCE when the Detail button is the target", async function () {
+    // Two handlers now sit over one click. The button's own is the click's;
+    // the row must not take it as well.
+    const page = await openRoster();
+    const calls = recordOpens(page);
+    rowFor(page, "Bravo Logistics").querySelector(".roster-go-link").click();
+    await settle();
+    assert.deepEqual(calls, ["bravo"], "the row and the button both fired");
+  });
+
+  test.it("keeps the Detail button on every row", async function () {
+    // It is the affordance a screen reader announces and the one an operator
+    // can point at. A whole-row target is an addition to it, not a swap.
+    const page = await openRoster();
+    assert.equal(page.root.querySelectorAll(".roster-go-link").length, 3);
+  });
+
+  test.it("leaves a link inside a cell to lead where it leads", async function () {
+    // Nothing in a cell links out today. This is what stops the row taking
+    // the click when something does — a policy link on a flag, a platform
+    // deep link — rather than the guard being rediscovered then.
+    const page = await openRoster();
+    const calls = recordOpens(page);
+    const link = page.document.createElement("a");
+    link.setAttribute("href", "https://example.test/");
+    rowFor(page, "Bravo Logistics").querySelector(".roster-client").appendChild(link);
+    link.click();
+    await settle();
+    assert.deepEqual(calls, [], "the row hijacked a link inside it");
+  });
+
+  test.it("does not navigate on the click that ends a text selection", async function () {
+    // Dragging across two cells to copy a figure ends in a click. A row that
+    // navigated on it would take the screen away at the moment the operator
+    // finished reading, and lose the selection with it.
+    const page = await openRoster();
+    const calls = recordOpens(page);
+    selectText(page, "128,400");
+    rowFor(page, "Bravo Logistics").querySelector(".roster-num").click();
+    await settle();
+    assert.deepEqual(calls, []);
+  });
+
+  test.it("navigates again once the selection is collapsed", async function () {
+    const page = await openRoster();
+    const calls = recordOpens(page);
+    page.sandbox.getSelection = () => ({ isCollapsed: true, toString: () => "" });
+    rowFor(page, "Bravo Logistics").querySelector(".roster-num").click();
+    await settle();
+    assert.deepEqual(calls, ["bravo"]);
+  });
+
+  test.it("is reachable by keyboard", async function () {
+    const page = await openRoster();
+    rows(page).forEach((r) =>
+      assert.equal(r.getAttribute("tabindex"), "0", r.getAttribute("data-client-name"))
+    );
+  });
+
+  test.it("opens on Enter", async function () {
+    const page = await openRoster();
+    const calls = recordOpens(page);
+    rowFor(page, "Carol Foods").dispatchEvent({ type: "keydown", key: "Enter" });
+    await settle();
+    assert.deepEqual(calls, ["carol"]);
+  });
+
+  test.it("ignores every other key", async function () {
+    // Typing is not navigating — including Space, which scrolls a table an
+    // operator is reading rather than opening whatever row has focus.
+    const page = await openRoster();
+    const calls = recordOpens(page);
+    ["a", " ", "Tab", "ArrowDown", "Escape"].forEach((key) =>
+      rowFor(page, "Carol Foods").dispatchEvent({ type: "keydown", key: key })
+    );
+    await settle();
+    assert.deepEqual(calls, []);
+  });
+
+  test.it("does not double-open when Enter lands on the Detail button", async function () {
+    // A button's Enter is its own activation AND arrives as a click. Both
+    // reach the row, and neither may be taken again.
+    const page = await openRoster();
+    const calls = recordOpens(page);
+    const link = rowFor(page, "Bravo Logistics").querySelector(".roster-go-link");
+    link.dispatchEvent({ type: "keydown", key: "Enter" });
+    link.click();
+    await settle();
+    assert.deepEqual(calls, ["bravo"]);
+  });
+
+  test.it("stays a row, and its cells stay cells", async function () {
+    // A <tr> that claimed role="button" would stop being a row, and every
+    // figure under it would stop being announced with its column. The row is
+    // focusable; it does not pretend to be a control.
+    const page = await openRoster();
+    const row = rowFor(page, "Bravo Logistics");
+    assert.equal(row.getAttribute("role"), null);
+    assert.equal(row.tagName, "TR");
+    assert.ok(row.querySelectorAll("td").length >= 6);
+  });
+
+  test.it("looks like a target", async function () {
+    const page = await openRoster();
+    const cursor = cascade(rowFor(page, "Bravo Logistics"), "cursor");
+    assert.ok(cursor, "nothing declares a cursor on a roster row");
+    assert.equal(cursor.value, "pointer", "won by: " + cursor.selector);
+  });
+
+  test.it("leaves the totals row inert", async function () {
+    // It stands for no client, so there is nothing for it to open.
+    const page = await openRoster();
+    const total = page.root.querySelector(".roster-total");
+    assert.ok(total, "no totals row");
+    assert.equal(total.getAttribute("tabindex"), null);
+    const calls = recordOpens(page);
+    total.click();
+    await settle();
+    assert.deepEqual(calls, []);
   });
 });


### PR DESCRIPTION
Closes #707.

## 1. The whole row opens its client

The table's rows are 44px tall and carry the client's name, its health dot
and every figure — the row reads as one object — but the only part of it
that opened anything was the button in the last column. A click anywhere on
the row now opens that client, and the row carries `tabindex="0"` so Enter
does the same.

It takes only the clicks nobody else wanted:

- **A click on a real control is that control's.** `a`, `button`, `input`,
  `select`, `textarea`, and anything `contenteditable` that is not `"false"`,
  checked from the event target up to the row. So the "Detail →" button still
  opens the client **exactly once** — the test asserts the count, not just
  the slug — and a link added to a cell later still leads where it leads.
- **A click that ends a text selection is a selection.** Dragging across two
  cells to copy a figure ends in a click, and a row that navigated on it
  would take the screen away at the moment the operator finished reading,
  losing the copied figure with it.
- **The row's table semantics stay.** No `role` is set: a `<tr>` that claimed
  to be a button would stop being a row and the figures under it would stop
  being announced with their columns. The row is merely focusable, and the
  announced control for a client is still the "Detail →" button — which is
  why it is kept rather than replaced.

`cursor: pointer` and a `--surface-2` tint on hover say the row is a target.
A tint rather than the card's `border-color` change, because these rows share
collapsed borders and a border that lit up would move the row below it; the
focus outline is inset for the same reason.

Row and button now share one `openRosterClient()`, so a client opened either
way lands in the same place with the same selection recorded.

## 2. The remembered table/cards choice — what was measured

The report was that the chosen view is not the one showing next time. **It
did not reproduce.** What was measured, against the bytes that ship, driven
through the real `app.html` + `app.css` in `dom_harness`:

| Hypothesis | Result |
|---|---|
| (a) the write and the read disagree on the key | **No.** One `ROSTER_VIEW_KEY` const serves both, and the new round-trip test fails when they are made to differ. |
| (b) the restore runs after the default is drawn | **No.** Both containers ship `hidden`, and `rosterViewFor()` runs inside `renderRoster()` before anything is drawn — there is no `await` between `setReportsView("index")` and the first draw, so no frame in between. |
| (c) "a shrunk roster keeps the cards" misfires | **No.** `rosterViewFor()` only forces cards below `ROSTER_TABLE_MIN`; checked at 2 and 3 visible clients, and with an archived client in the roster. |
| (d) a refused write is swallowed | **Real, but not this.** `writeRosterView` does swallow a `setItem` that throws — deliberately, and documented in the file — so a browser that refuses storage gets a toggle that silently forgets. That is not what a normal Chrome on a loopback origin does. |

Also ruled out, each by direct measurement rather than by reading: a stale
installed wheel (the file in site-packages is byte-identical to `main`, at
0.15.0); a duplicate `<script>` tag; a second copy of the assets in
`mureo-agency` / `mureo-pro`; a key collision with `mureo.locale`,
`mureo.reports.client_order` or `mureo.reports.triage.dismissed`; the
`[data-reports-view]` selector also matching the `data-reports-view-switch`
wrapper (it does not — attribute selectors match the exact name); the
double-`renderAll()` at boot (#223) racing a toggle click; a click landing
mid-render; navigating away and back; and a period switch. Every read path
re-reads storage, so the preference cannot be lost while the store persists.

**So the PR does not carry a fix for it — it carries the test that was
missing, and the finding.** Every test covering this preference seeded the
key into a page and asserted what drew; none let one page WRITE the choice
and a second page READ it. `openRoster({ carry })` copies a finished page's
store into the next one, exactly as a browser carries `localStorage` across
F5. Asserted in both directions — "table" is also the default, so a test that
only ever asserted the table would pass with the storage unread — plus across
a client detail and back, which is the other "next time" an operator means.

The one explanation left standing is **origin instability**, and it is worth
checking before changing any code: `localStorage` is scoped to
`scheme://host:port`, and the configure server prefers 7613 but falls back to
an **ephemeral port** when it is busy (`ConfigureWizard._bind_server`, logged
at INFO and never surfaced; the service status readers exist precisely to
"prefer the actually-bound port/url from configure.json so an ephemeral-port
fallback is reported"). A different port is a different, empty store. So is
`localhost:7613` versus `127.0.0.1:7613`. If that is what happened, the
language would have reset to English and the card drag order would be gone
**at the same time** — one question settles it.

## Verification

- `node --test tests/js/*.test.js` — **515 pass, 0 fail** (was 498; 17 new).
- Mutation-checked, since green tests only prove the code passes its tests:
  dropping the control guard fails 3, the selection guard 1, `tabindex` 1,
  accepting a key other than Enter 1, opening the wrong slug 3; making the
  write key differ from the read key fails 4, and neutering the restore
  fails 3.
- `pytest tests/` — 14 failed / 9908 passed on this branch and **the same 14
  on `main`** (`582e061`); diff of the two runs is empty but for the elapsed
  time. All 14 are pre-existing in this dev environment (locally installed
  plugins change the tool inventory).
- `black --check` clean over 744 files; `ruff check` clean.

No new i18n strings, no new served asset, no Python touched.
