### PR TITLE
fix: keep tests from writing stub tokens into the real credentials file (#739)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -408,6 +408,11 @@ This rule was reinforced after PR #20 (2026-04-19, OAuth helper extraction — 6
   asserts every anchor still resolves, so a refactor cannot turn the harness into a
   no-op that always "passes".
 - Framework: pytest + pytest-asyncio
+- Run the suite in a clean virtualenv (mureo + `[dev]`, nothing else). The root
+  `tests/conftest.py` also points the home directory at a temp dir and hides any
+  installed `mureo.runtime_context_factory` entry point for every test, so a
+  credentials writer called without a `path` cannot reach the real
+  `~/.mureo/credentials.json` or a plugin's shared store (#739)
 - All external API calls (Google Ads, Meta Ads) **must** be mocked in tests
 - Use `@pytest.mark.unit` / `@pytest.mark.integration` for categorization
 - Async test mode: auto (`asyncio_mode = "auto"`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ### Fixed
 
+- **Running the test suite no longer writes stub tokens into a real
+  credentials file** (#739). Several Meta token tests called
+  `refresh_meta_token_if_needed` with no `path` against a mocked Graph that
+  answers 200 — so the save that follows the refresh ran for real. With no
+  plugin installed that write went to the contributor's own
+  `~/.mureo/credentials.json`; with a `mureo.runtime_context_factory`
+  installed alongside mureo it went wherever that host's `SecretStore` points,
+  because the write-path resolver prefers the store over the default it is
+  handed. Either way a test's `refreshed-1` could end up as the stored Meta
+  access token, and the process-wide context cache meant a later `HOME` patch
+  could not take it back.
+
+  The root `conftest.py` now isolates every test: the home directory points at
+  a throwaway temp dir, the runtime-context factory group reads empty, and the
+  cached context is dropped on both sides of the test. Tests that install
+  their own fake factory are unaffected — they patch the same seam later in
+  the stack. The Meta provenance tests pass an explicit `path` and assert the
+  refreshed token reached it, and `tests/test_conftest_credential_isolation.py`
+  pins the isolation itself so it cannot quietly stop working.
+
 - **A proposal card has room inside its frame again, and its note sits under
   its title** (#737). On the detail screen the warn-tinted cards in the
   proposals panel rendered with no horizontal padding — the text ran up

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,15 @@ ruff check mureo/
 pytest tests/ -v
 ```
 
+Run the suite in a clean virtualenv that has mureo and its `[dev]` extra and
+nothing else. The root `tests/conftest.py` points the home directory at a
+throwaway temp dir and hides any installed `mureo.runtime_context_factory`
+entry point for the duration of every test, so a test that exercises a
+credentials writer can never reach your real `~/.mureo/credentials.json` — nor
+a plugin's shared credential store, which the write-path resolver would
+otherwise prefer (#739). Keeping the venv clean keeps whatever else is
+installed out of the results as well.
+
 ### With Coverage
 
 ```bash

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,3 +50,64 @@ def _reset_duplicate_account_warn_latch():
     platform_guards._DUPLICATE_ACCOUNT_WARNED.clear()
     yield
     platform_guards._DUPLICATE_ACCOUNT_WARNED.clear()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_credential_writes(monkeypatch, tmp_path_factory):
+    """Keep every test's credential writes inside a throwaway home (#739).
+
+    The two ``path``-less credential writers — ``refresh_meta_token_if_needed``
+    and ``save_amazon_access_token`` — resolve their destination through
+    ``mureo.auth._resolve_write_path`` →
+    ``mureo.core.runtime_context.runtime_credentials_path``. That resolver has
+    two ways of reaching a real file:
+
+    - the fallback is ``Path.home() / ".mureo" / "credentials.json"``, i.e. the
+      contributor's OWN credentials; and
+    - when ANY ``mureo.runtime_context_factory`` entry point is installed in
+      the interpreter running the suite, the fallback is ignored entirely and
+      the write lands wherever that plugin's ``SecretStore`` points — which on
+      an operator machine is the shared credentials file. ``pip install -e .``
+      of a host distribution alongside mureo is enough to arm this.
+
+    Tests that never meant to write anything real were doing exactly that: a
+    mocked Graph 200 makes the refresh succeed, and the save that follows is
+    not mocked. Because ``get_runtime_context`` caches the resolved context
+    process-wide, a later ``HOME`` patch could not undo it either.
+
+    So: point ``HOME`` (POSIX ``Path.home()``) and ``USERPROFILE`` (Windows
+    ``Path.home()``; CI runs test-windows) at a fresh temp dir, make the
+    factory group look empty, and drop the cached context on both sides of the
+    test. Autouse in the root ``conftest.py`` for the same reason as the
+    fixtures above: a per-module opt-in only protects the modules that
+    remember, which is the failure mode this replaces.
+
+    Tests that deliberately install a fake factory keep working — they patch
+    the same ``entry_points`` attribute later in the stack, so their stub wins
+    for the duration of the test and unwinds before this fixture restores the
+    original.
+    """
+    from mureo.core import runtime_context
+    from mureo.core.runtime_context import (
+        RUNTIME_CONTEXT_FACTORY_ENTRY_POINT_GROUP,
+    )
+
+    home = tmp_path_factory.mktemp("home")
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+
+    real_entry_points = runtime_context.entry_points
+
+    def _entry_points_without_factories(*args, **kwargs):
+        """Hide installed factories; every other group is passed through."""
+        if kwargs.get("group") == RUNTIME_CONTEXT_FACTORY_ENTRY_POINT_GROUP:
+            return []
+        return real_entry_points(*args, **kwargs)
+
+    monkeypatch.setattr(
+        runtime_context, "entry_points", _entry_points_without_factories
+    )
+
+    runtime_context.reset_runtime_context()
+    yield
+    runtime_context.reset_runtime_context()

--- a/tests/test_conftest_credential_isolation.py
+++ b/tests/test_conftest_credential_isolation.py
@@ -1,0 +1,202 @@
+"""The root conftest keeps credential writes off the real machine (#739).
+
+``tests/conftest.py::_isolate_credential_writes`` is the only thing standing
+between a ``path``-less ``refresh_meta_token_if_needed`` /
+``save_amazon_access_token`` in a test and the contributor's own
+``~/.mureo/credentials.json`` — or, when a ``mureo.runtime_context_factory``
+distribution is installed next to mureo, the host plugin's shared credential
+store, which the resolver prefers over the default path entirely.
+
+An isolation fixture that quietly stops working is worse than none, because
+the suite still passes while writing stub tokens into a real file. So the
+fixture gets its own pins: the home directory really moved, the factory group
+really looks empty, the resolver really returns its default, and a full
+``path``-less refresh really lands inside the temp home. The last test proves
+the fixture does not overreach — a test that installs its own fake factory
+still gets it.
+
+Marks: unit — httpx is mocked, nothing touches the network.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from mureo.auth import MetaAdsCredentials, refresh_meta_token_if_needed
+from mureo.core import runtime_context
+from mureo.core.runtime_context import (
+    RUNTIME_CONTEXT_FACTORY_ENTRY_POINT_GROUP,
+    default_runtime_context,
+    runtime_credentials_path,
+)
+
+# Every lookup below goes through the MODULE attribute, never a name imported
+# into this module: the fixture (and the runtime-context tests) monkeypatch
+# ``mureo.core.runtime_context.entry_points``, and a from-import would bind the
+# original and pass vacuously.
+
+pytestmark = pytest.mark.unit
+
+#: The contributor's actual home, captured at IMPORT time. Collection runs
+#: before any function-scoped fixture, so this is the value ``Path.home()``
+#: would return if the fixture were not there — which is exactly what the
+#: first test asserts it is no longer.
+_REAL_HOME = Path(os.path.expanduser("~"))
+
+
+def _aged_creds() -> MetaAdsCredentials:
+    """A credential old enough that the 53-day age rule fires."""
+    obtained = datetime.now(tz=timezone.utc) - timedelta(days=55)
+    return MetaAdsCredentials(
+        access_token="stale-token",
+        app_id="app-1",
+        app_secret="secret-1",
+        token_obtained_at=obtained.isoformat(),
+    )
+
+
+class _Graph:
+    """Patch ``mureo.auth.httpx.AsyncClient`` with a 200 exchange."""
+
+    def __init__(self, token: str) -> None:
+        self._token = token
+        self._patcher = patch("mureo.auth.httpx.AsyncClient")
+
+    def __enter__(self) -> _Graph:
+        cls = self._patcher.start()
+        client = AsyncMock()
+        client.post = AsyncMock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "access_token": self._token,
+                    "token_type": "bearer",
+                    "expires_in": 5183944,
+                },
+                request=httpx.Request("POST", "https://graph.facebook.com/"),
+            )
+        )
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=False)
+        cls.return_value = client
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self._patcher.stop()
+
+
+class _FakeEP:
+    """Stands in for an ``importlib.metadata`` entry point."""
+
+    def __init__(self, name: str, target: Any) -> None:
+        self.name = name
+        self._target = target
+
+    def load(self) -> Any:
+        return self._target
+
+
+# ---------------------------------------------------------------------------
+# The fixture's three moving parts
+# ---------------------------------------------------------------------------
+
+
+def test_the_home_directory_is_not_the_real_one() -> None:
+    """``Path.home()`` follows ``HOME`` / ``USERPROFILE``, and both point at a
+    temp dir for the duration of every test."""
+
+    assert Path.home() != _REAL_HOME
+    assert Path.home() == Path(os.environ["HOME"])
+
+
+def test_no_runtime_context_factory_is_visible() -> None:
+    """Whatever is installed in the interpreter, the resolver's group reads
+    empty — the plugin relocation cannot engage."""
+
+    visible = runtime_context.entry_points(
+        group=RUNTIME_CONTEXT_FACTORY_ENTRY_POINT_GROUP
+    )
+    assert list(visible) == []
+
+
+def test_other_entry_point_groups_still_resolve() -> None:
+    """Only the factory group is hidden; the wrapper delegates every other
+    group untouched, so a test that enumerates providers or console scripts
+    sees exactly what ``importlib.metadata`` would return."""
+
+    from importlib.metadata import entry_points as real_entry_points
+
+    seen = runtime_context.entry_points(group="console_scripts")
+    assert sorted(ep.name for ep in seen) == sorted(
+        ep.name for ep in real_entry_points(group="console_scripts")
+    )
+
+
+def test_the_resolver_returns_the_caller_default(tmp_path: Path) -> None:
+    """With no factory visible, ``runtime_credentials_path`` hands back the
+    default it was given rather than a store's location."""
+
+    sentinel = tmp_path / "sentinel" / "credentials.json"
+    assert runtime_credentials_path(sentinel) == sentinel
+
+
+# ---------------------------------------------------------------------------
+# The write that used to escape
+# ---------------------------------------------------------------------------
+
+
+async def test_a_path_less_refresh_writes_inside_the_temp_home() -> None:
+    """The #739 reproduction, with the fixture in place: a mocked 200 makes
+    the refresh succeed, the save runs for real, and it lands under the temp
+    home instead of the contributor's own credentials file."""
+
+    with _Graph("refreshed-in-temp-home"):
+        await refresh_meta_token_if_needed(_aged_creds())
+
+    written = Path.home() / ".mureo" / "credentials.json"
+    assert written.exists()
+    assert not str(written).startswith(str(_REAL_HOME) + os.sep)
+
+    section = json.loads(written.read_text(encoding="utf-8"))["meta_ads"]
+    assert section["access_token"] == "refreshed-in-temp-home"
+
+
+# ---------------------------------------------------------------------------
+# ...without disarming the tests that need a factory
+# ---------------------------------------------------------------------------
+
+
+async def test_a_test_installed_factory_still_steers_the_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The fixture hides *installed* factories, not the fake ones the
+    runtime-context tests inject: those patch the same module attribute later
+    in the stack, so their stub wins for the length of the test."""
+
+    tenant = tmp_path / "tenant" / "credentials.json"
+
+    def fake_entry_points(*, group: str) -> list[_FakeEP]:
+        assert group == RUNTIME_CONTEXT_FACTORY_ENTRY_POINT_GROUP
+        return [
+            _FakeEP(
+                "tenant",
+                lambda: default_runtime_context(credentials_path=tenant),
+            )
+        ]
+
+    monkeypatch.setattr("mureo.core.runtime_context.entry_points", fake_entry_points)
+
+    with _Graph("refreshed-for-the-tenant"):
+        await refresh_meta_token_if_needed(_aged_creds())
+
+    section = json.loads(tenant.read_text(encoding="utf-8"))["meta_ads"]
+    assert section["access_token"] == "refreshed-for-the-tenant"
+    assert not (Path.home() / ".mureo" / "credentials.json").exists()

--- a/tests/test_meta_token_provenance.py
+++ b/tests/test_meta_token_provenance.py
@@ -59,6 +59,22 @@ def _in_days(days: int) -> str:
     return (datetime.now(tz=timezone.utc) + timedelta(days=days)).isoformat()
 
 
+def _stored_token(path: Path) -> str:
+    """The ``meta_ads`` access token the refresh persisted to ``path``.
+
+    Every test below hands ``refresh_meta_token_if_needed`` an explicit
+    ``path``: a mocked Graph 200 means the save really runs, and a
+    ``path``-less call resolves through ``auth._resolve_write_path``, which
+    lands on the host's own credentials file whenever a
+    ``mureo.runtime_context_factory`` is installed in the interpreter running
+    the suite (#739). Reading the file back also pins that the token the
+    exchange returned is the one that reached disk.
+    """
+    section = json.loads(path.read_text(encoding="utf-8"))["meta_ads"]
+    token: str = section["access_token"]
+    return token
+
+
 def _graph_ok(token: str = "new-token") -> httpx.Response:
     return httpx.Response(
         200,
@@ -192,9 +208,10 @@ async def test_a_pasted_system_user_token_does_send_the_flag(tmp_path: Path) -> 
 # ---------------------------------------------------------------------------
 
 
-async def test_known_expiry_alone_does_not_arm_the_flag() -> None:
+async def test_known_expiry_alone_does_not_arm_the_flag(tmp_path: Path) -> None:
     """An expiry with no provenance is exactly the state cycle two lands in."""
 
+    path = tmp_path / "credentials.json"
     creds = MetaAdsCredentials(
         access_token="tok",
         app_id="app-1",
@@ -205,13 +222,15 @@ async def test_known_expiry_alone_does_not_arm_the_flag() -> None:
     )
 
     with _Graph() as graph:
-        await refresh_meta_token_if_needed(creds)
+        await refresh_meta_token_if_needed(creds, path=path)
 
     assert _FLAG not in graph.last_body
+    assert _stored_token(path) == "refreshed-1"
 
 
 @pytest.mark.parametrize("token_type", ["USER", "PAGE", "APP", "", "SYSTEM  USER"])
-async def test_only_system_user_arms_the_flag(token_type: str) -> None:
+async def test_only_system_user_arms_the_flag(token_type: str, tmp_path: Path) -> None:
+    path = tmp_path / "credentials.json"
     creds = MetaAdsCredentials(
         access_token="tok",
         app_id="app-1",
@@ -222,17 +241,21 @@ async def test_only_system_user_arms_the_flag(token_type: str) -> None:
     )
 
     with _Graph() as graph:
-        await refresh_meta_token_if_needed(creds)
+        await refresh_meta_token_if_needed(creds, path=path)
 
     assert _FLAG not in graph.last_body
+    assert _stored_token(path) == "refreshed-1"
 
 
 @pytest.mark.parametrize("token_type", ["SYSTEM_USER", "system_user", " System_User "])
-async def test_graph_casing_and_padding_are_tolerated(token_type: str) -> None:
+async def test_graph_casing_and_padding_are_tolerated(
+    token_type: str, tmp_path: Path
+) -> None:
     """Graph's documented spelling is upper-case, but a value that round-trips
     through JSON and a UI should not decide a security-relevant branch on
     whitespace."""
 
+    path = tmp_path / "credentials.json"
     creds = MetaAdsCredentials(
         access_token="tok",
         app_id="app-1",
@@ -243,17 +266,19 @@ async def test_graph_casing_and_padding_are_tolerated(token_type: str) -> None:
     )
 
     with _Graph() as graph:
-        await refresh_meta_token_if_needed(creds)
+        await refresh_meta_token_if_needed(creds, path=path)
 
     assert graph.last_body[_FLAG] == "true"
+    assert _stored_token(path) == "refreshed-1"
 
 
-async def test_a_failed_inspection_leaves_the_flag_off() -> None:
+async def test_a_failed_inspection_leaves_the_flag_off(tmp_path: Path) -> None:
     """``token_inspect_failed`` means mureo never learned the type. Guessing
     "probably system user, the card asks for one" is the guess that put the
     parameter on a user token in the first place — and omitting it costs
     nothing, since the exchange returns a 60-day token either way."""
 
+    path = tmp_path / "credentials.json"
     creds = MetaAdsCredentials(
         access_token="tok",
         app_id="app-1",
@@ -265,9 +290,10 @@ async def test_a_failed_inspection_leaves_the_flag_off() -> None:
     )
 
     with _Graph() as graph:
-        await refresh_meta_token_if_needed(creds)
+        await refresh_meta_token_if_needed(creds, path=path)
 
     assert _FLAG not in graph.last_body
+    assert _stored_token(path) == "refreshed-1"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #739.

## What

The unit suite could write a mocked Graph response (`refreshed-1`) into a real credentials file. Four tests in `tests/test_meta_token_provenance.py` called `refresh_meta_token_if_needed(creds)` with no `path`; the mocked 200 makes the save run for real, and `_resolve_write_path()` → `runtime_credentials_path()` ignores its default whenever a `mureo.runtime_context_factory` entry point is installed in the interpreter — so on a developer machine with a host plugin the write landed in the plugin's shared credentials file. The process-wide context cache meant a later `HOME` patch could not undo it. CI never saw it because no plugin is installed there.

## Changes

- `tests/conftest.py`: autouse `_isolate_credential_writes` — `HOME` / `USERPROFILE` → per-test temp dir, `mureo.core.runtime_context.entry_points` wrapped to return `[]` for the factory group (other groups pass through), `reset_runtime_context()` before and after each test. Tests that inject their own fake factory patch the same attribute later in the stack and keep working.
- `tests/test_meta_token_provenance.py`: the four tests pass an explicit `path=tmp_path / ...` and assert the refreshed token reached that file.
- `tests/test_conftest_credential_isolation.py`: pins the isolation — home moved, factory group empty, other groups still resolve, resolver returns its default, a path-less refresh lands inside the temp home, and a test-installed fake factory still steers the write. A mutation run with the fixture disabled fails three of the six.
- Audited the other path-less callers (`test_meta_token_refresh.py`, `test_meta_token_expiry_refresh.py`, `test_auth_amazon.py`, `test_auth_amazon_obtained_at.py`, `test_credentials_concurrency.py`): all already stub the save or pin the default path; unchanged.
- CHANGELOG `[Unreleased]` / Fixed; CONTRIBUTING.md and AGENTS.md: run the suite in a clean venv, the root conftest isolates home and plugins.

## Verification

Clean venv (mureo + `[dev]`, no plugins): `10476 passed, 9 skipped` in the full suite; `black --check` and `ruff check` clean; no entry under the real home's `.mureo` was modified during the run.

Test/tooling only; no product behaviour change.
