### PR TITLE
chore: release v0.17.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mureo",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Your local-first AI ad ops crew for Google Ads, Meta Ads, Search Console & GA4. mureo sits on top of the official ad-platform MCPs, gates every change against your strategy, correlates outcomes locally, and keeps an auditable decision log — credentials never leave your machine.",
   "author": {
     "name": "Logly Inc.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,50 @@
 ## [Unreleased]
 
+## [0.17.0] - 2026-08-29
+
+### Changed (BREAKING)
+
+- **`period` on the three period-over-period Google Ads tools is a closed
+  enum now, and a window they cannot measure is refused instead of silently
+  replaced** (#716, #718). `google_ads_performance_analyze`,
+  `google_ads_search_terms_review` and `google_ads_negative_keywords_suggest`
+  do not report on the window you ask for alone — they derive the
+  equal-length window immediately before it — so a window with no fixed
+  length has no comparison to be made against.
+
+  **`TODAY`, `YESTERDAY`, `THIS_MONTH` and `LAST_MONTH` are no longer
+  accepted on those three tools**, nor are the five week constants. What
+  remains is `LAST_7_DAYS`, `LAST_14_DAYS`, `LAST_30_DAYS`, `LAST_90_DAYS`,
+  and an explicit `BETWEEN 'YYYY-MM-DD' AND 'YYYY-MM-DD'` range of up to 730
+  days. Every other Google Ads reporting tool keeps the full constant list;
+  only these three, which need a *length*, are narrowed.
+
+  **A call that passed one of those values was not answering the question it
+  looked like it was answering.** The comparison resolver read the length out
+  of a lookup table and fell back to seven days for anything absent, so
+  `THIS_MONTH` returned the last 7 days measured against the 7 before them,
+  under a heading that said the month: no error, right-looking numbers,
+  wrong dates. The narrowing turns that wrong answer into a schema error at
+  the dispatcher, naming the value it will not honour.
+
+  *Migration.* `LAST_MONTH` → the month written out, e.g. `BETWEEN
+  '2026-07-01' AND '2026-07-31'`. `THIS_MONTH` → `LAST_7_DAYS`,
+  `LAST_14_DAYS` or `LAST_30_DAYS`, or the month-to-date range written out.
+  `TODAY` / `YESTERDAY` → an explicit one- or two-day range, keeping in mind
+  that the comparison window is the same length again.
+
+- **`google_ads_keywords_audit` and
+  `google_ads_keywords_cross_adgroup_duplicates` validate their `period`**
+  (#718). Both declared it as an unconstrained string, so a lowercase
+  constant, a misspelling, or the `'YYYY-MM-DD..YYYY-MM-DD'` form their own
+  descriptions advertised — Meta-only syntax that no Google Ads code path has
+  ever parsed — travelled all the way to the API before failing, or was
+  quietly upper-cased on the way. They are on the same shared schema as the
+  other sixteen tools now: the same constant list, the same exact `BETWEEN`
+  spelling, and the same refusal at the dispatcher for anything else. Both
+  have supported arbitrary ranges all along; only the spelling of them was
+  documented wrong.
+
 ### Added
 
 - **The day-grain history write is usable without a path, and knows whose day
@@ -36,6 +81,50 @@
   days, and without the bound an anchor of `2099-01-01` would make every date
   this side of the century a "complete past day". A past anchor is left alone
   — it can only make the check stricter.
+
+- **The client list says when a summary could not be fetched** (#714). The
+  health band 0.16.0 put at the top of a roster of two or more clients — the
+  day, the fraction that raised nothing, and four counted blocks (nothing
+  raised, watch, needs attention, not running) — now carries one line beneath
+  it stating how many clients mureo could not reach just now, and that a
+  reload will retry.
+
+  A failed summary request yields `null`, and those clients are counted as
+  "nothing raised" **deliberately**: routing a restarting daemon or a dropped
+  network into "needs attention" paints the screen red about live ad accounts
+  that may be perfectly fine. The other half of that decision is that the
+  screen has to say the check did not happen, or a green roster nobody
+  verified reads as a verified one. The note is a fact about the *request*,
+  not about an account: the triage vocabulary, the four blocks and their
+  partition of the roster are untouched, and a client mureo could not reach
+  keeps the bucket it had. Neutral colour, not a fourth alarm; hidden
+  entirely at zero failures, and on the detail view.
+
+### Changed
+
+- **`LAST_90_DAYS` is expanded against the *server's* date, and says so**
+  (#717). Google Ads has no 90-day range constant, so every other constant is
+  resolved by Google in the **account's** reporting time zone while this one
+  is resolved by mureo from its own clock. When the two zones differ the
+  window's edges can sit **up to a day apart** from where an account-local
+  reader would put them. The tool descriptions and
+  `skills/_mureo-google-ads/SKILL.md` now state the asymmetry rather than
+  folding it into a blanket "account time zone" claim, and point a caller who
+  needs an exact boundary at an explicit `BETWEEN` range.
+
+- **The list screen's model is one module, and each client is graded once per
+  render** (#715). `dashboard_reports.js` (909 lines) gave up
+  `reports_index.js` — `buildReportsIndexModel(rows, summaries)`, the whole
+  model behind the list screen — and `dashboard_reports_changes.js`, the
+  detail view's day-over-day tier moved whole. `triageClientHealth` used to
+  run four times per client per render, and the portfolio strip counted the
+  alert layer a fifth time; the verdict is computed once, in grid order, and
+  handed to the band, the cards, the rows, the chips and the strip. It is not
+  a second opinion — the verdict is still `reports_triage.js`'s, and
+  `buildReportsIndexModel` is now the only caller of `triageHealthCounts` in
+  the shipped assets, which a test asserts as an absence everywhere else.
+  Behaviour-preserving: the same nodes in the same order, the same payloads,
+  no i18n key added or dropped.
 
 ### Fixed
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "mureo",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini.",
   "contextFileName": "CONTEXT.md"
 }

--- a/mureo/__init__.py
+++ b/mureo/__init__.py
@@ -1,3 +1,3 @@
 """mureo — your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."""
 
-__version__ = "0.16.0"
+__version__ = "0.17.0"

--- a/mureo/_data/skills/_mureo-amazon-ads/SKILL.md
+++ b/mureo/_data/skills/_mureo-amazon-ads/SKILL.md
@@ -2,7 +2,7 @@
 name: _mureo-amazon-ads
 description: "Amazon Ads (official MCP, bridged by mureo): query campaigns, ad groups, ads and targets, run reports, and manage account access under Amazon's own tool names."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
   openclaw:
     category: "advertising"
     requires:

--- a/mureo/_data/skills/_mureo-google-ads/SKILL.md
+++ b/mureo/_data/skills/_mureo-google-ads/SKILL.md
@@ -2,7 +2,7 @@
 name: _mureo-google-ads
 description: "Google Ads: Manage campaigns, ad groups, ads, keywords, budgets, and performance analysis."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
   openclaw:
     category: "advertising"
     requires:

--- a/mureo/_data/skills/_mureo-learning/SKILL.md
+++ b/mureo/_data/skills/_mureo-learning/SKILL.md
@@ -2,7 +2,7 @@
 name: _mureo-learning
 description: "Evidence-based marketing decision framework: statistical thinking for AI agents operating ad accounts."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
   openclaw:
     category: "marketing"
     requires:

--- a/mureo/_data/skills/_mureo-meta-ads/SKILL.md
+++ b/mureo/_data/skills/_mureo-meta-ads/SKILL.md
@@ -2,7 +2,7 @@
 name: _mureo-meta-ads
 description: "Meta Ads: Manage campaigns, ad sets, ads, insights, and audiences on Facebook/Instagram."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
   openclaw:
     category: "advertising"
     requires:

--- a/mureo/_data/skills/_mureo-shared/SKILL.md
+++ b/mureo/_data/skills/_mureo-shared/SKILL.md
@@ -2,7 +2,7 @@
 name: _mureo-shared
 description: "mureo: Shared patterns for authentication, security rules, and output formatting."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
   openclaw:
     category: "advertising"
     requires:

--- a/mureo/_data/skills/_mureo-strategy/SKILL.md
+++ b/mureo/_data/skills/_mureo-strategy/SKILL.md
@@ -2,7 +2,7 @@
 name: _mureo-strategy
 description: "Strategy Context: Manage business strategy files (STRATEGY.md, STATE.json) for strategy-driven ad operations."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
   openclaw:
     category: "advertising"
     requires:

--- a/mureo/_data/skills/ad-fatigue-check/SKILL.md
+++ b/mureo/_data/skills/ad-fatigue-check/SKILL.md
@@ -2,7 +2,7 @@
 name: ad-fatigue-check
 description: "Detect creative fatigue across active ads — rising frequency, declining CTR week-over-week, and CPM drift — score each ad FATIGUED / WATCH / FRESH, and hand the evidence to a creative refresh. Use when the user asks whether creatives are worn out, why CTR is falling, if frequency is too high, when to rotate or refresh ads, or requests クリエイティブ疲弊チェック / 広告の疲弊を確認 / フリークエンシーが高い / CTRが落ちてきた / そろそろ差し替え時か. Reads active ads per platform, applies documented fatigue thresholds with noise guards, and routes fatigued ads to /creative-generate or /creative-refresh."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
 ---
 
 # Ad Fatigue Check

--- a/mureo/_data/skills/audience-review/SKILL.md
+++ b/mureo/_data/skills/audience-review/SKILL.md
@@ -2,7 +2,7 @@
 name: audience-review
 description: "Audit who your ads actually target and where they run, compare it against the STRATEGY.md Persona, and surface exclusions, bid adjustments, lookalikes, and placement pruning tied to that Persona. Use when the user asks to review targeting, audiences, demographics, placements, or device performance, to check whether spend matches the Persona, to find wasted placements (e.g. Audience Network with no conversions), or requests オーディエンスレビュー / 配置レビュー / ターゲティング見直し / ペルソナと配信のズレを確認 / 除外設定を提案して. Reads Persona + Target Audience from STRATEGY.md and drives the read-only targeting tools."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
 ---
 
 # Audience Review

--- a/mureo/_data/skills/budget-pacing/SKILL.md
+++ b/mureo/_data/skills/budget-pacing/SKILL.md
@@ -2,7 +2,7 @@
 name: budget-pacing
 description: "Month-to-date spend vs the monthly budget target, projected month-end landing, and pace alerts across all configured platforms. Use when the user asks about pacing, burn rate, whether they will overspend or underspend this month, monthly-budget tracking, landing/forecast, 'are we on budget', or requests 予算ペーシング / 着地予測 / 予算消化ペース. DISTINCT from /budget-rebalance (which reallocates budget between campaigns) — this manages total-spend trajectory toward a monthly target. Reads STRATEGY.md Guardrails / a Monthly Budget section and STATE.json."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
 ---
 
 # Budget Pacing

--- a/mureo/_data/skills/budget-rebalance/SKILL.md
+++ b/mureo/_data/skills/budget-rebalance/SKILL.md
@@ -2,7 +2,7 @@
 name: budget-rebalance
 description: "Rebalance campaign budgets across all configured platforms based on strategy and performance signals. Use when the user asks to optimize budgets, redistribute spend, scale efficient campaigns, or cap overspending ones. Reads STRATEGY.md goals, analyzes campaign efficiency, and proposes budget changes with rationale. Also use when the user asks in Japanese (予算を最適化して / 予算の再配分 / 好調なキャンペーンに予算を寄せて / 予算リバランス)."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
 ---
 
 # Budget Rebalance

--- a/mureo/_data/skills/competitive-scan/SKILL.md
+++ b/mureo/_data/skills/competitive-scan/SKILL.md
@@ -2,7 +2,7 @@
 name: competitive-scan
 description: "Scan competitor activity using auction insights and market signals. Use when the user asks about competitors, market dynamics, impression share changes, competitor moves, or competitive positioning. Also use when the user asks in Japanese (競合の動きを調べて / 競合分析 / インプレッションシェアの変化を確認 / 競合にシェアを取られていないか)."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
 ---
 
 # Competitive Scan

--- a/mureo/_data/skills/creative-generate/SKILL.md
+++ b/mureo/_data/skills/creative-generate/SKILL.md
@@ -2,7 +2,7 @@
 name: creative-generate
 description: "Generate creator-quality ad creatives — text-free key visuals plus composed banners — from a strategy-grounded brief. Use when the user asks to create ad creatives, generate ad images or banners, make banner variations, design display / social ad creatives, or asks in Japanese (クリエイティブ作成 / バナー作成 / 広告画像を生成 / バナーのバリエーションを作って). Runs a 6-step workflow (brief → copy → visuals → art-direction scoring loop → HTML/CSS composition → delivery) via the creative_studio_* MCP tools, then hands approved banners to the existing upload tools."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
 ---
 
 # Creative Generate

--- a/mureo/_data/skills/creative-refresh/SKILL.md
+++ b/mureo/_data/skills/creative-refresh/SKILL.md
@@ -2,7 +2,7 @@
 name: creative-refresh
 description: "Refresh ad copy and creative assets based on performance signals and brand voice. Use when the user asks to refresh creative, propose new ad copy, A/B test creatives, update RSA assets, swap Performance Max asset-group headlines, descriptions, images or logos, rotate underperformers, or visually evaluate / compare banner (image) creatives. Also use when the user asks in Japanese (クリエイティブを刷新して / 広告文の改善案がほしい / RSAアセットの入れ替え / P-MAXの見出しを差し替えて / P-MAXの画像を差し替えて / バナーを比較評価して)."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
 ---
 
 # Creative Refresh

--- a/mureo/_data/skills/daily-check/SKILL.md
+++ b/mureo/_data/skills/daily-check/SKILL.md
@@ -2,7 +2,7 @@
 name: daily-check
 description: "Run a daily health check on all configured ad accounts (Google Ads, Meta Ads, Amazon Ads, TikTok Ads, Search Console, GA4, and any configured plugin platform). Use when the user asks for a daily review, health check, status update, anomaly detection, or 'how are my campaigns doing today'. Reads STRATEGY.md and STATE.json, runs platform-specific health diagnostics, checks goal progress, evaluates pending action_log observations, and reports findings as Healthy / Watch / Action-needed. Also use when the user asks in Japanese (デイリーチェック / 今日のアカウント状況は / 異常がないか確認して / 日次ヘルスチェック)."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
 ---
 
 # Daily Check

--- a/mureo/_data/skills/experiment/SKILL.md
+++ b/mureo/_data/skills/experiment/SKILL.md
@@ -2,7 +2,7 @@
 name: experiment
 description: "Design, run, and evaluate a controlled A/B test (split test) on your ad accounts with evidence discipline — one variable, a falsifiable hypothesis, a fixed window, and a per-variant outcome verdict. Use when the user asks to run an A/B test, split test, or experiment, to 'test whether X beats Y', to validate a creative-refresh or learning hunch properly, to validate a breakdown exclusion or reallocation hypothesis before acting on it, or requests A/Bテスト / スプリットテスト設計 / 実験を回したい / どちらが勝ったか評価して / 仮説を検証したい. Forces a designed experiment instead of an ad-hoc change, records the baseline in action_log, and forbids peeking-based decisions before the window closes."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
 ---
 
 # Experiment

--- a/mureo/_data/skills/goal-review/SKILL.md
+++ b/mureo/_data/skills/goal-review/SKILL.md
@@ -2,7 +2,7 @@
 name: goal-review
 description: "Review Goal progress against STRATEGY.md targets. Use when the user asks to evaluate goal achievement, review KPI progress, assess strategy performance, or check if targets are being met. Also use when the user asks in Japanese (目標の進捗を確認 / KPIレビュー / ゴール達成状況は / 目標に届きそうか)."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
 ---
 
 # Goal Review

--- a/mureo/_data/skills/incident-postmortem/SKILL.md
+++ b/mureo/_data/skills/incident-postmortem/SKILL.md
@@ -2,7 +2,7 @@
 name: incident-postmortem
 description: "Close the learning loop after a rescue or incident — reconstruct the timeline from action_log, run root-cause analysis (platform / site / measurement / external), produce a structured postmortem document, distill reusable insights via /learn, and propose preventive guardrails. Use after a /rescue, a CPA spike, a conversion drop, or a runaway-spend event has been handled, or when the user asks for a postmortem, retrospective, root-cause writeup, or requests インシデント振り返り / ポストモーテム / 事後分析 / なぜ起きたのか / 再発防止策. Read-and-document only — makes no ad-platform writes."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
 ---
 
 # Incident Postmortem

--- a/mureo/_data/skills/lead-form-create/SKILL.md
+++ b/mureo/_data/skills/lead-form-create/SKILL.md
@@ -2,7 +2,7 @@
 name: lead-form-create
 description: "Create a Meta Instant Form (Lead Ad form) through a one-question-at-a-time interview. Use when the user asks to create a lead form, Instant Form, CV form, or similar. The agent collects required parameters via a guided dialogue, confirms, then calls meta_ads_lead_forms_create. Also use when the user asks in Japanese (リードフォームを作成 / インスタントフォームを作って / CVフォーム作成)."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
 ---
 
 # Lead Form Create

--- a/mureo/_data/skills/learn/SKILL.md
+++ b/mureo/_data/skills/learn/SKILL.md
@@ -2,7 +2,7 @@
 name: learn
 description: "Save a marketing diagnosis insight to the pro-diagnosis knowledge base so it is applied in future operations across all platforms. Use when the user runs /learn, explicitly teaches the agent a marketing insight, corrects the agent's analysis, or asks to remember/record an operational learning for next time. Also use when the user asks in Japanese (この学びを記録して / 次回から反映して / 運用の気づきを覚えておいて)."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
 ---
 
 # Learn

--- a/mureo/_data/skills/monthly-report/SKILL.md
+++ b/mureo/_data/skills/monthly-report/SKILL.md
@@ -2,7 +2,7 @@
 name: monthly-report
 description: "Stakeholder / client-facing monthly digest across all configured platforms: the previous full calendar month with month-over-month comparison, per-Goal attainment, an action-log recap grouped by command with outcome verdicts, budget utilization, and next-month recommendations. Use when the user asks for a monthly report, month-end summary, client report, monthly recap / digest, or requests 月次レポート / 月次まとめ / クライアント向けレポート. Written in plain language for a client audience."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
 ---
 
 # Monthly Report

--- a/mureo/_data/skills/onboard/SKILL.md
+++ b/mureo/_data/skills/onboard/SKILL.md
@@ -2,7 +2,7 @@
 name: onboard
 description: "Initial account setup — create STRATEGY.md and STATE.json from scratch, import platform data, and establish baseline metrics. Use when the user is starting fresh with mureo, has no STRATEGY.md yet, or asks to set up a new account. Also use when the user asks in Japanese (初期セットアップ / STRATEGY.mdを作成して / mureoを使い始めたい / アカウントの立ち上げ)."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
 ---
 
 # Onboard

--- a/mureo/_data/skills/rescue/SKILL.md
+++ b/mureo/_data/skills/rescue/SKILL.md
@@ -2,7 +2,7 @@
 name: rescue
 description: "Emergency performance fix when an ad account is in trouble. Use when the user reports a sudden CPA spike, conversion drop, runaway spend, or asks for an urgent performance rescue. Sets Operation Mode to TURNAROUND_RESCUE and applies stabilization actions. Also use when the user asks in Japanese (CPAが急に悪化した / CVが激減した / 広告費が暴走している / 緊急で立て直して)."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
 ---
 
 # Rescue

--- a/mureo/_data/skills/search-term-cleanup/SKILL.md
+++ b/mureo/_data/skills/search-term-cleanup/SKILL.md
@@ -2,7 +2,7 @@
 name: search-term-cleanup
 description: "Audit and clean up search terms (negative keywords, intent classification, query hygiene). Use when the user asks to clean up search queries, add negative keywords, review search term reports, or improve match quality. Cross-references Search Console, GA4, and ad platform data. Also use when the user asks in Japanese (検索語句のクリーンアップ / 除外キーワードを追加して / 無駄な検索クエリを止めたい)."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
 ---
 
 # Search Term Cleanup

--- a/mureo/_data/skills/sync-state/SKILL.md
+++ b/mureo/_data/skills/sync-state/SKILL.md
@@ -2,7 +2,7 @@
 name: sync-state
 description: "Sync STATE.json with current campaign data from all platforms. Use when the user asks to refresh state, sync campaigns, update STATE.json from live data, or pull latest campaign snapshots. Also use when the user asks in Japanese (STATE.jsonを更新 / 最新データに同期して / キャンペーン情報を取り込み直して)."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
 ---
 
 # Sync State

--- a/mureo/_data/skills/tracking-health/SKILL.md
+++ b/mureo/_data/skills/tracking-health/SKILL.md
@@ -2,7 +2,7 @@
 name: tracking-health
 description: "Preventive audit of conversion tracking across all configured ad platforms — Meta pixels + CAPI, Google Ads conversion actions, and final-URL tracking-parameter consistency on every platform — with a GA4 cross-check. Use when the user asks to check tracking, audit conversion measurement, verify pixels / tags, check that ads carry the right utm / tracking parameters for the campaign they are in, diagnose why conversions stopped or look wrong, sanity-check CV counting, or requests a 計測ヘルスチェック / タグ・計測監査 / パラメータ整合性チェック / 計測が壊れていないか確認. Reads STRATEGY.md and STATE.json, produces a per-platform tracking scorecard (OK / Watch / Broken per check) and a fix list ranked by revenue risk."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
 ---
 
 # Tracking Health

--- a/mureo/_data/skills/weekly-report/SKILL.md
+++ b/mureo/_data/skills/weekly-report/SKILL.md
@@ -2,7 +2,7 @@
 name: weekly-report
 description: "Generate a weekly summary report across all platforms. Use when the user asks for a weekly report, summary, recap, end-of-week review, or weekly digest. Also use when the user asks in Japanese (週次レポート / 今週のまとめ / 週報を作成して)."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
 ---
 
 # Weekly Report

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mureo"
-version = "0.16.0"
+version = "0.17.0"
 description = "Your local-first AI ad ops crew. Works with Claude Code, Cursor, Codex & Gemini."
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/skills/_mureo-amazon-ads/SKILL.md
+++ b/skills/_mureo-amazon-ads/SKILL.md
@@ -2,7 +2,7 @@
 name: _mureo-amazon-ads
 description: "Amazon Ads (official MCP, bridged by mureo): query campaigns, ad groups, ads and targets, run reports, and manage account access under Amazon's own tool names."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
   openclaw:
     category: "advertising"
     requires:

--- a/skills/_mureo-google-ads/SKILL.md
+++ b/skills/_mureo-google-ads/SKILL.md
@@ -2,7 +2,7 @@
 name: _mureo-google-ads
 description: "Google Ads: Manage campaigns, ad groups, ads, keywords, budgets, and performance analysis."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
   openclaw:
     category: "advertising"
     requires:

--- a/skills/_mureo-learning/SKILL.md
+++ b/skills/_mureo-learning/SKILL.md
@@ -2,7 +2,7 @@
 name: _mureo-learning
 description: "Evidence-based marketing decision framework: statistical thinking for AI agents operating ad accounts."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
   openclaw:
     category: "marketing"
     requires:

--- a/skills/_mureo-meta-ads/SKILL.md
+++ b/skills/_mureo-meta-ads/SKILL.md
@@ -2,7 +2,7 @@
 name: _mureo-meta-ads
 description: "Meta Ads: Manage campaigns, ad sets, ads, insights, and audiences on Facebook/Instagram."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
   openclaw:
     category: "advertising"
     requires:

--- a/skills/_mureo-pro-diagnosis/SKILL.md
+++ b/skills/_mureo-pro-diagnosis/SKILL.md
@@ -2,7 +2,7 @@
 name: _mureo-pro-diagnosis
 description: "Professional marketing diagnostic frameworks: expert-level campaign analysis that grows with your experience."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
   openclaw:
     category: "marketing"
     requires:

--- a/skills/_mureo-shared/SKILL.md
+++ b/skills/_mureo-shared/SKILL.md
@@ -2,7 +2,7 @@
 name: _mureo-shared
 description: "mureo: Shared patterns for authentication, security rules, and output formatting."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
   openclaw:
     category: "advertising"
     requires:

--- a/skills/_mureo-strategy/SKILL.md
+++ b/skills/_mureo-strategy/SKILL.md
@@ -2,7 +2,7 @@
 name: _mureo-strategy
 description: "Strategy Context: Manage business strategy files (STRATEGY.md, STATE.json) for strategy-driven ad operations."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
   openclaw:
     category: "advertising"
     requires:

--- a/skills/ad-fatigue-check/SKILL.md
+++ b/skills/ad-fatigue-check/SKILL.md
@@ -2,7 +2,7 @@
 name: ad-fatigue-check
 description: "Detect creative fatigue across active ads — rising frequency, declining CTR week-over-week, and CPM drift — score each ad FATIGUED / WATCH / FRESH, and hand the evidence to a creative refresh. Use when the user asks whether creatives are worn out, why CTR is falling, if frequency is too high, when to rotate or refresh ads, or requests クリエイティブ疲弊チェック / 広告の疲弊を確認 / フリークエンシーが高い / CTRが落ちてきた / そろそろ差し替え時か. Reads active ads per platform, applies documented fatigue thresholds with noise guards, and routes fatigued ads to /creative-generate or /creative-refresh."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
 ---
 
 # Ad Fatigue Check

--- a/skills/audience-review/SKILL.md
+++ b/skills/audience-review/SKILL.md
@@ -2,7 +2,7 @@
 name: audience-review
 description: "Audit who your ads actually target and where they run, compare it against the STRATEGY.md Persona, and surface exclusions, bid adjustments, lookalikes, and placement pruning tied to that Persona. Use when the user asks to review targeting, audiences, demographics, placements, or device performance, to check whether spend matches the Persona, to find wasted placements (e.g. Audience Network with no conversions), or requests オーディエンスレビュー / 配置レビュー / ターゲティング見直し / ペルソナと配信のズレを確認 / 除外設定を提案して. Reads Persona + Target Audience from STRATEGY.md and drives the read-only targeting tools."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
 ---
 
 # Audience Review

--- a/skills/budget-pacing/SKILL.md
+++ b/skills/budget-pacing/SKILL.md
@@ -2,7 +2,7 @@
 name: budget-pacing
 description: "Month-to-date spend vs the monthly budget target, projected month-end landing, and pace alerts across all configured platforms. Use when the user asks about pacing, burn rate, whether they will overspend or underspend this month, monthly-budget tracking, landing/forecast, 'are we on budget', or requests 予算ペーシング / 着地予測 / 予算消化ペース. DISTINCT from /budget-rebalance (which reallocates budget between campaigns) — this manages total-spend trajectory toward a monthly target. Reads STRATEGY.md Guardrails / a Monthly Budget section and STATE.json."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
 ---
 
 # Budget Pacing

--- a/skills/budget-rebalance/SKILL.md
+++ b/skills/budget-rebalance/SKILL.md
@@ -2,7 +2,7 @@
 name: budget-rebalance
 description: "Rebalance campaign budgets across all configured platforms based on strategy and performance signals. Use when the user asks to optimize budgets, redistribute spend, scale efficient campaigns, or cap overspending ones. Reads STRATEGY.md goals, analyzes campaign efficiency, and proposes budget changes with rationale. Also use when the user asks in Japanese (予算を最適化して / 予算の再配分 / 好調なキャンペーンに予算を寄せて / 予算リバランス)."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
 ---
 
 # Budget Rebalance

--- a/skills/competitive-scan/SKILL.md
+++ b/skills/competitive-scan/SKILL.md
@@ -2,7 +2,7 @@
 name: competitive-scan
 description: "Scan competitor activity using auction insights and market signals. Use when the user asks about competitors, market dynamics, impression share changes, competitor moves, or competitive positioning. Also use when the user asks in Japanese (競合の動きを調べて / 競合分析 / インプレッションシェアの変化を確認 / 競合にシェアを取られていないか)."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
 ---
 
 # Competitive Scan

--- a/skills/creative-generate/SKILL.md
+++ b/skills/creative-generate/SKILL.md
@@ -2,7 +2,7 @@
 name: creative-generate
 description: "Generate creator-quality ad creatives — text-free key visuals plus composed banners — from a strategy-grounded brief. Use when the user asks to create ad creatives, generate ad images or banners, make banner variations, design display / social ad creatives, or asks in Japanese (クリエイティブ作成 / バナー作成 / 広告画像を生成 / バナーのバリエーションを作って). Runs a 6-step workflow (brief → copy → visuals → art-direction scoring loop → HTML/CSS composition → delivery) via the creative_studio_* MCP tools, then hands approved banners to the existing upload tools."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
 ---
 
 # Creative Generate

--- a/skills/creative-refresh/SKILL.md
+++ b/skills/creative-refresh/SKILL.md
@@ -2,7 +2,7 @@
 name: creative-refresh
 description: "Refresh ad copy and creative assets based on performance signals and brand voice. Use when the user asks to refresh creative, propose new ad copy, A/B test creatives, update RSA assets, swap Performance Max asset-group headlines, descriptions, images or logos, rotate underperformers, or visually evaluate / compare banner (image) creatives. Also use when the user asks in Japanese (クリエイティブを刷新して / 広告文の改善案がほしい / RSAアセットの入れ替え / P-MAXの見出しを差し替えて / P-MAXの画像を差し替えて / バナーを比較評価して)."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
 ---
 
 # Creative Refresh

--- a/skills/daily-check/SKILL.md
+++ b/skills/daily-check/SKILL.md
@@ -2,7 +2,7 @@
 name: daily-check
 description: "Run a daily health check on all configured ad accounts (Google Ads, Meta Ads, Amazon Ads, TikTok Ads, Search Console, GA4, and any configured plugin platform). Use when the user asks for a daily review, health check, status update, anomaly detection, or 'how are my campaigns doing today'. Reads STRATEGY.md and STATE.json, runs platform-specific health diagnostics, checks goal progress, evaluates pending action_log observations, and reports findings as Healthy / Watch / Action-needed. Also use when the user asks in Japanese (デイリーチェック / 今日のアカウント状況は / 異常がないか確認して / 日次ヘルスチェック)."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
 ---
 
 # Daily Check

--- a/skills/experiment/SKILL.md
+++ b/skills/experiment/SKILL.md
@@ -2,7 +2,7 @@
 name: experiment
 description: "Design, run, and evaluate a controlled A/B test (split test) on your ad accounts with evidence discipline — one variable, a falsifiable hypothesis, a fixed window, and a per-variant outcome verdict. Use when the user asks to run an A/B test, split test, or experiment, to 'test whether X beats Y', to validate a creative-refresh or learning hunch properly, to validate a breakdown exclusion or reallocation hypothesis before acting on it, or requests A/Bテスト / スプリットテスト設計 / 実験を回したい / どちらが勝ったか評価して / 仮説を検証したい. Forces a designed experiment instead of an ad-hoc change, records the baseline in action_log, and forbids peeking-based decisions before the window closes."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
 ---
 
 # Experiment

--- a/skills/goal-review/SKILL.md
+++ b/skills/goal-review/SKILL.md
@@ -2,7 +2,7 @@
 name: goal-review
 description: "Review Goal progress against STRATEGY.md targets. Use when the user asks to evaluate goal achievement, review KPI progress, assess strategy performance, or check if targets are being met. Also use when the user asks in Japanese (目標の進捗を確認 / KPIレビュー / ゴール達成状況は / 目標に届きそうか)."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
 ---
 
 # Goal Review

--- a/skills/incident-postmortem/SKILL.md
+++ b/skills/incident-postmortem/SKILL.md
@@ -2,7 +2,7 @@
 name: incident-postmortem
 description: "Close the learning loop after a rescue or incident — reconstruct the timeline from action_log, run root-cause analysis (platform / site / measurement / external), produce a structured postmortem document, distill reusable insights via /learn, and propose preventive guardrails. Use after a /rescue, a CPA spike, a conversion drop, or a runaway-spend event has been handled, or when the user asks for a postmortem, retrospective, root-cause writeup, or requests インシデント振り返り / ポストモーテム / 事後分析 / なぜ起きたのか / 再発防止策. Read-and-document only — makes no ad-platform writes."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
 ---
 
 # Incident Postmortem

--- a/skills/lead-form-create/SKILL.md
+++ b/skills/lead-form-create/SKILL.md
@@ -2,7 +2,7 @@
 name: lead-form-create
 description: "Create a Meta Instant Form (Lead Ad form) through a one-question-at-a-time interview. Use when the user asks to create a lead form, Instant Form, CV form, or similar. The agent collects required parameters via a guided dialogue, confirms, then calls meta_ads_lead_forms_create. Also use when the user asks in Japanese (リードフォームを作成 / インスタントフォームを作って / CVフォーム作成)."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
 ---
 
 # Lead Form Create

--- a/skills/learn/SKILL.md
+++ b/skills/learn/SKILL.md
@@ -2,7 +2,7 @@
 name: learn
 description: "Save a marketing diagnosis insight to the pro-diagnosis knowledge base so it is applied in future operations across all platforms. Use when the user runs /learn, explicitly teaches the agent a marketing insight, corrects the agent's analysis, or asks to remember/record an operational learning for next time. Also use when the user asks in Japanese (この学びを記録して / 次回から反映して / 運用の気づきを覚えておいて)."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
 ---
 
 # Learn

--- a/skills/monthly-report/SKILL.md
+++ b/skills/monthly-report/SKILL.md
@@ -2,7 +2,7 @@
 name: monthly-report
 description: "Stakeholder / client-facing monthly digest across all configured platforms: the previous full calendar month with month-over-month comparison, per-Goal attainment, an action-log recap grouped by command with outcome verdicts, budget utilization, and next-month recommendations. Use when the user asks for a monthly report, month-end summary, client report, monthly recap / digest, or requests 月次レポート / 月次まとめ / クライアント向けレポート. Written in plain language for a client audience."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
 ---
 
 # Monthly Report

--- a/skills/onboard/SKILL.md
+++ b/skills/onboard/SKILL.md
@@ -2,7 +2,7 @@
 name: onboard
 description: "Initial account setup — create STRATEGY.md and STATE.json from scratch, import platform data, and establish baseline metrics. Use when the user is starting fresh with mureo, has no STRATEGY.md yet, or asks to set up a new account. Also use when the user asks in Japanese (初期セットアップ / STRATEGY.mdを作成して / mureoを使い始めたい / アカウントの立ち上げ)."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
 ---
 
 # Onboard

--- a/skills/rescue/SKILL.md
+++ b/skills/rescue/SKILL.md
@@ -2,7 +2,7 @@
 name: rescue
 description: "Emergency performance fix when an ad account is in trouble. Use when the user reports a sudden CPA spike, conversion drop, runaway spend, or asks for an urgent performance rescue. Sets Operation Mode to TURNAROUND_RESCUE and applies stabilization actions. Also use when the user asks in Japanese (CPAが急に悪化した / CVが激減した / 広告費が暴走している / 緊急で立て直して)."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
 ---
 
 # Rescue

--- a/skills/search-term-cleanup/SKILL.md
+++ b/skills/search-term-cleanup/SKILL.md
@@ -2,7 +2,7 @@
 name: search-term-cleanup
 description: "Audit and clean up search terms (negative keywords, intent classification, query hygiene). Use when the user asks to clean up search queries, add negative keywords, review search term reports, or improve match quality. Cross-references Search Console, GA4, and ad platform data. Also use when the user asks in Japanese (検索語句のクリーンアップ / 除外キーワードを追加して / 無駄な検索クエリを止めたい)."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
 ---
 
 # Search Term Cleanup

--- a/skills/sync-state/SKILL.md
+++ b/skills/sync-state/SKILL.md
@@ -2,7 +2,7 @@
 name: sync-state
 description: "Sync STATE.json with current campaign data from all platforms. Use when the user asks to refresh state, sync campaigns, update STATE.json from live data, or pull latest campaign snapshots. Also use when the user asks in Japanese (STATE.jsonを更新 / 最新データに同期して / キャンペーン情報を取り込み直して)."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
 ---
 
 # Sync State

--- a/skills/tracking-health/SKILL.md
+++ b/skills/tracking-health/SKILL.md
@@ -2,7 +2,7 @@
 name: tracking-health
 description: "Preventive audit of conversion tracking across all configured ad platforms — Meta pixels + CAPI, Google Ads conversion actions, and final-URL tracking-parameter consistency on every platform — with a GA4 cross-check. Use when the user asks to check tracking, audit conversion measurement, verify pixels / tags, check that ads carry the right utm / tracking parameters for the campaign they are in, diagnose why conversions stopped or look wrong, sanity-check CV counting, or requests a 計測ヘルスチェック / タグ・計測監査 / パラメータ整合性チェック / 計測が壊れていないか確認. Reads STRATEGY.md and STATE.json, produces a per-platform tracking scorecard (OK / Watch / Broken per check) and a fix list ranked by revenue risk."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
 ---
 
 # Tracking Health

--- a/skills/weekly-report/SKILL.md
+++ b/skills/weekly-report/SKILL.md
@@ -2,7 +2,7 @@
 name: weekly-report
 description: "Generate a weekly summary report across all platforms. Use when the user asks for a weekly report, summary, recap, end-of-week review, or weekly digest. Also use when the user asks in Japanese (週次レポート / 今週のまとめ / 週報を作成して)."
 metadata:
-  version: 0.16.0
+  version: 0.17.0
 ---
 
 # Weekly Report


### PR DESCRIPTION
Cuts a `0.17.0` section and bumps every version string. One breaking narrowing
of a Google Ads parameter, a much larger additive counterweight, and no change
to the MCP tool count.

## What ships

**Changed (BREAKING)**

- **`period` on the three period-over-period Google Ads tools is a closed enum**
  (#716, #718). `google_ads_performance_analyze`,
  `google_ads_search_terms_review` and `google_ads_negative_keywords_suggest`
  derive the equal-length window immediately before the one you ask for, so a
  window with no fixed length has no comparison. **`TODAY`, `YESTERDAY`,
  `THIS_MONTH`, `LAST_MONTH` and the five week constants are no longer
  accepted** on those three. What remains: `LAST_7_DAYS`, `LAST_14_DAYS`,
  `LAST_30_DAYS`, `LAST_90_DAYS`, or `BETWEEN 'YYYY-MM-DD' AND 'YYYY-MM-DD'` up
  to 730 days. The other 15 Google Ads reporting tools keep the full list.
- **`google_ads_keywords_audit` and
  `google_ads_keywords_cross_adgroup_duplicates` validate `period`** (#718).
  Both declared it an unconstrained string; they are on the shared schema now,
  so a lowercase constant or a `'YYYY-MM-DD..YYYY-MM-DD'` range (Meta-only
  syntax their own descriptions advertised) is refused at the dispatcher
  instead of failing at the API.

**Added**

- **A public, path-free daily-history write with an `as_of_date` anchor**
  (#710). `mureo.context.daily.with_platform_daily(doc, ...)` performs the whole
  daily merge on a `StateDocument` — guard, per-date merge, `fetched_at`, 35-day
  trim — touching no filesystem; `capped_platform_daily` is the retention rule
  alone. Completeness is judged against the *account's* day when the caller
  states it, with the self-reported anchor bounded to ±2 days of the server's
  date. Both halves additive.
- **The client list says when a summary could not be fetched** (#714). One
  neutral line under 0.16.0's health band: how many clients mureo could not
  reach just now, and that a reload retries. A fact about the request, not
  about an account — the four blocks still partition the roster unchanged.

**Changed**

- **`LAST_90_DAYS` is expanded against the server's date, and says so** (#717) —
  every other constant is resolved by Google in the account's zone, so the edges
  can sit up to a day apart. Stated in the schemas and the skill.
- **The list screen's model is one module, graded once per render** (#715).
  `reports_index.js` + `dashboard_reports_changes.js` out of a 909-line
  `dashboard_reports.js`; `triageClientHealth` ran four times per client per
  render and the strip counted a fifth time. Behaviour-preserving.

**Fixed**

- **An explicit `BETWEEN` range on all 18 Google Ads reporting tools** (#716,
  #717, #718). The month before last was unreachable at campaign grain; the
  client underneath has parsed the form all along, only the schema forbade it.
  Bounded at 730 days, so `ALL_TIME` stays out by the back door too.
- **`LAST_90_DAYS` was offered, recommended, and failed every time** (#717) —
  no such GAQL constant, so the call died in the validator. Now resolved into
  the 90 days ending yesterday. Five week constants that always worked
  downstream are reachable; three enum copies collapsed into one derived from
  the validator's whitelist.
- **A period-over-period tool no longer answers about a window you did not ask
  for** (#716, #718). `_PERIOD_DAYS.get(period.upper(), 7)` turned `THIS_MONTH`
  into the last 7 days: no error, right-looking numbers, wrong dates.

## Why minor, not major

The narrowing removes values that **never produced a correct answer**. They were
silently replaced by the last 7 days and reported under the wrong heading, so
nothing that was right stops working — a wrong number becomes a schema error
naming the offending value, and the CHANGELOG spells out the migration
(`LAST_MONTH` → the month written out as a `BETWEEN` range, and so on).

Pre-1.0, and the additive half is larger: `BETWEEN` on 18 tools, five constants
made reachable, `LAST_90_DAYS` fixed from always-fails, a public daily-history
API. **No MCP tool is added or removed — the count stays at 226.** No STATE.json
key changes, no re-authentication, no migration.

## Contents

- `CHANGELOG.md`: a new `[0.17.0] - 2026-08-29` section. The `[Unreleased]`
  Added (#710) and Fixed (#716/#717/#718) blocks move down verbatim; the section
  gains the `Changed (BREAKING)` block, the #714 Added entry and the #715/#717
  Changed block, none of which the merged PRs wrote down themselves.
- `pyproject.toml`, `mureo/__init__.py`, `.claude-plugin/plugin.json`,
  `gemini-extension.json`: 0.16.0 -> 0.17.0
- 53 SKILL.md frontmatter `version` fields synced

58 files, the same set and the same shape as the v0.16.0 release commit in #719
(57 version lines + the CHANGELOG).

## Verification

Base commit `343a4ef`.

- `ruff check .` — all checks passed; `black --check .` — 752 files unchanged.
- **Version pins green.** `pytest tests/test_plugin_manifests.py
  tests/test_cli_version.py tests/test_doc_claims.py` — **54 passed**: both
  plugin manifests against `pyproject.toml`, every packaged SKILL.md frontmatter
  `version` against the package version, the `mureo --version` surface, and the
  doc/registry tool-count reconciliation.
- **The only `0.16.0` left in the tree** is the CHANGELOG's own `[0.16.0] -
  2026-08-27` history heading.
- Tool count **226**, unchanged by this PR and unchanged by everything in the
  release.

The full suite was not re-run for this release commit: it touches only version
strings and the CHANGELOG. CI on this PR is the authority.
