### PR TITLE
fix: make the credential-isolation guard pass on Windows (#739)

### DIFF
--- a/tests/test_conftest_credential_isolation.py
+++ b/tests/test_conftest_credential_isolation.py
@@ -163,7 +163,13 @@ async def test_a_path_less_refresh_writes_inside_the_temp_home() -> None:
 
     written = Path.home() / ".mureo" / "credentials.json"
     assert written.exists()
-    assert not str(written).startswith(str(_REAL_HOME) + os.sep)
+    # Inside the fixture's temp home, and not the contributor's own file. Not
+    # "outside the real home": on Windows the runner's temp directory lives
+    # under %USERPROFILE%\AppData\Local\Temp, so every temp home is inside
+    # the real one and that stricter check fails for the wrong reason.
+    temp_home = Path(os.environ["HOME"]).resolve()
+    assert written.resolve().is_relative_to(temp_home)
+    assert written.resolve() != (_REAL_HOME / ".mureo" / "credentials.json").resolve()
 
     section = json.loads(written.read_text(encoding="utf-8"))["meta_ads"]
     assert section["access_token"] == "refreshed-in-temp-home"


### PR DESCRIPTION
Follow-up to #741 (#739). `main` has been red on `test-windows` since it landed: that job was not in the PR's check list at the time.

## Why it failed

`tests/test_conftest_credential_isolation.py::test_a_path_less_refresh_writes_inside_the_temp_home` asserted that the file the refresh wrote was *not under the contributor's real home*. On the Windows runner the per-test temp home is created under `%USERPROFILE%\AppData\Local\Temp`, so every temp home is inside the real home and the assertion fails for a reason unrelated to what it guards.

## Change

The guard now asserts what it means: the written file is inside the fixture's temp home, and it is not the contributor's own credentials file. Same protection, no dependency on where the OS keeps its temp directory. Test-only.

## Verification

Clean venv, macOS: the 6 guard tests pass. Windows is verified by this PR's own `test-windows` job.
