### PR TITLE
fix: give the proposal cards back their own box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 ## [Unreleased]
 
+### Fixed
+
+- **A proposal card has room inside its frame again, and its note sits under
+  its title** (#737). On the detail screen the warn-tinted cards in the
+  proposals panel rendered with no horizontal padding — the text ran up
+  against the yellow border — and the note flowed *beside* the title instead
+  of under it, squeezing the title into a narrow wrapped column.
+
+  Neither was ever written down. A proposal card is an `<li>` inside a
+  `.dashboard-section`, so the setup screens' generic row rule
+  `.dashboard-section li` outranks the card's own single-class rule and was
+  answering for it: `padding: 11px 0` instead of `8px 10px`, and
+  `display: flex; align-items: center` instead of block flow. The card's own
+  layout is restated where it wins, and every other declaration that generic
+  rule makes is answered there too rather than left to it — including the
+  bottom border, which was a grey hairline in the middle of a yellow box and
+  missing altogether on the last card.
+
+  The "+N more" line under the cards was losing the same way, on the one
+  thing it declares: it rendered at body size rather than at the caption size
+  it asks for, under a hairline it never asked for. Both are fixed together.
+
+  This is the same trap the action-log rows were taken out of when they
+  became a timeline (#691); the proposal card was left on the losing side.
+  The card's colours are untouched.
+
 ## [0.17.2] - 2026-08-31
 
 ### Changed

--- a/docs/strategy-context.md
+++ b/docs/strategy-context.md
@@ -1565,6 +1565,29 @@ its count and its "more" line keep the edge they share with every other
 panel, so the cards read as a group set in from the text that introduces
 them rather than as a panel knocked out of alignment.
 
+That inset was only half the reason the cards looked wrong, and #737 is the
+other half — the same specificity trap #691 hit at the action log, on a
+component that had never been taken off the losing side. Every one of these
+list items is an `<li>` inside `.dashboard-section`, so the setup screens'
+generic row rule `.dashboard-section li` (0,1,1) outranks a bare
+`.reports-proposal` (0,1,0) and answered for it: the card computed to
+`padding: 11px 0` — horizontal padding gone, which is the owner's report that
+the text touches the yellow frame — and to `display: flex; align-items:
+center`, which laid the body out beside the title and squeezed the title into
+a narrow wrapped column. Nothing in the stylesheet ever said either of those
+things about a proposal.
+
+The rule this repo now keeps for anything it renders as an `li`: **restate
+the component's own layout at two classes, and answer EVERY declaration the
+generic row rule makes**, not only the ones whose damage is currently
+visible. Silence is what caused this — an unanswered declaration is one the
+setup screens are still deciding, and it becomes a defect the day either side
+changes. The `:last-child` reset needs three, because the generic one is
+`.dashboard-section li:last-child` (0,2,1) and it takes the bottom edge off
+the last row of a setup list, which on a card is one side of the box. What is
+NOT restated is the design: the warn tint, the border colour and the radius
+stay on the base rule, because the generic rule says nothing about them.
+
 Three things follow from moving a ground under content that was drawn against
 a different one. The breakdown tables' header rows were tinted with the ground
 itself, which read as a header while the section around it was the page and

--- a/mureo/_data/web/app.css
+++ b/mureo/_data/web/app.css
@@ -4828,6 +4828,79 @@ dialog[data-confirm-dialog] [data-confirm-ok] {
   color: var(--muted);
 }
 
+/* SCOPED, and for the reason #691 documents at .dashboard-reports-actions-list
+   (#737). Both list items above are `<li>` inside `.dashboard-section`, so the
+   setup screens' generic row rule `.dashboard-section li` (0,1,1) outranks a
+   bare `.reports-proposal` / `.reports-proposal-more` (0,1,0), and every
+   declaration the two rules share was being answered by the generic one. On a
+   live v0.17.2 render the card computed to `padding: 11px 0` and
+   `display: flex; align-items: center` — the horizontal padding gone, which is
+   the owner's report that the text touches the yellow frame, and the body laid
+   out BESIDE the head, which squeezed the title into a narrow wrapped column.
+   Nothing in this file ever said either of those things about a proposal.
+
+   So the card's own layout is restated at (0,2,0), which beats (0,1,1)
+   outright rather than depending on which rule comes later in the file, and
+   every OTHER declaration the generic rule makes is answered here too — all
+   seven of them, listed in the generic rule's own order so the two can be read
+   side by side. Silence is what caused this; an unanswered declaration is one
+   the setup screens are still deciding.
+
+   The tint, the border colour and the radius are NOT restated: those the base
+   rule already wins, because the generic rule says nothing about them. */
+.reports-proposal-list .reports-proposal {
+  /* (1) display — the defect. Block flow: the head keeps its own flex row
+     (`.reports-proposal-head` is a separate element and unaffected), and the
+     body sits below it at full width, which is what a card is. */
+  display: block;
+  /* (2) justify-content and (3) align-items — inert on a block box, and
+     stated for that reason: `center` on the flex box the generic rule made is
+     what put the body beside the title. `normal` is the initial value, so
+     this restores the box rather than picking a new alignment. */
+  justify-content: normal;
+  align-items: normal;
+  /* (4) gap — likewise inert here; the generic 12px was a flex gap. */
+  gap: 0;
+  /* (5) padding — the other half of the defect. The base rule's own value,
+     restated where it can win. */
+  padding: 8px 10px;
+  /* (6) border-bottom — the base rule sets the `border` SHORTHAND, and a
+     longhand at higher specificity beats one side of it, so the card's bottom
+     edge was a --hairline in the middle of a --warn-line box. */
+  border-bottom: 1px solid var(--warn-line);
+  /* (7) font-size — nothing inside the card inherits it (the title, the date
+     and the body each state their own), so this is inert today. Stated anyway
+     so the enumeration is complete and a text child added later cannot
+     silently pick up the setup screens' body size. */
+  font-size: inherit;
+}
+
+/* `.dashboard-section li:last-child` is (0,2,1) and takes the bottom edge off
+   the last row of a setup list. On a card that is the edge of the box, so the
+   reset needs (0,3,0) to outrank it — the same arrangement
+   `.dashboard-reports-actions-list .report-action:last-child` uses. */
+.reports-proposal-list .reports-proposal:last-child {
+  border-bottom: 1px solid var(--warn-line);
+}
+
+/* The "+N more" row is the same `<li>` in the same list and was losing the
+   same way — visibly, on the one declaration it makes: `.dashboard-section li`
+   supplies `font-size: var(--type-body-size)` at (0,1,1), so the line rendered
+   at body size rather than at the caption size stated above, under a hairline
+   it never asked for. It is a plain line of text, not a card, so the box
+   declarations are answered with the initial values rather than with a
+   design. Its colour is untouched — the generic rule says nothing about it,
+   and the detail screen's own --ink-soft lift still applies. */
+.reports-proposal-list .reports-proposal-more {
+  display: block;
+  justify-content: normal;
+  align-items: normal;
+  gap: 0;
+  padding: 0;
+  border-bottom: 0;
+  font-size: var(--type-caption-size);
+}
+
 /* "2 done this month" — the figure in blue, the caption quiet. Blue
    because it is information about work already done, not a verdict. */
 .reports-proposals-count {

--- a/tests/js/reports_detail_surfaces.test.js
+++ b/tests/js/reports_detail_surfaces.test.js
@@ -425,6 +425,160 @@ test.describe("nothing inside a block goes flat against it", function () {
 });
 
 // ---------------------------------------------------------------------
+// The proposal card against the setup screens' generic row rule
+// ---------------------------------------------------------------------
+
+test.describe("a proposal card keeps its own box, not a setup row's", function () {
+  //: What `.dashboard-section li` (0,1,1) declares. Read out of the
+  //: stylesheet rather than copied, so a declaration ADDED to the generic
+  //: rule later fails here instead of silently reaching the card again —
+  //: which is exactly how #737 happened to a component that had already
+  //: been fixed once, at the action log (#691).
+  function genericRowProperties() {
+    const css = require("node:fs").readFileSync(path.join(WEB, "app.css"), "utf-8");
+    const at = css.indexOf("\n.dashboard-section li {");
+    assert.notEqual(at, -1, ".dashboard-section li has no rule in app.css");
+    return css
+      .slice(at)
+      .split("}", 1)[0]
+      .split("{")[1]
+      .split(";")
+      .map(function (d) {
+        return d.split(":")[0].trim();
+      })
+      .filter(Boolean);
+  }
+
+  test.it("answers every declaration the generic row rule makes", async function () {
+    // The bug is not any one property — it is that a rule the component
+    // never mentions was answering for it. So the assertion is over the
+    // generic rule's whole declaration list: for each one, the winner on
+    // the rendered card must be a proposal selector.
+    const page = await openDetail({ display: DISPLAY });
+    const card = detailView(page).querySelectorAll(".reports-proposal")[0];
+    assert.ok(card, "the proposals panel drew no card");
+    const answered = genericRowProperties().map(function (prop) {
+      const won = cascade(card, prop);
+      return [prop, won && won.selector];
+    });
+    for (const [prop, selector] of answered) {
+      assert.ok(
+        selector && /\breports-proposal\b/.test(selector),
+        prop + " on the card is decided by " + selector
+      );
+    }
+    // …and the list is not empty, or the loop above proves nothing.
+    assert.ok(answered.length >= 6, "the generic row rule declares almost nothing");
+  });
+
+  test.it("lays the card out as a block, not as a flex row", async function () {
+    // `display: flex` + `align-items: center` from the generic rule put the
+    // body BESIDE the head and squeezed the title into a narrow wrapped
+    // column. Block flow is what a card is.
+    const page = await openDetail({ display: DISPLAY });
+    const card = detailView(page).querySelectorAll(".reports-proposal")[0];
+    assert.equal(styleOfNode(card, ".reports-proposal", "display"), "block");
+    assert.equal(styleOfNode(card, ".reports-proposal", "align-items"), "normal");
+    assert.equal(styleOfNode(card, ".reports-proposal", "justify-content"), "normal");
+  });
+
+  test.it("keeps the horizontal padding the owner found missing", async function () {
+    // `padding: 11px 0` — horizontal zero — is the reported symptom: the
+    // text runs up against the warn-tint frame.
+    const page = await openDetail({ display: DISPLAY });
+    const card = detailView(page).querySelectorAll(".reports-proposal")[0];
+    const padding = styleOfNode(card, ".reports-proposal", "padding");
+    assert.equal(padding, "8px 10px");
+    assert.ok(
+      !/\b0(px)?\s*$/.test(padding),
+      "the card's horizontal padding is zero again: " + padding
+    );
+  });
+
+  test.it("keeps the box a --warn-line box on all four sides", async function () {
+    // The base rule sets the `border` SHORTHAND; the generic rule sets the
+    // `border-bottom` LONGHAND at higher specificity, so the card's bottom
+    // edge was a --hairline in the middle of a --warn-line box — and none
+    // at all on the last card, where `li:last-child` (0,2,1) takes it away.
+    const page = await openDetail({ display: DISPLAY });
+    const cards = detailView(page).querySelectorAll(".reports-proposal");
+    assert.ok(cards.length >= 2, "one card cannot show a :last-child problem");
+    for (const card of cards) {
+      assert.equal(
+        styleOfNode(card, ".reports-proposal", "border-bottom"),
+        "1px solid var(--warn-line)"
+      );
+    }
+  });
+
+  test.it("puts the body below the head rather than beside it", async function () {
+    // The harness models no layout, so this is pinned at its MECHANISM: the
+    // card is a block box (its children are stacked block boxes, not flex
+    // items in a row), the head keeps its own flex row, and the body is a
+    // later child of the card than the head.
+    const page = await openDetail({ display: DISPLAY });
+    const card = detailView(page).querySelectorAll(".reports-proposal")[0];
+    assert.equal(styleOfNode(card, ".reports-proposal", "display"), "block");
+    const head = card.querySelectorAll(".reports-proposal-head")[0];
+    const body = card.querySelectorAll(".reports-proposal-body")[0];
+    assert.ok(head && body, "the card drew no head or no body");
+    assert.equal(
+      styleOfNode(head, ".reports-proposal-head", "display"),
+      "flex",
+      "the head lost the row it is supposed to keep"
+    );
+    const order = card.children.map(function (n) {
+      return n.getAttribute("class");
+    });
+    assert.deepEqual(order, ["reports-proposal-head", "reports-proposal-body"]);
+  });
+
+  test.it("gives the +N more row back the caption size it declares", async function () {
+    // The same `<li>` in the same list, losing the same way on the one
+    // declaration it makes: the generic rule's `font-size` (0,1,1) beat
+    // `.reports-proposal-more` (0,1,0), so the line rendered at body size
+    // under a hairline it never asked for. The fixture states five
+    // proposals and the list caps at four, so the row is drawn.
+    const page = await openDetail({ display: DISPLAY });
+    const more = detailView(page).querySelectorAll(".reports-proposal-more")[0];
+    assert.ok(more, "the +N more row did not render");
+    assert.equal(
+      styleOfNode(more, ".reports-proposal-more", "font-size"),
+      "var(--type-caption-size)"
+    );
+    assert.equal(styleOfNode(more, ".reports-proposal-more", "display"), "block");
+    assert.equal(styleOfNode(more, ".reports-proposal-more", "padding"), "0");
+    assert.equal(styleOfNode(more, ".reports-proposal-more", "border-bottom"), "0");
+  });
+
+  test.it("wins by specificity, not by source order", async function () {
+    // (0,2,0) beats the generic (0,1,1) outright, and the :last-child reset
+    // is (0,3,0) against its (0,2,1). Pinned in the stylesheet because a
+    // later refactor that moves these rules ABOVE the generic ones would
+    // otherwise reintroduce the bug with every assertion above still green.
+    const css = require("node:fs").readFileSync(path.join(WEB, "app.css"), "utf-8");
+    for (const sel of [
+      ".reports-proposal-list .reports-proposal",
+      ".reports-proposal-list .reports-proposal:last-child",
+      ".reports-proposal-list .reports-proposal-more",
+    ]) {
+      assert.notEqual(
+        css.indexOf("\n" + sel + " {"),
+        -1,
+        sel + " has no rule in app.css"
+      );
+    }
+    // The design itself stays on the base rule: this pass restates layout,
+    // it does not repaint the card.
+    const at = css.indexOf("\n.reports-proposal {");
+    const base = css.slice(at).split("}", 1)[0];
+    assert.match(base, /background: var\(--warn-tint\);/);
+    assert.match(base, /border: 1px solid var\(--warn-line\);/);
+    assert.match(base, /border-radius: var\(--r-sm\);/);
+  });
+});
+
+// ---------------------------------------------------------------------
 // The action log: cards on the rail
 // ---------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #737.

**UI change: full-page captures (light and dark) need the owner's approval
before merge.**

## What was wrong

A proposal card is an `<li>` inside a `.dashboard-section`, so the setup
screens' generic row rule `.dashboard-section li` (0,1,1) outranks a bare
`.reports-proposal` (0,1,0) and was answering for it. All seven of its
declarations reached the card — reproduced by the JS suite's cascade model
against the real app.css before any fix, which agrees with the issue's live
measurement:

| declaration | was decided by | should be |
|---|---|---|
| `display: flex` | `.dashboard-section li` | `block` |
| `justify-content: space-between` | `.dashboard-section li` | inert on a block box |
| `align-items: center` | `.dashboard-section li` | inert on a block box |
| `gap: 12px` | `.dashboard-section li` | inert on a block box |
| `padding: 11px 0` | `.dashboard-section li` | `8px 10px` |
| `border-bottom: 1px solid var(--hairline)` | `.dashboard-section li` / `li:last-child` | `1px solid var(--warn-line)` |
| `font-size: var(--type-body-size)` | `.dashboard-section li` | `inherit` |

The two visible ones are the report: `padding: 11px 0` is the missing space
between the text and the yellow frame, and `display: flex; align-items:
center` laid the note out beside the title and squeezed the title into a
narrow wrapped column. Nothing in the stylesheet ever said either of those
things about a proposal. This is the trap `#691` documents at
`.dashboard-reports-actions-list` (app.css:3500-3537); the proposal card was
left on the losing side of it.

## The fix

`.reports-proposal-list .reports-proposal` (0,2,0) restates the card's own
layout — which beats (0,1,1) outright rather than depending on which rule
comes later in the file — and answers **all seven**, not only the two whose
damage was visible. Silence is what caused this: an unanswered declaration is
one the setup screens are still deciding, and it becomes a defect the day
either side changes. Each is commented in the generic rule's own order so the
two can be read side by side.

`.reports-proposal-list .reports-proposal:last-child` takes (0,3,0), because
`.dashboard-section li:last-child` is (0,2,1) and takes the bottom edge off
the last row of a setup list — which on a card is one side of the box. Same
arrangement `.dashboard-reports-actions-list .report-action:last-child` uses.

**No design change.** The warn tint, the border colour and the radius are not
restated: the generic rule says nothing about them, so the base rule already
wins them.

## The sibling in the same panel

`.reports-proposal-more` — the "+N more" row — is the same `<li>` in the same
list, and it was losing the same way, **visibly**, on the one declaration it
makes: `.dashboard-section li`'s `font-size: var(--type-body-size)` (0,1,1)
beat its own `font-size: var(--type-caption-size)` (0,1,0), so the line
rendered at body size, under a hairline it never asked for. Fixed in the same
block, with the box declarations answered at their initial values rather than
with a design — it is a line of text, not a card. Its colour is untouched, so
the detail screen's `--ink-soft` lift still applies.

Everything else rendered as an `<li>` in this path was checked:

- `.report-action` (`dashboard_reports_detail.js:643`) — already scoped by
  #691. Not touched.
- `.reports-archived-row` (`dashboard_reports.js:403`) — **loses too, and is
  deliberately left alone.** It declares `display: flex`, `align-items:
  center` and `justify-content: space-between`, which are the same values the
  generic rule supplies, so the only differences are `gap` (its `10px` loses
  to `12px`) and a `padding: 11px 0` + hairline it never declared. It is on
  the archived-clients drawer of the **list** screen, not this panel, and
  nothing about it is visibly wrong — it reads as a row divider on a list of
  rows. Reporting it rather than fixing it: it is a separate surface and a
  separate capture.
- `reports_display.js` renders no elements at all (it is the read model).

## Tests

`tests/js/reports_detail_surfaces.test.js`, seven pins in the style of the
action-row ones, resolved through the real stylesheet cascade:

- **the enumeration** — reads `.dashboard-section li`'s declaration list out
  of app.css and asserts that for *every* property in it the winning selector
  on the rendered card is a proposal selector. This is the regression pin: a
  declaration added to the generic rule later fails here instead of silently
  reaching the card again, which is exactly how a component that had already
  been fixed once ended up in this issue.
- `display: block`, `align-items: normal`, `justify-content: normal`
- `padding: 8px 10px`, plus an explicit "the horizontal padding is not zero"
- `border-bottom: 1px solid var(--warn-line)` on **every** card, checked over
  at least two so the `:last-child` case is exercised
- the body sits below the head — pinned at its mechanism, since the harness
  models no layout: the card is a block box, the head keeps its own flex row,
  and the body is a later child of the card than the head
- the "+N more" row's caption size, display, padding and border
- the three scoped rules exist, and the base rule still carries the tint,
  border colour and radius

Mutation-checked, six ways: deleting the scoped card rule fails 5; dropping
only `padding` fails 2; only `display: block` fails 3; the `:last-child`
reset fails 3; the `-more` rule fails 2; and **adding a new declaration to the
generic `.dashboard-section li`** fails 1 — the enumeration pin.

## Verification

Base `4b94b92` (v0.17.2).

- `black --check .` — 759 files unchanged. `ruff check .` — all checks passed.
- `mypy mureo` — 14 errors in 11 files, every one a missing third-party stub;
  identical to the baseline on this machine.
- `node --test tests/js/*.test.js` — **695 passed, 0 failed** (was 688).
- Full `pytest` — **10457 passed, 8 skipped, 14 failed**; the failure set is
  diff-identical to the pre-change baseline here. CI on this PR is the
  authority.
