### PR TITLE
Detail screen: per-section report surfaces instead of one whole-report slab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,11 +42,15 @@
   (#731). The report surface was painted once, across the whole report, and
   the groupings sat on it in two accidental styles: the chart and the
   proposals were white cards, and the tiers, the recent-actions log, the
-  funnel and the report text sat bare on the tint. The surface now belongs to
-  each grouping — every one of them a rounded, padded block with whitespace
-  between it and the next — and the page behind them is the ordinary
-  dashboard ground. The 運用ナビ band keeps its blue: it is a voice, not a
-  section. The client list screen is unchanged.
+  funnel, the breakdown tables, the stated values, the verdict chips and the
+  report text sat bare on the tint. The surface now belongs to each grouping
+  — every one of them a rounded, padded block with whitespace between it and
+  the next — and the page behind them is the ordinary dashboard ground. The
+  運用ナビ band keeps its blue: it is a voice, not a section. The breakdown
+  tables' header rows step one further along the same family so a header
+  cannot read as the block showing through the table, and the captions that
+  moved from a white panel onto the ground take the next ink up, which
+  restores AA for them at small sizes. The client list screen is unchanged.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,18 @@
   it is stored exactly as before and the response says the expiry is
   unknown. Neither the token nor the app secret is ever echoed back.
 
+### Changed
+
+- **A client's detail screen reads as sections rather than one tinted page**
+  (#731). The report surface was painted once, across the whole report, and
+  the groupings sat on it in two accidental styles: the chart and the
+  proposals were white cards, and the tiers, the recent-actions log, the
+  funnel and the report text sat bare on the tint. The surface now belongs to
+  each grouping — every one of them a rounded, padded block with whitespace
+  between it and the next — and the page behind them is the ordinary
+  dashboard ground. The 運用ナビ band keeps its blue: it is a voice, not a
+  section. The client list screen is unchanged.
+
 ### Fixed
 
 - **Analytics-only Meta traffic renews the token like every other path**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,11 +46,16 @@
   report text sat bare on the tint. The surface now belongs to each grouping
   — every one of them a rounded, padded block with whitespace between it and
   the next — and the page behind them is the ordinary dashboard ground. The
-  運用ナビ band keeps its blue: it is a voice, not a section. The breakdown
-  tables' header rows step one further along the same family so a header
-  cannot read as the block showing through the table, and the captions that
-  moved from a white panel onto the ground take the next ink up, which
-  restores AA for them at small sizes. The client list screen is unchanged.
+  運用ナビ band keeps its blue: it is a voice, not a section. Inside the
+  recent-actions block each logged entry is now a white card of its own
+  rather than a row divided by a hairline, so an entry stands off the block's
+  ground instead of reading as one line of a ruled sheet; the timeline rail
+  and its dots are unchanged, with the list opening a gutter so a card cannot
+  cover them. The breakdown tables' header rows step one further along the
+  same family so a header cannot read as the block showing through the table,
+  and the captions that moved from a white panel onto the ground take the
+  next ink up, which restores AA for them at small sizes. The client list
+  screen is unchanged.
 
 ### Fixed
 

--- a/docs/strategy-context.md
+++ b/docs/strategy-context.md
@@ -1512,14 +1512,26 @@ On the DETAIL screen the same ground sits one level lower. A single slab
 across a whole report made six unrelated groupings read as one continuous
 tinted page, so the slab comes off there and **every top-level grouping
 carries the ground itself** — the three tiers, the recent-actions log, the
-funnel, the report text, the chart and the proposals panel, each a rounded,
-padded block with whitespace between it and the next. One section vocabulary
-instead of two: before this, the chart and the proposals were white cards and
-everything else sat bare on the tint. The 運用ナビ band keeps its blue — it
-is a voice, not a section. Which of the two screens is showing is carried by
-a class on the shared container rather than by the markup inside it, so the
-list screen's ground cannot change because the detail view rendered
-something.
+funnel, the report text, the chart, the proposals panel, the breakdown
+tables, the stated values and the verdict chips, each a rounded, padded block
+with whitespace between it and the next. One section vocabulary instead of
+two: before this, the chart and the proposals were white cards and everything
+else sat bare on the tint. The 運用ナビ band keeps its blue — it is a voice,
+not a section. Which of the two screens is showing is carried by a class on
+the shared container rather than by the markup inside it, so the list
+screen's ground cannot change because the detail view rendered something.
+
+Two things follow from moving a ground under content that was drawn against a
+different one. The breakdown tables' header rows were tinted with the ground
+itself, which read as a header while the section around it was the page and
+would read as a gap once the section became that colour — so inside a block
+they step one further along the same family (`--report-line`), which is a
+bigger step from the white table body than they had before. And `--muted` was
+chosen against a white panel, where it is 4.96:1; on this ground it is 4.31:1,
+under AA for small text. Every caption the change puts on the ground takes
+`--ink-soft` instead (9.2:1 light, 11.5:1 dark) — still plainly quieter than
+`--ink`, which is the whole job those lines do. A caption that kept its
+background keeps its colour: this is a repair, not a repaint.
 
 #### The shape of the page
 

--- a/docs/strategy-context.md
+++ b/docs/strategy-context.md
@@ -1503,10 +1503,23 @@ Every block carries its word as well as its colour, and none of them is
 faded at zero: a partition an operator cannot see all of is not one.
 
 The report screens themselves sit on a **ground** — `--report-surface`, with
-`--report-line` / `--report-line-strong` for the panel edges — applied to the
-container that holds the list AND the detail, so the two screens cannot drift
-apart. White panels stand off it with one step of edge and the shallowest
-shadow in the system; table header rows take the ground colour.
+`--report-line` / `--report-line-strong` for the panel edges. On the LIST
+screen it is one slab, painted on the container that holds both screens:
+white panels stand off it with one step of edge and the shallowest shadow in
+the system, and table header rows take the ground colour.
+
+On the DETAIL screen the same ground sits one level lower. A single slab
+across a whole report made six unrelated groupings read as one continuous
+tinted page, so the slab comes off there and **every top-level grouping
+carries the ground itself** — the three tiers, the recent-actions log, the
+funnel, the report text, the chart and the proposals panel, each a rounded,
+padded block with whitespace between it and the next. One section vocabulary
+instead of two: before this, the chart and the proposals were white cards and
+everything else sat bare on the tint. The 運用ナビ band keeps its blue — it
+is a voice, not a section. Which of the two screens is showing is carried by
+a class on the shared container rather than by the markup inside it, so the
+list screen's ground cannot change because the detail view rendered
+something.
 
 #### The shape of the page
 

--- a/docs/strategy-context.md
+++ b/docs/strategy-context.md
@@ -1521,8 +1521,18 @@ not a section. Which of the two screens is showing is carried by a class on
 the shared container rather than by the markup inside it, so the list
 screen's ground cannot change because the detail view rendered something.
 
-Two things follow from moving a ground under content that was drawn against a
-different one. The breakdown tables' header rows were tinted with the ground
+Inside a block, what an operator counts stays a **white card on that ground**.
+The recent-actions log is the case that made the rule: its entries were rows
+divided by hairlines, which on a tinted block read as one ruled sheet with
+nothing standing out, so each entry is a card now — `--surface`, a hairline
+edge, `--r-md`, the same shape the change cells beside it already have — with
+air between them instead of a divider. The #691 timeline survives that
+intact: the rail is still the list's own left border and each entry still
+carries its dot on it, with the list opening a gutter so a card starts clear
+of the dots rather than covering them.
+
+Three things follow from moving a ground under content that was drawn against
+a different one. The breakdown tables' header rows were tinted with the ground
 itself, which read as a header while the section around it was the page and
 would read as a gap once the section became that colour — so inside a block
 they step one further along the same family (`--report-line`), which is a
@@ -1531,7 +1541,10 @@ chosen against a white panel, where it is 4.96:1; on this ground it is 4.31:1,
 under AA for small text. Every caption the change puts on the ground takes
 `--ink-soft` instead (9.2:1 light, 11.5:1 dark) — still plainly quieter than
 `--ink`, which is the whole job those lines do. A caption that kept its
-background keeps its colour: this is a repair, not a repaint.
+background keeps its colour: this is a repair, not a repaint, and it is why
+the log's own time and observation lines are `--muted` again once its entries
+became cards, while the block's heading and its pager — which are still on
+the ground — are not.
 
 #### The shape of the page
 

--- a/mureo/_data/web/app.css
+++ b/mureo/_data/web/app.css
@@ -5099,16 +5099,20 @@ dialog[data-confirm-dialog] [data-confirm-ok] {
    the 1px --report-line edge is what bounds a block — which is exactly the
    job it did for the slab this replaces. Nothing inside a block is painted
    from --report-surface, so no inner element goes flat against it: the
-   cards, the funnel cells and the change cells are --surface, the chips and
-   the tabs are --surface-2, and the two table headers that DO use the token
-   (.roster on the list screen, .reports-breakdown-table here) are not
-   inside one of these blocks. */
+   cards, the funnel cells and the change cells are --surface, and the chips
+   and the tabs are --surface-2. The one element that DID use the token
+   inside a block — the breakdown table's header row — is re-stepped just
+   below, and the list screen's .roster header is not in this scope at
+   all. */
 .dashboard-reports-detail .reports-tier,
 .dashboard-reports-detail .dashboard-reports-block,
 .dashboard-reports-detail .reports-funnel,
 .dashboard-reports-detail .reports-prose,
 .dashboard-reports-detail .reports-chart,
-.dashboard-reports-detail .reports-panel {
+.dashboard-reports-detail .reports-panel,
+.dashboard-reports-detail .reports-breakdown,
+.dashboard-reports-detail .reports-stated,
+.dashboard-reports-detail .reports-highlights {
   background: var(--report-surface);
   border: 1px solid var(--report-line);
   border-radius: var(--r-lg);
@@ -5134,6 +5138,60 @@ dialog[data-confirm-dialog] [data-confirm-ok] {
    them, and two surfaces touching read as one section with a seam. */
 .dashboard-reports-detail .dashboard-reports-block {
   margin-bottom: 20px;
+}
+
+/* The breakdown table's header row took --report-surface, which worked while
+   the section around it was the page: a tinted strip at the top of a white
+   table. Now that the section IS that colour, the same fill would be the
+   ground showing through the table — the header would stop being a header
+   and become a gap.
+
+   So it steps one further along the SAME family: --report-line is the token
+   that already means "one step off this ground", so the row is a step from
+   the ground it sits on AND a bigger step from the white body than it had
+   before (1.42:1 light / 1.55:1 dark against the body, up from 1.15 / 1.10;
+   1.23 / 1.70 against the section). --ink-soft on it is 7.5:1 light and
+   6.8:1 dark, so the header text gains contrast rather than spending it.
+
+   Detail scope only: the list screen's .roster header keeps --report-surface,
+   because over there the table sits inside a WHITE panel and the tint is what
+   separates the header from it. */
+.dashboard-reports-detail .reports-breakdown-table thead th {
+  background: var(--report-line);
+}
+
+/* ---- text that moved onto the ground (#731) -------------------------- */
+/* --muted was chosen against a WHITE panel, where it is 4.96:1. On the
+   report ground it is 4.31:1 — under AA for small text — and this change
+   moves several captions from the one to the other. Inside the detail's
+   blocks they take --ink-soft instead: 9.2:1 light, 11.5:1 dark, still
+   plainly quieter than --ink, which is the whole job those lines do.
+
+   ONLY the lines that sit on the ground itself. A caption inside a white
+   card, a --surface-2 chip or a tinted proposal keeps --muted, because it
+   kept its background too — recolouring those would be repainting the
+   screen rather than repairing a regression this change caused.
+
+   The one exception is the proposal date, which is on --warn-tint and was
+   measured at 4.49:1 there: under AA on its own terms, in a panel this
+   change is repainting anyway. */
+.dashboard-reports-detail .reports-panel-note,
+.dashboard-reports-detail .reports-proposals-count,
+.dashboard-reports-detail .reports-proposal-more,
+.dashboard-reports-detail .reports-proposal-date,
+.dashboard-reports-detail .reports-chart-tick,
+.dashboard-reports-detail .reports-tier-note,
+.dashboard-reports-detail .reports-client-kpi-label,
+.dashboard-reports-detail .report-latest-generated,
+.dashboard-reports-detail .report-latest-stats caption.report-stats-title,
+.dashboard-reports-detail .report-latest-stats .report-stat-key,
+.dashboard-reports-detail .report-latest-stats .report-stat-more,
+.dashboard-reports-detail .dashboard-reports-block h3,
+.dashboard-reports-detail .report-action-time,
+.dashboard-reports-detail .report-action-meta,
+.dashboard-reports-detail .reports-actions-page-btn,
+.dashboard-reports-detail .reports-actions-page-count {
+  color: var(--ink-soft);
 }
 
 /* Every block above that declares its own `display` needs this, and the

--- a/mureo/_data/web/app.css
+++ b/mureo/_data/web/app.css
@@ -1666,6 +1666,27 @@ dialog[data-confirm-dialog] [data-confirm-ok] {
   margin-top: 18px;
 }
 
+/* ---- …except on the detail screen (#731) -------------------------------
+   One slab painted across a whole report is what the ground above IS, and
+   on the LIST screen it is right: the cards are one set of things, and the
+   ground is what makes them one set. On the DETAIL screen the same paint
+   turned six unrelated groupings into one continuous tinted page, so the
+   ground moves DOWN there — off the container and onto each section, one
+   block at a time (see "one surface per section" further down).
+
+   Scoped by a class `setReportsView` puts on the container rather than by
+   `:has()`, because the container is shared: a rule that asked which of the
+   two screens was rendered inside it would make the index's ground depend
+   on the detail view's markup, which is the drift this whole seam exists to
+   prevent.
+
+   Transparent rather than dropped: the 1px border and the 16px of padding
+   stay in the box, so taking the paint off moves nothing by a pixel. */
+.dashboard-reports.is-detail {
+  background: transparent;
+  border-color: transparent;
+}
+
 .dashboard-reports-head {
   display: flex;
   flex-wrap: wrap;
@@ -5050,6 +5071,69 @@ dialog[data-confirm-dialog] [data-confirm-ok] {
   font-size: var(--type-caption-size);
   color: var(--ink-soft);
   white-space: pre-wrap;
+}
+
+/* ---- one surface per section (#731) ---------------------------------- */
+/* The detail screen is a column of BLOCKS, not one tinted page. Every
+   top-level grouping carries the same ground — the three tiers, the recent
+   actions, the funnel, the prose disclosure, the chart and the proposals
+   panel — rounded, padded, and separated from the next by whitespace.
+
+   ONE vocabulary, deliberately. Before this, the sections split into two
+   looks by accident of history: the chart and the proposals were white
+   cards, and everything else sat bare on the container's slab. Two of the
+   six reading as "a thing" and four as "the page" is not a hierarchy an
+   operator can use, and neither the split nor the slab said anything about
+   what the sections are.
+
+   Scoped on `.dashboard-reports-detail`, which is the detail view's own
+   node, so the rules cannot reach the list screen at all: `.reports-panel`
+   in particular is the client list, the alert layer and the rail over
+   there, and it must stay white on the slab. Two classes (0,2,0) beat the
+   one-class rules they override, so this does not depend on source order
+   either.
+
+   Both themes come from the token: light is a cool tint UNDER white cards,
+   dark is a step below the page with the panels lighter still. In dark the
+   ground and the page are within a few units of each other by design, so
+   the 1px --report-line edge is what bounds a block — which is exactly the
+   job it did for the slab this replaces. Nothing inside a block is painted
+   from --report-surface, so no inner element goes flat against it: the
+   cards, the funnel cells and the change cells are --surface, the chips and
+   the tabs are --surface-2, and the two table headers that DO use the token
+   (.roster on the list screen, .reports-breakdown-table here) are not
+   inside one of these blocks. */
+.dashboard-reports-detail .reports-tier,
+.dashboard-reports-detail .dashboard-reports-block,
+.dashboard-reports-detail .reports-funnel,
+.dashboard-reports-detail .reports-prose,
+.dashboard-reports-detail .reports-chart,
+.dashboard-reports-detail .reports-panel {
+  background: var(--report-surface);
+  border: 1px solid var(--report-line);
+  border-radius: var(--r-lg);
+  padding: 16px 18px;
+  box-shadow: var(--shadow-sm);
+}
+
+/* The funnel had no box of its own, so its ROW carried the gap to the
+   section below it. The block carries it now — left on the row it would
+   open 20px of empty tint inside the block instead of between two of
+   them. */
+.dashboard-reports-detail .reports-funnel {
+  margin-bottom: 20px;
+}
+
+.dashboard-reports-detail .reports-funnel-row {
+  margin-bottom: 0;
+}
+
+/* The recent-actions log carried air ABOVE it and none below, which is the
+   right answer for a block with no edges and the wrong one for a block with
+   them: it and the report text underneath would meet with nothing between
+   them, and two surfaces touching read as one section with a seam. */
+.dashboard-reports-detail .dashboard-reports-block {
+  margin-bottom: 20px;
 }
 
 /* Every block above that declares its own `display` needs this, and the

--- a/mureo/_data/web/app.css
+++ b/mureo/_data/web/app.css
@@ -5140,6 +5140,54 @@ dialog[data-confirm-dialog] [data-confirm-ok] {
   margin-bottom: 20px;
 }
 
+/* ---- the log's entries, as cards on the rail (#731) ------------------- */
+/* The block keeps the ground; each ENTRY lifts off it. On the tint, rows
+   divided by hairlines read as one ruled sheet — the owner's word for the
+   capture was that nothing stood out — so an entry is now the same white
+   card the change cells and the platform cards on this screen already are:
+   --surface, a --hairline edge, --r-md. Its own edge separates it from the
+   next one, so the row divider goes and 10px of air replaces it.
+
+   The #691 TIMELINE SURVIVES, and the geometry is the reason this is not
+   simply "add a background". The rail is the ul's own border-left and each
+   entry's dot is an absolutely-positioned ::before straddling it. A card
+   drawn at the old 2px inset would have taken that dot under its own left
+   border. So the list opens a 16px gutter and the dot's offset is re-stated
+   against the card's padding box:
+
+     rail line at R..R+1  |  ul padding-left 16  |  card border 1
+     card padding box     = R + 1 + 16 + 1        = R + 18
+     dot (8px) at left:-21 -> centre R + 18 - 21 + 4 = R + 1
+
+   which is exactly where the dot sits today (2px inset, left:-6px -> R+1).
+   The dot is in the gutter and the card starts 13px clear of it, so the two
+   never overlap.
+
+   The last card is the one contested edge: `.report-action:last-child` is
+   (0,3,0) and takes `border-bottom` away to end the ruled sheet. So the
+   reset is scoped too — (0,4,0) beats it outright, rather than the card's
+   bottom edge depending on which rule came later in the file. */
+.dashboard-reports-detail .dashboard-reports-block .dashboard-reports-actions-list {
+  padding-left: 16px;
+}
+
+.dashboard-reports-detail .dashboard-reports-actions-list .report-action {
+  padding: 12px 14px;
+  margin-bottom: 10px;
+  background: var(--surface);
+  border: 1px solid var(--hairline);
+  border-radius: var(--r-md);
+}
+
+.dashboard-reports-detail .dashboard-reports-actions-list .report-action:last-child {
+  margin-bottom: 0;
+  border-bottom: 1px solid var(--hairline);
+}
+
+.dashboard-reports-detail .dashboard-reports-actions-list .report-action::before {
+  left: -21px;
+}
+
 /* The breakdown table's header row took --report-surface, which worked while
    the section around it was the page: a tinted strip at the top of a white
    table. Now that the section IS that colour, the same fill would be the
@@ -5170,7 +5218,10 @@ dialog[data-confirm-dialog] [data-confirm-ok] {
    ONLY the lines that sit on the ground itself. A caption inside a white
    card, a --surface-2 chip or a tinted proposal keeps --muted, because it
    kept its background too — recolouring those would be repainting the
-   screen rather than repairing a regression this change caused.
+   screen rather than repairing a regression this change caused. That is why
+   the log's own time and observation-due lines are NOT here: the entries
+   became white cards above, so those two are back on --surface at 4.96:1,
+   while the block's heading and its pager are still on the ground and are.
 
    The one exception is the proposal date, which is on --warn-tint and was
    measured at 4.49:1 there: under AA on its own terms, in a panel this
@@ -5187,8 +5238,6 @@ dialog[data-confirm-dialog] [data-confirm-ok] {
 .dashboard-reports-detail .report-latest-stats .report-stat-key,
 .dashboard-reports-detail .report-latest-stats .report-stat-more,
 .dashboard-reports-detail .dashboard-reports-block h3,
-.dashboard-reports-detail .report-action-time,
-.dashboard-reports-detail .report-action-meta,
 .dashboard-reports-detail .reports-actions-page-btn,
 .dashboard-reports-detail .reports-actions-page-count {
   color: var(--ink-soft);

--- a/mureo/_data/web/dashboard_reports.js
+++ b/mureo/_data/web/dashboard_reports.js
@@ -188,10 +188,25 @@
     return ((active || rows[0]) || {}).slug || null;
   }
 
+  //: The modifier the shared container carries while the detail view is up.
+  //: app.css scopes the detail screen's paint on it (#731) — the ground the
+  //: report screens sit on is the CONTAINER's, and the container is one node
+  //: for both screens, so the only way the two can differ is a mark put on
+  //: here, where the switch between them is already made.
+  const REPORTS_DETAIL_CLASS = "is-detail";
+
   // Toggle the index (client grid) vs detail (one client) views, and the
   // detail's back bar (only meaningful when there is an index to return to).
   function setReportsView(view) {
     REPORTS_VIEW_STATE.reportsView = view;
+    // The index keeps its one-slab ground; the detail screen takes it off
+    // and gives every section its own (#731). A class rather than `:has()`
+    // in the stylesheet: one screen's paint must not be decided by what the
+    // other one happens to have rendered inside the same container.
+    const ground = document.querySelector("[data-dashboard-reports]");
+    if (ground) {
+      ground.classList.toggle(REPORTS_DETAIL_CLASS, view === "detail");
+    }
     const index = document.querySelector("[data-reports-clients]");
     const detail = document.querySelector("[data-reports-detail]");
     const back = document.querySelector("[data-reports-back]");
@@ -750,6 +765,7 @@
 
 
   const api = {
+    REPORTS_DETAIL_CLASS: REPORTS_DETAIL_CLASS,
     renderReports: renderReports,
     enterReportsSection: enterReportsSection,
     wireReportsBackButton: wireReportsBackButton,

--- a/tests/js/reports_detail_surfaces.test.js
+++ b/tests/js/reports_detail_surfaces.test.js
@@ -1,0 +1,365 @@
+// One surface per section on the detail screen (#731).
+//
+// Run with:  node --test tests/js/*.test.js
+//
+// The report screens share ONE container — `[data-dashboard-reports]` wraps
+// the list and the detail alike — and that container carries the ground both
+// screens sit on. The owner asked for the detail screen to stop being one
+// continuous tinted page and become a column of bounded blocks instead, and
+// the index to keep exactly what it has.
+//
+// So the two screens now want different paint out of one element, which is
+// the whole difficulty and the whole of what this suite guards:
+//
+//   • the container is MARKED while the detail view is up, and unmarked on
+//     the way back — a class the stylesheet scopes on, put on by the one
+//     function that already decides which screen is showing. Miss the
+//     unmark and the index loses its ground the first time an operator
+//     opens a client and comes back;
+//   • every top-level grouping of the detail view carries the ground itself,
+//     so nothing sits bare on the page;
+//   • the index is UNTOUCHED — asserted here rather than left to a capture,
+//     because "the other screen still looks the same" is exactly the claim a
+//     shared container makes easy to break and hard to see.
+//
+// Driven against the real app.css through the harness's cascade, because a
+// scoped override is a specificity question and a substring pin cannot ask
+// it: `.reports-panel` is on both screens, and only the detail's copy may
+// be repainted.
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+
+const { loadDashboardPage, settle, cascade } = require("./dom_harness.js");
+
+const WEB = path.join(__dirname, "..", "..", "mureo", "_data", "web");
+
+//: The modifier the shared container carries while the detail view is up,
+//: restated here because app.css scopes the detail screen's paint on it. A
+//: test below asserts the module publishes this exact string, so the test,
+//: the stylesheet and the JS cannot drift apart silently.
+const DETAIL_CLASS = "is-detail";
+
+const TODAY = new Date().toISOString().slice(0, 10);
+
+/** `n` days before today, as `YYYY-MM-DD`. */
+function daysAgo(n) {
+  return new Date(Date.now() - n * 86400000).toISOString().slice(0, 10);
+}
+
+/** Seven calendar-adjacent days of one metric — enough for the chart. */
+function week(metric) {
+  const out = [];
+  for (let i = 7; i >= 1; i--) {
+    const totals = {};
+    totals[metric] = 10 + i;
+    out.push({ date: daysAgo(i), totals: totals });
+  }
+  return out;
+}
+
+function platform(totals, daily) {
+  return {
+    key: "google_ads",
+    display_name: "Google Ads",
+    totals: totals,
+    metrics_period: "YESTERDAY",
+    campaign_count: 2,
+    freshness: { fetched_at: new Date().toISOString(), stale: false },
+    not_collected: null,
+    daily: daily || [],
+    daily_delta: null,
+  };
+}
+
+const PLATFORMS = [
+  platform(
+    { spend: 42000, impressions: 100000, clicks: 900, conversions: 8, cpa: 5250 },
+    week("conversions")
+  ),
+];
+
+const ACTIONS = [
+  {
+    at: new Date().toISOString(),
+    kind: "budget",
+    platform: "google_ads",
+    summary: "Raised the Brand budget",
+  },
+];
+
+//: A contract stating the sections the legacy screen does not draw.
+const DISPLAY = {
+  source: "daily-check",
+  generated_at: new Date(Date.now() - 3 * 3600000).toISOString(),
+  nav_message: "CPA is over target — pause the two worst ad groups",
+  proposals: [{ title: "Pause two ad groups", body: "Both 3x target CPA", date: TODAY }],
+};
+
+function summaryWith(overrides) {
+  return Object.assign(
+    {
+      client: "alpha",
+      period: "YESTERDAY",
+      periods: ["YESTERDAY"],
+      non_canonical_periods: [],
+      last_synced_at: new Date().toISOString(),
+      platforms: PLATFORMS,
+      platform_conflicts: [],
+      recent_actions: ACTIONS,
+      reports: {},
+      observations_due: { count: 0, oldest_due: null },
+      display: null,
+      server_today: TODAY,
+    },
+    overrides
+  );
+}
+
+/** A single-client (OSS-shaped) install, which opens on the detail view. */
+async function openDetail(overrides) {
+  const page = loadDashboardPage({
+    "/api/reports/clients": {
+      clients: [{ slug: "alpha", name: "Alpha", active: true }],
+      can_archive: false,
+    },
+    "/api/reports/summary": () => summaryWith(overrides),
+  });
+  page.document.dispatchEvent({ type: "mureo:ready" });
+  await settle();
+  page.root.querySelector('[data-dashboard-nav="reports"]').click();
+  await settle();
+  return page;
+}
+
+/** A two-client roster, which opens on the index. */
+async function openIndex() {
+  const roster = [
+    { slug: "alpha", name: "Alpha", active: true },
+    { slug: "beta", name: "Beta", active: true },
+  ];
+  const page = loadDashboardPage({
+    "/api/reports/clients": { clients: roster, can_archive: false },
+    "/api/reports/summary": () => summaryWith({}),
+  });
+  page.document.dispatchEvent({ type: "mureo:ready" });
+  await settle();
+  page.root.querySelector('[data-dashboard-nav="reports"]').click();
+  await settle();
+  return page;
+}
+
+const container = (page) => page.root.querySelector("[data-dashboard-reports]");
+
+/** The winning declaration for `property` on `node`. */
+function styleOfNode(node, label, property) {
+  assert.ok(node, label + " is not in the page");
+  const won = cascade(node, property);
+  return won ? won.value : undefined;
+}
+
+function styleOf(page, sel, property) {
+  return styleOfNode(page.root.querySelector(sel), sel, property);
+}
+
+// ---------------------------------------------------------------------
+// The scope: one container, two screens
+// ---------------------------------------------------------------------
+
+test.describe("the detail view marks the container it shares with the index", function () {
+  test.it("marks it on the way in and clears it on the way back", async function () {
+    const page = await openIndex();
+    assert.equal(
+      container(page).classList.contains(DETAIL_CLASS),
+      false,
+      "the index is already marked as the detail screen"
+    );
+
+    page.root.querySelector(".roster-name").click();
+    await settle();
+    assert.equal(
+      container(page).classList.contains(DETAIL_CLASS),
+      true,
+      "opening a client did not mark the container"
+    );
+
+    page.root.querySelector("[data-reports-back]").click();
+    await settle();
+    assert.equal(
+      container(page).classList.contains(DETAIL_CLASS),
+      false,
+      "the mark survived the trip back to the index"
+    );
+  });
+
+  test.it("marks it on a single-client install too, which never sees an index", async function () {
+    // The OSS shape: the detail IS the section, so it is reached without a
+    // click on anything. A mark applied only from the card grid would leave
+    // this install on the index's paint forever.
+    const page = await openDetail();
+    assert.equal(container(page).classList.contains(DETAIL_CLASS), true);
+  });
+
+  test.it("publishes the class name the stylesheet scopes on", async function () {
+    // The string is in three files. This is the one place they meet.
+    const page = await openDetail();
+    assert.equal(page.sandbox.MUREO_DASHBOARD_REPORTS.REPORTS_DETAIL_CLASS, DETAIL_CLASS);
+    const fs = require("node:fs");
+    const css = fs.readFileSync(path.join(WEB, "app.css"), "utf-8");
+    assert.ok(
+      css.includes(".dashboard-reports." + DETAIL_CLASS + " {"),
+      "app.css scopes nothing on " + DETAIL_CLASS
+    );
+  });
+});
+
+// ---------------------------------------------------------------------
+// The ground comes off the container, and onto the sections
+// ---------------------------------------------------------------------
+
+test.describe("the detail screen's ground is its sections', not the page's", function () {
+  test.it("takes the slab off the container while the detail is up", async function () {
+    const page = await openDetail();
+    assert.equal(
+      styleOfNode(container(page), ".dashboard-reports", "background"),
+      "transparent",
+      "the whole-report slab is still painted under the detail view"
+    );
+    // Transparent rather than dropped: the border and the padding are still
+    // in the box, so nothing inside it moves by a pixel.
+    assert.equal(
+      styleOfNode(container(page), ".dashboard-reports", "border-color"),
+      "transparent"
+    );
+    assert.equal(styleOfNode(container(page), ".dashboard-reports", "padding"), "16px");
+  });
+
+  //: Every top-level grouping of the detail view, and the screen it appears
+  //: on: the legacy three-tier screen, or the contract-driven one.
+  const SECTIONS = [
+    [".reports-tier", "legacy"],
+    [".dashboard-reports-block", "legacy"],
+    [".reports-prose", "legacy"],
+    [".reports-funnel", "contract"],
+    [".reports-chart", "contract"],
+    [".reports-proposals", "contract"],
+  ];
+
+  test.it("gives every grouping the report surface, rounded and padded", async function () {
+    const pages = {
+      legacy: await openDetail({
+        reports: {
+          YESTERDAY: {
+            narrative: "Spend held, CPA improved.",
+            generated_at: new Date().toISOString(),
+          },
+        },
+      }),
+      contract: await openDetail({ display: DISPLAY }),
+    };
+    SECTIONS.forEach(function ([sel, screen]) {
+      const page = pages[screen];
+      assert.equal(
+        styleOf(page, sel, "background"),
+        "var(--report-surface)",
+        sel + " is not on the report surface"
+      );
+      assert.equal(
+        styleOf(page, sel, "border-radius"),
+        "var(--r-lg)",
+        sel + " is not a rounded block"
+      );
+      assert.equal(
+        styleOf(page, sel, "border"),
+        "1px solid var(--report-line)",
+        sel + " has no edge on that ground"
+      );
+      assert.ok(styleOf(page, sel, "padding"), sel + " has no padding of its own");
+    });
+  });
+
+  test.it("keeps the funnel's gap outside the block it now sits in", async function () {
+    // The row carried `margin-bottom: 20px` to separate the funnel from the
+    // chart. Left there it would open 20px of empty tint INSIDE the new
+    // block instead of between it and the next one.
+    const page = await openDetail({ display: DISPLAY });
+    assert.equal(styleOf(page, ".reports-funnel-row", "margin-bottom"), "0");
+    assert.equal(styleOf(page, ".reports-funnel", "margin-bottom"), "20px");
+  });
+
+  test.it("separates the blocks that sit in the flow with whitespace", async function () {
+    // Two surfaces touching read as one section with a seam. The chart and
+    // the proposals are grid items and take their gap from the grid; these
+    // four are in the flow and have to state it. The recent-actions log is
+    // the one that had air above it and none below, which was the right
+    // answer for a block with no edges.
+    const page = await openDetail({
+      display: DISPLAY,
+      reports: { YESTERDAY: { narrative: "Spend held.", generated_at: TODAY } },
+    });
+    [".reports-tier", ".dashboard-reports-block", ".reports-funnel", ".reports-prose"].forEach(
+      function (sel) {
+        const gap = styleOf(page, sel, "margin-bottom") || styleOf(page, sel, "margin");
+        assert.ok(gap, sel + " states no gap to the block under it");
+        assert.ok(
+          parseFloat(String(gap).split(/\s+/).pop()) > 0,
+          sel + " meets the next block with no whitespace: " + gap
+        );
+      }
+    );
+  });
+
+  test.it("leaves the 運用ナビ band blue — it is a voice, not a section", async function () {
+    const page = await openDetail({ display: DISPLAY });
+    assert.equal(styleOf(page, ".reports-nav-band", "background"), "var(--report-blue)");
+  });
+});
+
+// ---------------------------------------------------------------------
+// The index screen is out of scope, and stays that way
+// ---------------------------------------------------------------------
+
+test.describe("the list screen keeps the ground it had", function () {
+  test.it("keeps the slab on the container", async function () {
+    const page = await openIndex();
+    assert.equal(
+      styleOfNode(container(page), ".dashboard-reports", "background"),
+      "var(--report-surface)"
+    );
+    assert.equal(
+      styleOfNode(container(page), ".dashboard-reports", "border"),
+      "1px solid var(--report-line)"
+    );
+  });
+
+  test.it("keeps its panels white on that slab", async function () {
+    // `.reports-panel` is on BOTH screens. Repainting it outright — rather
+    // than inside the detail's scope — would recolour the client list, the
+    // alert layer and the rail, which is the one thing #731 must not do.
+    const page = await openIndex();
+    const grid = page.root.querySelector("[data-reports-index-grid]");
+    const panels = grid.querySelectorAll(".reports-panel");
+    assert.ok(panels.length >= 2, "the index rendered no panels to check");
+    panels.forEach(function (node) {
+      assert.equal(
+        styleOfNode(node, ".reports-panel", "background"),
+        "var(--surface)",
+        "an index panel was repainted with the detail screen's ground"
+      );
+    });
+  });
+
+  test.it("still comes back to the slab after a client and back", async function () {
+    // The end-to-end of the mark: paint, not just a class attribute.
+    const page = await openIndex();
+    page.root.querySelector(".roster-name").click();
+    await settle();
+    page.root.querySelector("[data-reports-back]").click();
+    await settle();
+    assert.equal(
+      styleOfNode(container(page), ".dashboard-reports", "background"),
+      "var(--report-surface)"
+    );
+  });
+});

--- a/tests/js/reports_detail_surfaces.test.js
+++ b/tests/js/reports_detail_surfaces.test.js
@@ -398,6 +398,114 @@ test.describe("nothing inside a block goes flat against it", function () {
 });
 
 // ---------------------------------------------------------------------
+// The action log: cards on the rail
+// ---------------------------------------------------------------------
+
+test.describe("each logged entry lifts off the block's ground", function () {
+  /** The declarations of the first rule whose selector is exactly `sel`. */
+  function ruleOf(css, sel) {
+    const at = css.indexOf("\n" + sel + " {");
+    assert.notEqual(at, -1, sel + " has no rule in app.css");
+    return css.slice(at).split("}", 1)[0];
+  }
+
+  /** The first number in `prop`'s declaration in `body`. */
+  function px(body, prop) {
+    // `[{;]` and not `^`: `ruleOf` hands back the selector as well as the
+    // body, so the first declaration follows the brace rather than starting
+    // the string.
+    const m = new RegExp("[{;]\\s*" + prop + "\\s*:\\s*(-?[\\d.]+)px").exec(body);
+    assert.ok(m, prop + " is not a px length in: " + body.trim());
+    return parseFloat(m[1]);
+  }
+
+  test.it("draws an entry as a white card, not a ruled row", async function () {
+    const page = await openDetail({ display: DISPLAY });
+    const row = detailView(page).querySelectorAll(".report-action")[0];
+    assert.ok(row, "the log drew no entry");
+    assert.equal(styleOfNode(row, ".report-action", "background"), "var(--surface)");
+    assert.equal(
+      styleOfNode(row, ".report-action", "border"),
+      "1px solid var(--hairline)"
+    );
+    assert.equal(styleOfNode(row, ".report-action", "border-radius"), "var(--r-md)");
+    // …on the ground the block still carries, which is what it lifts off.
+    assert.equal(
+      styleOf(page, ".dashboard-reports-block", "background"),
+      "var(--report-surface)"
+    );
+  });
+
+  test.it("gives the last card its bottom edge back", async function () {
+    // `.report-action:last-child` exists to END a ruled sheet by removing
+    // that hairline. On a card it would cut the bottom edge off the last
+    // entry, so the scoped reset has to outrank it rather than merely
+    // follow it in the file.
+    const fs = require("node:fs");
+    const css = fs.readFileSync(path.join(WEB, "app.css"), "utf-8");
+    const scoped = ruleOf(
+      css,
+      ".dashboard-reports-detail .dashboard-reports-actions-list .report-action:last-child"
+    );
+    assert.match(scoped, /border-bottom: 1px solid var\(--hairline\);/);
+    assert.match(scoped, /margin-bottom: 0;/);
+  });
+
+  test.it("keeps the dot straddling the rail the cards moved away from", function () {
+    // The #691 timeline is the ul's `border-left` and a ::before per entry.
+    // A card drawn at the old 2px inset takes that dot under its own left
+    // border, so the list opens a gutter and the dot's offset is re-stated
+    // against the card's padding box. This is that arithmetic, read out of
+    // the stylesheet — the harness models no layout, and a dot that has
+    // drifted off the rail is invisible to every other assertion here.
+    const fs = require("node:fs");
+    const css = fs.readFileSync(path.join(WEB, "app.css"), "utf-8");
+
+    const railWidth = 1; // .dashboard-reports-block .dashboard-reports-actions-list
+    assert.match(
+      ruleOf(css, ".dashboard-reports-block .dashboard-reports-actions-list"),
+      /border-left: 1px solid var\(--hairline\);/,
+      "the rail is gone"
+    );
+    const gutter = px(
+      ruleOf(
+        css,
+        ".dashboard-reports-detail .dashboard-reports-block .dashboard-reports-actions-list"
+      ),
+      "padding-left"
+    );
+    const card = ruleOf(
+      css,
+      ".dashboard-reports-detail .dashboard-reports-actions-list .report-action"
+    );
+    const cardBorder = px(card, "border");
+    const dot = ruleOf(css, ".dashboard-reports-actions-list .report-action::before");
+    const size = px(dot, "width");
+    const offset = px(
+      ruleOf(
+        css,
+        ".dashboard-reports-detail .dashboard-reports-actions-list .report-action::before"
+      ),
+      "left"
+    );
+
+    // x = 0 at the rail's left edge; the line covers 0..railWidth.
+    const cardPaddingBox = railWidth + gutter + cardBorder;
+    const dotLeft = cardPaddingBox + offset;
+    const dotCentre = dotLeft + size / 2;
+    assert.ok(
+      dotCentre >= -1 && dotCentre <= railWidth + 1,
+      "the dot no longer straddles the rail: centre at " + dotCentre
+    );
+    // …and it clears the card, rather than sitting under its left border.
+    assert.ok(
+      dotLeft + size <= railWidth + gutter,
+      "the dot runs under the card's left edge"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------
 // The captions that moved from a white panel onto the ground
 // ---------------------------------------------------------------------
 
@@ -423,11 +531,14 @@ test.describe("small text on the ground keeps AA", function () {
     ".report-latest-stats .report-stat-key",
     ".report-latest-stats .report-stat-more",
     ".dashboard-reports-block h3",
-    ".report-action-time",
-    ".report-action-meta",
     ".reports-actions-page-btn",
     ".reports-actions-page-count",
   ];
+
+  //: The two that came BACK off the lift. The log's entries are white cards
+  //: now, so its time and observation-due lines are on --surface again —
+  //: 4.96:1, the same "kept its background" rule as everything else here.
+  const RESTORED = [".report-action-time", ".report-action-meta"];
 
   test.it("scopes every one of them, and scopes them to the detail", function () {
     const fs = require("node:fs");
@@ -437,6 +548,13 @@ test.describe("small text on the ground keeps AA", function () {
         css.includes(".dashboard-reports-detail " + sel + ",\n") ||
           css.includes(".dashboard-reports-detail " + sel + " {"),
         sel + " is not lifted off --muted in the detail scope"
+      );
+    });
+    RESTORED.forEach(function (sel) {
+      assert.equal(
+        css.includes(".dashboard-reports-detail " + sel + ",\n"),
+        false,
+        sel + " is lifted again, and it is back on a white card"
       );
     });
   });
@@ -454,8 +572,6 @@ test.describe("small text on the ground keeps AA", function () {
       ".reports-proposal-date",
       ".reports-chart-tick",
       ".reports-tier-note",
-      ".report-action-time",
-      ".report-action-meta",
       // `.reports-actions-page-btn` is deliberately NOT here: its `:hover`
       // rule outranks the lift, and the harness treats an unmodelled
       // pseudo-class as matching, so it would answer for a hover state no
@@ -484,7 +600,7 @@ test.describe("small text on the ground keeps AA", function () {
       ".report-action-platform",
       ".reports-stated-label",
       ".reports-breakdown-note",
-    ].forEach(function (sel) {
+    ].concat(RESTORED).forEach(function (sel) {
       assert.equal(
         styleIn(page, sel, "color"),
         "var(--muted)",

--- a/tests/js/reports_detail_surfaces.test.js
+++ b/tests/js/reports_detail_surfaces.test.js
@@ -82,19 +82,45 @@ const PLATFORMS = [
 
 const ACTIONS = [
   {
-    at: new Date().toISOString(),
-    kind: "budget",
+    timestamp: new Date().toISOString(),
+    action: "budget_raised",
     platform: "google_ads",
     summary: "Raised the Brand budget",
+    observation_due: TODAY,
   },
 ];
 
-//: A contract stating the sections the legacy screen does not draw.
+//: A contract stating the sections the legacy screen does not draw. Five
+//: proposals, because the list caps at four and the "+N more" row is one of
+//: the lines this suite is about.
 const DISPLAY = {
   source: "daily-check",
   generated_at: new Date(Date.now() - 3 * 3600000).toISOString(),
   nav_message: "CPA is over target — pause the two worst ad groups",
-  proposals: [{ title: "Pause two ad groups", body: "Both 3x target CPA", date: TODAY }],
+  highlights: [
+    { tone: "bad", text: "CPA 12% over target" },
+    { tone: "good", text: "CV goal met" },
+  ],
+  proposals: [1, 2, 3, 4, 5].map(function (n) {
+    return { title: "Pause ad group " + n, body: "3x target CPA", date: TODAY };
+  }),
+  breakdown: {
+    campaigns: [
+      {
+        name: "Brand Search",
+        spend: 42000,
+        mcpa: 5200,
+        target_cpa: 4500,
+        state: "worsening",
+        note: "capped every afternoon",
+      },
+    ],
+    adgroups: [{ name: "Brand — exact", spend: 12000, state: "target_met" }],
+  },
+  stated_values: [
+    { label: "CVR", value: 0.021 },
+    { label: "goals met", value: "3 of 7" },
+  ],
 };
 
 function summaryWith(overrides) {
@@ -161,6 +187,19 @@ function styleOfNode(node, label, property) {
 
 function styleOf(page, sel, property) {
   return styleOfNode(page.root.querySelector(sel), sel, property);
+}
+
+const detailView = (page) => page.root.querySelector("[data-reports-detail]");
+
+/**
+ * The same, for the first `sel` INSIDE the detail view.
+ *
+ * Several of these class names are on both screens — `.reports-panel-note`
+ * is the index rail's note too, and it comes first in the document — so a
+ * page-wide querySelector would answer about the wrong screen.
+ */
+function styleIn(page, sel, property) {
+  return styleOfNode(detailView(page).querySelectorAll(sel)[0], sel, property);
 }
 
 // ---------------------------------------------------------------------
@@ -244,6 +283,9 @@ test.describe("the detail screen's ground is its sections', not the page's", fun
     [".reports-funnel", "contract"],
     [".reports-chart", "contract"],
     [".reports-proposals", "contract"],
+    [".reports-breakdown", "contract"],
+    [".reports-stated", "contract"],
+    [".reports-highlights", "contract"],
   ];
 
   test.it("gives every grouping the report surface, rounded and padded", async function () {
@@ -313,6 +355,160 @@ test.describe("the detail screen's ground is its sections', not the page's", fun
   test.it("leaves the 運用ナビ band blue — it is a voice, not a section", async function () {
     const page = await openDetail({ display: DISPLAY });
     assert.equal(styleOf(page, ".reports-nav-band", "background"), "var(--report-blue)");
+  });
+});
+
+// ---------------------------------------------------------------------
+// What the sections do to the things inside them
+// ---------------------------------------------------------------------
+
+test.describe("nothing inside a block goes flat against it", function () {
+  test.it("steps the breakdown header off both the block and the table", async function () {
+    // The header row took --report-surface, which was a tint on a white
+    // table while the section around it was the page. Now that the section
+    // IS that colour the same fill would read as the ground showing through
+    // the table — a header that has stopped being a header.
+    const page = await openDetail({ display: DISPLAY });
+    const table = page.root.querySelector(".reports-breakdown-table");
+    assert.ok(table, "the breakdown table did not render");
+    const th = table.querySelectorAll("th")[0];
+    const section = styleOf(page, ".reports-breakdown", "background");
+    const body = styleOfNode(table, ".reports-breakdown-table", "background");
+    const header = styleOfNode(th, ".reports-breakdown-table thead th", "background");
+    assert.equal(section, "var(--report-surface)");
+    assert.equal(body, "var(--surface)");
+    assert.equal(header, "var(--report-line)");
+    assert.equal(
+      new Set([section, body, header]).size,
+      3,
+      "the block, the table and its header are not three different fills"
+    );
+  });
+
+  test.it("leaves the list screen's roster header on the ground it had", async function () {
+    // The same token, on the other screen, where the table sits inside a
+    // WHITE panel and the tint is exactly what separates the header from it.
+    const page = await openIndex();
+    const th = page.root.querySelector(".roster").querySelectorAll("th")[0];
+    assert.equal(
+      styleOfNode(th, ".roster thead th", "background"),
+      "var(--report-surface)"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------
+// The captions that moved from a white panel onto the ground
+// ---------------------------------------------------------------------
+
+test.describe("small text on the ground keeps AA", function () {
+  //: Every --muted line the new blocks put on the ground itself. --muted is
+  //: 4.96:1 on a white panel and 4.31:1 on this ground, which is under AA
+  //: for small text, so each of these takes --ink-soft (9.2:1 light,
+  //: 11.5:1 dark) inside the detail scope. Restated here so the set is
+  //: checkable at a glance, and asserted against the stylesheet below.
+  //:
+  //: The proposal DATE is the one that is not on the ground — it is on the
+  //: --warn-tint proposal, where it measured 4.49:1 on its own terms.
+  const LIFTED = [
+    ".reports-panel-note",
+    ".reports-proposals-count",
+    ".reports-proposal-more",
+    ".reports-proposal-date",
+    ".reports-chart-tick",
+    ".reports-tier-note",
+    ".reports-client-kpi-label",
+    ".report-latest-generated",
+    ".report-latest-stats caption.report-stats-title",
+    ".report-latest-stats .report-stat-key",
+    ".report-latest-stats .report-stat-more",
+    ".dashboard-reports-block h3",
+    ".report-action-time",
+    ".report-action-meta",
+    ".reports-actions-page-btn",
+    ".reports-actions-page-count",
+  ];
+
+  test.it("scopes every one of them, and scopes them to the detail", function () {
+    const fs = require("node:fs");
+    const css = fs.readFileSync(path.join(WEB, "app.css"), "utf-8");
+    LIFTED.forEach(function (sel) {
+      assert.ok(
+        css.includes(".dashboard-reports-detail " + sel + ",\n") ||
+          css.includes(".dashboard-reports-detail " + sel + " {"),
+        sel + " is not lifted off --muted in the detail scope"
+      );
+    });
+  });
+
+  test.it("resolves to --ink-soft on the nodes an operator sees", async function () {
+    // The stylesheet pin above cannot see a rule that loses its cascade.
+    // These are the same lines, asked of the rendered page — and asked
+    // INSIDE the detail view, because `.reports-panel-note` is also the
+    // index rail's note and it comes first in the document.
+    const page = await openDetail({ display: DISPLAY });
+    [
+      ".reports-panel-note",
+      ".reports-proposals-count",
+      ".reports-proposal-more",
+      ".reports-proposal-date",
+      ".reports-chart-tick",
+      ".reports-tier-note",
+      ".report-action-time",
+      ".report-action-meta",
+      // `.reports-actions-page-btn` is deliberately NOT here: its `:hover`
+      // rule outranks the lift, and the harness treats an unmodelled
+      // pseudo-class as matching, so it would answer for a hover state no
+      // operator is in. The stylesheet pin above covers it.
+      ".reports-actions-page-count",
+    ].forEach(function (sel) {
+      assert.equal(
+        styleIn(page, sel, "color"),
+        "var(--ink-soft)",
+        sel + " is still --muted on the report ground"
+      );
+    });
+    // `.dashboard-reports-block h3` — the log's own caption heading — is
+    // not asked here either: the harness's compound matcher rejects a type
+    // selector carrying a digit, so `h3` matches nothing and the cascade
+    // comes back empty for BOTH rules. The stylesheet pin covers it.
+  });
+
+  test.it("leaves --muted alone where the background did not move", async function () {
+    // A caption inside a white card or a --surface-2 chip kept its
+    // background, so it keeps its colour: this is a repair of a regression,
+    // not a repaint of the screen.
+    const page = await openDetail({ display: DISPLAY });
+    [
+      ".reports-funnel-label",
+      ".report-action-platform",
+      ".reports-stated-label",
+      ".reports-breakdown-note",
+    ].forEach(function (sel) {
+      assert.equal(
+        styleIn(page, sel, "color"),
+        "var(--muted)",
+        sel + " was recoloured, and its background never moved"
+      );
+    });
+    // A chart tab that is not the selected one — the selected segment is
+    // filled and carries its own colour, which is not what this asks.
+    const tab = detailView(page)
+      .querySelectorAll(".reports-chart-tab")
+      .find(function (n) {
+        return !n.classList.contains("is-active");
+      });
+    assert.ok(tab, "the chart drew no idle tab to check");
+    assert.equal(styleOfNode(tab, ".reports-chart-tab", "color"), "var(--muted)");
+  });
+
+  test.it("does not reach the list screen's copies of the same classes", async function () {
+    // `.reports-panel-note` is the rail's note over there, on a white panel.
+    const page = await openIndex();
+    const grid = page.root.querySelector("[data-reports-index-grid]");
+    const note = grid.querySelectorAll(".reports-panel-note")[0];
+    assert.ok(note, "the index rendered no panel note to check");
+    assert.equal(styleOfNode(note, ".reports-panel-note", "color"), "var(--muted)");
   });
 });
 

--- a/tests/js/reports_detail_tiers.test.js
+++ b/tests/js/reports_detail_tiers.test.js
@@ -592,17 +592,28 @@ test.describe("the action row wins its own layout", function () {
     }
   });
 
-  test.it("keeps the padding that makes room for the rail", async function () {
+  test.it("keeps a padding of its own, not the generic row's", async function () {
     // The same collision took the row's padding: `.dashboard-section li` sets
-    // `padding: 11px 0`, so the 20px left inset the timeline dots sit in was
-    // being discarded and the markers landed on top of the text.
+    // `padding: 11px 0`, so the left inset the timeline dots sit in was being
+    // discarded and the markers landed on top of the text.
+    //
+    // WHERE that inset lives moved in #731 — the entries are cards now and
+    // the gutter the dots sit in belongs to the list (asserted below and in
+    // reports_detail_surfaces.test.js, which does the dot arithmetic). What
+    // this asks is unchanged: the entry has a padding of its OWN, on both
+    // axes, and the generic row rule is not the one that wins it.
     const row = await actionRow();
     const padding = cascade(row, "padding");
     assert.ok(padding, "the row computes no padding");
     assert.match(
-      padding.value,
-      /20px$/,
+      padding.selector,
+      /\.report-action$/,
       "padding computes to '" + padding.value + "' via `" + padding.selector + "`"
+    );
+    assert.equal(
+      /(^|\s)0$/.test(padding.value.trim()),
+      false,
+      "the row lost its horizontal padding: '" + padding.value + "'"
     );
   });
 
@@ -614,10 +625,14 @@ test.describe("the action row wins its own layout", function () {
       border && !/^0/.test(border.value),
       "the rail computes to '" + (border && border.value) + "'"
     );
-    const padding = cascade(list, "padding");
-    assert.match(
-      padding.value,
-      /2px$/,
+    // The room beside the rail. It is a `padding-left` of its own since #731
+    // (a 16px gutter, so a card cannot cover the dots) rather than the last
+    // value of the `padding` shorthand, so ask for the LONGHAND first —
+    // reading the shorthand alone would answer 2px and see nothing.
+    const padding = cascade(list, "padding-left") || cascade(list, "padding");
+    const inset = parseFloat(padding.value.trim().split(/\s+/).pop());
+    assert.ok(
+      inset > 0,
       "the list padding computes to '" +
         padding.value +
         "' via `" +


### PR DESCRIPTION
Closes #731

## What changed

The report surface was painted once, across the whole report:
`.dashboard-reports` carried it as a single slab under both report screens. On
the detail screen that made six unrelated groupings read as one continuous
tinted page — and the groupings themselves split into two looks by accident of
history: the chart and the proposals were white cards, and the tiers, the
recent-actions log, the funnel and the report text sat bare on the tint.

The ground now sits one level lower on that screen:

- the slab comes off the container **while the detail view is up**;
- every top-level grouping carries `--report-surface` itself — the three
  tiers, the recent-actions log (pager included), the funnel, the report-text
  disclosure, the chart and the proposals panel — rounded (`--r-lg`), padded
  (16px 18px), edged with `--report-line`, separated by whitespace;
- `.reports-nav-band` keeps its blue. It is a voice, not a section.

**The list screen is out of scope and unchanged.**

## How the two screens are kept apart

The container is shared — `[data-dashboard-reports]` wraps the list and the
detail alike — so `setReportsView()` marks it with `is-detail` while the detail
view is showing and clears it on the way back. A class rather than `:has()`:
the list screen's ground must not be decided by what the detail view happened
to render inside the same node. The constant is published as
`MUREO_DASHBOARD_REPORTS.REPORTS_DETAIL_CLASS`, and a test asserts the JS, the
stylesheet and the test agree on the string.

The section rules themselves are scoped on `.dashboard-reports-detail`, the
detail view's own node, so they cannot reach the list screen at all —
`.reports-panel` in particular is the client list, the alert layer and the rail
over there.

## Themes

Both come from the existing token. Measured, at the declared values:

| | light | dark |
|---|---|---|
| section vs page | 1.05 | 1.01 |
| section edge vs section | 1.23 | 1.70 |
| card (`--surface`) on section | 1.15 | 1.10 |
| `--ink` on section | 15.7 | 16.6 |
| `--ink-soft` on section | 9.2 | 11.5 |

In dark the ground and the page are within a few units of each other by
design, so the `--report-line` edge is what bounds a block — exactly the job it
did for the slab this replaces. Nothing inside a block is painted from
`--report-surface`, so no inner element goes flat against it: the cards, the
funnel cells and the change cells are `--surface`, the chips and the tabs are
`--surface-2`, and the two table headers that do use the token (`.roster` on
the list screen, `.reports-breakdown-table` here) are not inside one of these
blocks.

One consequence worth stating: `--muted` text that moves from a white panel
onto the section ground goes from 4.96:1 to **4.31:1** in light (dark improves,
5.47 → 5.99). That affects the chart's note line and the proposals' date/"more"
lines. It is the treatment the report screens already ship — every muted line
on the index sits on this same ground today — but it is below AA for small
text, and worth a decision rather than a silent inheritance.

## Tests

`tests/js/reports_detail_surfaces.test.js`, driven against the real app.html
and the real app.css through the harness's cascade:

- the container is marked on the way into a detail view and unmarked on the way
  back, including the single-client install that never sees an index;
- the slab is off the container in the detail view, and back on after a trip to
  a client and back;
- every grouping carries the surface, the radius, the edge and a padding;
- the funnel's 20px gap moved from its row to the block, so it does not open
  inside the block;
- the blocks in the flow each state a gap to the next;
- the band is still blue;
- the index keeps its slab and its white `.reports-panel`s.

Mutation-checked: dropping the class toggle fails 3 of them, making it
add-only (never cleared) fails 2, dropping the recent-actions gap fails 1.

No DOM, no render logic and no API changed.

## Verification

- `node --test tests/js/*.test.js` — 676 pass, 0 fail
- full `pytest tests/` — 14 failed / 10456 passed, identical to the
  pre-change baseline on this machine (all 14 are environment-dependent and
  unrelated: live-client stubs, MCP tool listing, two web-handler archive
  tests)
- `black --check` clean, `ruff check` clean, `mypy mureo` identical to baseline

Screenshots are the owner's call before merge — **do not merge on CI alone.**
